### PR TITLE
feat: implements SHOW_REGISTRATION_LINKS feature toggle

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -344,6 +344,9 @@ FEATURES = {
     # Allow public account creation
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
 
+    # Allow showing the registration links
+    'SHOW_REGISTRATION_LINKS': True,
+
     # Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
     'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True,
 

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -154,7 +154,7 @@
   </section>
 </div>
 
-% if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
+% if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True):
 <div class="wrapper-content-cta wrapper">
   <section class="content content-cta">
     <header>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -364,7 +364,7 @@
           <li class="nav-item nav-not-signedin-help">
             <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a>
           </li>
-          % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
+          % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True):
               <li class="nav-item nav-not-signedin-signup">
                 <a class="action action-signup" href="${settings.FRONTEND_REGISTER_URL}?next=${quote_plus(request.build_absolute_uri(settings.LOGIN_URL))}">${_("Sign Up")}</a>
               </li>

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -779,6 +779,15 @@ FEATURES = {
     # .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
 
+    # .. toggle_name: FEATURES['SHOW_REGISTRATION_LINKS']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Allow registration links. If this is disabled, users will no longer see buttons to the
+    #   the signup page.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2023-03-27
+    'SHOW_REGISTRATION_LINKS': True,
+
     # .. toggle_name: FEATURES['ENABLE_COOKIE_CONSENT']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -76,7 +76,8 @@
                 this.platformName = options.platform_name;
                 this.supportURL = options.support_link;
                 this.passwordResetSupportUrl = options.password_reset_support_link;
-                this.createAccountOption = options.account_creation_allowed;
+                this.createAccountOption = options.account_creation_allowed && options.register_links_allowed;
+                this.showRegisterLinks = options.register_links_allowed;
                 this.hideAuthWarnings = options.hide_auth_warnings || false;
                 this.pipelineUserDetails = options.third_party_auth.pipeline_user_details;
                 this.enterpriseName = options.enterprise_name || '';
@@ -162,6 +163,7 @@
                         supportURL: this.supportURL,
                         passwordResetSupportUrl: this.passwordResetSupportUrl,
                         createAccountOption: this.createAccountOption,
+                        showRegisterLinks: this.showRegisterLinks,
                         hideAuthWarnings: this.hideAuthWarnings,
                         pipelineUserDetails: this.pipelineUserDetails,
                         enterpriseName: this.enterpriseName,
@@ -187,7 +189,8 @@
 
                     this.subview.passwordHelp = new PasswordResetView({
                         fields: data.fields,
-                        model: this.resetModel
+                        model: this.resetModel,
+                        showRegisterLinks: this.showRegisterLinks
                     });
 
                     // Listen for 'password-email-sent' event to toggle sub-views
@@ -212,6 +215,7 @@
                         hideAuthWarnings: this.hideAuthWarnings,
                         is_require_third_party_auth_enabled: this.is_require_third_party_auth_enabled,
                         enableCoppaCompliance: this.enable_coppa_compliance,
+                        showRegisterLinks: this.showRegisterLinks
                     });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.

--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -33,9 +33,14 @@
             optionalStr: gettext('(optional)'),
             submitButton: '',
             isEnterpriseEnable: false,
+            showRegisterLinks: true,
 
             initialize: function(data) {
                 this.model = data.model;
+                this.showRegisterLinks = (
+                    typeof data.showRegisterLinks !== 'undefined'
+                ) ? data.showRegisterLinks : this.showRegisterLinks;
+
                 this.preRender(data);
 
                 this.tpl = $(this.tpl).html();
@@ -98,6 +103,7 @@
                         supplementalText: data[i].supplementalText || '',
                         supplementalLink: data[i].supplementalLink || '',
                         loginIssueSupportLink: data[i].loginIssueSupportLink || '',
+                        showRegisterLinks: this.showRegisterLinks,
                         isEnterpriseEnable: this.isEnterpriseEnable
                     })));
                 }

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -53,6 +53,9 @@
                 this.supportURL = data.supportURL;
                 this.passwordResetSupportUrl = data.passwordResetSupportUrl;
                 this.createAccountOption = data.createAccountOption;
