### PR TITLE
feat: add open responses card to page and resources

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2706,6 +2706,7 @@ TEXTBOOKS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-
 WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/course_wiki.html"
 CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html#adding-custom-pages"
 COURSE_LIVE_HELP_URL = "https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_assets/course_live.html"
+ORA_SETTINGS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/ora_settings.html"
 
 # keys for  big blue button live provider
 COURSE_LIVE_GLOBAL_CREDENTIALS = {}

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -267,3 +267,48 @@ class CustomPagesCourseApp(CourseApp):
     @staticmethod
     def legacy_link(course_key: CourseKey):
         return urls.reverse('tabs_handler', kwargs={'course_key_string': course_key})
+
+
+class ORASettingsApp(CourseApp):
+    """
+    Course App config for ORA app.
+    """
+
+    app_id = "ora_settings"
+    name = _("Open Response Assessment Settings")
+    description = _("Course level settings for Open Response Assessment.")
+    documentation_links = {
+        "learn_more_configuration": settings.ORA_SETTINGS_HELP_URL,
+    }
+
+    @classmethod
+    def is_available(cls, course_key: CourseKey) -> bool:
+        """
+        Open response is available for course with at least one ORA.
+        """
+        oras = modulestore().get_items(course_key, qualifiers={'category': 'openassessment'})
+        return len(oras) > 0
+
+    @classmethod
+    def is_enabled(cls, course_key: CourseKey) -> bool:
+        """
+        Get open response enabled status from course overview model.
+        """
+        return True
+
+    @classmethod
+    def set_enabled(cls, course_key: CourseKey, enabled: bool, user: 'User') -> bool:
+        """
+        Update open response enabled status in modulestore. Always enable to avoid confusion that user can disable ora.
+        """
+        return True
+
+    @classmethod
+    def get_allowed_operations(cls, course_key: CourseKey, user: Optional[User] = None) -> Dict[str, bool]:
+        """
+        Get allowed operations for open response app.
+        """
+        return {
+            "enable": False,
+            "configure": True,
+        }

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5211,6 +5211,7 @@ TEXTBOOKS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-
 WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/course_wiki.html"
 CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html#adding-custom-pages"
 COURSE_BULK_EMAIL_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/manage_live_course/bulk_email.html"
+ORA_SETTINGS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/ora_settings.html"
 
 ################# Bulk Course Email Settings #################
 # If set, recipients of bulk course email messages will be filtered based on the last_login date of their User account.

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
             "wiki = lms.djangoapps.course_wiki.plugins.course_app:WikiCourseApp",
             "custom_pages = lms.djangoapps.courseware.plugins:CustomPagesCourseApp",
             "live = openedx.core.djangoapps.course_live.plugins:LiveCourseApp",
+            "ora_settings = lms.djangoapps.courseware.plugins:ORASettingsApp",
         ],
         "openedx.course_tool": [
             "calendar_sync_toggle = openedx.features.calendar_sync.plugins:CalendarSyncToggleTool",


### PR DESCRIPTION
## Description

Adding Open Responses to turn on flexible peer grading for the course. 

<img width="2371" alt="Screenshot 2023-07-10 at 4 52 31 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/83240113/6c243de2-9d32-4584-b70a-0ed698223e39">
<img width="2366" alt="Screenshot 2023-07-10 at 4 52 24 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/83240113/c3df19be-8b68-4761-8d48-bc2ba81399a1">

Ticket: https://2u-internal.atlassian.net/browse/AU-1279
Related PR: https://github.com/openedx/frontend-app-course-authoring/pull/524

## Useful information

- It seems the plugin is using `course_apps_courseappstatus` for the settings. There isn't the need to update the model.
- `is_enabled` seem to be use as default unless there is an entry in `course_apps_courseappstatus`
- You can query this config with `CourseAppStatus.objects.get(course_key=course_key, app_id='flexible_peer_grading')`

## Testing instructions

- You need to enable course waffle flag `discussions.pages_and_resources_mfe` to have Page & Resource option on the course outline.
- You should be able to see Open response options
  - If the option isn't available you might need to 
    - go to devstack `make dev.shell.studio`
    - `make requirements` for `setup.py` to pick up
    - then restart lms + studio with `make lms-restart studio-restart` or `make dev.restart-container.lms+studio` if the restart didn't work.

