### PR TITLE
feat: remove learner home redirect percentage

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -521,7 +521,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     if not UserProfile.objects.filter(user=user).exists():
         return redirect(reverse('account_settings'))
 
-    if should_redirect_to_learner_home_mfe(user):
+    if should_redirect_to_learner_home_mfe():
         return redirect(settings.LEARNER_HOME_MICROFRONTEND_URL)
 
     platform_name = configuration_helpers.get_value("platform_name", settings.PLATFORM_NAME)

--- a/lms/djangoapps/learner_home/test_waffle.py
+++ b/lms/djangoapps/learner_home/test_waffle.py
@@ -30,25 +30,19 @@ class TestLearnerHomeRedirect(SharedModuleStoreTestCase):
         mock_enable_learner_home.is_enabled.return_value = False
 
         # When I check if I should redirect
-        redirect_choice = should_redirect_to_learner_home_mfe(self.user)
+        redirect_choice = should_redirect_to_learner_home_mfe()
 
         # Then I never redirect
         self.assertFalse(redirect_choice)
 
-    @ddt.data((0, True), (50, False), (100, True))
-    @ddt.unpack
     @patch("lms.djangoapps.learner_home.waffle.ENABLE_LEARNER_HOME_MFE")
-    @override_settings(LEARNER_HOME_MFE_REDIRECT_PERCENTAGE=50)
-    def test_should_redirect_to_learner_home_enabled(
-        self, user_id, expect_redirect, mock_enable_learner_home
-    ):
+    def test_should_redirect_to_learner_home_enabled(self, mock_enable_learner_home):
         # Given Learner Home MFE feature is enabled
         mock_enable_learner_home.is_enabled.return_value = True
-        self.user.id = user_id
 
         # When I check if I should redirect
-        redirect_choice = should_redirect_to_learner_home_mfe(self.user)
+        redirect_choice = should_redirect_to_learner_home_mfe()
 
         # Then I redirect based on configuration
         # (currently user ID % 100 < redirect percentage)
-        self.assertEqual(expect_redirect, redirect_choice)
+        self.assertEqual(mock_enable_learner_home, redirect_choice)

--- a/lms/djangoapps/learner_home/waffle.py
+++ b/lms/djangoapps/learner_home/waffle.py
@@ -23,25 +23,11 @@ ENABLE_LEARNER_HOME_MFE = WaffleFlag(
 )
 
 
-def should_redirect_to_learner_home_mfe(user):
+def should_redirect_to_learner_home_mfe():
     """
-    Redirect a percentage of learners to Learner Home for experimentation.
-
-    Percentage is based on the LEARNER_HOME_MFE_REDIRECT_PERCENTAGE setting.
+    Redirect a learners to the Learning MFE when enabled.
     """
 
-    is_learning_mfe_enabled = configuration_helpers.get_value(
+    return configuration_helpers.get_value(
         "ENABLE_LEARNER_HOME_MFE", ENABLE_LEARNER_HOME_MFE.is_enabled()
     )
-
-    learning_mfe_redirect_percent = configuration_helpers.get_value(
-        "LEARNER_HOME_MFE_REDIRECT_PERCENTAGE",
-        settings.LEARNER_HOME_MFE_REDIRECT_PERCENTAGE,
-    )
-
-    # Redirect when 1) Learner Home MFE is enabled and 2) a user falls into the
-    # target range for experimental rollout.
-    if is_learning_mfe_enabled and user.id % 100 < learning_mfe_redirect_percent:
-        return True
-
-    return False

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5016,8 +5016,6 @@ HIBP_LOGIN_BLOCK_PASSWORD_FREQUENCY_THRESHOLD = 5
 # .. toggle_tickets: https://openedx.atlassian.net/browse/VAN-838
 ENABLE_DYNAMIC_REGISTRATION_FIELDS = False
 
-LEARNER_HOME_MFE_REDIRECT_PERCENTAGE = 0
-
 ############### Settings for the ace_common plugin #################
 # Note that all settings are actually defined by the plugin
 # pylint: disable=wrong-import-position


### PR DESCRIPTION
## Description

During experimental rollout, we added a percentage rollout scheme for learner home. Remove this change and update function signatures to reflect this.

## Supporting information

JIRA:

## Testing instructions

Given `ENABLE_LEARNER_HOME_MFE` is still enabled, users should be redirected from old student dashboard to new Learner Home.

When disabled, students should be able to visit the old student dashboard without redirect.

## Deadline

None

## Other information

This should accompany changes to remove the `LEARNER_HOME_MFE_REDIRECT_PERCENTAGE` from edX configuration.