### PR TITLE
feat: Remove JWT_AUTH_REFRESH_COOKIE and should be cleaned.

### DIFF
--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -327,7 +327,6 @@ JWT_AUTH:
     JWT_AUDIENCE: lms-key
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
     JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
-    JWT_AUTH_REFRESH_COOKIE: edx-jwt-refresh-cookie
     JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
     JWT_ISSUERS:
     -   AUDIENCE: lms-key

--- a/lms/envs/devstack-experimental.yml
+++ b/lms/envs/devstack-experimental.yml
@@ -363,7 +363,6 @@ JWT_AUTH:
     JWT_AUDIENCE: lms-key
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
     JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
-    JWT_AUTH_REFRESH_COOKIE: edx-jwt-refresh-cookie
     JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
     JWT_ISSUERS:
     -   AUDIENCE: lms-key


### PR DESCRIPTION
Description:
The setting JWT_AUTH_REFRESH_COOKIE is meaningless and unused and should be cleaned up to avoid confusion.
In the very early days of introducing MFEs, we thought we were going to need this cookie in addition to the JWT cookie. However, it turned out we didn't need it, but the setting stuck around the contagion of it (being in cookiecutter and other template libraries) has resulted in it uselessly being copied to many repos.

Supporting information:
as per the original ticket https://github.com/openedx/public-engineering/issues/190, this setting is removed.