### PR TITLE
temp: fix use len(list) not list.count() in expire_and_create_entitlements

### DIFF
--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -136,4 +136,4 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
     except Exception as exc:  # pylint: disable=broad-except
         LOGGER.exception('Failed to expire entitlements that reached their expiration period')
 
-    LOGGER.info('Successfully completed the task expire_and_create_entitlements after examining %d entries', entitlement_ids.count())  # lint-amnesty, pylint: disable=line-too-long
+    LOGGER.info('Successfully completed the task expire_and_create_entitlements after examining %d entries', len(entitlement_ids))  # lint-amnesty, pylint: disable=line-too-long


### PR DESCRIPTION
## Description

On running expire_and_create_entitlements, we get error: 

```
TypeError: count() takes exactly one argument (0 given)
```

<details>
<summary>Full error:</summary>

```
Jun 23 20:32:00 ip-10-3-70-106 [service_variant=lms][celery.app.trace][env:stage-edx-edxapp] ERROR [ip-<redacted IP address>] [user None] [ip None] [trace.py:265] - Task common.djangoapps.entitlements.tasks.expire_and_create_entitlements[<redacted task id>] raised unexpected: TypeError('count() takes exactly one argument (0 given)')
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/application_celery.py", line 99, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_django_utils/monitoring/internal/code_owner/utils.py", line 193, in new_function
    return wrapped_function(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/entitlements/tasks.py", line 139, in expire_and_create_entitlements
    LOGGER.info('Successfully completed the task expire_and_create_entitlements after examining %d entries', entitlement_ids.count())  # lint-amnesty, pylint: disable=line-too-long
TypeError: count() takes exactly one argument (0 given)
```
</details>

This PR fixes that error.

## Additional Information

* Jira: [REV-3574](https://2u-internal.atlassian.net/browse/REV-3574)
* This PR is a fix forward for:
  - https://github.com/openedx/edx-platform/pull/32564
  - https://github.com/openedx/edx-platform/pull/32562
  - https://github.com/openedx/edx-platform/pull/32528