### PR TITLE
fix: fix entitlement revocation task

### DIFF
--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -177,6 +177,7 @@ def retry_revoke_subscriptions_verified_access(self, revocable_entitlement_uuids
                     user_id,
                     revocable_entitlement_uuids
                 )
+                return
         log.info('B2C_SUBSCRIPTIONS: Starting revoke_entitlements_and_downgrade_courses_to_audit for user %s and '
                  'awarded_cert_course_ids %s and revocable_entitlement_uuids %s from retry task',
                  user_id,


### PR DESCRIPTION
This PR fixes a bug in the entitlements revocation task. Upon hitting max retries we should just log the error out and exit without doing anything. Previously it was logging the error out but by mistake also calling the revocation utility which was expiring entitlements and downgrading courses which was having unintended consequences.