### PR TITLE
Pin urllib3 version to urllib3<2.0.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -92,3 +92,8 @@ django-ipware==4.0.2
 # Pinning this version for now so this could be fixed in a separate PR later on
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/32093
 pytz<2023
+
+# urllib3>=2.0.0 conflicts with elastic search && snowflake-connector-python packages
+# which require urllib3<2 for now.
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/32222
+urllib3<2.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,3 +97,7 @@ pytz<2023
 # which require urllib3<2 for now.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/32222
 urllib3<2.0.0
+
+# Sphinx==5.3.0 requires docutils<0.20 
+# Issue to unpin Sphinx to resolve this constraint: https://github.com/openedx/edx-lint/issues/338
+docutils<0.20

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -79,7 +79,7 @@ six==1.16.0
     #   chem
     #   codejail-includes
     #   python-dateutil
-sympy==1.11.1
+sympy==1.12
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -95,7 +95,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/edx/paver.txt
     #   elasticsearch
@@ -250,7 +250,7 @@ django-appconf==1.0.5
     #   django-statici18n
 django-cache-memoize==0.1.10
     # via edx-enterprise
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/edx/base.in
 django-classy-tags==4.0.0
     # via django-sekizai
@@ -407,7 +407,9 @@ djfernet==0.8.1
 docopt==0.6.2
     # via -r requirements/edx/base.in
 docutils==0.19
-    # via botocore
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   botocore
 done-xblock==2.0.5
     # via -r requirements/edx/base.in
 drf-jwt==1.19.2
@@ -484,7 +486,7 @@ edx-enterprise==3.62.6
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==3.9.6
+edx-event-bus-kafka==4.0.0
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.2
     # via ora2
@@ -569,7 +571,7 @@ event-tracking==2.1.0
     #   -r requirements/edx/base.in
     #   edx-proctoring
     #   edx-search
-fastavro==1.7.3
+fastavro==1.7.4
     # via openedx-events
 filelock==3.12.0
     # via snowflake-connector-python
@@ -589,7 +591,7 @@ fs-s3fs==0.1.8
     #   openedx-django-pyfs
 future==0.18.3
     # via pyjwkest
-geoip2==4.6.0
+geoip2==4.7.0
     # via -r requirements/edx/base.in
 glob2==0.7
     # via -r requirements/edx/base.in
@@ -711,7 +713,7 @@ markupsafe==2.1.2
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.2.0
+maxminddb==2.3.0
     # via geoip2
 mock==5.0.2
     # via -r requirements/edx/paver.txt
@@ -769,7 +771,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/base.in
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/base.in
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
@@ -855,7 +857,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
     #   edx-token-utils
     #   lti-consumer-xblock
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/edx/base.in
     #   drf-jwt
@@ -966,11 +968,11 @@ rapidfuzz==3.0.0
     # via levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
-redis==4.5.4
+redis==4.5.5
     # via -r requirements/edx/base.in
 regex==2023.5.5
     # via nltk
-requests==2.29.0
+requests==2.30.0
     # via
     #   -r requirements/edx/paver.txt
     #   algoliasearch
@@ -998,7 +1000,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/base.in
     #   social-auth-core
-ruamel-yaml==0.17.22
+ruamel-yaml==0.17.26
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -1104,7 +1106,7 @@ super-csv==3.0.1
     # via
     #   -r requirements/edx/base.in
     #   edx-bulk-grades
-sympy==1.11.1
+sympy==1.12
     # via openedx-calc
 testfixtures==7.1.0
     # via edx-enterprise
@@ -1129,9 +1131,9 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.15
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.txt
     #   elasticsearch
-    #   geoip2
     #   py2neo
     #   requests
     #   snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -135,7 +135,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/edx/testing.txt
     #   elasticsearch
@@ -349,7 +349,7 @@ django-cache-memoize==0.1.10
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/edx/testing.txt
 django-classy-tags==4.0.0
     # via
@@ -523,6 +523,7 @@ docopt==0.6.2
     # via -r requirements/edx/testing.txt
 docutils==0.19
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   sphinx
@@ -609,7 +610,7 @@ edx-enterprise==3.62.6
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.9.6
+edx-event-bus-kafka==4.0.0
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.2
     # via
@@ -716,7 +717,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==18.6.2
+faker==18.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -724,7 +725,7 @@ fastapi==0.95.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-fastavro==1.7.3
+fastavro==1.7.4
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-events
@@ -755,11 +756,11 @@ future==0.18.3
     # via
     #   -r requirements/edx/testing.txt
     #   pyjwkest
-geoip2==4.6.0
+geoip2==4.7.0
     # via -r requirements/edx/testing.txt
 glob2==0.7
     # via -r requirements/edx/testing.txt
-grimp==2.3
+grimp==2.4
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
@@ -951,7 +952,7 @@ markupsafe==2.1.2
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.2.0
+maxminddb==2.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   geoip2
@@ -981,7 +982,7 @@ multidict==6.0.4
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.2.0
+mypy==1.3.0
     # via -r requirements/edx/development.in
 mypy-extensions==1.0.0
     # via mypy
