### PR TITLE
fix: Incorrect symbols on wiki create article page for Palm

### DIFF
--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -76,11 +76,15 @@
           {% block wiki_breadcrumbs %}{% endblock %}
 
           {% if messages %}
+            {% comment %}
+              The message is not actually safe, but StatusAlertRenderer uses react which adds escaping,
+              so marking as safe keeps the message from being double-escaped.
+            {% endcomment %}
             {% for message in messages %}
               <div id="alert_stat_bar"></div>
               <script type="text/javascript">
                 new StatusAlertRenderer(
-                  "{{ message }}",
+                  "{{ message|safe }}",
                   "#alert_stat_bar",
                   ".nav nav-tabs"
                 );


### PR DESCRIPTION
## Description

This is a [backport](https://github.com/openedx/edx-platform/pull/32628) from master
The mistake on the confirmation message about creating the wiki article:

![screen_3](https://github.com/openedx/edx-platform/assets/98233552/c7ebbacf-ef49-4670-ad10-40567be108ee)
