### PR TITLE
feat: move XQueueService from the runtime to ProblemBlock [FC-0026]

### DIFF
--- a/common/djangoapps/terrain/stubs/start.py
+++ b/common/djangoapps/terrain/stubs/start.py
@@ -13,11 +13,13 @@ from .ecommerce import StubEcommerceService
 from .edxnotes import StubEdxNotesService
 from .lti import StubLtiService
 from .video_source import VideoSourceHttpService
+from .xqueue import StubXQueueService
 from .youtube import StubYouTubeService
 
 USAGE = "USAGE: python -m stubs.start SERVICE_NAME PORT_NUM [CONFIG_KEY=CONFIG_VAL, ...]"
 
 SERVICES = {
+    'xqueue': StubXQueueService,
     'youtube': StubYouTubeService,
     'comments': StubCommentsService,
     'lti': StubLtiService,

--- a/common/djangoapps/terrain/stubs/start.py
+++ b/common/djangoapps/terrain/stubs/start.py
@@ -13,13 +13,11 @@ from .ecommerce import StubEcommerceService
 from .edxnotes import StubEdxNotesService
 from .lti import StubLtiService
 from .video_source import VideoSourceHttpService
-from .xqueue import StubXQueueService
 from .youtube import StubYouTubeService
 
 USAGE = "USAGE: python -m stubs.start SERVICE_NAME PORT_NUM [CONFIG_KEY=CONFIG_VAL, ...]"
 
 SERVICES = {
-    'xqueue': StubXQueueService,
     'youtube': StubYouTubeService,
     'comments': StubCommentsService,
     'lti': StubLtiService,

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -53,7 +53,6 @@ from xmodule.util.sandboxing import SandboxService
 from xmodule.services import EventPublishingService, RebindUserService, SettingsService, TeamsConfigurationService
 from common.djangoapps.static_replace.services import ReplaceURLService
 from common.djangoapps.static_replace.wrapper import replace_urls_wrapper
-from xmodule.capa.xqueue_interface import XQueueService  # lint-amnesty, pylint: disable=wrong-import-order
 from lms.djangoapps.courseware.access import get_user_role, has_access
 from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam, user_has_passed_entrance_exam
 from lms.djangoapps.courseware.masquerade import (
@@ -445,8 +444,6 @@ def prepare_runtime_for_user(
 
         Because it does an access check, it may return None.
         """
-        # TODO: fix this so that make_xqueue_callback uses the block passed into
-        # inner_get_block, not the parent's callback.  Add it as an argument....
         return get_block_for_descriptor_internal(
             user=user,
             block=block,
@@ -549,7 +546,6 @@ def prepare_runtime_for_user(
         'content_type_gating': ContentTypeGatingService(),
         'cache': CacheService(cache),
         'sandbox': SandboxService(contentstore=contentstore, course_id=course_id),
-        'xqueue': partial(XQueueService, user.id),
         'replace_urls': replace_url_service,
         # Rebind module service to deal with noauth modules getting attached to users.
         'rebind_user': RebindUserService(

--- a/xmodule/capa/tests/test_xqueue_interface.py
+++ b/xmodule/capa/tests/test_xqueue_interface.py
@@ -1,41 +1,52 @@
-# -*- coding: utf-8 -*-
-"""
-Tests the xqueue service interface.
-"""
+"""Test the XQueue service and interface."""
 
 from unittest import TestCase
+from unittest.mock import Mock
+
 from django.conf import settings
+from django.test.utils import override_settings
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
+from xblock.fields import ScopeIds
 
 from xmodule.capa.xqueue_interface import XQueueInterface, XQueueService
 
 
 class XQueueServiceTest(TestCase):
-    """
-    Tests the XQueue service methods.
-    """
-    @staticmethod
-    def construct_callback(*args, **kwargs):
-        return 'https://lms.url/callback'
-
+    """Test the XQueue service methods."""
     def setUp(self):
         super().setUp()
-        self.service = XQueueService(
-            url=settings.XQUEUE_INTERFACE['url'],
-            django_auth=settings.XQUEUE_INTERFACE['django_auth'],
-            basic_auth=settings.XQUEUE_INTERFACE['basic_auth'],
-            construct_callback=self.construct_callback,
-            default_queuename='my-very-own-queue',
-            waittime=settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS,
-        )
+        location = BlockUsageLocator(CourseLocator("test_org", "test_course", "test_run"), "problem", "ExampleProblem")
+        self.block = Mock(scope_ids=ScopeIds('user1', 'mock_problem', location, location))
+        self.service = XQueueService(self.block)
 
     def test_interface(self):
+        """Test that the `XQUEUE_INTERFACE` settings are passed from the service to the interface."""
         assert isinstance(self.service.interface, XQueueInterface)
+        assert self.service.interface.url == 'http://sandbox-xqueue.edx.org'
+        assert self.service.interface.auth['username'] == 'lms'
+        assert self.service.interface.auth['password'] == '***REMOVED***'
+        assert self.service.interface.session.auth.username == 'anant'
+        assert self.service.interface.session.auth.password == 'agarwal'
 
     def test_construct_callback(self):
-        assert self.service.construct_callback() == 'https://lms.url/callback'
+        """Test that the XQueue callback is initialized correctly, and can be altered through the settings."""
+        usage_id = self.block.scope_ids.usage_id
+        callback_url = f'courses/{usage_id.context_key}/xqueue/user1/{usage_id}'
+
+        assert self.service.construct_callback() == f'{settings.LMS_ROOT_URL}/{callback_url}/score_update'
+        assert self.service.construct_callback('alt_dispatch') == f'{settings.LMS_ROOT_URL}/{callback_url}/alt_dispatch'
+
+        custom_callback_url = 'http://alt.url'
+        with override_settings(XQUEUE_INTERFACE={**settings.XQUEUE_INTERFACE, 'callback_url': custom_callback_url}):
+            assert self.service.construct_callback() == f'{custom_callback_url}/{callback_url}/score_update'
 
     def test_default_queuename(self):
-        assert self.service.default_queuename == 'my-very-own-queue'
+        """Check the format of the default queue name."""
+        assert self.service.default_queuename == 'test_org-test_course'
 
     def test_waittime(self):
+        """Check that the time between requests is retrieved correctly from the settings."""
         assert self.service.waittime == 5
+
+        with override_settings(XQUEUE_WAITTIME_BETWEEN_REQUESTS=15):
+            assert self.service.waittime == 15

--- a/xmodule/capa/xqueue_interface.py
+++ b/xmodule/capa/xqueue_interface.py
@@ -1,16 +1,16 @@
 """
 LMS Interface to external queueing system (xqueue)
 """
-from typing import Callable, TYPE_CHECKING
+from typing import Dict, Optional, TYPE_CHECKING
 
 import hashlib
 import json
 import logging
 
 import requests
-import six
 from django.conf import settings
 from django.urls import reverse
+from requests.auth import HTTPBasicAuth
 
 if TYPE_CHECKING:
     from xmodule.capa_block import ProblemBlock
@@ -31,7 +31,7 @@ def make_hashkey(seed):
     Generate a string key by hashing
     """
     h = hashlib.md5()
-    h.update(six.b(str(seed)))
+    h.update(str(seed).encode('latin-1'))
     return h.hexdigest()
 
 
@@ -71,13 +71,13 @@ def parse_xreply(xreply):
     return (return_code, content)
 
 
-class XQueueInterface(object):
+class XQueueInterface:
     """
     Interface to the external grading system
     """
 
-    def __init__(self, url, django_auth, requests_auth=None):
-        self.url = six.text_type(url)
+    def __init__(self, url: str, django_auth: Dict[str, str], requests_auth: Optional[HTTPBasicAuth] = None):
+        self.url = url
         self.auth = django_auth
         self.session = requests.Session()
         self.session.auth = requests_auth
@@ -166,7 +166,7 @@ class XQueueService:
 
     def __init__(self, block: 'ProblemBlock'):
         basic_auth = settings.XQUEUE_INTERFACE.get('basic_auth')
-        requests_auth = requests.auth.HTTPBasicAuth(*basic_auth) if basic_auth else None
+        requests_auth = HTTPBasicAuth(*basic_auth) if basic_auth else None
         self._interface = XQueueInterface(
             settings.XQUEUE_INTERFACE['url'], settings.XQUEUE_INTERFACE['django_auth'], requests_auth
         )
@@ -180,12 +180,21 @@ class XQueueService:
         """
         return self._interface
 
-    @property
-    def construct_callback(self) -> Callable[[str], str]:
+    def construct_callback(self, dispatch: str = 'score_update') -> str:
         """
-        Returns the function to construct the XQueue callback.
+        Return a fully qualified callback URL for external queueing system.
         """
-        return self._make_xqueue_callback
+        relative_xqueue_callback_url = reverse(
+            'xqueue_callback',
+            kwargs=dict(
+                course_id=str(self._block.scope_ids.usage_id.context_key),
+                userid=str(self._block.scope_ids.user_id),
+                mod_id=str(self._block.scope_ids.usage_id),
+                dispatch=dispatch,
+            ),
+        )
+        xqueue_callback_url_prefix = settings.XQUEUE_INTERFACE.get('callback_url', settings.LMS_ROOT_URL)
+        return xqueue_callback_url_prefix + relative_xqueue_callback_url
 
     @property
     def default_queuename(self) -> str:
@@ -201,19 +210,3 @@ class XQueueService:
         Returns the number of seconds to wait in between calls to XQueue.
         """
         return settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS
-
-    def _make_xqueue_callback(self, dispatch: str = 'score_update') -> str:
-        """
-        Return a fully qualified callback URL for external queueing system.
-        """
-        relative_xqueue_callback_url = reverse(
-            'xqueue_callback',
-            kwargs=dict(
-                course_id=str(self._block.scope_ids.usage_id.context_key),
-                userid=str(self._block.scope_ids.user_id),
-                mod_id=str(self._block.scope_ids.usage_id),
-                dispatch=dispatch,
-            ),
-        )
-        xqueue_callback_url_prefix = settings.XQUEUE_INTERFACE.get('callback_url', settings.LMS_ROOT_URL)
-        return xqueue_callback_url_prefix + relative_xqueue_callback_url

--- a/xmodule/capa/xqueue_interface.py
+++ b/xmodule/capa/xqueue_interface.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.urls import reverse
 
 if TYPE_CHECKING:
-    from xblock.core import XBlock
+    from xmodule.capa_block import ProblemBlock
 
 log = logging.getLogger(__name__)
 dateformat = '%Y%m%d%H%M%S'
@@ -161,18 +161,16 @@ class XQueueService:
     XBlock service providing an interface to the XQueue service.
 
     Args:
-        user_id: The user ID.
-        block: The XBlock.
+        block: The `ProblemBlock` instance.
     """
 
-    def __init__(self, user_id: int, block: 'XBlock'):
+    def __init__(self, block: 'ProblemBlock'):
         basic_auth = settings.XQUEUE_INTERFACE.get('basic_auth')
         requests_auth = requests.auth.HTTPBasicAuth(*basic_auth) if basic_auth else None
         self._interface = XQueueInterface(
             settings.XQUEUE_INTERFACE['url'], settings.XQUEUE_INTERFACE['django_auth'], requests_auth
         )
 
-        self._user_id = user_id
         self._block = block
 
     @property
@@ -212,7 +210,7 @@ class XQueueService:
             'xqueue_callback',
             kwargs=dict(
                 course_id=str(self._block.scope_ids.usage_id.context_key),
-                userid=str(self._user_id),
+                userid=str(self._block.scope_ids.user_id),
                 mod_id=str(self._block.scope_ids.usage_id),
                 dispatch=dispatch,
             ),

--- a/xmodule/tests/__init__.py
+++ b/xmodule/tests/__init__.py
@@ -161,14 +161,6 @@ def get_test_system(
     services = {
         'user': user_service,
         'mako': mako_service,
-        'xqueue': XQueueService(
-            url='http://xqueue.url',
-            django_auth={},
-            basic_auth=[],
-            default_queuename='testqueue',
-            waittime=10,
-            construct_callback=Mock(name='get_test_system.xqueue.construct_callback', side_effect="/"),
-        ),
         'replace_urls': replace_url_service,
         'cache': CacheService(DoNothingCache()),
         'field-data': DictFieldData({}),
@@ -224,14 +216,6 @@ def prepare_block_runtime(
     services = {
         'user': user_service,
         'mako': mako_service,
-        'xqueue': XQueueService(
-            url='http://xqueue.url',
-            django_auth={},
-            basic_auth=[],
-            default_queuename='testqueue',
-            waittime=10,
-            construct_callback=Mock(name='get_test_system.xqueue.construct_callback', side_effect="/"),
-        ),
         'replace_urls': replace_url_service,
         'cache': CacheService(DoNothingCache()),
         'field-data': DictFieldData({}),

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1240,31 +1240,6 @@ class ModuleSystemShim:
         self._deprecated_render_template = render_template
 
     @property
-    def xqueue(self):
-        """
-        Returns a dict containing the XQueueInterface object, as well as parameters for the specific StudentModule:
-        * interface: XQueueInterface object
-        * construct_callback: function to construct the fully-qualified LMS callback URL.
-        * default_queuename: default queue name for the course in XQueue
-        * waittime: number of seconds to wait in between calls to XQueue
-
-        Deprecated in favor of the xqueue service.
-        """
-        warnings.warn(
-            'runtime.xqueue is deprecated. Please use the xqueue service instead.',
-            DeprecationWarning, stacklevel=3,
-        )
-        xqueue_service = self._runtime_services.get('xqueue') or self._services.get('xqueue')
-        if xqueue_service:
-            return {
-                'interface': xqueue_service.interface,
-                'construct_callback': xqueue_service.construct_callback,
-                'default_queuename': xqueue_service.default_queuename,
-                'waittime': xqueue_service.waittime,
-            }
-        return None
-
-    @property
     def can_execute_unsafe_code(self):
         """
         Returns a function which returns a boolean, indicating whether or not to allow the execution of unsafe,


### PR DESCRIPTION
## Description

The goal of FC-0026 is to remove the XBlock-specific handling from the `prepare_runtime_for_user` function.
The XQueueService is used only by the ProblemBlock. Therefore, this PR moves it out of the runtime, and into the ProblemBlock, where it's initialized only when it's going to be used.

## Supporting information

Private-ref: [BB-7448](https://tasks.opencraft.com/browse/BB-7448)

## Testing instructions

1. Add the following to your `lms/envs/private.py` (I have no idea how to do this in Tutor):
    ```python
    XQUEUE_INTERFACE = {
        'url': 'http://edx.devstack.xqueue:18040',
        'callback_url': 'http://edx.devstack.lms:18000',
        'basic_auth': ['edx', 'edx'],
        'django_auth': {
            'username': 'lms',
            'password': 'password'
        }
    }
    ```
2. Ensure you have started the `xqueue` service (`make dev.up.xqueue`).
3. Clone an `xqueue-watcher` with a dummy grader: https://github.com/open-craft/xqueue-watcher/tree/jill/bd-13-dummy-grader (this is a custom branch). It doesn't need to be inside the devstack.
4. Run `make requirements` (preferably in a virtualenv) and `python -m xqueue_watcher -d .` to start it.
5. Create an Advanced Problem Block with the following content:
    ```xml
    <problem>
      <coderesponse queuename="open-ended">
        <label>Write a program that prints "hello world".</label>
        <textbox rows="10" cols="80" mode="python" tabsize="4"/>
        <codeparam>
          <initial_display>
    # students write your program here
    print ""
          </initial_display>
          <answer_display>
            print "hello world"
          </answer_display>
          <grader_payload>
            {"output": "hello world", "max_length": 2}
          </grader_payload>
        </codeparam>
      </coderesponse>
    </problem>
    ```
6. Publish the XBlock (it won't work without this).
7. Check that submitting the answer from Studio shows the following error: " Error: No grader has been set up for this problem. ".
8. Check that submitting the answer works from the LMS and Preview.

## Other information

This change is backward-incompatible with the deprecated `xqueue` shim from the runtime. The XQueue is only used by the ProblemBlock, so it is a safe approach. Also, the XQueueService has existed since Nutmeg, so it should be fine to remove this shim already.