### PR TITLE
fix: update name of topic used to publish `CERTIFICATE_CREATED` events

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -169,7 +169,7 @@ def listen_for_certificate_created_event(sender, signal, **kwargs):
     if SEND_CERTIFICATE_CREATED_SIGNAL.is_enabled():
         get_producer().send(
             signal=CERTIFICATE_CREATED,
-            topic='certificates',
+            topic='learning-certificate-lifecycle',
             event_key_field='certificate.course.course_key',
             event_data={'certificate': kwargs['certificate']},
             event_metadata=kwargs['metadata']

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -513,5 +513,5 @@ class CertificateEventBusTests(ModuleStoreTestCase):
         data = mock_producer.return_value.send.call_args.kwargs
         assert data['signal'].event_type == CERTIFICATE_CREATED.event_type
         assert data['event_data']['certificate'] == expected_certificate_data
-        assert data['topic'] == 'certificates'
+        assert data['topic'] == 'learning-certificate-lifecycle'
         assert data['event_key_field'] == 'certificate.course.course_key'


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

[APER-2347]

This PR updates the name of the topic we are publishing our `CERTIFICATE_CREATED` events to. We had put a very generic name when writing the publishing code (and this was way before the actual topic was created). Now that the Confluent configuration is ready we need to update the name in our publishing code.