### PR TITLE
chore: replace edx-shinx-theme with sphinx-book-theme in dev dependencies

### DIFF
--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -15,7 +15,7 @@
 
 click                                   # Used for perf_tests utilities in modulestore
 django-debug-toolbar                    # A set of panels that display debug information about the current request/response
-edx-sphinx-theme                        # Documentation theme
+sphinx-book-theme                       # Documentation theme
 mypy                                    # static type checking
 pywatchman                              # More efficient checking for runserver reload trigger events
 sphinxcontrib-openapi[markdown]         # OpenAPI (fka Swagger) spec renderer for Sphinx

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 acid-xblock==0.2.1
     # via -r requirements/edx/testing.txt
 aiohttp==3.8.4
@@ -74,6 +76,7 @@ babel==2.11.0
     #   -r requirements/edx/testing.txt
     #   enmerkar
     #   enmerkar-underscore
+    #   pydata-sphinx-theme
     #   sphinx
 backoff==1.10.0
     # via
@@ -86,6 +89,7 @@ backports-zoneinfo==0.2.1
 beautifulsoup4==4.12.2
     # via
     #   -r requirements/edx/testing.txt
+    #   pydata-sphinx-theme
     #   pynliner
 billiard==3.6.4.0
     # via
@@ -529,6 +533,7 @@ docutils==0.19
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   botocore
+    #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
 done-xblock==2.0.5
@@ -1067,6 +1072,7 @@ packaging==23.1
     #   build
     #   drf-yasg
     #   py2neo
+    #   pydata-sphinx-theme
     #   pytest
     #   snowflake-connector-python
     #   sphinx
@@ -1172,11 +1178,15 @@ pydantic==1.10.9
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.1
     # via
     #   -r requirements/edx/testing.txt
+    #   accessible-pygments
     #   diff-cover
     #   py2neo
+    #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
 pyjwkest==1.4.2
@@ -1476,7 +1486,6 @@ six==1.16.0
     #   edx-lint
     #   edx-milestones
     #   edx-rbac
-    #   edx-sphinx-theme
     #   event-tracking
     #   fs
     #   fs-s3fs
@@ -1540,9 +1549,12 @@ soupsieve==2.4.1
 sphinx==5.3.0
     # via
     #   -c requirements/edx/../common_constraints.txt
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
+sphinx-book-theme==1.0.1
+    # via -r requirements/edx/development.in
 sphinx-mdinclude==0.5.3
     # via sphinxcontrib-openapi
 sphinxcontrib-applehelp==1.0.4
@@ -1640,6 +1652,7 @@ typing-extensions==4.6.3
     #   import-linter
     #   mypy
     #   pydantic
+    #   pydata-sphinx-theme
     #   pylint
     #   pylti1p3
     #   snowflake-connector-python


### PR DESCRIPTION
As part of the deprecation process for edx-sphinx-theme a previous PR switched
to sphinx-book-theme, however edx-sphinx-theme still remained as a dependency in
one place, which is now removed in this PR.
