### PR TITLE
feat: create Course Limited Staff role [BB-7503]

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -15,6 +15,7 @@ from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseCreatorRole,
     CourseInstructorRole,
+    CourseLimitedStaffRole,
     CourseRole,
     CourseStaffRole,
     GlobalStaff,
@@ -92,6 +93,9 @@ def get_user_permissions(user, course_key, org=None):
         return all_perms
     if course_key and user_has_role(user, CourseInstructorRole(course_key)):
         return all_perms
+    # Limited Course Staff does not have access to Studio.
+    if course_key and user_has_role(user, CourseLimitedStaffRole(course_key)):
+        return STUDIO_NO_PERMISSIONS
     # Staff have all permissions except EDIT_ROLES:
     if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
         return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -12,7 +12,12 @@ from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseInstructorRole,
     CourseRole,
+    CourseLimitedStaffRole,
     CourseStaffRole,
+    CourseFinanceAdminRole,
+    CourseSalesAdminRole,
+    LibraryUserRole,
+    CourseDataResearcherRole,
     GlobalStaff,
     OrgContentCreatorRole,
     OrgInstructorRole,
@@ -162,8 +167,13 @@ class RoleCacheTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-clas
 
     ROLES = (
         (CourseStaffRole(IN_KEY), ('staff', IN_KEY, 'edX')),
+        (CourseLimitedStaffRole(IN_KEY), ('limited_staff', IN_KEY, 'edX')),
         (CourseInstructorRole(IN_KEY), ('instructor', IN_KEY, 'edX')),
         (OrgStaffRole(IN_KEY.org), ('staff', None, 'edX')),
+        (CourseFinanceAdminRole(IN_KEY), ('finance_admin', IN_KEY, 'edX')),
+        (CourseSalesAdminRole(IN_KEY), ('sales_admin', IN_KEY, 'edX')),
+        (LibraryUserRole(IN_KEY), ('library_user', IN_KEY, 'edX')),
+        (CourseDataResearcherRole(IN_KEY), ('data_researcher', IN_KEY, 'edX')),
         (OrgInstructorRole(IN_KEY.org), ('instructor', None, 'edX')),
         (CourseBetaTesterRole(IN_KEY), ('beta_testers', IN_KEY, 'edX')),
     )
@@ -183,7 +193,13 @@ class RoleCacheTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-clas
             if other_role == role:
                 continue
 
-            assert not cache.has_role(*other_target)
+            role_base_id = getattr(role, "BASE_ROLE", None)
+            other_role_id = getattr(other_role, "ROLE", None)
+
+            if other_role_id and role_base_id == other_role_id:
+                assert cache.has_role(*other_target)
+            else:
+                assert not cache.has_role(*other_target)
 
     @ddt.data(*ROLES)
     @ddt.unpack

--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -17,7 +17,8 @@ from common.djangoapps.student.roles import (
     CourseCcxCoachRole,
     CourseDataResearcherRole,
     CourseInstructorRole,
-    CourseStaffRole
+    CourseLimitedStaffRole,
+    CourseStaffRole,
 )
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params
 from openedx.core.djangoapps.django_comment_common.models import Role
@@ -28,6 +29,7 @@ ROLES = {
     'beta': CourseBetaTesterRole,
     'instructor': CourseInstructorRole,
     'staff': CourseStaffRole,
+    'limited_staff': CourseLimitedStaffRole,
     'ccx_coach': CourseCcxCoachRole,
     'data_researcher': CourseDataResearcherRole,
 }

--- a/lms/static/js/fixtures/instructor_dashboard/membership.html
+++ b/lms/static/js/fixtures/instructor_dashboard/membership.html
@@ -10,6 +10,7 @@
       <label>Select a course team role:
         <select id="member-lists-selector" class="member-lists-selector">
           <option value="staff">Staff</option>
+          <option value="limited_staff">Limited Staff</option>
           <option value="instructor">Admin</option>
           <option value="beta">Beta Testers</option>
           <option value="Administrator">Discussion Admins</option>

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -177,6 +177,19 @@ from openedx.core.djangolib.markup import HTML, Text
       data-add-button-label="${_("Add Staff")}"
     ></div>
 
+    <div class="auth-list-container"
+      data-rolename="limited_staff"
+      data-display-name="${_("Limited Staff")}"
+      data-info-text="
+        ${_("Course team members with the Limited Staff role help you manage your course. "
+        "Limited Staff can enroll and unenroll learners, as well as modify their grades and "
+        "access all course data. Limited Staff don't have access to your course in Studio. "
+        "You can only give course team roles to enrolled users.")}"
+      data-list-endpoint="${ section_data['list_course_role_members_url'] }"
+      data-modify-endpoint="${ section_data['modify_access_url'] }"
+      data-add-button-label="${_("Add Limited Staff")}"
+    ></div>
+
     ## Note that "Admin" is identified as "Instructor" in the Django admin panel.
     <div class="auth-list-container"
       data-rolename="instructor"


### PR DESCRIPTION
## Description

![image](https://github.com/openedx/edx-platform/assets/18251194/85ad5aa7-8e08-431f-a4f4-e771f3814575)

* Makes it possible to inherit permissions of some of the built-in roles.
* Adds a new course team role, which has the same permissions as `Course Staff`, but no Studio access.

This should be considered as a temporary workaround. Ideally, we should wait for “Fine grained RBAC” to be implemented (see [this roadmap item](https://github.com/openedx/platform-roadmap/issues/246)) and build new roles using the refactored systems. See [this document](https://docs.google.com/document/d/1Imgf3wXpJaoc_dw-jJwBLdkRWHNLlHyTScaNJoJQOic/edit#heading=h.nw8md6e8b4lk) as well for additional context.

## Testing instructions

1. Switch your devstack to `open-craft:0x29a/bb7503/disable-instructor-access-to-studio`.
2. Register two users, `course_staff@example.com` and `course_limited_staff@example.com`.
3. As a Django staff user, assign `course_staff@example.com` to `Staff` course team role using the Instructor Dashboard.
4. As a Django staff user, assign `course_limited_staff@example.com` to `Limited Staff` course team role using the Instructor Dashboard.
5. As `course_staff@example.com`, ensure that you can access Studio.
6. As `course_limited_staff@example.com`, ensure that you have the same permissions as `course_staff@example.com` (like accessing the Instructor Dashboard, etc), but don't have access to Studio.

[private-ref](https://tasks.opencraft.com/browse/BB-7503)