### PR TITLE
feat: allow course entitlements REST API to be filtered on course_uuid

### DIFF
--- a/common/djangoapps/entitlements/rest_api/v1/filters.py
+++ b/common/djangoapps/entitlements/rest_api/v1/filters.py
@@ -41,6 +41,7 @@ class CourseEntitlementFilter(filters.FilterSet):
     uuid = UUIDListFilter()
     user = filters.CharFilter(field_name='user__username')
     course_uuid = UUIDListFilter(field_name='course_uuid')
+    expired_at__isnull = filters.BooleanFilter(field_name='expired_at', lookup_expr='isnull')
 
     class Meta:
         model = CourseEntitlement

--- a/common/djangoapps/entitlements/rest_api/v1/filters.py
+++ b/common/djangoapps/entitlements/rest_api/v1/filters.py
@@ -40,7 +40,8 @@ class CourseEntitlementFilter(filters.FilterSet):
 
     uuid = UUIDListFilter()
     user = filters.CharFilter(field_name='user__username')
+    course_uuid = UUIDListFilter(field_name='course_uuid')
 
     class Meta:
         model = CourseEntitlement
-        fields = ('uuid', 'user')
+        fields = ('uuid', 'user', 'course_uuid')

--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
@@ -672,6 +672,34 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         results = response.data
         assert results.get('expired_at')
 
+    def test_entitlements_filter_on_course_uuid(self):
+        """
+        Verify that courses filtered properly on list of course_uuids.
+        """
+        entitlements = CourseEntitlementFactory.create_batch(5, user=self.user)
+        course_uuids_to_filter_on = {
+            str(entitlement.course_uuid)
+            for entitlement in entitlements[0:3]
+        }
+        # Create a 2nd entitlement for one of the ones to filter on
+        CourseEntitlementFactory.create(user=self.user, course_uuid=str(entitlements[0].course_uuid))
+
+        url = reverse('entitlements_api:v1:entitlements-list')
+        url += f'?user={self.user.username}'
+        url += f'&course_uuid={",".join(course_uuids_to_filter_on)}'
+
+        response = self.client.get(
+            url,
+            content_type='application/json',
+        )
+        assert response.status_code == 200
+
+        results = response.data
+        assert results['count'] == 4
+        actual_course_uuids = {entitlement['course_uuid'] for entitlement in results['results']}
+        assert actual_course_uuids == course_uuids_to_filter_on
+        assert len(actual_course_uuids) == 3
+
     def test_delete_and_revoke_entitlement(self):
         course_entitlement = CourseEntitlementFactory.create()
         url = reverse(self.ENTITLEMENTS_DETAILS_PATH, args=[str(course_entitlement.uuid)])

--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
@@ -672,17 +672,21 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         results = response.data
         assert results.get('expired_at')
 
-    def test_entitlements_filter_on_course_uuid(self):
+    def test_entitlements_filter_on_course_uuid_and_expired_at(self):
         """
         Verify that courses filtered properly on list of course_uuids.
         """
-        entitlements = CourseEntitlementFactory.create_batch(5, user=self.user)
+        entitlements = CourseEntitlementFactory.create_batch(5, user=self.user, expired_at=datetime.now())
         course_uuids_to_filter_on = {
             str(entitlement.course_uuid)
             for entitlement in entitlements[0:3]
         }
         # Create a 2nd entitlement for one of the ones to filter on
-        CourseEntitlementFactory.create(user=self.user, course_uuid=str(entitlements[0].course_uuid))
+        active_entitlement = CourseEntitlementFactory.create(
+            user=self.user,
+            course_uuid=str(entitlements[0].course_uuid),
+            expired_at=None,
+        )
 
         url = reverse('entitlements_api:v1:entitlements-list')
         url += f'?user={self.user.username}'
@@ -699,6 +703,17 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         actual_course_uuids = {entitlement['course_uuid'] for entitlement in results['results']}
         assert actual_course_uuids == course_uuids_to_filter_on
         assert len(actual_course_uuids) == 3
+
+        # Now lets confirm we filter out expired entitlements
+        url += '&expired_at__isnull=True'
+        response = self.client.get(
+            url,
+            content_type='application/json',
+        )
+        assert response.status_code == 200
+        results = response.data
+        assert results['count'] == 1
+        assert results['results'][0]['uuid'] == str(active_entitlement.uuid)
 
     def test_delete_and_revoke_entitlement(self):
         course_entitlement = CourseEntitlementFactory.create()


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
