### PR TITLE
fix: missing advance_settings_access template variable [BACKPORT]

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -43,7 +43,12 @@ from common.djangoapps.course_action_state.managers import CourseActionStateItem
 from common.djangoapps.course_action_state.models import CourseRerunState, CourseRerunUIStateManager
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.edxmako.shortcuts import render_to_response
-from common.djangoapps.student.auth import has_course_author_access, has_studio_read_access, has_studio_write_access
+from common.djangoapps.student.auth import (
+    has_course_author_access,
+    has_studio_read_access,
+    has_studio_write_access,
+    has_studio_advanced_settings_access
+)
 from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseStaffRole,
@@ -145,17 +150,6 @@ class AccessListFallback(Exception):
     available to a user, rather than using a shorter method (i.e. fetching by group)
     """
     pass  # lint-amnesty, pylint: disable=unnecessary-pass
-
-
-def has_advanced_settings_access(user):
-    """
-    If DISABLE_ADVANCED_SETTINGS feature is enabled, only global staff can access "Advanced Settings".
-    """
-    return (
-        not settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
-        or user.is_staff
-        or user.is_superuser
-    )
 
 
 def get_course_and_check_access(course_key, user, depth=0):
@@ -763,7 +757,6 @@ def course_index(request, course_key):
             'frontend_app_publisher_url': frontend_app_publisher_url,
             'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_block.id),
             'advance_settings_url': reverse_course_url('advanced_settings_handler', course_block.id),
-            'advance_settings_access': has_advanced_settings_access(request.user),
             'proctoring_errors': proctoring_errors,
         })
 
@@ -1432,7 +1425,7 @@ def advanced_settings_handler(request, course_key_string):
         json: update the Course's settings. The payload is a json rep of the
             metadata dicts.
     """
-    if not has_advanced_settings_access(request.user):
+    if not has_studio_advanced_settings_access(request.user):
         raise PermissionDenied()
 
     course_key = CourseKey.from_string(course_key_string)

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -7,6 +7,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
   from django.utils.translation import gettext as _
+  from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import utils
   from lms.djangoapps.certificates.api import can_show_certificate_available_date_field
   from openedx.core.djangolib.js_utils import (
@@ -721,7 +722,9 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="nav-item"><a href="${grading_config_url}">${_("Grading")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
+            % if has_studio_advanced_settings_access(request.user):
             <li class="nav-item"><a href="${advanced_config_url}">${_("Advanced Settings")}</a></li>
+            % endif
             % if mfe_proctored_exam_settings_url:
               <li class="nav-item"><a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a></li>
             % endif

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -11,6 +11,7 @@
   import json
   from cms.djangoapps.contentstore import utils
   from django.utils.translation import gettext as _
+  from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
   from openedx.core.djangolib.js_utils import (
       dump_js_escaped_json, js_escaped_string
@@ -165,7 +166,9 @@
             <li class="nav-item"><a href="${detailed_settings_url}">${_("Details & Schedule")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
+            % if has_studio_advanced_settings_access(request.user):
             <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
+            % endif
             % if mfe_proctored_exam_settings_url:
               <li class="nav-item"><a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a></li>
             % endif

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -7,6 +7,7 @@
   from django.urls import reverse
   from django.utils.translation import gettext as _
   from urllib.parse import quote_plus
+  from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
   from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
@@ -120,7 +121,7 @@
                     <a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a>
                   </li>
                   % endif
-                  % if advance_settings_access:
+                  % if has_studio_advanced_settings_access(request.user):
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
                   </li>

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -125,9 +125,23 @@ def has_course_author_access(user, course_key):
     return has_studio_write_access(user, course_key)
 
 
+def has_studio_advanced_settings_access(user):
+    """
+    If DISABLE_ADVANCED_SETTINGS feature is enabled, only Django Superuser
+    or Django Staff can access "Advanced Settings".
+
+    By default, this feature is disabled.
+    """
+    return (
+        not settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
+        or user.is_staff
+        or user.is_superuser
+    )
+
+
 def has_studio_read_access(user, course_key):
     """
-    Return True iff user is allowed to view this course/library in studio.
+    Return True if user is allowed to view this course/library in studio.
     Will also return True if user has write access in studio (has_course_author_access)
 
     There is currently no such thing as read-only course access in studio, but


### PR DESCRIPTION
Resolves https://github.com/openedx/wg-build-test-release/issues/272.

Backport of https://github.com/openedx/edx-platform/pull/32097

The cherry-pick was clean.