### PR TITLE
temp: save results & add tests/fixes for expire_and_create_entitlements

### DIFF
--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -65,7 +65,7 @@ def expire_old_entitlements(self, start, end, logid='...'):
     LOGGER.info('Successfully completed the task expire_old_entitlements after examining %d entries [%s]', entitlements.count(), logid)  # lint-amnesty, pylint: disable=line-too-long
 
 
-@shared_task(bind=True, ignore_result=True)
+@shared_task(bind=True)
 @set_code_owner_attribute
 def expire_and_create_entitlements(self, entitlement_ids, support_username):
     """

--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -100,7 +100,7 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
 
     try:
         for entitlement_id in entitlement_ids:
-            entitlement = CourseEntitlement.object.get(_id=entitlement_id)
+            entitlement = CourseEntitlement.objects.get(id=entitlement_id)
             LOGGER.info('Started expiring entitlement with id %d', entitlement.id)
             entitlement.expire_entitlement()
             LOGGER.info('Expired entitlement with id %d as expiration period has reached', entitlement.id)

--- a/common/djangoapps/entitlements/tests/test_tasks.py
+++ b/common/djangoapps/entitlements/tests/test_tasks.py
@@ -139,7 +139,6 @@ class TestExpireAndCreateEntitlementsTaskIntegration(TestCase):
 
         assert entitlement.expired_at is not None
 
-
     def test_actually_created(self):
         """
         Integration test with CourseEntitlement to make sure we are creating an


### PR DESCRIPTION
## Description

On running Celery task expire_and_create_entitlements, we get no error and no logs, but a successful task.

Trying 3 things to get it working:
- Save the results in Celery's state. Perhaps we'll get more diagnostic information.
- Fix a SyntaxError caught on re-review.
- Add basic tests for expire_and_create_entitlements.

## Additional Information

* Jira: [REV-3574](https://2u-internal.atlassian.net/browse/REV-3574)
* This PR is a fix forward for:
  - https://github.com/openedx/edx-platform/pull/32565
  - https://github.com/openedx/edx-platform/pull/32564
  - https://github.com/openedx/edx-platform/pull/32562
  - https://github.com/openedx/edx-platform/pull/32528