### PR TITLE
fix: Don't assume there is a context.

### DIFF
--- a/openedx/core/djangoapps/bookmarks/serializers.py
+++ b/openedx/core/djangoapps/bookmarks/serializers.py
@@ -51,7 +51,7 @@ class BookmarkSerializer(serializers.ModelSerializer):
         # Drop any fields that are not specified in the `fields` argument.
         required_fields = set(fields)
 
-        if 'request' in kwargs['context'] and is_schema_request(kwargs['context']['request']):
+        if 'context' in kwargs and 'request' in kwargs['context'] and is_schema_request(kwargs['context']['request']):
             # We are serving the schema: include everything
             required_fields.update(OPTIONAL_FIELDS)
 


### PR DESCRIPTION
Don't assume that there will be an extra `context` kwarg when using the
bookmark serializer.  We use it this way in the current code but that's
specific to us and not comon to all serializers.  There are a lot of API
documentation tools that automate introspecting serializers but they
won't know  that they have to send in a `context` to the serializer.

To make this serializer behave more like other serializers without
changing the behavior, we just need to check that the `context` value is
defined before we dig into it.  In the case that there is no `context`
we just treat it the same as if there is no `request` in the `context`.
