### PR TITLE
fix: return a 403 instead of a redirect from course_home_api api methods

### DIFF
--- a/lms/djangoapps/course_home_api/dates/views.py
+++ b/lms/djangoapps/course_home_api/dates/views.py
@@ -13,9 +13,10 @@ from rest_framework.response import Response
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_goals.models import UserActivity
 from lms.djangoapps.course_home_api.dates.serializers import DatesTabSerializer
+from lms.djangoapps.course_home_api.utils import get_course_or_403
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
-from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_date_blocks
 from lms.djangoapps.courseware.date_summary import TodaysDate
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -59,6 +60,7 @@ class DatesTabView(RetrieveAPIView):
 
         * 200 on success with above fields.
         * 401 if the user is not authenticated.
+        * 403 if the user does not have access to the course.
         * 404 if the course is not available or cannot be seen.
     """
 
@@ -79,7 +81,7 @@ class DatesTabView(RetrieveAPIView):
         monitoring_utils.set_custom_attribute('user_id', request.user.id)
         monitoring_utils.set_custom_attribute('is_staff', request.user.is_staff)
 
-        course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=False)
+        course = get_course_or_403(request.user, 'load', course_key, check_if_enrolled=False)
         is_staff = bool(has_access(request.user, 'staff', course_key))
 
         _, request.user = setup_masquerade(

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -109,6 +109,16 @@ class ResumeCourseSerializer(serializers.Serializer):
     url = serializers.URLField()
 
 
+class OutlineTabCourseAccessRedirectSerializer(serializers.Serializer):
+    """
+    Serializer for a Course Access Redirect response from the outline tab
+    """
+    url = serializers.URLField()
+    error_code = serializers.CharField(source='access_error.error_code')
+    developer_message = serializers.CharField(source='access_error.developer_message')
+    user_message = serializers.CharField(source='access_error.user_message')
+
+
 class OutlineTabSerializer(DatesBannerSerializer, VerifiedModeSerializer):
     """
     Serializer for the Outline Tab

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -20,7 +20,6 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
-from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.learning_sequences.api import replace_course_outline
 from openedx.core.djangoapps.content.learning_sequences.data import CourseOutlineData, CourseVisibility

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -20,6 +20,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
+from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.learning_sequences.api import replace_course_outline
 from openedx.core.djangoapps.content.learning_sequences.data import CourseOutlineData, CourseVisibility

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -21,8 +21,9 @@ from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.course_blocks.transformers import start_date
 
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
+from lms.djangoapps.course_home_api.utils import get_course_or_403
 from lms.djangoapps.courseware.courses import (
-    get_course_blocks_completion_summary, get_course_with_access, get_studio_url,
+    get_course_blocks_completion_summary, get_studio_url,
 )
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.courseware.views.views import credit_course_requirements, get_cert_data
@@ -128,6 +129,7 @@ class ProgressTabView(RetrieveAPIView):
 
         * 200 on success with above fields.
         * 401 if the user is not authenticated or not enrolled.
