### PR TITLE
Remove some usages of six (Python2 compat)

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -290,7 +290,7 @@ class CourseExportTask(UserTask):  # pylint: disable=abstract-method
             arguments_dict (dict): The arguments given to the task function
 
         Returns:
-            text_type: The generated name
+            str: The generated name
         """
         key = arguments_dict['course_key_string']
         return f'Export of {key}'
@@ -425,7 +425,7 @@ class CourseImportTask(UserTask):  # pylint: disable=abstract-method
             arguments_dict (dict): The arguments given to the task function
 
         Returns:
-            text_type: The generated name
+            str: The generated name
         """
         key = arguments_dict['course_key_string']
         filename = arguments_dict['archive_name']

--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -9,7 +9,6 @@ from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
-import six
 from six.moves.urllib.parse import quote
 %>
 
@@ -104,7 +103,7 @@ CMS.User.isGlobalStaff = '${is_global_staff | n, js_escaped_string}'=='True' ? t
         <div class="bit">
         % if context_course:
           <%
-            url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
+            url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='')
             details_url = utils.reverse_course_url('settings_handler', context_course.id)
             grading_url = utils.reverse_course_url('grading_handler', context_course.id)
             course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)

--- a/cms/templates/checklists.html
+++ b/cms/templates/checklists.html
@@ -2,8 +2,6 @@
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "files" %></%def>
 <%!
-  import six
-
   from cms.djangoapps.contentstore import utils
   from cms.djangoapps.contentstore.config.waffle_utils import should_show_checklists_quality
   from django.urls import reverse
@@ -40,7 +38,7 @@
         <%static:studiofrontend entry="courseHealthCheck">
 
             <%
-                course_key = six.text_type(context_course.id)
+                course_key = str(context_course.id)
                 certificates_url = ''
                 if has_certificates_enabled(context_course):
                     certificates_url = utils.reverse_course_url('certificates_list_handler', course_key)

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -3,7 +3,6 @@
 <%def name="online_help_token()"><% return "develop_course" %></%def>
 <%!
 import logging
-import six
 from six.moves.urllib.parse import quote
 
 from cms.djangoapps.contentstore.config.waffle_utils import should_show_checklists_quality
@@ -160,7 +159,7 @@ from django.urls import reverse
           <h2 class="title title-3">${_("This course has proctored exam settings that are incomplete or invalid.")}</h2>
           <p>
             % if mfe_proctored_exam_settings_url:
-              <% url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='') %>
+              <% url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='') %>
               ${Text(_("To update these settings go to the {link_start}Proctored Exam Settings page{link_end}.")).format(
                 link_start=HTML('<a href="${mfe_proctored_exam_settings_url}">').format(
                         mfe_proctored_exam_settings_url=mfe_proctored_exam_settings_url
@@ -263,7 +262,7 @@ from django.urls import reverse
                             },
                             "enable_quality": ${should_show_checklists_quality(context_course.id) | n, dump_js_escaped_json},
                             "links": {
-                                "settings": ${reverse('settings_handler', kwargs={'course_key_string': six.text_type(course_key)})| n, dump_js_escaped_json}
+                                "settings": ${reverse('settings_handler', kwargs={'course_key_string': str(course_key)})| n, dump_js_escaped_json}
                             }
                         }
                     </%static:studiofrontend>

--- a/cms/templates/export_git.html
+++ b/cms/templates/export_git.html
@@ -3,8 +3,6 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%!
-  import six
-
   from django.urls import reverse
   from django.utils.translation import gettext as _
 %>
@@ -41,7 +39,7 @@
         % else:
         <ul class="list-actions">
           <li class="item-action">
-            <a class="action action-export-git action-primary" href="${reverse('export_git', kwargs=dict(course_key_string=six.text_type(context_course.id)))}?action=push">
+            <a class="action action-export-git action-primary" href="${reverse('export_git', kwargs=dict(course_key_string=str(context_course.id)))}?action=push">
               <span class="icon fa fa-arrow-circle-o-down" aria-hidden="true"></span>
               <span class="copy">${_("Export to Git")}</span>
             </a>

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -11,7 +11,6 @@ from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
 from openedx.core.djangolib.markup import HTML, Text
-import six
 from six.moves.urllib.parse import quote
 %>
 
@@ -115,7 +114,7 @@ from six.moves.urllib.parse import quote
       <div class="bit">
       % if context_course:
         <%
-          url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
+          url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='')
           details_url = utils.reverse_course_url('settings_handler', context_course.id)
           grading_url = utils.reverse_course_url('grading_handler', context_course.id)
           course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -1,8 +1,6 @@
 ## xss-lint: disable=mako-missing-default
 <%inherit file="base.html" />
 <%!
-import six
-
 from django.utils.translation import gettext as _
 from django.urls import reverse
 
@@ -125,7 +123,7 @@ from openedx.core.djangolib.js_utils import (
         "${context_course.display_name_with_default | h}",
         ${users | n, dump_js_escaped_json},
         // xss-lint: disable=mako-invalid-js-filter
-        "${reverse('course_team_handler', kwargs={'course_key_string': six.text_type(context_course.id), 'email': '@@EMAIL@@'}) | n, js_escaped_string}",
+        "${reverse('course_team_handler', kwargs={'course_key_string': str(context_course.id), 'email': '@@EMAIL@@'}) | n, js_escaped_string}",
         ${request.user.id | n, dump_js_escaped_json},
         ${allow_actions | n, dump_js_escaped_json}
       );

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -14,7 +14,6 @@
       dump_js_escaped_json, js_escaped_string
   )
   from openedx.core.djangolib.markup import HTML, Text
-  import six
   from six.moves.urllib.parse import quote
   from six.moves.urllib import parse as urllib
 %>
@@ -711,7 +710,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
      <div class="bit">
      % if context_course:
           <%
-            url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
+            url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='')
             course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)
             grading_config_url = utils.reverse_course_url('grading_handler', context_course.id)
             advanced_config_url = utils.reverse_course_url('advanced_settings_handler', context_course.id)

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -3,7 +3,6 @@
 <%def name="online_help_token()"><% return "advanced" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
-  import six
   from six.moves.urllib.parse import quote
   from django.utils.translation import gettext as _
   from cms.djangoapps.contentstore import utils
@@ -43,7 +42,7 @@
           <h2 class="title title-3">${_("This course has proctored exam settings that are incomplete or invalid.")}</h2>
           <p>
             % if mfe_proctored_exam_settings_url:
-              <% url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='') %>
+              <% url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='') %>
               ${Text(_("You will be unable to make changes until the errors are resolved. To update these settings go to the {link_start}Proctored Exam Settings page{link_end}.")).format(
                 link_start=HTML('<a href="{mfe_proctored_exam_settings_url}">').format(
                         mfe_proctored_exam_settings_url=mfe_proctored_exam_settings_url
@@ -136,7 +135,7 @@
       <div class="bit">
       % if context_course:
         <%
-          url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
+          url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='')
           details_url = utils.reverse_course_url('settings_handler', context_course.id)
           grading_url = utils.reverse_course_url('grading_handler', context_course.id)
           course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -6,7 +6,6 @@
 
 <%namespace name='static' file='static_content.html'/>
 <%!
-  import six
   from six.moves.urllib.parse import quote
   import json
   from cms.djangoapps.contentstore import utils
@@ -158,7 +157,7 @@
       <div class="bit">
       % if context_course:
         <%
-          url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
+          url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='')
           detailed_settings_url = utils.reverse_course_url('settings_handler', context_course.id)
           course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)
           advanced_settings_url = utils.reverse_course_url('advanced_settings_handler', context_course.id)

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -1,7 +1,6 @@
 <%page expression_filter="h" args="online_help_token"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-  import six
   from six.moves.urllib.parse import quote
   from django.conf import settings
   from django.urls import reverse
