### PR TITLE
feat: configurable roll-forward of flex grading

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1080,6 +1080,36 @@ class ContentStoreTest(ContentStoreTestCase):
         """Test new course creation - happy path"""
         self.assert_created_course()
 
+    @ddt.data(True, False)
+    @mock.patch(
+        'cms.djangoapps.contentstore.views.course.default_enable_flexible_peer_openassessments'
+    )
+    def test_create_course__default_enable_flexible_peer_openassessments(
+        self,
+        mock_toggle_state,
+        mock_default_enable_flexible_peer_openassessments
+    ):
+        """
+        Test that flex peer grading is forced on, when enabled
+        """
+        # Given a new course run
+        test_course_data = {}
+        test_course_data.update(self.course_data)
+        course_key = _get_course_id(self.store, test_course_data)
+
+        # ... with org configured to / not to enable flex grading
+        mock_default_enable_flexible_peer_openassessments.return_value = mock_toggle_state
+
+        # When I create a new course
+        new_course_data = _create_course(self, course_key, test_course_data)
+
+        # Then the process completes successfully
+        new_course_key = CourseKey.from_string(new_course_data['course_key'])
+        new_course = self.store.get_course(new_course_key)
+
+        # ... and our setting got toggled appropriately on the course
+        self.assertEqual(new_course.force_on_flexible_peer_openassessments, mock_toggle_state)
+
     @override_settings(DEFAULT_COURSE_LANGUAGE='hr')
     def test_create_course_default_language(self):
         """Test new course creation and verify default language"""
@@ -2104,6 +2134,8 @@ class EntryPageTestCase(TestCase):
 def _create_course(test, course_key, course_data):
     """
     Creates a course via an AJAX request and verifies the URL returned in the response.
+
+    Returns the data of the POST response
     """
     course_url = get_url('course_handler', course_key, 'course_key_string')
     response = test.client.ajax_post(course_url, course_data)
@@ -2111,6 +2143,8 @@ def _create_course(test, course_key, course_data):
     data = parse_json(response)
     test.assertNotIn('ErrMsg', data)
     test.assertEqual(data['url'], course_url)
+
+    return data
 
 
 def _get_course_id(store, course_data):

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -317,3 +317,40 @@ class TestCourseListing(ModuleStoreTestCase):
             'run': '2021_T1'
         })
         self.assertEqual(response.status_code, 403)
+
+    @ddt.data(True, False)
+    @mock.patch(
+        'cms.djangoapps.contentstore.views.course.enable_flexible_peer_openassessments_on_rerun'
+    )
+    def test_course_rerun_enable_ora_flexible_peer_grading(
+        self,
+        mock_toggle_state,
+        mock_enable_flexible_peer_openassessments_on_rerun
+    ):
+        """
+        Test that flex peer grading is forced on, when enabled
+        """
+        # Given a valid course to rerun
+        add_organization({
+            'name': 'Test Flex Grading',
+            'short_name': self.source_course_key.org,
+            'description': 'Test roll-forward of flex grading setting',
+        })
+        mock_enable_flexible_peer_openassessments_on_rerun.return_val = mock_toggle_state
+
+        # When I rerun the course
+        response = self.client.ajax_post(self.course_create_rerun_url, {
+            'source_course_key': str(self.source_course_key),
+            'org': self.source_course_key.org, 'course': self.source_course_key.course, 'run': 'copy',
+            'display_name': 'New, exciting course run!',
+        })
+
+        # Then the process completes successfully
+        self.assertEqual(response.status_code, 200)
+
+        data = parse_json(response)
+        dest_course_key = CourseKey.from_string(data['destination_course_key'])
+        dest_course = self.store.get_course(dest_course_key)
+
+        # ... and our setting got toggled appropriately on the course
+        self.assertEqual(dest_course.force_on_flexible_peer_openassessments, mock_toggle_state)

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -4,6 +4,7 @@ Test view handler for rerun (and eventually create)
 
 
 import datetime
+from itertools import product
 from unittest import mock
 
 import ddt
@@ -318,13 +319,15 @@ class TestCourseListing(ModuleStoreTestCase):
         })
         self.assertEqual(response.status_code, 403)
 
