### PR TITLE
[3/3] build: commit builtinblocks Webpack config and stub out `xmodule_assets` 

### DIFF
--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -221,7 +221,7 @@ class TestTemplates(TestDiscussionXBlock):
         """
         permission_canary = object()
         with mock.patch(
-            'lms.djangoapps.discussion.django_comment_client.permissions.has_permission',
+            'xmodule.discussion_block.has_permission',
             return_value=permission_canary,
         ) as has_perm:
             actual_permission = self.block.has_permission("test_permission")

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -323,7 +323,6 @@ class SassWatcher(PatternMatchingEventHandler):
     """
     ignore_directories = True
     patterns = ['*.scss']
-    ignore_patterns = ['common/static/xmodule/*']
 
     def register(self, observer, directories):
         """
@@ -350,47 +349,6 @@ class SassWatcher(PatternMatchingEventHandler):
             compile_sass()      # pylint: disable=no-value-for-parameter
         except Exception:       # pylint: disable=broad-except
             traceback.print_exc()
-
-
-class XModuleSassWatcher(SassWatcher):
-    """
-    Watches for sass file changes
-    """
-    ignore_directories = True
-    ignore_patterns = []
-
-    @debounce()
-    def on_any_event(self, event):
-        print('\tCHANGED:', event.src_path)
-        try:
-            process_xmodule_assets()
-        except Exception:  # pylint: disable=broad-except
-            traceback.print_exc()
-
-
-class XModuleAssetsWatcher(PatternMatchingEventHandler):
-    """
-    Watches for css and js file changes
-    """
-    ignore_directories = True
-    patterns = ['*.css', '*.js']
-
-    def register(self, observer):
-        """
-        Register files with observer
-        """
-        observer.schedule(self, 'xmodule/', recursive=True)
-
-    @debounce()
-    def on_any_event(self, event):
-        print('\tCHANGED:', event.src_path)
-        try:
-            process_xmodule_assets()
-        except Exception:  # pylint: disable=broad-except
-            traceback.print_exc()
-
-        # To refresh the hash values of static xmodule content
-        restart_django_servers()
 
 
 @task
@@ -615,16 +573,13 @@ def process_npm_assets():
 
 
 @task
-@needs(
-    'pavelib.prereqs.install_python_prereqs',
-)
 @no_help
 def process_xmodule_assets():
     """
     Process XModule static assets.
     """
-    sh('xmodule_assets common/static/xmodule')
-    print("\t\tFinished processing xmodule assets.")
+    print("\t\tProcessing xmodule assets is no longer needed. This task is now a no-op.")
+    print("\t\tWhen paver is removed from edx-platform, this step will not replaced.")
 
 
 def restart_django_servers():
@@ -822,8 +777,6 @@ def watch_assets(options):
     observer = Observer(timeout=wait)
 
     SassWatcher().register(observer, sass_directories)
-    XModuleSassWatcher().register(observer, ['xmodule/'])
-    XModuleAssetsWatcher().register(observer)
 
     print("Starting asset watcher...")
     observer.start()
@@ -845,6 +798,7 @@ def watch_assets(options):
 @task
 @needs(
     'pavelib.prereqs.install_node_prereqs',
+    'pavelib.prereqs.install_python_prereqs',
 )
 @consume_args
 @timed
@@ -895,8 +849,6 @@ def update_assets(args):
     )
     args = parser.parse_args(args)
     collect_log_args = {}
-
-    process_xmodule_assets()
 
     # Build Webpack
     call_task('pavelib.assets.webpack', options={'settings': args.settings})

--- a/pavelib/js_test.py
+++ b/pavelib/js_test.py
@@ -26,7 +26,6 @@ __test__ = False  # do not collect
 @needs(
     'pavelib.prereqs.install_node_prereqs',
     'pavelib.utils.test.utils.clean_reports_dir',
-    'pavelib.assets.process_xmodule_assets',
 )
 @cmdopts([
     ("suite=", "s", "Test suite to run"),

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -214,7 +214,6 @@ class TestPaverServerTasks(PaverTestCase):
             expected_asset_settings = "test_static_optimized"
         expected_collect_static = not is_fast and expected_settings != Env.DEVSTACK_SETTINGS
         if not is_fast:
-            expected_messages.append("xmodule_assets common/static/xmodule")
             expected_messages.append("install npm_assets")
             expected_messages.extend(
                 [c.format(settings=expected_asset_settings,
@@ -259,7 +258,6 @@ class TestPaverServerTasks(PaverTestCase):
         expected_collect_static = not is_fast and expected_settings != Env.DEVSTACK_SETTINGS
         expected_messages = []
         if not is_fast:
-            expected_messages.append("xmodule_assets common/static/xmodule")
             expected_messages.append("install npm_assets")
             expected_messages.extend(
                 [c.format(settings=expected_asset_settings,

--- a/webpack.builtinblocks.config.js
+++ b/webpack.builtinblocks.config.js
@@ -1,0 +1,136 @@
+module.exports = {
+    "entry": {
+        "AboutBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/display.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/collapsible.js",
+            "./xmodule/js/src/html/imageModal.js",
+            "./xmodule/js/common_static/js/vendor/draggabilly.js"
+        ],
+        "AboutBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/edit.js"
+        ],
+        "AnnotatableBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/display.js",
+            "./xmodule/js/src/annotatable/display.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/collapsible.js"
+        ],
+        "AnnotatableBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/raw/edit/xml.js"
+        ],
+        "ConditionalBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/conditional/display.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/collapsible.js"
+        ],
+        "ConditionalBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/sequence/edit.js"
+        ],
+        "CourseInfoBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/display.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/collapsible.js",
+            "./xmodule/js/src/html/imageModal.js",
+            "./xmodule/js/common_static/js/vendor/draggabilly.js"
+        ],
+        "CourseInfoBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/edit.js"
+        ],
+        "CustomTagBlockDisplay": "./xmodule/js/src/xmodule.js",
+        "CustomTagBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/raw/edit/xml.js"
+        ],
+        "HtmlBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/display.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/collapsible.js",
+            "./xmodule/js/src/html/imageModal.js",
+            "./xmodule/js/common_static/js/vendor/draggabilly.js"
+        ],
+        "HtmlBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/edit.js"
+        ],
+        "LTIBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/lti/lti.js"
+        ],
+        "LTIBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/raw/edit/metadata-only.js"
+        ],
+        "LibraryContentBlockDisplay": "./xmodule/js/src/xmodule.js",
+        "LibraryContentBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/vertical/edit.js"
+        ],
+        "PollBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/poll/poll.js",
+            "./xmodule/js/src/poll/poll_main.js"
+        ],
+        "PollBlockEditor": "./xmodule/js/src/xmodule.js",
+        "ProblemBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/capa/display.js",
+            "./xmodule/js/src/collapsible.js",
+            "./xmodule/js/src/capa/imageinput.js",
+            "./xmodule/js/src/capa/schematic.js"
+        ],
+        "ProblemBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/problem/edit.js"
+        ],
+        "SequenceBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/sequence/display.js"
+        ],
+        "SequenceBlockEditor": "./xmodule/js/src/xmodule.js",
+        "SplitTestBlockDisplay": "./xmodule/js/src/xmodule.js",
+        "SplitTestBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/sequence/edit.js"
+        ],
+        "StaticTabBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/display.js",
+            "./xmodule/js/src/javascript_loader.js",
+            "./xmodule/js/src/collapsible.js",
+            "./xmodule/js/src/html/imageModal.js",
+            "./xmodule/js/common_static/js/vendor/draggabilly.js"
+        ],
+        "StaticTabBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/html/edit.js"
+        ],
+        "VideoBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/video/10_main.js"
+        ],
+        "VideoBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/tabs/tabs-aggregator.js"
+        ],
+        "WordCloudBlockDisplay": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/assets/word_cloud/src/js/word_cloud.js"
+        ],
+        "WordCloudBlockEditor": [
+            "./xmodule/js/src/xmodule.js",
+            "./xmodule/js/src/raw/edit/metadata-only.js"
+        ]
+    }
+};

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -9,7 +9,7 @@ var StringReplace = require('string-replace-webpack-plugin');
 var Merge = require('webpack-merge');
 
 var files = require('./webpack-config/file-lists.js');
-var xmoduleJS = require('./common/static/xmodule/webpack.xmodule.config.js');
+var builtinBlocksJS = require('./webpack.builtinblocks.config.js');
 
 var filesWithRequireJSBlocks = [
     path.resolve(__dirname, 'common/static/common/js/components/utils/view_utils.js'),
@@ -553,4 +553,4 @@ module.exports = Merge.smart({
         }
 
     }
-}, {web: xmoduleJS}, workerConfig());
+}, {web: builtinBlocksJS}, workerConfig());

--- a/xmodule/annotatable_block.py
+++ b/xmodule/annotatable_block.py
@@ -4,7 +4,6 @@ import logging
 import textwrap
 
 from lxml import etree
-from pkg_resources import resource_filename
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope, String
@@ -15,7 +14,6 @@ from xmodule.raw_block import RawMixin
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.xml_block import XmlMixin
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     XModuleMixin,
@@ -35,7 +33,6 @@ class AnnotatableBlock(
     XmlMixin,
     EditingMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):
@@ -73,22 +70,6 @@ class AnnotatableBlock(
 
     uses_xmodule_styles_setup = True
 
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/html/display.js'),
-            resource_filename(__name__, 'js/src/annotatable/display.js'),
-            resource_filename(__name__, 'js/src/javascript_loader.js'),
-            resource_filename(__name__, 'js/src/collapsible.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
-    studio_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/raw/edit/xml.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
     studio_js_module_name = "XMLEditingDescriptor"
     mako_template = "widgets/raw-edit.html"
 

--- a/xmodule/assets/README.rst
+++ b/xmodule/assets/README.rst
@@ -41,8 +41,8 @@ the corresponding folders in any enabled themes, as part of the edx-platform bui
 It is collected into the static root, and then linked to from XBlock fragments by the
 ``add_sass_to_fragment`` function in `builtin_assets.py`_.
 
-.. _AnnotatableBlockDisplay: https://github.com/openedx/edx-platform/tree/master/xmodule/assets/AnnotatableBlockDisplay.scss
-.. _AnnotatableBlockEditor: https://github.com/openedx/edx-platform/tree/master/xmodule/assets/AnnotatableBlockEditor.scss
+.. _AnnotatableBlockDisplay.scss: https://github.com/openedx/edx-platform/tree/master/xmodule/assets/AnnotatableBlockDisplay.scss
+.. _AnnotatableBlockEditor.scss: https://github.com/openedx/edx-platform/tree/master/xmodule/assets/AnnotatableBlockEditor.scss
 .. _annotatable/_display.scss: https://github.com/openedx/edx-platform/tree/master/xmodule/assets/annotatable/_display.scss
 .. _simplify things: https://github.com/openedx/edx-platform/issues/32621
 
@@ -59,7 +59,7 @@ Currently, edx-platform XBlock JS is defined both here in `xmodule/assets`_ and 
 
 * For many older blocks, their JS is:
 
-  * bundled using a generated Webpack config at ``common/static/xmodule/webpack.xmodule.config.js``,
+  * bundled using a `webpack.builtinblocks.config.js`_,
   * which is included into `webpack.common.config.js`_,
   * allowing it to be included into XBlock fragments using ``add_webpack_js_to_fragment`` from `builtin_assets.py`_.
 
@@ -74,11 +74,7 @@ Currently, edx-platform XBlock JS is defined both here in `xmodule/assets`_ and 
   * `VerticalBlock`_
   * `LibrarySourcedBlock`_
 
-As part of an `active build refactoring`_:
-
-* We will move ``webpack.xmodule.config.js`` here instead of generating it.
-* We will consolidate all edx-platform XBlock JS here in `xmodule/assets`_.
-* We will delete the ``xmodule_assets`` script.
+As part of an `active build refactoring`_, we will soon consolidate all edx-platform XBlock JS here in `xmodule/assets`_.
 
 .. _xmodule/assets: https://github.com/openedx/edx-platform/tree/master/xmodule/assets
 .. _xmodule/js: https://github.com/openedx/edx-platform/tree/master/xmodule/js
@@ -91,4 +87,5 @@ As part of an `active build refactoring`_:
 .. _builtin_assets.py: https://github.com/openedx/edx-platform/tree/master/xmodule/util/builtin_assets.py
 .. _static_content.py: https://github.com/openedx/edx-platform/blob/master/xmodule/static_content.py
 .. _library_source_block/style.css: https://github.com/openedx/edx-platform/blob/master/xmodule/assets/library_source_block/style.css
+.. _webpack.builtinblocks.config.js: https://github.com/openedx/edx-platform/blob/master/webpack.builtinblocks.config.js
 .. _webpack.common.config.js: https://github.com/openedx/edx-platform/blob/master/webpack.common.config.js

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -19,7 +19,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
 from lxml import etree
-from pkg_resources import resource_filename
 from pytz import utc
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
@@ -39,7 +38,6 @@ from xmodule.raw_block import RawMixin
 from xmodule.util.sandboxing import SandboxService
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
     XModuleToXBlockMixin,
@@ -131,7 +129,6 @@ class ProblemBlock(
     XmlMixin,
     EditingMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):
@@ -164,24 +161,6 @@ class ProblemBlock(
     icon_class = 'problem'
 
     uses_xmodule_styles_setup = True
-
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/javascript_loader.js'),
-            resource_filename(__name__, 'js/src/capa/display.js'),
-            resource_filename(__name__, 'js/src/collapsible.js'),
-            resource_filename(__name__, 'js/src/capa/imageinput.js'),
-            resource_filename(__name__, 'js/src/capa/schematic.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js')
-    }
-
-    studio_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/problem/edit.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
 
     display_name = String(
         display_name=_("Display Name"),

--- a/xmodule/conditional_block.py
+++ b/xmodule/conditional_block.py
@@ -9,7 +9,6 @@ import logging
 from lazy import lazy
 from lxml import etree
 from opaque_keys.edx.locator import BlockUsageLocator
-from pkg_resources import resource_filename
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import ReferenceList, Scope, String
@@ -23,7 +22,6 @@ from xmodule.util.builtin_assets import add_webpack_js_to_fragment
 from xmodule.validation import StudioValidation, StudioValidationMessage
 from xmodule.xml_block import XmlMixin
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     STUDENT_VIEW,
@@ -44,7 +42,6 @@ class ConditionalBlock(
     MakoTemplateBlockBase,
     XmlMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
     StudioEditableBlock,
@@ -146,21 +143,8 @@ class ConditionalBlock(
 
     show_in_read_only_mode = True
 
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/conditional/display.js'),
-            resource_filename(__name__, 'js/src/javascript_loader.js'),
-            resource_filename(__name__, 'js/src/collapsible.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
     mako_template = 'widgets/metadata-edit.html'
     studio_js_module_name = 'SequenceDescriptor'
-    studio_view_js = {
-        'js': [resource_filename(__name__, 'js/src/sequence/edit.js')],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
 
     # Map
     # key: <tag attribute in xml>

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -15,10 +15,12 @@ from xblock.fields import UNIQUE_ID, Scope, String
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
+from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.xblock_utils import get_css_dependencies, get_js_dependencies
 from xmodule.xml_block import XmlMixin
+
 
 log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)  # pylint: disable=invalid-name
@@ -154,9 +156,6 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlMixin):  # lint-amn
         :param str permission: Permission
         :rtype: bool
         """
