### PR TITLE
chore: update og:url for video sharing

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1863,7 +1863,11 @@ class PublicVideoXBlockView(BasePublicVideoXBlockView):
             'video_embed_url': urljoin(
                 settings.LMS_ROOT_URL,
                 reverse('render_public_video_xblock_embed', kwargs={'usage_key_string': str(video_block.location)})
-            )
+            ),
+            'video_url': urljoin(
+                settings.LMS_ROOT_URL,
+                reverse('render_public_video_xblock', kwargs={'usage_key_string': str(video_block.location)})
+            ),
         }
 
     def get_learn_more_button_url(self, course, catalog_course_data, utm_params):

--- a/lms/templates/public_video.html
+++ b/lms/templates/public_video.html
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 <meta data-rh="true" property="og:title" content="${social_sharing_metadata['video_title']}">
 <meta data-rh="true" property="og:description" content="${social_sharing_metadata['video_description']}">
 <meta data-rh="true" property="og:image" content="${social_sharing_metadata['video_thumbnail']}">
-<meta data-rh="true" property="og:url" content="${social_sharing_metadata['video_embed_url']}">
+<meta data-rh="true" property="og:url" content="${social_sharing_metadata['video_url']}">
 <meta data-rh="true" property="og:type" content="video.other">
 <meta data-rh="true" property="og:video" content="${social_sharing_metadata['video_embed_url']}">
 <meta data-rh="true" property="og:video:url" content="${social_sharing_metadata['video_embed_url']}">


### PR DESCRIPTION
## Description

`og:url` should be refer to the current page. It was referring to embed page that didn't have any meta tag.

https://2u-internal.atlassian.net/browse/AU-1219