### PR TITLE
feat: Update migration command.

### DIFF
--- a/.github/workflows/docker-compose.yml.mysqldbdump
+++ b/.github/workflows/docker-compose.yml.mysqldbdump
@@ -16,7 +16,7 @@ services:
       retries: 10
   edxapp:
     image: edxops/edxapp:latest
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_db'
+    command: bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && make migrate'
     volumes:
        - ../../:/edx/app/edxapp/edx-platform
     depends_on:


### PR DESCRIPTION
We are planning on deprecating paver,
starting with paver update_db. This replaces a call to paver with its replacement, `make migrate`.

https://github.com/openedx/devstack/issues/1085