### PR TITLE
feat: use username for course completion API instead of lms_user_id

### DIFF
--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
@@ -1392,4 +1392,4 @@ class RevokeSubscriptionsVerifiedAccessViewTest(ModuleStoreTestCase):
         assert response.status_code == 204
         mock_task.assert_called_once_with(args=([str(course_entitlement.uuid)],
                                                 [str(enrollment.course_id)],
-                                                self.user.id))
+                                                self.user.username))

--- a/common/djangoapps/entitlements/utils.py
+++ b/common/djangoapps/entitlements/utils.py
@@ -61,7 +61,7 @@ def is_course_run_entitlement_fulfillable(
     return course_overview.start and can_upgrade and (is_enrolled or can_enroll)
 
 
-def revoke_entitlements_and_downgrade_courses_to_audit(course_entitlements, user_id, awarded_cert_course_ids,
+def revoke_entitlements_and_downgrade_courses_to_audit(course_entitlements, username, awarded_cert_course_ids,
                                                        revocable_entitlement_uuids):
     """
     This method expires the entitlements for provided course_entitlements and also moves the enrollments
@@ -69,8 +69,8 @@ def revoke_entitlements_and_downgrade_courses_to_audit(course_entitlements, user
     """
 
     log.info('B2C_SUBSCRIPTIONS: Starting revoke_entitlements_and_downgrade_courses_to_audit for '
-             'user: %s, course_entitlements_uuids: %s, awarded_cert_course_ids: %s',
-             user_id,
+             'user: [%s], course_entitlements_uuids: %s, awarded_cert_course_ids: %s',
+             username,
              revocable_entitlement_uuids,
              awarded_cert_course_ids)
     for course_entitlement in course_entitlements:
@@ -87,11 +87,11 @@ def revoke_entitlements_and_downgrade_courses_to_audit(course_entitlements, user
                     course_entitlement.expire_entitlement()
                 update_enrollment(username, str(course_id), CourseMode.AUDIT, include_expired=True)
             else:
-                log.warning('B2C_SUBSCRIPTIONS: Enrollment mode mismatch for user_id: %s and course_id: %s',
-                            user_id,
+                log.warning('B2C_SUBSCRIPTIONS: Enrollment mode mismatch for user: %s and course_id: %s',
+                            username,
                             course_id)
     log.info('B2C_SUBSCRIPTIONS: Completed revoke_entitlements_and_downgrade_courses_to_audit for '
-             'user: %s, course_entitlements_uuids: %s, awarded_cert_course_ids: %s',
-             user_id,
+             'user: [%s], course_entitlements_uuids: %s, awarded_cert_course_ids: %s',
+             username,
              revocable_entitlement_uuids,
              awarded_cert_course_ids)

--- a/openedx/core/djangoapps/credentials/utils.py
+++ b/openedx/core/djangoapps/credentials/utils.py
@@ -110,11 +110,11 @@ def get_credentials(user, program_uuid=None, credential_type=None):
     )
 
 
-def get_courses_completion_status(lms_user_id, course_run_ids):
+def get_courses_completion_status(username, course_run_ids):
     """
-    Given the lms_user_id and course run ids, checks for course completion status
+    Given the username and course run ids, checks for course completion status
     Arguments:
-        lms_user_id (User): The user to authenticate as when requesting credentials.
+        username (User): Username of the user whose credentials are being requested.
         course_run_ids(List): list of course run ids for which we need to check the completion status
     Returns:
         list of course_run_ids for which user has completed the course
@@ -134,7 +134,7 @@ def get_courses_completion_status(lms_user_id, course_run_ids):
         api_response = api_client.post(
             completion_status_url,
             json={
-                'lms_user_id': lms_user_id,
+                'username': username,
                 'course_runs': course_run_ids,
             }
         )
@@ -142,16 +142,16 @@ def get_courses_completion_status(lms_user_id, course_run_ids):
         course_completion_response = api_response.json()
     except Exception as exc:  # pylint: disable=broad-except
         log.exception("An unexpected error occurred while reqeusting course completion statuses "
-                      "for lms_user_id [%s] for course_run_ids [%s] with exc [%s]:",
-                      lms_user_id,
+                      "for user [%s] for course_run_ids [%s] with exc [%s]:",
+                      username,
                       course_run_ids,
                       exc
                       )
         return [], True
     # Yes, This is course_credentials_data. The key is named status but
     # it contains all the courses data from credentials.
-    log.info("Course completion status response for lms_user_id [%s] for course_run_ids [%s] is [%s]",
-             lms_user_id,
+    log.info("Course completion status response for user [%s] for course_run_ids [%s] is [%s]",
+             username,
              course_run_ids,
              course_completion_response)
     course_credentials_data = course_completion_response.get('status', [])
@@ -159,8 +159,8 @@ def get_courses_completion_status(lms_user_id, course_run_ids):
         filtered_records = [course_data['course_run']['key'] for course_data in course_credentials_data if
                             course_data['course_run']['key'] in course_run_ids and
                             course_data['status'] == settings.CREDENTIALS_COURSE_COMPLETION_STATE]
-        log.info("Filtered course completion status response for lms_user_id [%s] for course_run_ids [%s] is [%s]",
-                 lms_user_id,
+        log.info("Filtered course completion status response for user [%s] for course_run_ids [%s] is [%s]",
+                 username,
                  course_run_ids,
                  filtered_records)
         return filtered_records, False


### PR DESCRIPTION
## Description
`lms_user_id` isn't being carried over to credentials database due to a configuration bug. This is causing issues when we are trying to get course completion based on lms_user_id. However we do have username being set correctly for the users in credentials service and the API also provides us with the option to either use lms_user_id or username. Hence this PR makes use of `username` instead of `lms_user_id` to fetch course completion status from credentials service.

**JIRA**: https://2u-internal.atlassian.net/browse/PON-417