-        # normal import causes the xmodule_assets command to fail due to circular import - hence importing locally
-        from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
-
         return has_permission(self.django_user, permission, self.course_key)
 
     def student_view(self, context=None):

--- a/xmodule/error_block.py
+++ b/xmodule/error_block.py
@@ -18,7 +18,6 @@ from xblock.fields import Scope, ScopeIds, String
 from xmodule.errortracker import exc_info_to_str
 from xmodule.modulestore import EdxJSONEncoder
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
     XModuleToXBlockMixin,
@@ -47,7 +46,6 @@ class ErrorFields:
 class ErrorBlock(
     ErrorFields,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):  # pylint: disable=abstract-method

--- a/xmodule/html_block.py
+++ b/xmodule/html_block.py
@@ -8,8 +8,6 @@ import sys
 import textwrap
 from datetime import datetime
 
-from pkg_resources import resource_filename
-
 from django.conf import settings
 from fs.errors import ResourceNotFound
 from lxml import etree
@@ -27,7 +25,6 @@ from xmodule.stringify import stringify_children
 from xmodule.util.misc import escape_html_characters
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     XModuleMixin,
@@ -47,7 +44,7 @@ _ = lambda text: text
 @XBlock.needs("user")
 class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
     XmlMixin, EditingMixin,