+        * 403 if the user does not have access to the course.
         * 404 if the course is not available or cannot be seen.
     """
 
@@ -190,7 +192,7 @@ class ProgressTabView(RetrieveAPIView):
         student = self._get_student_user(request, course_key, student_id, is_staff)
         username = get_enterprise_learner_generic_name(request) or student.username
 
-        course = get_course_with_access(student, 'load', course_key, check_if_enrolled=False)
+        course = get_course_or_403(student, 'load', course_key, check_if_enrolled=False)
 
         course_overview = CourseOverview.get_from_id(course_key)
         enrollment = CourseEnrollment.get_enrollment(student, course_key)

--- a/lms/djangoapps/course_home_api/tests/test_utils.py
+++ b/lms/djangoapps/course_home_api/tests/test_utils.py
@@ -1,0 +1,53 @@
+""" Tests for course home api utils """
+
+from contextlib import contextmanager
+from rest_framework.exceptions import PermissionDenied
+from unittest import mock
+
+from lms.djangoapps.course_home_api.utils import get_course_or_403
+from lms.djangoapps.courseware.access_response import AccessError
+from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+
+class GetCourseOr403Test(ModuleStoreTestCase):
+    """ Tests for get_course_or_403 """
+
+    @contextmanager
+    def mock_get_course(self, *args, **kwargs):
+        """ Mock base_get_course_with_access helper """
+        with mock.patch(
+            'lms.djangoapps.course_home_api.utils.base_get_course_with_access',
+            *args,
+            **kwargs
+        ) as mock_get:
+            yield mock_get
+
+    def test_no_exception(self):
+        """ If no exception is raised we should return the return of get_course_with_access """
+        expected_return = mock.Mock()
+        with self.mock_get_course(return_value=expected_return):
+            assert get_course_or_403() == expected_return
+
+    def test_redirect(self):
+        """ Test for behavior when get_course_with_access raises a redirect error """
+        expected_url = "www.testError.access/redirect.php?work=yes"
+        mock_access_error = AccessError('code', 'dev_msg', 'usr_msg')
+        mock_course_access_redirect = CourseAccessRedirect(expected_url, mock_access_error)
+
+        with self.mock_get_course(side_effect=mock_course_access_redirect):
+            try:
+                get_course_or_403()
+                self.fail('Call to get_course_or_403 should raise exception')
+            except PermissionDenied as e:
+                assert str(e.detail) == mock_access_error.user_message
+                assert e.detail.code == mock_access_error.error_code
+
+    def test_other_exception(self):
+        """ Any other exception should not be caught """
+        class MyException(Exception):
+            pass
+
+        with self.mock_get_course(side_effect=MyException()):
+            with self.assertRaises(MyException):
+                get_course_or_403()

--- a/lms/djangoapps/course_home_api/utils.py
+++ b/lms/djangoapps/course_home_api/utils.py
@@ -1,0 +1,24 @@
+""" Utilities for views in the course home api"""
+from rest_framework.exceptions import PermissionDenied
+
+from lms.djangoapps.courseware.courses import get_course_with_access as base_get_course_with_access
+from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
+
+
+def get_course_or_403(*args, **kwargs):
+    """
+    When we make requests to the various Learner Home API endpoints, we do not want to return the actual redirects,
+    Instead we should return an error code. The redirect info is returned from the course metadata endpoint and the
+    URL can be followed by whatever client is calling.
+    
+    Raises:
+     - 404 if course is not found
+     - 403 if the requesting user does not have access to the course
+    """
+    try:
+        return base_get_course_with_access(*args, **kwargs)
+    except CourseAccessRedirect as e:
+        raise PermissionDenied(
+            detail=e.access_error.user_message,
+            code=e.access_error.error_code
+        ) from e

--- a/lms/djangoapps/course_home_api/utils.py
+++ b/lms/djangoapps/course_home_api/utils.py
@@ -10,7 +10,7 @@ def get_course_or_403(*args, **kwargs):
     When we make requests to the various Learner Home API endpoints, we do not want to return the actual redirects,
     Instead we should return an error code. The redirect info is returned from the course metadata endpoint and the
     URL can be followed by whatever client is calling.
-    
+
     Raises:
      - 404 if course is not found
      - 403 if the requesting user does not have access to the course


### PR DESCRIPTION
### The issue:

When a learner navigates to a Learning MFE course overview page, we hit this API. This API uses `get_course_with_access` to check whether or not the learner can access this course. If not, `get_course_with_access` raises a `CourseAccessError`, which causes the request to return a 302 and a URL to redirect to.

This is useful in cases where the user is requesting a web page - they will be automatically redirected to another page depending on their state. However, this is being requested as an API request. When the error is raised, we then attempt to make an API request to various other sites. In this case, it's the learner home, which then requests the auth service, and causes the CORS. The CORS is an error, but it's not really the issue here. We shouldn't be making an ajax request to the redirect URL at all. We should be redirecting the user's web browser to the redirect URL.

With this change, I catch the redirect error and instead raise a 403 Forbidden. The actual information about the redirect is returned by the course metadata endpoint.

This error also exists in the course dates and course progress tab, but thy are significantly less likely urls for a learner to stumble upon, and therefore were not reported. This should fix them as well.

### Testing instructions
This needs to be paired with https://github.com/openedx/frontend-app-learning/pull/1111.
- Check out master/main on both repos and allow the applications to reload.
- Create a course with a start date in the future.
- Navigate to the learning MFE course outline for the course as global staff. You should be able to see the course outline.
- Copy the URL and open an incognito window and navigate to the same page as a non-logged-in user. You will be presented with the error page.
- Log in as a non-staff learner and navigate to the page again. You should see the same error.

Now check out both of these PRS and allow the applications to reload.
- Navigate to the same page as a non-logged-in user. You should be redirected to the login page.
- Log in as a non-staff learner and you should then be redirected to learner home and be presented with a message about the course not yet starting. 
- Navigate to the course again, still logged in. You should be redirected back to the learner home with the same message.