### PR TITLE
feat: update text for sharing to Twitter

### DIFF
--- a/lms/djangoapps/courseware/tests/test_sharing_sites.py
+++ b/lms/djangoapps/courseware/tests/test_sharing_sites.py
@@ -67,7 +67,7 @@ class TestSharingSites(TestCase):
             TEST_SHARING_SITE_CONFIG_WITH_ADDITIONAL_PARAMS,
         ]
         with patch('xmodule.video_block.sharing_sites.ALL_SHARING_SITES', new=sharing_site_configs):
-            sharing_sites_info = sharing_sites_info_for_video(TEST_PUBLIC_URL)
+            sharing_sites_info = sharing_sites_info_for_video(TEST_PUBLIC_URL, organization=None)
             for expected_config, actual_info in zip(sharing_site_configs, sharing_sites_info):
                 self.assertDictEqual(
                     actual_info,

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -23,6 +23,7 @@ from django.conf import settings
 from edx_django_utils.cache import RequestCache
 from lxml import etree
 from opaque_keys.edx.locator import AssetLocator
+from organizations.api import get_course_organization
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
@@ -480,11 +481,16 @@ class VideoBlock(
             'transcript_download_format': transcript_download_format,
             'transcript_download_formats_list': self.fields['transcript_download_format'].values,  # lint-amnesty, pylint: disable=unsubscriptable-object
         }
+
         if self.is_public_sharing_enabled():
             public_video_url = self.get_public_video_url()
             template_context['public_sharing_enabled'] = True
             template_context['public_video_url'] = public_video_url
-            template_context['sharing_sites_info'] = sharing_sites_info_for_video(public_video_url)
+            organization = get_course_organization(self.course_id)
+            template_context['sharing_sites_info'] = sharing_sites_info_for_video(
+                public_video_url,
+                organization=organization
+            )
 
         return self.runtime.service(self, 'mako').render_template('video.html', template_context)
 


### PR DESCRIPTION
## Description

Still needs manual testing (haven't set up local organizations API for testing in devstack yet)

1. Updated logic to include organization name (when available) in share text when posting to Twitter.
2. Pull Twitter handle from platform config.
3. Refactor away some no-longer-relevant code.

## Supporting information

JIRA: https://2u-internal.atlassian.net/browse/AU-1220

## Testing instructions

TODO
