### PR TITLE
[2/3] build: include built-in XBlock JS directly rather than copying it

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -98,8 +98,6 @@ dummy_locales:
 
 # Directories we don't search for strings.
 ignore_dirs:
-    - common/static/xmodule/modules
-    - common/static/xmodule/descriptors
     # Directories with no user-facing code.
     - '*/migrations'
     - '*/envs'

--- a/webpack-config/file-lists.js
+++ b/webpack-config/file-lists.js
@@ -10,9 +10,7 @@ module.exports = {
         path.resolve(__dirname, '../common/static/common/js/components/views/paging_footer.js'),
         path.resolve(__dirname, '../cms/static/js/views/paging.js'),
         path.resolve(__dirname, '../common/static/common/js/components/utils/view_utils.js'),
-        /descriptors\/js/,
-        /modules\/js/,
-        /xmodule\/js\/src\//,
+        /xmodule\/js\/src/,
         path.resolve(__dirname, '../openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmark_button.js')
     ],
 

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -13,9 +13,7 @@ var xmoduleJS = require('./common/static/xmodule/webpack.xmodule.config.js');
 
 var filesWithRequireJSBlocks = [
     path.resolve(__dirname, 'common/static/common/js/components/utils/view_utils.js'),
-    /descriptors\/js/,
-    /modules\/js/,
-    /xmodule\/js\/src\//
+    /xmodule\/js\/src/
 ];
 
 var defineHeader = /\(function ?\(((define|require|requirejs|\$)(, )?)+\) ?\{/;
@@ -311,14 +309,124 @@ module.exports = Merge.smart({
                     test: /xblock\/runtime.v1/,
                     loader: 'exports-loader?window.XBlock!imports-loader?XBlock=xblock/core,this=>window'
                 },
+                /*******************************************************************************************************
+                /* BUILT-IN XBLOCK ASSETS WITH GLOBAL DEFINITIONS:
+                 *
+                 * The monstrous list of globally-namespace modules below is the result of a JS build refactoring.
+                 * Originally, all of these modules were copied to common/static/xmodule/js/[module|descriptors]/, and
+                 * this file simply contained the lines:
+                 *
+                 *   {
+                 *       test: /descriptors\/js/,
+                 *       loader: 'imports-loader?this=>window'
+                 *   },
+                 *   {
+                 *       test: /modules\/js/,
+                 *       loader: 'imports-loader?this=>window'
+                 *   },
+                 *
+                 * We removed that asset copying because it added complexity to the build, but as a result, in order to
+                 * preserve exact parity with the preexisting global namespace, we had to enumerate all formely-copied
+                 * modules here. It is very likely that many of these modules do not need to be in this list. Future
+                 * refactorings are welcome to try to prune the list down to the minimal set of modules. As far as
+                 * we know, the only modules that absolutely need to be added to the global namespace are those
+                 * which define module types, for example "Problem" (in xmodule/js/src/capa/display.js).
+                 */
                 {
-                    test: /descriptors\/js/,
+                    test: /xmodule\/assets\/word_cloud\/src\/js\/word_cloud.js/,
                     loader: 'imports-loader?this=>window'
                 },
                 {
-                    test: /modules\/js/,
+                    test: /xmodule\/js\/common_static\/js\/vendor\/draggabilly.js/,
                     loader: 'imports-loader?this=>window'
                 },
+                {
+                    test: /xmodule\/js\/src\/annotatable\/display.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/capa\/display.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/capa\/imageinput.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/capa\/schematic.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/collapsible.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/conditional\/display.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/html\/display.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/html\/edit.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/html\/imageModal.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/javascript_loader.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/lti\/lti.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/poll\/poll.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/poll\/poll_main.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/problem\/edit.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/raw\/edit\/metadata-only.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/raw\/edit\/xml.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/sequence\/display.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/sequence\/edit.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/tabs\/tabs-aggregator.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/vertical\/edit.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                {
+                    test: /xmodule\/js\/src\/video\/10_main.js/,
+                    loader: 'imports-loader?this=>window'
+                },
+                /*
+                 * END BUILT-IN XBLOCK ASSETS WITH GLOBAL DEFINITIONS
+                 ******************************************************************************************************/
                 {
                     test: /codemirror/,
                     loader: 'exports-loader?window.CodeMirror'

--- a/xmodule/assets/README.rst
+++ b/xmodule/assets/README.rst
@@ -59,8 +59,7 @@ Currently, edx-platform XBlock JS is defined both here in `xmodule/assets`_ and 
 
 * For many older blocks, their JS is:
 
-  * copied to ``common/static/xmodule`` by `static_content.py`_ (aka ``xmodule_assets``),
-  * then bundled using a generated Webpack config at ``common/static/xmodule/webpack.xmodule.config.js``,
+  * bundled using a generated Webpack config at ``common/static/xmodule/webpack.xmodule.config.js``,
   * which is included into `webpack.common.config.js`_,
   * allowing it to be included into XBlock fragments using ``add_webpack_js_to_fragment`` from `builtin_assets.py`_.
 
@@ -77,7 +76,6 @@ Currently, edx-platform XBlock JS is defined both here in `xmodule/assets`_ and 
 
 As part of an `active build refactoring`_:
 
-* We update the older builtin XBlocks to reference their JS directly rather than using copies of it.
 * We will move ``webpack.xmodule.config.js`` here instead of generating it.
 * We will consolidate all edx-platform XBlock JS here in `xmodule/assets`_.
 * We will delete the ``xmodule_assets`` script.

--- a/xmodule/tests/test_content.py
+++ b/xmodule/tests/test_content.py
@@ -1,17 +1,14 @@
 """Tests for contents"""
 
 
-import os
 import unittest
 from unittest.mock import Mock, patch
 
 import ddt
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import AssetLocator, CourseLocator
-from path import Path as path
 
 from xmodule.contentstore.content import ContentStore, StaticContent, StaticContentStream
-from xmodule.static_content import XBLOCK_CLASSES, _write_js
 
 SAMPLE_STRING = """
 This is a sample string with more than 1024 bytes, the default STREAM_DATA_CHUNK_SIZE
@@ -205,13 +202,3 @@ class ContentTest(unittest.TestCase):  # lint-amnesty, pylint: disable=missing-c
             total_length += len(chunck)
 
         assert total_length == ((last_byte - first_byte) + 1)
-
-    def test_static_content_write_js(self):
-        """
-        Test that only one filename starts with 000.
-        """
-        output_root = path('common/static/xmodule/descriptors/js')
-        file_owners = _write_js(output_root, XBLOCK_CLASSES, 'get_studio_view_js')
-        js_file_paths = {file_path for file_path in sum(list(file_owners.values()), []) if os.path.basename(file_path).startswith('000-')}  # lint-amnesty, pylint: disable=line-too-long
-        assert len(js_file_paths) == 1
-        assert 'XModule.Descriptor = (function() {' in open(js_file_paths.pop()).read()


### PR DESCRIPTION
Part of a series of PRs:
* https://github.com/openedx/edx-platform/issues/32481

The previous one is:
* https://github.com/openedx/edx-platform/pull/32530

The next one is:
* https://github.com/openedx/edx-platform/pull/32685

To review this PR, look at just the latest commit (the one matching the PR title).

## Description and supporting info

As part of the static asset build, JS modules for most built-in XBlocks were unnecessarily copied from the original locations (under xmodule/js and common/static/js) to a git-ignored location (under common/static/xmodule), and then included into the Webpack builld via common/static/xmodule/webpack.xmodule.config.js.

With this commit, we stop copying the JS modules. Instead, we have common/static/xmodule/webpack.xmodule.config.js just reference the original source under xmodule/js and common/static/js.

This lets us us radically simplify the xmodule/static_content.py build script. It also sets the stage for the next change, in which we will check webpack.xmodule.config.js into the repository, and delete xmodule/static_content.py entirely.

common/static/xmodule/webpack.xmodule.config.js before:

    module.exports = {
        "entry": {
            "AboutBlockDisplay": [
                "./common/static/xmodule/modules/js/000-b82f6c436159f6bc7ca2513e29e82503.js",
                "./common/static/xmodule/modules/js/001-3ed86006526f75d6c844739193a84c11.js",
                "./common/static/xmodule/modules/js/002-3918b2d4f383c04fed8227cc9f523d6e.js",
                "./common/static/xmodule/modules/js/003-b3206f2283964743c4772b9d72c67d64.js",
                "./common/static/xmodule/modules/js/004-274b8109ca3426c2a6fde9ec2c56e969.js",
                "./common/static/xmodule/modules/js/005-26caba6f71877f63a7dd4f6796109bf6.js"
            ],
            "AboutBlockEditor": [
                "./common/static/xmodule/descriptors/js/000-b82f6c436159f6bc7ca2513e29e82503.js",
                "./common/static/xmodule/descriptors/js/001-19c4723cecaa5a5a46b8566b3544e732.js"
            ],
            // etc
        }
    };

common/static/xmodule/webpack.xmodule.config.js after:

    module.exports = {
        "entry": {
            "AboutBlockDisplay": [
                "./xmodule/js/src/xmodule.js",
                "./xmodule/js/src/html/display.js",
                "./xmodule/js/src/javascript_loader.js",
                "./xmodule/js/src/collapsible.js",
                "./xmodule/js/src/html/imageModal.js",
                "./xmodule/js/common_static/js/vendor/draggabilly.js"
            ],
            "AboutBlockEditor": [
                "./xmodule/js/src/xmodule.js",
                "./xmodule/js/src/html/edit.js"
            ],
            // etc
        }
    };

## Testing

I recommend building assets with this branch and smoke-testing the built-in XBlocks.

You can build assets and start the platform with Tutor Nightly:

```bash
tutor local stop
tutor config save --set EDX_PLATFORM_REPOSITORY=https://github.com/kdmccormick/edx-platform
tutor config save --set EDX_PLATFORM_VERSION=kdmccormick/xmodule-js-no-copy
tutor images build openedx
tutor local start -d
```

or do it standalone (I haven't tried this):

```bash
paver update_assets
./manage.py lms runserver
./manage.py cms runserver
```

Go into the demo course and try out a few built-in XBlocks. Affected XBlocks include:
* Sequentials aka subsections
* any Text aka HTML
* static tabs
* Video
* any Problem
* Annotatable
* Conditional
* Randomized Content aka library_content_block
* Poll (old)
* LTI (old)
* WordCloud

