### PR TITLE
feat: configure acceptable language codes for youtube transcripts

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1536,6 +1536,7 @@ YOUTUBE = {
     'TRANSCRIPTS': {
         'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
         'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+        'ALLOWED_LANGUAGE_CODES': ["en", "en-US", "en-GB"],
     },
 
     'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2949,6 +2949,7 @@ YOUTUBE = {
     'TRANSCRIPTS': {
         'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
         'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+        'ALLOWED_LANGUAGE_CODES': ["en", "en-US", "en-GB"],
     },
 
     'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080

--- a/xmodule/video_block/transcripts_utils.py
+++ b/xmodule/video_block/transcripts_utils.py
@@ -182,12 +182,13 @@ def get_transcript_link_from_youtube(youtube_id):
     try:
         youtube_html = requests.get(f"{youtube_url_base}{youtube_id}")
         caption_re = settings.YOUTUBE['TRANSCRIPTS']['CAPTION_TRACKS_REGEX']
+        allowed_language_codes = settings.YOUTUBE['TRANSCRIPTS']['ALLOWED_LANGUAGE_CODES']
         caption_matched = re.search(caption_re, youtube_html.content.decode("utf-8"))
         if caption_matched:
             caption_tracks = json.loads(f'[{caption_matched.group("caption_tracks")}]')
             for caption in caption_tracks:
-                if "languageCode" in caption.keys() and caption["languageCode"] == "en":
-                    return caption["baseUrl"]
+                if "languageCode" in caption.keys() and caption["languageCode"] in allowed_language_codes:
+                    return caption.get("baseUrl")
         return None
     except ConnectionError:
         return None


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Adds option to configure supported languageCodes for youtube transcripts. The default is now set to `["en", "en-US", "en-GB"]` as some videos like [this one](https://www.youtube.com/watch?v=4TcSrEzciHA) have transcripts in US english i.e. `en-US` as their language code.

## Testing instructions

* Setup your devstack with [frontend-app-course-authoring](https://github.com/openedx/frontend-app-course-authoring) using `make dev.up.lms+studio+frontend-app-course-authoring`.
* Enable the video upload pipeline with: `ENABLE_VIDEO_UPLOAD_PIPELINE` feature flag and [VideoUploadsEnabledByDefault](http://localhost:18000/admin/video_pipeline/videouploadsenabledbydefault/) enabled
* Run make studio-static
* Run make build in `frontend-lib-content-components` directory.
* Add `new_core_editors.use_video_gallery_flow` and `new_core_editors.use_new_video_editor` Waffle flags in lms admin.
* Login on studio with a super user.
* Add a new video xblock, this should open course authoring page.
* Paste https://www.youtube.com/watch?v=4TcSrEzciHA in URL field.
* Without this change, the transcripts will not be detected.
