### PR TITLE
fix: give superusers all studio permissions [BB-7481]

### DIFF
--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -136,7 +136,7 @@ class GlobalStaff(AccessRole):
     The global staff role
     """
     def has_user(self, user):
-        return bool(user and user.is_staff)
+        return bool(user and (user.is_superuser or user.is_staff))
 
     def add_users(self, *users):
         for user in users:


### PR DESCRIPTION
## Description

Users that have `is_superuser == True`, but `is_staff == False` can't access Studio. This PR fixes this.

## Testing instructions

1. Switch your devstack to this branch.
2. Create a superuser, set it's `is_staff` field to `False`.
3. Try clicking `View in Studio` button here: 
![image](https://github.com/openedx/edx-platform/assets/18251194/7a0456aa-baea-4773-aee0-30d3da3d7872)
4. You should be able to access Studio.

[private-ref](https://tasks.opencraft.com/browse/BB-7481)