### PR TITLE
feat!: remove block handling from runtime initialization of ReplaceURLService [FC-0026]

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -162,8 +162,6 @@ def _prepare_runtime_for_preview(request, block, field_data):
     course_id = block.location.course_key
     display_name_only = (block.category == 'static_tab')
 
-    replace_url_service = ReplaceURLService(course_id=course_id)
-
     wrappers = [
         # This wrapper wraps the block in the template specified above
         partial(
@@ -176,7 +174,7 @@ def _prepare_runtime_for_preview(request, block, field_data):
 
         # This wrapper replaces urls in the output that start with /static
         # with the correct course-specific url for the static content
-        partial(replace_urls_wrapper, replace_url_service=replace_url_service, static_replace_only=True),
+        partial(replace_urls_wrapper, replace_url_service=ReplaceURLService, static_replace_only=True),
         _studio_wrap_xblock,
     ]
 
@@ -215,7 +213,7 @@ def _prepare_runtime_for_preview(request, block, field_data):
         "teams_configuration": TeamsConfigurationService(),
         "sandbox": SandboxService(contentstore=contentstore, course_id=course_id),
         "cache": CacheService(cache),
-        'replace_urls': replace_url_service
+        'replace_urls': ReplaceURLService
     }
 
     block.runtime.get_block_for_descriptor = partial(_load_preview_block, request)

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -292,7 +292,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
 
     def test_replace_urls(self):
         html = '<a href="/static/id">'
-        assert self.block.runtime.replace_urls(html) == \
+        assert self.block.runtime.service(self.block, 'replace_urls').replace_urls(html) == \
             static_replace.replace_static_urls(html, course_id=self.course.id)
 
     def test_anonymous_user_id_preview(self):

--- a/common/djangoapps/static_replace/wrapper.py
+++ b/common/djangoapps/static_replace/wrapper.py
@@ -7,6 +7,6 @@ from openedx.core.lib.xblock_utils import wrap_fragment
 
 def replace_urls_wrapper(block, view, frag, context, replace_url_service, static_replace_only=False):  # pylint: disable=unused-argument
     """
-    Replace any static/course/jump-to-id URLs in XBlock to absolute URLs
+    Replace any static/course/jump-to-id URLs in XBlock to absolute URLs.
     """
-    return wrap_fragment(frag, replace_url_service.replace_urls(frag.content, static_replace_only))
+    return wrap_fragment(frag, replace_url_service(xblock=block).replace_urls(frag.content, static_replace_only))

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -58,7 +58,6 @@ from xmodule.modulestore.tests.test_asides import AsideTestType  # lint-amnesty,
 from xmodule.services import RebindUserServiceError
 from xmodule.video_block import VideoBlock  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.x_module import STUDENT_VIEW, DescriptorSystem  # lint-amnesty, pylint: disable=wrong-import-order