-    XModuleToXBlockMixin, HTMLSnippet, ResourceTemplates, XModuleMixin,
+    XModuleToXBlockMixin, ResourceTemplates, XModuleMixin,
 ):
     """
     The HTML XBlock mixin.
@@ -144,17 +141,6 @@ class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
         shim_xmodule_js(fragment, 'HTMLEditingDescriptor')
         return fragment
 
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/html/display.js'),
-            resource_filename(__name__, 'js/src/javascript_loader.js'),
-            resource_filename(__name__, 'js/src/collapsible.js'),
-            resource_filename(__name__, 'js/src/html/imageModal.js'),
-            resource_filename(__name__, 'js/common_static/js/vendor/draggabilly.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
     uses_xmodule_styles_setup = True
 
     mako_template = "widgets/html-edit.html"
@@ -162,13 +148,6 @@ class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
     filename_extension = "xml"
     template_dir_name = "html"
     show_in_read_only_mode = True
-
-    studio_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/html/edit.js')
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
 
     # VS[compat] TODO (cpennington): Delete this method once all fall 2012 course
     # are being edited in the cms

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -17,7 +17,6 @@ from lazy import lazy
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 from opaque_keys.edx.locator import LibraryLocator
-from pkg_resources import resource_filename
 from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.completable import XBlockCompletionMode
@@ -31,7 +30,6 @@ from xmodule.util.builtin_assets import add_webpack_js_to_fragment
 from xmodule.validation import StudioValidation, StudioValidationMessage
 from xmodule.xml_block import XmlMixin
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     STUDENT_VIEW,
@@ -76,7 +74,6 @@ class LibraryContentBlock(
     MakoTemplateBlockBase,
     XmlMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
     StudioEditableBlock,
@@ -95,19 +92,8 @@ class LibraryContentBlock(
 
     resources_dir = 'assets/library_content'
 
-    preview_view_js = {
-        'js': [],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
     mako_template = 'widgets/metadata-edit.html'
     studio_js_module_name = "VerticalDescriptor"
-    studio_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/vertical/edit.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
 
     show_in_read_only_mode = True
 

--- a/xmodule/lti_block.py
+++ b/xmodule/lti_block.py
@@ -68,7 +68,6 @@ import oauthlib.oauth1
 from django.conf import settings
 from lxml import etree
 from oauthlib.oauth1.rfc5849 import signature
-from pkg_resources import resource_filename
 from pytz import UTC
 from webob import Response
 from web_fragments.fragment import Fragment
@@ -88,7 +87,6 @@ from xmodule.raw_block import EmptyDataRawMixin
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.xml_block import XmlMixin
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     XModuleMixin,
@@ -284,7 +282,6 @@ class LTIBlock(
     EditingMixin,
     MakoTemplateBlockBase,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):  # pylint: disable=abstract-method
@@ -372,22 +369,9 @@ class LTIBlock(
     resources_dir = None
     uses_xmodule_styles_setup = True
 
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/lti/lti.js')
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
     mako_template = 'widgets/metadata-only-edit.html'
 
     studio_js_module_name = 'MetadataOnlyEditingDescriptor'
-    studio_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/raw/edit/metadata-only.js')
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
 
     def studio_view(self, _context):
         """

