### PR TITLE
feat: add show_preference flag in course enrollment API response

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -27,6 +27,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from ..base_notification import COURSE_NOTIFICATION_APPS
 
 
+@ddt.ddt
 class CourseEnrollmentListViewTest(ModuleStoreTestCase):
     """
     Tests for the CourseEnrollmentListView.
@@ -66,21 +67,26 @@ class CourseEnrollmentListViewTest(ModuleStoreTestCase):
         )
 
     @override_waffle_flag(ENABLE_NOTIFICATIONS, active=True)
-    def test_course_enrollment_list_view(self):
+    @ddt.data((False,), (True,))
+    @ddt.unpack
+    def test_course_enrollment_list_view(self, show_notifications_tray):
         """
         Test the CourseEnrollmentListView.
         """
         self.client.login(username=self.user.username, password='test')
-        url = reverse('enrollment-list')
-        response = self.client.get(url)
+        # Enable or disable the waffle flag based on the test case data
+        with override_waffle_flag(SHOW_NOTIFICATIONS_TRAY, active=show_notifications_tray):
+            url = reverse('enrollment-list')
+            response = self.client.get(url)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.data['results']
-        enrollments = CourseEnrollment.objects.filter(user=self.user, is_active=True)
-        expected_data = NotificationCourseEnrollmentSerializer(enrollments, many=True).data
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            data = response.data['results']
+            enrollments = CourseEnrollment.objects.filter(user=self.user, is_active=True)
+            expected_data = NotificationCourseEnrollmentSerializer(enrollments, many=True).data
 
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data, expected_data)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data, expected_data)
+            self.assertEqual(response.data['show_preferences'], show_notifications_tray)
 
     def test_course_enrollment_api_permission(self):
         """

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -1,6 +1,9 @@
 """
 Utils function for notifications app
 """
+from common.djangoapps.student.models import CourseEnrollment
+
+from .config.waffle import SHOW_NOTIFICATIONS_TRAY
 
 
 def find_app_in_normalized_apps(app_name, apps_list):
@@ -21,3 +24,21 @@ def find_pref_in_normalized_prefs(pref_name, app_name, prefs_list):
         if pref.get('name') == pref_name and pref.get('app_name') == app_name:
             return pref
     return None
+
+
+def get_show_notifications_tray(user):
+    """
+    Returns show_notifications_tray as boolean for the courses in which user is enrolled
+    """
+    show_notifications_tray = False
+    learner_enrollments_course_ids = CourseEnrollment.objects.filter(
+        user=user,
+        is_active=True
+    ).values_list('course_id', flat=True)
+
+    for course_id in learner_enrollments_course_ids:
+        if SHOW_NOTIFICATIONS_TRAY.is_enabled(course_id):
+            show_notifications_tray = True
+            break
+
+    return show_notifications_tray

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -64,12 +64,12 @@ class CourseEnrollmentListView(generics.ListAPIView):
     serializer_class = NotificationCourseEnrollmentSerializer
     permission_classes = [permissions.IsAuthenticated]
 
-    def get_paginated_response(self, show_preferences, data):
+    def get_paginated_response(self, data):
         """
         Return a response given serialized page data with show_preferences flag.
         """
         response = super().get_paginated_response(data)
-        response.data["show_preferences"] = show_preferences
+        response.data["show_preferences"] = get_show_notifications_tray(self.request.user)
         return response
 
     def get_queryset(self):
