### PR TITLE
refactor: removed notification app urls from cms

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -332,4 +332,3 @@ urlpatterns.extend(get_plugin_url_patterns(ProjectType.CMS))
 urlpatterns += [
     path('api/contentstore/', include('cms.djangoapps.contentstore.rest_api.urls'))
 ]
-

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -332,6 +332,4 @@ urlpatterns.extend(get_plugin_url_patterns(ProjectType.CMS))
 urlpatterns += [
     path('api/contentstore/', include('cms.djangoapps.contentstore.rest_api.urls'))
 ]
-urlpatterns += [
-    path('api/notifications/', include('openedx.core.djangoapps.notifications.urls')),
-]
+


### PR DESCRIPTION
### Description 
There is no use case right now for notification URLs in cms so this PR removes these URLs. 