-    @ddt.data(True, False)
+    @ddt.data(*product([True, False], [True, False]))
+    @ddt.unpack
     @mock.patch(
         'cms.djangoapps.contentstore.views.course.default_enable_flexible_peer_openassessments'
     )
     def test_default_enable_flexible_peer_openassessments_on_rerun(
         self,
         mock_toggle_state,
+        mock_original_course_setting,
         mock_default_enable_flexible_peer_openassessments
     ):
         """
@@ -336,6 +339,9 @@ class TestCourseListing(ModuleStoreTestCase):
             'short_name': self.source_course_key.org,
             'description': 'Test roll-forward of flex grading setting',
         })
+        source_course = self.store.get_course(self.source_course_key)
+        source_course.force_on_flexible_peer_openassessments = mock_original_course_setting
+        self.store.update_item(source_course, self.user.id)
         mock_default_enable_flexible_peer_openassessments.return_value = mock_toggle_state
 
         # When I create a new course
@@ -354,5 +360,12 @@ class TestCourseListing(ModuleStoreTestCase):
         dest_course_key = CourseKey.from_string(data['destination_course_key'])
         dest_course = self.store.get_course(dest_course_key)
 
-        # ... and our setting got toggled appropriately on the course
-        self.assertEqual(dest_course.force_on_flexible_peer_openassessments, mock_toggle_state)
+        # ... and our setting got enabled appropriately on our new course
+        if (mock_toggle_state):
+            self.assertTrue(dest_course.force_on_flexible_peer_openassessments)
+        # ... or preserved if the default enable setting is not on
+        else:
+            self.assertEqual(
+                source_course.force_on_flexible_peer_openassessments,
+                dest_course.force_on_flexible_peer_openassessments
+            )

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -361,7 +361,7 @@ class TestCourseListing(ModuleStoreTestCase):
         dest_course = self.store.get_course(dest_course_key)
 
         # ... and our setting got enabled appropriately on our new course
-        if (mock_toggle_state):
+        if mock_toggle_state:
             self.assertTrue(dest_course.force_on_flexible_peer_openassessments)
         # ... or preserved if the default enable setting is not on
         else:

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -320,12 +320,12 @@ class TestCourseListing(ModuleStoreTestCase):
 
     @ddt.data(True, False)
     @mock.patch(
-        'cms.djangoapps.contentstore.views.course.enable_flexible_peer_openassessments_on_rerun'
+        'cms.djangoapps.contentstore.views.course.default_enable_flexible_peer_openassessments'
     )
-    def test_course_rerun_enable_ora_flexible_peer_grading(
+    def test_default_enable_flexible_peer_openassessments_on_rerun(
         self,
         mock_toggle_state,
-        mock_enable_flexible_peer_openassessments_on_rerun
+        mock_default_enable_flexible_peer_openassessments
     ):
         """
         Test that flex peer grading is forced on, when enabled
@@ -336,13 +336,15 @@ class TestCourseListing(ModuleStoreTestCase):
             'short_name': self.source_course_key.org,
             'description': 'Test roll-forward of flex grading setting',
         })
-        mock_enable_flexible_peer_openassessments_on_rerun.return_val = mock_toggle_state
+        mock_default_enable_flexible_peer_openassessments.return_value = mock_toggle_state
 
-        # When I rerun the course
+        # When I create a new course
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'source_course_key': str(self.source_course_key),
-            'org': self.source_course_key.org, 'course': self.source_course_key.course, 'run': 'copy',
-            'display_name': 'New, exciting course run!',
+            'org': self.source_course_key.org,
+            'course': self.source_course_key.course,
+            'run': 'copy',
+            'display_name': 'New, exciting course!',
         })
 
         # Then the process completes successfully

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -476,3 +476,26 @@ def use_new_course_team_page(course_key):
     Returns a boolean if new studio course team mfe is enabled
     """
     return ENABLE_NEW_STUDIO_COURSE_TEAM_PAGE.is_enabled(course_key)
+
+
+# .. toggle_name: contentstore..course_rerun.enable_flexible_peer_openassessments
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag turns on the force_on_flexible_peer_openassessments
+#      setting for course reruns, where enabled.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-06-27
+# .. toggle_target_removal_date: 2024-01-27
+# .. toggle_tickets: AU-1289
+# .. toggle_warning:
+ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS_ON_RERUN = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.course_rerun.enable_flexible_peer_openassessments', __name__)
+
+
+def enable_flexible_peer_openassessments_on_rerun(course_key):
+    """
+    Returns a boolean if ORA flexible peer grading should be toggled on for a
+    course rerun. We expect this to be set at the organization level to opt 
+    in/out of rolling forward this feature.
+    """
+    return ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS_ON_RERUN.is_enabled(course_key)

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -482,7 +482,7 @@ def use_new_course_team_page(course_key):
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: This flag turns on the force_on_flexible_peer_openassessments
-#      setting for course reruns, where enabled.
+#      setting for course reruns or new courses, where enabled.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2023-06-27
 # .. toggle_target_removal_date: 2024-01-27
@@ -495,7 +495,7 @@ DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS = CourseWaffleFlag(
 def default_enable_flexible_peer_openassessments(course_key):
     """
     Returns a boolean if ORA flexible peer grading should be toggled on for a
