### PR TITLE
chore: adding pin to avoid test failures.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,6 +19,7 @@
 # 5.3.0 versions breaking timezone related tests. Adding pin for time being to clear upgrade pipeline. Unpin above
 # after fixing these failures.
 celery<5.3.0
+kombu=<5.3.0
 
 
 # required for celery>=5.2.0;<5.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,7 +19,7 @@
 # 5.3.0 versions breaking timezone related tests. Adding pin for time being to clear upgrade pipeline. Unpin above
 # after fixing these failures.
 celery<5.3.0
-kombu=<5.3.0
+kombu<5.3.0
 
 
 # required for celery>=5.2.0;<5.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,7 +14,12 @@
 
 # As it is not clarified what exact breaking changes will be introduced as per
 # the next major release, ensure the installed version is within boundaries.
-celery>=5.2.2,<6.0.0
+# celery>=5.2.2,<6.0.0
+
+# 5.3.0 versions breaking timezone related tests. Adding pin for time being to clear upgrade pipeline. Unpin above
+# after fixing these failures.
+celery<5.3.0
+
 
 # required for celery>=5.2.0;<5.3.0
 click>=8.0,<9.0

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -28,7 +28,7 @@ lxml==4.9.2
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   openedx-calc
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   chem
     #   openedx-calc
@@ -66,7 +66,7 @@ python-dateutil==2.8.2
     # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2023.5.5
+regex==2023.6.3
     # via nltk
 scipy==1.7.3
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -164,7 +164,7 @@ cryptography==38.0.4
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.6.0
+cssutils==2.7.1
     # via pynliner
 defusedxml==0.7.1
     # via
@@ -355,7 +355,7 @@ django-simple-history==3.0.0
     #   edx-proctoring
     #   learner-pathway-progress
     #   ora2
-django-splash==1.2.1
+django-splash==1.3.0
     # via -r requirements/edx/base.in
 django-statici18n==2.3.1
     # via
@@ -581,7 +581,7 @@ event-tracking==2.1.0
     #   edx-search
 fastavro==1.7.4
     # via openedx-events
-filelock==3.12.0
+filelock==3.12.2
     # via snowflake-connector-python
 frozenlist==1.3.3
     # via
@@ -662,7 +662,9 @@ jsonschema==4.17.3
 jwcrypto==1.5.0
     # via pylti1p3
 kombu==5.2.4
-    # via celery
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   celery
 laboratory==1.0.2
     # via -r requirements/edx/base.in
 lazy==1.5
@@ -674,7 +676,7 @@ lazy==1.5
     #   xblock
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.in
-levenshtein==0.21.0
+levenshtein==0.21.1
     # via python-levenshtein
 libsass==0.10.0
     # via
@@ -682,7 +684,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.5.2
+lti-consumer-xblock==9.5.3
     # via -r requirements/edx/base.in
 lxml==4.9.2
     # via
@@ -712,7 +714,7 @@ markdown==3.3.7
     #   xblock-poll
 markey==0.8
     # via enmerkar-underscore
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/edx/paver.txt
     #   chem
@@ -927,7 +929,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.21.0
+python-levenshtein==0.21.1
     # via -r requirements/edx/base.in
 python-memcached==1.59
     # via -r requirements/edx/paver.txt
@@ -978,7 +980,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.in
-rapidfuzz==3.0.0
+rapidfuzz==3.1.1
     # via levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
@@ -986,7 +988,7 @@ redis==4.5.5
     # via
     #   -r requirements/edx/base.in
     #   walrus
-regex==2023.5.5
+regex==2023.6.3
     # via nltk
 requests==2.31.0
     # via

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -8,11 +8,11 @@ chardet==5.1.0
     # via diff-cover
 coverage==7.2.7
     # via -r requirements/edx/coverage.in
-diff-cover==7.5.0
+diff-cover==7.6.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.2
     # via diff-cover
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 pluggy==1.0.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -242,7 +242,7 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
-cssutils==2.6.0
+cssutils==2.7.1
     # via
     #   -r requirements/edx/testing.txt
     #   pynliner
@@ -262,7 +262,7 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/testing.txt
     #   jwcrypto
-diff-cover==7.5.0
+diff-cover==7.6.0
     # via -r requirements/edx/testing.txt
 dill==0.3.6
     # via
@@ -466,7 +466,7 @@ django-simple-history==3.0.0
     #   edx-proctoring
     #   learner-pathway-progress
     #   ora2
-django-splash==1.2.1
+django-splash==1.3.0
     # via -r requirements/edx/testing.txt
 django-statici18n==2.3.1
     # via
@@ -726,11 +726,11 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.95.2
+fastapi==0.97.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -738,7 +738,7 @@ fastavro==1.7.4
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
@@ -889,6 +889,7 @@ jwcrypto==1.5.0
     #   pylti1p3
 kombu==5.2.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   celery
 laboratory==1.0.2
@@ -907,7 +908,7 @@ lazy-object-proxy==1.9.0
     #   astroid
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/testing.txt
-levenshtein==0.21.0
+levenshtein==0.21.1
     # via
     #   -r requirements/edx/testing.txt
     #   python-levenshtein
@@ -919,7 +920,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.5.2
+lti-consumer-xblock==9.5.3
     # via -r requirements/edx/testing.txt
 lxml==4.9.2
     # via
@@ -952,7 +953,7 @@ markey==0.8
     # via
     #   -r requirements/edx/testing.txt
     #   enmerkar-underscore
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/edx/testing.txt
     #   chem
