### PR TITLE
feat: ignore v2 xblocks in independence contract

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -115,6 +115,7 @@ ignore_imports =
     # cms.djangoapps.export_course_metadata.tasks
     #  -> openedx.core.djangoapps.schedules.content_highlights
     #  -> lms.djangoapps.courseware.block_render & lms.djangoapps.courseware.model_data
+    openedx.core.djangoapps.content_libraries.signal_handlers -> lms.djangoapps.grades.api
     openedx.core.djangoapps.schedules.content_highlights -> lms.djangoapps.courseware.*
     # cms.djangoapps.contentstore.[various]
     #  -> openedx.core.lib.gating.api

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,7 +115,11 @@ ignore_imports =
     # cms.djangoapps.export_course_metadata.tasks
     #  -> openedx.core.djangoapps.schedules.content_highlights
     #  -> lms.djangoapps.courseware.block_render & lms.djangoapps.courseware.model_data
-    openedx.core.djangoapps.content_libraries.signal_handlers -> lms.djangoapps.grades.api
+    openedx.core.djangoapps.content_libraries.* -> lms.djangoapps.grades.api
+    # cms.djangoapps.contentstore.tasks -> openedx.core.djangoapps.content_libraries.models
+    # -> openedx.core.djangoapps.content_libraries.apps
+    # -> openedx.core.djangoapps.content_libraries.signal_handlers
+    # -> lms.djangoapps.grades.api
     openedx.core.djangoapps.schedules.content_highlights -> lms.djangoapps.courseware.*
     # cms.djangoapps.contentstore.[various]
     #  -> openedx.core.lib.gating.api


### PR DESCRIPTION
## Description

As the CMS should be able to import v2 xblocks and the content libraries api, we should ignore the import that v2 xblocks has to the LMS.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
