### PR TITLE
feat!: upgrading django-storages.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,7 +20,8 @@ celery>=5.2.2,<6.0.0
 click>=8.0,<9.0
 
 # django-storages version 1.9 drops support for boto storage backend.
-django-storages<1.9
+# 1.9 gives an error for details https://github.com/jschneier/django-storages/issues/831
+django-storages==1.9.1
 
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -363,7 +363,7 @@ django-statici18n==2.3.1
     #   -r requirements/edx/base.in
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.8
+django-storages==1.9.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
@@ -659,7 +659,7 @@ jsonfield==3.1.0
     #   outcome-surveys
 jsonschema==4.17.3
     # via optimizely-sdk
-jwcrypto==1.4.2
+jwcrypto==1.5.0
     # via pylti1p3
 kombu==5.2.4
     # via celery
@@ -776,7 +776,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/base.in
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/base.in
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
@@ -791,7 +791,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.in
-ora2==5.0.1
+ora2==5.0.2
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
@@ -1013,7 +1013,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/base.in
     #   social-auth-core
-ruamel-yaml==0.17.28
+ruamel-yaml==0.17.31
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -1133,7 +1133,7 @@ tinycss2==1.1.1
     # via bleach
 tqdm==4.65.0
     # via nltk
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   asgiref
     #   django-countries

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -474,7 +474,7 @@ django-statici18n==2.3.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.8
+django-storages==1.9.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
@@ -726,7 +726,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==18.9.0
+faker==18.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -883,7 +883,7 @@ jsonschema==4.17.3
     #   -r requirements/edx/testing.txt
     #   optimizely-sdk
     #   sphinxcontrib-openapi
-jwcrypto==1.4.2
+jwcrypto==1.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylti1p3
@@ -1035,7 +1035,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/testing.txt
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/testing.txt
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
@@ -1050,7 +1050,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/testing.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/testing.txt
-ora2==5.0.1
+ora2==5.0.2
     # via -r requirements/edx/testing.txt
 oscrypto==1.3.0
     # via
@@ -1410,7 +1410,7 @@ rfc3986[idna2008]==1.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   httpx
-ruamel-yaml==0.17.28
+ruamel-yaml==0.17.31
     # via
     #   -r requirements/edx/testing.txt
     #   drf-yasg
@@ -1627,7 +1627,7 @@ tqdm==4.65.0
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/edx/testing.txt
     #   asgiref

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -101,7 +101,7 @@ stevedore==5.1.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via pydata-sphinx-theme
 urllib3==1.26.16
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -454,7 +454,7 @@ django-statici18n==2.3.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.8
+django-storages==1.9.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -700,7 +700,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==18.9.0
+faker==18.10.0
     # via factory-boy
 fastapi==0.95.2
     # via pact-python
@@ -840,7 +840,7 @@ jsonschema==4.17.3
     # via
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
-jwcrypto==1.4.2
+jwcrypto==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   pylti1p3
@@ -983,7 +983,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/base.txt
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
@@ -998,7 +998,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.0.1
+ora2==5.0.2
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via
@@ -1330,7 +1330,7 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 rfc3986[idna2008]==1.5.0
     # via httpx
-ruamel-yaml==0.17.28
+ruamel-yaml==0.17.31
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1507,7 +1507,7 @@ tqdm==4.65.0
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/edx/base.txt
     #   asgiref


### PR DESCRIPTION
Upgraded to 1.9.1  https://github.com/openedx/edx-platform/issues/31176

1.9 was giving an error. Details are [here](https://github.com/jschneier/django-storages/issues/831)

https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#191-2020-02-03
import/export of course working fine with `1.9.1`

**No more boto support with `django-storages`**

Only videos module is using boto directly without `djang-storages`.