### PR TITLE
fix: call signal once entry is saved

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -654,13 +654,13 @@ class PersistentCourseGrade(TimeStampedModel):
                 course_id=course_id,
                 user_id=user_id
             )
+            grade.passed_timestamp = now()
+            grade.save()
             COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY.send(
                 sender=None,
                 user_id=user_id,
                 course_id=course_id,
             )
-            grade.passed_timestamp = now()
-            grade.save()
 
         cls._emit_grade_calculated_event(grade)
         cls._update_cache(course_id, user_id, grade)


### PR DESCRIPTION
`COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY` signal was being called before the save of `PersistentCourseGrade` model object which is resulting in a bug that the `PersistentCourseGrade` object from the database is not found in the receiver. 
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
