### PR TITLE
feat: add ability to notify credentials about honor certificates

### DIFF
--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -426,7 +426,10 @@ def update_credentials_course_certificate_configuration_available_date(
     course_key = str(course_key)
     course_modes = CourseMode.objects.filter(course_id=course_key)
     # There should only ever be one certificate relevant mode per course run
-    modes = [mode.slug for mode in course_modes if mode.slug in CourseMode.CERTIFICATE_RELEVANT_MODES]
+    modes = [
+        mode.slug for mode in course_modes
+        if mode.slug in CourseMode.CERTIFICATE_RELEVANT_MODES or CourseMode.is_eligible_for_certificate(mode.slug)
+    ]
     if len(modes) != 1:
         LOGGER.exception(f"Either course {course_key} has no certificate mode or multiple modes. Task failed.")
         return
@@ -509,7 +512,10 @@ def award_course_certificate(self, username, course_run_key):
             )
             return
 
-        if certificate.mode in CourseMode.CERTIFICATE_RELEVANT_MODES:
+        if (
+            certificate.mode in CourseMode.CERTIFICATE_RELEVANT_MODES
+            or CourseMode.is_eligible_for_certificate(certificate.mode)
+        ):
             course_overview = get_course_overview_or_none(course_key)
             if not course_overview:
                 LOGGER.warning(


### PR DESCRIPTION
## Description

Honor mode is absent by default in the course list for "Program Records" that appears error for "Program Records" for users with permission "Active" after clicking on "View My Records" button:

![screen_5](https://github.com/openedx/edx-platform/assets/98233552/035e7645-f0aa-488f-ba75-c0afa4a937e5)

500 error appeared

Implemented:
- Developed solution for adding course mode "Honor" to the list of modes for "Program Records"
- "Earned" and "completed" status are set up for Honor Courses and Program after finishing the program for staff and particular user

Added a WaffleFlag course_modes.extend_certificate_relevant_modes_with_honor. When enabled - credential will receive data about the HONOR course certificates.