### PR TITLE
fix: Modify nextPaymentDate in program details subscriptions

### DIFF
--- a/lms/static/js/learner_dashboard/models/program_subscription_model.js
+++ b/lms/static/js/learner_dashboard/models/program_subscription_model.js
@@ -46,8 +46,8 @@ class ProgramSubscriptionModel extends Backbone.Model {
 
         const remainingDays = trialMoment.diff(moment.utc(), 'days');
 
-        const [nextPaymentDate] = ProgramSubscriptionModel.formatDate(
-            data.next_payment_date,
+        const [currentPeriodEnd] = ProgramSubscriptionModel.formatDate(
+            data.current_period_end,
             userPreferences
         );
         const [trialEndDate, trialEndTime] = ProgramSubscriptionModel.formatDate(
@@ -60,7 +60,7 @@ class ProgramSubscriptionModel extends Backbone.Model {
         super(
             {
                 hasActiveTrial,
-                nextPaymentDate,
+                currentPeriodEnd,
                 remainingDays,
                 subscriptionPrice,
                 subscriptionState,

--- a/lms/static/js/learner_dashboard/spec/program_alert_list_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_alert_list_view_spec.js
@@ -9,7 +9,7 @@ describe('Program Alert List View', () => {
         trialEndingAlerts: [{
             title: 'Test Program',
             hasActiveTrial: true,
-            nextPaymentDate: 'May 8, 2023',
+            currentPeriodEnd: 'May 8, 2023',
             remainingDays: 2,
             subscriptionPrice: '$100/month USD',
             subscriptionState: 'active',

--- a/lms/static/js/learner_dashboard/spec/program_details_header_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_details_header_spec.js
@@ -48,7 +48,7 @@ describe('Program Details Header View', () => {
         subscriptionData: [
             {
                 trial_end: '1970-01-01T03:25:45Z',
-                next_payment_date: '1970-06-03T07:12:04Z',
+                current_period_end: '1970-06-03T07:12:04Z',
                 price: '100.00',
                 currency: 'USD',
                 subscription_state: 'active',

--- a/lms/static/js/learner_dashboard/spec/program_details_sidebar_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_details_sidebar_view_spec.js
@@ -110,7 +110,7 @@ describe('Program Progress View', () => {
         isSubscriptionEligible = false;
         subscriptionData = {
             trial_end: '1970-01-01T03:25:45Z',
-            next_payment_date: '1970-06-03T07:12:04Z',
+            current_period_end: '1970-06-03T07:12:04Z',
             price: '100.00',
             currency: 'USD',
             subscription_state: 'pre',

--- a/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
@@ -471,7 +471,7 @@ describe('Program Details View', () => {
         subscriptionData: [
             {
                 trial_end: '1970-01-01T03:25:45Z',
-                next_payment_date: '1970-06-03T07:12:04Z',
+                current_period_end: '1970-06-03T07:12:04Z',
                 price: '100.00',
                 currency: 'USD',
                 subscription_state: 'pre',

--- a/lms/static/js/learner_dashboard/spec/program_list_header_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_list_header_view_spec.js
@@ -29,7 +29,7 @@ describe('Program List Header View', () => {
                 id: 'eeb25640-9741-4c11-963c-8a27337f217c',
                 resource_id: 'b90d70d5-f981-4508-bdeb-5b792d930c03',
                 trial_end: '2022-04-20T05:59:42Z',
-                next_payment_date: '2023-05-08T05:59:42Z',
+                current_period_end: '2023-05-08T05:59:42Z',
                 subscription_state: 'active',
             },
         ],

--- a/lms/templates/learner_dashboard/program_details_tab_view.underscore
+++ b/lms/templates/learner_dashboard/program_details_tab_view.underscore
@@ -87,14 +87,14 @@
                                 hasActiveTrial
                                 ? gettext('Active trial ends {trialEndDate} at {trialEndTime}')
                                 : subscriptionState === 'active'
-                                ? gettext('Your next billing date is {nextPaymentDate}')
+                                ? gettext('Your next billing date is {currentPeriodEnd}')
                                 : subscriptionState === 'inactive'
                                 ? gettext('Unlock verified access to all courses for {subscriptionPrice}. Cancel anytime.')
                                 : gettext('{subscriptionPrice} subscription after trial ends. Cancel anytime.')
                             ),
                             {
                                 subscriptionPrice,
-                                nextPaymentDate,
+                                currentPeriodEnd,
                                 trialEndDate,
                                 trialEndTime,
                             }

--- a/lms/templates/learner_dashboard/program_details_view.underscore
+++ b/lms/templates/learner_dashboard/program_details_view.underscore
@@ -62,14 +62,14 @@
                             hasActiveTrial
                             ? gettext('Active trial ends {trialEndDate} at {trialEndTime}')
                             : subscriptionState === 'active'
-                            ? gettext('Your next billing date is {nextPaymentDate}')
+                            ? gettext('Your next billing date is {currentPeriodEnd}')
                             : subscriptionState === 'inactive'
                             ? gettext('Unlock verified access to all courses for {subscriptionPrice}. Cancel anytime.')
                             : gettext('{subscriptionPrice} subscription after trial ends. Cancel anytime.')
                         ),
                         {
                             subscriptionPrice,
-                            nextPaymentDate,
+                            currentPeriodEnd,
                             trialEndDate,
                             trialEndTime,
                         }

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -1747,12 +1747,12 @@ class TestGetProgramsSubscriptionData(TestCase):
             {'id': uuid.uuid4(), 'resource_id': uuid.uuid4(),
              'resource_type': 'program', 'resource_data': None, 'trial_end': '1970-01-01T00:02:03Z',
              'price': '100.00', 'currency': 'USD', 'sub_type': 'stripe', 'identifier': 'dummy_1',
-             'next_payment_date': '1970-01-01T00:02:03Z', 'status': 'active',
+             'current_period_end': '1970-01-01T00:02:03Z', 'status': 'active',
              'customer': 1, 'subscription_state': 'active'},
             {'id': uuid.uuid4(), 'resource_id': uuid.uuid4(),
              'resource_type': 'program', 'resource_data': None, 'trial_end': '1970-01-01T03:25:12Z',
              'price': '1000.00', 'currency': 'USD', 'sub_type': 'stripe', 'identifier': 'dummy_2',
-             'next_payment_date': '1970-05-23T12:05:21Z', 'status': 'subscription_initiated',
+             'current_period_end': '1970-05-23T12:05:21Z', 'status': 'subscription_initiated',
              'customer': 1, 'subscription_state': 'notStarted'}
         ]
 


### PR DESCRIPTION
[PON-247](https://2u-internal.atlassian.net/browse/PON-247).

We're modifying the field `next_payment_date` in https://github.com/edx/subscriptions/pull/95 to `current_period_end` to match the name Stripe uses for the end of the billing cycle. This needs to be changed in this FE as well.

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->