@@ -81,7 +81,6 @@ class CourseEnrollmentListView(generics.ListAPIView):
         Returns the list of active course enrollments for which ENABLE_NOTIFICATIONS
         Waffle flag is enabled
         """
-        show_preferences = get_show_notifications_tray(request.user)
         queryset = self.filter_queryset(self.get_queryset())
         course_ids = queryset.values_list('course_id', flat=True)
 
@@ -93,10 +92,10 @@ class CourseEnrollmentListView(generics.ListAPIView):
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(show_preferences, serializer.data)
+            return self.get_paginated_response(serializer.data)
 
         return Response({
-            "show_preferences": show_preferences,
+            "show_preferences": get_show_notifications_tray(request.user),
             "results": self.get_serializer(queryset, many=True).data
         })
 

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -21,7 +21,7 @@ from openedx.core.djangoapps.notifications.models import (
 )
 
 from .base_notification import COURSE_NOTIFICATION_APPS
-from .config.waffle import ENABLE_NOTIFICATIONS, SHOW_NOTIFICATIONS_TRAY
+from .config.waffle import ENABLE_NOTIFICATIONS
 from .events import notification_preferences_viewed_event, notification_read_event, notification_preference_update_event
 from .models import Notification
 from .serializers import (
@@ -30,6 +30,7 @@ from .serializers import (
     UserCourseNotificationPreferenceSerializer,
     UserNotificationPreferenceUpdateSerializer
 )
+from .utils import get_show_notifications_tray
 
 
 class CourseEnrollmentListView(generics.ListAPIView):
@@ -63,6 +64,14 @@ class CourseEnrollmentListView(generics.ListAPIView):
     serializer_class = NotificationCourseEnrollmentSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+    def get_paginated_response(self, show_preferences, data):
+        """
+        Return a response given serialized page data with show_preferences flag.
+        """
+        response = super().get_paginated_response(data)
+        response.data["show_preferences"] = show_preferences
+        return response
+
     def get_queryset(self):
         user = self.request.user
         return CourseEnrollment.objects.filter(user=user, is_active=True)
@@ -72,6 +81,7 @@ class CourseEnrollmentListView(generics.ListAPIView):
         Returns the list of active course enrollments for which ENABLE_NOTIFICATIONS
         Waffle flag is enabled
         """
+        show_preferences = get_show_notifications_tray(request.user)
         queryset = self.filter_queryset(self.get_queryset())
         course_ids = queryset.values_list('course_id', flat=True)
 
@@ -83,9 +93,12 @@ class CourseEnrollmentListView(generics.ListAPIView):
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+            return self.get_paginated_response(show_preferences, serializer.data)
 
-        return Response(self.get_serializer(queryset, many=True).data)
+        return Response({
+            "show_preferences": show_preferences,
+            "results": self.get_serializer(queryset, many=True).data
+        })
 
 
 class UserNotificationPreferenceView(APIView):
@@ -292,7 +305,7 @@ class NotificationCountView(APIView):
             .annotate(count=Count('*'))
         )
         count_total = 0
-        show_notifications_tray_enabled = False
+        show_notifications_tray = get_show_notifications_tray(request.user)
         count_by_app_name_dict = {
             app_name: 0
             for app_name in COURSE_NOTIFICATION_APPS
@@ -304,18 +317,8 @@ class NotificationCountView(APIView):
             count_total += count
             count_by_app_name_dict[app_name] = count
 
-        learner_enrollments_course_ids = CourseEnrollment.objects.filter(
-            user=request.user,
-            is_active=True
-        ).values_list('course_id', flat=True)
-
-        for course_id in learner_enrollments_course_ids:
-            if SHOW_NOTIFICATIONS_TRAY.is_enabled(course_id):
-                show_notifications_tray_enabled = True
-                break
-
         return Response({
-            "show_notifications_tray": show_notifications_tray_enabled,
+            "show_notifications_tray": show_notifications_tray,
             "count": count_total,
             "count_by_app_name": count_by_app_name_dict,
         })


### PR DESCRIPTION
### [INF-952](https://2u-internal.atlassian.net/browse/INF-952)

-  Add show_preferences as key against show_notification_tray value in the course enrollment list API response.

<img width="619" alt="Screenshot 2023-07-12 at 7 45 08 PM" src="https://github.com/openedx/edx-platform/assets/79941147/a17138d8-ac68-4144-97bf-d98ef4f3b51f">
