### PR TITLE
feat: command to delete v1 libraries

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/delete_v1_libraries.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_v1_libraries.py
@@ -82,7 +82,6 @@ class Command(BaseCommand):
         else:
             v1_library_keys = list(map(self._parse_library_key, options['library_ids']))
 
-
         delete_libary_task_group = group([
             delete_v1_library.s(str(v1_library_key)) for v1_library_key in v1_library_keys
         ])

--- a/cms/djangoapps/contentstore/management/commands/delete_v1_libraries.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_v1_libraries.py
@@ -1,0 +1,106 @@
+"""A Command to  Copy or uncopy V1 Content Libraries entires to be stored as v2 content libraries."""
+
+import logging
+from textwrap import dedent
+
+from django.core.management import BaseCommand, CommandError
+
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import LibraryLocator
+
+from xmodule.modulestore.django import modulestore
+
+from celery import group
+
+from cms.djangoapps.contentstore.tasks import delete_v1_library
+
+from .prompt import query_yes_no
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Copy or uncopy V1 Content Libraries (default all) entires to be stored as v2 content libraries.
+    First Specify the uuid for the collection to store the content libraries in.
+    Specfiy --all for all libraries, library ids for specific libraries,
+    and -- file followed by the path for a list of libraries from a file.
+
+    Example usage:
+
+        $ ./manage.py cms copy_libraries_from_v1_to_v2 'collection_uuid' --all
+        $ ./manage.py cms copy_libraries_from_v1_to_v2
+            library-v1:edX+DemoX+Demo_Library'  'library-v1:edX+DemoX+Better_Library' -c 'collection_uuid'
+        $ ./manage.py cms copy_libraries_from_v1_to_v2 --all --uncopy
+        $ ./manage.py cms copy_libraries_from_v1_to_v2 'library-v1:edX+DemoX+Better_Library' --uncopy
+        $ ./manage.py cms copy_libraries_from_v1_to_v2
+            '11111111-2111-4111-8111-111111111111'
+            './list_of--library-locators- --file
+
+    Note:
+       This Command Also produces an "output file" which contains the mapping of locators and the status of the copy.
+    """
+
+    help = dedent(__doc__)
+    CONFIRMATION_PROMPT = "Reindexing all libraries might be a time consuming operation. Do you want to continue?"
+
+    def add_arguments(self, parser):
+        """arguements for command"""
+
+        parser.add_argument(
+            'library_ids',
+            nargs='*',
+            help='a space-seperated list of v1 library ids to copy'
+        )
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            dest='all',
+            help='Copy all libraries'
+        )
+        parser.add_argument(
+            'output_csv',
+            nargs='?',
+            default=None,
+            help='a file path to write the tasks output to. Without this the result is simply logged.'
+        )
+
+    def _parse_library_key(self, raw_value):
+        """ Parses library key from string """
+        result = CourseKey.from_string(raw_value)
+
+        if not isinstance(result, LibraryLocator):
+            raise CommandError(f"Argument {raw_value} is not a library key")
+        return result
+
+    def handle(self, *args, **options):  # lint-amnesty, pylint: disable=unused-argument
+        """Parse args and generate tasks for copying content."""
+        print(options)
+
+        if (not options['library_ids'] and not options['all']) or (options['library_ids'] and options['all']):
+            raise CommandError("delete_v1_libraries requires one or more <library_id>s or the --all flag.")
+
+        if options['all']:
+            store = modulestore()
+            if query_yes_no(self.CONFIRMATION_PROMPT, default="no"):
+                v1_library_keys = [
+                    library.location.library_key.replace(branch=None) for library in store.get_libraries()
+                ]
+            else:
+                return
+        else:
+            v1_library_keys = list(map(self._parse_library_key, options['library_ids']))
+
+
+        delete_libary_task_group = group([
+            delete_v1_library.s(str(v1_library_key)) for v1_library_key in v1_library_keys
+        ])
+
+        group_result = delete_libary_task_group.apply_async().get()
+        if options['output_csv']:
+            with open(options['output_csv'][0], 'w', encoding='utf-8', newline='') as output_writer:
+                output_writer.writerow("v1_library_id", "v2_library_id", "status", "error_msg")
+                for result in group_result:
+                    output_writer.write(result.keys())
+        log.info(group_result)
+

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -982,6 +982,20 @@ def delete_v1_library(v1_library_key_string):
     """
     v1_library_key = CourseKey.from_string(v1_library_key_string)
     if not modulestore().get_library(v1_library_key):
-        raise KeyError(f"Course not found: {v1_library_key}")
-    delete_course(v1_library_key, ModuleStoreEnum.UserID.mgmt_command, True)
-    LOGGER.info(f"Deleted course {v1_library_key}")
+        raise KeyError(f"Library not found: {v1_library_key}")
+    try:
+        delete_course(v1_library_key, ModuleStoreEnum.UserID.mgmt_command, True)
+        LOGGER.info(f"Deleted course {v1_library_key}")
+    except Exception as error:  # lint-amnesty, pylint: disable=broad-except
+        return {
+            "v1_library_id": v1_library_key_string,
+            "status": "FAILED",
+            "msg":
+            f"Error occurred deleting library: {str(error)}"
+        }
+
+    return {
+        "v1_library_id": v1_library_key_string,
+        "status": "SUCCESS",
+        "msg": "SUCCESS"
+    }

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -75,6 +75,10 @@ from .outlines_regenerate import CourseOutlineRegenerate
 from .toggles import bypass_olx_failure_enabled
 from .utils import course_import_olx_validation_is_enabled
 
+
+from cms.djangoapps.contentstore.utils import delete_course # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
+
 User = get_user_model()
 
 LOGGER = get_task_logger(__name__)
@@ -969,3 +973,15 @@ def create_v2_library_from_v1_library(v1_library_key_string, collection_uuid):
         "status": "SUCCESS",
         "msg": None
     }
+
+@shared_task(time_limit=30)
+@set_code_owner_attribute
+def delete_v1_library(v1_library_key_string):
+    """
+    Delete a v1 library index by key string.
+    """
+    v1_library_key = CourseKey.from_string(v1_library_key_string)
+    if not modulestore().get_library(v1_library_key):
+        raise KeyError(f"Course not found: {v1_library_key}")
+    delete_course(v1_library_key, ModuleStoreEnum.UserID.mgmt_command, True)
+    LOGGER.info(f"Deleted course {v1_library_key}")

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -76,7 +76,7 @@ from .toggles import bypass_olx_failure_enabled
 from .utils import course_import_olx_validation_is_enabled
 
 
-from cms.djangoapps.contentstore.utils import delete_course # lint-amnesty, pylint: disable=wrong-import-order
+from cms.djangoapps.contentstore.utils import delete_course  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 
 User = get_user_model()
@@ -973,6 +973,7 @@ def create_v2_library_from_v1_library(v1_library_key_string, collection_uuid):
         "status": "SUCCESS",
         "msg": None
     }
+
 
 @shared_task(time_limit=30)
 @set_code_owner_attribute


### PR DESCRIPTION


## Description

This PR adds a management command to delete v1 content libraries. CLI options are given for a singular library, as well as all libraries. The command raises some errors related to grading, as it uses the code to delete courses, but that is something I can live with for a quick and dirty version of this capability. Also, the pruner will have to be run later to remove any orphan blocks left behind by removing the index.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-10639

## Testing instructions

1. Create a v1 library.
2. run  ./manage.py cms delete_v1_libraries 'library-v1:edx+eaa' in cms shell.
3. go to libraries home
4. see that your library has been removed from the list.
