### PR TITLE
feat: add non_editable for core notifications

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -66,6 +66,7 @@ COURSE_NOTIFICATION_APPS = {
         'core_web': True,
         'core_email': True,
         'core_push': True,
+        'non_editable': []
     }
 }
 
@@ -260,6 +261,13 @@ class NotificationAppManager:
             'info': notification_app_attrs.get('core_info', ''),
         }
 
+    def add_core_notification_non_editable(self, notification_app_attrs, non_editable_channels):
+        """
+        Adds non_editable for core notification.
+        """
+        if notification_app_attrs.get('non_editable', None):
+            non_editable_channels['core'] = notification_app_attrs.get('non_editable')
+
     def get_notification_app_preferences(self):
         """
         Returns notification app preferences for the given name.
@@ -270,6 +278,7 @@ class NotificationAppManager:
             notification_types, core_notifications, \
                 non_editable_channels = NotificationTypeManager().get_notification_app_preference(notification_app_key)
             self.add_core_notification_preference(notification_app_attrs, notification_types)
+            self.add_core_notification_non_editable(notification_app_attrs, non_editable_channels)
 
             notification_app_preferences['enabled'] = notification_app_attrs.get('enabled', False)
             notification_app_preferences['core_notification_types'] = core_notifications

--- a/openedx/core/djangoapps/notifications/tests/test_base_notification.py
+++ b/openedx/core/djangoapps/notifications/tests/test_base_notification.py
@@ -207,7 +207,6 @@ class NotificationPreferenceSyncManagerTest(ModuleStoreTestCase):
         Tests if non_editable updates on existing preferences of core notification
         """
         current_config_version = get_course_notification_preference_config_version()
-        breakpoint()
         base_notification.COURSE_NOTIFICATION_APPS[self.default_app_name]['non_editable'] = ['web']
         self._set_notification_config_version(current_config_version + 1)
         new_config = CourseNotificationPreference.get_updated_user_course_preferences(self.user, self.course.id)

--- a/openedx/core/djangoapps/notifications/tests/test_base_notification.py
+++ b/openedx/core/djangoapps/notifications/tests/test_base_notification.py
@@ -202,6 +202,25 @@ class NotificationPreferenceSyncManagerTest(ModuleStoreTestCase):
         preference_non_editable = preferences[self.default_app_name]['non_editable'].get(self.default_type_name, [])
         assert preference_non_editable == []
 
+    def test_non_editable_addition_and_removal_for_core_notification(self):
+        """
+        Tests if non_editable updates on existing preferences of core notification
+        """
+        current_config_version = get_course_notification_preference_config_version()
+        breakpoint()
+        base_notification.COURSE_NOTIFICATION_APPS[self.default_app_name]['non_editable'] = ['web']
+        self._set_notification_config_version(current_config_version + 1)
+        new_config = CourseNotificationPreference.get_updated_user_course_preferences(self.user, self.course.id)
+        preferences = new_config.notification_preference_config
+        preference_non_editable = preferences[self.default_app_name]['non_editable']['core']
+        assert 'web' in preference_non_editable
+        base_notification.COURSE_NOTIFICATION_APPS[self.default_app_name]['non_editable'] = []
+        self._set_notification_config_version(current_config_version + 2)
+        new_config = CourseNotificationPreference.get_updated_user_course_preferences(self.user, self.course.id)
+        preferences = new_config.notification_preference_config
+        preference_non_editable = preferences[self.default_app_name]['non_editable'].get('core', [])
+        assert preference_non_editable == []
+
     def test_notification_type_info_updates(self):
         """
         Preference info updates when default info is update


### PR DESCRIPTION
### [INF-948](https://2u-internal.atlassian.net/browse/INF-948)

**Description**
We need to add non_editable for core notifications. I checked that the config parser is working correctly for non_editable in the core.

- Make core non_editable
- Test that the config parser works after this update and add related unit test

<img width="381" alt="Screenshot 2023-07-10 at 7 19 09 PM" src="https://github.com/openedx/edx-platform/assets/79941147/3923d6bf-59c8-4bee-859b-c4ef1ccd06f0">
