### PR TITLE
feat: add content field to response for Notification list retrieval api

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -178,3 +178,15 @@ class NotificationAppManager:
 
             return course_notification_preference_config
         return None
+
+
+def get_notification_content(notification_type, context):
+    """
+    Returns notification content for the given notification type with provided context.
+    """
+    notification_type = NotificationTypeManager().notification_types.get(notification_type, None)
+    if notification_type:
+        notification_type_content_template = notification_type.get('content_template', None)
+        if notification_type_content_template:
+            return notification_type_content_template.format(**context)
+    return ''

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField
 
-from openedx.core.djangoapps.notifications.base_notification import NotificationAppManager
+from openedx.core.djangoapps.notifications.base_notification import NotificationAppManager, get_notification_content
 
 User = get_user_model()
 
@@ -93,6 +93,13 @@ class Notification(TimeStampedModel):
 
     def __str__(self):
         return f'{self.user.username} - {self.course_id} - {self.app_name} - {self.notification_type}'
+
+    @property
+    def content(self):
+        """
+        Returns the content for the notification.
+        """
+        return get_notification_content(self.notification_type, self.content_context)
 
 
 class CourseNotificationPreference(TimeStampedModel):

--- a/openedx/core/djangoapps/notifications/serializers.py
+++ b/openedx/core/djangoapps/notifications/serializers.py
@@ -129,7 +129,6 @@ class NotificationSerializer(serializers.ModelSerializer):
     """
     Serializer for the Notification model.
     """
-
     class Meta:
         model = Notification
         fields = (
@@ -137,6 +136,7 @@ class NotificationSerializer(serializers.ModelSerializer):
             'app_name',
             'notification_type',
             'content_context',
+            'content',
             'content_url',
             'last_read',
             'last_seen',

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -285,8 +285,12 @@ class NotificationListAPIViewTest(APITestCase):
         # Create a notification for the user.
         Notification.objects.create(
             user=self.user,
-            app_name='app1',
-            notification_type='info',
+            app_name='discussion',
+            notification_type='new_response',
+            content_context={
+                'replier_name': 'test_user',
+                'post_title': 'This is a test post.',
+            }
         )
         self.client.login(username=self.user.username, password='test')
 
@@ -299,8 +303,12 @@ class NotificationListAPIViewTest(APITestCase):
         data = response.data['results']
         # Assert that the response contains the notification.
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['app_name'], 'app1')
-        self.assertEqual(data[0]['notification_type'], 'info')
+        self.assertEqual(data[0]['app_name'], 'discussion')
+        self.assertEqual(data[0]['notification_type'], 'new_response')
+        self.assertEqual(
+            data[0]['content'],
+            '<p><strong>test_user</strong> responded to your post <strong>This is a test post.</strong></p>'
+        )
 
     def test_list_notifications_with_app_name_filter(self):
         """
@@ -309,8 +317,12 @@ class NotificationListAPIViewTest(APITestCase):
         # Create two notifications for the user, one for each app name.
         Notification.objects.create(
             user=self.user,
-            app_name='app1',
-            notification_type='info',
+            app_name='discussion',
+            notification_type='new_response',
+            content_context={
+                'replier_name': 'test_user',
+                'post_title': 'This is a test post.',
+            }
         )
         Notification.objects.create(
             user=self.user,
@@ -320,7 +332,7 @@ class NotificationListAPIViewTest(APITestCase):
         self.client.login(username=self.user.username, password='test')
 
         # Make a request to the view with the app_name query parameter set to 'app1'.
-        response = self.client.get(self.url + "?app_name=app1")
+        response = self.client.get(self.url + "?app_name=discussion")
 
         # Assert that the response is successful.
         self.assertEqual(response.status_code, 200)
@@ -328,8 +340,12 @@ class NotificationListAPIViewTest(APITestCase):
         # Assert that the response contains only the notification for app1.
         data = response.data['results']
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['app_name'], 'app1')
-        self.assertEqual(data[0]['notification_type'], 'info')
+        self.assertEqual(data[0]['app_name'], 'discussion')
+        self.assertEqual(data[0]['notification_type'], 'new_response')
+        self.assertEqual(
+            data[0]['content'],
+            '<p><strong>test_user</strong> responded to your post <strong>This is a test post.</strong></p>'
+        )
 
     def test_list_notifications_without_authentication(self):
         """


### PR DESCRIPTION
### [INF-909](https://2u-internal.atlassian.net/browse/INF-909)

### Description

This PR addresses the `content` field on the Notification retrieval API. 
The content is calculated with the notification types' `content template`, and the `content_context` provided within the Notification.

This content is then returned within the API response for the Notification retrieval List API.