### PR TITLE
fix: providing_args commented code removed

### DIFF
--- a/cms/djangoapps/contentstore/signals/signals.py
+++ b/cms/djangoapps/contentstore/signals/signals.py
@@ -8,8 +8,4 @@ from django.dispatch import Signal
 # Signal that indicates that a course grading policy has been updated.
 # This signal is generated when a grading policy change occurs within
 # modulestore for either course or subsection changes.
-# providing_args=[
-#   'user_id',  # Integer User ID
-#   'course_key',  # Unicode string representing the course
-# ]
 GRADING_POLICY_CHANGED = Signal()

--- a/cms/djangoapps/course_creators/models.py
+++ b/cms/djangoapps/course_creators/models.py
@@ -12,15 +12,12 @@ from django.utils.translation import gettext_lazy as _
 from organizations.models import Organization
 
 # A signal that will be sent when users should be added or removed from the creator group
-# providing_args=["caller", "user", "state", "organizations"]
 update_creator_state = Signal()
 
 # A signal that will be sent when admin should be notified of a pending user request
-# providing_args=["user"]
 send_admin_notification = Signal()
 
 # A signal that will be sent when user should be notified of change in course creator privileges
-# providing_args=["user", "state"]
 send_user_notification = Signal()
 
 

--- a/common/djangoapps/student/signals/signals.py
+++ b/common/djangoapps/student/signals/signals.py
@@ -8,16 +8,12 @@ from django.dispatch import Signal
 # The purely documentational providing_args argument for Signal is deprecated.
 # So we are moving the args to a comment.
 
-# providing_args=['user', 'course_key', 'mode', 'countdown']
 ENROLLMENT_TRACK_UPDATED = Signal()
 
-# providing_args=["course_enrollment", "skip_refund"]
 UNENROLL_DONE = Signal()
 
-# providing_args=["event", "user", "course_id", "mode", "cost", "currency"]
 ENROLL_STATUS_CHANGE = Signal()
 
-# providing_args=["course_enrollment"]
 REFUND_ORDER = Signal()
 
 USER_EMAIL_CHANGED = Signal()

--- a/common/djangoapps/util/model_utils.py
+++ b/common/djangoapps/util/model_utils.py
@@ -12,7 +12,6 @@ from eventtracking import tracker
 # The setting name used for events when "settings" (account settings, preferences, profile information) change.
 USER_SETTINGS_CHANGED_EVENT_NAME = 'edx.user.settings.changed'
 # Used to signal a field value change
-# providing_args=["user", "table", "changed_values"]
 USER_FIELDS_CHANGED = Signal()
 
 

--- a/lms/djangoapps/grades/signals/signals.py
+++ b/lms/djangoapps/grades/signals/signals.py
@@ -14,21 +14,6 @@ from django.dispatch import Signal
 # regardless of the new and previous values of the score (i.e. it may be the
 # case that this signal is generated when a user re-attempts a problem but
 # receives the same score).
-# providing_args=[
-#         'user_id',  # Integer User ID
-#         'course_id',  # Unicode string representing the course
-#         'usage_id',  # Unicode string indicating the courseware instance
-#         'raw_earned',   # Score obtained by the user
-#         'raw_possible',  # Maximum score available for the exercise
-#         'weight',  # Weight of the problem
-#         'only_if_higher',   # Boolean indicating whether updates should be
-#                             # made only if the new score is higher than previous.
-#         'modified',  # A datetime indicating when the database representation of
-#                      # this the problem score was saved.
-#         'score_db_table',  # The database table that houses the score that changed.
-#         'score_deleted',  # Boolean indicating whether the score changed due to
-#                           # the user state being deleted.
-#     ]
 PROBLEM_RAW_SCORE_CHANGED = Signal()
 
 # Signal that indicates that a user's weighted score for a problem has been updated.
@@ -38,21 +23,6 @@ PROBLEM_RAW_SCORE_CHANGED = Signal()
 # regardless of the new and previous values of the score (i.e. it may be the
 # case that this signal is generated when a user re-attempts a problem but
 # receives the same score).
-# providing_args=[
-#         'user_id',  # Integer User ID
-#         'anonymous_user_id',  # Anonymous User ID
-#         'course_id',  # Unicode string representing the course
-#         'usage_id',  # Unicode string indicating the courseware instance
-#         'weighted_earned',   # Score obtained by the user
-#         'weighted_possible',  # Maximum score available for the exercise
-#         'only_if_higher',   # Boolean indicating whether updates should be
-#                             # made only if the new score is higher than previous.
-#         'modified',  # A datetime indicating when the database representation of
-#                      # this the problem score was saved.
-#         'score_db_table',  # The database table that houses the score that changed.
-#         'score_deleted',  # Boolean indicating whether the score changed due to
-#                           # the user state being deleted.
-#     ]
 PROBLEM_WEIGHTED_SCORE_CHANGED = Signal()
 
 