+                this.showRegisterLinks = (
+                    typeof data.showRegisterLinks !== 'undefined'
+                ) ? data.showRegisterLinks : this.showRegisterLinks;
                 this.accountActivationMessages = data.accountActivationMessages;
                 this.accountRecoveryMessages = data.accountRecoveryMessages;
                 this.hideAuthWarnings = data.hideAuthWarnings;

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -87,7 +87,8 @@
                         requiredStr: this.requiredStr,
                         optionalStr: fields[i].name === 'marketing_emails_opt_in' ? '' : this.optionalStr,
                         supplementalText: fields[i].supplementalText || '',
-                        supplementalLink: fields[i].supplementalLink || ''
+                        supplementalLink: fields[i].supplementalLink || '',
+                        showRegisterLinks: this.showRegisterLinks
                     })));
                 }
                 html.push('</div>');

--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -18,7 +18,7 @@ from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_
   courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
   allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
   can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
-  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True)
   should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
 %>
 <nav class="nav-links" aria-label=${_("Supplemental Links")}>

--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -33,7 +33,7 @@ from django.utils.translation import gettext as _
           <a class="btn" href="/courses">${_("Explore Courses")}</a>
         </li>
       %endif
-      % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
+      % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True):
         <li class="item nav-global-04">
           <a class="btn btn-neutral btn-register" href="/register${login_query()}">${_("Register")}</a>
         </li>

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -147,10 +147,12 @@
             <button type="button" class="enterprise-login field-link"><%- gettext("Sign in with your company or school") %></button>
         <% } %>
     <% } %>
-    <% if( form === 'password-reset' && name === 'email' ) { %>
+    <% if( (showRegisterLinks || loginIssueSupportLink) && form === 'password-reset' && name === 'email' ) { %>
         <button type="button" class="reset-help field-link" ><i class="fa fa-caret-right" /><%- gettext("Need other help signing in?") %></button>
         <div id="reset-help" style="display:none">
-            <button type="button" class="field-link form-toggle" data-type="register"><%- gettext("Create an account") %></button>
+            <% if ( showRegisterLinks ) { %>
+                <button type="button" class="field-link form-toggle" data-type="register"><%- gettext("Create an account") %></button>
+            <% } %>
             <% if ( loginIssueSupportLink ) { %>
                 <span><a  class="field-link" href="<%- loginIssueSupportLink %>"><%- gettext("Other sign-in issues") %></a></span>
             <% } %>

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -258,6 +258,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
             'account_creation_allowed': configuration_helpers.get_value(
                 'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)),
+            'register_links_allowed': settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True),
             'is_account_recovery_feature_enabled': is_secondary_email_feature_enabled(),
             'enterprise_slug_login_url': get_enterprise_slug_login_url(),
             'is_enterprise_enable': enterprise_enabled(),


### PR DESCRIPTION
## Description

This PR implements a `SHOW_REGISTRATION_LINKS` configuration variable to allow hiding the links to the registration form, while keeping the functionality for public registration enabled, through the `/register` url directly or through the API.

(cherry picked from commit 3025ab5fe6f6f53d6af5b36681355efafa37c74b)

## Supporting information

`Private-ref`: [BB-7694](https://tasks.opencraft.com/browse/BB-7694)

## Testing instructions

1. Set the `SHOW_REGISTRATION_LINKS` flag to `False` in both lms and cms
2. Check LMS: http://localhost:18000/ has no register button at the top
3. Check LMS: http://localhost:18000/register still works does work
4. Check LMS: http://localhost:18000/login doesn't show links to the registration form
5. Check CMS (studio): http://localhost:18010/ doesn't show links to register an account
