### PR TITLE
feat: adds waffle flag for show notifications tray

### DIFF
--- a/openedx/core/djangoapps/notifications/config/waffle.py
+++ b/openedx/core/djangoapps/notifications/config/waffle.py
@@ -24,6 +24,6 @@ ENABLE_NOTIFICATIONS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_notification
 # .. toggle_description: Waffle flag to show notifications tray
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2023-06-07
-# .. toggle_target_removal_date: 2023-06-07
+# .. toggle_target_removal_date: 2023-12-07
 # .. toggle_tickets: INF-902
 SHOW_NOTIFICATIONS_TRAY = CourseWaffleFlag(f"{WAFFLE_NAMESPACE}.show_notifications_tray", __name__)

--- a/openedx/core/djangoapps/notifications/config/waffle.py
+++ b/openedx/core/djangoapps/notifications/config/waffle.py
@@ -17,3 +17,13 @@ WAFFLE_NAMESPACE = 'notifications'
 # .. toggle_warning: When the flag is ON, Notifications feature is enabled.
 # .. toggle_tickets: INF-866
 ENABLE_NOTIFICATIONS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_notifications', __name__)
+
+# .. toggle_name: notifications.show_notifications_tray
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to show notifications tray
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2023-06-07
+# .. toggle_target_removal_date: 2023-06-07
+# .. toggle_tickets: INF-902
+SHOW_NOTIFICATIONS_TRAY = CourseWaffleFlag(f"{WAFFLE_NAMESPACE}.show_notifications_tray", __name__)

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -408,7 +408,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         super().setUp()
         self.user = UserFactory()
         self.client = APIClient()