-    course rerun. We expect this to be set at the organization level to opt
-    in/out of rolling forward this feature.
+    course rerun or new course. We expect this to be set at the organization
+    level to opt in/out of rolling forward this feature.
     """
     return DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS.is_enabled(course_key)

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -478,7 +478,7 @@ def use_new_course_team_page(course_key):
     return ENABLE_NEW_STUDIO_COURSE_TEAM_PAGE.is_enabled(course_key)
 
 
-# .. toggle_name: contentstore..course_rerun.enable_flexible_peer_openassessments
+# .. toggle_name: contentstore.default_enable_flexible_peer_openassessments
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: This flag turns on the force_on_flexible_peer_openassessments
@@ -488,14 +488,14 @@ def use_new_course_team_page(course_key):
 # .. toggle_target_removal_date: 2024-01-27
 # .. toggle_tickets: AU-1289
 # .. toggle_warning:
-ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS_ON_RERUN = CourseWaffleFlag(
-    f'{CONTENTSTORE_NAMESPACE}.course_rerun.enable_flexible_peer_openassessments', __name__)
+DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.default_enable_flexible_peer_openassessments', __name__)
 
 
-def enable_flexible_peer_openassessments_on_rerun(course_key):
+def default_enable_flexible_peer_openassessments(course_key):
     """
     Returns a boolean if ORA flexible peer grading should be toggled on for a
     course rerun. We expect this to be set at the organization level to opt 
     in/out of rolling forward this feature.
     """
-    return ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS_ON_RERUN.is_enabled(course_key)
+    return DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS.is_enabled(course_key)

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -495,7 +495,7 @@ DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS = CourseWaffleFlag(
 def default_enable_flexible_peer_openassessments(course_key):
     """
     Returns a boolean if ORA flexible peer grading should be toggled on for a