@@ -1113,7 +1114,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/edx/testing.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -1167,7 +1168,7 @@ pycryptodomex==3.18.0
     #   lti-consumer-xblock
     #   pyjwkest
     #   snowflake-connector-python
-pydantic==1.10.8
+pydantic==1.10.9
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
@@ -1264,7 +1265,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   edxval
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r requirements/edx/testing.txt
     #   pylint-pytest
@@ -1306,7 +1307,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.21.0
+python-levenshtein==0.21.1
     # via -r requirements/edx/testing.txt
 python-memcached==1.59
     # via -r requirements/edx/testing.txt
@@ -1364,7 +1365,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/testing.txt
-rapidfuzz==3.0.0
+rapidfuzz==3.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   levenshtein
@@ -1374,7 +1375,7 @@ redis==4.5.5
     # via
     #   -r requirements/edx/testing.txt
     #   walrus
-regex==2023.5.5
+regex==2023.6.3
     # via
     #   -r requirements/edx/testing.txt
     #   nltk

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -46,7 +46,7 @@ jinja2==3.1.2
     # via
     #   code-annotations
     #   sphinx
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 packaging==23.1
     # via

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -18,7 +18,7 @@ lazy==1.5
     # via -r requirements/edx/paver.in
 libsass==0.10.0
     # via -r requirements/edx/paver.in
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via -r requirements/edx/paver.in
 mock==5.0.2
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -231,7 +231,7 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
-cssutils==2.6.0
+cssutils==2.7.1
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
@@ -249,7 +249,7 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/base.txt
     #   jwcrypto
-diff-cover==7.5.0
+diff-cover==7.6.0
     # via -r requirements/edx/coverage.txt
 dill==0.3.6
     # via pylint
@@ -446,7 +446,7 @@ django-simple-history==3.0.0
     #   edx-proctoring
     #   learner-pathway-progress
     #   ora2
-django-splash==1.2.1
+django-splash==1.3.0
     # via -r requirements/edx/base.txt
 django-statici18n==2.3.1
     # via
@@ -700,15 +700,15 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==18.10.0
+faker==18.10.1
     # via factory-boy
-fastapi==0.95.2
+fastapi==0.97.0
     # via pact-python
 fastavro==1.7.4
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -846,6 +846,7 @@ jwcrypto==1.5.0
     #   pylti1p3
 kombu==5.2.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   celery
 laboratory==1.0.2
@@ -862,7 +863,7 @@ lazy-object-proxy==1.9.0
     # via astroid
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.txt
-levenshtein==0.21.0
+levenshtein==0.21.1
     # via
     #   -r requirements/edx/base.txt
     #   python-levenshtein
@@ -874,7 +875,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.5.2
+lti-consumer-xblock==9.5.3
     # via -r requirements/edx/base.txt
 lxml==4.9.2
     # via
@@ -907,7 +908,7 @@ markey==0.8
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar-underscore
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
@@ -1054,7 +1055,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   pylint
     #   virtualenv
@@ -1106,7 +1107,7 @@ pycryptodomex==3.18.0
     #   lti-consumer-xblock
     #   pyjwkest
     #   snowflake-connector-python
-pydantic==1.10.8
+pydantic==1.10.9
     # via fastapi
 pygments==2.15.1
     # via
@@ -1190,7 +1191,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r requirements/edx/testing.in
     #   pylint-pytest
@@ -1232,7 +1233,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.21.0
+python-levenshtein==0.21.1
     # via -r requirements/edx/base.txt
 python-memcached==1.59
     # via -r requirements/edx/base.txt
@@ -1287,7 +1288,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.txt
-rapidfuzz==3.0.0
+rapidfuzz==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   levenshtein
@@ -1297,7 +1298,7 @@ redis==4.5.5
     # via
     #   -r requirements/edx/base.txt
     #   walrus
-regex==2023.5.5
+regex==2023.6.3
     # via
     #   -r requirements/edx/base.txt
     #   nltk

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -12,5 +12,5 @@ idna==3.4
     # via requests
 requests==2.31.0
     # via -r scripts/xblock/requirements.in
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests


### PR DESCRIPTION
Added pin for kombu and celery. New version breaking tests with different timezone values. Will fix them in separate PR.

List of packages in the PR without any issue.</br> 
 - `cssutils` changes from `2.6.0` to `2.7.1`
- `diff-cover` changes from `7.5.0` to `7.6.0`
- `django-splash` changes from `1.2.1` to `1.3.0`
- `faker` changes from `18.10.0` to `18.10.1`
- `fastapi` changes from `0.95.2` to `0.97.0`
- `filelock` changes from `3.12.0` to `3.12.2`
- `levenshtein` changes from `0.21.0` to `0.21.1`
- `lti-consumer-xblock` changes from `9.5.2` to `9.5.3`
- `markupsafe` changes from `2.1.2` to `2.1.3`
- `platformdirs` changes from `3.5.1` to `3.5.3`
- `pydantic` changes from `1.10.8` to `1.10.9`
- `pytest` changes from `7.3.1` to `7.3.2`
- `python-levenshtein` changes from `0.21.0` to `0.21.1`
- `rapidfuzz` changes from `3.0.0` to `3.1.1`
- `regex` changes from `2023.5.5` to `2023.6.3`
- `urllib3` changes from `2.0.2` to `2.0.3`