### PR TITLE
fix: Fix split test event logging.

### DIFF
--- a/xmodule/split_test_block.py
+++ b/xmodule/split_test_block.py
@@ -409,7 +409,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
             )
             raise
         else:
-            self.runtime.publish('xblock.split_test.child_render', {'child_id': child_id})
+            self.runtime.publish(self, 'xblock.split_test.child_render', {'child_id': child_id})
             return Response()
 
     def get_icon_class(self):


### PR DESCRIPTION
In a refactor, this call to runtime.publish didn't actually match the API properly, causing runtime errors on LMS.
