### PR TITLE
[Palm backports] build: Use mongodbproxy from pypi

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -542,6 +542,7 @@ edx-toggles==5.0.0
     #   edx-completion
     #   edx-event-bus-kafka
     #   edx-name-affirmation
+    #   edx-search
     #   edxval
     #   learner-pathway-progress
     #   ora2
@@ -713,8 +714,6 @@ maxminddb==2.2.0
     # via geoip2
 mock==5.0.1
     # via -r requirements/edx/paver.txt
-mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
-    # via -r requirements/edx/github.in
 mongoengine==0.27.0
     # via -r requirements/edx/base.in
 monotonic==1.6
@@ -875,7 +874,6 @@ pymongo==3.13.0
     #   -r requirements/edx/paver.txt
     #   edx-opaque-keys
     #   event-tracking
-    #   mongodbproxy
     #   mongoengine
 pynacl==1.5.0
     # via edx-django-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -576,7 +576,7 @@ edx-django-release-util==1.2.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.0
     # via -r requirements/edx/testing.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-config-models
@@ -677,6 +677,7 @@ edx-toggles==5.0.0
     #   edx-completion
     #   edx-event-bus-kafka
     #   edx-name-affirmation
+    #   edx-search
     #   edxval
     #   learner-pathway-progress
     #   ora2
@@ -962,8 +963,6 @@ mistune==2.0.5
     # via sphinx-mdinclude
 mock==5.0.1
     # via -r requirements/edx/testing.txt
-mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
-    # via -r requirements/edx/testing.txt
 mongoengine==0.27.0
     # via -r requirements/edx/testing.txt
 monotonic==1.6
@@ -1216,7 +1215,6 @@ pymongo==3.13.0
     #   -r requirements/edx/testing.txt
     #   edx-opaque-keys
     #   event-tracking
-    #   mongodbproxy
     #   mongoengine
 pynacl==1.5.0
     # via

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -86,11 +86,3 @@
 ##############################################################################
 
 # ... add dependencies here
-
-
-##############################################################################
-# Legacy URL dependencies. To be removed. Don't add new URLs here!
-##############################################################################
-
-# https://github.com/openedx/MongoDBProxy/issues/18
-git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2

--- a/requirements/edx/pip.txt
+++ b/requirements/edx/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/edx/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1.2
     # via -r requirements/edx/pip.in
-setuptools==67.6.0
+setuptools==67.8.0
     # via -r requirements/edx/pip.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -64,7 +64,6 @@ attrs==22.2.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.11.0
     # via
@@ -555,7 +554,7 @@ edx-django-release-util==1.2.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.0
     # via -r requirements/edx/base.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -655,6 +654,7 @@ edx-toggles==5.0.0
     #   edx-completion
     #   edx-event-bus-kafka
     #   edx-name-affirmation
+    #   edx-search
     #   edxval
     #   learner-pathway-progress
     #   ora2
@@ -914,8 +914,6 @@ mccabe==0.7.0
     # via pylint
 mock==5.0.1
     # via -r requirements/edx/base.txt
-mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
-    # via -r requirements/edx/base.txt
 mongoengine==0.27.0
     # via -r requirements/edx/base.txt
 monotonic==1.6
@@ -1146,7 +1144,6 @@ pymongo==3.13.0
     #   -r requirements/edx/base.txt
     #   edx-opaque-keys
     #   event-tracking
-    #   mongodbproxy
     #   mongoengine
 pynacl==1.5.0
     # via


### PR DESCRIPTION
## Description, Supporting info

Backport of https://github.com/openedx/edx-platform/pull/32259

Unlike the original PR, this backport PR only updates the requirements pins necessary in order to install MongoDBProxy from PyPI.

Resolves https://github.com/openedx/MongoDBProxy/issues/18

## Testing instructions

TBD

## Deadline

ASAP since we are getting close to the Palm release

## Other information

N/A