### PR TITLE
feat: Pin python3-saml again for duplicate attributes issue

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -101,3 +101,11 @@ urllib3<2.0.0
 # Sphinx==5.3.0 requires docutils<0.20
 # Issue to unpin Sphinx to resolve this constraint: https://github.com/openedx/edx-lint/issues/338
 docutils<0.20
+
+# When we unpinned python3-saml and allowed it to upgrade from 1.9.0
+# to 1.15.0 it fixed a devstack issue around ports being dropped, but
+# introduced an issue around duplicate attributes (for some
+# IdPs). It's not clear which version introduces the second problem.
+#
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/32327
+python3-saml<1.10.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -173,6 +173,7 @@ defusedxml==0.7.1
     #   djangorestframework-xml
     #   ora2
     #   python3-openid
+    #   python3-saml
     #   social-auth-core
 deprecated==1.2.13
     # via jwcrypto
@@ -689,7 +690,6 @@ lxml==4.9.2
     #   olxcleaner
     #   openedx-calc
     #   ora2
-    #   python3-saml
     #   xblock
     #   xmlsec
 mailsnake==1.6.4
@@ -932,8 +932,10 @@ python3-openid==3.2.0 ; python_version >= "3"
     # via
     #   -r requirements/edx/base.in
     #   social-auth-core
-python3-saml==1.15.0
-    # via -r requirements/edx/base.in
+python3-saml==1.9.0
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.in
 pytz==2022.7.1
     # via
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -257,6 +257,7 @@ defusedxml==0.7.1
     #   djangorestframework-xml
     #   ora2
     #   python3-openid
+    #   python3-saml
     #   social-auth-core
 deprecated==1.2.13
     # via
@@ -926,7 +927,6 @@ lxml==4.9.2
     #   openedx-calc
     #   ora2
     #   pyquery
-    #   python3-saml
     #   xblock
     #   xmlsec
 mailsnake==1.6.4
@@ -1315,8 +1315,10 @@ python3-openid==3.2.0 ; python_version >= "3"
     # via
     #   -r requirements/edx/testing.txt
     #   social-auth-core
-python3-saml==1.15.0
-    # via -r requirements/edx/testing.txt
+python3-saml==1.9.0
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/testing.txt
 pytz==2022.7.1
     # via
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -244,6 +244,7 @@ defusedxml==0.7.1
     #   djangorestframework-xml
     #   ora2
     #   python3-openid
+    #   python3-saml
     #   social-auth-core
 deprecated==1.2.13
     # via
@@ -880,7 +881,6 @@ lxml==4.9.2
     #   openedx-calc
     #   ora2
     #   pyquery
-    #   python3-saml
     #   xblock
     #   xmlsec
 mailsnake==1.6.4
@@ -1240,8 +1240,10 @@ python3-openid==3.2.0 ; python_version >= "3"
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-python3-saml==1.15.0
-    # via -r requirements/edx/base.txt
+python3-saml==1.9.0
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 pytz==2022.7.1
     # via
     #   -c requirements/edx/../constraints.txt


### PR DESCRIPTION
We're seeing an issue with repeated attributes causing auth failure for some IdPs, and need to take some time to investigate. See unpinning issue https://github.com/openedx/edx-platform/issues/32327 for details.

This is expected to reintroduce some bugs in testing SAML in devstack.

This has the effect of reverting the following PRs:
- Unpinned: https://github.com/openedx/edx-platform/pull/32167 (partial)
- Upgraded: https://github.com/openedx/edx-platform/pull/32168

However, we're keeping the safe_lxml adjustments from the first PR, so it should be fine on that front to re-upgrade whenever we're ready.