### PR TITLE
fix: problem dropdown does not cover text anymore

### DIFF
--- a/xmodule/static/sass/include/capa/display.scss
+++ b/xmodule/static/sass/include/capa/display.scss
@@ -879,7 +879,7 @@ div.problem {
 // ====================
 .problem {
   .inputtype.option-input {
-    margin: (-$baseline/2) 0 $baseline;
+    margin: 0 0 0 0 !important;
 
     .indicator-container {
       display: inline-block;


### PR DESCRIPTION
Fix for [TNL-10868](https://2u-internal.atlassian.net/browse/TNL-10868).
There was a bug in which the dropdown in the "dropdown" problem xblock was overlapping the text above it, both in the course outline and in the preview.

The problem was a margin that had previously not been applied, presumably due to a missing scss import.
I had to override the margin since removing it and rebuilding static assets did not solve the problem; for some reason, there was still a bundled file with scss that applied it.

## How to test
- Go to course outline. Create a dropdown problem that includes a description. Check that it looks fine in the course outline.
- Check that it looks fine in the preview.
- Confirm that overriding the margin did not break another place where it may have been applied. (My understanding though is that the margin is only relevant for the dropdown problem, in which case it should be okay.)