### PR TITLE
Add enrollment date and custom fields to students profile information CSV

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1433,7 +1433,8 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         query_features = [
             'id', 'username', 'name', 'email', 'language', 'location',
             'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
-            'goals', 'enrollment_mode', 'last_login', 'date_joined', 'external_user_key'
+            'goals', 'enrollment_mode', 'last_login', 'date_joined', 'external_user_key',
+            'enrollment_date'
         ]
     keep_field_private(query_features, 'year_of_birth')  # protected information
 
@@ -1456,6 +1457,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         'last_login': _('Last Login'),
         'date_joined': _('Date Joined'),
         'external_user_key': _('External User Key'),
+        'enrollment_date': _('Enrollment Date'),
     }
 
     if is_course_cohorted(course.id):


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This pull request refactors the query of the students profile information CSV so it retrieves the CourseEnrollment object and adds by default the enrollment date on the CSV.
This change as direct impact to "Course Author" that have the "Data Researcher" role because they can better understand when its students have been enrolled in the course.

Additionally, another improvement has been implemented on the same use case. That allows site operators to include on the export custom fields if the platform has an extending User model. This can be used if you have an extended model that include for example an university student number and Site Operator want to export the student number on the student profile information CSV.

The pull request has impact on the use case: LMS > Course > Instructor > Data download > Download profile information as a CSV

## Supporting information

None.

## Testing instructions

LMS > Course > Instructor > Data download > Download profile information as a CSV

Open a course on the LMS, open the `Instructor` tab, select `Data download` and then click on the button `Download profile information as a CSV`. If you are running on the Devstack the exported file should be on the `/tmp/edx-s3` folder inside the LMS container.

Example:
```bash
make dev.shell.lms
cat /tmp/edx-s3/grades/bb6d638a296059742509a0d319ddf8456b6dbf9a/edX_DemoX_Demo_Course_student_profile_info_2023-05-09-1149.csv
```

## Deadline
None
I think this features can be easily backported to Palm and Olive.

## Other information
None.