### PR TITLE
feat: return denied when waffle flag disabled

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
@@ -12,6 +12,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.toggles import ENABLE_NEW_STUDIO_ADVANCED_SETTINGS_PAGE
 
+
 @override_waffle_flag(ENABLE_NEW_STUDIO_ADVANCED_SETTINGS_PAGE, active=True)
 @ddt.ddt
 class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
@@ -6,11 +6,13 @@ import json
 import ddt
 from django.test import override_settings
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from milestones.tests.utils import MilestonesTestCaseMixin
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.toggles import ENABLE_NEW_STUDIO_ADVANCED_SETTINGS_PAGE
 
-
+@override_waffle_flag(ENABLE_NEW_STUDIO_ADVANCED_SETTINGS_PAGE, active=True)
 @ddt.ddt
 class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
     """

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs.py
@@ -8,12 +8,15 @@ from urllib.parse import urlencode
 
 import ddt
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore.tests.factories import BlockFactory
 from xmodule.tabs import CourseTabList
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.toggles import ENABLE_NEW_STUDIO_CUSTOM_PAGES
 
 
+@override_waffle_flag(ENABLE_NEW_STUDIO_CUSTOM_PAGES, active=True)
 @ddt.ddt
 class TabsAPITests(CourseTestCase):
     """

--- a/cms/djangoapps/contentstore/rest_api/v0/views/tabs.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/tabs.py
@@ -79,6 +79,8 @@ class CourseTabListView(DeveloperErrorViewMixin, APIView):
         ```
         """
         course_key = CourseKey.from_string(course_id)
+        if not use_new_custom_pages(course_key):
+            return Response(status=status.HTTP_403_FORBIDDEN)
         if not has_studio_read_access(request.user, course_key):
             self.permission_denied(request)
 


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

The new Course Authoring MFEs are being rolled out to beta testers. Their access is dependent on a waffle flag for each page. To guarantee people who are not part of the beta testing group access the page, each of the API calls checks if the waffle flag is enabled. If the flag is not enabled, the API returns a 403 response, This response code will determine what is shown to the user in the MFE. This change impacts Authors.

## Supporting information

JIRA Ticket: [TNL-10916](https://2u-internal.atlassian.net/browse/TNL-10916)

## Testing instructions

1. Navigate to course authoring's [advanced settings page](http://localhost:2001/course/course-v1:krisEdx+ka101+2023-01/settings/advanced). The page should say under construction.
2. In Django Admin, enable `contentstore.new_studio_mfe.use_new_advanced_settings_page`
3. Navigate back to course authoring's [advanced settings page](http://localhost:2001/course/course-v1:krisEdx+ka101+2023-01/settings/advanced). The page should render the list/form of advanced settings.

## Deadline

None

## Other information

This change is connected to course-authoring [PR 537](https://github.com/openedx/frontend-app-course-authoring/pull/537). Use the branch in to connected PR for testing.
