### PR TITLE
fix: correct bug in sapsf country to code mapping

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -283,15 +283,17 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
     # Define a simple mapping to relate SAPSF values to Open edX-compatible values for
     # any given field. By default, this only contains the Country field, as SAPSF supplies
     # a country name, which has to be translated to a country code.
-    default_value_mapping = {
-        'country': {name: code for code, name in countries}
-    }
+    country_mapping = {name: code for code, name in countries}
 
     # Unfortunately, not everything has a 1:1 name mapping between Open edX and SAPSF, so
     # we need some overrides. TODO: Fill in necessary mappings
-    default_value_mapping.update({
+    country_mapping.update({
         'United States': 'US',
     })
+
+    default_value_mapping = {
+        'country': country_mapping
+    }
 
     def get_registration_fields(self, response):
         """

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -534,7 +534,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
                         'lastName': 'Smith',
                         'defaultFullName': 'John Smith',
                         'email': 'john@smith.com',
-                        'country': 'Australia',
+                        'country': 'United States',
                     }
                 })
             )
@@ -589,7 +589,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
         what we're looking for, and when an empty override is provided (expected behavior is that
         existing value maps will be left alone).
         """
-        expected_country = 'AU'
+        expected_country = 'US'
         provider_settings = {
             'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
             'sapsf_private_key': 'fake_private_key_here',
@@ -632,7 +632,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
                         'firstName': 'John',
                         'lastName': 'Smith',
                         'defaultFullName': 'John Smith',
-                        'country': 'Australia'
+                        'country': 'United States'
                     }
                 })
             )
@@ -666,7 +666,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
         what we're looking for, and when an empty override is provided (expected behavior is that
         existing value maps will be left alone).
         """
-        value_map = {'country': {'Australia': 'NZ'}}
+        value_map = {'country': {'United States': 'NZ'}}
         expected_country = 'NZ'
         provider_settings = {
             'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
@@ -695,8 +695,8 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
         what we're looking for, and when an empty override is provided (expected behavior is that
         existing value maps will be left alone).
         """
-        value_map = {'country': {'United States': 'blahfake'}}
-        expected_country = 'AU'
+        value_map = {'country': {'Australia': 'blahfake'}}
+        expected_country = 'US'
         provider_settings = {
             'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
             'sapsf_private_key': 'fake_private_key_here',
@@ -726,7 +726,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
         """
 
         value_map = {'country': {}}
-        expected_country = 'AU'
+        expected_country = 'US'
         provider_settings = {
             'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
             'sapsf_private_key': 'fake_private_key_here',


### PR DESCRIPTION
## Description
- https://2u-internal.atlassian.net/browse/ENT-6999
- https://github.com/openedx/edx-platform/pull/15739

There is a subtle bug in the way we try to convert some SAPSF 'country' values into the ISO codes we need for account registration, specifically rather than adding a mapping for 'United States' -> 'US' to the `country` key, the 'United States' value is added to the top level, as if it was a field name akin to 'country'. Our tests did not cover this specific scenario. Other customers are either in other countries or supply the ISO code directly which is why this hasn't come up before.

Specific area with the bug:

https://github.com/openedx/edx-platform/pull/15739/files#diff-ed995eacf61f11a5d953b567ee524453203102872a99d71dbc15da7773aba93dR149-R160