### PR TITLE
fix: improve username generation

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -100,7 +100,7 @@ def apply_settings(django_settings):
     django_settings.SOCIAL_AUTH_INACTIVE_USER_URL = '/auth/inactive'
 
     # Context processors required under Django.
-    django_settings.SOCIAL_AUTH_UUID_LENGTH = 6
+    django_settings.SOCIAL_AUTH_UUID_LENGTH = 10
     django_settings.DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] += (
         'social_django.context_processors.backends',
         'social_django.context_processors.login_redirect',

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -229,13 +229,18 @@ def username_suffix_generator(suffix_length=4):
     Generates a random, alternating number and letter string for the purpose of
     appending to non-unique usernames. Alternating is less likey to produce
     a significant/meaningful substring like an offensive word.
+    Whether the suffix starts with a letter or number is also randomized.
     """
+    # pick from letters, or numbers
+    choice_collections = [string.ascii_lowercase, string.digits]
+    # randomize which collection to pick from first
+    random.shuffle(choice_collections)
     output = ''
     for i in range(suffix_length):
         if (i % 2) == 0:
-            output += random.choice(string.ascii_lowercase)
+            output += random.choice(choice_collections[0])
         else:
-            output += random.choice(string.digits)
+            output += random.choice(choice_collections[1])
     return output
 
 


### PR DESCRIPTION
## Description

- increase suffix length setting (what we've done in the past)
- originally the username generator had a fixed-length suffix, this changes it to try different length suffixes at random (increasing the available address space)
- https://2u-internal.atlassian.net/browse/ENT-6800