### PR TITLE
fix: Update how we render the error pages.

### DIFF
--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -67,16 +67,16 @@ class MarketingSiteViewTests(TestCase):
         """
         Test the 404 view.
         """
-        url = reverse('static_template_view.views.render_404')
+        url = reverse('render_404')
         resp = self.client.get(url)
-        assert resp.status_code == 200
-        assert resp['Content-Type'] == 'text/html'
+        assert resp.status_code == 404
+        assert resp['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_500(self):
         """
         Test the 500 view.
         """
-        url = reverse('static_template_view.views.render_500')
+        url = reverse('render_500')
         resp = self.client.get(url)
         assert resp.status_code == 500
         assert resp['Content-Type'] == 'text/html; charset=utf-8'

--- a/lms/djangoapps/static_template_view/urls.py
+++ b/lms/djangoapps/static_template_view/urls.py
@@ -9,12 +9,6 @@ from django.urls import path, re_path
 from lms.djangoapps.static_template_view import views
 
 urlpatterns = [
-    # Semi-static views (these need to be rendered and have the login bar, but don't change)
-    path('404', views.render, {'template': '404.html'}, name="404"),
-    # display error page templates, for testing purposes
-    path('404', views.render_404, name='static_template_view.views.render_404'),
-    path('500', views.render_500, name='static_template_view.views.render_500'),
-
     path('blog', views.render, {'template': 'blog.html'}, name="blog"),
     path('contact', views.render, {'template': 'contact.html'}, name="contact"),
     path('donate', views.render, {'template': 'donate.html'}, name="donate"),

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -106,7 +106,7 @@ def render_403(request, exception=None):
 
 
 @fix_crum_request
-def render_404(request, exception):  # lint-amnesty, pylint: disable=unused-argument
+def render_404(request, exception=None):  # lint-amnesty, pylint: disable=unused-argument
     request.view_name = '404'
     return HttpResponseNotFound(render_to_string('static_templates/404.html', {}, request=request))
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -216,10 +216,10 @@ urlpatterns = [
                                    namespace='api_discounts')),
 
     # Provide URLs where we can see the rendered error pages without having to force an error.
-    path('403', handler403),
-    path('404', handler404),
-    path('429', handler429),
-    path('500', handler500),
+    path('403', handler403, name='render_403'),
+    path('404', handler404, name='render_404'),
+    path('429', handler429, name='render_429'),
+    path('500', handler500, name='render_500'),
 ]
 
 if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -214,6 +214,8 @@ urlpatterns = [
     ),
     path('api/discounts/', include(('openedx.features.discounts.urls', 'openedx.features.discounts'),
                                    namespace='api_discounts')),
+
+    # Provide URLs where we can see the rendered error pages without having to force an error.
     path('403', handler403),
     path('404', handler404),
     path('429', handler429),


### PR DESCRIPTION
We were adding paths for the error pages in two places so one of them
simply wasn't being used. The lms urls.py also covered the 429 wich the
static_templates_view urls.py did not cover.  We don't need both and we
need the definition of the handlerNNN variables in urls.py to override
the default django error views so I'll leave just those.

I also made the `exception` parameter for the `render_404` function
optional by adding a default value.  We don't use the exception when
rendering the 404 page but the exception argument is a part of the
default method signature for the function that `render_404` replaces so
I didn't want to remove it and cause issues when django tries to call
this function.
