### PR TITLE
fix: float "&nbsp;" symbol in the preview_body

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -402,10 +402,9 @@ class ThreadSerializer(_ContentSerializer):
 
     def get_preview_body(self, obj):
         """
-        Returns a cleaned and truncated version of the thread's body to display in a
-        preview capacity.
+        Returns a cleaned version of the thread's body to display in a preview capacity.
         """
-        return strip_tags(self.get_rendered_body(obj)).replace('\n', ' ')
+        return strip_tags(self.get_rendered_body(obj)).replace('\n', ' ').replace('&nbsp;', ' ')
 
     def get_close_reason(self, obj):
         """

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -242,6 +242,21 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
         serialized = self.serialize(thread_data)
         assert 'response_count' not in serialized
 
+    def test_get_preview_body(self):
+        """
+        Test for the 'get_preview_body' method.
+
+        This test verifies that the 'get_preview_body' method returns a cleaned
+        version of the thread's body that is suitable for display as a preview.
+        The test specifically focuses on handling the presence of multiple
+        spaces within the body.
+        """
+        thread_data = self.make_cs_content(
+            {"body": "<p>This  is  a test thread body  with some text.</p>"}
+        )
+        serialized = self.serialize(thread_data)
+        assert serialized['preview_body'] == "This  is  a test thread body  with some text."
+
 
 @ddt.ddt
 class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):


### PR DESCRIPTION
## Description

The issue is with the preview_body field when formatting the post body. If there are multiple consecutive spaces in the body of a post, the space character is replaced with `&nbsp;`.

Before:

<img width="903" alt="screen_2" src="https://github.com/openedx/edx-platform/assets/98233552/463ff348-6a59-40f0-86f3-d15a44b0ced0">

After:

<img width="1026" alt="screen_1" src="https://github.com/openedx/edx-platform/assets/98233552/33bca474-83f7-4685-b5ef-55324b73fe97"