### PR TITLE
fix: update Studio DEFAULT_FILE_STORAGE to s3boto3

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -338,7 +338,7 @@ AWS_S3_CUSTOM_DOMAIN = AUTH_TOKENS.get('AWS_S3_CUSTOM_DOMAIN', 'edxuploads.s3.am
 if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
     DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
 elif AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 else:
     DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 


### PR DESCRIPTION
## Description

s3boto is no longer a supported backend in django-storages, so this was causing failues on startup when trying to run with the tutor-minio plugin.