### PR TITLE
feat: Modified course_home_url for externally hosted courses

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5300,8 +5300,13 @@ URLS_2U_LOBS = {
     'boot_camps': 'https://www.edx.org/boot-camps',
 }
 
-############ Settings for externally hosted executive education courses ############
-EXEC_ED_LANDING_PAGE = "https://www.getsmarter.com/account"
+######### Settings for overriding the course metadata for externally hosted courses #########
+COURSE_HOME_URL_OVERRIDES_FOR_EXTERNAL_COURSES = [{
+    "course_type": "course-type-override",
+    "product_source": "external",
+    "course_home_url": "https://external.com",
+    "uses_additional_metadata": True,
+}]
 
 ############## PLOTLY ##############
 


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR conditionally modifies the course_home_url for externally hosted courses based on the COURSE_HOME_URL_OVERRIDES_FOR_EXTERNAL_COURSES django setting.

The URL will flow downstream to both the B2B and B2C learner dashboards. B2B enterprise-course-enrollments API gets the course_home_url via another B2C helper function get_course_run_url in edx-platform ([source](https://github.com/openedx/edx-platform/blob/ba8a3c130db5936bf0851b8db261b6c7499968e0/lms/djangoapps/course_api/api.py#L281-L293)) whereas the B2C learner home init API calls course_home_url directly ([source](https://github.com/openedx/edx-platform/blob/ba8a3c130db5936bf0851b8db261b6c7499968e0/lms/djangoapps/learner_home/serializers.py#L114-L115)).