### PR TITLE
feat: temporary setting to configure topic name for xblock events

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -177,8 +177,9 @@ def listen_for_xblock_published(sender, signal, **kwargs):
     Publish XBLOCK_PUBLISHED signals onto the event bus.
     """
     if settings.FEATURES.get("ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS"):
+        topic = getattr(settings, "EVENT_BUS_XBLOCK_LIFECYCLE_TOPIC", "course-authoring-xblock-lifecycle")
         get_producer().send(
-            signal=XBLOCK_PUBLISHED, topic='xblock-published',
+            signal=XBLOCK_PUBLISHED, topic=topic,
             event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
             event_metadata=kwargs['metadata'],
         )
@@ -190,8 +191,9 @@ def listen_for_xblock_deleted(sender, signal, **kwargs):
     Publish XBLOCK_DELETED signals onto the event bus.
     """
     if settings.FEATURES.get("ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS"):
+        topic = getattr(settings, "EVENT_BUS_XBLOCK_LIFECYCLE_TOPIC", "course-authoring-xblock-lifecycle")
         get_producer().send(
-            signal=XBLOCK_DELETED, topic='xblock-deleted',
+            signal=XBLOCK_DELETED, topic=topic,
             event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
             event_metadata=kwargs['metadata'],
         )
@@ -203,8 +205,9 @@ def listen_for_xblock_duplicated(sender, signal, **kwargs):
     Publish XBLOCK_DUPLICATED signals onto the event bus.
     """
     if settings.FEATURES.get("ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS"):
+        topic = getattr(settings, "EVENT_BUS_XBLOCK_LIFECYCLE_TOPIC", "course-authoring-xblock-lifecycle")
         get_producer().send(
-            signal=XBLOCK_DUPLICATED, topic='xblock-duplicated',
+            signal=XBLOCK_DUPLICATED, topic=topic,
             event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
             event_metadata=kwargs['metadata'],
         )

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -305,6 +305,7 @@ EVENT_BUS_PRODUCER = 'edx_event_bus_redis.create_producer'
 EVENT_BUS_REDIS_CONNECTION_URL = 'redis://:password@edx.devstack.redis:6379/'
 EVENT_BUS_TOPIC_PREFIX = 'dev'
 EVENT_BUS_CONSUMER = 'edx_event_bus_redis.RedisEventConsumer'
+EVENT_BUS_XBLOCK_LIFECYCLE_TOPIC = 'course-authoring-xblock-lifecycle'
 
 ################# New settings must go ABOVE this line #################
 ########################################################################


### PR DESCRIPTION
A temporary setting to configure topic name for xblock related openedx events. This will be removed once the decision in https://github.com/openedx/openedx-events/pull/224 is approved and implemented.

`Private-ref`: [BB-7555](https://tasks.opencraft.com/browse/BB-7555)