### PR TITLE
fix: discussion errors in the demo course

### DIFF
--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -12,6 +12,8 @@ import uuid
 
 from unittest import mock
 import ddt
+from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
@@ -166,6 +168,7 @@ class TestViews(TestDiscussionXBlock):
             }
         )
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     @ddt.data(
         (False, False, False),
         (True, False, False),
@@ -230,6 +233,7 @@ class TestTemplates(TestDiscussionXBlock):
         fragment = self.block.author_view({})
         assert f'data-discussion-id="{self.discussion_id}"' in fragment.content
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     @ddt.data(
         (True, False, False),
         (False, True, False),
@@ -289,6 +293,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
             block = block.get_parent()
         return block
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     def test_html_with_user(self):
         """
         Test rendered DiscussionXBlock permissions.
@@ -307,6 +312,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         assert 'data-user-create-comment="false"' in html
         assert 'data-user-create-subcomment="false"' in html
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     def test_discussion_render_successfully_with_orphan_parent(self):
         """
         Test that discussion xblock render successfully
@@ -406,6 +412,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
     Test the number of queries executed when rendering the XBlock.
     """
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     def test_permissions_query_load(self):
         """
         Tests that the permissions queries are cached when rendering numerous discussion XBlocks.


### PR DESCRIPTION
### Description

This bug was taken from the [discussion](https://github.com/openedx/wg-build-test-release/issues/276).

<img width="1071" alt="before" src="https://github.com/openedx/edx-platform/assets/98233552/ea5572f4-7ee8-4a3d-9f9e-dae453002772">

This issue is possible for the Demo course as well as other courses. 
To reproduce this bug, you need the following conditions:
  - The platform should have the forum service disabled.
  - A discussion is created for a unit in the Studio.

This fix eliminates the possibility of displaying the Discussion block of the `settings.FEATURE` ENABLE_DISCUSSION_SERVICE is set to False:

<img width="1071" alt="after" src="https://github.com/openedx/edx-platform/assets/98233552/21c99d57-70ad-4746-b122-805337f7271e">