-from common.djangoapps import static_replace
 from common.djangoapps.course_modes.models import CourseMode  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.student.tests.factories import (
     BetaTesterFactory,
@@ -2895,22 +2894,6 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
     def test_cache(self):
         assert hasattr(self.block.runtime.cache, 'get')
         assert hasattr(self.block.runtime.cache, 'set')
-
-    def test_replace_urls(self):
-        html = '<a href="/static/id">'
-        assert self.block.runtime.replace_urls(html) == \
-            static_replace.replace_static_urls(html, course_id=self.course.id)
-
-    def test_replace_course_urls(self):
-        html = '<a href="/course/id">'
-        assert self.block.runtime.replace_course_urls(html) == \
-            static_replace.replace_course_urls(html, course_key=self.course.id)
-
-    def test_replace_jump_to_id_urls(self):
-        html = '<a href="/jump_to_id/id">'
-        jump_to_id_base_url = reverse('jump_to_id', kwargs={'course_id': str(self.course.id), 'module_id': ''})
-        assert self.block.runtime.replace_jump_to_id_urls(html) == \
-            static_replace.replace_jump_to_id_urls(html, self.course.id, jump_to_id_base_url)
 
     @XBlock.register_temp_plugin(PureXBlock, 'pure')
     @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -11,7 +11,6 @@ from django.utils.functional import cached_property
 from fs.memoryfs import MemoryFS
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
-from common.djangoapps.static_replace.services import ReplaceURLService
 from common.djangoapps.student.models import anonymous_id_for_user
 from openedx.core.djangoapps.xblock.apps import get_xblock_app_config
 
@@ -161,39 +160,6 @@ class RuntimeShim:
         # The older ImportSystem runtime could do this because it stored the course_id
         # as part of the runtime.
         raise NotImplementedError("This newer runtime does not support process_xml()")
-
-    def replace_urls(self, html_str):
-        """
-        Deprecated in favor of the replace_urls service.
-        """
-        warnings.warn(
-            'replace_urls is deprecated. Please use ReplaceURLService instead.',
-            DeprecationWarning, stacklevel=3,
-        )
-        return ReplaceURLService(
-            xblock=self._active_block,
-            lookup_asset_url=self._lookup_asset_url
-        ).replace_urls(html_str)
-
-    def replace_course_urls(self, html_str):
-        """
-        Deprecated in favor of the replace_urls service.
-        """
-        warnings.warn(
-            'replace_course_urls is deprecated. Please use ReplaceURLService instead.',
-            DeprecationWarning, stacklevel=3,
-        )
-        return html_str
-
-    def replace_jump_to_id_urls(self, html_str):
-        """
-        Deprecated in favor of the replace_urls service.
-        """
-        warnings.warn(
-            'replace_jump_to_id_urls is deprecated. Please use ReplaceURLService instead.',
-            DeprecationWarning, stacklevel=3,
-        )
-        return html_str
 
     @property
     def resources_fs(self):

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1293,51 +1293,6 @@ class ModuleSystemShim:
         return self._runtime_services.get('cache') or self._services.get('cache') or DoNothingCache()
 
     @property
-    def replace_urls(self):
-        """
-        Returns a function to replace static urls with course specific urls.
-
-        Deprecated in favor of the replace_urls service.
-        """
-        warnings.warn(
-            'runtime.replace_urls is deprecated. Please use the replace_urls service instead.',
-            DeprecationWarning, stacklevel=2,
-        )
-        replace_urls_service = self._runtime_services.get('replace_urls') or self._services.get('replace_urls')
-        if replace_urls_service:
-            return partial(replace_urls_service.replace_urls, static_replace_only=True)
-
-    @property
-    def replace_course_urls(self):
-        """
-        Returns a function to replace static urls with course specific urls.
-
-        Deprecated in favor of the replace_urls service.
-        """
-        warnings.warn(
-            'runtime.replace_course_urls is deprecated. Please use the replace_urls service instead.',
-            DeprecationWarning, stacklevel=2,
-        )
-        replace_urls_service = self._runtime_services.get('replace_urls') or self._services.get('replace_urls')
-        if replace_urls_service:
-            return partial(replace_urls_service.replace_urls)
-
-    @property
-    def replace_jump_to_id_urls(self):
-        """
-        Returns a function to replace static urls with course specific urls.
-
-        Deprecated in favor of the replace_urls service.
-        """
-        warnings.warn(
-            'runtime.replace_jump_to_id_urls is deprecated. Please use the replace_urls service instead.',
-            DeprecationWarning, stacklevel=2,
-        )
-        replace_urls_service = self._runtime_services.get('replace_urls') or self._services.get('replace_urls')
-        if replace_urls_service:
-            return partial(replace_urls_service.replace_urls)
-
-    @property
     def filestore(self):
         """
         A filestore ojbect. Defaults to an instance of OSFS based at settings.DATA_DIR.


### PR DESCRIPTION
## Description

The goal of FC-0026 is to remove the XBlock-specific handling from the prepare_runtime_for_user function. This part handles the `ReplaceURLService`.

## Supporting information

Private-ref: [BB-7448](https://tasks.opencraft.com/browse/BB-7448)

## Testing instructions

1. Install `xblock-utils` from https://github.com/openedx/xblock-utils/pull/207.
2. Install `edx-sga==0.22.0` (https://github.com/mitodl/edx-sga/pull/339).
3. Set up the `edx-sga` XBlock and test that replacing URLs in the `Solution` field:
    1. If you're using the Demo course, add `<img src="/static/images_course_image.jpg" />` and check that the image is rendered in Studio, Preview, and LMS. If you're using a custom course, you can upload an image under `Content -> Files & Uploads` in Studio.
    2. Within the demo course, add the `<a href="/jump_to_id/vertical_0270f6de40fc">link</a>` link and see if it's redirecting users to the "Introduction: Video and Sequences" unit in LMS and Preview. This feature doesn't work in Studio.

## Other information

This change is backward-incompatible with the deprecated shims for replacing URLs directly from the runtime. We're removing them to make the runtime block-agnostic.