@@ -1028,7 +1029,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/testing.txt
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/testing.txt
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
@@ -1170,7 +1171,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
     #   edx-token-utils
     #   lti-consumer-xblock
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   drf-jwt
@@ -1355,13 +1356,13 @@ rapidfuzz==3.0.0
     #   levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
-redis==4.5.4
+redis==4.5.5
     # via -r requirements/edx/testing.txt
 regex==2023.5.5
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
-requests==2.29.0
+requests==2.30.0
     # via
     #   -r requirements/edx/testing.txt
     #   algoliasearch
@@ -1395,7 +1396,7 @@ rfc3986[idna2008]==1.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   httpx
-ruamel-yaml==0.17.22
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/edx/testing.txt
     #   drf-yasg
@@ -1563,7 +1564,7 @@ super-csv==3.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-bulk-grades
-sympy==1.11.1
+sympy==1.12
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-calc
@@ -1634,9 +1635,9 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.15
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   elasticsearch
-    #   geoip2
     #   pact-python
     #   py2neo
     #   requests

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -15,7 +15,7 @@ babel==2.11.0
     #   sphinx
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==2.0.12
     # via
@@ -29,6 +29,7 @@ code-annotations==1.3.0
     # via -r requirements/edx/doc.in
 docutils==0.19
     # via
+    #   -c requirements/edx/../constraints.txt
     #   pydata-sphinx-theme
     #   sphinx
 gitdb==4.0.10
@@ -68,7 +69,7 @@ pytz==2022.7.1
     #   babel
 pyyaml==6.0
     # via code-annotations
-requests==2.29.0
+requests==2.30.0
     # via sphinx
 smmap==5.0.0
     # via gitdb
@@ -103,6 +104,8 @@ text-unidecode==1.3
 typing-extensions==4.5.0
     # via pydata-sphinx-theme
 urllib3==1.26.15
-    # via requests
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   requests
 zipp==3.15.0
     # via importlib-metadata

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==2.0.12
     # via
@@ -37,7 +37,7 @@ pymongo==3.13.0
     #   edx-opaque-keys
 python-memcached==1.59
     # via -r requirements/edx/paver.in
-requests==2.29.0
+requests==2.30.0
     # via -r requirements/edx/paver.in
 six==1.16.0
     # via
@@ -49,7 +49,9 @@ stevedore==5.0.0
     #   -r requirements/edx/paver.in
     #   edx-opaque-keys
 urllib3==1.26.15
-    # via requests
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   requests
 watchdog==3.0.0
     # via -r requirements/edx/paver.in
 wrapt==1.15.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -127,7 +127,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -331,7 +331,7 @@ django-cache-memoize==0.1.10
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/edx/base.txt
 django-classy-tags==4.0.0
     # via
@@ -503,6 +503,7 @@ docopt==0.6.2
     # via -r requirements/edx/base.txt
 docutils==0.19
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
 done-xblock==2.0.5
@@ -587,7 +588,7 @@ edx-enterprise==3.62.6
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.9.6
+edx-event-bus-kafka==4.0.0
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -689,11 +690,11 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==18.6.2
+faker==18.7.0
     # via factory-boy
 fastapi==0.95.1
     # via pact-python
-fastavro==1.7.3
+fastavro==1.7.4
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
@@ -724,11 +725,11 @@ future==0.18.3
     # via
     #   -r requirements/edx/base.txt
     #   pyjwkest
-geoip2==4.6.0
+geoip2==4.7.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-grimp==2.3
+grimp==2.4
     # via import-linter
 gunicorn==20.1.0
     # via -r requirements/edx/base.txt
@@ -906,7 +907,7 @@ markupsafe==2.1.2
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.2.0
+maxminddb==2.3.0
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -975,7 +976,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/base.txt
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
@@ -1105,7 +1106,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
     #   edx-token-utils
     #   lti-consumer-xblock
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1277,13 +1278,13 @@ rapidfuzz==3.0.0
     #   levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
-redis==4.5.4
+redis==4.5.5
     # via -r requirements/edx/base.txt
 regex==2023.5.5
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-requests==2.29.0
+requests==2.30.0
     # via
     #   -r requirements/edx/base.txt
     #   algoliasearch
@@ -1314,7 +1315,7 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 rfc3986[idna2008]==1.5.0
     # via httpx
-ruamel-yaml==0.17.22
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1450,7 +1451,7 @@ super-csv==3.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades
-sympy==1.11.1
+sympy==1.12
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
@@ -1512,9 +1513,9 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.15
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   elasticsearch
-    #   geoip2
     #   pact-python
     #   py2neo
     #   requests

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
 idna==3.4
     # via requests
-requests==2.29.0
+requests==2.30.0
     # via -r scripts/xblock/requirements.in
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests


### PR DESCRIPTION
## Description
- Resolves issue https://github.com/openedx/edx-platform/issues/32202
- Had to pin the `urllib3<2.0.0` due to further conflicts with `snowflake-connector-python` and `elasticsearch` packages. 
- Had to pin the `docutils<0.20` due to conflict with `Sphinx` package requirement.
- Created follow up Issue https://github.com/openedx/edx-platform/issues/32222 to resolve this constraint later on.