### PR TITLE
fix: use search instead of list for users in notification admin

### DIFF
--- a/openedx/core/djangoapps/notifications/admin.py
+++ b/openedx/core/djangoapps/notifications/admin.py
@@ -8,7 +8,10 @@ from .models import CourseNotificationPreference, Notification
 
 
 class NotificationAdmin(admin.ModelAdmin):
-    pass
+    """
+    Admin for Notifications
+    """
+    raw_id_fields = ('user',)
 
 
 class CourseNotificationPreferenceAdmin(admin.ModelAdmin):
@@ -16,6 +19,7 @@ class CourseNotificationPreferenceAdmin(admin.ModelAdmin):
     Admin for Course Notification Preferences
     """
     model = CourseNotificationPreference
+    raw_id_fields = ('user',)
     list_display = ['get_username', 'course_id', 'notification_preference_config']
 
     @admin.display(description='Username', ordering='user__username')


### PR DESCRIPTION
# Ticket 
https://2u-internal.atlassian.net/browse/INF-956
# Description
Update Notification and CourseNotificationPreference to use search instead of user list.

<img width="512" alt="Screenshot 2023-07-18 at 11 17 46 AM" src="https://github.com/openedx/edx-platform/assets/26253150/0f104ce8-957b-4253-bbec-5fd0e81399ef">

