### PR TITLE
fix: Add pkg-config to other package install block.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && \
         libpython3.8 \
         libpython3.8-stdlib \
         libmysqlclient21 \
+        pkg-config \
         libssl1.1 \
         libxmlsec1-openssl \
         # lynx: Required by https://github.com/openedx/edx-platform/blob/b489a4ecb122/openedx/core/lib/html_to_text.py#L16


### PR DESCRIPTION
We are still seeing issues running devstack provisioning of LMS because it's missing pkg-config. We believe this might be the location we need to add the package to.
