### PR TITLE
fix: remove drag and drop from V1 llibs

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -306,8 +306,8 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
     # by the components in the order listed in COMPONENT_TYPES.
     component_types = COMPONENT_TYPES[:]
 
-    # Libraries do not support discussions and openassessment and other libraries
-    component_not_supported_by_library = ['discussion', 'library', 'openassessment']
+    # Libraries do not support discussions, drag-and-drop, and openassessment and other libraries
+    component_not_supported_by_library = ['discussion', 'library', 'openassessment', 'drag-and-drop-v2']
     if library:
         component_types = [component for component in component_types
                            if component not in set(component_not_supported_by_library)]


### PR DESCRIPTION
## Description

Drag and drop v2 should not be offered in V1 Library Authoring. This changes removes that from the "add new component" tab. This will be backported to palm.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-10749

## Testing instructions

Create a Library. Don't see an option under "add new component" for drag-and-drop.
