### PR TITLE
fix: TypeError exception during student.send_activation_email task 

### DIFF
--- a/openedx/core/djangoapps/user_authn/tasks.py
+++ b/openedx/core/djangoapps/user_authn/tasks.py
@@ -45,7 +45,7 @@ def check_pwned_password_and_send_track_event(user_id, password, internal_user=F
 
 @shared_task(bind=True, default_retry_delay=30, max_retries=2)
 @set_code_owner_attribute
-def send_activation_email(self, msg_string, from_address=None):
+def send_activation_email(self, msg_string, from_address=None, site_id=None):
     """
     Sending an activation email to the user.
     """
@@ -62,7 +62,7 @@ def send_activation_email(self, msg_string, from_address=None):
 
     dest_addr = msg.recipient.email_address
 
-    site = Site.objects.get_current()
+    site = Site.objects.get(id=site_id) if site_id else Site.objects.get_current()
     user = User.objects.get(id=msg.recipient.lms_user_id)
 
     try:


### PR DESCRIPTION
## Description

[backport from master](https://github.com/openedx/edx-platform/pull/32623)

TypeError exception during student.send_activation_email task