### PR TITLE
build: copy from node_modules using NPM postinstall hook, not Paver (RE-MERGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,9 +115,16 @@ COPY requirements requirements
 RUN pip install -r requirements/pip.txt
 RUN pip install -r requirements/edx/base.txt
 
-# Install node and node modules
+# Install node and npm
 RUN nodeenv /edx/app/edxapp/nodeenv --node=16.14.0 --prebuilt
 RUN npm install -g npm@8.5.x
+
+# This script is used by an npm post-install hook.
+# We copy it into the image now so that it will be available when we run `npm install` in the next step.
+# The script itself will copy certain modules into some uber-legacy parts of edx-platform which still use RequireJS.
+COPY scripts/copy-node-modules.sh scripts/copy-node-modules.sh
+
+# Install node modules
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 RUN npm set progress=false && npm ci

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "edx",
   "version": "0.1.0",
   "repository": "https://github.com/openedx/edx-platform",
+  "scripts": {
+    "postinstall": "scripts/copy-node-modules.sh"
+  },
   "dependencies": {
     "@babel/core": "7.19.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.18.9",

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -611,8 +611,7 @@ def process_npm_assets():
     """
     Process vendor libraries installed via NPM.
     """
-    print("\t\tProcessing NPM assets is now done automatically in an npm post-install hook.")
-    print("\t\tThis function is now a no-op.")
+    sh('scripts/copy-node-modules.sh')
 
 
 @task

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -46,39 +46,6 @@ COMMON_LOOKUP_PATHS = [
     path('node_modules'),
 ]
 
-# A list of NPM installed libraries that should be copied into the common
-# static directory.
-# If string ends with '/' then all file in the directory will be copied.
-NPM_INSTALLED_LIBRARIES = [
-    'backbone.paginator/lib/backbone.paginator.js',
-    'backbone/backbone.js',
-    'bootstrap/dist/js/bootstrap.bundle.js',
-    'hls.js/dist/hls.js',
-    'jquery-migrate/dist/jquery-migrate.js',
-    'jquery.scrollto/jquery.scrollTo.js',
-    'jquery/dist/jquery.js',
-    'moment-timezone/builds/moment-timezone-with-data.js',
-    'moment/min/moment-with-locales.js',
-    'picturefill/dist/picturefill.js',
-    'requirejs/require.js',
-    'underscore.string/dist/underscore.string.js',
-    'underscore/underscore.js',
-    '@edx/studio-frontend/dist/',
-    'which-country/index.js'
-]
-
-# A list of NPM installed developer libraries that should be copied into the common
-# static directory only in development mode.
-NPM_INSTALLED_DEVELOPER_LIBRARIES = [
-    'sinon/pkg/sinon.js',
-    'squirejs/src/Squire.js',
-]
-
-# Directory to install static vendor files
-NPM_JS_VENDOR_DIRECTORY = path('common/static/common/js/vendor')
-NPM_CSS_VENDOR_DIRECTORY = path("common/static/common/css/vendor")
-NPM_CSS_DIRECTORY = path("common/static/common/css")
-
 # system specific lookup path additions, add sass dirs if one system depends on the sass files for other systems
 SASS_LOOKUP_DEPENDENCIES = {
     'cms': [path('lms') / 'static' / 'sass' / 'partials', ],
@@ -644,60 +611,8 @@ def process_npm_assets():
     """
     Process vendor libraries installed via NPM.
     """
-    def copy_vendor_library(library, skip_if_missing=False):
-        """
-        Copies a vendor library to the shared vendor directory.
-        """
-        if library.startswith('node_modules/'):
-            library_path = library
-        else:
-            library_path = f'node_modules/{library}'
-
-        if library.endswith('.css') or library.endswith('.css.map'):
-            vendor_dir = NPM_CSS_VENDOR_DIRECTORY
-        else:
-            vendor_dir = NPM_JS_VENDOR_DIRECTORY
-        if os.path.exists(library_path):
-            sh('/bin/cp -rf {library_path} {vendor_dir}'.format(
-                library_path=library_path,
-                vendor_dir=vendor_dir,
-            ))
-        elif not skip_if_missing:
-            raise Exception(f'Missing vendor file {library_path}')
-
-    def copy_vendor_library_dir(library_dir, skip_if_missing=False):
-        """
-        Copies all vendor libraries in directory to the shared vendor directory.
-        """
-        library_dir_path = f'node_modules/{library_dir}'
-        print(f'Copying vendor library dir: {library_dir_path}')
-        if os.path.exists(library_dir_path):
-            for dirpath, _, filenames in os.walk(library_dir_path):
-                for filename in filenames:
-                    copy_vendor_library(os.path.join(dirpath, filename), skip_if_missing=skip_if_missing)
-
-    # Skip processing of the libraries if this is just a dry run
-    if tasks.environment.dry_run:
-        tasks.environment.info("install npm_assets")
-        return
-
-    # Ensure that the vendor directory exists
-    NPM_JS_VENDOR_DIRECTORY.mkdir_p()
-    NPM_CSS_DIRECTORY.mkdir_p()
-    NPM_CSS_VENDOR_DIRECTORY.mkdir_p()
-
-    # Copy each file to the vendor directory, overwriting any existing file.
-    print("Copying vendor files into static directory")
-    for library in NPM_INSTALLED_LIBRARIES:
-        if library.endswith('/'):
-            copy_vendor_library_dir(library)
-        else:
-            copy_vendor_library(library)
-
-    # Copy over each developer library too if they have been installed
-    print("Copying developer vendor files into static directory")
-    for library in NPM_INSTALLED_DEVELOPER_LIBRARIES:
-        copy_vendor_library(library, skip_if_missing=True)
+    print("\t\tProcessing NPM assets is now done automatically in an npm post-install hook.")
+    print("\t\tThis function is now a no-op.")
 
 
 @task
@@ -983,7 +898,6 @@ def update_assets(args):
     collect_log_args = {}
 
     process_xmodule_assets()
-    process_npm_assets()
 
     # Build Webpack
     call_task('pavelib.assets.webpack', options={'settings': args.settings})

--- a/pavelib/utils/test/suites/js_suite.py
+++ b/pavelib/utils/test/suites/js_suite.py
@@ -39,8 +39,6 @@ class JsTestSuite(TestSuite):
         if self.mode == 'run' and not self.run_under_coverage:
             test_utils.clean_dir(self.report_dir)
 
-        assets.process_npm_assets()
-
     @property
     def _default_subsuites(self):
         """

--- a/scripts/copy-node-modules.sh
+++ b/scripts/copy-node-modules.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copy certain npm-installed assets from node_modules to other folders in
+# edx-platform. These assets are used by certain especially-old legacy LMS & CMS
+# frontends that are not set up to import from node_modules directly.
+# Many of the destination folders are named "vendor", because they originally
+# held vendored-in (directly-committed) libraries; once we moved most frontends
+# to use NPM, we decided to keep library versions in-sync by copying to the
+# former "vendor" directories.
+
+# Enable stricter error handling.
+set -euo pipefail
+
+COL_LOG="\e[36m"  # Log/step/section color (cyan)
+COL_OFF="\e[0m"   # Normal color
+
+# Keep these as variables in case we ever want to parameterize this script's
+# input or output dirs, as proposed in:
+# https://github.com/openedx/wg-developer-experience/issues/150
+# https://github.com/openedx/wg-developer-experience/issues/151
+node_modules="node_modules"
+vendor_js="common/static/common/js/vendor"
+vendor_css="common/static/common/css/vendor"
+
+# Stylized logging.
+log ( ) {
+	echo -e "${COL_LOG}$* $COL_OFF"
+}
+
+log "====================================================================================="
+log "Copying required assets from node_modules..."
+log "-------------------------------------------------------------------------------"
+
+# Start echoing all commands back to user for ease of debugging.
+set -x
+
+log "Ensuring vendor directories exist..."
+mkdir -p "$vendor_js"
+mkdir -p "$vendor_css"
+
+log "Copying studio-frontend JS & CSS from node_modules into vendor directores..."
+while read -r -d $'\0' src_file ; do
+    if [[ "$src_file" = *.css ]] || [[ "$src_file" = *.css.map ]] ; then
+        cp --force "$src_file" "$vendor_css"
+    else
+        cp --force "$src_file" "$vendor_js"
+    fi
+done < <(find "$node_modules/@edx/studio-frontend/dist" -type f -print0)
+
+log "Copying certain JS modules from node_modules into vendor directory..."
+cp --force \
+    "$node_modules/backbone.paginator/lib/backbone.paginator.js" \
+    "$node_modules/backbone/backbone.js" \
+    "$node_modules/bootstrap/dist/js/bootstrap.bundle.js" \
+    "$node_modules/hls.js/dist/hls.js" \
+    "$node_modules/jquery-migrate/dist/jquery-migrate.js" \
+    "$node_modules/jquery.scrollto/jquery.scrollTo.js" \
+    "$node_modules/jquery/dist/jquery.js" \
+    "$node_modules/moment-timezone/builds/moment-timezone-with-data.js" \
+    "$node_modules/moment/min/moment-with-locales.js" \
+    "$node_modules/picturefill/dist/picturefill.js" \
+    "$node_modules/requirejs/require.js" \
+    "$node_modules/underscore.string/dist/underscore.string.js" \
+    "$node_modules/underscore/underscore.js" \
+    "$node_modules/which-country/index.js" \
+    "$vendor_js"
+
+log "Copying certain JS developer modules into vendor directory..."
+if [[ "${NODE_ENV:-production}" = development ]] ; then
+    cp --force "$node_modules/sinon/pkg/sinon.js" "$vendor_js"
+    cp --force "$node_modules/squirejs/src/Squire.js" "$vendor_js"
+else
+    # TODO: https://github.com/openedx/edx-platform/issues/31768
+    # In the old implementation of this scipt (pavelib/assets.py), these two
+    # developer libraries were copied into the JS vendor directory whether not
+    # the build was for prod or dev. In order to exactly match the output of
+    # the old script, this script will also copy them in for prod builds.
+    # However, in the future, it would be good to only copy them for dev
+    # builds. Furthermore, these libraries should not be `npm install`ed
+    # into prod builds in the first place.
+    cp --force "$node_modules/sinon/pkg/sinon.js" "$vendor_js" || true      # "|| true" means "tolerate errors"; in this case,
+    cp --force "$node_modules/squirejs/src/Squire.js" "$vendor_js" || true  # that's "tolerate if these files don't exist."
+fi
+
+# Done echoing.
+set +x
+
+log "-------------------------------------------------------------------------------"
+log " Done copying required assets from node_modules."
+log "====================================================================================="
+


### PR DESCRIPTION
This is a fixed version of https://github.com/openedx/edx-platform/pull/32717, which we reverted in https://github.com/openedx/edx-platform/pull/32766.

First commit is the same as the original PR. See that PR for details & testing info.

Second commit contains the fixes. You can test the fix simply by running `make docker_build` in the edx-platform root. If the build succeeds then all is well.