@@ -60,63 +30,26 @@ PROBLEM_WEIGHTED_SCORE_CHANGED = Signal()
 # for possible persistence and update.  Typically, most clients should listen
 # to the PROBLEM_WEIGHTED_SCORE_CHANGED signal instead, since that is signalled
 # only after the problem's score is changed.
-# providing_args=[
-#         'block',  # Course block object
-#         'user',   # User object
-#         'raw_earned',    # Score obtained by the user
-#         'raw_possible',  # Maximum score available for the exercise
-#         'only_if_higher',   # Boolean indicating whether updates should be
-#                             # made only if the new score is higher than previous.
-#         'score_db_table',  # The database table that houses the score that changed.
-#     ]
 SCORE_PUBLISHED = Signal()
 
 
 # Signal that indicates that a user's score for a subsection has been updated.
 # This is a downstream signal of PROBLEM_WEIGHTED_SCORE_CHANGED sent for each
 # affected containing subsection.
-# providing_args=[
-#         'course',  # Course object
-#         'course_structure',  # BlockStructure object
-#         'user',  # User object
-#         'subsection_grade',  # SubsectionGrade object
-#     ]
 SUBSECTION_SCORE_CHANGED = Signal()
 
 # Signal that indicates that a user's score for a subsection has been overridden.
 # This signal is generated when a user's exam attempt state is set to rejected or
 # to verified from rejected. This signal may also be sent by any other client
 # using the GradesService to override subsections in the future.
-# providing_args=[
-#         'user_id',  # Integer User ID
-#         'course_id',  # Unicode string representing the course
-#         'usage_id',  # Unicode string indicating the courseware instance
-#         'only_if_higher',   # Boolean indicating whether updates should be
-#                             # made only if the new score is higher than previous.
-#         'modified',  # A datetime indicating when the database representation of
-#                      # this subsection override score was saved.
-#         'score_deleted',  # Boolean indicating whether the override score was
-#                           # deleted in this event.
-#         'score_db_table',  # The database table that houses the subsection override
-#                            # score that was created.
-#     ]
 SUBSECTION_OVERRIDE_CHANGED = Signal()
 
 
 # This Signal indicates that the user has received a passing grade in the course for the first time.
 # Any subsequent grade changes that may vary the passing/failing status will not re-trigger this event.
 # Emits course grade passed first time event
-# providing_args=[
-#         'course_id',  # Course object id
-#         'user_id',  # User object id
-#     ]
 COURSE_GRADE_PASSED_FIRST_TIME = Signal()
 COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY = Signal()
 
 # This Signal indicates that a segment event has fired for user who has passed a course for the first time
-# providing_args=[
-#     'user_id',  # User object id
-#     'course_id',  # Course object id
-#     'event_properties',  # Segment event properties that will be needed for follow up event
-# ]
 SCHEDULE_FOLLOW_UP_SEGMENT_EVENT_FOR_COURSE_PASSED_FIRST_TIME = Signal()

--- a/lms/djangoapps/verify_student/signals.py
+++ b/lms/djangoapps/verify_student/signals.py
@@ -18,7 +18,6 @@ log = logging.getLogger(__name__)
 
 
 # Signal for emitting IDV submission and review updates
-# providing_args = ["attempt_id", "user_id", "status", "full_name", "profile_name"]
 idv_update_signal = Signal()
 
 

--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -17,13 +17,9 @@ from .models import CourseOverview
 
 LOG = logging.getLogger(__name__)
 
-# providing_args=["updated_course_overview", "previous_start_date"]
 COURSE_START_DATE_CHANGED = Signal()
-# providing_args=["updated_course_overview", "previous_self_paced"]
 COURSE_PACING_CHANGED = Signal()
-# providing_args=["courserun_key"]
 IMPORT_COURSE_DETAILS = Signal()
-# providing_args=["courserun_key"]
 DELETE_COURSE_DETAILS = Signal()
 
 

--- a/openedx/core/djangoapps/content_libraries/signals.py
+++ b/openedx/core/djangoapps/content_libraries/signals.py
@@ -4,14 +4,10 @@ Content libraries related signals.
 
 from django.dispatch import Signal
 
-# providing_args=['library_key']
 CONTENT_LIBRARY_CREATED = Signal()
-# providing_args=['library_key', 'update_blocks']
 CONTENT_LIBRARY_UPDATED = Signal()
-# providing_args=['library_key']
 CONTENT_LIBRARY_DELETED = Signal()
 
