### PR TITLE
chore: remove studio check for public sharing

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -254,22 +254,12 @@ class TestVideoPublicAccess(BaseTestVideoXBlock):
         with patch.object(PUBLIC_VIDEO_SHARE, 'is_enabled', return_value=enabled):
             yield
 
-    @ddt.data(
-        (True, False),
-        (False, False),
-        (False, True),
-        (True, True),
-    )
-    @ddt.unpack
-    def test_is_public_sharing_enabled(self, is_studio, feature_enabled):
+    @ddt.data(True, False)
+    def test_is_public_sharing_enabled(self, feature_enabled):
         """Test public video url."""
         assert self.block.public_access is True
-        if is_studio:
-            self.block.runtime.is_author_mode = True
-
         with self.mock_feature_toggle(enabled=feature_enabled):
-            assert self.block.is_public_sharing_enabled() == \
-                (not is_studio and feature_enabled)
+            assert self.block.is_public_sharing_enabled() == feature_enabled
 
     def test_is_public_sharing_enabled__not_public(self):
         self.block.public_access = False

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -18,10 +18,8 @@ import json
 import logging
 from collections import OrderedDict, defaultdict
 from operator import itemgetter
-from urllib.parse import urljoin
 
 from django.conf import settings
-from django.urls import reverse
 from edx_django_utils.cache import RequestCache
 from lxml import etree
 from opaque_keys.edx.locator import AssetLocator
@@ -488,11 +486,6 @@ class VideoBlock(
             template_context['public_video_url'] = public_video_url
             template_context['sharing_sites_info'] = sharing_sites_info_for_video(public_video_url)
 
-        # Public video previewing / social media sharing
-        if self.is_public_sharing_enabled():
-            template_context['public_sharing_enabled'] = True
-            template_context['public_video_url'] = self.get_public_video_url()
-
         return self.runtime.service(self, 'mako').render_template('video.html', template_context)
 
     def get_course_video_sharing_override(self):
@@ -512,11 +505,6 @@ class VideoBlock(
         """
         Is public sharing enabled for this video?
         """
-
-        # Sharing is DISABLED from studio
-        is_studio = getattr(self.runtime, "is_author_mode", False)
-        if is_studio:
-            return False
 
         # Video share feature must be enabled for sharing settings to take effect
         feature_enabled = PUBLIC_VIDEO_SHARE.is_enabled(self.location.course_key)
@@ -543,15 +531,7 @@ class VideoBlock(
         """
         Returns the public video url
         """
-        return urljoin(
-            settings.LMS_ROOT_URL,
-            reverse(
-                'render_public_video_xblock',
-                kwargs={
-                    'usage_key_string': str(self.location)
-                }
-            )
-        )
+        return fr'{settings.LMS_ROOT_URL}/videos/{str(self.location)}'
 
     def validate(self):
         """
@@ -674,7 +654,7 @@ class VideoBlock(
         # be shared with leaners. This is not possible with default rendering logic in backbonjs code, that is why
         # we are setting a new type and then do a custom rendering in backbonejs code to render the desired UI.
         editable_fields['public_access']['type'] = 'PublicAccess'
-        editable_fields['public_access']['url'] = fr'{settings.LMS_ROOT_URL}/videos/{str(self.location)}'
+        editable_fields['public_access']['url'] = self.get_public_video_url()
 
         # construct transcripts info and also find if `en` subs exist
         transcripts_info = self.get_transcripts_info()


### PR DESCRIPTION
## Description

TLDR; when the feature enable, the share link should show on the studio/preview as well

Studio & preview views do not show the for videos when enabled. This change is to make sure the share button also show in those and also give the correct link.

https://2u-internal.atlassian.net/browse/AU-1181