### PR TITLE
Kristin aoki/update studio header waffle flag checks

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -414,3 +414,23 @@ def use_new_unit_page(course_key):
     Returns a boolean if new studio course outline mfe is enabled
     """
     return ENABLE_NEW_STUDIO_UNIT_PAGE.is_enabled(course_key)
+
+
+# .. toggle_name: new_studio_mfe.use_new_course_team_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new studio course team page mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-5-15
+# .. toggle_target_removal_date: 2023-8-31
+# .. toggle_tickets: TNL-10619
+# .. toggle_warning:
+ENABLE_NEW_STUDIO_COURSE_TEAM_PAGE = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_new_course_team_page', __name__)
+
+
+def use_new_course_team_page(course_key):
+    """
+    Returns a boolean if new studio course team mfe is enabled
+    """
+    return ENABLE_NEW_STUDIO_COURSE_TEAM_PAGE.is_enabled(course_key)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -36,6 +36,7 @@ from cms.djangoapps.contentstore.toggles import (
     use_new_export_page,
     use_new_files_uploads_page,
     use_new_grading_page,
+    use_new_course_team_page,
     use_new_home_page,
     use_new_import_page,
     use_new_schedule_details_page,
@@ -276,6 +277,19 @@ def get_grading_url(course_locator) -> str:
         if mfe_base_url:
             grading_url = course_mfe_url
     return grading_url
+
+
+def get_course_team_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for course team page view.
+    """
+    course_team_url = None
+    if use_new_course_team_page(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/course_team'
+        if mfe_base_url:
+            course_team_url = course_mfe_url
+    return course_team_url
 
 
 def get_updates_url(course_locator) -> str:

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -227,13 +227,13 @@ def get_editor_page_base_url(course_locator) -> str:
     return editor_url
 
 
-def get_studio_home_url(course_locator):
+def get_studio_home_url():
     """
     Gets course authoring microfrontend URL for Studio Home view.
     """
     studio_home_url = None
     if use_new_home_page():
-        mfe_base_url = get_course_authoring_url(course_locator)
+        mfe_base_url = settings.COURSE_AUTHORING_MICROFRONTEND_URL
         if mfe_base_url:
             studio_home_url = f'{mfe_base_url}/home'
     return studio_home_url
@@ -246,7 +246,7 @@ def get_schedule_details_url(course_locator) -> str:
     schedule_details_url = None
     if use_new_schedule_details_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/settings/details/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/settings/details'
         if mfe_base_url:
             schedule_details_url = course_mfe_url
     return schedule_details_url
@@ -259,7 +259,7 @@ def get_advanced_settings_url(course_locator) -> str:
     advanced_settings_url = None
     if use_new_advanced_settings_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/settings/advanced/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/settings/advanced'
         if mfe_base_url:
             advanced_settings_url = course_mfe_url
     return advanced_settings_url
@@ -272,7 +272,7 @@ def get_grading_url(course_locator) -> str:
     grading_url = None
     if use_new_grading_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/settings/grading/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/settings/grading'
         if mfe_base_url:
             grading_url = course_mfe_url
     return grading_url
@@ -285,7 +285,7 @@ def get_updates_url(course_locator) -> str:
     updates_url = None
     if use_new_updates_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/course_info/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/course_info'
         if mfe_base_url:
             updates_url = course_mfe_url
     return updates_url
@@ -298,7 +298,7 @@ def get_import_url(course_locator) -> str:
     import_url = None
     if use_new_import_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/import/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/import'
         if mfe_base_url:
             import_url = course_mfe_url
     return import_url
@@ -311,7 +311,7 @@ def get_export_url(course_locator) -> str:
     export_url = None
     if use_new_export_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/export/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/export'
         if mfe_base_url:
             export_url = course_mfe_url
     return export_url
@@ -324,7 +324,7 @@ def get_files_uploads_url(course_locator) -> str:
     files_uploads_url = None
     if use_new_files_uploads_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/assets/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/assets'
         if mfe_base_url:
             files_uploads_url = course_mfe_url
     return files_uploads_url
@@ -337,7 +337,7 @@ def get_video_uploads_url(course_locator) -> str:
     video_uploads_url = None
     if use_new_video_uploads_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/assets/{course_locator}'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/videos/'
         if mfe_base_url:
             video_uploads_url = course_mfe_url
     return video_uploads_url

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -9,7 +9,7 @@
   from urllib.parse import quote_plus
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
-  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
@@ -64,6 +64,7 @@
             video_upload_mfe_enabled = toggles.use_new_video_uploads_page(context_course.id)
             schedule_details_mfe_enabled = toggles.use_new_schedule_details_page(context_course.id)
             grading_mfe_enabled = toggles.use_new_grading_page(context_course.id)
+            course_team_mfe_enabled = toggles.use_new_course_team_page(context_course.id)
             advanced_settings_mfe_enabled = toggles.use_new_advanced_settings_page(context_course.id)
             import_mfe_enabled = toggles.use_new_import_page(context_course.id)
             export_mfe_enabled = toggles.use_new_export_page(context_course.id)
@@ -173,9 +174,16 @@
                     <a href="${get_grading_url(course_key)}">${_("Grading")}</a>
                   </li>
                   % endif
+                  % if not course_team_mfe_enabled:
                   <li class="nav-item nav-course-settings-team">
                     <a href="${course_team_url}">${_("Course Team")}</a>
                   </li>
+                  % endif
+                  % if not course_team_mfe_enabled:
+                  <li class="nav-item nav-course-settings-team">
+                    <a href="${get_course_team_url(course_key)}">${_("Course Team")}</a>
+                  </li>
+                  % endif
                   <li class="nav-item nav-course-settings-group-configurations">
                     <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': six.text_type(course_key)})}">${_("Group Configurations")}</a>
                   </li>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -9,7 +9,7 @@
   from urllib.parse import quote_plus
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
-  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
@@ -17,12 +17,23 @@
   <header class="primary" role="banner">
     <div class="wrapper wrapper-l">
       <h1 class="branding">
+        % if not toggles.use_new_home_page():
         <a class="brand-link" href="/">
           <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
             % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
             <span class="font-italic"> <span class="tilted">|</span> EDGE</span>
             % endif
         </a>
+        % endif
+        % if toggles.use_new_home_page():
+        <a class="brand-link" href="${get_studio_home_url()}">
+          <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
+            % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
+            <span class="font-italic"> <span class="tilted">|</span> EDGE</span>
+            % endif
+        </a>
+        % endif
+
       </h1>
 
       % if context_course:
@@ -46,13 +57,32 @@
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
             pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
+            studio_home_mfe_enabled = toggles.use_new_home_page()
+            course_outline_mfe_enabled = toggles.use_new_course_outline_page(context_course.id)
+            updates_mfe_enabled = toggles.use_new_updates_page(context_course.id)
+            files_uploads_mfe_enabled = toggles.use_new_files_uploads_page(context_course.id)
+            video_upload_mfe_enabled = toggles.use_new_video_uploads_page(context_course.id)
+            schedule_details_mfe_enabled = toggles.use_new_schedule_details_page(context_course.id)
+            grading_mfe_enabled = toggles.use_new_grading_page(context_course.id)
+            advanced_settings_mfe_enabled = toggles.use_new_advanced_settings_page(context_course.id)
+            import_mfe_enabled = toggles.use_new_import_page(context_course.id)
+            export_mfe_enabled = toggles.use_new_export_page(context_course.id)
+
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
+        % if not course_outline_mfe_enabled:
         <a class="course-link" href="${index_url}">
           <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
           <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
         </a>
+        % endif
+        % if course_outline_mfe_enabled:
+        <a class="course-link" href="${get_course_outline_url(course_key)}">
+          <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
+          <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
+        </a>
+        % endif
       </h2>
 
       <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
@@ -64,12 +94,26 @@
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
                 <ul>
+                  % if not course_outline_mfe_enabled:
                   <li class="nav-item nav-course-courseware-outline">
                     <a href="${index_url}">${_("Outline")}</a>
                   </li>
+                  % endif
+                  % if course_outline_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-outline">
+                    <a href="${get_course_outline_url(course_key)}">${_("Outline")}</a>
+                  </li>
+                  % endif
+                  % if not updates_mfe_enabled:
                   <li class="nav-item nav-course-courseware-updates">
                     <a href="${course_info_url}">${_("Updates")}</a>
                   </li>
+                  % endif
+                  % if updates_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-updates">
+                    <a href="${get_updates_url(course_key)}">${_("Updates")}</a>
+                  </li>
+                  % endif
                   % if not pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-pages">
                     <a href="${tabs_url}">${_("Pages")}</a>
@@ -77,7 +121,7 @@
                   % endif
                   % if pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-pages-resources">
-                    <a href="${get_pages_and_resources_url(course_key)}" rel="external">${_("Pages & Resources")}</a>
+                    <a href="${get_pages_and_resources_url(course_key)}">${_("Pages & Resources")}</a>
                   </li>
                   % endif
                   <li class="nav-item nav-course-courseware-uploads">
@@ -88,9 +132,14 @@
                     <a href="${textbooks_url}">${_("Textbooks")}</a>
                   </li>
                   % endif
-                  % if context_course.video_pipeline_configured:
+                  % if context_course.video_pipeline_configured and not video_upload_mfe_enabled:
                   <li class="nav-item nav-course-courseware-videos">
                     <a href="${videos_url}">${_("Video Uploads")}</a>
+                  </li>
+                  % endif
+                  % if context_course.video_pipeline_configured and video_upload_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-videos">
+                    <a href="${get_video_uploads_url(course_key)}">${_("Video Uploads")}</a>
                   </li>
                   % endif
                 </ul>
@@ -104,12 +153,26 @@
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
                 <ul>
+                  % if not schedule_details_mfe_enabled:
                   <li class="nav-item nav-course-settings-schedule">
                     <a href="${settings_url}">${_("Schedule & Details")}</a>
                   </li>
+                  % endif
+                  % if schedule_details_mfe_enabled:
+                  <li class="nav-item nav-course-settings-schedule">
+                    <a href="${get_schedule_details_url(course_key)}">${_("Schedule & Details")}</a>
+                  </li>
+                  % endif
+                  % if not grading_mfe_enabled:
                   <li class="nav-item nav-course-settings-grading">
                     <a href="${grading_url}">${_("Grading")}</a>
                   </li>
+                  % endif
+                  % if grading_mfe_enabled:
+                  <li class="nav-item nav-course-settings-grading">
+                    <a href="${get_grading_url(course_key)}">${_("Grading")}</a>
+                  </li>
+                  % endif
                   <li class="nav-item nav-course-settings-team">
                     <a href="${course_team_url}">${_("Course Team")}</a>
                   </li>
@@ -121,9 +184,14 @@
                     <a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a>
                   </li>
                   % endif
-                  % if has_studio_advanced_settings_access(request.user):
+                  % if has_studio_advanced_settings_access(request.user) and not advanced_settings_mfe_enabled:
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
+                  </li>
+                  % endif
+                  % if has_studio_advanced_settings_access(request.user) and advanced_settings_mfe_enabled:
+                  <li class="nav-item nav-course-settings-advanced">
+                    <a href="${get_advanced_settings_url}">${_("Advanced Settings")}</a>
                   </li>
                   % endif
                   % if certificates_url:


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This changes dynamically changes the page links in Studio's header depending on the corresponding waffle flag. When the flag is enabled, the user will be navigated to the `course-authoring` mfe. If the flag is disabled, the user will remain in studio. It is important to not that this change only impacts the header. Any other links on Studio pages are not controlled by the waffle flag. That work is to be done as the mfe pages are built. This change impacts Developers and Authors.

## Supporting information

JIRA Ticket: [TNL-10723](https://2u-internal.atlassian.net/browse/TNL-10723)

- `contentstore.new_studio_mfe.use_new_advanced_settings_page`
- `contentstore.new_studio_mfe.use_new_schedule_details_page`
- `contentstore.new_studio_mfe.use_new_grading_page`
- `contentstore.new_studio_mfe.use_new_updates_page`
- `contentstore.new_studio_mfe.use_new_import_page`
- `contentstore.use_new_export_page`
- `contentstore.new_studio_mfe.use_new_video_uploads_page`
- `contentstore.new_studio_mfe.use_new_files_uploads_page`
- `contentstore.new_studio_mfe.use_new_course_outline_page`

## Testing instructions

1.  Using Django admin, enable one of the flags listed above.
2. Reload Studio, use the nav bar and click on the corresponding page.
3. Should be navigated to a page in the `course-authoring` MFE.
4. Navigate back to studio.
5. In the nav bar, click on another page that is NOT enabled by the flags listed above.
6. Should navigate to the page and remain in Studio.

## Deadline

None