### PR TITLE
backport: feat: add ability to notify credentials about honor certificates

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -20,6 +20,7 @@ from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.django.models import CourseKeyField
 from simple_history.models import HistoricalRecords
 
+from common.djangoapps.course_modes.toggles import EXTEND_CERTIFICATE_RELEVANT_MODES_WITH_HONOR_FLAG
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.cache_utils import request_cached
 
@@ -834,6 +835,21 @@ class CourseMode(models.Model):
                 ineligible_modes.append(cls.HONOR)
 
         return mode_slug not in ineligible_modes
+
+    @classmethod
+    def get_certificate_relevant_modes(cls):
+        """
+        Wrapper for CERTIFICATE_RELEVANT_MODES.
+        When EXTEND_CERTIFICATE_RELEVANT_MODES_WITH_HONOR_FLAG is enabled we want to add HONOR mode.
+        We may want that when using the HONOR courses in the programs and need to notify credentials
+        about such course certificates.
+        """
+        cert_relevant_modes = cls.CERTIFICATE_RELEVANT_MODES
+
+        if EXTEND_CERTIFICATE_RELEVANT_MODES_WITH_HONOR_FLAG.is_enabled():
+            cert_relevant_modes += [cls.HONOR]
+
+        return cert_relevant_modes
 
     def to_tuple(self):
         """

--- a/common/djangoapps/course_modes/toggles.py
+++ b/common/djangoapps/course_modes/toggles.py
@@ -1,0 +1,20 @@
+"""
+Toggles for the Course Modes app
+"""
+
+from edx_toggles.toggles import WaffleFlag
+
+
+# .. toggle_name: course_modes.extend_certificate_relevant_modes_with_honor
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Determines whether the HONOR certificates should be sent to the Credentials
+#  service to update user credentials.
+# .. toggle_use_cases: vip
+# .. toggle_creation_date: 2022-06-21
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: RGOeX-1413
+EXTEND_CERTIFICATE_RELEVANT_MODES_WITH_HONOR_FLAG = WaffleFlag(
+    'course_modes.extend_certificate_relevant_modes_with_honor', __name__,
+)

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -384,7 +384,9 @@ def update_credentials_course_certificate_configuration_available_date(
     course_key = str(course_key)
     course_modes = CourseMode.objects.filter(course_id=course_key)
     # There should only ever be one certificate relevant mode per course run
-    modes = [mode.slug for mode in course_modes if mode.slug in CourseMode.CERTIFICATE_RELEVANT_MODES]
+    # get_certificate_relevant_modes() used to decide if HONOR mode should be processed along
+    # with the default certificate relevant modes
+    modes = [mode.slug for mode in course_modes if mode.slug in CourseMode.get_certificate_relevant_modes()]
     if len(modes) != 1:
         LOGGER.exception(
             f'Either course {course_key} has no certificate mode or multiple modes. Task failed.'
@@ -471,7 +473,9 @@ def award_course_certificate(self, username, course_run_key):
                 f"for {course_key} to user {username}"
             )
             return
-        if certificate.mode in CourseMode.CERTIFICATE_RELEVANT_MODES:
+        # get_certificate_relevant_modes() used to decide if HONOR mode should be processed along
+        # with the default certificate relevant modes
+        if certificate.mode in CourseMode.get_certificate_relevant_modes():
             try:
                 course_overview = CourseOverview.get_from_id(course_key)
             except (CourseOverview.DoesNotExist, OSError):


### PR DESCRIPTION
## Description

[backport from master](https://github.com/openedx/edx-platform/pull/32633)

Honor mode is absent by default in the course list for "Program Records" that appears error for "Program Records" for users with permission "Active" after clicking on "View My Records" button:

![screen_5](https://github.com/openedx/edx-platform/assets/98233552/035e7645-f0aa-488f-ba75-c0afa4a937e5)

500 error appeared

Implemented:
- Developed solution for adding course mode "Honor" to the list of modes for "Program Records"
- "Earned" and "completed" status are set up for Honor Courses and Program after finishing the program for staff and particular user

Added a WaffleFlag course_modes.extend_certificate_relevant_modes_with_honor. When enabled - credential will receive data about the HONOR course certificates.