### PR TITLE
feat: enrollment mode and organisation auth id

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -200,6 +200,7 @@ class EnrollmentSerializer(serializers.Serializer):
     hasOptedOutOfEmail = serializers.SerializerMethodField()
     lastEnrolled = serializers.DateTimeField(source="created")
     isEnrolled = serializers.BooleanField(source="is_active")
+    mode = serializers.CharField()
 
     def get_accessExpirationDate(self, instance):
         return self.context.get("audit_access_deadlines", {}).get(instance.course_id)
@@ -495,6 +496,7 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
         "hasOptedOutOfEmail": False,
         "lastEnrolled": None,
         "isEnrolled": False,
+        "mode": None,
     }
 
     # These fields contain all real data and will be serialized
@@ -561,6 +563,7 @@ class EnterpriseDashboardSerializer(serializers.Serializer):
     label = serializers.CharField(source="name")
     url = serializers.SerializerMethodField()
     uuid = serializers.UUIDField()
+    authOrgId = serializers.CharField(source="auth_org_id")
     isLearnerPortalEnabled = serializers.BooleanField(source="enable_learner_portal")
 
     def get_url(self, instance):

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -1132,6 +1132,7 @@ class TestEnterpriseDashboardSerializer(TestCase):
             "slug": str(uuid4()),
             "enable_learner_portal": True,
             "uuid": str(uuid4()),
+            "auth_org_id": str(uuid4()),
         }
 
     def test_structure(self):
@@ -1140,7 +1141,7 @@ class TestEnterpriseDashboardSerializer(TestCase):
 
         output_data = EnterpriseDashboardSerializer(input_data).data
 
-        expected_keys = ["label", "url", "uuid", "isLearnerPortalEnabled"]
+        expected_keys = ["label", "url", "uuid", "isLearnerPortalEnabled", "authOrgId"]
         self.assertEqual(output_data.keys(), set(expected_keys))
 
     def test_happy_path(self):
@@ -1159,6 +1160,7 @@ class TestEnterpriseDashboardSerializer(TestCase):
                 + input_data["slug"],
                 "uuid": input_data["uuid"],
                 "isLearnerPortalEnabled": input_data["enable_learner_portal"],
+                "authOrgId": input_data["auth_org_id"],
             },
         )
 


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

These changes will help differentiate working with the frontend changes based on the course enrollment type. These changes look like this in the browser developer console. 

<img width="518" alt="Screenshot 2023-07-18 at 7 28 02 PM" src="https://github.com/openedx/edx-platform/assets/106396899/d947590e-7fa4-4348-af3a-f79572a2ed8f">

## Supporting information

JIRA: [ENT-7373](https://2u-internal.atlassian.net/browse/ENT-7373), [ENT-7374](https://2u-internal.atlassian.net/browse/ENT-7374)

## Testing instructions

 - Start [LMS](https://github.com/openedx/edx-platform) and [frontend-app-learner-dashboard](https://github.com/openedx/frontend-app-learner-dashboard)
 - Login for the learner dashboard
 - Check the response for the init API call

## Other information

Include anything else that will help reviewers and consumers understand the change.
- These changes are required for the ticket [ENT-7188](https://2u-internal.atlassian.net/browse/ENT-7188)
