### PR TITLE
feat: remove block-specific handling from runtime role checks [FC-0026]

### DIFF
--- a/common/djangoapps/xblock_django/constants.py
+++ b/common/djangoapps/xblock_django/constants.py
@@ -3,12 +3,26 @@ Constants used by DjangoXBlockUserService
 """
 
 # Optional attributes stored on the XBlockUser
+
+# The anonymous user ID for the user in the course.
 ATTR_KEY_ANONYMOUS_USER_ID = 'edx-platform.anonymous_user_id'
+# The global (course-agnostic) anonymous user ID for the user.
 ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID = 'edx-platform.deprecated_anonymous_user_id'
+# The country code determined from the user's request IP address.
 ATTR_KEY_REQUEST_COUNTRY_CODE = 'edx-platform.request_country_code'
+# Whether the user is authenticated or anonymous.
 ATTR_KEY_IS_AUTHENTICATED = 'edx-platform.is_authenticated'
+# The personally identifiable user ID.
 ATTR_KEY_USER_ID = 'edx-platform.user_id'
+# The username.
 ATTR_KEY_USERNAME = 'edx-platform.username'
+# Whether the user is enrolled in the course as a Beta Tester.
+ATTR_KEY_USER_IS_BETA_TESTER = 'edx-platform.user_is_beta_tester'
+# Whether the user has staff access to the platform.
+ATTR_KEY_USER_IS_GLOBAL_STAFF = 'edx-platform.user_is_global_staff'
+# Whether the user is a course team member with 'Staff' or 'Admin' access.
 ATTR_KEY_USER_IS_STAFF = 'edx-platform.user_is_staff'
+# A dict containing user's entries from the `UserPreference` model.
 ATTR_KEY_USER_PREFERENCES = 'edx-platform.user_preferences'
+# The user's role in the course ('staff', 'instructor', or 'student').
 ATTR_KEY_USER_ROLE = 'edx-platform.user_role'

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -18,6 +18,8 @@ from .constants import (
     ATTR_KEY_REQUEST_COUNTRY_CODE,
     ATTR_KEY_USER_ID,
     ATTR_KEY_USERNAME,
+    ATTR_KEY_USER_IS_BETA_TESTER,
+    ATTR_KEY_USER_IS_GLOBAL_STAFF,
     ATTR_KEY_USER_IS_STAFF,
     ATTR_KEY_USER_PREFERENCES,
     ATTR_KEY_USER_ROLE,
@@ -36,7 +38,10 @@ class DjangoXBlockUserService(UserService):
         Constructs a DjangoXBlockUserService object.
 
         Args:
-            user_is_staff(bool): optional - whether the user is staff in the course
+            django_user(User): optional - the user we are binding to the runtime. Is `None` for an anonymous user.
+            user_is_beta_tester(bool): optional - whether the user is enrolled in the course as a Beta Tester.
+            user_is_global_staff(bool): optional - whether the user has staff access to the platform.
+            user_is_staff(bool): optional - whether the user is a course team member with 'Staff' or 'Admin' access.
             user_role(str): optional -- user's role in the course ('staff', 'instructor', or 'student')
             anonymous_user_id(str): optional - anonymous_user_id for the user in the course
             deprecated_anonymous_user_id(str): optional - There are XBlocks (CAPA and HTML) that use the per-student
@@ -46,6 +51,8 @@ class DjangoXBlockUserService(UserService):
         """
         super().__init__(**kwargs)
         self._django_user = django_user
+        self._user_is_beta_tester = kwargs.get('user_is_beta_tester', False)
+        self._user_is_global_staff = kwargs.get('user_is_global_staff', False)
         self._user_is_staff = kwargs.get('user_is_staff', False)
         self._user_role = kwargs.get('user_role', 'student')
         self._anonymous_user_id = kwargs.get('anonymous_user_id', None)
@@ -121,6 +128,8 @@ class DjangoXBlockUserService(UserService):
             xblock_user.opt_attrs[ATTR_KEY_REQUEST_COUNTRY_CODE] = self._request_country_code
             xblock_user.opt_attrs[ATTR_KEY_USER_ID] = django_user.id
             xblock_user.opt_attrs[ATTR_KEY_USERNAME] = django_user.username
