### PR TITLE
feat: added endpoint for context needed for recommendations experiment

### DIFF
--- a/lms/djangoapps/learner_recommendations/serializers.py
+++ b/lms/djangoapps/learner_recommendations/serializers.py
@@ -86,6 +86,12 @@ class AboutPageRecommendationsSerializer(serializers.Serializer):
     )
 
 
+class RecommendationsContextSerializer(serializers.Serializer):
+    """Serializer for recommendations context"""
+
+    countryCode = serializers.CharField(allow_blank=True)
+
+
 class CrossProductRecommendationsSerializer(serializers.Serializer):
     """
     Cross product recommendation courses for course about page

--- a/lms/djangoapps/learner_recommendations/tests/test_serializers.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_serializers.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from lms.djangoapps.learner_recommendations.serializers import (
     DashboardRecommendationsSerializer,
+    RecommendationsContextSerializer,
     CrossProductRecommendationsSerializer,
     CrossProductAndAmplitudeRecommendationsSerializer,
     AmplitudeRecommendationsSerializer
@@ -87,6 +88,42 @@ class TestDashboardRecommendationsSerializer(TestCase):
                     },
                 ],
                 "isControl": False,
+            },
+        )
+
+
+class TestRecommendationsContextSerializer(TestCase):
+    """Tests for RecommendationsContextSerializer"""
+
+    def test_successful_serialization(self):
+        """Test that context data serializes correctly"""
+
+        serialized_data = RecommendationsContextSerializer(
+            {
+                "countryCode": "US",
+            }
+        ).data
+
+        self.assertDictEqual(
+            serialized_data,
+            {
+                "countryCode": "US",
+            },
+        )
+
+    def test_empty_response_serialization(self):
+        """Test that an empty response serializes correctly"""
+
+        serialized_data = RecommendationsContextSerializer(
+            {
+                "countryCode": "",
+            }
+        ).data
+
+        self.assertDictEqual(
+            serialized_data,
+            {
+                "countryCode": "",
             },
         )
 

--- a/lms/djangoapps/learner_recommendations/tests/test_views.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_views.py
@@ -157,7 +157,6 @@ class TestAboutPageRecommendationsView(TestRecommendationsBase):
         assert segment_mock.call_args[0][1] == "edx.bi.user.recommendations.viewed"
 
 
-@ddt.ddt
 class TestRecommendationsContextView(APITestCase):
     """Unit tests for the Recommendations Context View"""
 

--- a/lms/djangoapps/learner_recommendations/tests/test_views.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_views.py
@@ -157,6 +157,37 @@ class TestAboutPageRecommendationsView(TestRecommendationsBase):
         assert segment_mock.call_args[0][1] == "edx.bi.user.recommendations.viewed"
 
 
+@ddt.ddt
+class TestRecommendationsContextView(APITestCase):
+    """Unit tests for the Recommendations Context View"""
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.password = "test"
+        self.url = reverse_lazy("learner_recommendations:recommendations_context")
+
+    @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
+    def test_successful_response(self, country_code_from_ip_mock):
+        """Test that country code gets sent back when authenticated"""
+
+        country_code_from_ip_mock.return_value = "za"
+        self.client.login(username=self.user.username, password=self.password)
+
+        response = self.client.get(self.url)
+        response_data = json.loads(response.content)
+
+        self.assertEqual(response_data["countryCode"], "za")
+
+    def test_unauthenticated_response(self):
+        """
+        Test that a 401 is sent back if an anauthenticated user calls endpoint
+        """
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 401)
+
+
 class TestCrossProductRecommendationsView(APITestCase):
     """Unit tests for the Cross Product Recommendations View"""
 

--- a/lms/djangoapps/learner_recommendations/urls.py
+++ b/lms/djangoapps/learner_recommendations/urls.py
@@ -25,4 +25,7 @@ urlpatterns = [
     re_path(r"^courses/$",
             views.DashboardRecommendationsApiView.as_view(),
             name="courses"),
+    re_path(r'^recommendations_context/$',
+            views.RecommendationsContextView.as_view(),
+            name='recommendations_context'),
 ]

--- a/lms/djangoapps/learner_recommendations/views.py
+++ b/lms/djangoapps/learner_recommendations/views.py
@@ -37,6 +37,7 @@ from lms.djangoapps.learner_recommendations.utils import (
 from lms.djangoapps.learner_recommendations.serializers import (
     AboutPageRecommendationsSerializer,
     DashboardRecommendationsSerializer,
+    RecommendationsContextSerializer,
     CrossProductAndAmplitudeRecommendationsSerializer,
     CrossProductRecommendationsSerializer,
     AmplitudeRecommendationsSerializer,
@@ -192,6 +193,37 @@ class CrossProductRecommendationsView(APIView):
                     "courses": unrestricted_courses
                 }).data,
             status=200
+        )
+
+
+class RecommendationsContextView(APIView):
+    """
+    *Example Request*
+
+    GET /api/learner_recommendations/recommendations_context/
+    """
+
+    authentication_classes = (
+        JwtAuthentication,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated, NotJwtRestrictedApplication)
+
+    def get(self, request):
+        """
+        Returns the context needed for the recommendations experiment:
+        - Country Code
+        """
+        ip_address = get_client_ip(request)[0]
+        country_code = country_code_from_ip(ip_address)
+
+        return Response(
+            RecommendationsContextSerializer(
+                {
+                    "countryCode": country_code,
+                }
+            ).data,
+            status=200,
         )
 
 


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Added separate endpoint for getting context needed for activating experiments on the Learner Dashboard (right now, all we need is the user's country code)

NB: Previously, the user's country code was gotten from the `prod-edx-cf-loc` cookie. This was later discovered to be a cookie that was only set after visiting edx.org, therefore it is not reliable for getting the user's country code.

## Supporting information

**JIRA Ticket:** [PTECH-3294](https://jira.2u.com/browse/PTECH-3294)

## Testing instructions

The endpoint, `api/learner_recommendations/recommendations_context/`, was queried and confirmed to send back the correct object with a `countryCode` field
