### PR TITLE
fix: email templates caching

### DIFF
--- a/openedx/core/djangoapps/theming/template_loaders.py
+++ b/openedx/core/djangoapps/theming/template_loaders.py
@@ -27,13 +27,17 @@ class ThemeFilesystemLoader(FilesystemLoader):
     is_usable = True
     _accepts_engine_in_init = True
 
-    def __init__(self, engine, dirs=None):
-        if not dirs:
-            self.dirs = engine.dirs
+    def get_dirs(self):
+        """
+        Override get_dirs method.
+
+        Make the theme templates a priority, avoiding cashing templates for django ones.
+        """
+        dirs = super().get_dirs()
         theme_dirs = self.get_theme_template_sources()
-        if isinstance(theme_dirs, list):
-            self.dirs = theme_dirs + self.dirs
-        super().__init__(engine, self.dirs)
+        if theme_dirs:
+            dirs = theme_dirs + dirs
+        return dirs
 
     @staticmethod
     def get_theme_template_sources():


### PR DESCRIPTION
## Description

Make the theme templates a priority, avoiding cashing templates for Django ones.

[Edx Discussion Forum post](https://discuss.openedx.org/t/edx-ace-emails-theming-issue-using-microsites/6139)