+            xblock_user.opt_attrs[ATTR_KEY_USER_IS_BETA_TESTER] = self._user_is_beta_tester
+            xblock_user.opt_attrs[ATTR_KEY_USER_IS_GLOBAL_STAFF] = self._user_is_global_staff
             xblock_user.opt_attrs[ATTR_KEY_USER_IS_STAFF] = self._user_is_staff
             xblock_user.opt_attrs[ATTR_KEY_USER_ROLE] = self._user_role
             user_preferences = get_user_preferences(django_user)

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -61,12 +61,19 @@ from xmodule.video_block import VideoBlock  # lint-amnesty, pylint: disable=wron
 from xmodule.x_module import STUDENT_VIEW, DescriptorSystem  # lint-amnesty, pylint: disable=wrong-import-order
 from common.djangoapps import static_replace
 from common.djangoapps.course_modes.models import CourseMode  # lint-amnesty, pylint: disable=reimported
-from common.djangoapps.student.tests.factories import GlobalStaffFactory
-from common.djangoapps.student.tests.factories import RequestFactoryNoCsrf
-from common.djangoapps.student.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import (
+    BetaTesterFactory,
+    GlobalStaffFactory,
+    InstructorFactory,
+    RequestFactoryNoCsrf,
+    StaffFactory,
+    UserFactory,
+)
 from common.djangoapps.xblock_django.constants import (
     ATTR_KEY_ANONYMOUS_USER_ID,
     ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID,
+    ATTR_KEY_USER_IS_BETA_TESTER,
+    ATTR_KEY_USER_IS_GLOBAL_STAFF,
     ATTR_KEY_USER_IS_STAFF,
     ATTR_KEY_USER_ROLE,
 )
@@ -2346,17 +2353,6 @@ class LMSXBlockServiceBindingTest(LMSXBlockServiceMixin):
         service = self.block.runtime.service(self.block, expected_service)
         assert service is not None
 
-    def test_beta_tester_fields_added(self):
-        """
-        Tests that the beta tester fields are set on LMS runtime.
-        """
-        self.block.days_early_for_beta = 5
-        self._prepare_runtime()
-
-        # pylint: disable=no-member
-        assert not self.block.runtime.user_is_beta_tester
-        assert self.block.runtime.days_early_for_beta == 5
-
     def test_get_set_tag(self):
         """
         Tests the user service interface.
@@ -2684,8 +2680,12 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         """
         assert getattr(self.block.runtime, attribute) == expected_value
 
-    @patch('lms.djangoapps.courseware.block_render.has_access', Mock(return_value=True, autospec=True))
-    def test_user_is_staff(self):
+    @ddt.data((True, 'staff'), (False, 'student'))
+    @ddt.unpack
+    def test_user_is_staff(self, is_staff, expected_role):
+        if is_staff:
+            self.user = StaffFactory(course_key=self.course.id)
+
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
@@ -2696,15 +2696,18 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             course=self.course,
         )
         block_user_info = self.block.runtime.service(self.block, "user").get_current_user()
-        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_IS_STAFF)
-        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_ROLE) == 'student'
+        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_IS_STAFF) == is_staff
+        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_ROLE) == expected_role
         with warnings.catch_warnings():  # For now, also test the deprecated accessors for backwards compatibility:
             warnings.simplefilter("ignore", category=DeprecationWarning)
-            assert self.block.runtime.user_is_staff
-            assert self.block.runtime.get_user_role() == 'student'
+            assert self.block.runtime.user_is_staff == is_staff
+            assert self.block.runtime.get_user_role() == expected_role
 
-    @patch('lms.djangoapps.courseware.block_render.get_user_role', Mock(return_value='instructor', autospec=True))
-    def test_get_user_role(self):
+    @ddt.data(True, False)
+    def test_user_is_admin(self, is_global_staff):
+        if is_global_staff:
+            self.user = GlobalStaffFactory.create()
+
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
@@ -2715,10 +2718,51 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             course=self.course,
         )
         block_user_info = self.block.runtime.service(self.block, "user").get_current_user()
-        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_ROLE) == 'instructor'
+        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_IS_GLOBAL_STAFF) == is_global_staff
+        with warnings.catch_warnings():  # For now, also test the deprecated accessors for backwards compatibility:
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            assert self.block.runtime.user_is_admin == is_global_staff
+
+    @ddt.data(True, False)
+    def test_user_is_beta_tester(self, is_beta_tester):
+        if is_beta_tester:
+            self.user = BetaTesterFactory(course_key=self.course.id)
+
+        _ = render.prepare_runtime_for_user(
+            self.user,
+            self.student_data,
+            self.block,
+            self.course.id,
+            self.track_function,
+            self.request_token,
+            course=self.course,
+        )
+        block_user_info = self.block.runtime.service(self.block, "user").get_current_user()
+        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_IS_BETA_TESTER) == is_beta_tester
+        with warnings.catch_warnings():  # For now, also test the deprecated accessors for backwards compatibility:
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            assert self.block.runtime.user_is_beta_tester == is_beta_tester
+
+    @ddt.data((True, 'instructor'), (False, 'student'))
+    @ddt.unpack
+    def test_get_user_role(self, is_instructor, expected_role):
+        if is_instructor:
+            self.user = InstructorFactory(course_key=self.course.id)
+
+        _ = render.prepare_runtime_for_user(
+            self.user,
+            self.student_data,
+            self.block,
+            self.course.id,
+            self.track_function,
+            self.request_token,
+            course=self.course,
+        )
+        block_user_info = self.block.runtime.service(self.block, "user").get_current_user()
+        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_ROLE) == expected_role
         with warnings.catch_warnings():  # For now, also test the deprecated accessor for backwards compatibility:
             warnings.simplefilter("ignore", category=DeprecationWarning)