-# Same providing_args=['library_key', 'usage_key'] for next 3 signals.
 LIBRARY_BLOCK_CREATED = Signal()
 LIBRARY_BLOCK_DELETED = Signal()
 LIBRARY_BLOCK_UPDATED = Signal()

--- a/openedx/core/djangoapps/course_apps/signals.py
+++ b/openedx/core/djangoapps/course_apps/signals.py
@@ -5,5 +5,4 @@ from django.dispatch import Signal
 
 # A signal that's dispatched when the status for a course app that's available for a course
 # isn't present in the `CourseAppStatus` table.
-# providing_args=["course_key", "is_enabled"]
 COURSE_APP_STATUS_INIT = Signal()

--- a/openedx/core/djangoapps/course_groups/signals/signals.py
+++ b/openedx/core/djangoapps/course_groups/signals/signals.py
@@ -4,5 +4,4 @@ Cohorts related signals.
 
 from django.dispatch import Signal
 
-# providing_args=['user', 'course_key']
 COHORT_MEMBERSHIP_UPDATED = Signal()

--- a/openedx/core/djangoapps/django_comment_common/signals.py
+++ b/openedx/core/djangoapps/django_comment_common/signals.py
@@ -4,7 +4,6 @@
 
 from django.dispatch import Signal
 
-# Same providing_args=['user', 'post'] for all following signals.
 thread_created = Signal()
 thread_edited = Signal()
 thread_voted = Signal()

--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -6,39 +6,24 @@ This module contains all general use signals.
 from django.dispatch import Signal
 
 # Signal that fires when a user is graded
-# providing_args=["user", "course_grade", "course_key", "deadline"]
 COURSE_GRADE_CHANGED = Signal()
 
 # Signal that fires when a user is awarded a certificate in a course (in the certificates django app)
 # TODO: runtime coupling between apps will be reduced if this event is changed to carry a username
 # rather than a User object; however, this will require changes to the milestones and badges APIs
-# Same providing_args=["user", "course_key", "mode", "status"] for next 3 signals.
 COURSE_CERT_CHANGED = Signal()
 COURSE_CERT_AWARDED = Signal()
 COURSE_CERT_REVOKED = Signal()
-# providing_args=["course_key",]
 COURSE_CERT_DATE_CHANGE = Signal()
 
-# providing_args=['user', 'course_id', 'subsection_id', 'subsection_grade', ]
 COURSE_ASSESSMENT_GRADE_CHANGED = Signal()
 
 # Signal that indicates that a user has passed a course.
-# providing_args=[
-#    'user',  # user object
-#    'course_id',  # course.id
-# ]
 COURSE_GRADE_NOW_PASSED = Signal()
 #Signal that indicates a user is now failing a course that they had previously passed.
-# providing_args=[
-#     'user',  # user object
-#     'course_id',  # course.id
-#     'grade',  # CourseGrade object
-# ]
 COURSE_GRADE_NOW_FAILED = Signal()
 
 # Signal that indicates that a user has become verified for certificate purposes
-# providing_args=['user']
 LEARNER_NOW_VERIFIED = Signal()
 
-# providing_args=['user']
 USER_ACCOUNT_ACTIVATED = Signal()  # Signal indicating email verification

--- a/openedx/core/djangoapps/user_api/accounts/signals.py
+++ b/openedx/core/djangoapps/user_api/accounts/signals.py
@@ -6,13 +6,10 @@ Django Signal related functionality for user_api accounts
 from django.dispatch import Signal
 
 # Signal to retire a user from LMS-initiated mailings (course mailings, etc)
-# providing_args=["user"]
 USER_RETIRE_MAILINGS = Signal()
 
 # Signal to retire LMS critical information
-# providing_args=["user"]
 USER_RETIRE_LMS_CRITICAL = Signal()
 
 # Signal to retire LMS misc information
-# providing_args=["user"]
 USER_RETIRE_LMS_MISC = Signal()

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -28,7 +28,6 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
 
 log = logging.getLogger(__name__)
 
-# providing_args=['user', 'response']
 CREATE_LOGON_COOKIE = Signal()
 
 

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -104,7 +104,6 @@ REGISTRATION_UTM_PARAMETERS = {
 REGISTRATION_UTM_CREATED_AT = 'registration_utm_created_at'
 IS_MARKETABLE = 'is_marketable'
 # used to announce a registration
-# providing_args=["user", "registration"]
 REGISTER_USER = Signal()
 
 


### PR DESCRIPTION
While adding the support for django 4.0, as `providing_args` was deprecated so we removed it from the code and commended its code chunks for references. So now its no more needed that's why removed all the commented code.