### PR TITLE
Ignore uwsgi.ini file (created by Tutor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ cms/envs/private.py
 .redcar/
 codekit-config.json
 .pycharm_helpers/
+.vscode
 /_mac/*
 /IntelliLang.xml
 /conda_packages.xml
@@ -124,7 +125,10 @@ logs
 chromedriver.log
 ghostdriver.log
 
-### Celery artifacts ###
+### Deployment artifacts
+uwsgi.ini
+
+### Celery artifacts
 celerybeat-schedule
 
 ### Unknown artifacts
@@ -140,9 +144,6 @@ autodeploy.properties
 .ws_migrations_complete
 dist
 *.bak
-
-# Visual Studio Code
-.vscode
 
 # Locally generated PII reports
 pii_report


### PR DESCRIPTION
## Description

When running Tutor in dev mode (or other modes) with a bind-mounted `edx-platform`, I keep seeing a `uwsgi.ini` file show up as a modified file in the `git status`. I believe it is [created by Tutor](https://github.com/overhangio/tutor/blob/de0093aa8de0c65a715f5e9d8245105a97d2cad3/tutor/templates/local/docker-compose.yml#L114) and gets re-created if deleted, so seems like it should be ignored.

## Supporting information

I couldn't find prior discussions of this - is it just me who notices it?

## Testing instructions

Run a Tutor devstack with bind-mounted edx-platform, make sure git shows no changes to edx-platform.

## Deadline

None