-            assert self.block.runtime.get_user_role() == 'instructor'
+            assert self.block.runtime.get_user_role() == expected_role
 
     def test_anonymous_student_id(self):
         expected_anon_id = anonymous_id_for_user(self.user, self.course.id)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -795,7 +795,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.in
-ora2==5.0.2
+ora2==5.0.3
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1052,7 +1052,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/testing.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/testing.txt
-ora2==5.0.2
+ora2==5.0.3
     # via -r requirements/edx/testing.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1000,7 +1000,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.0.2
+ora2==5.0.3
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -43,6 +43,8 @@ from common.djangoapps.xblock_django.constants import (
     ATTR_KEY_ANONYMOUS_USER_ID,
     ATTR_KEY_REQUEST_COUNTRY_CODE,
     ATTR_KEY_USER_ID,
+    ATTR_KEY_USER_IS_BETA_TESTER,
+    ATTR_KEY_USER_IS_GLOBAL_STAFF,
     ATTR_KEY_USER_IS_STAFF,
     ATTR_KEY_USER_ROLE,
 )
@@ -1189,6 +1191,36 @@ class ModuleSystemShim:
         user_service = self._runtime_services.get('user') or self._services.get('user')
         if user_service:
             return partial(user_service.get_current_user().opt_attrs.get, ATTR_KEY_USER_ROLE)
+
+    @property
+    def user_is_beta_tester(self):
+        """
+        Returns whether the current user is enrolled in the course as a beta tester.
+
+        Deprecated in favor of the user service.
+        """
+        warnings.warn(
+            'runtime.user_is_beta_tester is deprecated. Please use the user service instead.',
+            DeprecationWarning, stacklevel=2,
+        )
+        user_service = self._runtime_services.get('user') or self._services.get('user')
+        if user_service:
+            return user_service.get_current_user().opt_attrs.get(ATTR_KEY_USER_IS_BETA_TESTER)
+
+    @property
+    def user_is_admin(self):
+        """
+        Returns whether the current user has global staff permissions.
+
+        Deprecated in favor of the user service.
+        """
+        warnings.warn(
+            'runtime.user_is_admin is deprecated. Please use the user service instead.',
+            DeprecationWarning, stacklevel=2,
+        )
+        user_service = self._runtime_services.get('user') or self._services.get('user')
+        if user_service:
+            return user_service.get_current_user().opt_attrs.get(ATTR_KEY_USER_IS_GLOBAL_STAFF)
 
     @property
     def render_template(self):


### PR DESCRIPTION
## Description

The goal of FC-0026 is to remove the XBlock-specific handling from the prepare_runtime_for_user function. This part handles user role checks.
We have the following attributes in the runtime:
1. `user_is_staff` - this is redundant because `x_module.py` already contains a shim with the `user_is_staff` property. We can remove it without any consequences.
2. `user_is_admin` and `user_is_beta_tester` - these two are good candidates for the `user` service, so we can move them there. However, the `ora2` XBlock uses these runtime attributes, so we need a compatibility shim in `x_module.py`. I tried switching `ora2` to the user service, but this will require a significant effort (preferably also to the workbench from `xblock-sdk`), so adding shims is a safer approach at the moment.
3. `days_early_for_beta` - this variable is already available directly in the XBlock (via the `InheritanceMixin`), so adding it to the runtime is redundant. However, this runtime attribute is used by the `ora2` block, so we can remove it only after merging https://github.com/openedx/edx-ora2/pull/1977.

## Supporting information

Private-ref: [BB-7448](https://tasks.opencraft.com/browse/BB-7448)

## Testing instructions

1. Use testing instructions from https://github.com/openedx/edx-ora2/pull/1977.
2. Check that you can see the `.wrapper--staff-toolbar` element in LMS when logged in as the `edx` user.

## Other information

We are removing `days_early_for_beta` from the runtime. Therefore, this should be merged after https://github.com/openedx/edx-ora2/pull/1977.