### PR TITLE
feat!: openedx-django-pyfs will now use boto3 to generate-urls.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -117,6 +117,3 @@ docutils<0.20
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/32327
 python3-saml<1.10.0
 
-
-# its a temporary pin. Unpin after releasing xblock-sdk new version. It will be using `openedx-django-pyfs` new ver.
-openedx-django-pyfs==3.2.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -772,10 +772,8 @@ openedx-blockstore==1.3.1
     # via -r requirements/edx/base.in
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-django-pyfs==3.2.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   xblock
+openedx-django-pyfs==3.3.0
+    # via xblock
 openedx-django-require==2.0.0
     # via -r requirements/edx/base.in
 openedx-django-wiki==2.0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1028,9 +1028,8 @@ openedx-blockstore==1.3.1
     # via -r requirements/edx/testing.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-django-pyfs==3.2.1
+openedx-django-pyfs==3.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   xblock
 openedx-django-require==2.0.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -976,9 +976,8 @@ openedx-blockstore==1.3.1
     # via -r requirements/edx/base.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-django-pyfs==3.2.1
+openedx-django-pyfs==3.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   xblock
 openedx-django-require==2.0.0


### PR DESCRIPTION
Upgrading code from boto to boto3 in following repos. This will effect all other xblocks also.

https://github.com/openedx/xblock-sdk/pull/287
https://github.com/openedx/django-pyfs/pull/127