### PR TITLE
temp: fix EncodeError for username in expire_and_create_entitlements

### DIFF
--- a/common/djangoapps/entitlements/management/commands/expire_and_create_entitlements.py
+++ b/common/djangoapps/entitlements/management/commands/expire_and_create_entitlements.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
 
         logger.info('Looking for entitlements which may be expirable.')
 
-        support_user = User.objects.get(username=options.get('username'))
+        support_username = options.get('username')
         current_date = date.today()
         exceptional_courses = options.get('exceptional_course_uuids')
 
@@ -105,6 +105,6 @@ class Command(BaseCommand):
             start = batch_num * batch_size
             end = min(start + batch_size, entitlements_to_expire, entitlements_count)
             entitlement_ids = [entitlement.id for entitlement in entitlements[start:end]]
-            expire_and_create_entitlements.delay(entitlement_ids, support_user)
+            expire_and_create_entitlements.delay(entitlement_ids, support_username)
 
         logger.info('Done. Successfully enqueued %d tasks.', num_batches)

--- a/common/djangoapps/entitlements/management/commands/expire_and_create_entitlements.py
+++ b/common/djangoapps/entitlements/management/commands/expire_and_create_entitlements.py
@@ -9,14 +9,11 @@ from math import ceil
 from textwrap import dedent
 
 from django.core.management import BaseCommand
-from django.contrib.auth import get_user_model
 
 from common.djangoapps.entitlements.tasks import expire_and_create_entitlements
 from common.djangoapps.entitlements.models import CourseEntitlement
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
-User = get_user_model()
 
 
 class Command(BaseCommand):

--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -64,7 +64,7 @@ def expire_old_entitlements(self, start, end, logid='...'):
 
 @shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
-def expire_and_create_entitlements(self, entitlement_ids, support_user):
+def expire_and_create_entitlements(self, entitlement_ids, support_username):
     """
     Expire entitlements older than one year.
 
@@ -76,13 +76,15 @@ def expire_and_create_entitlements(self, entitlement_ids, support_user):
 
     Args:
         entitlement_ids (List<int>): A list of entitlement ids to expire.
-        support_user (django.contrib.auth.models.user): The username to attribute
-        the entitlement expiration and recreation to.
+        support_username (str): The username to attribute the entitlement
+            expiration and recreation to.
 
     Returns:
         None
 
     """
+    support_user = User.objects.get(username=support_username)
+
     first_entitlement_id = entitlement_ids[0]
     last_entitlement_id = entitlement_ids[-1]
 

--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -4,6 +4,7 @@ This file contains celery tasks for entitlements-related functionality.
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings  # lint-amnesty, pylint: disable=unused-import
+from django.contrib.auth import get_user_model
 from edx_django_utils.monitoring import set_code_owner_attribute
 
 from common.djangoapps.entitlements.models import CourseEntitlement, CourseEntitlementSupportDetail
@@ -15,6 +16,8 @@ LOGGER = get_task_logger(__name__)
 # time of 2047 seconds (about 30 minutes). Setting this to None could yield
 # unwanted behavior: infinite retries.
 MAX_RETRIES = 11
+
+User = get_user_model()
 
 
 @shared_task(bind=True, ignore_result=True)


### PR DESCRIPTION
## Description

On running the management command, we get the folowing error:

    kombu.exceptions.EncodeError: Object of type User is not JSON serializable

Pass a string of the username instead in the parameters of the tasks created by the expire_and_create_entitlements management command.

This PR is very similar to https://github.com/openedx/edx-platform/pull/32562, but for another parameter.

## Additional Information

* Jira: [REV-3574](https://2u-internal.atlassian.net/browse/REV-3574)
* This PR is a fix forward for:
  - https://github.com/openedx/edx-platform/pull/32562
  - https://github.com/openedx/edx-platform/pull/32528