### PR TITLE
feat: add header_meta to base template

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -63,6 +63,7 @@ from openedx.core.release import RELEASE_LINE
     <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
+    <%block name="header_meta"></%block>
     <% favicon_url = branding_api.get_favicon_url() %>
     <link rel="icon" type="image/x-icon" href="${favicon_url}"/>
     <%static:css group='style-vendor'/>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -85,7 +85,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
   <% favicon_url = branding_api.get_favicon_url() %>
   <link rel="icon" type="image/x-icon" href="${favicon_url}"/>
 
-
+  <%block name="header_meta"/>
 
   <%static:css group='style-vendor'/>
   % if '/' in self.attr.main_css:

--- a/lms/templates/public_video.html
+++ b/lms/templates/public_video.html
@@ -4,9 +4,8 @@ from django.utils.translation import gettext as _
 %>
 <%inherit file="courseware/courseware-chromeless.html"/>
 
-<%block name="head_extra">
+<%block name="header_meta">
 <!-- OpenGraph tags  -->
-<meta data-rh="true" property="og:type" content="website">
 <meta data-rh="true" property="og:site_name" content="edX">
 <meta data-rh="true" property="og:title" content="${social_sharing_metadata['video_title']}">
 <meta data-rh="true" property="og:description" content="${social_sharing_metadata['video_description']}">


### PR DESCRIPTION
## Description

Add `header_meta` to base template inserting meta tag. The reason that `head_extra` isn't suffice was because some crawler (Facebook) only read small portion of the page. `head_extra` and `header_extra` sometime include inline javascript and css, which increase the header size significantly. This cause the crawler not to be able to get the meta tag.

https://2u-internal.atlassian.net/browse/AU-1219
