### PR TITLE
perf: pull user's profile information for serialization w/ ret. arch

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -993,7 +993,7 @@ class AccountRetirementStatusView(ViewSet):
             state_obj = RetirementState.objects.get(state_name=state)
 
             retirements = UserRetirementStatus.objects.select_related(
-                'user', 'current_state', 'last_state'
+                'user', 'current_state', 'last_state', 'user__profile'
             ).filter(
                 current_state=state_obj, created__lt=end_date, created__gte=start_date
             ).order_by(


### PR DESCRIPTION
JIRA:CR-5812

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

A user retirement archival job, which cleans up the table in which distantly retired users are stored after packaging them up for longer-term cold storage, is failing due to poor performance of this endpoint. We have a glut of users who were deleted recently, which caused the archive job to fail when this large bulk fell into the date range over which it's attempting to archive. The code changes in this PR would improve performance by preventing repeated queries to the user_profile table, at the cost of increasing the number of columns returned by an already large query:
<img width="1495" alt="Screenshot 2023-05-24 at 10 41 47 AM" src="https://github.com/openedx/edx-platform/assets/6405097/48bc2692-2a0a-460b-8f88-a6535e20adf2">

I suspect we'll still need to add a new archive endpoint with pagination to address this fully, but if this gets us through then it'd be nice, so worth trying.