### PR TITLE
feat: trigger signals to import and delete course details

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -6,6 +6,7 @@ Signal handler for invalidating cached course overviews
 import logging
 
 from django.db import transaction
+from django.db.models.signals import post_save
 from django.dispatch import Signal
 from django.dispatch.dispatcher import receiver
 
@@ -20,6 +21,10 @@ LOG = logging.getLogger(__name__)
 COURSE_START_DATE_CHANGED = Signal()
 # providing_args=["updated_course_overview", "previous_self_paced"]
 COURSE_PACING_CHANGED = Signal()
+# providing_args=["courserun_key"]
+IMPORT_COURSE_DETAILS = Signal()
+# providing_args=["courserun_key"]
+DELETE_COURSE_DETAILS = Signal()
 
 
 @receiver(SignalHandler.course_published)
@@ -43,6 +48,26 @@ def _listen_for_course_delete(sender, course_key, **kwargs):  # pylint: disable=
     invalidates the corresponding CourseOverview cache entry if one exists.
     """
     CourseOverview.objects.filter(id=course_key).delete()
+    courserun_key = str(course_key)
+    LOG.info(f'DELETE_COURSE_DETAILS triggered upon course_deleted signal. Key: [{courserun_key}]')
+    DELETE_COURSE_DETAILS.send(
+        sender=None,
+        courserun_key=courserun_key,
+    )
+
+
+@receiver(post_save, sender=CourseOverview)
+def trigger_import_course_details_signal(sender, instance, created, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
+    """
+    Triggers the `IMPORT_COURSE_DETAILS` signal which will be handled in `federated_content_connector` plugin
+    """
+    if created:
+        courserun_key = str(instance.id)
+        LOG.info(f'IMPORT_COURSE_DETAILS triggered upon CourseOverview.post_save signal. Key: [{courserun_key}]')
+        IMPORT_COURSE_DETAILS.send(
+            sender=None,
+            courserun_key=courserun_key,
+        )
 
 
 def _check_for_course_changes(previous_course_overview, updated_course_overview):


### PR DESCRIPTION
**Description:** Trigger signal whenever a `CourseOverview` object is created or deleted so that we can act accordingly in the the [plugin](https://github.com/openedx/edx-platform/pull/32389).

**JIRA:** https://2u-internal.atlassian.net/browse/ENT-7163

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Tested the signals in devstck.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
