### PR TITLE
fix: oscm@edx.org is not the right email for asking about APIs

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2241,6 +2241,12 @@ PARTNER_SUPPORT_EMAIL = ''
 # Affiliate cookie tracking
 AFFILIATE_COOKIE_NAME = 'dev_affiliate_id'
 
+# API access management
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
+API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
+API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
+AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+
 ############## Settings for Studio Context Sensitive Help ##############
 
 HELP_TOKENS_INI_FILE = REPO_ROOT / "cms" / "envs" / "help_tokens.ini"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2,8 +2,6 @@ swagger: '2.0'
 info:
   title: Open edX API
   description: APIs for access to Open edX information
-  contact:
-    email: oscm@edx.org
   version: v1
 basePath: /api
 consumes:

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -140,6 +140,11 @@ if RELEASE_LINE == "master":
         'course_author': 'https://edx.readthedocs.io/projects/edx-partner-course-staff',
     }
 
+# API access management
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
+API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
+API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
+AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -509,6 +509,12 @@ SUBSCRIPTIONS_LEARNER_HELP_CENTER_URL = None
 SUBSCRIPTIONS_BUY_SUBSCRIPTION_URL = f"{SUBSCRIPTIONS_ROOT_URL}/api/v1/stripe-subscribe/"
 SUBSCRIPTIONS_MANAGE_SUBSCRIPTION_URL = None
 
+# API access management
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
+API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
+API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
+AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+
 ################# New settings must go ABOVE this line #################
 ########################################################################
 # See if the developer has any local overrides.

--- a/openedx/core/apidocs.py
+++ b/openedx/core/apidocs.py
@@ -2,6 +2,7 @@
 Open API support.
 """
 
+from django.conf import settings
 from edx_api_doc_tools import make_api_info
 from rest_framework import serializers
 
@@ -10,7 +11,7 @@ api_info = make_api_info(
     version="v1",
     description="APIs for access to Open edX information",
     #terms_of_service="https://www.google.com/policies/terms/",         # TODO: Do we have these?
-    email="oscm@edx.org",
+    email=settings.API_ACCESS_MANAGER_EMAIL,
     #license=openapi.License(name="BSD License"),                       # TODO: What does this mean?
 )
 


### PR DESCRIPTION
We get about one email per month from people looking for access to edX APIs.  Those emails come to the now almost defunct oscm@edx.org email address.  I think that's because of these swagger references.

I suppose someone could find this email address on an Open edX installation, and people would write to it, but I find in practice this doesn't happen.
