### PR TITLE
fix: discussion errors in the demo course for Palm

### DIFF
--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -12,6 +12,8 @@ import uuid
 
 from unittest import mock
 import ddt
+from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
@@ -167,6 +169,7 @@ class TestViews(TestDiscussionXBlock):
             }
         )
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     @ddt.data(
         (False, False, False),
         (True, False, False),
@@ -231,6 +234,7 @@ class TestTemplates(TestDiscussionXBlock):
         fragment = self.block.author_view({})
         assert f'data-discussion-id="{self.discussion_id}"' in fragment.content
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     @ddt.data(
         (True, False, False),
         (False, True, False),
@@ -290,6 +294,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
             block = block.get_parent()
         return block
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     def test_html_with_user(self):
         """
         Test rendered DiscussionXBlock permissions.
@@ -308,6 +313,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         assert 'data-user-create-comment="false"' in html
         assert 'data-user-create-subcomment="false"' in html
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     def test_discussion_render_successfully_with_orphan_parent(self):
         """
         Test that discussion xblock render successfully
@@ -407,6 +413,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
     Test the number of queries executed when rendering the XBlock.
     """
 
+    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
     def test_permissions_query_load(self):
         """
         Tests that the permissions queries are cached when rendering numerous discussion XBlocks.

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -163,6 +163,9 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlMixin):  # lint-amn
         """
         Renders student view for LMS.
         """
+        # to prevent a circular import issue
+        import lms.djangoapps.discussion.django_comment_client.utils as utils
+
         fragment = Fragment()
 
         if not self.is_visible:
@@ -189,21 +192,23 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlMixin):  # lint-amn
                 ),
             )
 
-        context = {
-            'discussion_id': self.discussion_id,
-            'display_name': self.display_name if self.display_name else _("Discussion"),
-            'user': self.django_user,
-            'course_id': self.course_key,
-            'discussion_category': self.discussion_category,
-            'discussion_target': self.discussion_target,
-            'can_create_thread': self.has_permission("create_thread"),
-            'can_create_comment': self.has_permission("create_comment"),
-            'can_create_subcomment': self.has_permission("create_sub_comment"),
-            'login_msg': login_msg,
-        }
+        if utils.is_discussion_enabled(self.course_key):
+            context = {
+                'discussion_id': self.discussion_id,
+                'display_name': self.display_name if self.display_name else _("Discussion"),
+                'user': self.django_user,
+                'course_id': self.course_key,
+                'discussion_category': self.discussion_category,
+                'discussion_target': self.discussion_target,
+                'can_create_thread': self.has_permission("create_thread"),
+                'can_create_comment': self.has_permission("create_comment"),
+                'can_create_subcomment': self.has_permission("create_sub_comment"),
+                'login_msg': login_msg,
+            }
+            fragment.add_content(
+                self.runtime.service(self, 'mako').render_template('discussion/_discussion_inline.html', context)
+            )
 
-        fragment.add_content(self.runtime.service(self, 'mako').render_template('discussion/_discussion_inline.html',
-                                                                                context))
         fragment.initialize_js('DiscussionInlineBlock')
 
         return fragment


### PR DESCRIPTION
This is a [backport](https://github.com/openedx/edx-platform/pull/32456) from the master branch

### Description

This is a bug fix that was taken from the [discussion](https://github.com/openedx/wg-build-test-release/issues/276).

<img width="1071" alt="before" src="https://github.com/openedx/edx-platform/assets/98233552/ea5572f4-7ee8-4a3d-9f9e-dae453002772">

This issue is possible for the Demo course as well as other courses. 
To reproduce this bug, you need the following conditions:
  - The platform should have the forum service disabled.
  - A discussion is created for a unit in the Studio.

This fix eliminates the possibility of displaying the Discussion block if the environment variable ENABLE_DISCUSSION_SERVICE is set to False:

<img width="1071" alt="after" src="https://github.com/openedx/edx-platform/assets/98233552/21c99d57-70ad-4746-b122-805337f7271e">