### PR TITLE
fix: mathjax resize on sindow resize

### DIFF
--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -81,6 +81,12 @@
   <!-- Configure and load MathJax -->
   <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
+      styles: {
+        '.MathJax_SVG>svg': { 'max-width': '100%' },
+      },
+      CommonHTML: { linebreaks: { automatic: true } },
+      SVG: { linebreaks: { automatic: true } },
+      "HTML-CSS": { linebreaks: { automatic: true } },
       tex2jax: {
         inlineMath: [
           ["\\(","\\)"],
@@ -92,6 +98,18 @@
         ]
       }
     });
+    window.addEventListener('resize', MJrenderer);
+    let 1 = -1;
+    let delay = 1000;
+    function MJrenderer() {
+      if (t >= 0) {
+        window.clearTimeout(t);
+      }
+      t = window.setTimeout(function() {
+        MathJax.Hub.Queue(["Rerenderer", MathJax.Hub]);
+        t = -1;
+      }, delay);
+    };
   </script>
   <script type="text/x-mathjax-config">
     MathJax.Hub.signal.Interest(function(message) {

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -29,6 +29,9 @@
 %if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    CommonHTML: { linebreaks: { automatic: true } },
+    SVG: { linebreaks: { automatic: true } },
+    "HTML-CSS": { linebreaks: { automatic: true } },
     tex2jax: {inlineMath: [ ['$','$'], ["\\(","\\)"]],
               displayMath: [ ['$$','$$'], ["\\[","\\]"]]}
   });
@@ -36,7 +39,13 @@
 %else:
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    styles: {
+      '.MathJax_SVG>svg': { 'max-width': '100%', },
+    },
     messageStyle: "none",
+    CommonHTML: { linebreaks: { automatic: true } },
+    SVG: { linebreaks: { automatic: true } },
+    "HTML-CSS": { linebreaks: { automatic: true } },
     tex2jax: {
       inlineMath: [
         ["\\(","\\)"],
@@ -84,6 +93,21 @@
             autocollapse: false,
             explorer: true
         }
+    };
+    window.addEventListener('resize', MJrerender);
+
+    let t = -1;
+    let delay = 1000;
+    function MJrerender() {
+      if (t >= 0) {
+        // If we are still waiting, then the user is still resizing =>
+        // postpone the action further!
+        window.clearTimeout(t);
+      }
+      t = window.setTimeout(function() {
+        MathJax.Hub.Queue(["Rerender",MathJax.Hub]);
+        t = -1; // Reset the handle
+      }, delay);
     };
 </script>
 

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -29,6 +29,9 @@
 %if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    styles: {
+      '.MathJax_SVG>svg': { 'max-width': '100%', },
+    },
     CommonHTML: { linebreaks: { automatic: true } },
     SVG: { linebreaks: { automatic: true } },
     "HTML-CSS": { linebreaks: { automatic: true } },


### PR DESCRIPTION
## Description

Forces MathJax in common template to resize and wrap when the window resizes.

## Supporting information

JIRA: [AU-1099](https://2u-internal.atlassian.net/browse/AU-1099)

## Testing instructions

Create a unit with very long mathjax equation and resize window to ensure it resizes/wraps (the wrap is briefly delayed).

![image](https://github.com/openedx/edx-platform/assets/5533134/ac11e3b1-464a-4ed3-b08b-25fc4bad6a96)