-        self.user = UserFactory()
+
         course = CourseFactory.create(
             org='testorg',
             number='testcourse',
@@ -433,27 +433,22 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
 
     @ddt.data((False,), (True,))
     @ddt.unpack
-    def test_get_unseen_notifications_count_with_show_notifications_tray(self, show_notification_tray_enabled):
+    def test_get_unseen_notifications_count_with_show_notifications_tray(self, show_notifications_tray_enabled):
         """
-        Test that the endpoint returns the correct count of unseen notifications and show_notification_tray value.
+        Test that the endpoint returns the correct count of unseen notifications and show_notifications_tray value.
         """
         self.client.login(username=self.user.username, password='test')
 
         # Enable or disable the waffle flag based on the test case data
-        with override_waffle_flag(SHOW_NOTIFICATIONS_TRAY, active=show_notification_tray_enabled):
+        with override_waffle_flag(SHOW_NOTIFICATIONS_TRAY, active=show_notifications_tray_enabled):
 
             # Make a request to the view
             response = self.client.get(self.url)
-            learner_enrollments = CourseEnrollment.objects.filter(user=self.user, is_active=True)
-            expected_data = any(
-                SHOW_NOTIFICATIONS_TRAY.is_enabled(enrollment.course.id)
-                for enrollment in learner_enrollments
-            )
 
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['count'], 4)
             self.assertEqual(response.data['count_by_app_name'], {'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1})
-            self.assertEqual(response.data['show_notifications_tray'], expected_data)
+            self.assertEqual(response.data['show_notifications_tray'], show_notifications_tray_enabled)
 
     def test_get_unseen_notifications_count_for_unauthenticated_user(self):
         """

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -16,7 +16,7 @@ from rest_framework.test import APIClient, APITestCase
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS, SHOW_NOTIFICATIONS_TRAY
 from openedx.core.djangoapps.notifications.models import (
     Notification,
     CourseNotificationPreference,
@@ -397,31 +397,63 @@ class NotificationListAPIViewTest(APITestCase):
         self.assertEqual([data[0]['id'], data[1]['id']], [notification2.id, notification1.id])
 
 
-class NotificationCountViewSetTestCase(APITestCase):
+@ddt.ddt
+class NotificationCountViewSetTestCase(ModuleStoreTestCase):
     """
     Tests for the NotificationCountViewSet.
     """
 
     def setUp(self):
         # Create a user.
+        super().setUp()
         self.user = UserFactory()
+        self.client = APIClient()
+        self.user = UserFactory()
+        course = CourseFactory.create(
+            org='testorg',
+            number='testcourse',
+            run='testrun'
+        )
+
+        course_overview = CourseOverviewFactory.create(id=course.id, org='AwesomeOrg')
+        self.enrollment = CourseEnrollment.objects.create(
+            user=self.user,
+            course=course_overview,
+            is_active=True,
+            mode='audit'
+        )
+
         self.url = reverse('notifications-count')
+
         # Create some notifications for the user.
         Notification.objects.create(user=self.user, app_name='App Name 1', notification_type='Type A')
         Notification.objects.create(user=self.user, app_name='App Name 1', notification_type='Type B')
         Notification.objects.create(user=self.user, app_name='App Name 2', notification_type='Type A')
         Notification.objects.create(user=self.user, app_name='App Name 3', notification_type='Type C')
 
-    def test_get_unseen_notifications_count(self):
+    @ddt.data((False,), (True,))
+    @ddt.unpack
+    def test_get_unseen_notifications_count_with_show_notifications_tray(self, show_notification_tray_enabled):
         """
-        Test that the endpoint returns the correct count of unseen notifications.
+        Test that the endpoint returns the correct count of unseen notifications and show_notification_tray value.
         """
         self.client.login(username=self.user.username, password='test')
-        response = self.client.get(self.url)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['count'], 4)
-        self.assertEqual(response.data['count_by_app_name'], {'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1})
+        # Enable or disable the waffle flag based on the test case data
+        with override_waffle_flag(SHOW_NOTIFICATIONS_TRAY, active=show_notification_tray_enabled):
+
+            # Make a request to the view
+            response = self.client.get(self.url)
+            learner_enrollments = CourseEnrollment.objects.filter(user=self.user, is_active=True)
+            expected_data = any(
+                SHOW_NOTIFICATIONS_TRAY.is_enabled(enrollment.course.id)
+                for enrollment in learner_enrollments
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data['count'], 4)
+            self.assertEqual(response.data['count_by_app_name'], {'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1})
+            self.assertEqual(response.data['show_notifications_tray'], expected_data)
 
     def test_get_unseen_notifications_count_for_unauthenticated_user(self):
         """

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -4,7 +4,6 @@ Views for the notifications API.
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.db.models import Count
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
@@ -19,7 +18,7 @@ from openedx.core.djangoapps.notifications.models import (
     get_course_notification_preference_config_version
 )
 
-from .config.waffle import ENABLE_NOTIFICATIONS
+from .config.waffle import ENABLE_NOTIFICATIONS, SHOW_NOTIFICATIONS_TRAY
 from .models import Notification
 from .serializers import (
     NotificationCourseEnrollmentSerializer,
@@ -27,8 +26,6 @@ from .serializers import (
     UserCourseNotificationPreferenceSerializer,
     UserNotificationPreferenceUpdateSerializer
 )
-
-User = get_user_model()
 
 
 class CourseEnrollmentListView(generics.ListAPIView):
@@ -247,19 +244,20 @@ class NotificationListAPIView(generics.ListAPIView):
 
 class NotificationCountView(APIView):
     """
-    API view for getting the unseen notifications count for a user.
+    API view for getting the unseen notifications count and show_notification_tray flag for a user.
     """
 
     permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request):
         """
-        Get the unseen notifications count for a user.
+        Get the unseen notifications count show_notification_tray flag for a user .
 
         **Permissions**: User must be authenticated.
         **Response Format**:
         ```json
         {
+            "show_notifications_tray": (bool) show_notifications_tray,
             "count": (int) total_number_of_unseen_notifications,
             "count_by_app_name": {
                 (str) app_name: (int) number_of_unseen_notifications,
@@ -286,9 +284,20 @@ class NotificationCountView(APIView):
 
             count_total += count
             count_by_app_name_dict[app_name] = count
-        # Return the unseen notifications count for the user and the unseen notifications count for each app name.
 
+        # Retrieve active course enrollments for the current user
+        learner_enrollments = CourseEnrollment.objects.filter(user=request.user, is_active=True)
+
+        # Check if the show_notifications_tray flag is enabled for any of the learner's enrollments
+        show_notifications_tray_enabled = any(
+            SHOW_NOTIFICATIONS_TRAY.is_enabled(enrollment.course.id)
+            for enrollment in learner_enrollments
+        )
+
+        # Return the unseen notifications count for the user, the count of unseen notifications for each app name,
+        # and whether the notifications tray should be shown or hidden.
         return Response({
+            "show_notifications_tray": show_notifications_tray_enabled,
             "count": count_total,
             "count_by_app_name": count_by_app_name_dict,
         })


### PR DESCRIPTION
[INF-902](https://2u-internal.atlassian.net/browse/INF-902)
#### Description
Created a new course waffle flag `show_notifications_tray` that will be used to show the notifications tray.
In the notifications count api  a bool `show_notifications_tray` is end to determine if the user should be show the notifications tray. 
The value of the bool is calculated using the following conditions:
The user must have have an active enrollment in at least one of the courses for which the above flag is enabled. 