### PR TITLE
fix: unrestrict enterprise learner from B2C subscriptions

### DIFF
--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -17,7 +17,7 @@ from web_fragments.fragment import Fragment
 
 from common.djangoapps.student.models import anonymous_id_for_user
 from common.djangoapps.student.roles import GlobalStaff
-from lms.djangoapps.learner_dashboard.utils import program_tab_view_is_enabled, user_b2c_subscriptions_enabled
+from lms.djangoapps.learner_dashboard.utils import b2c_subscriptions_enabled, program_tab_view_is_enabled
 from openedx.core.djangoapps.catalog.utils import get_programs
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.programs.models import (
@@ -58,7 +58,7 @@ class ProgramsFragmentView(EdxFragmentView):
             raise Http404
 
         meter = ProgramProgressMeter(request.site, user, mobile_only=mobile_only)
-        is_user_b2c_subscriptions_enabled = user_b2c_subscriptions_enabled(user, mobile_only)
+        is_user_b2c_subscriptions_enabled = b2c_subscriptions_enabled(mobile_only)
         programs_subscription_data = get_programs_subscription_data(user) if is_user_b2c_subscriptions_enabled else []
 
         context = {
@@ -120,7 +120,7 @@ class ProgramDetailsFragmentView(EdxFragmentView):
 
         program_discussion_lti = ProgramDiscussionLTI(program_uuid, request)
         program_live_lti = ProgramLiveLTI(program_uuid, request)
-        is_user_b2c_subscriptions_enabled = user_b2c_subscriptions_enabled(user, mobile_only)
+        is_user_b2c_subscriptions_enabled = b2c_subscriptions_enabled(mobile_only)
         program_subscription_data = (
             get_programs_subscription_data(user, program_uuid)
             if is_user_b2c_subscriptions_enabled

--- a/lms/djangoapps/learner_dashboard/utils.py
+++ b/lms/djangoapps/learner_dashboard/utils.py
@@ -12,7 +12,6 @@ from lms.djangoapps.learner_dashboard.config.waffle import (
     ENABLE_PROGRAM_TAB_VIEW
 )
 from lms.djangoapps.program_enrollments.api import get_program_enrollment
-from openedx.features.enterprise_support.utils import is_enterprise_learner
 
 FAKE_COURSE_KEY = CourseKey.from_string('course-v1:fake+course+run')
 
@@ -60,10 +59,10 @@ def b2c_subscriptions_is_enabled() -> bool:
     return ENABLE_B2C_SUBSCRIPTIONS.is_enabled()
 
 
-def user_b2c_subscriptions_enabled(user, is_mobile=False) -> bool:
+def b2c_subscriptions_enabled(is_mobile=False) -> bool:
     """
-    Check if user is eligible to see B2C subscriptions.
+    Check whether B2C Subscriptions pages should be shown to user.
     """
-    if not is_mobile and not is_enterprise_learner(user) and b2c_subscriptions_is_enabled():
+    if not is_mobile and b2c_subscriptions_is_enabled():
         return True
     return False


### PR DESCRIPTION
This PR un restricts the Enterprise learners from accessing B2C subscriptions. 