--- a/xmodule/poll_block.py
+++ b/xmodule/poll_block.py
@@ -13,7 +13,6 @@ import logging
 from collections import OrderedDict
 from copy import deepcopy
 
-from pkg_resources import resource_filename
 from web_fragments.fragment import Fragment
 
 from lxml import etree
@@ -24,7 +23,6 @@ from xmodule.mako_block import MakoTemplateBlockBase
 from xmodule.stringify import stringify_children
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     XModuleMixin,
@@ -42,7 +40,6 @@ class PollBlock(
     MakoTemplateBlockBase,
     XmlMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):  # pylint: disable=abstract-method
@@ -83,22 +80,6 @@ class PollBlock(
 
     resources_dir = None
     uses_xmodule_styles_setup = True
-
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/javascript_loader.js'),
-            resource_filename(__name__, 'js/src/poll/poll.js'),
-            resource_filename(__name__, 'js/src/poll/poll_main.js')
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
-    # There is no studio_view() for this XBlock but this is needed to make the
-    # the static_content command happy.
-    studio_view_js = {
-        'js': [],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js')
-    }
 
     def handle_ajax(self, dispatch, data):  # lint-amnesty, pylint: disable=unused-argument
         """Ajax handler.

--- a/xmodule/randomize_block.py
+++ b/xmodule/randomize_block.py
@@ -11,7 +11,6 @@ from xmodule.mako_block import MakoTemplateBlockBase
 from xmodule.seq_block import SequenceMixin
 from xmodule.xml_block import XmlMixin
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     STUDENT_VIEW,
     XModuleMixin,
@@ -26,7 +25,6 @@ class RandomizeBlock(
     MakoTemplateBlockBase,
     XmlMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -14,7 +14,6 @@ from django.conf import settings
 
 from lxml import etree
 from opaque_keys.edx.keys import UsageKey
-from pkg_resources import resource_filename
 from pytz import UTC
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
@@ -25,7 +24,6 @@ from xblock.fields import Boolean, Integer, List, Scope, String
 from edx_toggles.toggles import WaffleFlag, SettingDictToggle
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     STUDENT_VIEW,
@@ -258,7 +256,6 @@ class SequenceBlock(
     MakoTemplateBlockBase,
     XmlMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):
@@ -270,20 +267,6 @@ class SequenceBlock(
 
     show_in_read_only_mode = True
     uses_xmodule_styles_setup = True
-
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/sequence/display.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js')
-    }
-
-    # There is no studio_view() for this XBlock but this is needed to make the
-    # the static_content command happy.
-    studio_view_js = {
-        'js': [],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js')
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/xmodule/split_test_block.py
+++ b/xmodule/split_test_block.py
@@ -12,7 +12,6 @@ from uuid import uuid4
 
 from django.utils.functional import cached_property
 from lxml import etree
-from pkg_resources import resource_filename
 from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.core import XBlock
@@ -26,7 +25,6 @@ from xmodule.util.builtin_assets import add_webpack_js_to_fragment
 from xmodule.validation import StudioValidation, StudioValidationMessage
 from xmodule.xml_block import XmlMixin
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     STUDENT_VIEW,
@@ -132,7 +130,6 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
     MakoTemplateBlockBase,
     XmlMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
     StudioEditableBlock,
@@ -158,17 +155,8 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
 
     show_in_read_only_mode = True
 
-    preview_view_js = {
-        'js': [],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
     mako_template = "widgets/metadata-only-edit.html"
     studio_js_module_name = 'SequenceDescriptor'
-    studio_view_js = {
-        'js': [resource_filename(__name__, 'js/src/sequence/edit.js')],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
 
     @cached_property
     def child_block(self):

--- a/xmodule/static_content.py
+++ b/xmodule/static_content.py
@@ -1,204 +1,25 @@
 # /usr/bin/env python
 """
-Generate <output_root>/webpack.xmodule.config.js, with a display & editor Webpack bundle for each builtin block.
+This module used to hold a CLI utility for gathering up the JS and Sass used by several built-in XBlocks.
 
-It looks like this:
+It now remains as a stub, just for backwards compatibility.
 
-  module.exports = {
-      "entry": {
-          "AboutBlockDisplay": [
-              "./xmodule/js/src/xmodule.js",
-              "./xmodule/js/src/html/display.js",
-              "./xmodule/js/src/javascript_loader.js",
-              "./xmodule/js/src/collapsible.js",
-              "./xmodule/js/src/html/imageModal.js",
-              "./xmodule/js/common_static/js/vendor/draggabilly.js"
-          ],
-          "AboutBlockEditor": [
-              "./xmodule/js/src/xmodule.js",
-              "./xmodule/js/src/html/edit.js"
-          ],
-          "AnnotatableBlockDisplay": [
-              "./xmodule/js/src/xmodule.js",
-              "./xmodule/js/src/html/display.js",
-              "./xmodule/js/src/annotatable/display.js",
-              "./xmodule/js/src/javascript_loader.js",
-              "./xmodule/js/src/collapsible.js"
-          ],
-          ... etc.
-      }
-  }
-
-Don't add to this! It will soon be removed as part of: https://github.com/openedx/edx-platform/issues/32481
+It will soon be removed as part of https://github.com/openedx/edx-platform/issues/31798.
 """
-
-
-import errno
-import json
 import logging
-import os
 import sys
-import textwrap
-from pkg_resources import resource_filename
-
-import django
-from pathlib import Path as path
-
-from xmodule.annotatable_block import AnnotatableBlock
-from xmodule.capa_block import ProblemBlock
-from xmodule.conditional_block import ConditionalBlock
-from xmodule.html_block import AboutBlock, CourseInfoBlock, HtmlBlock, StaticTabBlock
-from xmodule.library_content_block import LibraryContentBlock
-from xmodule.lti_block import LTIBlock
-from xmodule.poll_block import PollBlock
-from xmodule.seq_block import SequenceBlock
-from xmodule.split_test_block import SplitTestBlock
-from xmodule.template_block import CustomTagBlock
-from xmodule.word_cloud_block import WordCloudBlock
-from xmodule.x_module import HTMLSnippet
-
-LOG = logging.getLogger(__name__)
-
-
-class VideoBlock(HTMLSnippet):  # lint-amnesty, pylint: disable=abstract-method
-    """
-    Static assets for VideoBlock.
-    Kept here because importing VideoBlock code requires Django to be setup.
-    """
-
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/video/10_main.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js')
-    }
-
-    studio_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/tabs/tabs-aggregator.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
-
-# List of XBlocks which use this static content setup.
-# Should only be used for XModules being converted to XBlocks.
-XBLOCK_CLASSES = [
-    AboutBlock,
-    AnnotatableBlock,
-    ConditionalBlock,
-    CourseInfoBlock,
-    CustomTagBlock,
-    HtmlBlock,
-    LibraryContentBlock,
-    LTIBlock,
-    PollBlock,
-    ProblemBlock,
-    SequenceBlock,
-    SplitTestBlock,
-    StaticTabBlock,
-    VideoBlock,
-    WordCloudBlock,
-]
-
-
-def _ensure_dir(directory):
-    """Ensure that `directory` exists."""
-    try:
-        os.makedirs(directory)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST:
-            pass
-        else:
-            raise
-
-
-def write_webpack(output_file, module_files, descriptor_files):
-    """
-    Write all xmodule and xmodule descriptor javascript into module-specific bundles.
-
-    The output format should be suitable for smart-merging into an existing webpack configuration.
-    """
-    _ensure_dir(output_file.parent)
-
-    config = {
-        'entry': {}
-    }
-    for (owner, unique_files) in list(module_files.items()) + list(descriptor_files.items()):
-        if len(unique_files) == 1:
-            unique_files = unique_files[0]
-        config['entry'][owner] = unique_files
-    with output_file.open('w') as outfile:
-        outfile.write(
-            textwrap.dedent("""\
-                module.exports = {config_json};
-            """).format(
-                config_json=json.dumps(
-                    config,
-                    indent=4,
-                    sort_keys=True,
-                )
-            )
-        )
 
 
 def main():
     """
-    Generate the weback config.
-
-    Usage: static_content.py <output_root>
+    Warn that this script is now a stub, and return success (zero).
     """
-    from django.conf import settings
-    # Install only the apps whose models are imported when this runs
-    installed_apps = (
-        'django.contrib.auth',
-        'django.contrib.contenttypes',
-        'config_models',
-        'openedx.core.djangoapps.video_config',
-        'openedx.core.djangoapps.video_pipeline',
+    logging.warning(
+        "xmodule/static_content.py, aka xmodule_assets, is now a no-op. "
+        "Please remove calls to it from your build pipeline. It will soon be deleted.",
     )
-    try:
-        import edxval  # lint-amnesty, pylint: disable=unused-import
-        installed_apps += ('edxval',)
-    except ImportError:
-        pass
-    if not settings.configured:
-        settings.configure(
-            INSTALLED_APPS=installed_apps,
-        )
-    django.setup()
-
-    try:
-        root = path(sys.argv[1])
-    except IndexError:
-        sys.exit(main.__doc__)
-
-    # We assume this module is located at edx-platform/xmodule/static_content.py.
-    # Not the most robust assumption, but this script will be gone soon.
-    repo_root = path(__file__).parent.parent
-
-    module_files = {
-        class_.get_preview_view_js_bundle_name(): [
-            "./" + str(path(fragment_path).relative_to(repo_root))
-            for fragment_path in [
-                class_.get_preview_view_js()['xmodule_js'],
-                *class_.get_preview_view_js().get('js', []),
-            ]
-        ]
-        for class_ in XBLOCK_CLASSES
-    }
-    descriptor_files = {
-        class_.get_studio_view_js_bundle_name(): [
-            "./" + str(path(fragment_path).relative_to(repo_root))
-            for fragment_path in [
-                class_.get_studio_view_js()['xmodule_js'],
-                *class_.get_studio_view_js().get('js', []),
-            ]
-        ]
-        for class_ in XBLOCK_CLASSES
-    }
-    write_webpack(root / 'webpack.xmodule.config.js', module_files, descriptor_files)
+    return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/xmodule/template_block.py
+++ b/xmodule/template_block.py
@@ -6,13 +6,11 @@ from string import Template
 from xblock.core import XBlock
 
 from lxml import etree
-from pkg_resources import resource_filename
 from web_fragments.fragment import Fragment
 from xmodule.editing_block import EditingMixin
 from xmodule.raw_block import RawMixin
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     XModuleMixin,
@@ -28,7 +26,6 @@ class CustomTagTemplateBlock(  # pylint: disable=abstract-method
     XmlMixin,
     EditingMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):
@@ -64,15 +61,6 @@ class CustomTagBlock(CustomTagTemplateBlock):  # pylint: disable=abstract-method
     """
     resources_dir = None
     template_dir_name = 'customtag'
-
-    preview_view_js = {
-        'js': [],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-    studio_view_js = {
-        'js': [resource_filename(__name__, 'js/src/raw/edit/xml.js')],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
 
     def studio_view(self, _context):
         """

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -52,7 +52,7 @@ from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_
 from xmodule.video_block import manage_video_subtitles_save
 from xmodule.x_module import (
     PUBLIC_VIEW, STUDENT_VIEW,
-    HTMLSnippet, ResourceTemplates, shim_xmodule_js,
+    ResourceTemplates, shim_xmodule_js,
     XModuleMixin, XModuleToXBlockMixin,
 )
 from xmodule.xml_block import XmlMixin, deserialize_field, is_pointer_tag, name_to_pathname
@@ -121,7 +121,7 @@ EXPORT_IMPORT_STATIC_DIR = 'static'
 @XBlock.needs('mako', 'user')
 class VideoBlock(
         VideoFields, VideoTranscriptsMixin, VideoStudioViewHandlers, VideoStudentViewHandlers,
-        EmptyDataRawMixin, XmlMixin, EditingMixin, XModuleToXBlockMixin, HTMLSnippet,
+        EmptyDataRawMixin, XmlMixin, EditingMixin, XModuleToXBlockMixin,
         ResourceTemplates, XModuleMixin, LicenseMixin):
     """
     XML source example:
@@ -282,6 +282,9 @@ class VideoBlock(
         return fragment
 
     def get_html(self, view=STUDENT_VIEW, context=None):  # lint-amnesty, pylint: disable=arguments-differ, too-many-statements
+        """
+        Return html for a given view of this block.
+        """
         context = context or {}
         track_status = (self.download_track and self.track)
         transcript_download_format = self.transcript_download_format if not track_status else None

--- a/xmodule/word_cloud_block.py
+++ b/xmodule/word_cloud_block.py
@@ -10,8 +10,6 @@ If student have answered - words he entered and cloud.
 import json
 import logging
 
-from pkg_resources import resource_filename
-
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Integer, List, Scope, String
@@ -20,7 +18,6 @@ from xmodule.raw_block import EmptyDataRawMixin
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
 from xmodule.xml_block import XmlMixin
 from xmodule.x_module import (
-    HTMLSnippet,
     ResourceTemplates,
     shim_xmodule_js,
     XModuleMixin,
@@ -49,7 +46,6 @@ class WordCloudBlock(  # pylint: disable=abstract-method
     XmlMixin,
     EditingMixin,
     XModuleToXBlockMixin,
-    HTMLSnippet,
     ResourceTemplates,
     XModuleMixin,
 ):
@@ -112,19 +108,6 @@ class WordCloudBlock(  # pylint: disable=abstract-method
     resources_dir = 'assets/word_cloud'
     template_dir_name = 'word_cloud'
 
-    preview_view_js = {
-        'js': [
-            resource_filename(__name__, 'assets/word_cloud/src/js/word_cloud.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
-
-    studio_view_js = {
-        'js': [
-            resource_filename(__name__, 'js/src/raw/edit/metadata-only.js'),
-        ],
-        'xmodule_js': resource_filename(__name__, 'js/src/xmodule.js'),
-    }
     studio_js_module_name = "MetadataOnlyEditingDescriptor"
     mako_template = "widgets/metadata-only-edit.html"
 

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -206,40 +206,6 @@ class AsideKeyGenerator(IdGenerator):
         raise NotImplementedError("Specific Modulestores must provide implementations of create_definition")
 
 
-class HTMLSnippet:
-    """
-    A base class defining an interface for an object that is able to present an
-    html snippet, along with associated javascript and css
-    """
-
-    preview_view_js = {}
-    studio_view_js = {}
-
-    @classmethod
-    def get_preview_view_js(cls):
-        return cls.preview_view_js
-
-    @classmethod
-    def get_preview_view_js_bundle_name(cls):
-        return cls.__name__ + 'Display'
-
-    @classmethod
-    def get_studio_view_js(cls):
-        return cls.studio_view_js
-
-    @classmethod
-    def get_studio_view_js_bundle_name(cls):
-        return cls.__name__ + 'Editor'
-
-    def get_html(self):
-        """
-        Return the html used to display this snippet
-        """
-        raise NotImplementedError(
-            "get_html() must be provided by specific modules - not present in {}"
-            .format(self.__class__))
-
-
 def shim_xmodule_js(fragment, js_module_name):
     """
     Set up the XBlock -> XModule shim on the supplied :class:`web_fragments.fragment.Fragment`


### PR DESCRIPTION
Part of a series of PRs:
* https://github.com/openedx/edx-platform/issues/32481

The previous one is:
* https://github.com/openedx/edx-platform/pull/32480

To review this PR, look at just the latest commit (the one matching the PR title).

## Description and supporting info

The Webpack configuration file for built-in XBlock JS used to be generated at build time and git-ignored. It lived at common/static/xmodule/webpack.xmodule.config.js. It was generated because the JS that it referred to was also generated at build-time, and the filenames of those JS modules were not static.

Now that its contents have been made entirely static [1], there is no reason we need to continue generating this Webpack configuration file. So, we check it into edx-platform under the name ./webpack.builtinblocks.config.js. We choose to put it in the repo's root directory because the paths contained in the config file are relative to the repo's root.

This allows us to behead both the xmodule/static_content.py (`xmodule_assets`) script andthe  `process_xmodule_assets` paver task, a major step in removing the need for Python in the edx-platform asset build [2]. It also allows us to delete the `HTMLSnippet` class and all associated attributes, which were exclusively used by xmodule/static_content.py..

We leave `xmodule_assets` and  `process_xmodule_assets` in as stubs for now in order to avoid breaking external code (like Tutor) which calls Paver; the entire pavelib/assets.py function will be eventually removed soon anyway [3]. Further, to avoid extraneous refactoring, we keep one method of `HTMLSnippet` around on a few of its former subclasses: `get_html`. This method was originally part of the XModule framework; now, it is left over on a few classes as a simple internal helper method.

References:
1. https://github.com/openedx/edx-platform/pull/32480
2. https://github.com/openedx/edx-platform/issues/31800
3.  https://github.com/openedx/edx-platform/issues/31895


## Testing

Follow the same instructions from https://github.com/openedx/edx-platform/pull/32480, but sub in this branch.