### PR TITLE
temp: added standard logging and removed celery logging

### DIFF
--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -147,4 +147,4 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
 
     log.info('Successfully completed the task expire_and_create_entitlements after examining %d entries, task id :%s',
              len(entitlement_ids),
-             self.id)  # lint-amnesty, pylint: disable=line-too-long
+             self.id)

--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -1,6 +1,7 @@
 """
 This file contains celery tasks for entitlements-related functionality.
 """
+import logging
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings  # lint-amnesty, pylint: disable=unused-import
@@ -10,6 +11,7 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 from common.djangoapps.entitlements.models import CourseEntitlement, CourseEntitlementSupportDetail
 
 LOGGER = get_task_logger(__name__)
+log = logging.getLogger(__name__)
 
 # Maximum number of retries before giving up on awarding credentials.
 # For reference, 11 retries with exponential backoff yields a maximum waiting
@@ -91,19 +93,24 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
     first_entitlement_id = entitlement_ids[0]
     last_entitlement_id = entitlement_ids[-1]
 
-    LOGGER.info(
-        'Running task expire_and_create_entitlements over %d entitlements from id %d to id %d',
+    log.info(
+        'Running task expire_and_create_entitlements over %d entitlements from id %d to id %d, task id :%s',
         len(entitlement_ids),
         first_entitlement_id,
         last_entitlement_id,
+        self.id
     )
 
     try:
         for entitlement_id in entitlement_ids:
             entitlement = CourseEntitlement.objects.get(id=entitlement_id)
-            LOGGER.info('Started expiring entitlement with id %d', entitlement.id)
+            log.info('Started expiring entitlement with id %d, task id :%s',
+                     entitlement.id,
+                     self.id)
             entitlement.expire_entitlement()
-            LOGGER.info('Expired entitlement with id %d as expiration period has reached', entitlement.id)
+            log.info('Expired entitlement with id %d as expiration period has reached, task id :%s',
+                     entitlement.id,
+                     self.id)
             support_detail = {
                 'action': 'EXPIRE',
                 'comments': 'REV-3574',
@@ -127,13 +134,17 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
                 'support_user': support_user,
             }
             CourseEntitlementSupportDetail.objects.create(**support_detail)
-            LOGGER.info(
-                'created new entitlement with id %d corresponding to above expired entitlement with id %d',
+            log.info(
+                'created new entitlement with id %d corresponding to above expired entitlement with id %d, task id :%s ',
                 new_entitlement.id,
                 entitlement.id,
+                self.id
             )
 
     except Exception as exc:  # pylint: disable=broad-except
-        LOGGER.exception('Failed to expire entitlements that reached their expiration period')
+        log.exception('Failed to expire entitlements that reached their expiration period, task id :%s',
+                      self.id)
 
-    LOGGER.info('Successfully completed the task expire_and_create_entitlements after examining %d entries', len(entitlement_ids))  # lint-amnesty, pylint: disable=line-too-long
+    log.info('Successfully completed the task expire_and_create_entitlements after examining %d entries, task id :%s',
+             len(entitlement_ids),
+             self.id)  # lint-amnesty, pylint: disable=line-too-long

--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -98,7 +98,7 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
         len(entitlement_ids),
         first_entitlement_id,
         last_entitlement_id,
-        self.id
+        self.request.id
     )
 
     try:
@@ -106,11 +106,11 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
             entitlement = CourseEntitlement.objects.get(id=entitlement_id)
             log.info('Started expiring entitlement with id %d, task id :%s',
                      entitlement.id,
-                     self.id)
+                     self.request.id)
             entitlement.expire_entitlement()
             log.info('Expired entitlement with id %d as expiration period has reached, task id :%s',
                      entitlement.id,
-                     self.id)
+                     self.request.id)
             support_detail = {
                 'action': 'EXPIRE',
                 'comments': 'REV-3574',
@@ -135,16 +135,18 @@ def expire_and_create_entitlements(self, entitlement_ids, support_username):
             }
             CourseEntitlementSupportDetail.objects.create(**support_detail)
             log.info(
-                'created new entitlement with id %d corresponding to above expired entitlement with id %d, task id :%s ',
+                'created new entitlement with id %d corresponding to above expired entitlement'
+                'with id %d, task id :%s ',
                 new_entitlement.id,
                 entitlement.id,
-                self.id
+                self.request.id
             )
 
     except Exception as exc:  # pylint: disable=broad-except
         log.exception('Failed to expire entitlements that reached their expiration period, task id :%s',
-                      self.id)
+                      self.request.id)
 
-    log.info('Successfully completed the task expire_and_create_entitlements after examining %d entries, task id :%s',
+    log.info('Successfully completed the task expire_and_create_entitlements after examining'
+             '%d entries, task id :%s',
              len(entitlement_ids),
-             self.id)
+             self.request.id)


### PR DESCRIPTION
## Description

On running Celery task expire_and_create_entitlements, we get no logs, but a successful task.
So, 

- Added standard logging
- Removed celery logging
- Added task id to every log message


## Additional Information

* Jira: [REV-3574](https://2u-internal.atlassian.net/browse/REV-3574)
* This PR is a fix forward for:
  - https://github.com/openedx/edx-platform/pull/32565
  - https://github.com/openedx/edx-platform/pull/32564
  - https://github.com/openedx/edx-platform/pull/32562
  - https://github.com/openedx/edx-platform/pull/32528
  - https://github.com/openedx/edx-platform/pull/32568