### PR TITLE
fix: MathJax equations flickering

### DIFF
--- a/cms/djangoapps/pipeline_js/js/xmodule.js
+++ b/cms/djangoapps/pipeline_js/js/xmodule.js
@@ -32,7 +32,10 @@ define(
                             ['\\[', '\\]'],
                             ['[mathjax]', '[/mathjax]']
                         ]
-                    }
+                    },
+                    CommonHTML: { linebreaks: { automatic: true } },
+                    SVG: { linebreaks: { automatic: true } },
+                    "HTML-CSS": { linebreaks: { automatic: true } },
                 });
 
                 // In order to eliminate all flashing during interactive
@@ -42,6 +45,25 @@ define(
                 // the fast preview setting as shown in the context menu.
                 window.MathJax.Hub.processSectionDelay = 0;
                 window.MathJax.Hub.Configured();
+
+                window.addEventListener('resize', MJrenderer);
+
+                let t = -1;
+                let delay = 1000;
+                let oldWidth = document.documentElement.scrollWidth;
+                function MJrenderer() {
+                    // don't rerender if the window is the same size as before
+                    if (t >= 0) {
+                      window.clearTimeout(t);
+                    }
+                    if (oldWidth !== document.documentElement.scrollWidth) {
+                      t = window.setTimeout(function() {
+                        oldWidth = document.documentElement.scrollWidth;
+                        MathJax.Hub.Queue(["Rerender", MathJax.Hub]);
+                        t = -1;
+                      }, delay);
+                    }
+                  };
             }
         );
         window.CodeMirror = CodeMirror;

--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -81,6 +81,12 @@
   <!-- Configure and load MathJax -->
   <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
+      styles: {
+        '.MathJax_SVG>svg': { 'max-width': '100%' },
+      },
+      CommonHTML: { linebreaks: { automatic: true } },
+      SVG: { linebreaks: { automatic: true } },
+      "HTML-CSS": { linebreaks: { automatic: true } },
       tex2jax: {
         inlineMath: [
           ["\\(","\\)"],
@@ -92,6 +98,18 @@
         ]
       }
     });
+    window.addEventListener('resize', MJrenderer);
+    let 1 = -1;
+    let delay = 1000;
+    function MJrenderer() {
+      if (t >= 0) {
+        window.clearTimeout(t);
+      }
+      t = window.setTimeout(function() {
+        MathJax.Hub.Queue(["Rerenderer", MathJax.Hub]);
+        t = -1;
+      }, delay);
+    };
   </script>
   <script type="text/x-mathjax-config">
     MathJax.Hub.signal.Interest(function(message) {

--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -99,16 +99,22 @@
       }
     });
     window.addEventListener('resize', MJrenderer);
-    let 1 = -1;
+
+    let t = -1;
     let delay = 1000;
+    let oldWidth = document.documentElement.scrollWidth;
     function MJrenderer() {
+      // don't rerender if the window is the same size as before
       if (t >= 0) {
         window.clearTimeout(t);
       }
-      t = window.setTimeout(function() {
-        MathJax.Hub.Queue(["Rerenderer", MathJax.Hub]);
-        t = -1;
-      }, delay);
+      if (oldWidth !== document.documentElement.scrollWidth) {
+        t = window.setTimeout(function() {
+          oldWidth = document.documentElement.scrollWidth;
+          MathJax.Hub.Queue(["Rerender", MathJax.Hub]);
+          t = -1;
+        }, delay);
+      }
     };
   </script>
   <script type="text/x-mathjax-config">

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -97,20 +97,23 @@
             explorer: true
         }
     };
-    window.addEventListener('resize', MJrerender);
+    window.addEventListener('resize', MJrenderer);
 
     let t = -1;
     let delay = 1000;
-    function MJrerender() {
+    let oldWidth = document.documentElement.scrollWidth;
+    function MJrenderer() {
+      // don't rerender if the window is the same size as before
       if (t >= 0) {
-        // If we are still waiting, then the user is still resizing =>
-        // postpone the action further!
         window.clearTimeout(t);
       }
-      t = window.setTimeout(function() {
-        MathJax.Hub.Queue(["Rerender",MathJax.Hub]);
-        t = -1; // Reset the handle
-      }, delay);
+      if (oldWidth !== document.documentElement.scrollWidth) {
+        t = window.setTimeout(function() {
+          oldWidth = document.documentElement.scrollWidth;
+          MathJax.Hub.Queue(["Rerender", MathJax.Hub]);
+          t = -1;
+        }, delay);
+      }
     };
 </script>
 

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -29,6 +29,12 @@
 %if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    styles: {
+      '.MathJax_SVG>svg': { 'max-width': '100%', },
+    },
+    CommonHTML: { linebreaks: { automatic: true } },
+    SVG: { linebreaks: { automatic: true } },
+    "HTML-CSS": { linebreaks: { automatic: true } },
     tex2jax: {inlineMath: [ ['$','$'], ["\\(","\\)"]],
               displayMath: [ ['$$','$$'], ["\\[","\\]"]]}
   });
@@ -36,7 +42,13 @@
 %else:
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    styles: {
+      '.MathJax_SVG>svg': { 'max-width': '100%', },
+    },
     messageStyle: "none",
+    CommonHTML: { linebreaks: { automatic: true } },
+    SVG: { linebreaks: { automatic: true } },
+    "HTML-CSS": { linebreaks: { automatic: true } },
     tex2jax: {
       inlineMath: [
         ["\\(","\\)"],
@@ -84,6 +96,21 @@
             autocollapse: false,
             explorer: true
         }
+    };
+    window.addEventListener('resize', MJrerender);
+
+    let t = -1;
+    let delay = 1000;
+    function MJrerender() {
+      if (t >= 0) {
+        // If we are still waiting, then the user is still resizing =>
+        // postpone the action further!
+        window.clearTimeout(t);
+      }
+      t = window.setTimeout(function() {
+        MathJax.Hub.Queue(["Rerender",MathJax.Hub]);
+        t = -1; // Reset the handle
+      }, delay);
     };
 </script>
 


### PR DESCRIPTION
reimplement of openedx/edx-platform#32606

## Description

- Forces MathJax in common template to resize and wrap when the window resizes.
- Make sure not to redraw when it wasn't trigger by the window resize.

https://github.com/openedx/edx-platform/assets/83240113/5d60954e-6edb-45af-a70c-ac41cbb87f47


