### PR TITLE
test:enable the disabled tests in test_capa_block.py 

### DIFF
--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -2039,46 +2039,48 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
                    ('shuffle', ['choice_3', 'choice_1', 'choice_2', 'choice_0'])
             assert event_info['success'] == 'correct'
 
-    @unittest.skip("masking temporarily disabled")
     def test_save_unmask(self):
-        """On problem save, unmasked data should appear on publish."""
+        """
+        On problem save, unmasked data should appear on publish.
+        Since masking is disabled in pull #3872, we resort to check actual answers.
+        """
         block = CapaFactory.create(xml=self.common_shuffle_xml)
         with patch.object(block.runtime, 'publish') as mock_publish:
             get_request_dict = {CapaFactory.input_key(): 'mask_0'}
             block.save_problem(get_request_dict)
             mock_call = mock_publish.mock_calls[0]
-            event_info = mock_call[1][1]
-            assert event_info['answers'][CapaFactory.answer_key()] == 'choice_2'
+            event_info = mock_call[1][2]
+            assert event_info['answers'][CapaFactory.answer_key()] == 'mask_0'
             assert event_info['permutation'][CapaFactory.answer_key()] is not None
 
-    @unittest.skip("masking temporarily disabled")
     def test_reset_unmask(self):
         """On problem reset, unmask names should appear publish."""
         block = CapaFactory.create(xml=self.common_shuffle_xml)
         get_request_dict = {CapaFactory.input_key(): 'mask_0'}
         block.submit_problem(get_request_dict)
         # On reset, 'old_state' should use unmasked names
+        # Since masking is disabled in pull #3872, we resort to check actual answers.
         with patch.object(block.runtime, 'publish') as mock_publish:
             block.reset_problem(None)
-            mock_call = mock_publish.mock_calls[0]
-            event_info = mock_call[1][1]
-            assert mock_call[1][0] == 'reset_problem'
-            assert event_info['old_state']['student_answers'][CapaFactory.answer_key()] == 'choice_2'
+            mock_call = mock_publish.mock_calls[1]
+            event_info = mock_call[1][2]
+            assert mock_call[1][1] == 'reset_problem'
+            assert event_info['old_state']['student_answers'][CapaFactory.answer_key()] == 'mask_0'
             assert event_info['permutation'][CapaFactory.answer_key()] is not None
 
-    @unittest.skip("masking temporarily disabled")
     def test_rescore_unmask(self):
         """On problem rescore, unmasked names should appear on publish."""
         block = CapaFactory.create(xml=self.common_shuffle_xml)
         get_request_dict = {CapaFactory.input_key(): 'mask_0'}
         block.submit_problem(get_request_dict)
         # On rescore, state/student_answers should use unmasked names
+        # Since masking is disabled in pull #3872, we resort to check actual answers.
         with patch.object(block.runtime, 'publish') as mock_publish:
-            block.rescore_problem(only_if_higher=False)  # lint-amnesty, pylint: disable=no-member
-            mock_call = mock_publish.mock_calls[0]
-            event_info = mock_call[1][1]
-            assert mock_call[1][0] == 'problem_rescore'
-            assert event_info['state']['student_answers'][CapaFactory.answer_key()] == 'choice_2'
+            block.rescore(only_if_higher=False)  # lint-amnesty, pylint: disable=no-member
+            mock_call = mock_publish.mock_calls[1]
+            event_info = mock_call[1][2]
+            assert mock_call[1][1] == 'problem_rescore'
+            assert event_info['state']['student_answers'][CapaFactory.answer_key()] == 'mask_0'
             assert event_info['permutation'][CapaFactory.answer_key()] is not None
 
     def test_check_unmask_answerpool(self):


### PR DESCRIPTION
## Description

In #3872, masking is disabled, so instead of removing these tests, we can enable them but change the assertion to test actual answer responses. Also, the rescore function name was changed from `rescore_problem` to `rescore`.

Resolves https://github.com/openedx/edx-platform/issues/31695

## Supporting information

PR where masking was disabled - #3872 

## Testing instructions

`xmodule/tests/test_capa_block.py` should pass as expected with all tests.

## Deadline

None

## Other information

NA