### PR TITLE
build: copy from node_modules using NPM postinstall hook, not Paver

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "edx",
   "version": "0.1.0",
   "repository": "https://github.com/openedx/edx-platform",
+  "scripts": {
+    "postinstall": "scripts/copy-node-modules.sh"
+  },
   "dependencies": {
     "@babel/core": "7.19.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.18.9",

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -46,39 +46,6 @@ COMMON_LOOKUP_PATHS = [
     path('node_modules'),
 ]
 
-# A list of NPM installed libraries that should be copied into the common
-# static directory.
-# If string ends with '/' then all file in the directory will be copied.
-NPM_INSTALLED_LIBRARIES = [
-    'backbone.paginator/lib/backbone.paginator.js',
-    'backbone/backbone.js',
-    'bootstrap/dist/js/bootstrap.bundle.js',
-    'hls.js/dist/hls.js',
-    'jquery-migrate/dist/jquery-migrate.js',
-    'jquery.scrollto/jquery.scrollTo.js',
-    'jquery/dist/jquery.js',
-    'moment-timezone/builds/moment-timezone-with-data.js',
-    'moment/min/moment-with-locales.js',
-    'picturefill/dist/picturefill.js',
-    'requirejs/require.js',
-    'underscore.string/dist/underscore.string.js',
-    'underscore/underscore.js',
-    '@edx/studio-frontend/dist/',
-    'which-country/index.js'
-]
-
-# A list of NPM installed developer libraries that should be copied into the common
-# static directory only in development mode.
-NPM_INSTALLED_DEVELOPER_LIBRARIES = [
-    'sinon/pkg/sinon.js',
-    'squirejs/src/Squire.js',
-]
-
-# Directory to install static vendor files
-NPM_JS_VENDOR_DIRECTORY = path('common/static/common/js/vendor')
-NPM_CSS_VENDOR_DIRECTORY = path("common/static/common/css/vendor")
-NPM_CSS_DIRECTORY = path("common/static/common/css")
-
 # system specific lookup path additions, add sass dirs if one system depends on the sass files for other systems
 SASS_LOOKUP_DEPENDENCIES = {
     'cms': [path('lms') / 'static' / 'sass' / 'partials', ],
@@ -644,60 +611,8 @@ def process_npm_assets():
     """
     Process vendor libraries installed via NPM.
     """
-    def copy_vendor_library(library, skip_if_missing=False):
-        """
-        Copies a vendor library to the shared vendor directory.
-        """
-        if library.startswith('node_modules/'):
-            library_path = library
-        else:
-            library_path = f'node_modules/{library}'
-
-        if library.endswith('.css') or library.endswith('.css.map'):
-            vendor_dir = NPM_CSS_VENDOR_DIRECTORY
-        else:
-            vendor_dir = NPM_JS_VENDOR_DIRECTORY
-        if os.path.exists(library_path):
-            sh('/bin/cp -rf {library_path} {vendor_dir}'.format(
-                library_path=library_path,
-                vendor_dir=vendor_dir,
-            ))
-        elif not skip_if_missing:
-            raise Exception(f'Missing vendor file {library_path}')
-
-    def copy_vendor_library_dir(library_dir, skip_if_missing=False):
-        """
-        Copies all vendor libraries in directory to the shared vendor directory.
-        """
-        library_dir_path = f'node_modules/{library_dir}'
-        print(f'Copying vendor library dir: {library_dir_path}')
-        if os.path.exists(library_dir_path):
-            for dirpath, _, filenames in os.walk(library_dir_path):
-                for filename in filenames:
-                    copy_vendor_library(os.path.join(dirpath, filename), skip_if_missing=skip_if_missing)
-
-    # Skip processing of the libraries if this is just a dry run
-    if tasks.environment.dry_run:
-        tasks.environment.info("install npm_assets")
-        return
-
-    # Ensure that the vendor directory exists
-    NPM_JS_VENDOR_DIRECTORY.mkdir_p()
-    NPM_CSS_DIRECTORY.mkdir_p()
-    NPM_CSS_VENDOR_DIRECTORY.mkdir_p()
-
-    # Copy each file to the vendor directory, overwriting any existing file.
-    print("Copying vendor files into static directory")
-    for library in NPM_INSTALLED_LIBRARIES:
-        if library.endswith('/'):
-            copy_vendor_library_dir(library)
-        else:
-            copy_vendor_library(library)
-
-    # Copy over each developer library too if they have been installed
-    print("Copying developer vendor files into static directory")
-    for library in NPM_INSTALLED_DEVELOPER_LIBRARIES:
-        copy_vendor_library(library, skip_if_missing=True)
+    print("\t\tProcessing NPM assets is now done automatically in an npm post-install hook.")
+    print("\t\tThis function is now a no-op.")
 
 
 @task
@@ -983,7 +898,6 @@ def update_assets(args):
     collect_log_args = {}
 
     process_xmodule_assets()
-    process_npm_assets()
 
     # Build Webpack
     call_task('pavelib.assets.webpack', options={'settings': args.settings})

--- a/pavelib/utils/test/suites/js_suite.py
+++ b/pavelib/utils/test/suites/js_suite.py
@@ -39,8 +39,6 @@ class JsTestSuite(TestSuite):
         if self.mode == 'run' and not self.run_under_coverage:
             test_utils.clean_dir(self.report_dir)
 
-        assets.process_npm_assets()
-
     @property
     def _default_subsuites(self):
         """

--- a/scripts/copy-node-modules.sh
+++ b/scripts/copy-node-modules.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copy certain npm-installed assets from node_modules to other folders in
+# edx-platform. These assets are used by certain especially-old legacy LMS & CMS
+# frontends that are not set up to import from node_modules directly.
+# Many of the destination folders are named "vendor", because they originally
+# held vendored-in (directly-committed) libraries; once we moved most frontends
+# to use NPM, we decided to keep library versions in-sync by copying to the
+# former "vendor" directories.
+
+# Enable stricter error handling.
+set -euo pipefail
+
+COL_LOG="\e[36m"  # Log/step/section color (cyan)
+COL_OFF="\e[0m"   # Normal color
+
+# Keep these as variables in case we ever want to parameterize this script's
+# input or output dirs, as proposed in:
+# https://github.com/openedx/wg-developer-experience/issues/150
+# https://github.com/openedx/wg-developer-experience/issues/151
+node_modules="node_modules"
+vendor_js="common/static/common/js/vendor"
+vendor_css="common/static/common/css/vendor"
+
+# Stylized logging.
+log ( ) {
+	echo -e "${COL_LOG}$* $COL_OFF"
+}
+
+log "====================================================================================="
+log "Copying required assets from node_modules..."
+log "-------------------------------------------------------------------------------"
+
+# Start echoing all commands back to user for ease of debugging.
+set -x
+
+log "Ensuring vendor directories exist..."
+mkdir -p "$vendor_js"
+mkdir -p "$vendor_css"
+
+log "Copying studio-frontend JS & CSS from node_modules into vendor directores..."
+while read -r -d $'\0' src_file ; do
+    if [[ "$src_file" = *.css ]] || [[ "$src_file" = *.css.map ]] ; then
+        cp --force "$src_file" "$vendor_css"
+    else
+        cp --force "$src_file" "$vendor_js"
+    fi
+done < <(find "$node_modules/@edx/studio-frontend/dist" -type f -print0)
+
+log "Copying certain JS modules from node_modules into vendor directory..."
+cp --force \
+    "$node_modules/backbone.paginator/lib/backbone.paginator.js" \
+    "$node_modules/backbone/backbone.js" \
+    "$node_modules/bootstrap/dist/js/bootstrap.bundle.js" \
+    "$node_modules/hls.js/dist/hls.js" \
+    "$node_modules/jquery-migrate/dist/jquery-migrate.js" \
+    "$node_modules/jquery.scrollto/jquery.scrollTo.js" \
+    "$node_modules/jquery/dist/jquery.js" \
+    "$node_modules/moment-timezone/builds/moment-timezone-with-data.js" \
+    "$node_modules/moment/min/moment-with-locales.js" \
+    "$node_modules/picturefill/dist/picturefill.js" \
+    "$node_modules/requirejs/require.js" \
+    "$node_modules/underscore.string/dist/underscore.string.js" \
+    "$node_modules/underscore/underscore.js" \
+    "$node_modules/which-country/index.js" \
+    "$vendor_js"
+
+log "Copying certain JS developer modules into vendor directory..."
+if [[ "${NODE_ENV:-production}" = development ]] ; then
+    cp --force "$node_modules/sinon/pkg/sinon.js" "$vendor_js"
+    cp --force "$node_modules/squirejs/src/Squire.js" "$vendor_js"
+else
+    # TODO: https://github.com/openedx/edx-platform/issues/31768
+    # In the old implementation of this scipt (pavelib/assets.py), these two
+    # developer libraries were copied into the JS vendor directory whether not
+    # the build was for prod or dev. In order to exactly match the output of
+    # the old script, this script will also copy them in for prod builds.
+    # However, in the future, it would be good to only copy them for dev
+    # builds. Furthermore, these libraries should not be `npm install`ed
+    # into prod builds in the first place.
+    cp --force "$node_modules/sinon/pkg/sinon.js" "$vendor_js" || true      # "|| true" means "tolerate errors"; in this case,
+    cp --force "$node_modules/squirejs/src/Squire.js" "$vendor_js" || true  # that's "tolerate if these files don't exist."
+fi
+
+# Done echoing.
+set +x
+
+log "-------------------------------------------------------------------------------"
+log " Done copying required assets from node_modules."
+log "====================================================================================="
+


### PR DESCRIPTION
During the review of ADR 17 [1], Régis pointed out [2] that the shell script which replaces Paver's `process_npm_assets`  could be automatically invoked as an NPM post-install hook, ensuring that the step is seamlessly executed whenever `npm install` is run. I had avoided using that suggestion, as I worried that it would make it harder to move node_modules out of the edx-platform directory in Tutor's openedx image.

Since then, two things have changed. Firstly, Tutor v16's new persistent mounts interface [3] has lessened the importance of moving node_modules. Secondly, I have realized that using a post-install hook would not preclude us from modifying the underlying script (scripts/copy-node-modules.sh) to look in an alternative location for node_modules, should that end up being something we want to do.

This commit modifies the ADR based on those findings, stubs out Paver's `process_npm_assets`, and adds the suggested post-install hook and replacement Bash script.

References:
1. https://github.com/openedx/edx-platform/blob/master/docs/decisions/0017-reimplement-asset-processing.rst
2. https://github.com/openedx/edx-platform/pull/31790#discussion_r1122802492
3. https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1600-2023-06-14

Part of: https://github.com/openedx/edx-platform/issues/31604

### Testing

I tested this by comparing the exact node_modules asset copies, as generated by the old Paver command versus this new shell script & post-install hook.

Using latest Tutor Nightly and a recently-pulled openedx image:

```bash
# ensure latest master & clean slate
cd edx-platform
git switch master
git pull
git clean -f common/static

# we'll use compare_common_static to hold the contents of common/static in a few different scenarios
rm -rf compare_common_static
mkdir compare_common_static

# scenario A: output from the current image
tutor local copyfrom lms common/static compare_common_static/image

tutor mounts add .

# scenario B: output from old paver task on master
git switch master
tutor local run lms openedx-assets npm
cp -r common/static compare_common_static/paver

# scenario C: output from new copy-node-modules shell script
git switch kdmccormick/copy-node-modules
tutor local run lms scripts/copy-node-modules.sh
tutor local copyfrom lms common/static compare_common_static/shell

# scenario D: output from new copy-node-modules shell script, invoked by npm post-install hook
git switch kdmccormick/copy-node-modules
tutor local run lms npm install
tutor local copyfrom lms common/static compare_common_static/npm-install

# compare out of all scenarios -- they should be the exact same! (diff should have no output)
cd compare_common_static
diff -r image paver
diff -r image shell
diff -r image npm-install
```