### PR TITLE
fix: work around existing css that fail to draw mathjax

### DIFF
--- a/cms/djangoapps/pipeline_js/js/xmodule.js
+++ b/cms/djangoapps/pipeline_js/js/xmodule.js
@@ -63,7 +63,14 @@ define(
                         t = -1;
                       }, delay);
                     }
-                  };
+
+                    // this is added to compensate for custom css that accidentally hide mathjax
+                    $('.MathJax_SVG>svg').toArray().forEach(el => {
+                        if ($(el).width() === 0) {
+                        $(el).css('max-width', 'inherit');
+                        }
+                    });
+                };
             }
         );
         window.CodeMirror = CodeMirror;

--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -115,6 +115,13 @@
           t = -1;
         }, delay);
       }
+
+      // this is added to compensate for custom css that accidentally hide mathjax
+      $('.MathJax_SVG>svg').toArray().forEach(el => {
+        if ($(el).width() === 0) {
+          $(el).css('max-width', 'inherit');
+        }
+      });
     };
   </script>
   <script type="text/x-mathjax-config">

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -114,6 +114,13 @@
           t = -1;
         }, delay);
       }
+
+      // this is added to compensate for custom css that accidentally hide mathjax
+      $('.MathJax_SVG>svg').toArray().forEach(el => {
+        if ($(el).width() === 0) {
+          $(el).css('max-width', 'inherit');
+        }
+      });
     };
 </script>
 


### PR DESCRIPTION
## Description

Some of the `MathJax` fail to draw due to some of the existing css. This pr is to add to this pr https://github.com/openedx/edx-platform/pull/32696. 

Ticket: https://2u-internal.atlassian.net/browse/AU-1365


