### PR TITLE
feat: add tracking event for notifications app mark all as read

### DIFF
--- a/openedx/core/djangoapps/notifications/events.py
+++ b/openedx/core/djangoapps/notifications/events.py
@@ -1,12 +1,13 @@
 """ Events for notification app. """
 
 from eventtracking import tracker
-from common.djangoapps.track import contexts
 
+from common.djangoapps.track import contexts
 
 NOTIFICATION_PREFERENCES_VIEWED = 'edx.notifications.preferences.viewed'
 NOTIFICATION_GENERATED = 'edx.notifications.generated'
-NOTIFICATION_READ = 'edx.notifications.read'
+NOTIFICATION_READ = 'edx.notification.read'
+NOTIFICATION_APP_ALL_READ = 'edx.notifications.app_all_read'
 NOTIFICATION_PREFERENCES_UPDATED = 'edx.notifications.preferences.updated'
 
 
@@ -74,7 +75,7 @@ def notification_generated_event(user, notification):
 
 def notification_read_event(user, notification):
     """
-    Emit an event when a notification is read.
+    Emit an event when a notification app is marked read for a user.
     """
     context = contexts.course_context_from_course_id(notification.course_id)
     with tracker.get_tracker().context(NOTIFICATION_READ, context):
@@ -82,6 +83,19 @@ def notification_read_event(user, notification):
             NOTIFICATION_READ,
             notification_event_context(user, notification.course_id, notification)
         )
+
+
+def notifications_app_all_read_event(user, app_name):
+    """
+    Emit an event when a notification is read.
+    """
+    tracker.emit(
+        NOTIFICATION_APP_ALL_READ,
+        {
+            'user_id': str(user.id),
+            'notification_app': app_name,
+        }
+    )
 
 
 def notification_preference_update_event(user, course_id, updated_preference):

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -588,7 +588,8 @@ class NotificationReadAPIViewTestCase(APITestCase):
             Notification.objects.create(user=self.user, app_name=app_name, notification_type='Type A')
             Notification.objects.create(user=self.user, app_name=app_name, notification_type='Type B')
 
-    def test_mark_all_notifications_read_with_app_name(self):
+    @mock.patch("eventtracking.tracker.emit")
+    def test_mark_all_notifications_read_with_app_name(self, mock_emit):
         # Create a PATCH request to mark all notifications as read for already existing app e.g 'discussion'
         app_name = next(iter(COURSE_NOTIFICATION_APPS))
         data = {'app_name': app_name}
@@ -599,6 +600,9 @@ class NotificationReadAPIViewTestCase(APITestCase):
         self.assertEqual(response.data, {'message': 'Notifications marked read.'})
         notifications = Notification.objects.filter(user=self.user, app_name=app_name, last_read__isnull=False)
         self.assertEqual(notifications.count(), 2)
+        event_name, event_data = mock_emit.call_args[0]
+        self.assertEqual(event_name, 'edx.notifications.app_all_read')
+        self.assertEqual(event_data['notification_app'], 'discussion')
 
     def test_mark_all_notifications_read_with_invalid_app_name(self):
         # Create a PATCH request to mark all notifications as read for 'app_name_1'
@@ -623,7 +627,7 @@ class NotificationReadAPIViewTestCase(APITestCase):
         notifications = Notification.objects.filter(user=self.user, id=notification_id, last_read__isnull=False)
         self.assertEqual(notifications.count(), 1)
         event_name, event_data = mock_emit.call_args[0]
-        self.assertEqual(event_name, 'edx.notifications.read')
+        self.assertEqual(event_name, 'edx.notification.read')
         self.assertEqual(event_data.get('notification_metadata').get('notification_id'), notification_id)
         self.assertEqual(event_data['notification_app'], 'discussion')
         self.assertEqual(event_data['notification_type'], 'Type A')


### PR DESCRIPTION
[INF-933](https://2u-internal.atlassian.net/browse/INF-933)

## Description

**Event name:** `edx.notifications.app_all_read`
Emitted whenever mark as read option is used on a notification_app
