### PR TITLE
feat!: Upgrading django-storages version.

### DIFF
--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -233,7 +233,7 @@ class ReportStore:
             return DjangoStorageReportStore(
                 storage_class=DJANGO_STORE_STORAGE_CLASS,
                 storage_kwargs={
-                    'bucket': config['BUCKET'],
+                    'bucket_name': config['BUCKET'],
                     'location': config['ROOT_PATH'],
                     'custom_domain': config.get("CUSTOM_DOMAIN", None),
                     'querystring_expire': 300,

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,8 +20,7 @@ celery>=5.2.2,<6.0.0
 click>=8.0,<9.0
 
 # django-storages version 1.9 drops support for boto storage backend.
-# 1.9 gives an error for details https://github.com/jschneier/django-storages/issues/831
-django-storages==1.9.1
+django-storages==1.10.1
 
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -28,7 +28,7 @@ lxml==4.9.2
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   openedx-calc
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   chem
     #   openedx-calc
@@ -66,7 +66,7 @@ python-dateutil==2.8.2
     # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2023.5.5
+regex==2023.6.3
     # via nltk
 scipy==1.7.3
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,8 +51,10 @@ babel==2.11.0
     #   enmerkar-underscore
 backoff==1.10.0
     # via analytics-python
-backports-zoneinfo==0.2.1
-    # via icalendar
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   icalendar
+    #   kombu
 beautifulsoup4==4.12.2
     # via pynliner
 billiard==3.6.4.0
@@ -363,7 +365,7 @@ django-statici18n==2.3.1
     #   -r requirements/edx/base.in
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.9.1
+django-storages==1.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
@@ -661,7 +663,7 @@ jsonschema==4.17.3
     # via optimizely-sdk
 jwcrypto==1.5.0
     # via pylti1p3
-kombu==5.2.4
+kombu==5.3.0
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/base.in
@@ -712,7 +714,7 @@ markdown==3.3.7
     #   xblock-poll
 markey==0.8
     # via enmerkar-underscore
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/edx/paver.txt
     #   chem
@@ -771,7 +773,9 @@ openedx-blockstore==1.3.1
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-django-pyfs==3.2.1
-    # via xblock
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   xblock
 openedx-django-require==2.0.0
     # via -r requirements/edx/base.in
 openedx-django-wiki==2.0.0
@@ -975,7 +979,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.in
-rapidfuzz==3.0.0
+rapidfuzz==3.1.0
     # via levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
@@ -983,7 +987,7 @@ redis==4.5.5
     # via
     #   -r requirements/edx/base.in
     #   walrus
-regex==2023.5.5
+regex==2023.6.3
     # via nltk
 requests==2.31.0
     # via
@@ -1137,8 +1141,11 @@ typing-extensions==4.6.3
     # via
     #   asgiref
     #   django-countries
+    #   kombu
     #   pylti1p3
     #   snowflake-connector-python
+tzdata==2023.3
+    # via backports-zoneinfo
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.in

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -12,7 +12,7 @@ diff-cover==7.5.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.2
     # via diff-cover
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 pluggy==1.0.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -79,10 +79,11 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   analytics-python
-backports-zoneinfo==0.2.1
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   icalendar
+    #   kombu
 beautifulsoup4==4.12.2
     # via
     #   -r requirements/edx/testing.txt
@@ -474,7 +475,7 @@ django-statici18n==2.3.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.9.1
+django-storages==1.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
@@ -726,11 +727,11 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.95.2
+fastapi==0.96.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -887,7 +888,7 @@ jwcrypto==1.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylti1p3
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   celery
@@ -952,7 +953,7 @@ markey==0.8
     # via
     #   -r requirements/edx/testing.txt
     #   enmerkar-underscore
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/edx/testing.txt
     #   chem
@@ -1029,6 +1030,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
 openedx-django-pyfs==3.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   xblock
 openedx-django-require==2.0.0
@@ -1362,7 +1364,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/testing.txt
-rapidfuzz==3.0.0
+rapidfuzz==3.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   levenshtein
@@ -1372,7 +1374,7 @@ redis==4.5.5
     # via
     #   -r requirements/edx/testing.txt
     #   walrus
-regex==2023.5.5
+regex==2023.6.3
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1635,12 +1637,17 @@ typing-extensions==4.6.3
     #   django-countries
     #   grimp
     #   import-linter
+    #   kombu
     #   mypy
     #   pydantic
     #   pylint
     #   pylti1p3
     #   snowflake-connector-python
     #   starlette
+tzdata==2023.3
+    # via
+    #   -r requirements/edx/testing.txt
+    #   backports-zoneinfo
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -46,7 +46,7 @@ jinja2==3.1.2
     # via
     #   code-annotations
     #   sphinx
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 packaging==23.1
     # via

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -18,7 +18,7 @@ lazy==1.5
     # via -r requirements/edx/paver.in
 libsass==0.10.0
     # via -r requirements/edx/paver.in
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via -r requirements/edx/paver.in
 mock==5.0.2
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -74,10 +74,11 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-backports-zoneinfo==0.2.1
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/base.txt
     #   icalendar
+    #   kombu
 beautifulsoup4==4.12.2
     # via
     #   -r requirements/edx/base.txt
@@ -454,7 +455,7 @@ django-statici18n==2.3.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.9.1
+django-storages==1.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -700,9 +701,9 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==18.10.0
+faker==18.10.1
     # via factory-boy
-fastapi==0.95.2
+fastapi==0.96.0
     # via pact-python
 fastavro==1.7.4
     # via
@@ -844,7 +845,7 @@ jwcrypto==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   pylti1p3
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -907,7 +908,7 @@ markey==0.8
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar-underscore
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
@@ -977,6 +978,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
 openedx-django-pyfs==3.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   xblock
 openedx-django-require==2.0.0
@@ -1285,7 +1287,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.txt
-rapidfuzz==3.0.0
+rapidfuzz==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   levenshtein
@@ -1295,7 +1297,7 @@ redis==4.5.5
     # via
     #   -r requirements/edx/base.txt
     #   walrus
-regex==2023.5.5
+regex==2023.6.3
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1515,11 +1517,16 @@ typing-extensions==4.6.3
     #   django-countries
     #   grimp
     #   import-linter
+    #   kombu
     #   pydantic
     #   pylint
     #   pylti1p3
     #   snowflake-connector-python
     #   starlette
+tzdata==2023.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   backports-zoneinfo
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
WIP

https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#1101-2020-09-13

It has breaking changes.


```
/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/storages/backends/s3boto3.py:340: UserWarning: 
The default behavior of S3Boto3Storage is insecure and will change in django-storages 1.10. By default files 
and new buckets are saved with an ACL of 'public-read' (globally publicly readable). Version 1.10 will default to
 using the bucket's ACL. To opt into the new behavior set AWS_DEFAULT_ACL = None, otherwise to silence this 
warning explicitly set AWS_DEFAULT_ACL.
```