### PR TITLE
fix: email templates caching

### DIFF
--- a/openedx/core/djangoapps/theming/template_loaders.py
+++ b/openedx/core/djangoapps/theming/template_loaders.py
@@ -35,6 +35,17 @@ class ThemeFilesystemLoader(FilesystemLoader):
             self.dirs = theme_dirs + self.dirs
         super().__init__(engine, self.dirs)
 
+    def get_dirs(self):
+        """
+        Override get_dirs method.
+        Make the theme templates a priority, avoiding cashing templates for django ones.
+        """
+        self.dirs = self.engine.dirs
+        theme_dirs = self.get_theme_template_sources()
+        if isinstance(theme_dirs, list):
+            self.dirs = theme_dirs + self.dirs
+        return self.dirs
+
     @staticmethod
     def get_theme_template_sources():
         """


### PR DESCRIPTION
## Description

[backport from master](https://github.com/openedx/edx-platform/pull/32627)

Make the theme templates a priority, avoiding cashing templates for Django ones.
