### PR TITLE
Prep guides to replace "Technical Docs" by adding redirecting.

### DIFF
--- a/docs/guides/Makefile
+++ b/docs/guides/Makefile
@@ -20,3 +20,11 @@ clean:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+update_redirects:
+	# This updates redirects.txt, creating redirects for any files that have moved (relative to master).
+	sphinx-build -b rediraffewritediff "$(SOURCEDIR)" "$(BUILDDIR)"
+
+check_redirects:
+	# Check to make sure that any files that got moved have a redirect in redirects.txt
+	sphinx-build -b rediraffecheckdiff "$(SOURCEDIR)" "$(BUILDDIR)"

--- a/docs/guides/conf.py
+++ b/docs/guides/conf.py
@@ -62,10 +62,15 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinxcontrib.openapi',
+    'sphinxext.rediraffe',
     'sphinx_design',
     'code_annotations.contrib.sphinx.extensions.featuretoggles',
     'code_annotations.contrib.sphinx.extensions.settings',
 ]
+
+# Rediraffe related settings.
+rediraffe_redirects = "redirects.txt"
+rediraffe_branch = 'origin/master'
 
 # code_annotations.(featuretoggles|settings) related settings.
 edxplatform_repo_url = "https://github.com/openedx/edx-platform"

--- a/docs/guides/redirects.txt
+++ b/docs/guides/redirects.txt
@@ -1,0 +1,2 @@
+"featuretoggles.rst" "references/featuretoggles.rst"
+"settings.rst" "references/settings.rst"

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1615,6 +1615,7 @@ sphinx==6.2.1
     #   sphinx-design
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
+    #   sphinxext-rediraffe
 sphinx-book-theme==1.0.1
     # via -r requirements/edx/doc.txt
 sphinx-design==0.4.1
@@ -1653,6 +1654,8 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
+sphinxext-rediraffe==0.2.7
+    # via -r requirements/edx/doc.txt
 sqlparse==0.4.4
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.in
+++ b/requirements/edx/doc.in
@@ -7,3 +7,4 @@ gitpython                 # fetch git repo information
 Sphinx                    # Documentation builder
 sphinx-design             # provides various responsive web-components
 sphinxcontrib-openapi[markdown] # Be able to render openapi schema in a sphinx project
+sphinxext-rediraffe       # Quickly and easily redirect when we move pages around.

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -119,6 +119,7 @@ sphinx==6.2.1
     #   sphinx-design
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
+    #   sphinxext-rediraffe
 sphinx-book-theme==1.0.1
     # via -r requirements/edx/doc.in
 sphinx-design==0.4.1
@@ -141,6 +142,8 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+sphinxext-rediraffe==0.2.7
+    # via -r requirements/edx/doc.in
 stevedore==5.1.0
     # via code-annotations
 text-unidecode==1.3


### PR DESCRIPTION
- docs: Add config for redirecting pages.
- docs: Manually add some redirects.
- chore: Run `make upgrade`
