### PR TITLE
feat: Add JwtAuthentication as a default DRF auth class.

### DIFF
--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -307,4 +307,4 @@ class BasketOrderViewTests(UserMixin, TestCase):
         """ The view should return 403 if the user is not logged in. """
         self.client.logout()
         response = self.client.get(self.path)
-        assert response.status_code == 403
+        assert response.status_code == 401

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3332,7 +3332,14 @@ CROSS_DOMAIN_CSRF_COOKIE_NAME = ''
 REST_FRAMEWORK = {
     # These default classes add observability around endpoints using defaults, and should
     # not be used anywhere else.
+    # Notes on Order:
+    # 1. `JwtAuthentication` does not check `is_active`, so email validation does not affect it. However,
+    #    `SessionAuthentication` does. These work differently, and order changes in what way, which really stinks. See
+    #    https://github.com/openedx/public-engineering/issues/165 for details.
+    # 2. `JwtAuthentication` may also update the database based on contents. Since the LMS creates these JWTs, this
+    #    shouldn't have any affect at this time. But it could, when and if another service started creating the JWTs.
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'openedx.core.djangolib.default_auth_classes.DefaultJwtAuthentication',
         'openedx.core.djangolib.default_auth_classes.DefaultSessionAuthentication',
     ],
     'DEFAULT_PAGINATION_CLASS': 'edx_rest_framework_extensions.paginators.DefaultPagination',

--- a/openedx/core/djangoapps/embargo/tests/test_views.py
+++ b/openedx/core/djangoapps/embargo/tests/test_views.py
@@ -148,7 +148,7 @@ class CheckCourseAccessViewTest(CourseApiFactoryMixin, ModuleStoreTestCase):
     def test_course_access_endpoint_with_logged_out_user(self):
         self.client.logout()
         response = self.client.get(self.url, data=self.request_data)
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     def test_course_access_endpoint_with_non_staff_user(self):
         user = UserFactory(is_staff=False)

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -150,12 +150,12 @@ class RoleTestCase(UserApiTestCase):
         self.assertHttpMethodNotAllowed(self.request_with_auth("delete", self.LIST_URI))
 
     def test_list_unauthorized(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     @override_settings(DEBUG=True)
     @override_settings(EDX_API_KEY=None)
     def test_debug_auth(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     @override_settings(DEBUG=False)
     @override_settings(EDX_API_KEY=TEST_API_KEY)
@@ -164,7 +164,7 @@ class RoleTestCase(UserApiTestCase):
         self.assertHttpOK(
             self.request_with_auth("get", self.LIST_URI,
                                    **self.basic_auth("someuser", "somepass")))
-        self.assertHttpForbidden(
+        self.assertHttpNotAuthorized(
             self.client.get(self.LIST_URI, **self.basic_auth("someuser", "somepass")))
 
     def test_get_list_nonempty(self):
@@ -236,12 +236,12 @@ class UserViewSetTest(UserApiTestCase):
         self.assertHttpMethodNotAllowed(self.request_with_auth("delete", self.LIST_URI))
 
     def test_list_unauthorized(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     @override_settings(DEBUG=True)
     @override_settings(EDX_API_KEY=None)
     def test_debug_auth(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     @override_settings(DEBUG=False)
     @override_settings(EDX_API_KEY=TEST_API_KEY)
@@ -250,7 +250,7 @@ class UserViewSetTest(UserApiTestCase):
         self.assertHttpOK(
             self.request_with_auth("get", self.LIST_URI,
                                    **self.basic_auth('someuser', 'somepass')))
-        self.assertHttpForbidden(
+        self.assertHttpNotAuthorized(
             self.client.get(self.LIST_URI, **self.basic_auth('someuser', 'somepass')))
 
     def test_get_list_nonempty(self):
@@ -303,7 +303,7 @@ class UserViewSetTest(UserApiTestCase):
         self.assertHttpMethodNotAllowed(self.request_with_auth("delete", self.detail_uri))
 
     def test_get_detail_unauthorized(self):
-        self.assertHttpForbidden(self.client.get(self.detail_uri))
+        self.assertHttpNotAuthorized(self.client.get(self.detail_uri))
 
     def test_get_detail(self):
         user = self.users[1]
@@ -342,12 +342,12 @@ class UserPreferenceViewSetTest(CacheIsolationTestCase, UserApiTestCase):
         self.assertHttpMethodNotAllowed(self.request_with_auth("delete", self.LIST_URI))
 
     def test_list_unauthorized(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     @override_settings(DEBUG=True)
     @override_settings(EDX_API_KEY=None)
     def test_debug_auth(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     def test_get_list_nonempty(self):
         result = self.get_json(self.LIST_URI)
@@ -433,7 +433,7 @@ class UserPreferenceViewSetTest(CacheIsolationTestCase, UserApiTestCase):
         self.assertHttpMethodNotAllowed(self.request_with_auth("delete", self.detail_uri))
 
     def test_detail_unauthorized(self):
-        self.assertHttpForbidden(self.client.get(self.detail_uri))
+        self.assertHttpNotAuthorized(self.client.get(self.detail_uri))
 
     def test_get_detail(self):
         pref = self.prefs[1]
@@ -466,12 +466,12 @@ class PreferenceUsersListViewTest(UserApiTestCase):
         self.assertHttpMethodNotAllowed(self.request_with_auth("delete", self.LIST_URI))
 
     def test_unauthorized(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     @override_settings(DEBUG=True)
     @override_settings(EDX_API_KEY=None)
     def test_debug_auth(self):
-        self.assertHttpForbidden(self.client.get(self.LIST_URI))
+        self.assertHttpNotAuthorized(self.client.get(self.LIST_URI))
 
     def test_get_basic(self):
         result = self.get_json(self.LIST_URI)
@@ -583,8 +583,8 @@ class UpdateEmailOptInTestCase(UserAPITestCase, SharedModuleStoreTestCase):
 
     def test_update_email_opt_in_anonymous_user(self):
         """
-        Test that an anonymous user gets 403 response when
-        updating email optin preference.
+        Test that an anonymous user gets 401 response when
+        updating email opt-in preference.
         """
         self.client.logout()
         response = self.client.post(self.url, {

--- a/openedx/core/lib/api/test_utils.py
+++ b/openedx/core/lib/api/test_utils.py
@@ -64,6 +64,10 @@ class ApiTestCase(TestCase):
         """Assert that the given response has the status code 201"""
         assert response.status_code == 201
 
+    def assertHttpNotAuthorized(self, response):
+        """Assert that the given response has the status code 401"""
+        assert response.status_code == 401
+
     def assertHttpForbidden(self, response):
         """Assert that the given response has the status code 403"""
         assert response.status_code == 403


### PR DESCRIPTION
By default DRF sets 'DEFAULT_AUTHENTICATION_CLASSES' to:

```
[
    'rest_framework.authentication.SessionAuthentication',
    'rest_framework.authentication.BasicAuthentication'
]
```

We also want to allow for JWT Authentication as a valid default auth
choice.  This will allow users to send JWT tokens in the authorization
header to any existing API endpoints and access them. If any APIs have
set custom authentication classes, this will not override that.

I believe this is a fairly safe change to make since it only adds one
authentication class and does not impact authorization of any of the
endpoints that might be affected.
