### PR TITLE
fix: videoblockpreview to videoblockdisplay

### DIFF
--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -276,7 +276,7 @@ class VideoBlock(
             return self.student_view(context)
 
         fragment = Fragment(self.get_html(view=PUBLIC_VIEW, context=context))
-        add_webpack_js_to_fragment(fragment, 'VideoBlockPreview')
+        add_webpack_js_to_fragment(fragment, 'VideoBlockDisplay')
         shim_xmodule_js(fragment, 'Video')
         return fragment
 


### PR DESCRIPTION
https://github.com/openedx/edx-platform/pull/32592 changed some webpack loading, and renamed the video display bundle from VideoBlockPreview to VideoBlockDisplay but the code for the public view did not include the updated name.