### PR TITLE
fix: remove deprecated django-debug-toolbar Logging Panel

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -99,7 +99,6 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.request.RequestPanel',
     'debug_toolbar.panels.sql.SQLPanel',
     'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
     'debug_toolbar.panels.profiling.ProfilingPanel',
     'debug_toolbar.panels.history.HistoryPanel',
 )

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -98,7 +98,6 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.request.RequestPanel',
     'debug_toolbar.panels.sql.SQLPanel',
     'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
     'debug_toolbar.panels.history.HistoryPanel',
     # ProfilingPanel has been intentionally removed for default devstack.py
     # runtimes for performance reasons. If you wish to re-enable it in your


### PR DESCRIPTION
## Description

I saw this deprecation warning (on my tutor devstack) so I'm fixing it:

```
2023-06-21 20:47:47,092 WARNING 30 [py.warnings] [user None] [ip None] warnings.py:109 -
/openedx/venv/lib/python3.8/site-packages/debug_toolbar/settings.py:83: DeprecationWarning:
Please remove debug_toolbar.panels.logging.LoggingPanel from your DEBUG_TOOLBAR_PANELS setting.
```

## Supporting information

From [the official changelog](https://django-debug-toolbar.readthedocs.io/en/latest/changes.html) for django debug toolbar **4.0.0 (2023-04-03)**:

> Removed the logging panel. The panel’s implementation was too complex, caused memory leaks and sometimes very verbose and hard to silence output in some environments (but not others). The maintainers judged that time and effort is better invested elsewhere.

## Testing instructions

n/a

## Deadline

None

## Misc

Private ref: MNG-3766