### PR TITLE
temp: fix entitlements_to_expire should be capped at entitlements_count

### DIFF
--- a/common/djangoapps/entitlements/management/commands/expire_and_create_entitlements.py
+++ b/common/djangoapps/entitlements/management/commands/expire_and_create_entitlements.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
         entitlements_count = entitlements.count()
         logger.info('Total entitlements that have reached expiration period are %d ', entitlements_count)
 
-        entitlements_to_expire = max(1, options.get('count'))
+        entitlements_to_expire = min(max(1, options.get('count')), entitlements_count)
         batch_size = max(1, options.get('batch_size'))
         num_batches = ceil(entitlements_to_expire / batch_size) if entitlements else 0
 
@@ -100,7 +100,7 @@ class Command(BaseCommand):
 
         for batch_num in range(num_batches):
             start = batch_num * batch_size
-            end = min(start + batch_size, entitlements_to_expire, entitlements_count)
+            end = min(start + batch_size, entitlements_to_expire)
             entitlement_ids = [entitlement.id for entitlement in entitlements[start:end]]
             expire_and_create_entitlements.delay(entitlement_ids, support_username)
 


### PR DESCRIPTION
## Description

On running Celery task expire_and_create_entitlements, for 6 entitlements to expire we get 100 batches:

```
15:58:48 2023-06-26 15:59:19,674 INFO 20101 [common.djangoapps.entitlements.management.commands.expire_and_create_entitlements] [user None] [ip None] expire_and_create_entitlements.py:86 - Total entitlements that have reached expiration period are 6 
15:58:48 2023-06-26 15:59:19,678 INFO 20101 [common.djangoapps.entitlements.management.commands.expire_and_create_entitlements] [user None] [ip None] expire_and_create_entitlements.py:95 - Found 100 batches. To enqueue entitlement expiration tasks, pass the -c or --commit flags.]
```

Cap the number of entitlements to expire to the total number of entitlements.

## Additional Information

* Jira: [REV-3574](https://2u-internal.atlassian.net/browse/REV-3574)
* This PR is a fix forward for:
  - https://github.com/openedx/edx-platform/pull/32577
  - https://github.com/openedx/edx-platform/pull/32568
  - https://github.com/openedx/edx-platform/pull/32565
  - https://github.com/openedx/edx-platform/pull/32564
  - https://github.com/openedx/edx-platform/pull/32562
  - https://github.com/openedx/edx-platform/pull/32528