-    course rerun. We expect this to be set at the organization level to opt 
+    course rerun. We expect this to be set at the organization level to opt
     in/out of rolling forward this feature.
     """
     return DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS.is_enabled(course_key)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -61,7 +61,6 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -87,7 +87,7 @@ from ..course_info_model import delete_course_update, get_course_updates, update
 from ..courseware_index import CoursewareSearchIndexer, SearchIndexingError
 from ..tasks import rerun_course as rerun_course_task
 from ..toggles import (
-    enable_flexible_peer_openassessments_on_rerun,
+    default_enable_flexible_peer_openassessments,
     split_library_view_on_dashboard,
     use_new_course_outline_page,
     use_new_home_page,
@@ -995,6 +995,11 @@ def create_new_course(user, org, number, run, fields):
     new_course = create_new_course_in_store(store_for_new_course, user, org, number, run, fields)
     add_organization_course(org_data, new_course.id)
     update_course_discussions_settings(new_course.id)
+
+    # Enable certain fields rolling forward, where configured
+    new_course.force_on_flexible_peer_openassessments = default_enable_flexible_peer_openassessments(new_course.id)
+    modulestore().update_item(new_course, new_course.published_by)
+
     return new_course
 
 
@@ -1059,7 +1064,7 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     fields['video_upload_pipeline'] = {}
 
     # Enable certain fields rolling forward, where configured
-    fields['force_on_flexible_peer_openassessments'] = enable_flexible_peer_openassessments_on_rerun(source_course_key)
+    fields['force_on_flexible_peer_openassessments'] = default_enable_flexible_peer_openassessments(source_course_key)
 
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)
     args = [str(source_course_key), str(destination_course_key), user.id, json_fields]

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -61,6 +61,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
@@ -1055,6 +1056,11 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     fields['enrollment_start'] = None
     fields['enrollment_end'] = None
     fields['video_upload_pipeline'] = {}
+
+    # Enable certain fields rolling forward, where configured
+    fields['force_on_flexible_peer_openassessments'] = \
+        CourseWaffleFlag('openresponseassessment.force_on_flexible_peer_grading', __name__) \
+        .is_enabled(source_course_key)
 
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)
     args = [str(source_course_key), str(destination_course_key), user.id, json_fields]

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -87,13 +87,14 @@ from ..course_info_model import delete_course_update, get_course_updates, update
 from ..courseware_index import CoursewareSearchIndexer, SearchIndexingError
 from ..tasks import rerun_course as rerun_course_task
 from ..toggles import (
+    enable_flexible_peer_openassessments_on_rerun,
     split_library_view_on_dashboard,
     use_new_course_outline_page,
     use_new_home_page,
     use_new_updates_page,
     use_new_advanced_settings_page,
     use_new_grading_page,
-    use_new_schedule_details_page,
+    use_new_schedule_details_page
 )
 from ..utils import (
     add_instructor,
@@ -1058,9 +1059,7 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     fields['video_upload_pipeline'] = {}
 
     # Enable certain fields rolling forward, where configured
-    fields['force_on_flexible_peer_openassessments'] = \
-        CourseWaffleFlag('openresponseassessment.force_on_flexible_peer_grading', __name__) \
-        .is_enabled(source_course_key)
+    fields['force_on_flexible_peer_openassessments'] = enable_flexible_peer_openassessments_on_rerun(source_course_key)
 
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)
     args = [str(source_course_key), str(destination_course_key), user.id, json_fields]

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -997,7 +997,8 @@ def create_new_course(user, org, number, run, fields):
     update_course_discussions_settings(new_course.id)
 
     # Enable certain fields rolling forward, where configured
-    new_course.force_on_flexible_peer_openassessments = default_enable_flexible_peer_openassessments(new_course.id)
+    if default_enable_flexible_peer_openassessments(new_course.id):
+        new_course.force_on_flexible_peer_openassessments = True
     modulestore().update_item(new_course, new_course.published_by)
 
     return new_course
@@ -1064,7 +1065,8 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     fields['video_upload_pipeline'] = {}
 
     # Enable certain fields rolling forward, where configured
-    fields['force_on_flexible_peer_openassessments'] = default_enable_flexible_peer_openassessments(source_course_key)
+    if default_enable_flexible_peer_openassessments(source_course_key):
+        fields['force_on_flexible_peer_openassessments'] = True
 
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)
     args = [str(source_course_key), str(destination_course_key), user.id, json_fields]


### PR DESCRIPTION
## Description

Add ability to roll-forward ORA flex peer grading feature.

When **enabled** for an Organization or course, flex peer grading will be turned on at the course level for new course reruns.

When **disabled** for an Organization or course, flex peer grading setting will be **unmodified** from default (for new course) or previous (for rerun) value.
 
## Supporting information

JIRA: https://2u-internal.atlassian.net/browse/AU-1289

## Testing instructions

**Regression behavior:**
1. Create a rerun of a course using example API requests.
2. The **FEATURE NAME TBD** value on the course should be false.

**Negative case:**
1. Create a new Organization override in [Home](http://localhost:18000/admin/) › [Waffle_Utils](http://localhost:18000/admin/waffle_utils/) › [Waffle flag org overrides](http://localhost:18000/admin/waffle_utils/waffleflagorgoverridemodel/) called `openresponseassessment.force_on_flexible_peer_grading`. Set to **FORCE OFF**.
3. Create a rerun of a course using example API requests.
4. The **FEATURE NAME TBD** value on the course should be **FALSE**.

**New behavior:**
1. Create/edit an Organization override in [Home](http://localhost:18000/admin/) › [Waffle_Utils](http://localhost:18000/admin/waffle_utils/) › [Waffle flag org overrides](http://localhost:18000/admin/waffle_utils/waffleflagorgoverridemodel/) called `openresponseassessment.force_on_flexible_peer_grading`. Set to **FORCE ON**.
3. Create a rerun of a course using example API requests.
4. The **FEATURE NAME TBD** value on the course should be **TRUE**.

## Other information

**Dependencies:**
- [x] Work in [AU-1269](https://2u-internal.atlassian.net/browse/AU-1269) to establish the field in course metadata. 
