### PR TITLE
Return MFE course home url instead of legacy url as course_root in the email_context

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -63,6 +63,9 @@ from lms.djangoapps.instructor_task.subtasks import (
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.courses import course_image_url
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
 
 log = logging.getLogger('edx.celery.task')
 
@@ -116,10 +119,8 @@ def _get_course_email_context(course):
     course_title = course.display_name
     course_end_date = get_default_time_display(course.end)
     course_root = reverse('course_root', kwargs={'course_id': course_id})
-    course_url = '{}{}'.format(
-        settings.LMS_ROOT_URL,
-        course_root
-    )
+    course_key = CourseKey.from_string(course_id)
+    course_url = get_learning_mfe_home_url(course_key=course_key, url_fragment='home')
     image_url = f'{settings.LMS_ROOT_URL}{course_image_url(course)}'
     lms_root_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
     email_context = {


### PR DESCRIPTION
## Description

Currently, using `course_url` variable in an email template managed by ace will result in an url pointing to the legacy view. It is expected to return the learning MFE url of the course instead.

## Supporting information

This variable is used [in one of the bulk email templates](https://github.com/openedx/edx-platform/blob/9b644109feb402b915cdefae0bb56348878a956e/lms/templates/bulk_email/edx_ace/bulkemail/email/body.html#L27), [course enrollment emails](https://github.com/openedx/edx-platform/blob/9b644109feb402b915cdefae0bb56348878a956e/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html#L46) and probably other places.

## Testing instructions

Send a bulk email to yourself and check the link at the footer.

## Deadline

None.

