### PR TITLE
temp: remove flaky test_login_and_registration_form_ratelimited

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -118,25 +118,6 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         expected_data = f'"initial_mode": "{initial_mode}"'
         self.assertContains(response, expected_data)
 
-    def test_login_and_registration_form_ratelimited(self):
-        """
-        Test that rate limiting for logistration enpoints works as expected.
-        """
-        login_url = reverse('signin_user')
-        for _ in range(5):
-            response = self.client.get(login_url)
-            assert response.status_code == 200
-
-        # then the rate limiter should kick in and give a HttpForbidden response
-        response = self.client.get(login_url)
-        assert response.status_code == 429
-
-        # now reset the time to 6 mins from now in future in order to unblock
-        reset_time = datetime.now(UTC) + timedelta(seconds=361)
-        with freeze_time(reset_time):
-            response = self.client.get(login_url)
-            assert response.status_code == 200
-
     @mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
     @ddt.data("signin_user", "register_user")
     def test_login_and_registration_form_already_authenticated(self, url_name):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -1,7 +1,6 @@
 """ Tests for Logistration views. """
 
 
-from datetime import datetime, timedelta
 from http.cookies import SimpleCookie
 from urllib.parse import urlencode
 from unittest import mock
@@ -18,8 +17,6 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from freezegun import freeze_time
-from pytz import UTC
 
 from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.branding.api import get_privacy_url


### PR DESCRIPTION
## Description

The test LoginAndRegistrationTest.test_login_and_registration_form_ratelimited was found to be flaky, so it is (temporarily) being removed.

Error details:
```
=================================== FAILURES ===================================
____ LoginAndRegistrationTest.test_login_and_registration_form_ratelimited _____

self = <openedx.core.djangoapps.user_authn.views.tests.test_logistration.LoginAndRegistrationTest testMethod=test_login_and_registration_form_ratelimited>

    def test_login_and_registration_form_ratelimited(self):
        """
        Test that rate limiting for logistration enpoints works as expected.
        """
        login_url = reverse('signin_user')
        for _ in range(5):
            response = self.client.get(login_url)
            assert response.status_code == 200
    
        # then the rate limiter should kick in and give a HttpForbidden response
        response = self.client.get(login_url)
>       assert response.status_code == 429
E       assert 200 == 429
E        +  where 200 = <HttpResponse status_code=200, "text/html; charset=utf-8">.status_code

openedx/core/djangoapps/user_authn/views/tests/test_logistration.py:132: AssertionError
```

## Supporting information

* Private ticket for fixing the flaky test: https://2u-internal.atlassian.net/browse/CR-5847
* See https://2u-internal.atlassian.net/wiki/spaces/TE/pages/12812492/Flaky+Test+Process for why this has been deleted.

## Other information

- [idea] It is unclear whether it would pass if it were tried one more time, or given a little more sleep, but maybe the test could be written so if the 429 isn't seen when expected, it does a very small sleep and tries one last time. Or, maybe there is a real bug in the rate limiting code and real failures to rate limit might occur at times? 
  - If you choose the workaround in place of looking to see if there is a real flaky bug, then you should comment next to the workaround that if it ever fails, we should really look into whether this is a bug that is not self-healing with our security code.
- [idea] Rerunning the test many times in a tight loop locally may help duplicate?