### PR TITLE
fix: when no option selected, the criteria should try to create

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -305,7 +305,8 @@ class StaffAssessSerializer(serializers.Serializer):
     def get_options_selected(self, instance):
         options_selected = {}
         for criterion in instance.get("criteria"):
-            options_selected[criterion["name"]] = criterion["selectedOption"]
+            if criterion["selectedOption"]:
+                options_selected[criterion["name"]] = criterion["selectedOption"]
 
         return options_selected
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -718,6 +718,13 @@ class TestStaffAssessSerializer(TestCase):
         ],
     }
 
+    grade_data_no_selected_option = {
+        "overallFeedback": "was pretty good",
+        "criteria": [
+            {"name": "firstCriterion", "selectedOption": None},
+        ],
+    }
+
     submission_uuid = "foo"
 
     def test_staff_assess_serializer(self):
@@ -752,6 +759,21 @@ class TestStaffAssessSerializer(TestCase):
             },
             "criterion_feedback": {},
             "overall_feedback": "",
+            "submission_uuid": self.submission_uuid,
+            "assess_type": "full-grade",
+        }
+
+        assert serializer.data == expected_value
+
+    def test_staff_assess_no_selected_option(self):
+        """When selected option is None, it should be ignored"""
+        context = {"submission_uuid": self.submission_uuid}
+        serializer = StaffAssessSerializer(self.grade_data_no_selected_option, context=context)
+
+        expected_value = {
+            "options_selected": {},
+            "criterion_feedback": {},
+            "overall_feedback": "was pretty good",
             "submission_uuid": self.submission_uuid,
             "assess_type": "full-grade",
         }


### PR DESCRIPTION
When selectedOption is empty from the client side, we shouldn't include in the criteria map. Assuming it already pass the validation from the client side.

### Steps to reproduce this issue:

1. As an instructor, create an ORA. (Note: I selected "Self assessment to Peer" in my test. Presumably this issue will be repro-able even if just Staff assessment is selected but noting in case it's something specific to when both assessment steps are enabled.)
2. Click to edit the ORA.
3. Go to the Assessment Steps tab.
4. Check the box next to "Staff assessment".
5. Under Rubric, click on the "X" to delete the first criterion.
6. Click on the "X" next to delete the last criterion's options (Options are where points are specified).
7. Change "Feedback for this criterion" to "Required".
8. Save and publish your changes.
9. As a learner, go to the ORA assignment and submit something so it can be "graded".
10. (If you've got peers enabled to, you'll need to grade some peers now. Otherwise can skip.)
11. As an instructor, go to the ORA assignment and click on "Grade available responses."
12. Get redirected to the Enhanced Staff Grader page.
13. Check the box next to a learner's name. 
14. Click on "View Selected Responses".
15. Click on "Start grading".
16. See the Rubric on the side.
17. Add some comments under "Provide feedback".
18. Add optional comments under "Overall comments".
19. Click "Submit grade".

Ticket: https://2u-internal.atlassian.net/browse/AU-878
Related PR: https://github.com/openedx/frontend-app-ora-grading/pull/187