### PR TITLE
feat: create user profile if not found in current job command

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/populate_enterprise_learner_current_job.py
+++ b/openedx/core/djangoapps/user_api/management/commands/populate_enterprise_learner_current_job.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from common.djangoapps.student.models import User
+from common.djangoapps.student.models import User, UserProfile
 from openedx.core.djangoapps.user_api import errors
 
 LOGGER = logging.getLogger(__name__)
@@ -66,10 +66,12 @@ class Command(BaseCommand):
         Helper method to return the user profile object based on username.
         """
         try:
-            user = User.objects.filter(username=username).select_related('profile').first()
+            existing_user = User.objects.get(username=username)
         except ObjectDoesNotExist:
             raise errors.UserNotFound()  # lint-amnesty, pylint: disable=raise-missing-from
-        return user.profile
+
+        existing_user_profile, _ = UserProfile.objects.get_or_create(user=existing_user)
+        return existing_user_profile
 
     def _update_current_job_of_learner(self, username, current_job):
         """


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This pull request adds functionality to create user profile while fetching it through username if it does not exist in the `populate_enterprise_learner_current_job` management command which is used to fetch current job of enterprise learners from course-discovery to LMS.  

## Supporting information

JIRA: [ENT-7260](https://2u-internal.atlassian.net/browse/ENT-7260)

## Related Code
The [prior art](https://github.com/openedx/edx-platform/blob/44d48f63efe8c7bd5f52dbfe3233c726622d63fe/openedx/core/djangoapps/user_api/accounts/api.py#L513) for these changes. 

## Testing instructions

Go to the devstack directory
Run `make dev.shell.lms`
Run `python manage.py lms populate_enterprise_learner_current_job`
