### PR TITLE
fix: embed video css

### DIFF
--- a/lms/templates/public_video_share_embed.html
+++ b/lms/templates/public_video_share_embed.html
@@ -62,6 +62,7 @@ from openedx.core.djangolib.markup import HTML
   <%static:css group='style-course'/>
     
   <%include file="widgets/segment-io.html" />
+  ${HTML(fragment.head_html())}
 
   <meta name="path_prefix" content="${EDX_ROOT_URL}">
   <% google_site_verification_id = configuration_helpers.get_value('GOOGLE_SITE_VERIFICATION_ID', settings.GOOGLE_SITE_VERIFICATION_ID) %>


### PR DESCRIPTION
## Description

- add `fragment.head_html()` so the html generated for emebed video would include `VideoPreview.css`
- `video_public` inherit it from `lms/templates/courseware/courseware-chromeless.html`

Before:
<img width="958" alt="Screenshot 2023-05-31 at 1 29 47 PM" src="https://github.com/openedx/edx-platform/assets/83240113/2df90c73-9fc3-4b14-b703-e75f5405efa7">

After:
<img width="961" alt="Screenshot 2023-05-31 at 1 12 08 PM" src="https://github.com/openedx/edx-platform/assets/83240113/eedf6e5b-ff2b-46bb-9c2e-b725613417eb">


Ticket: https://2u-internal.atlassian.net/browse/AU-124