### PR TITLE
fix: upgrade oauthlib and django-oauth-toolkit to new versions.

### DIFF
--- a/common/djangoapps/third_party_auth/lti.py
+++ b/common/djangoapps/third_party_auth/lti.py
@@ -11,8 +11,8 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from oauthlib.common import Request
 from oauthlib.oauth1.rfc5849.signature import (
     collect_parameters,
-    construct_base_string,
-    normalize_base_string_uri,
+    signature_base_string,
+    base_string_uri,
     normalize_parameters,
     sign_hmac_sha1
 )
@@ -154,10 +154,10 @@ class LTIAuthBackend(BaseAuth):
         # we proceed through the entire validation before rejecting any request for any reason.
         # However, as noted there, the value of doing this is dubious.
         try:
-            base_uri = normalize_base_string_uri(request.uri)
+            base_uri = base_string_uri(request.uri)
             parameters = collect_parameters(uri_query=request.uri_query, body=request.body)
             parameters_string = normalize_parameters(parameters)
-            base_string = construct_base_string(request.http_method, base_uri, parameters_string)
+            base_string = signature_base_string(request.http_method, base_uri, parameters_string)
 
             computed_signature = sign_hmac_sha1(base_string, str(lti_consumer_secret), '')
             submitted_signature = request.oauth_signature

--- a/openedx/core/djangoapps/oauth_dispatch/api.py
+++ b/openedx/core/djangoapps/oauth_dispatch/api.py
@@ -33,7 +33,9 @@ def create_dot_access_token(request, user, client, expires_in=None, scopes=None)
         request_validator=dot_settings.OAUTH2_VALIDATOR_CLASS(),
     )
     _populate_create_access_token_request(request, user, client, scopes)
-    return token_generator.create_token(request, refresh_token=True)
+    token = token_generator.create_token(request, refresh_token=True)
+    token_generator.request_validator.save_token(token, request)
+    return token
 
 
 def _get_expires_in_value(expires_in):

--- a/openedx/core/djangoapps/oauth_dispatch/api.py
+++ b/openedx/core/djangoapps/oauth_dispatch/api.py
@@ -34,6 +34,10 @@ def create_dot_access_token(request, user, client, expires_in=None, scopes=None)
     )
     _populate_create_access_token_request(request, user, client, scopes)
     token = token_generator.create_token(request, refresh_token=True)
+    # This save_token call is required with BearerAuthentication. Once the DEPR for
+    # BearerAuthentication is complete and it has been fully removed, we may no
+    # longer need to save the token, since JWT tokens don't rely on the database.
+    # See DEPR https://github.com/openedx/edx-drf-extensions/issues/284
     token_generator.request_validator.save_token(token, request)
     return token
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,8 +31,9 @@ django-storages==1.9.1
 edx-enterprise==4.0.16
 
 # django-oauth-toolkit version >2.0.0 has breaking changes.
-# and versions from 1.3.3 to 2.0.0 have some migrations related changes.
-# so upgrading minor version one by one.
+# More details mentioned on this issue https://github.com/openedx/edx-platform/issues/32884
+# Versions from 1.3.3 to 2.0.0 have some migrations related changes.
+# so we're upgrading minor versions one by one.
 django-oauth-toolkit==1.4.1
 
 # Will be updated once we update python-dateutil package

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,10 +30,10 @@ django-storages==1.9.1
 # for them.
 edx-enterprise==4.0.16
 
-# django-oauth-toolkit version >2.0.0 has breaking changes.
-# More details mentioned on this issue https://github.com/openedx/edx-platform/issues/32884
-# Versions from 1.3.3 to 2.0.0 have some migrations related changes.
-# so we're upgrading minor versions one by one.
+# 1. django-oauth-toolkit version >=2.0.0 has breaking changes. More details
+#    mentioned on this issue https://github.com/openedx/edx-platform/issues/32884
+# 2. Versions from 1.5.0 to 2.0.0 have some migrations related changes.
+#    so we're upgrading minor versions one by one.
 django-oauth-toolkit==1.4.1
 
 # Will be updated once we update python-dateutil package

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,11 +30,10 @@ django-storages==1.9.1
 # for them.
 edx-enterprise==4.0.16
 
-# oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
-oauthlib==3.0.1
-
-# django-auth-toolkit==1.3.3 requires oauthlib>=3.1.0 which is pinned because of test failures
-django-oauth-toolkit<=1.3.2
+# django-oauth-toolkit version >2.0.0 has breaking changes.
+# and versions from 1.3.3 to 2.0.0 have some migrations related changes.
+# so upgrading minor version one by one.
+django-oauth-toolkit==1.4.1
 
 # Will be updated once we update python-dateutil package
 matplotlib<3.4.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -321,7 +321,7 @@ django-multi-email-field==0.7.0
     # via edx-enterprise
 django-mysql==4.11.0
     # via -r requirements/edx/kernel.in
-django-oauth-toolkit==1.3.2
+django-oauth-toolkit==1.4.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -738,9 +738,8 @@ numpy==1.22.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.0.1
+oauthlib==3.2.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-oauth-toolkit
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -520,7 +520,7 @@ django-mysql==4.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-oauth-toolkit==1.3.2
+django-oauth-toolkit==1.4.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
@@ -1253,9 +1253,8 @@ numpy==1.22.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.0.1
+oauthlib==3.2.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-oauth-toolkit

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -383,7 +383,7 @@ django-multi-email-field==0.7.0
     #   edx-enterprise
 django-mysql==4.11.0
     # via -r requirements/edx/base.txt
-django-oauth-toolkit==1.3.2
+django-oauth-toolkit==1.4.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -877,9 +877,8 @@ numpy==1.22.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.0.1
+oauthlib==3.2.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -415,7 +415,7 @@ django-multi-email-field==0.7.0
     #   edx-enterprise
 django-mysql==4.11.0
     # via -r requirements/edx/base.txt
-django-oauth-toolkit==1.3.2
+django-oauth-toolkit==1.4.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -946,9 +946,8 @@ numpy==1.22.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.0.1
+oauthlib==3.2.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   lti-consumer-xblock


### PR DESCRIPTION
🔗🔗🔗 **Issue link**

https://github.com/openedx/edx-platform/issues/32515

📝📝📝 **Description**

- `django-oauth-toolkit` and `oauthlib` versions have been pinned for the last 3 years due to test failures
- In this PR we're unpinning them to `django-oauth-toolkit==1.7.1` and `oauthlib==3.2.2`
- Moving oauthlib to latest version wasn't a big deal as we only had to update a few method names
- But moving `django-oauth-toolkit` from `1.x.x` to `2.x.x` is a little bit tricky as in `2.x.x` the `client_secret` is being hashed 
https://django-oauth-toolkit.readthedocs.io/en/latest/changelog.html#id12:~:text=%231093%20(Breaking,before%20hitting%20Save
 whereas in the previous releases, it was just a plain text. That's why we're just upgrading `django-oauth-toolkit` to the latest `1.x` release for now.

🔍🔍🔍 **Tested on**

- [Sandbox](https://awais786.sandbox.edx.org/) configured with ecommerce.

⚠️⚠️⚠️ **Migrating from django-oauth-toolkit from 1.x.x to 2.x.x**

- We need to be aware that in the future if we do any attempt to migrate DOT to `2.x.x`, it will [update all the existing](https://github.com/jazzband/django-oauth-toolkit/blob/2.0.0/oauth2_provider/migrations/0006_alter_application_client_secret.py#L10C5-L10C48) `client secrets` as well.
- And then we can't downgrade its version. It's only one way.
```
raise IrreversibleError("Operation %s in %s is not reversible" % (operation, self))
django.db.migrations.exceptions.IrreversibleError: Operation <RunPython <function forwards_func at 0x7f6956652430>> in oauth2_provider.0006_alter_application_client_secret is not reversible
``` 
