### PR TITLE
[WIP] feat: add "catalog" only option to Course Catalog Visibility

### DIFF
--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -47,6 +47,7 @@ from common.djangoapps.util.milestones_helpers import fulfill_course_milestone, 
 from xmodule.course_block import (  # lint-amnesty, pylint: disable=wrong-import-order
     CATALOG_VISIBILITY_ABOUT,
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
+    CATALOG_VISIBILITY_CATALOG,
     CATALOG_VISIBILITY_NONE
 )
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
@@ -589,7 +590,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
 
     def test__catalog_visibility(self):
         """
-        Tests the catalog visibility tri-states
+        Tests the catalog visibility 4-states
         """
         user = UserFactory.create()
         course_id = CourseLocator('edX', 'test', '2012_Fall')
@@ -611,6 +612,17 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         )
         assert not access._has_access_course(user, 'see_in_catalog', course)
         assert access._has_access_course(user, 'see_about_page', course)
+        assert access._has_access_course(staff, 'see_in_catalog', course)
+        assert access._has_access_course(staff, 'see_about_page', course)
+
+        # Now set visibility to just catalog, which means it should be included in the
+        # discovery API but the about page is not public, hence not appear in the catalog
+        course = Mock(
+            id=CourseLocator('edX', 'test', '2012_Fall'),
+            catalog_visibility=CATALOG_VISIBILITY_CATALOG
+        )
+        assert not access._has_access_course(user, 'see_in_catalog', course)
+        assert not access._has_access_course(user, 'see_about_page', course)
         assert access._has_access_course(staff, 'see_in_catalog', course)
         assert access._has_access_course(staff, 'see_about_page', course)
 

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -37,6 +37,7 @@ _ = lambda text: text
 
 CATALOG_VISIBILITY_CATALOG_AND_ABOUT = "both"
 CATALOG_VISIBILITY_ABOUT = "about"
+CATALOG_VISIBILITY_CATALOG = "catalog"
 CATALOG_VISIBILITY_NONE = "none"
 
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
@@ -759,17 +760,19 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
     catalog_visibility = String(
         display_name=_("Course Visibility In Catalog"),
         help=_(
-            # Translators: the quoted words 'both', 'about', and 'none' must be
+            # Translators: the quoted words 'both', 'about', 'catalog' and 'none' must be
             # left untranslated.  Leave them as English words.
             "Defines the access permissions for showing the course in the course catalog. This can be set to one "
-            "of three values: 'both' (show in catalog and allow access to about page), 'about' (only allow access "
-            "to about page), 'none' (do not show in catalog and do not allow access to an about page)."
+            "of four values: 'both' (show in catalog and allow access to about page), 'about' (only allow access "
+            "to about page), 'catalog' (show in Discovery API but do not allow public access to about page), "
+            "'none' (do not show in catalog and do not allow access to an about page)."
         ),
         default=DEFAULT_COURSE_VISIBILITY_IN_CATALOG,
         scope=Scope.settings,
         values=[
             {"display_name": "Both", "value": CATALOG_VISIBILITY_CATALOG_AND_ABOUT},
             {"display_name": "About", "value": CATALOG_VISIBILITY_ABOUT},
+            {"display_name": "Catalog", "value": CATALOG_VISIBILITY_CATALOG},
             {"display_name": "None", "value": CATALOG_VISIBILITY_NONE},
         ],
     )


### PR DESCRIPTION
This new option introduces setting the course catalog visibility option to `catalog` only. To allow private courses to be available on the enterprise catalog without making their about page visible.

## Supporting information

`Private-ref`: [BB-7617](https://tasks.opencraft.com/browse/BB-7617)

## Testing instructions

- Setup master devstack
- Make sure the site the following [site setting configurations](https://discuss.openedx.org/t/how-to-hide-courses-from-discover-new/4455/2?u=yusuf) are set: 
    ```json
    {
       "COURSE_CATALOG_VISIBILITY_PERMISSION": "see_in_catalog",
       "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page"
    }
    ``` 
- Login to LMS as a non-staff (non-superuser) user
    - View courses catalog and make you have can see a course in the catalog
    - Click on the course and make sure the about page is accessible
- Login to Discovery service as admin as super user
    - Access the of discovery service `courses` API endpoint: `http://localhost:18381/api/v1/courses/`
    - Confirm that the course that was visible to the user in the course catalog from the previous step is there and the `course_runs` field is populated
- Login to Studio as a course Admin (or superuser)
    - Select the course from the previous steps, click on the top navbar  `Settings` > `Advanced Settings`
    - Confirm that the `Course Visibility In Catalog` is initially set to `"both"`
    - Change the value of the `Course Visibility In Catalog` to `"catalog"` and click save (it takes a little bit of time but once it completes it will scroll to the top and show you a success message)
- Go to the discovery shell `make discovery-shell` and run the following commands:
    - `./manage.py refresh_course_metadata`
    - `./manage.py update_index --disable-change-limit`
- Go back to the LMS course catalog logged in as the normal user, and still see the course show, but when you click on it the about page returns a `404`
- Access the discovery service `courses` API endpoint again: `http://localhost:18381/api/v1/courses/`
    - Confirm that the course still shows along with the `course_runs` field still populated, should look something like this:
    ```json
    {
        "count": 5,
        "next": null,
        "previous": null,
        "results": [
            {
                "key": "edX+DemoX",
                "uuid": "6d98911b-a46b-42f3-84de-d25c0bdc2bef",
                "title": "Demonstration Course",
                "course_runs": [
                    {
                        "key": "course-v1:edX+DemoX+Demo_Course",
                        "uuid": "6b05b35d-9f2a-46ac-ba07-90b4e060ee4b",
                        "title": "Demonstration Course",
                        "external_key": null,
                        "image": null,
                        "short_description": null,
                        "..."
                    }
                ]
            },
            "..."
        ]
    }

    ```

