### PR TITLE
fix: changes count_by_app_name in counts api to return apps with zero…

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -468,7 +468,8 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
 
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['count'], 4)
-            self.assertEqual(response.data['count_by_app_name'], {'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1})
+            self.assertEqual(response.data['count_by_app_name'], {
+                'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1, 'discussion': 0})
             self.assertEqual(response.data['show_notifications_tray'], show_notifications_tray_enabled)
 
     def test_get_unseen_notifications_count_for_unauthenticated_user(self):
@@ -489,7 +490,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['count'], 0)
-        self.assertEqual(response.data['count_by_app_name'], {})
+        self.assertEqual(response.data['count_by_app_name'], {'discussion': 0})
 
 
 class MarkNotificationsSeenAPIViewTestCase(APITestCase):

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -13,14 +13,6 @@ def find_app_in_normalized_apps(app_name, apps_list):
     return None
 
 
-def get_notifications_app_names_list(course_notificaton_apps):
-    """
-    Returns list of course notification app names
-    """
-    app_names = list(course_notificaton_apps.keys())
-    return app_names
-
-
 def find_pref_in_normalized_prefs(pref_name, app_name, prefs_list):
     """
     Returns preference based on preference_name and app_name

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -13,6 +13,14 @@ def find_app_in_normalized_apps(app_name, apps_list):
     return None
 
 
+def get_notifications_app_names_list(course_notificaton_apps):
+    """
+    Returns list of course notification app names
+    """
+    app_names = list(course_notificaton_apps.keys())
+    return app_names
+
+
 def find_pref_in_normalized_prefs(pref_name, app_name, prefs_list):
     """
     Returns preference based on preference_name and app_name

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -29,7 +29,6 @@ from .serializers import (
     UserCourseNotificationPreferenceSerializer,
     UserNotificationPreferenceUpdateSerializer
 )
-from .utils import get_notifications_app_names_list
 
 
 class CourseEnrollmentListView(generics.ListAPIView):
@@ -290,19 +289,17 @@ class NotificationCountView(APIView):
             .annotate(count=Count('*'))
         )
         count_total = 0
-        count_by_app_name_dict = {}
         show_notifications_tray_enabled = False
-        notification_apps = get_notifications_app_names_list(COURSE_NOTIFICATION_APPS)
+        count_by_app_name_dict = {
+            app_name: 0
+            for app_name in COURSE_NOTIFICATION_APPS
+        }
 
         for item in count_by_app_name:
             app_name = item['app_name']
             count = item['count']
             count_total += count
             count_by_app_name_dict[app_name] = count
-
-        for app_name in notification_apps:
-            if app_name not in count_by_app_name_dict:
-                count_by_app_name_dict[app_name] = 0
 
         learner_enrollments_course_ids = CourseEnrollment.objects.filter(
             user=request.user,

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -17,7 +17,7 @@ from rest_framework.views import APIView
 from common.djangoapps.student.models import CourseEnrollment
 from openedx.core.djangoapps.notifications.models import (
     CourseNotificationPreference,
-    get_course_notification_preference_config_version,
+    get_course_notification_preference_config_version
 )
 
 from .base_notification import COURSE_NOTIFICATION_APPS
@@ -29,6 +29,7 @@ from .serializers import (
     UserCourseNotificationPreferenceSerializer,
     UserNotificationPreferenceUpdateSerializer
 )
+from .utils import get_notifications_app_names_list
 
 
 class CourseEnrollmentListView(generics.ListAPIView):
@@ -291,12 +292,17 @@ class NotificationCountView(APIView):
         count_total = 0
         count_by_app_name_dict = {}
         show_notifications_tray_enabled = False
+        notification_apps = get_notifications_app_names_list(COURSE_NOTIFICATION_APPS)
 
         for item in count_by_app_name:
             app_name = item['app_name']
             count = item['count']
             count_total += count
             count_by_app_name_dict[app_name] = count
+
+        for app_name in notification_apps:
+            if app_name not in count_by_app_name_dict:
+                count_by_app_name_dict[app_name] = 0
 
         learner_enrollments_course_ids = CourseEnrollment.objects.filter(
             user=request.user,


### PR DESCRIPTION
[INF-939](https://2u-internal.atlassian.net/browse/INF-939)

Previously in [Notifications count API](http://localhost:18000/api/notifications/count/), the count_by_app_name query was returning apps only if they had unseen notifications. However, it has been modified to include apps even if their unseen count is zero.