### PR TITLE
[3/6] build: stop suffixing XModule SCSS with hashes 

### DIFF
--- a/xmodule/static_content.py
+++ b/xmodule/static_content.py
@@ -150,9 +150,8 @@ def _write_styles(selector, output_root, classes, css_attribute, suffix):
         ))
         module_styles_lines.extend(f'  @import "{name}";' for name in fragment_names)
         module_styles_lines.append('}')
-        file_hash = hashlib.md5("".join(fragment_names).encode('ascii')).hexdigest()
 
-        contents[f"{class_.__name__}{suffix}.{file_hash}.scss"] = '\n'.join(module_styles_lines)
+        contents[f"{class_.__name__}{suffix}.scss"] = '\n'.join(module_styles_lines)
 
     _write_files(output_root, contents)
 

--- a/xmodule/util/xmodule_django.py
+++ b/xmodule/util/xmodule_django.py
@@ -61,9 +61,9 @@ class XModuleWebpackLoader(WebpackLoader):
                             'path': '/openedx/edx-platform/common/static/bundles/AnnotatableBlockPreview.js.map'
                         },
                         {
-                            'name': 'AnnotatableBlockPreview.85745121.css',
-                            'path': 'common/static/css/xmodule/AnnotatableBlockPreview.85745121.css',
-                            'publicPath': '/static/css/xmodule/AnnotatableBlockPreview.85745121.css'
+                            'name': 'AnnotatableBlockPreview.css',
+                            'path': 'common/static/css/xmodule/AnnotatableBlockPreview.css',
+                            'publicPath': '/static/css/xmodule/AnnotatableBlockPreview.css'
                         }
                     ],
                     ...


### PR DESCRIPTION
## Supporting information

This is a part of a series of PRs:
* https://github.com/openedx/edx-platform/issues/32292

The previous PR is:
* https://github.com/openedx/edx-platform/pull/32287

The next PR is:
* https://github.com/openedx/edx-platform/pull/32289

## Description

Similar to https://github.com/openedx/edx-platform/pull/32287,
this change removes another unnecessary step from the
`xmodule_assets` script. The script, which generates XModule
SCSS "entrypoint" files (synthesizing one or more "source" SCSS
resources), was appending MD5 hashes to each SCSS entrypoint filename:

    common/static/xmodule/descriptors/scss:
       AboutBlockStudio.768623f4d8d73dfb637fc94583adb990.scss
       AnnotatableBlockStudio.be69909d83985d31e206fad272906958.scss
       ConditionalBlockStudio.d41d8cd98f00b204e9800998ecf8427e.scss
       CourseInfoBlockStudio.768623f4d8d73dfb637fc94583adb990.scss
       CustomTagBlockStudio.be69909d83985d31e206fad272906958.scss
       HtmlBlockStudio.768623f4d8d73dfb637fc94583adb990.scss
       LibraryContentBlockStudio.d41d8cd98f00b204e9800998ecf8427e.scss
       LTIBlockStudio.d41d8cd98f00b204e9800998ecf8427e.scss
       PollBlockStudio.d41d8cd98f00b204e9800998ecf8427e.scss
       ProblemBlockStudio.5893b30426f88e14712556c6c4342f23.scss
       SequenceBlockStudio.d41d8cd98f00b204e9800998ecf8427e.scss
       SplitTestBlockStudio.d41d8cd98f00b204e9800998ecf8427e.scss
       StaticTabBlockStudio.768623f4d8d73dfb637fc94583adb990.scss
       VideoBlockStudio.e4a6920a875dfb91eb65ee7e6dad7e2e.scss
       WordCloudBlockStudio.d41d8cd98f00b204e9800998ecf8427e.scss
    common/static/xmodule/modules/scss:
       AboutBlockPreview.05a6cbd5c10100a245fa2cbf151b9770.scss
       AnnotatableBlockPreview.7e95b106aa0a61824f4290da1374960d.scss
       ConditionalBlockPreview.d41d8cd98f00b204e9800998ecf8427e.scss
       CourseInfoBlockPreview.05a6cbd5c10100a245fa2cbf151b9770.scss
       CustomTagBlockPreview.d41d8cd98f00b204e9800998ecf8427e.scss
       HtmlBlockPreview.05a6cbd5c10100a245fa2cbf151b9770.scss
       LibraryContentBlockPreview.d41d8cd98f00b204e9800998ecf8427e.scss
       LTIBlockPreview.a763928b2c415251720f8634b8daee59.scss
       PollBlockPreview.39730e54c1eebbafd18a82fbb09c1e37.scss
       ProblemBlockPreview.70b905ac161108a0a03c639232450aaa.scss
       SequenceBlockPreview.e2336fa64ba495fa7c0f4f838d20ad8c.scss
       SplitTestBlockPreview.d41d8cd98f00b204e9800998ecf8427e.scss
       StaticTabBlockPreview.05a6cbd5c10100a245fa2cbf151b9770.scss
       VideoBlockPreview.b2de5e1c4da8cba16ce1c4bdeab50f9e.scss
       WordCloudBlockPreview.7b899a56a70d29c58cf14b7e1888a0ec.scss

It's unclear why these MD5 hashes needed to be appended.
A comment in xmodule/static_content.py hints that it might have
something to do with de-duplication, but that doesn't make any sense,
because each XModule has exactly two SCSS entrypoint files (one for
studio_view and one for other student/author_views) and none of those
entrypoint files can possibly be shared between XModules.

Soon, as part of deleting the `xmodule_assets` script,
we would like to just check these SCSS files into version control
rather than generating them. In order to do that, we will need to
drop the hashes. This PR does that.
The new output looks like this:

    common/static/xmodule/descriptors:
       AboutBlockStudio.scss
       AnnotatableBlockStudio.scss
       ConditionalBlockStudio.scss
       CourseInfoBlockStudio.scss
       CustomTagBlockStudio.scss
       HtmlBlockStudio.scss
       LibraryContentBlockStudio.scss
       LTIBlockStudio.scss
       PollBlockStudio.scss
       ProblemBlockStudio.scss
       SequenceBlockStudio.scss
       SplitTestBlockStudio.scss
       StaticTabBlockStudio.scss
       VideoBlockStudio.scss
       WordCloudBlockStudio.scss
    common/static/xmodule/modules:
       AboutBlockPreview.scss
       AnnotatableBlockPreview.scss
       ConditionalBlockPreview.scss
       CourseInfoBlockPreview.scss
       CustomTagBlockPreview.scss
       HtmlBlockPreview.scss
       LibraryContentBlockPreview.scss
       LTIBlockPreview.scss
       PollBlockPreview.scss
       ProblemBlockPreview.scss
       SequenceBlockPreview.scss
       SplitTestBlockPreview.scss
       StaticTabBlockPreview.scss
       VideoBlockPreview.scss
       WordCloudBlockPreview.scss

## Testing Instructions

* Build the Tutor openedx image with this branch
* Browse the demo course in the Studio outline editor
* Browse the demo course in Learning MFE

## Deadline

Medium-high urgency, as this is in the critical path to a long line of DevX improvement PRs.
