### PR TITLE
feat: remove field-data binding from the runtime [FC-0026]

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -68,13 +68,8 @@ class TestXBlockI18nService(ModuleStoreTestCase):
         self.test_language = 'dummy language'
         self.request = mock.Mock()
         self.course = CourseFactory.create()
-        self.field_data = mock.Mock()
         self.block = BlockFactory(category="pure", parent=self.course)
-        _prepare_runtime_for_preview(
-            self.request,
-            self.block,
-            self.field_data,
-        )
+        _prepare_runtime_for_preview(self.request, self.block)
         self.addCleanup(translation.deactivate)
 
     def get_block_i18n_service(self, block):

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -149,14 +149,13 @@ def preview_layout_asides(block, context, frag, view_name, aside_frag_fns, wrap_
     return result
 
 
-def _prepare_runtime_for_preview(request, block, field_data):
+def _prepare_runtime_for_preview(request, block):
     """
     Sets properties in the runtime of the specified block that is
     required for rendering block previews.
 
     request: The active django request
     block: An XBlock
-    field_data: Wrapped field data for previews
     """
 
     course_id = block.location.course_key
@@ -199,7 +198,6 @@ def _prepare_runtime_for_preview(request, block, field_data):
         deprecated_anonymous_user_id = anonymous_id_for_user(request.user, None)
 
     services = {
-        "field-data": field_data,
         "i18n": XBlockI18nService,
         'mako': mako_service,
         "settings": SettingsService(),
@@ -266,9 +264,7 @@ def _load_preview_block(request: Request, block: XModuleMixin):
     else:
         wrapper = partial(LmsFieldData, student_data=student_data)
 
-    # wrap the _field_data upfront to pass to _prepare_runtime_for_preview
-    wrapped_field_data = wrapper(block._field_data)  # pylint: disable=protected-access
-    _prepare_runtime_for_preview(request, block, wrapped_field_data)
+    _prepare_runtime_for_preview(request, block)
 
     block.bind_for_student(
         request.user.id,

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -172,7 +172,6 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
         self.assertFalse(modulestore().has_changes(modulestore().get_item(block.location)))
 
 
-@XBlock.needs("field-data")
 @XBlock.needs("i18n")
 @XBlock.needs("mako")
 @XBlock.needs("replace_urls")
@@ -204,7 +203,6 @@ class StudioXBlockServiceBindingTest(ModuleStoreTestCase):
         self.user = UserFactory()
         self.course = CourseFactory.create()
         self.request = mock.Mock()
-        self.field_data = mock.Mock()
 
     @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
     @ddt.data("user", "i18n", "field-data", "teams_configuration", "replace_urls")
@@ -213,11 +211,7 @@ class StudioXBlockServiceBindingTest(ModuleStoreTestCase):
         Tests that the 'user' and 'i18n' services are provided by the Studio runtime.
         """
         block = BlockFactory(category="pure", parent=self.course)
-        _prepare_runtime_for_preview(
-            self.request,
-            block,
-            self.field_data,
-        )
+        _prepare_runtime_for_preview(self.request, block)
         service = block.runtime.service(block, expected_service)
         self.assertIsNotNone(service)
 
@@ -241,14 +235,9 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         self.request = RequestFactory().get('/dummy-url')
         self.request.user = self.user
         self.request.session = {}
-        self.field_data = mock.Mock()
         self.contentstore = contentstore()
         self.block = BlockFactory(category="problem", parent=course)
-        _prepare_runtime_for_preview(
-            self.request,
-            block=self.block,
-            field_data=mock.Mock(),
-        )
+        _prepare_runtime_for_preview(self.request, block=self.block)
         self.course = self.store.get_item(course.location)
 
     def test_get_user_role(self):
@@ -303,11 +292,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         """Test anonymous_user_id on a block which uses per-student anonymous IDs"""
         # Create the runtime with the flag turned on.
         block = BlockFactory(category="problem", parent=self.course)
-        _prepare_runtime_for_preview(
-            self.request,
-            block=block,
-            field_data=mock.Mock(),
-        )
+        _prepare_runtime_for_preview(self.request, block=block)
         deprecated_anonymous_user_id = (
             block.runtime.service(block, 'user').get_current_user().opt_attrs.get(ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID)
         )
@@ -318,11 +303,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         """Test anonymous_user_id on a block which uses per-course anonymous IDs"""
         # Create the runtime with the flag turned on.
         block = BlockFactory(category="lti", parent=self.course)
-        _prepare_runtime_for_preview(
-            self.request,
-            block=block,
-            field_data=mock.Mock(),
-        )
+        _prepare_runtime_for_preview(self.request, block=block)
 
         anonymous_user_id = (
             block.runtime.service(block, 'user').get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID)

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -525,7 +525,6 @@ def prepare_runtime_for_user(
 
     services = {
         'fs': FSService(),
-        'field-data': student_data,
         'mako': mako_service,
         'user': DjangoXBlockUserService(
             user,

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -433,9 +433,6 @@ def prepare_runtime_for_user(
     Arguments:
         see arguments for get_block()
         request_token (str): A token unique to the request use by xblock initialization
-
-    Returns:
-        KvsFieldData:  student_data bound to, primarily, the user and block
     """
 
     def inner_get_block(block):
@@ -524,14 +521,11 @@ def prepare_runtime_for_user(
         if staff_access:
             block_wrappers.append(partial(add_staff_markup, user, disable_staff_debug_info))
 
-    field_data = DateLookupFieldData(block._field_data, course_id, user)  # pylint: disable=protected-access
-    field_data = LmsFieldData(field_data, student_data)
-
     store = modulestore()
 
     services = {
         'fs': FSService(),
-        'field-data': field_data,
+        'field-data': student_data,
         'mako': mako_service,
         'user': DjangoXBlockUserService(
             user,
@@ -601,8 +595,6 @@ def prepare_runtime_for_user(
 
     block.runtime.set('position', position)
 
-    return field_data
-
 
 # TODO: Find all the places that this method is called and figure out how to
 # get a loaded course passed into it
@@ -619,7 +611,7 @@ def get_block_for_descriptor_internal(user, block, student_data, course_id, trac
         request_token (str): A unique token for this request, used to isolate xblock rendering
     """
 
-    student_data = prepare_runtime_for_user(
+    prepare_runtime_for_user(
         user=user,
         student_data=student_data,  # These have implicit user bindings, the rest of args are considered not to
         block=block,
@@ -644,8 +636,6 @@ def get_block_for_descriptor_internal(user, block, student_data, course_id, trac
             partial(LmsFieldData, student_data=student_data),
         ],
     )
-
-    block.scope_ids = block.scope_ids._replace(user_id=user.id)
 
     # Do not check access when it's a noauth request.
     # Not that the access check needs to happen after the block is bound

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -105,7 +105,6 @@ TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
 
 @XBlock.needs('fs')
-@XBlock.needs('field-data')
 @XBlock.needs('mako')
 @XBlock.needs('user')
 @XBlock.needs('verification')

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -2283,7 +2283,7 @@ class LMSXBlockServiceMixin(SharedModuleStoreTestCase):
         """
         Instantiate the runtem.
         """
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,
@@ -2654,7 +2654,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         self.track_function = Mock()
         self.request_token = Mock()
         self.contentstore = contentstore()
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,
@@ -2682,7 +2682,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         if is_staff:
             self.user = StaffFactory(course_key=self.course.id)
 
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,
@@ -2704,7 +2704,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         if is_global_staff:
             self.user = GlobalStaffFactory.create()
 
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,
@@ -2724,7 +2724,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         if is_beta_tester:
             self.user = BetaTesterFactory(course_key=self.course.id)
 
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,
@@ -2745,7 +2745,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         if is_instructor:
             self.user = InstructorFactory(course_key=self.course.id)
 
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,
@@ -2774,7 +2774,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         anonymous_student_id value.
         """
 
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.problem_block,
@@ -2788,7 +2788,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID
         ) == anonymous_id_for_user(self.user, None)
 
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,
@@ -2808,7 +2808,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         ) == anonymous_id_for_user(self.user, None)
 
     def test_user_service_with_anonymous_user(self):
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             AnonymousUser(),
             self.student_data,
             self.block,
@@ -2837,7 +2837,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
 
         Newer code should use the user service, which gets tested in test_user_service.py
         """
-        _ = render.prepare_runtime_for_user(
+        render.prepare_runtime_for_user(
             self.user,
             self.student_data,
             self.block,

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -354,7 +354,7 @@ class IndexQueryTestCase(ModuleStoreTestCase):
         self.client.login(username=self.user.username, password=self.user_password)
         CourseEnrollment.enroll(self.user, course.id)
 
-        with self.assertNumQueries(203, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
+        with self.assertNumQueries(177, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             with check_mongo_calls(3):
                 url = reverse(
                     'courseware_section',

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -274,7 +274,7 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
     def test_schedule_context(self):
         resolver = self.create_resolver()
         # using this to make sure the select_related stays intact
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(30):
             sc = resolver.get_schedules()
             schedules = list(sc)
         apple_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/store_apple_229x78.jpg'

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -49,7 +49,7 @@ class TestCourseUpdatesPage(BaseCourseUpdatesTestCase):
 
         # Fetch the view and verify that the query counts haven't changed
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(54, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
+        with self.assertNumQueries(52, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             with check_mongo_calls(3):
                 url = course_updates_url(self.course)
                 self.client.get(url)

--- a/xmodule/services.py
+++ b/xmodule/services.py
@@ -201,7 +201,7 @@ class RebindUserService(Service):
         with modulestore().bulk_operations(self.course_id):
             course = modulestore().get_course(course_key=self.course_id)
 
-        inner_student_data = self._ref["prepare_runtime_for_user"](
+        self._ref["prepare_runtime_for_user"](
             user=real_user,
             student_data=student_data_real_user,  # These have implicit user bindings, rest of args considered not to
             block=block,
@@ -215,11 +215,9 @@ class RebindUserService(Service):
             [
                 partial(DateLookupFieldData, course_id=self.course_id, user=self.user),
                 partial(OverrideFieldData.wrap, real_user, course),
-                partial(LmsFieldData, student_data=inner_student_data),
+                partial(LmsFieldData, student_data=student_data_real_user),
             ],
         )
-
-        block.scope_ids = block.scope_ids._replace(user_id=real_user.id)
 
 
 class EventPublishingService(Service):


### PR DESCRIPTION
## Description

The goal of FC-0026 is to remove the XBlock-specific handling from the prepare_runtime_for_user function. This part handles the `field-data`. Please take a look at the review comments that explain each significant change.

## Supporting information

Private-ref: [BB-7448](https://tasks.opencraft.com/browse/BB-7448)

## Testing instructions

Ensure that XBlocks work correctly in the LMS, Preview, and Studio. Check that importing and exporting the course works.