### PR TITLE
fix: make mathjax overflow scrollable

### DIFF
--- a/cms/djangoapps/pipeline_js/js/xmodule.js
+++ b/cms/djangoapps/pipeline_js/js/xmodule.js
@@ -32,7 +32,16 @@ define(
                             ['\\[', '\\]'],
                             ['[mathjax]', '[/mathjax]']
                         ]
-                    }
+                    },
+                    styles: {
+                        '.MathJax_SVG': {
+                            'overflow-x': 'scroll',
+                            'max-width': '100% !important',
+                        },
+                        '.MathJax_SVG>svg': {
+                            'display': 'block',
+                        },
+                    },
                 });
 
                 // In order to eliminate all flashing during interactive

--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -90,7 +90,16 @@
           ["\\[","\\]"],
           ['[mathjax]','[/mathjax]']
         ]
-      }
+      },
+      styles: {
+        '.MathJax_SVG': {
+          'overflow-x': 'scroll',
+          'max-width': '100% !important',
+        },
+        '.MathJax_SVG>svg': {
+          'display': 'block',
+        },
+      },
     });
   </script>
   <script type="text/x-mathjax-config">

--- a/common/static/common/js/discussion/mathjax_include.js
+++ b/common/static/common/js/discussion/mathjax_include.js
@@ -24,7 +24,16 @@ if (typeof MathJax === 'undefined') {
                     ['\\[', '\\]'],
                     ['[mathjax]', '[/mathjax]']
                 ]
-            }
+            },
+            styles: {
+                '.MathJax_SVG': {
+                    'overflow-x': 'scroll',
+                    'max-width': '100% !important',
+                },
+                '.MathJax_SVG>svg': {
+                    'display': 'block',
+                },
+              },
         });
         if (disableFastPreview) {
             MathJax.Hub.processSectionDelay = 0;

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -46,7 +46,16 @@
         ["\\[","\\]"],
         ['[mathjax]','[/mathjax]']
       ]
-    }
+    },
+    styles: {
+      '.MathJax_SVG': {
+        'overflow-x': 'scroll',
+        'max-width': '100% !important',
+      },
+      '.MathJax_SVG>svg': {
+        'display': 'block',
+      },
+    },
   });
 </script>
 %endif

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -471,7 +471,8 @@ DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 # from .common import _make_mako_template_dirs
 # ENABLE_COMPREHENSIVE_THEMING = True
 # COMPREHENSIVE_THEME_DIRS = [
-#     "/edx/app/edxapp/edx-platform/themes/"
+#     "/edx/app/edxapp/edx-platform/themes/",
+#     "/edx/src/edx-themes/edx-platform"
 # ]
 # TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
 # derive_settings(__name__)


### PR DESCRIPTION
## Description
Student couldn't MathJax on the smaller screen. The solution I am going for was to make MathJax scrollable when it is off screen.

Ticket: https://2u-internal.atlassian.net/browse/AU-1099


https://github.com/openedx/edx-platform/assets/83240113/25e3ce93-8431-415b-9e37-0b3e0c37b494

