### PR TITLE
fix: added response for austin masters program in CPR views

### DIFF
--- a/lms/djangoapps/learner_recommendations/tests/test_views.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_views.py
@@ -693,7 +693,7 @@ class TestProductRecommendationsView(APITestCase):
 
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
     @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
-    def test_is_enrolled_in_masters_program(
+    def test_zero_cross_product_and_amplitude_recommendations(
         self,
         is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
@@ -717,13 +717,14 @@ class TestProductRecommendationsView(APITestCase):
 
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
     @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
-    def test_successful_response(
+    def test_zero_amplitude_recommendations(
         self,
         is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
     ):
         """
-        0 amplitude courses are returned if the user is enrolled in ut austin masters program
+        Verify that 0 amplitude courses are returned
+        if the user is enrolled in ut austin masters program
         """
         is_user_enrolled_in_ut_austin_masters_program_mock.return_value = True
         country_code_from_ip_mock.return_value = "za"

--- a/lms/djangoapps/learner_recommendations/tests/test_views.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_views.py
@@ -425,8 +425,10 @@ class TestProductRecommendationsView(APITestCase):
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_course_data")
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_amplitude_course_recommendations")
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_successful_response(
         self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
         get_amplitude_course_recommendations_mock,
         get_course_data_view_mock,
@@ -437,6 +439,7 @@ class TestProductRecommendationsView(APITestCase):
         Verify 2 cross product course recommendations are returned
         and 4 amplitude courses are returned
         """
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = False
         country_code_from_ip_mock.return_value = "za"
         get_user_enrolled_course_keys_mock.return_value = []
         get_amplitude_course_recommendations_mock.return_value = [False, True, self.amplitude_keys]
@@ -461,8 +464,10 @@ class TestProductRecommendationsView(APITestCase):
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_course_data")
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_amplitude_course_recommendations")
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_successful_course_filtering(
         self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
         get_amplitude_course_recommendations_mock,
         get_course_data_view_mock,
@@ -474,6 +479,7 @@ class TestProductRecommendationsView(APITestCase):
         and 2 amplitude courses are returned with filtering done for
         enrolled courses and courses with country restrictions
         """
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = False
         country_code_from_ip_mock.return_value = "cn"
         get_user_enrolled_course_keys_mock.return_value = self.enrolled_course_run_keys
         get_amplitude_course_recommendations_mock.return_value = [False, True, self.amplitude_keys]
@@ -509,8 +515,10 @@ class TestProductRecommendationsView(APITestCase):
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_course_data")
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_amplitude_course_recommendations")
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_fallback_recommendations_when_enrolled_courses_removed(
         self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
         get_amplitude_course_recommendations_mock,
         get_course_data_view_mock,
@@ -522,7 +530,7 @@ class TestProductRecommendationsView(APITestCase):
         and 4 fallback amplitude recommendations are returned if no courses are left
         after filtering due to courses being already enrolled in
         """
-
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = False
         country_code_from_ip_mock.return_value = "za"
         get_user_enrolled_course_keys_mock.return_value = self.amplitude_course_run_keys
         get_amplitude_course_recommendations_mock.return_value = [False, True, self.amplitude_keys]
@@ -548,8 +556,10 @@ class TestProductRecommendationsView(APITestCase):
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_course_data")
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_amplitude_course_recommendations")
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_fallback_recommendations_when_error_querying_amplitude(
         self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
         get_amplitude_course_recommendations_mock,
         get_course_data_mock,
@@ -559,7 +569,7 @@ class TestProductRecommendationsView(APITestCase):
         and 4 fallback amplitude recommendations are returned
         if there was an error querying amplitude for recommendations
         """
-
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = False
         country_code_from_ip_mock.return_value = "za"
         get_amplitude_course_recommendations_mock.side_effect = Exception()
 
@@ -582,8 +592,10 @@ class TestProductRecommendationsView(APITestCase):
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_course_data")
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_amplitude_course_recommendations")
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_fallback_recommendations_when_no_amplitude_recommended_keys(
         self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
         get_amplitude_course_recommendations_mock,
         get_course_data_mock,
@@ -593,7 +605,7 @@ class TestProductRecommendationsView(APITestCase):
         and 4 fallback amplitude recommendations are returned
         if amplitude gave back no course keys
         """
-
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = False
         country_code_from_ip_mock.return_value = "za"
         get_amplitude_course_recommendations_mock.side_effect = [False, True, []]
 
@@ -616,8 +628,10 @@ class TestProductRecommendationsView(APITestCase):
     @mock.patch("lms.djangoapps.learner_recommendations.utils.get_course_data")
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_amplitude_course_recommendations")
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_response_with_amplitude_and_no_cross_product_courses(
         self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
         get_amplitude_course_recommendations_mock,
         get_course_data_mock,
@@ -627,7 +641,7 @@ class TestProductRecommendationsView(APITestCase):
         Verify that if no cross product courses are returned,
         then 4 fallback amplitude recommendations will still be returned
         """
-
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = False
         country_code_from_ip_mock.return_value = "za"
         get_user_enrolled_course_keys_mock.return_value = self.enrolled_course_run_keys
         get_amplitude_course_recommendations_mock.return_value = [False, True, self.amplitude_keys]
@@ -648,8 +662,10 @@ class TestProductRecommendationsView(APITestCase):
     @mock.patch("lms.djangoapps.learner_recommendations.utils.get_course_data")
     @mock.patch("lms.djangoapps.learner_recommendations.views.get_amplitude_course_recommendations")
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_amplitude_only_url_response(
         self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
         country_code_from_ip_mock,
         get_amplitude_course_recommendations_mock,
         get_course_data_mock,
@@ -659,7 +675,7 @@ class TestProductRecommendationsView(APITestCase):
         Verify that if no course key was provided in the url,
         only 1 field for amplitude courses are sent back
         """
-
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = False
         country_code_from_ip_mock.return_value = "za"
         get_user_enrolled_course_keys_mock.return_value = self.enrolled_course_run_keys
         get_amplitude_course_recommendations_mock.return_value = [False, True, self.amplitude_keys]
@@ -675,6 +691,49 @@ class TestProductRecommendationsView(APITestCase):
         self.assertEqual(len(response_content), 1)
         self.assertEqual(len(amplitude_course_data), 4)
 
+    @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
+    def test_is_enrolled_in_masters_program(
+        self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
+        country_code_from_ip_mock,
+    ):
+        """
+        Verify 0 cross product course recommendations are returned
+        and 0 amplitude courses are returned if the user is enrolled in ut austin masters program
+        """
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = True
+        country_code_from_ip_mock.return_value = "za"
+
+        response = self.client.get(self._get_url('edx+HL0'))
+        response_content = json.loads(response.content)
+        cross_product_course_data = response_content["crossProductCourses"]
+        amplitude_course_data = response_content["amplitudeCourses"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(cross_product_course_data), 0)
+        self.assertEqual(len(amplitude_course_data), 0)
+
+
+    @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
+    def test_successful_response(
+        self,
+        is_user_enrolled_in_ut_austin_masters_program_mock,
+        country_code_from_ip_mock,
+    ):
+        """
+        0 amplitude courses are returned if the user is enrolled in ut austin masters program
+        """
+        is_user_enrolled_in_ut_austin_masters_program_mock.return_value = True
+        country_code_from_ip_mock.return_value = "za"
+
+        response = self.client.get(self._get_url())
+        response_content = json.loads(response.content)
+        amplitude_course_data = response_content["amplitudeCourses"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(amplitude_course_data), 0)
 
 @ddt.ddt
 class TestDashboardRecommendationsApiView(TestRecommendationsBase):

--- a/lms/djangoapps/learner_recommendations/tests/test_views.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_views.py
@@ -714,7 +714,6 @@ class TestProductRecommendationsView(APITestCase):
         self.assertEqual(len(cross_product_course_data), 0)
         self.assertEqual(len(amplitude_course_data), 0)
 
-
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
     @mock.patch("lms.djangoapps.learner_recommendations.views.is_user_enrolled_in_ut_austin_masters_program")
     def test_zero_amplitude_recommendations(
@@ -735,6 +734,7 @@ class TestProductRecommendationsView(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(amplitude_course_data), 0)
+
 
 @ddt.ddt
 class TestDashboardRecommendationsApiView(TestRecommendationsBase):

--- a/lms/djangoapps/learner_recommendations/views.py
+++ b/lms/djangoapps/learner_recommendations/views.py
@@ -272,6 +272,18 @@ class ProductRecommendationsView(APIView):
         Helper for collecting and forming a response for
         cross product and Amplitude recommendations
         """
+
+        if is_user_enrolled_in_ut_austin_masters_program(user):
+            return Response(
+                CrossProductAndAmplitudeRecommendationsSerializer(
+                {
+                    "crossProductCourses": [],
+                    "amplitudeCourses": []
+                }
+                ).data,
+                status=200
+            )
+
         amplitude_recommendations = self._get_amplitude_recommendations(user, user_country_code)
         cross_product_recommendations = self._get_cross_product_recommendations(course_key, user_country_code)
 
@@ -289,6 +301,15 @@ class ProductRecommendationsView(APIView):
         """
         Helper for collecting and forming a response for Amplitude recommendations only
         """
+
+        if is_user_enrolled_in_ut_austin_masters_program(user):
+            return Response(
+                AmplitudeRecommendationsSerializer({
+                  "amplitudeCourses": []
+                }).data,
+                status=200
+            )
+
         amplitude_recommendations = self._get_amplitude_recommendations(user, user_country_code)
 
         return Response(

--- a/lms/djangoapps/learner_recommendations/views.py
+++ b/lms/djangoapps/learner_recommendations/views.py
@@ -276,10 +276,10 @@ class ProductRecommendationsView(APIView):
         if is_user_enrolled_in_ut_austin_masters_program(user):
             return Response(
                 CrossProductAndAmplitudeRecommendationsSerializer(
-                {
-                    "crossProductCourses": [],
-                    "amplitudeCourses": []
-                }
+                    {
+                        "crossProductCourses": [],
+                        "amplitudeCourses": []
+                    }
                 ).data,
                 status=200
             )
@@ -305,7 +305,7 @@ class ProductRecommendationsView(APIView):
         if is_user_enrolled_in_ut_austin_masters_program(user):
             return Response(
                 AmplitudeRecommendationsSerializer({
-                  "amplitudeCourses": []
+                    "amplitudeCourses": []
                 }).data,
                 status=200
             )


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

- Added check to `product_recommendations` endpoints for checking if a user is enrolled in a UT Austin masters program, in which case, we will return an empty response

## Supporting information

**JIRA Ticket**: [PTECH-3275](https://jira.2u.com/browse/PTECH-3275)

## Testing instructions

Confirmed that when the method, `is_user_enrolled_in_ut_austin_masters_program` returns true, then the field values returned from the `product_recommendations` endpoint are empty arrays.

