### PR TITLE
feat: add course waffle flag for learner assistant

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -96,6 +96,18 @@ COURSEWARE_OPTIMIZED_RENDER_XBLOCK = CourseWaffleFlag(
 # .. toggle_status: unsupported
 COURSES_INVITE_ONLY = SettingToggle('COURSES_INVITE_ONLY', default=False)
 
+# .. toggle_name: courseware.learning_assistant
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables an the visibility of an LTI-based learning assistant
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-07-05
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: MST-1977
+COURSEWARE_LEARNING_ASSISTANT = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.learning_assistant', __name__
+)
+
 
 ENABLE_OPTIMIZELY_IN_COURSEWARE = WaffleSwitch(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     'RET.enable_optimizely_in_courseware', __name__
@@ -137,3 +149,7 @@ def course_is_invitation_only(courselike) -> bool:
     """Returns whether the course is invitation only or not."""
     # We also mark Old Mongo courses (deprecated keys) as invitation only to cut off enrollment
     return COURSES_INVITE_ONLY.is_enabled() or courselike.invitation_only or courselike.id.deprecated
+
+
+def learning_assistant_is_active(course_key):
+    return COURSEWARE_LEARNING_ASSISTANT.is_enabled(course_key)

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -114,6 +114,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     linkedin_add_to_profile_url = serializers.URLField()
     is_integrity_signature_enabled = serializers.BooleanField()
     user_needs_integrity_signature = serializers.BooleanField()
+    learning_assistant_launch_url = serializers.CharField()
 
     def __init__(self, *args, **kwargs):
         """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -32,6 +32,7 @@ from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.courseware.tabs import ExternalLinkCourseTab
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.courseware.toggles import (
+    COURSEWARE_LEARNING_ASSISTANT,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
 )
@@ -428,6 +429,19 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         courseware_data = response.json()
         assert 'can_access_proctored_exams' in courseware_data
         assert courseware_data['can_access_proctored_exams'] == result
+
+    @ddt.data(
+        True,
+        False
+    )
+    def test_learning_assistant_launch_url(self, enabled):
+        with override_waffle_flag(COURSEWARE_LEARNING_ASSISTANT, active=enabled):
+            response = self.client.get(self.url)
+        launch_url = response.json()['learning_assistant_launch_url']
+        if enabled:
+            assert launch_url == ""
+        else:
+            assert launch_url is None
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -41,7 +41,7 @@ from lms.djangoapps.courseware.masquerade import (
 )
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.courseware.block_render import get_block_by_usage_id
-from lms.djangoapps.courseware.toggles import course_exit_page_is_active
+from lms.djangoapps.courseware.toggles import course_exit_page_is_active, learning_assistant_is_active
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.gating.api import get_entrance_exam_score, get_entrance_exam_usage_key
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -359,6 +359,15 @@ class CoursewareMeta:
             enrollment_active = self.enrollment['is_active']
             return enrollment_active and CourseMode.is_eligible_for_certificate(enrollment_mode)
 
+    @property
+    def learning_assistant_launch_url(self):
+        """
+        Returns a URL for the learning assistant LTI launch if applicable, otherwise None
+        """
+        if learning_assistant_is_active(self.course_key):
+            return ""  # TODO: replace empty string with LTI launch URL as part of MST-1975
+        return None
+
 
 class CoursewareInformation(RetrieveAPIView):
     """
@@ -448,6 +457,7 @@ class CoursewareInformation(RetrieveAPIView):
             verified mode. Will update to reverify URL if necessary.
         * linkedin_add_to_profile_url: URL to add the effective user's certificate to a LinkedIn Profile.
         * user_needs_integrity_signature: Whether the user needs to sign the integrity agreement for the course
+        * learning_assistant_launch_url: URL for the LTI launch of a learning assistant
 
     **Parameters:**
 


### PR DESCRIPTION
## [MST-1977](https://2u-internal.atlassian.net/browse/MST-1977)

Create course waffle flag to enable visibility of a learner assistant in the Learning MFE. The courseware API response will be modified as part of the follow up tickets to [MST-1975](https://2u-internal.atlassian.net/browse/MST-1975).