### PR TITLE
fix: conditional rendering of course team link

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -179,7 +179,7 @@
                     <a href="${course_team_url}">${_("Course Team")}</a>
                   </li>
                   % endif
-                  % if not course_team_mfe_enabled:
+                  % if course_team_mfe_enabled:
                   <li class="nav-item nav-course-settings-team">
                     <a href="${get_course_team_url(course_key)}">${_("Course Team")}</a>
                   </li>


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR fixes the bug that generated a duplicate dropdown item for "Course Team". There was a extraneous `not` conditional on the second option for Course Team. This resulted in the duplicate options and the second one landing on broken page. Now one dropdown item for "Course Team" appears in the Studio Header. This change impacts Authors.

## Supporting information

JIRA Ticket: [TNL-10729](https://2u-internal.atlassian.net/browse/TNL-10729)

## Testing instructions

1. Open a course
2. Click on the settings dropdown in the header
3. Only one "Course Team" item should be present

## Deadline

None
