### PR TITLE
fix: Add platform name to mobile config cache key

### DIFF
--- a/lms/djangoapps/mobile_api/middleware.py
+++ b/lms/djangoapps/mobile_api/middleware.py
@@ -99,7 +99,7 @@ class AppVersionUpgrade(MiddlewareMixin):
                 request_cache_dict[self.USER_APP_VERSION] = platform.version
                 last_supported_date_cache_key = self._get_cache_key_name(
                     self.LAST_SUPPORTED_DATE_HEADER,
-                    platform.version
+                    platform.NAME + platform.version
                 )
                 latest_version_cache_key = self._get_cache_key_name(self.LATEST_VERSION_HEADER, platform.NAME)
                 cached_data = cache.get_many([last_supported_date_cache_key, latest_version_cache_key])


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Update the cache key name to contain the platform name to avoid collision between same versions and different platform in the cache.
More explanation in the ticket comments.

## Supporting information

Jira ticket: https://2u-internal.atlassian.net/browse/LEARNER-9378 


## Deadline

None
