### PR TITLE
fix: change response of course enrollment api for notifications

### DIFF
--- a/openedx/core/djangoapps/notifications/serializers.py
+++ b/openedx/core/djangoapps/notifications/serializers.py
@@ -26,7 +26,7 @@ class NotificationCourseEnrollmentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CourseEnrollment
-        fields = ('course', 'is_active', 'mode')
+        fields = ('course',)
 
 
 class UserNotificationPreferenceSerializer(serializers.ModelSerializer):
@@ -70,4 +70,5 @@ class NotificationSerializer(serializers.ModelSerializer):
             'content_url',
             'last_read',
             'last_seen',
+            'created',
         )

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -38,8 +38,6 @@ class CourseEnrollmentListView(generics.ListAPIView):
                     "id": (int) course_id,
                     "display_name": (str) course_display_name
                 },
-                "is_active": (bool) is_enrollment_active,
-                "mode": (str) enrollment_mode
             },
             ...
         ]


### PR DESCRIPTION
Removed unnecessary fields from course enrollment api response for notifications.
New api response
```json
[
  {
    "course": {
      "id": "course.id",
      "name": "course.display_name"
    }
  },
  ...
]
```

Ticket Link: [INF-892](https://2u-internal.atlassian.net/browse/INF-892)
