### PR TITLE
fix: added correct url in notification content_url

### DIFF
--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -3,6 +3,7 @@ Utils for discussion API.
 """
 from typing import List, Dict
 
+from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.paginator import Paginator
 from django.db.models.functions import Length
@@ -398,7 +399,7 @@ class DiscussionNotificationSender:
                 **extra_context,
             },
             notification_type=notification_type,
-            content_url=self.thread.url_with_id(params={'id': self.thread.id}),
+            content_url=f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/posts/{self.thread.id}",
             app_name="discussion",
             course_key=self.course.id,
         )

--- a/openedx/core/djangoapps/notifications/tasks.py
+++ b/openedx/core/djangoapps/notifications/tasks.py
@@ -129,7 +129,7 @@ def create_notification_pref_if_not_exists(user_ids: List, preferences: List, co
     new_preferences = []
 
     for user_id in user_ids:
-        if not any(preference.user_id == user_id for preference in preferences):
+        if not any(preference.user_id == int(user_id) for preference in preferences):
             new_preferences.append(CourseNotificationPreference(
                 user_id=user_id,
                 course_id=course_id,


### PR DESCRIPTION
## Ticket : https://2u-internal.atlassian.net/browse/INF-951


## Description : 

thread.url_with_id does not return url for thread in discussions MFE this issue is fixed in PR
Fixed issues with the comparison operator, that was causing duplicate notifications.