### PR TITLE
feat: default grade designations configurable from settings

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
@@ -40,3 +40,6 @@ class CourseGradingSerializer(serializers.Serializer):
     course_details = CourseGradingModelSerializer()
     show_credit_eligibility = serializers.BooleanField()
     is_credit_course = serializers.BooleanField()
+    default_grade_designations = serializers.ListSerializer(
+        child=serializers.CharField()
+    )

--- a/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
@@ -85,7 +85,8 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
                 "minimum_grade_credit": 0.7
             },
             "show_credit_eligibility": false,
-            "is_credit_course": true
+            "is_credit_course": true,
+            "default_grade_designations": ["A","B","C","D"]
         }
         ```
         """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
@@ -42,10 +42,21 @@ class CourseGradingViewTest(CourseTestCase, PermissionAccessMixin):
             "course_details": grading_data.__dict__,
             "show_credit_eligibility": False,
             "is_credit_course": False,
+            "default_grade_designations": ['A', 'B', 'C', 'D'],
         }
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(expected_response, response.data)
+
+    @patch("django.conf.settings.DEFAULT_GRADE_DESIGNATIONS", ['A', 'B'])
+    def test_default_grade_designations_setting(self):
+        """
+        Check that DEFAULT_GRADE_DESIGNATIONS setting reflects correctly in API.
+        """
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(['A', 'B'], response.data["default_grade_designations"])
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREDIT_ELIGIBILITY": True})
     def test_credit_eligibility_setting(self):

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1486,7 +1486,8 @@ def get_course_grading(course_key):
         'grading_url': reverse_course_url('grading_handler', course_key),
         'is_credit_course': is_credit_course(course_key),
         'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_key),
-        'course_assignment_lists': dict(course_assignment_lists)
+        'course_assignment_lists': dict(course_assignment_lists),
+        'default_grade_designations': settings.DEFAULT_GRADE_DESIGNATIONS
     }
 
     return grading_context

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2439,6 +2439,15 @@ SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = 'edx.lms.core.default'
 # Rate limit for regrading tasks that a grading policy change can kick off
 POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
 
+# .. setting_name: DEFAULT_GRADE_DESIGNATIONS
+# .. setting_default: ['A', 'B', 'C', 'D']
+# .. setting_description: The default 'pass' grade cutoff designations to be used. The failure grade
+#     is always 'F' and should not be included in this list.
+# .. setting_warning: The DEFAULT_GRADE_DESIGNATIONS list must have more than one designation,
+#     or else ['A', 'B', 'C', 'D'] will be used as the default grade designations. Also, only the first
+#     11 grade designations are used by the UI, so it's advisable to restrict the list to 11 items.
+DEFAULT_GRADE_DESIGNATIONS = ['A', 'B', 'C', 'D']
+
 ############## Settings for CourseGraph ############################
 
 # .. setting_name: COURSEGRAPH_JOB_QUEUE

--- a/cms/static/js/factories/settings_graders.js
+++ b/cms/static/js/factories/settings_graders.js
@@ -3,7 +3,7 @@ define([
 ], function($, GradingView, CourseGradingPolicyModel) {
     'use strict';
 
-    return function(courseDetails, gradingUrl, courseAssignmentLists) {
+    return function(courseDetails, gradingUrl, courseAssignmentLists, gradeDesignations) {
         var model, editor;
 
         $('form :input')
@@ -19,7 +19,8 @@ define([
         editor = new GradingView({
             el: $('.settings-grading'),
             model: model,
-            courseAssignmentLists: courseAssignmentLists
+            courseAssignmentLists: courseAssignmentLists,
+            gradeDesignations: gradeDesignations
         });
         editor.render();
     };

--- a/cms/static/js/views/settings/grading.js
+++ b/cms/static/js/views/settings/grading.js
@@ -34,6 +34,7 @@ function(ValidatingView, _, $, ui, GraderView, StringUtils, HtmlUtils) {
                 $('#course_grade_cutoff-tpl').text()
             );
             this.setupCutoffs();
+            this.setupGradeDesignations(options.gradeDesignations);
 
             this.listenTo(this.model, 'invalid', this.handleValidationError);
             this.listenTo(this.model, 'change', this.showNotificationBar);
@@ -318,7 +319,7 @@ function(ValidatingView, _, $, ui, GraderView, StringUtils, HtmlUtils) {
         addNewGrade: function(e) {
             e.preventDefault();
             var gradeLength = this.descendingCutoffs.length; // cutoffs doesn't include fail/f so this is only the passing grades
-            if (gradeLength > 3) {
+            if (gradeLength > this.GRADES.length - 1) {
             // TODO shouldn't we disable the button
                 return;
             }
@@ -398,6 +399,9 @@ function(ValidatingView, _, $, ui, GraderView, StringUtils, HtmlUtils) {
             }
             this.descendingCutoffs = _.sortBy(this.descendingCutoffs,
                 function(gradeEle) { return -gradeEle.cutoff; });
+        },
+        setupGradeDesignations: function(gradeDesignations) {
+            if (Array.isArray(gradeDesignations) && gradeDesignations.length > 1) { this.GRADES = gradeDesignations.slice(0, 11); }
         },
         revertView: function() {
             var self = this;

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -777,23 +777,23 @@
                 height: 17px;
               }
 
-              &:nth-child(1) {
+              &:nth-child(5n+1) {
                 background: #4fe696;
               }
 
-              &:nth-child(2) {
+              &:nth-child(5n+2) {
                 background: #ffdf7e;
               }
 
-              &:nth-child(3) {
+              &:nth-child(5n+3) {
                 background: #ffb657;
               }
 
-              &:nth-child(4) {
+              &:nth-child(5n+4) {
                 background: #ef54a1;
               }
 
-              &:nth-child(5),
+              &:nth-child(5n+5),
               &.bar-fail {
                 background: #fb336c;
               }

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -37,6 +37,7 @@
             ),
             "${grading_url | n, js_escaped_string}",
             ${course_assignment_lists | n, dump_js_escaped_json},
+            ${default_grade_designations | n, dump_js_escaped_json},
         );
     });
 </%block>


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Currently a maximum of 5 grade cutoffs are configurable from the Grading Settings in Studio.
However, some universities might require more that 5 cutoffs depending on their grading policy.

Also, when a new grade cutoff is added, a default grade desgination is assigned to this cufoff. These default grade designations are hard coded in the javascript code. This means, if the maximum number of grade cutoff are to be increased, more default grade designations also need to be defined.

This PR address this issue.

In this PR, a new setting `DEFAULT_GRADE_DESIGNATIONS` is introduced which can be used to define the pass grade designations. This has a default value of `['A', 'B', 'C', 'D']`, which is the current default.

The maximum number of grade cutoffs is now dependent on the length of the grade designations list, instead of being hard-coded to 5.

As before, the failure grade designation is always set to `F` which cannot be changed and is not to be included in the `DEFAULT_GRADE_DESIGNATIONS` list.

Ex. If there is a need to configure 7 grade cutoffs instead of the default 5, the following setting can be used:
```
DEFAULT_GRADE_DESIGNATIONS = ['A+', 'A', 'B+', 'B', 'C', 'D']
```

The `DEFAULT_GRADE_DESIGNATIONS` list must have more than 1 desginations, otherwise the default grade designations falls back to `['A', 'B', 'C', 'D']`.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

### Default Scenario
1. Start studio in devstack using the PR branch
2. Open an exisiting course or create a new one.
3. Go to `Settings` --> `Grading`
4. Click on the `+` button repeatedly to add new grade cutoffs
5. Verify that maximum 5 grade cutoff designations are configurable with the values `'A', 'B', 'C', 'D' and 'F'`

### Modify Grade Designations
1. Add this to `cms\envs\devstack.py` : `DEFAULT_GRADE_DESIGNATIONS = ['A+', 'A', 'B+', 'B', 'C', 'D']`
2. Start studio in devstack using the PR branch
3. Open an exisiting course or create a new one.
4. Go to `Settings` --> `Grading`
5. Click on the `+` button repeatedly to add new grade cutoffs
6. Verify that maximum 7 grade cutoff designations are configurable with the values `'A+', 'A', 'B+', 'B', 'C', 'D' and 'F'`

### Grade Designations Fallback
1. Add this to `cms\envs\devstack.py` : `DEFAULT_GRADE_DESIGNATIONS = ['A+']`
2. Start studio in devstack using the PR branch
3. Open an exisiting course or create a new one.
4. Go to `Settings` --> `Grading`
5. Click on the `+` button repeatedly to add new grade cutoffs
6. Verify that maximum 5 grade cutoff designations are configurable with the values `'A', 'B', 'C', 'D' and 'F'`

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

OpenCraft internal ticket : [BB-7378](https://tasks.opencraft.com/browse/BB-7378)
