### PR TITLE
feat: allow oauth configuration per site and backend

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -854,7 +854,7 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
     This step is controlled by the `sync_learner_profile_data` flag on the provider's configuration.
     """
     current_provider = provider.Registry.get_from_pipeline({'backend': strategy.request.backend.name, 'kwargs': kwargs})
-    if user and current_provider.sync_learner_profile_data:
+    if user and current_provider and current_provider.sync_learner_profile_data:
         # Keep track of which incoming values get applied.
         changed = {}
 
@@ -931,7 +931,7 @@ def set_id_verification_status(auth_entry, strategy, details, user=None, *args, 
     Use the user's authentication with the provider, if configured, as evidence of their identity being verified.
     """
     current_provider = provider.Registry.get_from_pipeline({'backend': strategy.request.backend.name, 'kwargs': kwargs})
-    if user and current_provider.enable_sso_id_verification:
+    if user and current_provider and current_provider.enable_sso_id_verification:
         # Get previous valid, non expired verification attempts for this SSO Provider and user
         verifications = SSOVerification.objects.filter(
             user=user,

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -47,7 +47,7 @@ def inactive_user_view(request):
     if third_party_auth.is_enabled() and pipeline.running(request):
         running_pipeline = pipeline.get(request)
         third_party_provider = provider.Registry.get_from_pipeline(running_pipeline)
-        if third_party_provider.skip_email_verification and not activated:
+        if third_party_provider and third_party_provider.skip_email_verification and not activated:
             user.is_active = True
             user.save()
             activated = True


### PR DESCRIPTION
## Description

Currently, we can only add oauth configuration for a given backend to only a single site. This PR includes `site_id` in `KEY_FIELDS` for oauth configuration provider allowing a backend configuration for each site.

## Supporting information

Mostly copied from https://github.com/eduNEXT/edunext-platform/pull/601 except for minor changes like ignoring `site_id` in provider id as site_id is already considered while fetching the correct configuration.

## Testing instructions

* Get lms devstack up and running using `make lms-up`
* Add some sites via admin: http://localhost:18000/admin/sites/site/
* Add dummy oauth config for multiple sites: http://localhost:18000/admin/third_party_auth/oauth2providerconfig/
* Each site should have a current configuration.
   ![image](https://github.com/openedx/edx-platform/assets/10894099/275b7bd2-d7bb-4fe6-aad7-7e3e79da7365)
* Without this PR, only one current configuration is enabled even if sites are different.

