### PR TITLE
feat: add notifications mark as read API

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -517,7 +517,7 @@ class NotificationReadAPIViewTestCase(APITestCase):
 
         # Create some sample notifications for the user with already existing apps and with invalid app name
         Notification.objects.create(user=self.user, app_name='app_name_2', notification_type='Type A')
-        for app_name in COURSE_NOTIFICATION_APPS.keys():
+        for app_name in COURSE_NOTIFICATION_APPS:
             Notification.objects.create(user=self.user, app_name=app_name, notification_type='Type A')
             Notification.objects.create(user=self.user, app_name=app_name, notification_type='Type B')
 

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -541,7 +541,7 @@ class NotificationReadAPIViewTestCase(APITestCase):
         response = self.client.patch(self.url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data, {'message': 'Invalid app_name or notification_id.'})
+        self.assertEqual(response.data, {'error': 'Invalid app_name or notification_id.'})
 
     def test_mark_notification_read_with_notification_id(self):
         # Create a PATCH request to mark notification as read for notification_id: 2
@@ -602,4 +602,4 @@ class NotificationReadAPIViewTestCase(APITestCase):
         response = self.client.patch(self.url, {})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data, {'message': 'Invalid app_name or notification_id.'})
+        self.assertEqual(response.data, {'error': 'Invalid app_name or notification_id.'})

--- a/openedx/core/djangoapps/notifications/urls.py
+++ b/openedx/core/djangoapps/notifications/urls.py
@@ -10,6 +10,7 @@ from .views import (
     MarkNotificationsUnseenAPIView,
     NotificationCountView,
     NotificationListAPIView,
+    NotificationReadAPIView,
     UserNotificationPreferenceView
 )
 
@@ -30,6 +31,7 @@ urlpatterns = [
         MarkNotificationsUnseenAPIView.as_view(),
         name='mark-notifications-unseen'
     ),
+    path('read/', NotificationReadAPIView.as_view(), name='notifications-read'),
 
 ]
 

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -18,6 +18,7 @@ from openedx.core.djangoapps.notifications.models import (
     get_course_notification_preference_config_version
 )
 
+from .base_notification import COURSE_NOTIFICATION_APPS
 from .config.waffle import ENABLE_NOTIFICATIONS, SHOW_NOTIFICATIONS_TRAY
 from .models import Notification
 from .serializers import (
@@ -334,3 +335,62 @@ class MarkNotificationsUnseenAPIView(UpdateAPIView):
         notifications.update(last_seen=datetime.now())
 
         return Response({'message': 'Notifications marked unseen.'}, status=200)
+
+
+class NotificationReadAPIView(APIView):
+    """
+    API view for marking user notifications as read, either all notifications or a single notification
+    """
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def patch(self, request, *args, **kwargs):
+        """
+        Marks all notifications or single notification read for the given
+        app name or notification id for the authenticated user.
+
+        Requests:
+        PATCH /api/notifications/read/{app_name}
+        PATCH /api/notifications/read/{notification_id
+
+        Parameters:
+            request (Request): The request object containing the app name or notification id.
+                {
+                    "app_name": (str) app_name,
+                    "notification_id": (int) notification_id
+                }
+
+        Returns:
+        - 200: OK status code if the notification or notifications were successfully marked read.
+        - 400: Bad Request status code if the app name or notification id is invalid.
+        - 403: Forbidden status code if the user is not authenticated.
+        - 404: Not Found status code if the notification or notifications were not found.
+        """
+        app_name = request.data.get('app_name')
+        notification_id = request.data.get('notification_id')
+
+        if not app_name and not notification_id:
+            return Response({'message': 'Invalid app name or notification id.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if app_name and app_name not in COURSE_NOTIFICATION_APPS:
+            return Response({'message': 'Invalid app name.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        query_params = {
+            'user': request.user,
+            'last_read__isnull': True,
+        }
+
+        if app_name:
+            query_params['app_name'] = app_name
+
+        if notification_id:
+            query_params['id'] = notification_id
+
+        notifications = Notification.objects.filter(**query_params)
+
+        if notification_id and not notifications.exists():
+            return Response({'message': 'Notification not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+        notifications.update(last_read=datetime.now())
+
+        return Response({'message': 'Notifications marked read.'}, status=status.HTTP_200_OK)

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -350,8 +350,7 @@ class NotificationReadAPIView(APIView):
         app name or notification id for the authenticated user.
 
         Requests:
-        PATCH /api/notifications/read/{app_name}
-        PATCH /api/notifications/read/{notification_id
+        PATCH /api/notifications/read/
 
         Parameters:
             request (Request): The request object containing the app name or notification id.

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext as _
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from rest_framework import generics, permissions, status
@@ -176,7 +177,7 @@ class UserNotificationPreferenceView(APIView):
         )
         if user_course_notification_preference.config_version != get_course_notification_preference_config_version():
             return Response(
-                {'error': 'The notification preference config version is not up to date.'},
+                {'error': _('The notification preference config version is not up to date.')},
                 status=status.HTTP_409_CONFLICT,
             )
 
@@ -325,7 +326,7 @@ class MarkNotificationsUnseenAPIView(UpdateAPIView):
         app_name = self.kwargs.get('app_name')
 
         if not app_name:
-            return Response({'message': 'Invalid app name.'}, status=400)
+            return Response({'error': _('Invalid app name.')}, status=400)
 
         notifications = Notification.objects.filter(
             user=request.user,
@@ -335,7 +336,7 @@ class MarkNotificationsUnseenAPIView(UpdateAPIView):
 
         notifications.update(last_seen=datetime.now())
 
-        return Response({'message': 'Notifications marked unseen.'}, status=200)
+        return Response({'message': _('Notifications marked unseen.')}, status=200)
 
 
 class NotificationReadAPIView(APIView):
@@ -373,7 +374,7 @@ class NotificationReadAPIView(APIView):
             notification = get_object_or_404(Notification, pk=notification_id, user=request.user)
             notification.last_read = read_at
             notification.save()
-            return Response({'message': 'Notification marked read.'}, status=status.HTTP_200_OK)
+            return Response({'message': _('Notification marked read.')}, status=status.HTTP_200_OK)
 
         app_name = request.data.get('app_name', '')
 
@@ -384,6 +385,6 @@ class NotificationReadAPIView(APIView):
                 last_read__isnull=True,
             )
             notifications.update(last_read=read_at)
-            return Response({'message': 'Notifications marked read.'}, status=status.HTTP_200_OK)
+            return Response({'message': _('Notifications marked read.')}, status=status.HTTP_200_OK)
 
-        return Response({'message': 'Invalid app_name or notification_id.'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({'error': _('Invalid app_name or notification_id.')}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
### [INF-913](https://2u-internal.atlassian.net/browse/INF-913)

### Description
Implement two new APIs:
- API to mark a single notification as read.
- API to mark all notifications of an app name as read.

**Request URL**
```python
PATCH /api/notifications/read/
```

**Request Body**
```python
{
    "app_name": (str) app_name,
    "notification_id": (int) notification_id
}
```

**Response**
```python
    200: OK status code if the notification or notifications were successfully marked read.
    400: Bad Request status code if the app name or notification id is invalid.
    403: Forbidden status code if the user is not authenticated.
    404: Not Found status code if the notification or notifications were not found.
```
