### PR TITLE
fix: update shard names for GH tests

### DIFF
--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -17,23 +17,24 @@ jobs:
         python-version: [ '3.8' ]
         django-version:
           - "pinned"
-        shard_name: [
-            "lms-1",
-            "lms-2",
-            "lms-3",
-            "lms-4",
-            "lms-5",
-            "lms-6",
-            "openedx-1",
-            "openedx-2",
-            "openedx-3",
-            "openedx-4",
-            "cms-1",
-            "cms-2",
-            "common-1",
-            "common-2",
-            "common-3",
-        ]
+        # When updating the shards, remember to make the same changes in
+        # .github/workflows/unit-tests.yml
+        shard_name:
+          - "lms-1"
+          - "lms-2"
+          - "lms-3"
+          - "lms-4"
+          - "lms-5"
+          - "lms-6"
+          - "openedx-1"
+          - "openedx-2"
+          - "openedx-3"
+          - "openedx-4"
+          - "cms-1"
+          - "cms-2"
+          - "common-1"
+          - "common-2"
+          - "xmodule-1"
     name: gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,8 @@ jobs:
         django-version:
           - "pinned"
           #- "4.0"
+        # When updating the shards, remember to make the same changes in
+        # .github/workflows/unit-tests-gh-hosted.yml
         shard_name:
           - "lms-1"
           - "lms-2"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -82,7 +82,7 @@ jobs:
   # https://github.com/orgs/community/discussions/33579
   success:
     name: Tests successful
-    if: always()
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     needs:
       - run-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github hosted tests weren't working because shards were not up to date.

See https://github.com/openedx/edx-platform/pull/32124#issuecomment-1540733670 for more info.