@@ -39,23 +38,23 @@
       % if context_course:
       <%
             course_key = context_course.id
-            url_encoded_course_key = quote(six.text_type(course_key).encode('utf-8'), safe='')
-            index_url = reverse('course_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            course_team_url = reverse('course_team_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            assets_url = reverse('assets_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            textbooks_url = reverse('textbooks_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            videos_url = reverse('videos_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            import_url = reverse('import_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            course_info_url = reverse('course_info_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            export_url = reverse('export_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            settings_url = reverse('settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            grading_url = reverse('grading_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            tabs_url = reverse('tabs_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            url_encoded_course_key = quote(str(course_key).encode('utf-8'), safe='')
+            index_url = reverse('course_handler', kwargs={'course_key_string': str(course_key)})
+            course_team_url = reverse('course_team_handler', kwargs={'course_key_string': str(course_key)})
+            assets_url = reverse('assets_handler', kwargs={'course_key_string': str(course_key)})
+            textbooks_url = reverse('textbooks_list_handler', kwargs={'course_key_string': str(course_key)})
+            videos_url = reverse('videos_handler', kwargs={'course_key_string': str(course_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': str(course_key)})
+            course_info_url = reverse('course_info_handler', kwargs={'course_key_string': str(course_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': str(course_key)})
+            settings_url = reverse('settings_handler', kwargs={'course_key_string': str(course_key)})
+            grading_url = reverse('grading_handler', kwargs={'course_key_string': str(course_key)})
+            advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': str(course_key)})
+            tabs_url = reverse('tabs_handler', kwargs={'course_key_string': str(course_key)})
             certificates_url = ''
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
-                certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
+                certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': str(course_key)})
+            checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
             pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
             studio_home_mfe_enabled = toggles.use_new_home_page()
             course_outline_mfe_enabled = toggles.use_new_course_outline_page(context_course.id)
@@ -185,7 +184,7 @@
                   </li>
                   % endif
                   <li class="nav-item nav-course-settings-group-configurations">
-                    <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': six.text_type(course_key)})}">${_("Group Configurations")}</a>
+                    <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': str(course_key)})}">${_("Group Configurations")}</a>
                   </li>
                   % if mfe_proctored_exam_settings_url:
                   <li class="nav-item nav-course-settings-exams">
@@ -230,7 +229,7 @@
                   </li>
                   % if toggles.EXPORT_GIT.is_enabled() and context_course.giturl:
                   <li class="nav-item nav-course-tools-export-git">
-                    <a href="${reverse('export_git', kwargs=dict(course_key_string=six.text_type(course_key)))}">${_("Export to Git")}</a>
+                    <a href="${reverse('export_git', kwargs=dict(course_key_string=str(course_key)))}">${_("Export to Git")}</a>
                   </li>
                   % endif
                   <li class="nav-item nav-course-tools-checklists">
@@ -245,10 +244,10 @@
       % elif context_library:
        <%
             library_key = context_library.location.course_key
-            index_url = reverse('library_handler', kwargs={'library_key_string': six.text_type(library_key)})
-            import_url = reverse('import_handler', kwargs={'course_key_string': six.text_type(library_key)})
-            lib_users_url = reverse('manage_library_users', kwargs={'library_key_string': six.text_type(library_key)})
-            export_url = reverse('export_handler', kwargs={'course_key_string': six.text_type(library_key)})
+            index_url = reverse('library_handler', kwargs={'library_key_string': str(library_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': str(library_key)})
+            lib_users_url = reverse('manage_library_users', kwargs={'library_key_string': str(library_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': str(library_key)})
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Library:")}</span>

--- a/cms/templates/widgets/metadata-edit.html
+++ b/cms/templates/widgets/metadata-edit.html
@@ -5,9 +5,8 @@
   import hashlib
   import copy
   import json
-  from six import text_type
   from xmodule.modulestore import EdxJSONEncoder
-  hlskey = hashlib.md5(text_type(module.location).encode('utf-8')).hexdigest()
+  hlskey = hashlib.md5(str(module.location).encode('utf-8')).hexdigest()
 %>
 
 ## js templates

--- a/cms/templates/widgets/source-edit.html
+++ b/cms/templates/widgets/source-edit.html
@@ -2,8 +2,7 @@
 <%
   import hashlib
   from openedx.core.djangolib.js_utils import js_escaped_string
-  from six import text_type
-  hlskey = hashlib.md5(text_type(module.location).encode('utf-8')).hexdigest()
+  hlskey = hashlib.md5(str(module.location).encode('utf-8')).hexdigest()
 %>
 
   <section id="hls-modal-${hlskey}" class="upload-modal modal" style="overflow:scroll; background:#ddd; padding: 10px 0;box-shadow: 0 0 5px 0 #555;" >

--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -1,14 +1,11 @@
 """
 Set up lookup paths for mako templates.
 """
-
-
 import contextlib
 import hashlib
 import os
 
 import pkg_resources
-import six
 from django.conf import settings
 from mako.exceptions import TopLevelLookupException
 from mako.lookup import TemplateLookup
@@ -54,7 +51,7 @@ class DynamicTemplateLookup(TemplateLookup):
         # and "foo.html.py" in the module directory has no way to know that.
         # Update the module_directory argument to point to a directory
         # specifically for this lookup path.
-        unique = hashlib.md5(six.b(":".join(str(d) for d in self.directories))).hexdigest()
+        unique = hashlib.md5((":".join(str(d) for d in self.directories)).encode()).hexdigest()
         self.template_args['module_directory'] = os.path.join(self.__original_module_directory, unique)
 
         # Also clear the internal caches. Ick.

--- a/common/djangoapps/student/management/tests/test_bulk_change_enrollment_csv.py
+++ b/common/djangoapps/student/management/tests/test_bulk_change_enrollment_csv.py
@@ -3,7 +3,6 @@
 from tempfile import NamedTemporaryFile
 
 import pytest
-import six
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -50,7 +49,7 @@ class BulkChangeEnrollmentCSVTests(SharedModuleStoreTestCase):
         """Write a test csv file with the lines provided"""
         csv.write(b"course_id,user,mode,\n")
         for line in lines:
-            csv.write(six.b(line))
+            csv.write(line.encode())
         csv.seek(0)
         return csv
 

--- a/common/djangoapps/student/management/tests/test_bulk_unenroll.py
+++ b/common/djangoapps/student/management/tests/test_bulk_unenroll.py
@@ -2,7 +2,6 @@
 
 from tempfile import NamedTemporaryFile
 
-import six
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from testfixtures import LogCapture
@@ -48,7 +47,7 @@ class BulkUnenrollTests(SharedModuleStoreTestCase):
         """Write a test csv file with the lines provided"""
         csv.write(b"username,course_id\n")
         for line in lines:
-            csv.write(six.b(line))
+            csv.write(line.encode())
         csv.seek(0)
         return csv
 

--- a/common/djangoapps/student/management/tests/test_recover_account.py
+++ b/common/djangoapps/student/management/tests/test_recover_account.py
@@ -4,7 +4,6 @@ Test cases for recover account management command
 import re
 from tempfile import NamedTemporaryFile
 import pytest
-import six
 
 from django.core import mail
 from django.conf import settings
@@ -40,7 +39,7 @@ class RecoverAccountTests(TestCase):
         """Write a test csv file with the lines provided"""
         csv.write(b"username,current_email,desired_email\n")
         for line in lines:
-            csv.write(six.b(line))
+            csv.write(line.encode())
         csv.seek(0)
         return csv
 

--- a/common/djangoapps/student/management/tests/test_unsubscribe_user_email.py
+++ b/common/djangoapps/student/management/tests/test_unsubscribe_user_email.py
@@ -4,7 +4,6 @@ from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
 import pytest
-import six
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
@@ -34,7 +33,7 @@ class UnsubscribeUserEmailTests(TestCase):
 
         csv.write(b"email\n")
         for line in lines:
-            csv.write(six.b(line))
+            csv.write(line.encode())
         csv.seek(0)
         return csv
 

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -4,7 +4,6 @@ Tests of student.roles
 
 
 import ddt
-import six
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
@@ -70,7 +69,7 @@ class RolesTestCase(TestCase):
             f'Student has premature access to {self.course_key}'
         CourseStaffRole(self.course_key).add_users(self.student)
         assert CourseStaffRole(self.course_key).has_user(self.student), \
-            f"Student doesn't have access to {six.text_type(self.course_key)}"
+            f"Student doesn't have access to {str(self.course_key)}"
 
         # remove access and confirm
         CourseStaffRole(self.course_key).remove_users(self.student)
@@ -85,7 +84,7 @@ class RolesTestCase(TestCase):
             f'Student has premature access to {self.course_key.org}'
         OrgStaffRole(self.course_key.org).add_users(self.student)
         assert OrgStaffRole(self.course_key.org).has_user(self.student), \
-            f"Student doesn't have access to {six.text_type(self.course_key.org)}"
+            f"Student doesn't have access to {str(self.course_key.org)}"
 
         # remove access and confirm
         OrgStaffRole(self.course_key.org).remove_users(self.student)
@@ -101,16 +100,16 @@ class RolesTestCase(TestCase):
         OrgInstructorRole(self.course_key.org).add_users(self.student)
         CourseInstructorRole(self.course_key).add_users(self.student)
         assert OrgInstructorRole(self.course_key.org).has_user(self.student), \
-            f"Student doesn't have access to {six.text_type(self.course_key.org)}"
+            f"Student doesn't have access to {str(self.course_key.org)}"
         assert CourseInstructorRole(self.course_key).has_user(self.student), \
-            f"Student doesn't have access to {six.text_type(self.course_key)}"
+            f"Student doesn't have access to {str(self.course_key)}"
 
         # remove access and confirm
         OrgInstructorRole(self.course_key.org).remove_users(self.student)
         assert not OrgInstructorRole(self.course_key.org).has_user(self.student), \
             f'Student still has access to {self.course_key.org}'
         assert CourseInstructorRole(self.course_key).has_user(self.student), \
-            f"Student doesn't have access to {six.text_type(self.course_key)}"
+            f"Student doesn't have access to {str(self.course_key)}"
 
         # ok now keep org role and get rid of course one
         OrgInstructorRole(self.course_key.org).add_users(self.student)
@@ -118,7 +117,7 @@ class RolesTestCase(TestCase):
         assert OrgInstructorRole(self.course_key.org).has_user(self.student), \
             f'Student lost has access to {self.course_key.org}'
         assert not CourseInstructorRole(self.course_key).has_user(self.student), \
-            f"Student doesn't have access to {six.text_type(self.course_key)}"
+            f"Student doesn't have access to {str(self.course_key)}"
 
     def test_get_user_for_role(self):
         """

--- a/common/djangoapps/terrain/stubs/http.py
+++ b/common/djangoapps/terrain/stubs/http.py
@@ -202,7 +202,7 @@ class StubHttpRequestHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
         if content is not None:
-            if not six.PY2 and isinstance(content, str):
+            if isinstance(content, str):
                 content = content.encode('utf-8')
             self.wfile.write(content)
 

--- a/common/djangoapps/track/contexts.py
+++ b/common/djangoapps/track/contexts.py
@@ -5,7 +5,6 @@ import logging
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, LearningContextKey
-from six import text_type  # lint-amnesty, pylint: disable=unused-import
 
 from openedx.core.lib.request_utils import COURSE_REGEX
 

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -1,8 +1,6 @@
 """
 Views related to the Custom Courses feature.
 """
-
-
 import csv
 import datetime
 import functools
@@ -11,7 +9,6 @@ import logging
 from copy import deepcopy
 
 import pytz
-import six
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib import messages
@@ -538,8 +535,7 @@ def ccx_grades_csv(request, course, ccx=None):
                 if not header:
                     # Encode the header row in utf-8 encoding in case there are
                     # unicode characters
-                    header = [section['label'].encode('utf-8') if six.PY2 else section['label']
-                              for section in course_grade.summary['section_breakdown']]
+                    header = [section['label'] for section in course_grade.summary['section_breakdown']]
                     rows.append(["id", "email", "username", "grade"] + header)
 
                 percents = {

--- a/lms/djangoapps/discussion/notification_prefs/views.py
+++ b/lms/djangoapps/discussion/notification_prefs/views.py
@@ -7,7 +7,6 @@ from base64 import urlsafe_b64decode, urlsafe_b64encode
 from binascii import Error
 from hashlib import sha256
 
-import six
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
@@ -53,7 +52,7 @@ class UsernameCipher:
     @staticmethod
     def _get_aes_cipher(initialization_vector):
         hash_ = sha256()
-        hash_.update(six.b(settings.SECRET_KEY))
+        hash_.update(settings.SECRET_KEY.encode())
         return Cipher(AES(hash_.digest()), CBC(initialization_vector), backend=default_backend())
 
     @staticmethod

--- a/lms/djangoapps/grades/api.py
+++ b/lms/djangoapps/grades/api.py
@@ -9,7 +9,6 @@ from datetime import datetime
 import pytz
 from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from six import text_type
 
 from common.djangoapps.track.event_transaction_utils import create_new_event_transaction_id, set_event_transaction_type
 # Public Grades Modules

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -4,8 +4,6 @@
 
 <%! import json %>
 <%!
-import six
-
 from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
@@ -41,7 +39,7 @@ from openedx.core.djangolib.js_utils import (
 
 <%static:require_module module_name="teams/js/teams_tab_factory" class_name="TeamsTabFactory">
     TeamsTabFactory({
-        courseID: '${six.text_type(course.id) | n, js_escaped_string}',
+        courseID: '${str(course.id) | n, js_escaped_string}',
         topics: ${topics | n, dump_js_escaped_json},
         hasManagedTopic: ${has_managed_teamset | n, dump_js_escaped_json},
         hasPublicManagedTopic: ${has_public_managed_teamset | n, dump_js_escaped_json},

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -96,7 +96,7 @@ class TestModelStrings(SharedModuleStoreTestCase):
             "<CourseTeamMembership id=1 user_id=1 team_id=1>"
         )
 
-    def test_team_membership_text_type(self):
+    def test_team_membership_str(self):
         assert str(self.team_membership) == (
             "the-user is member of The Team in edx/the-course/1"
         )

--- a/lms/templates/conditional_block.html
+++ b/lms/templates/conditional_block.html
@@ -3,14 +3,13 @@
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
-from six import text_type
 %>
 
 <%
 def _message(reqm, message):
     return Text(message).format(link=HTML("<a href={url}>{url_name}</a>").format(
-        url = reverse('jump_to', kwargs=dict(course_id=text_type(reqm.course_id),
-                        location=text_type(reqm.location))),
+        url = reverse('jump_to', kwargs=dict(course_id=str(reqm.course_id),
+                        location=str(reqm.location))),
         url_name = reqm.display_name_with_default))
 %>
 % if message:

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -3,11 +3,10 @@
 <%!
 from django.utils.translation import gettext as _
 from django.urls import reverse
-from six import text_type
 %>
 <%page args="course" expression_filter="h"/>
 <article class="course" id="${course.id}" role="region" aria-label="${course.display_name_with_default}">
-  <a href="${reverse('about_course', args=[text_type(course.id)])}">
+  <a href="${reverse('about_course', args=[str(course.id)])}">
     <header class="course-image">
       <div class="cover-image">
         <img src="${course.course_image_url}" alt="${course.display_name_with_default} ${course.display_number_with_default}" />

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -6,7 +6,6 @@ from django.utils.translation import pgettext
 from django.urls import reverse
 from lms.djangoapps.courseware.courses import get_course_about_section
 from django.conf import settings
-from six import text_type
 from common.djangoapps.edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import clean_dangerous_html, HTML, Text
@@ -217,7 +216,7 @@ from six import string_types
           %endif
 
           % if pre_requisite_courses:
-          <% prc_target = reverse('about_course', args=[text_type(pre_requisite_courses[0]['key'])]) %>
+          <% prc_target = reverse('about_course', args=[str(pre_requisite_courses[0]['key'])]) %>
           <li class="prerequisite-course important-dates-item">
             <span class="icon fa fa-list-ul" aria-hidden="true"></span>
             <p class="important-dates-item-title">${_("Prerequisites")}</p>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -10,8 +10,6 @@ from common.djangoapps.edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import clean_dangerous_html, HTML, Text
 from openedx.core.lib.courses import course_image_url
-
-from six import string_types
 %>
 
 <%inherit file="../main.html" />
@@ -170,7 +168,7 @@ from six import string_types
             <li class="important-dates-item">
               <span class="icon fa fa-calendar" aria-hidden="true"></span>
               <p class="important-dates-item-title">${_("Classes Start")}</p>
-              % if isinstance(course_start_date, string_types):
+              % if isinstance(course_start_date, str):
                   <span class="important-dates-item-text start-date">${course_start_date}</span>
               % else:
                   <%
@@ -190,7 +188,7 @@ from six import string_types
             <li class="important-dates-item">
                 <span class="icon fa fa-calendar" aria-hidden="true"></span>
                 <p class="important-dates-item-title">${_("Classes End")}</p>
-                  % if isinstance(course_end_date, string_types):
+                  % if isinstance(course_end_date, str):
                       <span class="important-dates-item-text final-date">${course_end_date}</span>
                   % else:
                     <%

--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -6,7 +6,6 @@ import six
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 from django.conf import settings
-from six import text_type
 %>
 
 <header>
@@ -20,7 +19,7 @@ from six import text_type
         site_domain = static.get_value('site_domain', settings.SITE_NAME)
         site_protocol = 'https' if settings.HTTPS == 'on' else 'http'
         platform_name = static.get_platform_name()
-        course_path = reverse('about_course', args=[text_type(course.id)])
+        course_path = reverse('about_course', args=[str(course.id)])
         course_url = f"{site_protocol}://{site_domain}{course_path}"
 
         ## Translators: This text will be automatically posted to the student's

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -3,7 +3,6 @@
 <%namespace name='static' file='/static_content.html'/>
 <%def name="online_help_token()"><% return "courseware" %></%def>
 <%!
-import six
 import waffle
 
 from django.conf import settings
@@ -224,13 +223,13 @@ ${HTML(fragment.foot_html())}
                             % endif
                             % if chapter:
                                 <span class="nav-item nav-item-chapter" data-course-position="${course.position}" data-chapter-position="${chapter.position}">
-                                    <a href="${course_url}#${six.text_type(chapter.location)}">${chapter.display_name_with_default}</a>
+                                    <a href="${course_url}#${str(chapter.location)}">${chapter.display_name_with_default}</a>
                                 </span>
                                 <span class="icon fa fa-angle-right" aria-hidden="true"></span>
                             % endif
                             % if section:
                                 <span class="nav-item nav-item-section">
-                                    <a href="${course_url}#${six.text_type(section.location)}">${section.display_name_with_default}</a>
+                                    <a href="${course_url}#${str(section.location)}">${section.display_name_with_default}</a>
                                 </span>
                                 <span class="icon fa fa-angle-right" aria-hidden="true"></span>
                             % endif

--- a/lms/templates/courseware/gradebook.html
+++ b/lms/templates/courseware/gradebook.html
@@ -4,7 +4,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.urls import reverse
-from six import text_type
 %>
 
 <%block name="js_extra">
@@ -58,7 +57,7 @@ from six import text_type
         %for student in students:
         <tr>
           <td>
-            <a href="${reverse('student_progress', kwargs=dict(course_id=text_type(course_id), student_id=student['id']))}">${student['username']}</a>
+            <a href="${reverse('student_progress', kwargs=dict(course_id=str(course_id), student_id=student['id']))}">${student['username']}</a>
           </td>
         </tr>
         %endfor

--- a/lms/templates/courseware/xqa_interface.html
+++ b/lms/templates/courseware/xqa_interface.html
@@ -1,8 +1,5 @@
 ## xss-lint: disable=mako-missing-default
 <%namespace name='static' file='/static_content.html'/>
-<%!
-import six
-%>
 
 <script type="text/javascript" src="${static.url('js/vendor/jquery.leanModal.js')}"></script>
 <script type="text/javascript" src="${static.url('js/staff_debug_actions.js')}"></script>
@@ -28,7 +25,7 @@ function setup_debug(element_id, edit_link, staff_context){
             var username_or_email = $("#" + element_id + "_history_student_username").val();
             var location = $("#" + element_id + "_history_location").val();
             // xss-lint: disable=mako-invalid-js-filter
-            $("#" + element_id + "_history_text").load('/courses/' + "${six.text_type(getattr(course,'id','')) | u}" +
+            $("#" + element_id + "_history_text").load('/courses/' + "${str(getattr(course,'id','')) | u}" +
                 "/submission_history/" + encodeURIComponent(username_or_email) + "/" + location);
             return false;
         }

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -4,7 +4,6 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 import pytz
-import six
 from datetime import datetime, timedelta
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -220,7 +219,7 @@ from common.djangoapps.student.models import CourseEnrollment
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)
                 is_course_voucher_refundable = (session_id in enrolled_courses_voucher_refundable)
                 course_requirements = courses_requirements_not_met.get(session_id)
-                related_programs = inverted_programs.get(six.text_type(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
+                related_programs = inverted_programs.get(str(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
                 show_consent_link = (session_id in consent_required_courses)
                 resume_button_url = resume_button_urls[dashboard_index]
               %>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -2,7 +2,6 @@
 
 <%!
 import datetime
-import six
 
 from django.conf import settings
 from django.utils.http import urlencode, urlquote_plus
@@ -174,7 +173,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                             % endif
                         </span>
                     % else:
-                        % if isinstance(course_date, six.string_types):
+                        % if isinstance(course_date, str):
                             <span class="info-date-block">${container_string.format(date=course_date)}</span>
                         % elif course_date is not None:
                             <span class="info-date-block localized-datetime" data-language="${user_language}" data-timezone="${user_timezone}" data-datetime="${course_date.strftime('%Y-%m-%dT%H:%M:%S%z')}" data-format=${format} data-string="${container_string}"></span>
@@ -272,7 +271,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                         <ul class="actions-dropdown-list" id="actions-dropdown-list-${dashboard_index}" aria-label="${_('Available Actions')}" role="menu">
                           % if can_unenroll:
                             <li class="actions-item" id="actions-item-unenroll-${dashboard_index}" role="menuitem">
-                              <% course_refund_url = reverse('course_run_refund_status', args=[six.text_type(course_overview.id)]) %>
+                              <% course_refund_url = reverse('course_run_refund_status', args=[str(course_overview.id)]) %>
                                   <a href="#unenroll-modal" class="action action-unenroll" rel="leanModal"
                                     data-course-id="${course_overview.id}"
                                     data-course-number="${course_overview.number}"
@@ -419,7 +418,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
 
         % if course_requirements:
         ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
-        <% prc_target = reverse('about_course', args=[six.text_type(course_requirements['courses'][0]['key'])]) %>
+        <% prc_target = reverse('about_course', args=[str(course_requirements['courses'][0]['key'])]) %>
         <div class="prerequisites">
           <p class="tip">
             ${Text(_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.")).format(

--- a/lms/templates/dashboard/_dashboard_entitlement_actions.html
+++ b/lms/templates/dashboard/_dashboard_entitlement_actions.html
@@ -1,7 +1,6 @@
 <%page args="course_overview, entitlement, dashboard_index, can_refund_entitlement, show_email_settings" expression_filter="h"/>
 
 <%!
-import six
 from django.utils.translation import gettext as _
 from django.urls import reverse
 %>
@@ -39,7 +38,7 @@ dropdown_btn_id = "entitlement-actions-dropdown-btn-{}".format(dashboard_index)
             data-dropdown-button-selector="#${dropdown_btn_id}"
             data-course-name="${course_overview.display_name_with_default}"
             data-course-number="${course_overview.number}"
-            data-entitlement-api-endpoint="${reverse('entitlements_api:v1:enrollments', args=[six.text_type(entitlement.uuid)]) + '?is_refund=true'}">
+            data-entitlement-api-endpoint="${reverse('entitlements_api:v1:enrollments', args=[str(entitlement.uuid)]) + '?is_refund=true'}">
             ${_('Unenroll')}
           </a>
         </li>
@@ -54,7 +53,7 @@ dropdown_btn_id = "entitlement-actions-dropdown-btn-{}".format(dashboard_index)
             data-course-id="${course_overview.id}"
             data-course-number="${course_overview.number}"
             data-dashboard-index="${dashboard_index}"
-            data-optout="${six.text_type(course_overview.id) in course_optouts}">${_('Email Settings')}</a>
+            data-optout="${str(course_overview.id) in course_optouts}">${_('Email Settings')}</a>
         </li>
       % endif
       </ul>

--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -9,7 +9,6 @@
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from six import text_type
 
 from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
 %>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -14,7 +14,6 @@
 <%namespace name='static' file='static_content.html'/>
 <% online_help_token = self.online_help_token() if hasattr(self, 'online_help_token') else None %>
 <%!
-import six
 from lms.djangoapps.branding import api as branding_api
 from django.urls import reverse
 from django.utils.http import urlquote_plus
@@ -93,7 +92,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
       <%
       rtl_css_file = self.attr.main_css.replace('.css', '-rtl.css')
       %>
-      <link rel="stylesheet" href="${six.text_type(static.url(rtl_css_file))}" type="text/css" media="all" />
+      <link rel="stylesheet" href="${str(static.url(rtl_css_file))}" type="text/css" media="all" />
     % else:
       <link rel="stylesheet" href="${static.url(self.attr.main_css)}" type="text/css" media="all" />
     % endif

--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -7,7 +7,6 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
-from six import text_type
 %>
 
 <ol class="left list-inline nav-global">

--- a/lms/templates/public_video_share_embed.html
+++ b/lms/templates/public_video_share_embed.html
@@ -5,7 +5,6 @@
 
 <%namespace name='static' file='static_content.html'/>
 <%!
-import six
 from lms.djangoapps.branding import api as branding_api
 from django.utils.translation import gettext as _
 from django.utils.translation import get_language_bidi
@@ -45,7 +44,7 @@ from openedx.core.djangolib.markup import HTML
       <%
       rtl_css_file = self.attr.main_css.replace('.css', '-rtl.css')
       %>
-      <link rel="stylesheet" href="${six.text_type(static.url(rtl_css_file))}" type="text/css" media="all" />
+      <link rel="stylesheet" href="${str(static.url(rtl_css_file))}" type="text/css" media="all" />
     % else:
       <link rel="stylesheet" href="${static.url(self.attr.main_css)}" type="text/css" media="all" />
     % endif

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -4,7 +4,6 @@
 from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML
 from openedx.core.djangolib.js_utils import js_escaped_string
-from six import text_type
 %>
 
 ## The JS for this is defined in xqa_interface.html
@@ -100,7 +99,7 @@ ${block_content | n, decode.utf8}
 
     <div class="staff_info" style="display:block">
       is_released = ${is_released}
-      location = ${text_type(location)}
+      location = ${str(location)}
 
       <table summary="${_('Module Fields')}">
         <tr><th>${_('Module Fields')}</th></tr>

--- a/lms/templates/support/index.html
+++ b/lms/templates/support/index.html
@@ -1,7 +1,6 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-import six
 from django.urls import reverse
 from django.utils.translation import gettext as _
 %>
@@ -18,7 +17,7 @@ ${_("Student Support")}
   <h1>${_("Student Support")}</h1>
   <ul>
     % for url in urls:
-    <li><a href="${url["url"]}">${six.text_type(url["name"])}</a>: ${six.text_type(url["description"])}</li>
+    <li><a href="${url["url"]}">${str(url["name"])}</a>: ${str(url["description"])}</li>
     % endfor
   </ul>
 </section>

--- a/lms/templates/survey/survey.html
+++ b/lms/templates/survey/survey.html
@@ -2,7 +2,6 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%!
-import six
 from django.utils.translation import gettext as _
 from django.urls import reverse
 from django.utils import html
@@ -24,7 +23,7 @@ from openedx.core.djangolib.markup import Text, HTML
       <input type="hidden" name="_redirect_url" value="${redirect_url}" />
 
       % if course:
-        <input type="hidden" name="course_id" value="${six.text_type(course.id)}" />
+        <input type="hidden" name="course_id" value="${str(course.id)}" />
 
         <div class="header-survey">
           <h4 class="course-info">

--- a/openedx/core/djangoapps/credit/signature.py
+++ b/openedx/core/djangoapps/credit/signature.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 
 def _encode_secret(secret, provider_id):
     """
-    Helper function for encoding text_type secrets into ascii.
+    Helper function for encoding string secrets into ascii.
     """
     try:
         secret.encode('ascii')

--- a/themes/stanford-style/lms/templates/register-form.html
+++ b/themes/stanford-style/lms/templates/register-form.html
@@ -1,7 +1,6 @@
 ## xss-lint: disable=mako-missing-default
 <%!
 from common.djangoapps import third_party_auth
-import six
 from common.djangoapps.third_party_auth import pipeline, provider
 from django.utils.translation import ugettext as _
 from django_countries import countries
@@ -169,7 +168,7 @@ from common.djangoapps.student.models import UserProfile
         <select id="country" name="country" ${'required aria-required="true"' if settings.REGISTRATION_EXTRA_FIELDS['country'] == 'required' else ''}>
           <option value="">--</option>
           %for code, country_name in countries:
-          <option value="${code}">${ six.text_type(country_name) }</option>
+          <option value="${code}">${ str(country_name) }</option>
           %endfor
         </select>
       </div>

--- a/xmodule/capa/capa_problem.py
+++ b/xmodule/capa/capa_problem.py
@@ -22,7 +22,6 @@ from copy import deepcopy
 from datetime import datetime
 from xml.sax.saxutils import unescape
 
-import six
 from django.conf import settings
 
 from lxml import etree
@@ -182,7 +181,7 @@ class LoncapaProblem(object):
         self.problem_text = problem_text
 
         # parse problem XML file into an element tree
-        if isinstance(problem_text, six.text_type):
+        if isinstance(problem_text, str):
             # etree chokes on Unicode XML with an encoding declaration
             problem_text = problem_text.encode('utf-8')
         self.tree = etree.XML(problem_text)
@@ -659,7 +658,7 @@ class LoncapaProblem(object):
                 self.find_answer_text(answer_id, answer) for answer in current_answer
             )
 
-        elif isinstance(current_answer, six.string_types) and current_answer.startswith('choice_'):
+        elif isinstance(current_answer, str) and current_answer.startswith('choice_'):
             # Many problem (e.g. checkbox) report "choice_0" "choice_1" etc.
             # Here we transform it
             elems = self.tree.xpath('//*[@id="{answer_id}"]//*[@name="{choice_number}"]'.format(
@@ -678,7 +677,7 @@ class LoncapaProblem(object):
                 log.warning("Multiple answers found for answer id: %s and choice number: %s", answer_id, current_answer)
                 answer_text = "Multiple answers found"
 
-        elif isinstance(current_answer, six.string_types):
+        elif isinstance(current_answer, str):
             # Already a string with the answer
             answer_text = current_answer
 
@@ -809,7 +808,7 @@ class LoncapaProblem(object):
         """
         includes = self.tree.findall('.//include')
         for inc in includes:
-            filename = inc.get('file') if six.PY3 else inc.get('file').decode('utf-8')
+            filename = inc.get('file')
             if filename is not None:
                 try:
                     # open using LoncapaSystem OSFS filesystem
@@ -962,7 +961,7 @@ class LoncapaProblem(object):
 
         Used by get_html.
         """
-        if not isinstance(problemtree.tag, six.string_types):
+        if not isinstance(problemtree.tag, str):
             # Comment and ProcessingInstruction nodes are not Elements,
             # and we're ok leaving those behind.
             # BTW: etree gives us no good way to distinguish these things

--- a/xmodule/capa/inputtypes.py
+++ b/xmodule/capa/inputtypes.py
@@ -427,10 +427,7 @@ class OptionInput(InputTypeBase):
         options = re.sub(r"([a-zA-Z])('|\\')([a-zA-Z])", r"\1&#39;\3", options)
         options = re.sub(r"\\'", r"&#39;", options)  # replace already escaped single quotes
         # parse the set of possible options
-        if six.PY3:
-            lexer = shlex.shlex(options[1:-1])
-        else:
-            lexer = shlex.shlex(options[1:-1].encode('utf-8'))
+        lexer = shlex.shlex(options[1:-1])
 
         lexer.quotes = "'"
         # Allow options to be separated by whitespace as well as commas
@@ -438,10 +435,7 @@ class OptionInput(InputTypeBase):
 
         # remove quotes
         # convert escaped single quotes (html encoded string) back to single quotes
-        if six.PY3:
-            tokens = [x[1:-1].replace("&#39;", "'") for x in lexer]
-        else:
-            tokens = [x[1:-1].decode('utf-8').replace("&#39;", "'") for x in lexer]
+        tokens = [x[1:-1].replace("&#39;", "'") for x in lexer]
 
         # make list of (option_id, option_description), with description=id
         return [(t, t) for t in tokens]

--- a/xmodule/capa/inputtypes.py
+++ b/xmodule/capa/inputtypes.py
@@ -55,7 +55,6 @@ from calc.preview import latex_preview
 from chem import chemcalc
 
 from lxml import etree
-from six import text_type
 
 from xmodule.capa.xqueue_interface import XQUEUE_TIMEOUT
 from openedx.core.djangolib.markup import HTML, Text
@@ -86,7 +85,7 @@ class Status(object):
     }
     __slots__ = ('classname', '_status', 'display_name', 'display_tooltip')
 
-    def __init__(self, status, gettext_func=six.text_type):
+    def __init__(self, status, gettext_func=str):
         self.classname = self.css_classes.get(status, status)
         _ = gettext_func
         names = {
@@ -111,7 +110,7 @@ class Status(object):
                 ['incomplete', 'unanswered', 'unsubmitted'], _('Not yet answered.')
             )
         )
-        self.display_name = names.get(status, six.text_type(status))
+        self.display_name = names.get(status, str(status))
         self.display_tooltip = tooltips.get(status, '')
         self._status = status or ''
 
@@ -256,7 +255,7 @@ class InputTypeBase(object):
         except Exception as err:  # lint-amnesty, pylint: disable=broad-except
             # Something went wrong: add xml to message, but keep the traceback
             msg = "Error in xml '{x}': {err} ".format(
-                x=etree.tostring(xml), err=text_type(err))
+                x=etree.tostring(xml), err=str(err))
             six.reraise(Exception, Exception(msg), sys.exc_info()[2])
 
     @classmethod
@@ -565,7 +564,7 @@ class ChoiceGroup(InputTypeBase):
         return choices
 
     def get_user_visible_answer(self, internal_answer):
-        if isinstance(internal_answer, six.string_types):
+        if isinstance(internal_answer, str):
             return self._choices_map[internal_answer]
 
         return [self._choices_map[i] for i in internal_answer]
@@ -1572,7 +1571,7 @@ class AnnotationInput(InputTypeBase):
             d = {}
 
         comment_value = d.get('comment', '')
-        if not isinstance(comment_value, six.string_types):
+        if not isinstance(comment_value, str):
             comment_value = ''
 
         options_value = d.get('options', [])

--- a/xmodule/capa/responsetypes.py
+++ b/xmodule/capa/responsetypes.py
@@ -40,7 +40,6 @@ from lxml.html.soupparser import fromstring as fromstring_bs  # uses Beautiful S
 from pyparsing import ParseException
 from pytz import UTC
 from shapely.geometry import MultiPoint, Point
-from six import text_type
 from six.moves import map, range, zip
 
 import xmodule.capa.safe_exec as safe_exec
@@ -185,14 +184,14 @@ class LoncapaResponse(six.with_metaclass(abc.ABCMeta, object)):
         for abox in inputfields:
             if abox.tag not in self.allowed_inputfields:
                 msg = "%s: cannot have input field %s" % (
-                    six.text_type(self), abox.tag)
+                    str(self), abox.tag)
                 msg += "\nSee XML source line %s" % getattr(
                     xml, 'sourceline', '[unavailable]')
                 raise LoncapaProblemError(msg)
 
         if self.max_inputfields and len(inputfields) > self.max_inputfields:
             msg = "%s: cannot have more than %s input fields" % (
-                six.text_type(self), self.max_inputfields)
+                str(self), self.max_inputfields)
             msg += "\nSee XML source line %s" % getattr(
                 xml, 'sourceline', '[unavailable]')
             raise LoncapaProblemError(msg)
@@ -200,7 +199,7 @@ class LoncapaResponse(six.with_metaclass(abc.ABCMeta, object)):
         for prop in self.required_attributes:
             if not xml.get(prop):
                 msg = "Error in problem specification: %s missing required attribute %s" % (
-                    six.text_type(self), prop)
+                    str(self), prop)
                 msg += "\nSee XML source line %s" % getattr(
                     xml, 'sourceline', '[unavailable]')
                 raise LoncapaProblemError(msg)
@@ -373,7 +372,7 @@ class LoncapaResponse(six.with_metaclass(abc.ABCMeta, object)):
 
         # This is the "feedback hint" event
         event_info = {}
-        event_info['module_id'] = text_type(self.capa_block.location)
+        event_info['module_id'] = str(self.capa_block.location)
         event_info['problem_part_id'] = self.id
         event_info['trigger_type'] = 'single'  # maybe be overwritten by log_extra
         event_info['hint_label'] = label
@@ -1466,7 +1465,7 @@ class OptionResponse(LoncapaResponse):
             for key, val in six.iteritems(self.context):
                 # convert val into unicode because student answer always be a unicode string
                 # even it is a list, dict etc.
-                if six.text_type(val) == student_answers[aid]:
+                if str(val) == student_answers[aid]:
                     return '$' + key
         return None
 
@@ -1614,10 +1613,10 @@ class NumericalResponse(LoncapaResponse):
                 err.args[0]
             )
         except ValueError as val_err:
-            if 'factorial' in text_type(val_err):  # lint-amnesty, pylint: disable=no-else-raise
+            if 'factorial' in str(val_err):  # lint-amnesty, pylint: disable=no-else-raise
                 # This is thrown when fact() or factorial() is used in an answer
                 #   that evaluates on negative and/or non-integer inputs
-                # text_type(ve) will be: `factorial() only accepts integral values` or
+                # str(ve) will be: `factorial() only accepts integral values` or
                 # `factorial() not defined for negative values`
                 raise StudentInputError(  # lint-amnesty, pylint: disable=raise-missing-from
                     _("Factorial function evaluated outside its domain:"
@@ -2047,7 +2046,7 @@ class StringResponse(LoncapaResponse):
             except Exception as err:
                 msg = '[courseware.capa.responsetypes.stringresponse] {error}: {message}'.format(
                     error=_('error'),
-                    message=text_type(err)
+                    message=str(err)
                 )
                 log.error(msg, exc_info=True)
                 raise ResponseError(msg)  # lint-amnesty, pylint: disable=raise-missing-from
@@ -2178,7 +2177,7 @@ class CustomResponse(LoncapaResponse):
         """
         _ = edx_six.get_gettext(self.capa_system.i18n)
 
-        log.debug('%s: student_answers=%s', six.text_type(self), student_answers)
+        log.debug('%s: student_answers=%s', str(self), student_answers)
 
         # ordered list of answer id's
         # sort the responses on the bases of the problem's position number
@@ -2520,7 +2519,7 @@ class CustomResponse(LoncapaResponse):
 
         # Notify student with a student input error
         _, _, traceback_obj = sys.exc_info()
-        raise ResponseError(text_type(err), traceback_obj)
+        raise ResponseError(str(err), traceback_obj)
 
 #-----------------------------------------------------------------------------
 
@@ -2905,7 +2904,7 @@ class ExternalResponse(LoncapaResponse):
             # no <answer> stanza; get code from <script>
             self.code = self.context['script_code']
             if not self.code:
-                msg = '%s: Missing answer script code for externalresponse' % six.text_type(
+                msg = '%s: Missing answer script code for externalresponse' % str(
                     self)
                 msg += "\nSee XML source line %s" % getattr(
                     self.xml, 'sourceline', '[unavailable]')
@@ -3119,10 +3118,10 @@ class FormulaResponse(LoncapaResponse):
                     err.args[0]
                 )
             except ValueError as err:
-                if 'factorial' in text_type(err):
+                if 'factorial' in str(err):
                     # This is thrown when fact() or factorial() is used in a formularesponse answer
                     #   that tests on negative and/or non-integer inputs
-                    # text_type(err) will be: `factorial() only accepts integral values` or
+                    # str(err) will be: `factorial() only accepts integral values` or
                     # `factorial() not defined for negative values`
                     log.debug(
                         ('formularesponse: factorial function used in response '

--- a/xmodule/capa/responsetypes.py
+++ b/xmodule/capa/responsetypes.py
@@ -2291,7 +2291,7 @@ class CustomResponse(LoncapaResponse):
 
     def execute_check_function(self, idset, submission):  # lint-amnesty, pylint: disable=missing-function-docstring, too-many-statements
         # exec the check function
-        if isinstance(self.code, six.string_types):  # lint-amnesty, pylint: disable=too-many-nested-blocks
+        if isinstance(self.code, str):  # lint-amnesty, pylint: disable=too-many-nested-blocks
             try:
                 safe_exec.safe_exec(
                     self.code,
@@ -3547,7 +3547,7 @@ class AnnotationResponse(LoncapaResponse):
             json_d = {}
 
         comment_value = json_d.get('comment', '')
-        if not isinstance(json_d, six.string_types):
+        if not isinstance(json_d, str):
             comment_value = ''
 
         options_value = json_d.get('options', [])

--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -8,7 +8,6 @@ from codejail.safe_exec import not_safe_exec as codejail_not_safe_exec
 from codejail.safe_exec import safe_exec as codejail_safe_exec
 from edx_django_utils.monitoring import function_trace
 import six
-from six import text_type
 
 from . import lazymod
 from .remote_exec import is_codejail_rest_service_enabled, get_remote_exec
@@ -178,7 +177,7 @@ def safe_exec(
         except SafeExecException as e:
             # Saving SafeExecException e in exception to be used later.
             exception = e
-            emsg = text_type(e)
+            emsg = str(e)
         else:
             emsg = None
 

--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -1,13 +1,10 @@
 """Capa's specialized use of codejail.safe_exec."""
-
-
 import hashlib
 
 from codejail.safe_exec import SafeExecException, json_safe
 from codejail.safe_exec import not_safe_exec as codejail_not_safe_exec
 from codejail.safe_exec import safe_exec as codejail_safe_exec
 from edx_django_utils.monitoring import function_trace
-import six
 
 from . import lazymod
 from .remote_exec import is_codejail_rest_service_enabled, get_remote_exec
@@ -69,7 +66,7 @@ def update_hash(hasher, obj):
     `obj` in the process.  Only primitive JSON-safe types are supported.
 
     """
-    hasher.update(six.b(str(type(obj))))
+    hasher.update(str(type(obj)).encode())
     if isinstance(obj, (tuple, list)):
         for e in obj:
             update_hash(hasher, e)
@@ -78,7 +75,7 @@ def update_hash(hasher, obj):
             update_hash(hasher, k)
             update_hash(hasher, obj[k])
     else:
-        hasher.update(six.b(repr(obj)))
+        hasher.update(repr(obj).encode())
 
 
 @function_trace('safe_exec')

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -9,14 +9,13 @@ import unittest
 
 import pytest
 import random2 as random
-import six
 from codejail import jail_code
 from codejail.django_integration import ConfigureCodeJailMiddleware
 from codejail.safe_exec import SafeExecException
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.test import override_settings
-from six import text_type, unichr
+from six import unichr
 from six.moves import range
 
 from xmodule.capa.safe_exec import safe_exec, update_hash
@@ -77,7 +76,7 @@ class TestSafeExec(unittest.TestCase):  # lint-amnesty, pylint: disable=missing-
         g = {}
         with pytest.raises(SafeExecException) as cm:
             safe_exec("1/0", g)
-        assert 'ZeroDivisionError' in text_type(cm.value)
+        assert 'ZeroDivisionError' in str(cm.value)
 
 
 class TestSafeOrNot(unittest.TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -93,8 +92,8 @@ class TestSafeOrNot(unittest.TestCase):  # lint-amnesty, pylint: disable=missing
         g = {}
         with pytest.raises(SafeExecException) as cm:
             safe_exec('import sys; sys.exit(1)', g)
-        assert "SystemExit" not in text_type(cm)
-        assert "Couldn't execute jailed code" in text_type(cm)
+        assert "SystemExit" not in str(cm)
+        assert "Couldn't execute jailed code" in str(cm)
 
     def test_can_do_something_forbidden_if_run_unsafely(self):
         '''
@@ -104,7 +103,7 @@ class TestSafeOrNot(unittest.TestCase):  # lint-amnesty, pylint: disable=missing
         g = {}
         with pytest.raises(SystemExit) as cm:
             safe_exec('import sys; sys.exit(1)', g, unsafely=True)
-        assert "SystemExit" in text_type(cm)
+        assert "SystemExit" in str(cm)
 
 
 class TestLimitConfiguration(unittest.TestCase):
@@ -262,7 +261,7 @@ class TestSafeExecCaching(unittest.TestCase):
         # Check that using non-ASCII unicode does not raise an encoding error.
         # Try several non-ASCII unicode characters.
         for code in [129, 500, 2 ** 8 - 1, 2 ** 16 - 1]:
-            code_with_unichr = six.text_type("# ") + unichr(code)
+            code_with_unichr = str("# ") + unichr(code)
             try:
                 safe_exec(code_with_unichr, {}, cache=DictCache({}))
             except UnicodeEncodeError:

--- a/xmodule/capa/templates/choicegroup.html
+++ b/xmodule/capa/templates/choicegroup.html
@@ -1,12 +1,11 @@
 <%page expression_filter="h"/>
 <%!
 from openedx.core.djangolib.markup import HTML
-import six
 %>
 <%
   def is_radio_input(choice_id):
-    return input_type == 'radio' and ((isinstance(value, six.string_types) and (choice_id == value)) or (
-      not isinstance(value, six.string_types) and choice_id in value
+    return input_type == 'radio' and ((isinstance(value, str) and (choice_id == value)) or (
+      not isinstance(value, str) and choice_id in value
     ))
 %>
 <div class="choicegroup capa_inputtype" id="inputtype_${id}">

--- a/xmodule/capa/tests/helpers.py
+++ b/xmodule/capa/tests/helpers.py
@@ -8,7 +8,6 @@ import os.path
 import xml.sax.saxutils as saxutils
 
 import fs.osfs
-import six
 from mako.lookup import TemplateLookup
 from mock import MagicMock, Mock
 from path import Path
@@ -94,10 +93,7 @@ def mock_capa_block():
         return 'i4x://Foo/bar/mock/abc'
 
     capa_block = Mock()
-    if six.PY2:
-        capa_block.location.__unicode__ = mock_location_text
-    else:
-        capa_block.location.__str__ = mock_location_text
+    capa_block.location.__str__ = mock_location_text
     # The following comes into existence by virtue of being called
     # capa_block.runtime.publish
     return capa_block

--- a/xmodule/capa/tests/response_xml_factory.py
+++ b/xmodule/capa/tests/response_xml_factory.py
@@ -730,7 +730,7 @@ class StringResponseXMLFactory(ResponseXMLFactory):
         response_element = etree.Element("stringresponse")
 
         # Set the answer attribute
-        response_element.set("answer", six.text_type(answer))
+        response_element.set("answer", str(answer))
 
         # Set the case sensitivity and regexp:
         type_value = ''

--- a/xmodule/capa/tests/test_capa_problem.py
+++ b/xmodule/capa/tests/test_capa_problem.py
@@ -1,13 +1,11 @@
 """
 Test capa problem.
 """
-
-
 import textwrap
 import unittest
+
 import pytest
 import ddt
-import six
 from lxml import etree
 from markupsafe import Markup
 from mock import patch
@@ -430,7 +428,7 @@ class CAPAMultiInputProblemTest(unittest.TestCase):
 
     def assert_problem_data(self, problem_data):
         """Verify problem data is in expected state"""
-        for problem_value in six.viewvalues(problem_data):
+        for problem_value in problem_data.values():
             assert isinstance(problem_value['label'], Markup)
 
     def assert_problem_html(self, problem_html, group_label, *input_labels):

--- a/xmodule/capa/tests/test_capa_problem.py
+++ b/xmodule/capa/tests/test_capa_problem.py
@@ -733,4 +733,4 @@ class CAPAProblemReportHelpersTest(unittest.TestCase):
 
         # Ensure that the answer is a string so that the dict returned from this
         # function can eventualy be serialized to json without issues.
-        assert isinstance(problem.get_question_answers()['1_solution_1'], six.text_type)
+        assert isinstance(problem.get_question_answers()['1_solution_1'], str)

--- a/xmodule/capa/tests/test_inputtypes.py
+++ b/xmodule/capa/tests/test_inputtypes.py
@@ -1632,7 +1632,6 @@ class TestStatus(unittest.TestCase):
         """
         statobj = inputtypes.Status('test')
         assert str(statobj) == 'test'
-        assert six.text_type(statobj) == 'test'
 
     def test_classes(self):
         """

--- a/xmodule/capa/tests/test_responsetypes.py
+++ b/xmodule/capa/tests/test_responsetypes.py
@@ -20,7 +20,6 @@ import random2 as random
 import requests
 import six
 from pytz import UTC
-from six import text_type
 
 from xmodule.capa.correctmap import CorrectMap
 from xmodule.capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
@@ -798,7 +797,7 @@ class StringResponseTest(ResponseTest):  # pylint: disable=missing-class-docstri
         problem = self.build_problem(answer="a2", case_sensitive=False, regexp=True, additional_answers=['?\\d?'])
         with pytest.raises(Exception) as cm:
             self.assert_grade(problem, "a3", "correct")
-        exception_message = text_type(cm.value)
+        exception_message = str(cm.value)
         assert 'nothing to repeat' in exception_message
 
     def test_hints(self):

--- a/xmodule/capa/tests/test_responsetypes.py
+++ b/xmodule/capa/tests/test_responsetypes.py
@@ -2,8 +2,6 @@
 """
 Tests of responsetypes
 """
-
-
 import io
 import json
 import os
@@ -18,7 +16,6 @@ import mock
 import pyparsing
 import random2 as random
 import requests
-import six
 from pytz import UTC
 
 from xmodule.capa.correctmap import CorrectMap
@@ -2727,7 +2724,7 @@ class ChoiceTextResponseTest(ResponseTest):
         radiotextgroup.
         """
 
-        for name, inputs in six.iteritems(self.TEST_INPUTS):
+        for name, inputs in self.TEST_INPUTS.items():
             # Turn submission into the form expected when grading this problem.
             submission = self._make_answer_dict(inputs)
             # Lookup the problem_name, and the whether this test problem
@@ -2807,7 +2804,7 @@ class ChoiceTextResponseTest(ResponseTest):
             "checkbox_2_choices_2_inputs": checkbox_two_choices_two_inputs
         }
 
-        for name, inputs in six.iteritems(inputs):
+        for name, inputs in inputs.items():
             submission = self._make_answer_dict(inputs)
             # Load the test problem's name and desired correctness
             problem_name, correctness = scenarios[name]

--- a/xmodule/capa/util.py
+++ b/xmodule/capa/util.py
@@ -9,7 +9,6 @@ from cmath import isinf, isnan
 from decimal import Decimal
 
 import bleach
-import six
 from calc import evaluator
 from lxml import etree
 
@@ -121,7 +120,7 @@ def contextualize_text(text, context):  # private
         # Should be a separate dict of variables that should be
         # replaced.
         context_key = '$' + key
-        if context_key in (text.decode('utf-8') if six.PY3 and isinstance(text, bytes) else text):
+        if context_key in (text.decode('utf-8') if isinstance(text, bytes) else text):
             text = convert_to_str(text)
             context_value = convert_to_str(context[key])
             text = text.replace(context_key, context_value)

--- a/xmodule/modulestore/mongo/base.py
+++ b/xmodule/modulestore/mongo/base.py
@@ -8,7 +8,7 @@ structure:
     '_id': <location.as_dict>,
     'metadata': <dict containing all Scope.settings fields>
     'definition': <dict containing all Scope.content fields>
-    'definition.children': <list of all child text_type(location)s>
+    'definition.children': <list of all child str(location)s>
 }
 """
 


### PR DESCRIPTION
## Description

To make the code simpler and more readable, this PR gets rid of some usages of `six`. We don't need `six` at all now because Python2 support has long since been dropped.

Specifically, this PR eliminates usages of:
* `six.text_type()`, `six.string_types`
* `six.b()`
* `six.PY3`/`six.PY2`
* `six.iteritems()` and `six.viewvalues()`

Other usages of `six`, particularly `six.moves` remain for now, to keep this PR from getting too big.

## Testing instructions

No specific way to test this.

## Deadline

None

## Other information

Private ref: MNG-3767