### PR TITLE
[FC-0009] Update text of new clipboard menu, hide it in libraries

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -305,8 +305,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             selected_groups_label = _('Access restricted to: {list_of_groups}').format(list_of_groups=selected_groups_label)  # lint-amnesty, pylint: disable=line-too-long
         course = modulestore().get_course(xblock.location.course_key)
         can_edit = context.get('can_edit', True)
+        # Is this a course or a library?
+        is_course = xblock.scope_ids.usage_id.context_key.is_course
         # Copy-paste is a new feature; while we are beta-testing it, only beta users with the Waffle flag enabled see it
-        enable_copy_paste = can_edit and ENABLE_COPY_PASTE_FEATURE.is_enabled()
+        enable_copy_paste = can_edit and is_course and ENABLE_COPY_PASTE_FEATURE.is_enabled()
         template_context = {
             'xblock_context': context,
             'xblock': xblock,
@@ -316,10 +318,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_reorderable': is_reorderable,
             'can_edit': can_edit,
             'enable_copy_paste': enable_copy_paste,
-            'can_edit_visibility': context.get('can_edit_visibility', xblock.scope_ids.usage_id.context_key.is_course),
+            'can_edit_visibility': context.get('can_edit_visibility', is_course),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', xblock.scope_ids.usage_id.context_key.is_course),
+            'can_move': context.get('can_move', is_course),
             'language': getattr(course, 'language', None)
         }
 

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -147,7 +147,7 @@ block_is_unit = is_unit(xblock)
                                       <ul>
                                         % if not show_inline:
                                             <li class="nav-item">
-                                                <a class="copy-button" href="#" role="button">${_("Copy")}</a>
+                                                <a class="copy-button" href="#" role="button">${_("Copy to Clipboard")}</a>
                                             </li>
                                             % if can_add:
                                                 <li class="nav-item">


### PR DESCRIPTION
## Description

Based on user feedback, we are changing the text of the new "Copy" menu item to "Copy to Clipboard"

![Screenshot 2023-05-31 at 5 39 13 PM](https://github.com/openedx/edx-platform/assets/945577/062664ce-5eed-4e96-b48f-94904361350d)

I also noticed that the menu was displaying "Copy" when in content libraries, but we haven't turned on content library support yet, so I made the menu only visible in courses for now.

## Supporting information

This is https://github.com/openedx/modular-learning/issues/57

## Testing instructions

1. Go to http://studio.local.overhang.io:8001/admin/waffle/flag/ (or devstack/sandbox equivalent)
2. Add a new flag, `contentstore.enable_copy_paste_feature` and enable it for Everyone
3. Go to a Unit page in Studio and use the new actions menu to copy a component.
4. Go to a content library and make sure the new copy menu is not visible.

## Deadline

None

Private ref: MNG-3722