### PR TITLE
Redirect Technical docs pages to the new edx-platform docs site.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,10 @@ shell: ## launch a bash shell in a Docker container with all edx-platform depend
 # Order is very important in this list: files must appear after everything they include!
 REQ_FILES = \
 	requirements/edx/coverage \
-	requirements/edx/doc \
 	requirements/edx/paver \
 	requirements/edx-sandbox/py38 \
 	requirements/edx/base \
+	requirements/edx/doc \
 	requirements/edx/testing \
 	requirements/edx/development \
 	scripts/xblock/requirements

--- a/docs/technical/conf.py
+++ b/docs/technical/conf.py
@@ -9,13 +9,22 @@ import git
 # -- Project information -----------------------------------------------------
 
 project = "edx-platform Technical Reference"
-copyright = f'{datetime.now().year}, Axim Collaborative, Inc'  # pylint: disable=redefined-builtin
-author = 'Axim Collaborative, Inc'
+copyright = f"{datetime.now().year}, Axim Collaborative, Inc"  # pylint: disable=redefined-builtin
+author = "Axim Collaborative, Inc"
 release = ""
 
 # -- General configuration ---------------------------------------------------
 
-extensions = ["code_annotations.contrib.sphinx.extensions.featuretoggles", "code_annotations.contrib.sphinx.extensions.settings"]
+extensions = [
+    "code_annotations.contrib.sphinx.extensions.featuretoggles",
+    "code_annotations.contrib.sphinx.extensions.settings",
+    "sphinx_reredirects",
+]
+
+redirects = {
+    "*": "https://docs.openedx.org/projects/edx-platform/en/latest/$source.html",
+}
+
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
@@ -38,7 +47,7 @@ settings_repo_version = edx_platform_version
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = 'sphinx_book_theme'
+html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
@@ -72,5 +81,5 @@ html_theme_options = {
                 rel="license"
                 href="https://creativecommons.org/licenses/by-sa/4.0/"
             >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
-    """
+    """,
 }

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -601,7 +601,7 @@ geoip2==4.7.0
     # via -r requirements/edx/kernel.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
-gunicorn==20.1.0
+gunicorn==21.0.0
     # via -r requirements/edx/kernel.in
 help-tokens==2.2.0
     # via -r requirements/edx/kernel.in
@@ -799,6 +799,7 @@ outcome-surveys==2.4.0
 packaging==23.1
     # via
     #   drf-yasg
+    #   gunicorn
     #   py2neo
     #   snowflake-connector-python
 pansi==2020.7.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -955,7 +955,7 @@ grimp==2.5
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
-gunicorn==20.1.0
+gunicorn==21.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1331,6 +1331,7 @@ packaging==23.1
     #   -r requirements/edx/testing.txt
     #   build
     #   drf-yasg
+    #   gunicorn
     #   py2neo
     #   pydata-sphinx-theme
     #   pytest
@@ -1908,6 +1909,7 @@ sphinx==6.2.1
     #   pydata-sphinx-theme
     #   sphinx-book-theme
     #   sphinx-design
+    #   sphinx-reredirects
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
     #   sphinxext-rediraffe
@@ -1919,6 +1921,8 @@ sphinx-mdinclude==0.5.3
     # via
     #   -r requirements/edx/doc.txt
     #   sphinxcontrib-openapi
+sphinx-reredirects==0.1.2
+    # via -r requirements/edx/doc.txt
 sphinxcontrib-applehelp==1.0.4
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.in
+++ b/requirements/edx/doc.in
@@ -9,3 +9,4 @@ Sphinx                    # Documentation builder
 sphinx-design             # provides various responsive web-components
 sphinxcontrib-openapi[markdown] # Be able to render openapi schema in a sphinx project
 sphinxext-rediraffe       # Quickly and easily redirect when we move pages around.
+sphinx-reredirects        # Redirect from a sphinx project out to other places on the web including other sphinx projects

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -697,7 +697,7 @@ gitpython==3.1.32
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
-gunicorn==20.1.0
+gunicorn==21.0.0
     # via -r requirements/edx/base.txt
 help-tokens==2.2.0
     # via -r requirements/edx/base.txt
@@ -945,6 +945,7 @@ packaging==23.1
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
+    #   gunicorn
     #   py2neo
     #   pydata-sphinx-theme
     #   snowflake-connector-python
@@ -1319,6 +1320,7 @@ sphinx==6.2.1
     #   pydata-sphinx-theme
     #   sphinx-book-theme
     #   sphinx-design
+    #   sphinx-reredirects
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
     #   sphinxext-rediraffe
@@ -1328,6 +1330,8 @@ sphinx-design==0.4.1
     # via -r requirements/edx/doc.in
 sphinx-mdinclude==0.5.3
     # via sphinxcontrib-openapi
+sphinx-reredirects==0.1.2
+    # via -r requirements/edx/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -743,7 +743,7 @@ glob2==0.7
     # via -r requirements/edx/base.txt
 grimp==2.5
     # via import-linter
-gunicorn==20.1.0
+gunicorn==21.0.0
     # via -r requirements/edx/base.txt
 h11==0.14.0
     # via
@@ -1014,6 +1014,7 @@ packaging==23.1
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
+    #   gunicorn
     #   py2neo
     #   pytest
     #   snowflake-connector-python


### PR DESCRIPTION
We publish the two pages that were being published under here to the new
edx-platform docs under docs.openedx.org so update this doc site to
redirect to that site for all pages.

Once this version has been published, we should be safe to remove this
doc project from the platform and all future changes should go through
the single edx-platform docs site.
