### PR TITLE
Studio content api videos

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -14,6 +14,7 @@ from .views import (
     xblock,
     assets,
     videos,
+    transcripts,
 )
 
 app_name = 'v1'
@@ -56,22 +57,26 @@ urlpatterns = [
     ),
     re_path(
         fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
-        videos.VideosView.as_view(), name='studio_content_videos'
+        videos.VideosView.as_view(), name='studio_content_videos_uploads'
     ),
     re_path(
         fr'^videos/images/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
-        videos.VideoImagesView.as_view(), name='studio_content_videos'
+        videos.VideoImagesView.as_view(), name='studio_content_videos_images'
     ),
     re_path(
         fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
-        videos.VideoEncodingsDownloadView.as_view(), name='studio_content_videos'
+        videos.VideoEncodingsDownloadView.as_view(), name='studio_content_videos_encodings'
     ),
     re_path(
         r'^videos/features/$',
-        videos.VideoFeaturesView.as_view(), name='studio_content_videos'
+        videos.VideoFeaturesView.as_view(), name='studio_content_videos_features'
     ),
     re_path(
         fr'^videos/upload_link/{settings.COURSE_ID_PATTERN}$',
-        videos.UploadLinkView.as_view(), name='studio_content_videos'
+        videos.UploadLinkView.as_view(), name='studio_content_videos_upload_link'
+    ),
+    re_path(
+        fr'^video_transcripts/{settings.COURSE_ID_PATTERN}$',
+        transcripts.TranscriptView.as_view(), name='studio_content_video_transcripts'
     ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -13,6 +13,7 @@ from .views import (
     ProctoringErrorsView,
     xblock,
     assets,
+    videos,
 )
 
 app_name = 'v1'

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -18,6 +18,8 @@ from .views import (
 
 app_name = 'v1'
 
+VIDEO_ID_PATTERN = r'(?:/(?P<edx_video_id>[-\w]+))'
+
 urlpatterns = [
     re_path(
         fr'^proctored_exam_settings/{COURSE_ID_PATTERN}$',
@@ -51,5 +53,25 @@ urlpatterns = [
     re_path(
         fr'^file_assets/{settings.COURSE_ID_PATTERN}/{settings.ASSET_KEY_PATTERN}?$',
         assets.AssetsView.as_view(), name='studio_content_assets'
+    ),
+    re_path(
+        fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
+        videos.VideosView.as_view(), name='studio_content_videos'
+    ),
+    re_path(
+        fr'^videos/images/{settings.COURSE_ID_PATTERN}$',
+        videos.VideosView.as_view(), name='studio_content_videos'
+    ),
+    re_path(
+        fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
+        videos.VideosView.as_view(), name='studio_content_videos'
+    ),
+    re_path(
+        r'^videos/features/$',
+        videos.VideosView.as_view(), name='studio_content_videos'
+    ),
+    re_path(
+        fr'^videos/upload_link/{settings.COURSE_ID_PATTERN}$',
+        videos.VideosView.as_view(), name='studio_content_videos'
     ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -18,7 +18,7 @@ from .views import (
 
 app_name = 'v1'
 
-VIDEO_ID_PATTERN = r'(?:/(?P<edx_video_id>[-\w]+))'
+VIDEO_ID_PATTERN = r'(?:(?P<edx_video_id>[-\w]+))'
 
 urlpatterns = [
     re_path(

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -59,19 +59,19 @@ urlpatterns = [
         videos.VideosView.as_view(), name='studio_content_videos'
     ),
     re_path(
-        fr'^videos/images/{settings.COURSE_ID_PATTERN}$',
-        videos.VideosView.as_view(), name='studio_content_videos'
+        fr'^videos/images/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
+        videos.VideoImagesView.as_view(), name='studio_content_videos'
     ),
     re_path(
         fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
-        videos.VideosView.as_view(), name='studio_content_videos'
+        videos.VideoEncodingsDownloadView.as_view(), name='studio_content_videos'
     ),
     re_path(
         r'^videos/features/$',
-        videos.VideosView.as_view(), name='studio_content_videos'
+        videos.VideoFeaturesView.as_view(), name='studio_content_videos'
     ),
     re_path(
         fr'^videos/upload_link/{settings.COURSE_ID_PATTERN}$',
-        videos.VideosView.as_view(), name='studio_content_videos'
+        videos.UploadLinkView.as_view(), name='studio_content_videos'
     ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -6,3 +6,5 @@ from .grading import CourseGradingView
 from .proctoring import ProctoredExamSettingsView, ProctoringErrorsView
 from .settings import CourseSettingsView
 from .xblock import XblockView
+from .assets import AssetsView
+from .videos import VideosView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/assets.py
@@ -1,4 +1,6 @@
-# lint-amnesty, pylint: disable=missing-module-docstring
+"""
+Public rest API endpoints for the Studio Content API Assets.
+"""
 import logging
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, CreateAPIView
 from django.views.decorators.csrf import csrf_exempt
@@ -19,7 +21,7 @@ toggles = contentstore_toggles
 @view_auth_classes()
 class AssetsView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView, CreateAPIView):
     """
-    public rest API endpoint for the Studio Content API.
+    public rest API endpoints for the Studio Content API Assets.
     course_key: required argument, needed to authorize course authors and identify the asset.
     asset_key_string: required argument, needed to identify the asset.
     """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/transcripts.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/transcripts.py
@@ -1,0 +1,62 @@
+"""
+Public rest API endpoints for the Studio Content API video assets.
+"""
+import logging
+from rest_framework.generics import (
+    CreateAPIView,
+    RetrieveAPIView,
+    DestroyAPIView
+)
+from django.views.decorators.csrf import csrf_exempt
+from django.http import Http404
+
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
+from common.djangoapps.util.json_request import expect_json_in_class_view
+
+from ....api import course_author_access_required
+
+from cms.djangoapps.contentstore.transcript_storage_handlers import (
+    upload_transcript,
+    delete_video_transcript_or_404,
+    handle_transcript_download,
+)
+import cms.djangoapps.contentstore.toggles as contentstore_toggles
+
+log = logging.getLogger(__name__)
+toggles = contentstore_toggles
+
+
+@view_auth_classes()
+class TranscriptView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, DestroyAPIView):
+    """
+    public rest API endpoints for the Studio Content API video transcripts.
+    course_key: required argument, needed to authorize course authors and identify the video.
+    edx_video_id: optional query parameter, needed to identify the transcript.
+    language_code: optional query parameter, needed to identify the transcript.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    @csrf_exempt
+    @course_author_access_required
+    @expect_json_in_class_view
+    def create(self, request, course_key_string):  # pylint: disable=arguments-differ
+        return upload_transcript(request)
+
+    @course_author_access_required
+    def retrieve(self, request, course_key_string):  # pylint: disable=arguments-differ
+        """
+        Get a video transcript. edx_video_id and language_code query parameters are required.
+        """
+        return handle_transcript_download(request)
+
+    @course_author_access_required
+    def destroy(self, request, course_key_string):  # pylint: disable=arguments-differ
+        """
+        Delete a video transcript. edx_video_id and language_code query parameters are required.
+        """
+
+        return delete_video_transcript_or_404(request)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -1,0 +1,158 @@
+"""
+Public rest API endpoints for the Studio Content API video assets.
+"""
+import logging
+from rest_framework.generics import (
+    CreateAPIView,
+    RetrieveAPIView,
+    DestroyAPIView
+)
+from django.views.decorators.csrf import csrf_exempt
+from django.http import Http404
+
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
+from common.djangoapps.util.json_request import expect_json_in_class_view
+
+from ....api import course_author_access_required
+
+from cms.djangoapps.contentstore.video_storage_handlers import (
+    handle_videos,
+    get_video_encodings_download,
+    handle_video_images,
+    enabled_video_features,
+    handle_generate_video_upload_link
+)
+import cms.djangoapps.contentstore.toggles as contentstore_toggles
+
+log = logging.getLogger(__name__)
+toggles = contentstore_toggles
+
+
+@view_auth_classes()
+class VideosView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, DestroyAPIView):
+    """
+    public rest API endpoints for the Studio Content API video assets.
+    course_key: required argument, needed to authorize course authors and identify the video.
+    video_id: required argument, needed to identify the video.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        # TODO: probably want to refactor this to a decorator.
+        """
+        The dispatch method of a View class handles HTTP requests in general
+        and calls other methods to handle specific HTTP methods.
+        We use this to raise a 404 if the content api is disabled.
+        """
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    @csrf_exempt
+    @course_author_access_required
+    def create(self, request, course_key):  # pylint: disable=arguments-differ
+        return handle_videos(request, course_key.html_id())
+
+
+    @course_author_access_required
+    @expect_json_in_class_view
+    def retrieve(self, request, course_key, edx_video_id):  # pylint: disable=arguments-differ
+        return handle_videos(request, course_key.html_id(), edx_video_id)
+
+
+    @course_author_access_required
+    @expect_json_in_class_view
+    def destroy(self, request, course_key, edx_video_id):  # pylint: disable=arguments-differ
+        return handle_videos(request, course_key.html_id(), edx_video_id)
+
+
+@view_auth_classes()
+class VideoImagesView(DeveloperErrorViewMixin, CreateAPIView):
+    """
+    public rest API endpoint for uploading a video image.
+    course_key: required argument, needed to authorize course authors and identify the video.
+    video_id: required argument, needed to identify the video.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        # TODO: probably want to refactor this to a decorator.
+        """
+        The dispatch method of a View class handles HTTP requests in general
+        and calls other methods to handle specific HTTP methods.
+        We use this to raise a 404 if the content api is disabled.
+        """
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    @csrf_exempt
+    @course_author_access_required
+    def create(self, request, course_key):  # pylint: disable=arguments-differ
+        return handle_video_images(request, course_key.html_id())
+
+
+@view_auth_classes()
+class VideoEncodingsDownloadView(DeveloperErrorViewMixin, RetrieveAPIView):
+    """
+    public rest API endpoint providing a CSV report containing the encoded video URLs for video uploads.
+    course_key: required argument, needed to authorize course authors and identify relevant videos.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        # TODO: probably want to refactor this to a decorator.
+        """
+        The dispatch method of a View class handles HTTP requests in general
+        and calls other methods to handle specific HTTP methods.
+        We use this to raise a 404 if the content api is disabled.
+        """
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    @csrf_exempt
+    @course_author_access_required
+    def retrieve(self, request, course_key):  # pylint: disable=arguments-differ
+        return get_video_encodings_download(request, course_key.html_id())
+
+@view_auth_classes()
+class VideoFeaturesView(DeveloperErrorViewMixin, RetrieveAPIView):
+    """
+    public rest API endpoint providing a list of enabled video features.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        # TODO: probably want to refactor this to a decorator.
+        """
+        The dispatch method of a View class handles HTTP requests in general
+        and calls other methods to handle specific HTTP methods.
+        We use this to raise a 404 if the content api is disabled.
+        """
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    @csrf_exempt
+    def retrieve(self, request):  # pylint: disable=arguments-differ
+        return enabled_video_features(request)
+
+
+@view_auth_classes()
+class UploadLinkView(DeveloperErrorViewMixin, CreateAPIView):
+    """
+    public rest API endpoint providing a list of enabled video features.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        # TODO: probably want to refactor this to a decorator.
+        """
+        The dispatch method of a View class handles HTTP requests in general
+        and calls other methods to handle specific HTTP methods.
+        We use this to raise a 404 if the content api is disabled.
+        """
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    @csrf_exempt
+    @course_author_access_required
+    def create(self, request, course_key):  # pylint: disable=arguments-differ
+        return handle_generate_video_upload_link(request, course_key.html_id())

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -55,7 +55,7 @@ class VideosView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, Destro
 
     @course_author_access_required
     @expect_json_in_class_view
-    def retrieve(self, request, course_key, edx_video_id):  # pylint: disable=arguments-differ
+    def retrieve(self, request, course_key, edx_video_id=None):  # pylint: disable=arguments-differ
         return handle_videos(request, course_key.html_id(), edx_video_id)
 
 
@@ -86,8 +86,8 @@ class VideoImagesView(DeveloperErrorViewMixin, CreateAPIView):
 
     @csrf_exempt
     @course_author_access_required
-    def create(self, request, course_key):  # pylint: disable=arguments-differ
-        return handle_video_images(request, course_key.html_id())
+    def create(self, request, course_key, edx_video_id=None):  # pylint: disable=arguments-differ
+        return handle_video_images(request, course_key.html_id(), edx_video_id)
 
 
 @view_auth_classes()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -49,12 +49,12 @@ class VideosView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, Destro
 
     @csrf_exempt
     @course_author_access_required
+    @expect_json_in_class_view
     def create(self, request, course_key):  # pylint: disable=arguments-differ
         return handle_videos(request, course_key.html_id())
 
 
     @course_author_access_required
-    @expect_json_in_class_view
     def retrieve(self, request, course_key, edx_video_id=None):  # pylint: disable=arguments-differ
         return handle_videos(request, course_key.html_id(), edx_video_id)
 
@@ -86,6 +86,7 @@ class VideoImagesView(DeveloperErrorViewMixin, CreateAPIView):
 
     @csrf_exempt
     @course_author_access_required
+    @expect_json_in_class_view
     def create(self, request, course_key, edx_video_id=None):  # pylint: disable=arguments-differ
         return handle_video_images(request, course_key.html_id(), edx_video_id)
 
@@ -154,5 +155,6 @@ class UploadLinkView(DeveloperErrorViewMixin, CreateAPIView):
 
     @csrf_exempt
     @course_author_access_required
+    @expect_json_in_class_view
     def create(self, request, course_key):  # pylint: disable=arguments-differ
         return handle_generate_video_upload_link(request, course_key.html_id())

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -53,11 +53,9 @@ class VideosView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, Destro
     def create(self, request, course_key):  # pylint: disable=arguments-differ
         return handle_videos(request, course_key.html_id())
 
-
     @course_author_access_required
     def retrieve(self, request, course_key, edx_video_id=None):  # pylint: disable=arguments-differ
         return handle_videos(request, course_key.html_id(), edx_video_id)
-
 
     @course_author_access_required
     @expect_json_in_class_view
@@ -113,6 +111,7 @@ class VideoEncodingsDownloadView(DeveloperErrorViewMixin, RetrieveAPIView):
     @course_author_access_required
     def retrieve(self, request, course_key):  # pylint: disable=arguments-differ
         return get_video_encodings_download(request, course_key.html_id())
+
 
 @view_auth_classes()
 class VideoFeaturesView(DeveloperErrorViewMixin, RetrieveAPIView):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
@@ -1,4 +1,6 @@
-# lint-amnesty, pylint: disable=missing-module-docstring
+"""
+Public rest API endpoints for the Studio Content API.
+"""
 import logging
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, CreateAPIView
 from django.views.decorators.csrf import csrf_exempt
@@ -20,7 +22,7 @@ handle_xblock = view_handlers.handle_xblock
 @view_auth_classes()
 class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView, CreateAPIView):
     """
-    public rest API endpoint for the Studio Content API.
+    Public rest API endpoints for the Studio Content API.
     course_key: required argument, needed to authorize course authors.
     usage_key_string (optional):
     xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -497,6 +497,25 @@ def use_new_course_team_page(course_key):
     return ENABLE_NEW_STUDIO_COURSE_TEAM_PAGE.is_enabled(course_key)
 
 
+# .. toggle_name: contentstore.mock_video_uploads
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag mocks contentstore video uploads for local development, if you don't have access to AWS
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-7-25
+# .. toggle_tickets: TNL-10897
+# .. toggle_warning:
+MOCK_VIDEO_UPLOADS = WaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.mock_video_uploads', __name__)
+
+
+def use_mock_video_uploads():
+    """
+    Returns a boolean if video uploads should be mocked for local development
+    """
+    return MOCK_VIDEO_UPLOADS.is_enabled()
+
+
 # .. toggle_name: contentstore.default_enable_flexible_peer_openassessments
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -229,5 +229,6 @@ def validate_transcript_upload_data(data, files):
 
     return error
 
+
 def delete_video_transcript(video_id=None, language_code=None):
     return delete_video_transcript_source_function(video_id=video_id, language_code=language_code)

--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -1,0 +1,233 @@
+"""
+Business logic for video transcripts.
+"""
+
+
+import logging
+import os
+
+from django.core.files.base import ContentFile
+from django.http import HttpResponse, HttpResponseNotFound
+from django.utils.translation import gettext as _
+from edxval.api import (
+    create_or_update_video_transcript,
+    delete_video_transcript as delete_video_transcript_source_function,
+    get_3rd_party_transcription_plans,
+    get_available_transcript_languages,
+    get_video_transcript_data,
+    update_transcript_credentials_state_for_org
+)
+from opaque_keys.edx.keys import CourseKey
+
+from common.djangoapps.util.json_request import JsonResponse
+from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
+from openedx.core.djangoapps.video_pipeline.api import update_3rd_party_transcription_service_credentials
+from xmodule.video_block.transcripts_utils import Transcript, TranscriptsGenerationException  # lint-amnesty, pylint: disable=wrong-import-order
+
+from .video_storage_handlers import TranscriptProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TranscriptionProviderErrorType:
+    """
+    Transcription provider's error types enumeration.
+    """
+    INVALID_CREDENTIALS = 1
+
+
+def validate_transcript_credentials(provider, **credentials):
+    """
+    Validates transcript credentials.
+
+    Validations:
+        Providers must be either 3PlayMedia or Cielo24.
+        In case of:
+            3PlayMedia - 'api_key' and 'api_secret_key' are required.
+            Cielo24 - 'api_key' and 'username' are required.
+
+        It ignores any extra/unrelated parameters passed in credentials and
+        only returns the validated ones.
+    """
+    error_message, validated_credentials = '', {}
+    valid_providers = list(get_3rd_party_transcription_plans().keys())
+    if provider in valid_providers:
+        must_have_props = []
+        if provider == TranscriptProvider.THREE_PLAY_MEDIA:
+            must_have_props = ['api_key', 'api_secret_key']
+        elif provider == TranscriptProvider.CIELO24:
+            must_have_props = ['api_key', 'username']
+
+        missing = [
+            must_have_prop for must_have_prop in must_have_props if must_have_prop not in list(credentials.keys())   # lint-amnesty, pylint: disable=consider-iterating-dictionary
+        ]
+        if missing:
+            error_message = '{missing} must be specified.'.format(missing=' and '.join(missing))
+            return error_message, validated_credentials
+
+        validated_credentials.update({
+            prop: credentials[prop] for prop in must_have_props
+        })
+    else:
+        error_message = f'Invalid Provider {provider}.'
+
+    return error_message, validated_credentials
+
+
+def handle_transcript_credentials(request, course_key_string):
+    """
+    JSON view handler to update the transcript organization credentials.
+
+    Arguments:
+        request: WSGI request object
+        course_key_string: A course identifier to extract the org.
+
+    Returns:
+        - A 200 response if credentials are valid and successfully updated in edx-video-pipeline.
+        - A 404 response if transcript feature is not enabled for this course.
+        - A 400 if credentials do not pass validations, hence not updated in edx-video-pipeline.
+    """
+    course_key = CourseKey.from_string(course_key_string)
+    if not VideoTranscriptEnabledFlag.feature_enabled(course_key):
+        return HttpResponseNotFound()
+
+    provider = request.json.pop('provider')
+    error_message, validated_credentials = validate_transcript_credentials(provider=provider, **request.json)
+    if error_message:
+        response = JsonResponse({'error': error_message}, status=400)
+    else:
+        # Send the validated credentials to edx-video-pipeline and video-encode-manager
+        credentials_payload = dict(validated_credentials, org=course_key.org, provider=provider)
+        error_response, is_updated = update_3rd_party_transcription_service_credentials(**credentials_payload)
+        # Send appropriate response based on whether credentials were updated or not.
+        if is_updated:
+            # Cache credentials state in edx-val.
+            update_transcript_credentials_state_for_org(org=course_key.org, provider=provider, exists=is_updated)
+            response = JsonResponse(status=200)
+        else:
+            # Error response would contain error types and the following
+            # error type is received from edx-video-pipeline whenever we've
+            # got invalid credentials for a provider. Its kept this way because
+            # edx-video-pipeline doesn't support i18n translations yet.
+            error_type = error_response.get('error_type')
+            if error_type == TranscriptionProviderErrorType.INVALID_CREDENTIALS:
+                error_message = _('The information you entered is incorrect.')
+
+            response = JsonResponse({'error': error_message}, status=400)
+
+    return response
+
+
+def handle_transcript_download(request):
+    """
+    JSON view handler to download a transcript.
+
+    Arguments:
+        request: WSGI request object
+
+    Returns:
+        - A 200 response with SRT transcript file attached.
+        - A 400 if there is a validation error.
+        - A 404 if there is no such transcript.
+    """
+    missing = [attr for attr in ['edx_video_id', 'language_code'] if attr not in request.GET]
+    if missing:
+        return JsonResponse(
+            {'error': _('The following parameters are required: {missing}.').format(missing=', '.join(missing))},
+            status=400
+        )
+
+    edx_video_id = request.GET['edx_video_id']
+    language_code = request.GET['language_code']
+    transcript = get_video_transcript_data(video_id=edx_video_id, language_code=language_code)
+    if transcript:
+        name_and_extension = os.path.splitext(transcript['file_name'])
+        basename, file_format = name_and_extension[0], name_and_extension[1][1:]
+        transcript_filename = f'{basename}.{Transcript.SRT}'
+        transcript_content = Transcript.convert(
+            content=transcript['content'],
+            input_format=file_format,
+            output_format=Transcript.SRT
+        )
+        # Construct an HTTP response
+        response = HttpResponse(transcript_content, content_type=Transcript.mime_types[Transcript.SRT])
+        response['Content-Disposition'] = f'attachment; filename="{transcript_filename}"'
+    else:
+        response = HttpResponseNotFound()
+
+    return response
+
+
+def upload_transcript(request):
+    """
+    Upload a transcript file
+
+    Arguments:
+        request: A WSGI request object
+
+        Transcript file in SRT format
+    """
+    edx_video_id = request.POST['edx_video_id']
+    language_code = request.POST['language_code']
+    new_language_code = request.POST['new_language_code']
+    transcript_file = request.FILES['file']
+    try:
+        # Convert SRT transcript into an SJSON format
+        # and upload it to S3.
+        sjson_subs = Transcript.convert(
+            content=transcript_file.read().decode('utf-8'),
+            input_format=Transcript.SRT,
+            output_format=Transcript.SJSON
+        ).encode()
+        create_or_update_video_transcript(
+            video_id=edx_video_id,
+            language_code=language_code,
+            metadata={
+                'provider': TranscriptProvider.CUSTOM,
+                'file_format': Transcript.SJSON,
+                'language_code': new_language_code
+            },
+            file_data=ContentFile(sjson_subs),
+        )
+        response = JsonResponse(status=201)
+    except (TranscriptsGenerationException, UnicodeDecodeError):
+        LOGGER.error("Unable to update transcript on edX video %s for language %s", edx_video_id, new_language_code)
+        response = JsonResponse(
+            {'error': _('There is a problem with this transcript file. Try to upload a different file.')},
+            status=400
+        )
+    finally:
+        LOGGER.info("Updated transcript on edX video %s for language %s", edx_video_id, new_language_code)
+    return response
+
+
+def validate_transcript_upload_data(data, files):
+    """
+    Validates video transcript file.
+    Arguments:
+        data: A request's data part.
+        files: A request's files part.
+    Returns:
+        None or String
+        If there is error returns error message otherwise None.
+    """
+    error = None
+    # Validate the must have attributes - this error is unlikely to be faced by common users.
+    must_have_attrs = ['edx_video_id', 'language_code', 'new_language_code']
+    missing = [attr for attr in must_have_attrs if attr not in data]
+    if missing:
+        error = _('The following parameters are required: {missing}.').format(missing=', '.join(missing))
+    elif (
+        data['language_code'] != data['new_language_code'] and
+        data['new_language_code'] in get_available_transcript_languages(video_id=data['edx_video_id'])
+    ):
+        error = _('A transcript with the "{language_code}" language code already exists.'.format(  # lint-amnesty, pylint: disable=translation-of-non-string
+            language_code=data['new_language_code']
+        ))
+    elif 'file' not in files:
+        error = _('A transcript file is required.')
+
+    return error
+
+def delete_video_transcript(video_id=None, language_code=None):
+    return delete_video_transcript_source_function(video_id=video_id, language_code=language_code)

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -174,15 +174,6 @@ class StatusDisplayStrings:
         return _(StatusDisplayStrings._STATUS_MAP.get(val_status, StatusDisplayStrings._UNKNOWN))
 
 
-def _get_videos_post_method():
-    """
-    Return the appropriate method for creating a video upload
-    """
-    if use_mock_video_uploads():
-        return videos_post_mock
-    return videos_post
-
-
 def handle_videos(request, course_key_string, edx_video_id=None):
     """
     Restful handler for video uploads.
@@ -232,9 +223,7 @@ def handle_videos(request, course_key_string, edx_video_id=None):
         elif _is_pagination_context_update_request(request):
             return _update_pagination_context(request)
 
-        post_videos = _get_videos_post_method()
-
-        data, status = post_videos(course, request)
+        data, status = videos_post(course, request)
         return JsonResponse(data, status=status)
 
 
@@ -247,9 +236,7 @@ def handle_generate_video_upload_link(request, course_key_string):
     if not course:
         return Response(data='Course Not Found', status=rest_status.HTTP_400_BAD_REQUEST)
 
-    post_videos = _get_videos_post_method()
-
-    data, status = post_videos(course, request)
+    data, status = videos_post(course, request)
     return Response(data, status=status)
 
 
@@ -724,9 +711,6 @@ def videos_index_json(course):
     return JsonResponse({"videos": index_videos}, status=200)
 
 
-def videos_post_mock(_course, _request):
-    return {'files': [{'file_name': 'video.mp4', 'upload_url': 'http://example.com/put_video'}]}, 200
-
 def videos_post(course, request):
     """
     Input (JSON):
@@ -747,6 +731,10 @@ def videos_post(course, request):
 
     The returned array corresponds exactly to the input array.
     """
+
+    if (use_mock_video_uploads()):
+        return {'files': [{'file_name': 'video.mp4', 'upload_url': 'http://example.com/put_video'}]}, 200
+
     error = None
     data = request.json
     if 'files' not in data:

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -244,7 +244,7 @@ def handle_video_images(request, course_key_string, edx_video_id=None):
     """Function to handle image files"""
 
     # respond with a 404 if image upload is not enabled.
-    if not VIDEO_IMAGE_UPLOAD_ENABLED.is_enabled():
+    if not VIDEO_IMAGE_UPLOAD_ENABLED.is_enabled() and not use_mock_video_uploads():
         return HttpResponseNotFound()
 
     if 'file' not in request.FILES:

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -14,14 +14,12 @@ from uuid import uuid4
 from boto.s3.connection import S3Connection
 from boto import s3
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import FileResponse, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_noop
-from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from edx_toggles.toggles import WaffleSwitch
 from edxval.api import (
     SortDirection,
@@ -42,11 +40,10 @@ from edxval.api import (
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from rest_framework import status as rest_status
-from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
-from common.djangoapps.util.json_request import JsonResponse, expect_json
+from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
 from openedx.core.djangoapps.video_pipeline.config.waffle import (
@@ -54,7 +51,6 @@ from openedx.core.djangoapps.video_pipeline.config.waffle import (
     ENABLE_DEVSTACK_VIDEO_UPLOADS,
 )
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
-from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.video_block.transcripts_utils import Transcript  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .models import VideoUploadConfig
@@ -732,7 +728,7 @@ def videos_post(course, request):
     The returned array corresponds exactly to the input array.
     """
 
-    if (use_mock_video_uploads()):
+    if use_mock_video_uploads():
         return {'files': [{'file_name': 'video.mp4', 'upload_url': 'http://example.com/put_video'}]}, 200
 
     error = None

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -12,12 +12,15 @@ from django.urls import reverse
 from edxval import api
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.transcript_storage_handlers import (
+    TranscriptionProviderErrorType,
+    validate_transcript_credentials
+)
 from cms.djangoapps.contentstore.utils import reverse_course_url
 from common.djangoapps.student.roles import CourseStaffRole
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 
-from ..transcript_settings import TranscriptionProviderErrorType, validate_transcript_credentials
 
 
 @ddt.ddt
@@ -94,7 +97,7 @@ class TranscriptCredentialsTest(CourseTestCase):
         )
     )
     @ddt.unpack
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.update_3rd_party_transcription_service_credentials')
+    @patch('cms.djangoapps.contentstore.transcript_storage_handlers.update_3rd_party_transcription_service_credentials')
     def test_transcript_credentials_handler(self, request_payload, update_credentials_response, expected_status_code,
                                             expected_response, mock_update_credentials):
         """
@@ -211,7 +214,7 @@ class TranscriptDownloadTest(CourseTestCase):
         response = self.client.post(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_video_transcript_data')
+    @patch('cms.djangoapps.contentstore.transcript_storage_handlers.get_video_transcript_data')
     def test_transcript_download_handler(self, mock_get_video_transcript_data):
         """
         Tests that transcript download handler works as expected.
@@ -303,7 +306,7 @@ class TranscriptUploadTest(CourseTestCase):
         response = self.client.get(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript')
+    @patch('cms.djangoapps.contentstore.transcript_storage_handlers.create_or_update_video_transcript')
     @patch(
         'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
         Mock(return_value=['en']),
@@ -383,7 +386,7 @@ class TranscriptUploadTest(CourseTestCase):
         self.assertEqual(json.loads(response.content.decode('utf-8'))['error'], expected_error_message)
 
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en', 'es'])
     )
     def test_transcript_upload_handler_existing_transcript(self):
@@ -405,7 +408,7 @@ class TranscriptUploadTest(CourseTestCase):
         )
 
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler_with_image(self):
@@ -432,7 +435,7 @@ class TranscriptUploadTest(CourseTestCase):
             )
 
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler_with_invalid_transcript(self):
@@ -588,9 +591,9 @@ class TranscriptUploadApiTest(CourseTestCase):
         response = self.client.get(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript')
+    @patch('cms.djangoapps.contentstore.transcript_storage_handlers.create_or_update_video_transcript')
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler(self, mock_create_or_update_video_transcript):
@@ -668,7 +671,7 @@ class TranscriptUploadApiTest(CourseTestCase):
         self.assertEqual(json.loads(response.content.decode('utf-8'))['error'], expected_error_message)
 
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en', 'es'])
     )
     def test_transcript_upload_handler_existing_transcript(self):

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -22,7 +22,6 @@ from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 
 
-
 @ddt.ddt
 @patch(
     'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -307,7 +307,7 @@ class TranscriptUploadTest(CourseTestCase):
 
     @patch('cms.djangoapps.contentstore.transcript_storage_handlers.create_or_update_video_transcript')
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler(self, mock_create_or_update_video_transcript):
@@ -372,7 +372,7 @@ class TranscriptUploadTest(CourseTestCase):
     )
     @ddt.unpack
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler_missing_attrs(self, request_payload, expected_error_message):
@@ -657,7 +657,7 @@ class TranscriptUploadApiTest(CourseTestCase):
     )
     @ddt.unpack
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler_missing_attrs(self, request_payload, expected_error_message):
@@ -692,7 +692,7 @@ class TranscriptUploadApiTest(CourseTestCase):
         )
 
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler_with_image(self):
@@ -719,7 +719,7 @@ class TranscriptUploadApiTest(CourseTestCase):
             )
 
     @patch(
-        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        'cms.djangoapps.contentstore.transcript_storage_handlers.get_available_transcript_languages',
         Mock(return_value=['en']),
     )
     def test_transcript_upload_handler_with_invalid_transcript(self):

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -210,7 +210,7 @@ class VideoUploadPostTestsMixin:
     """
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.views.videos.S3Connection')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
     def test_post_success(self, mock_conn, mock_key):
         files = [
             {
@@ -552,7 +552,7 @@ class VideosHandlerTestCase(
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret', AWS_SECURITY_TOKEN='token')
     @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.views.videos.S3Connection')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
     @override_waffle_flag(ENABLE_DEVSTACK_VIDEO_UPLOADS, active=True)
     def test_devstack_upload_connection(self, mock_conn, mock_key):
         files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
@@ -580,7 +580,7 @@ class VideosHandlerTestCase(
         )
 
     @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.views.videos.S3Connection')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
     def test_send_course_to_vem_pipeline(self, mock_conn, mock_key):
         """
         Test that uploads always go to VEM S3 bucket by default.
@@ -770,7 +770,7 @@ class VideosHandlerTestCase(
         # Test should fail if video not found
         self.assertEqual(True, False, 'Invalid edx_video_id')
 
-    @patch('cms.djangoapps.contentstore.views.videos.LOGGER')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.LOGGER')
     def test_video_status_update_request(self, mock_logger):
         """
         Verifies that video status update request works as expected.
@@ -1447,8 +1447,8 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
     @ddt.unpack
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.views.videos.S3Connection')
-    @patch('cms.djangoapps.contentstore.views.videos.get_transcript_preferences')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.get_transcript_preferences')
     def test_transcript_preferences_metadata(self, transcript_preferences, is_video_transcript_enabled,
                                              mock_transcript_preferences, mock_conn, mock_key):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -46,9 +46,9 @@ from ..videos import (
     PUBLIC_VIDEO_SHARE,
     StatusDisplayStrings,
     TranscriptProvider,
-    _get_default_video_image_url,
     convert_video_status, storage_service_bucket, storage_service_key
 )
+from cms.djangoapps.contentstore.video_storage_handlers import  _get_default_video_image_url
 
 
 class VideoUploadTestBase:

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -43,12 +43,16 @@ from ..videos import (
     ENABLE_VIDEO_UPLOAD_PAGINATION,
     KEY_EXPIRATION_IN_SECONDS,
     VIDEO_IMAGE_UPLOAD_ENABLED,
-    PUBLIC_VIDEO_SHARE,
-    StatusDisplayStrings,
-    TranscriptProvider,
-    convert_video_status, storage_service_bucket, storage_service_key
 )
-from cms.djangoapps.contentstore.video_storage_handlers import _get_default_video_image_url
+from cms.djangoapps.contentstore.video_storage_handlers import (
+    _get_default_video_image_url,
+    TranscriptProvider,
+    StatusDisplayStrings,
+    convert_video_status,
+    storage_service_bucket,
+    storage_service_key,
+    PUBLIC_VIDEO_SHARE
+)
 
 
 class VideoUploadTestBase:

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -471,7 +471,7 @@ class VideosHandlerTestCase(
 
     @override_settings(AWS_ACCESS_KEY_ID="test_key_id", AWS_SECRET_ACCESS_KEY="test_secret")
     @patch("boto.s3.key.Key")
-    @patch("cms.djangoapps.contentstore.views.videos.S3Connection")
+    @patch("cms.djangoapps.contentstore.video_storage_handlers.S3Connection")
     @ddt.data(
         (
             [
@@ -533,7 +533,7 @@ class VideosHandlerTestCase(
             self.assertEqual(response['error'], "Request 'files' entry contain unsupported content_type")
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('cms.djangoapps.contentstore.views.videos.S3Connection')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
     def test_upload_with_non_ascii_charaters(self, mock_conn):
         """
         Test that video uploads throws error message when file name contains special characters.
@@ -614,7 +614,7 @@ class VideosHandlerTestCase(
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @patch('boto.s3.key.Key')
-    @patch('cms.djangoapps.contentstore.views.videos.S3Connection')
+    @patch('cms.djangoapps.contentstore.video_storage_handlers.S3Connection')
     @ddt.data(
         {
             'global_waffle': True,

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -48,7 +48,7 @@ from ..videos import (
     TranscriptProvider,
     convert_video_status, storage_service_bucket, storage_service_key
 )
-from cms.djangoapps.contentstore.video_storage_handlers import  _get_default_video_image_url
+from cms.djangoapps.contentstore.video_storage_handlers import _get_default_video_image_url
 
 
 class VideoUploadTestBase:

--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -4,19 +4,11 @@ Views related to the transcript preferences feature
 
 
 import logging
-import os
 
 from django.contrib.auth.decorators import login_required
-from django.core.files.base import ContentFile
-from django.http import HttpResponse, HttpResponseNotFound
+from django.http import HttpResponseNotFound
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
-from edxval.api import (
-    get_3rd_party_transcription_plans,
-    get_available_transcript_languages,
-    get_video_transcript_data,
-    update_transcript_credentials_state_for_org
-)
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.decorators import api_view
 
@@ -24,19 +16,12 @@ from cms.djangoapps.contentstore.transcript_storage_handlers import (
     validate_transcript_upload_data,
     upload_transcript,
     delete_video_transcript,
-    validate_transcript_credentials,
     handle_transcript_credentials,
     handle_transcript_download,
-    TranscriptionProviderErrorType,
 )
 from common.djangoapps.student.auth import has_studio_write_access
 from common.djangoapps.util.json_request import JsonResponse, expect_json
-from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
-from openedx.core.djangoapps.video_pipeline.api import update_3rd_party_transcription_service_credentials
 from openedx.core.lib.api.view_utils import view_auth_classes
-from xmodule.video_block.transcripts_utils import Transcript, TranscriptsGenerationException  # lint-amnesty, pylint: disable=wrong-import-order
-
-from .videos import TranscriptProvider
 
 __all__ = [
     'transcript_credentials_handler',

--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -7,7 +7,6 @@ import logging
 
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseNotFound
-from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.decorators import api_view

--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -12,8 +12,6 @@ from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from edxval.api import (
-    create_or_update_video_transcript,
-    delete_video_transcript,
     get_3rd_party_transcription_plans,
     get_available_transcript_languages,
     get_video_transcript_data,
@@ -22,6 +20,15 @@ from edxval.api import (
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.decorators import api_view
 
+from cms.djangoapps.contentstore.transcript_storage_handlers import (
+    validate_transcript_upload_data,
+    upload_transcript,
+    delete_video_transcript,
+    validate_transcript_credentials,
+    handle_transcript_credentials,
+    handle_transcript_download,
+    TranscriptionProviderErrorType,
+)
 from common.djangoapps.student.auth import has_studio_write_access
 from common.djangoapps.util.json_request import JsonResponse, expect_json
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
@@ -42,51 +49,6 @@ __all__ = [
 LOGGER = logging.getLogger(__name__)
 
 
-class TranscriptionProviderErrorType:
-    """
-    Transcription provider's error types enumeration.
-    """
-    INVALID_CREDENTIALS = 1
-
-
-def validate_transcript_credentials(provider, **credentials):
-    """
-    Validates transcript credentials.
-
-    Validations:
-        Providers must be either 3PlayMedia or Cielo24.
-        In case of:
-            3PlayMedia - 'api_key' and 'api_secret_key' are required.
-            Cielo24 - 'api_key' and 'username' are required.
-
-        It ignores any extra/unrelated parameters passed in credentials and
-        only returns the validated ones.
-    """
-    error_message, validated_credentials = '', {}
-    valid_providers = list(get_3rd_party_transcription_plans().keys())
-    if provider in valid_providers:
-        must_have_props = []
-        if provider == TranscriptProvider.THREE_PLAY_MEDIA:
-            must_have_props = ['api_key', 'api_secret_key']
-        elif provider == TranscriptProvider.CIELO24:
-            must_have_props = ['api_key', 'username']
-
-        missing = [
-            must_have_prop for must_have_prop in must_have_props if must_have_prop not in list(credentials.keys())   # lint-amnesty, pylint: disable=consider-iterating-dictionary
-        ]
-        if missing:
-            error_message = '{missing} must be specified.'.format(missing=' and '.join(missing))
-            return error_message, validated_credentials
-
-        validated_credentials.update({
-            prop: credentials[prop] for prop in must_have_props
-        })
-    else:
-        error_message = f'Invalid Provider {provider}.'
-
-    return error_message, validated_credentials
-
-
 @expect_json
 @login_required
 @require_POST
@@ -103,35 +65,7 @@ def transcript_credentials_handler(request, course_key_string):
         - A 404 response if transcript feature is not enabled for this course.
         - A 400 if credentials do not pass validations, hence not updated in edx-video-pipeline.
     """
-    course_key = CourseKey.from_string(course_key_string)
-    if not VideoTranscriptEnabledFlag.feature_enabled(course_key):
-        return HttpResponseNotFound()
-
-    provider = request.json.pop('provider')
-    error_message, validated_credentials = validate_transcript_credentials(provider=provider, **request.json)
-    if error_message:
-        response = JsonResponse({'error': error_message}, status=400)
-    else:
-        # Send the validated credentials to edx-video-pipeline and video-encode-manager
-        credentials_payload = dict(validated_credentials, org=course_key.org, provider=provider)
-        error_response, is_updated = update_3rd_party_transcription_service_credentials(**credentials_payload)
-        # Send appropriate response based on whether credentials were updated or not.
-        if is_updated:
-            # Cache credentials state in edx-val.
-            update_transcript_credentials_state_for_org(org=course_key.org, provider=provider, exists=is_updated)
-            response = JsonResponse(status=200)
-        else:
-            # Error response would contain error types and the following
-            # error type is received from edx-video-pipeline whenever we've
-            # got invalid credentials for a provider. Its kept this way because
-            # edx-video-pipeline doesn't support i18n translations yet.
-            error_type = error_response.get('error_type')
-            if error_type == TranscriptionProviderErrorType.INVALID_CREDENTIALS:
-                error_message = _('The information you entered is incorrect.')
-
-            response = JsonResponse({'error': error_message}, status=400)
-
-    return response
+    return handle_transcript_credentials(request, course_key_string)
 
 
 @login_required
@@ -148,112 +82,17 @@ def transcript_download_handler(request):
         - A 400 if there is a validation error.
         - A 404 if there is no such transcript.
     """
-    missing = [attr for attr in ['edx_video_id', 'language_code'] if attr not in request.GET]
-    if missing:
-        return JsonResponse(
-            {'error': _('The following parameters are required: {missing}.').format(missing=', '.join(missing))},
-            status=400
-        )
-
-    edx_video_id = request.GET['edx_video_id']
-    language_code = request.GET['language_code']
-    transcript = get_video_transcript_data(video_id=edx_video_id, language_code=language_code)
-    if transcript:
-        name_and_extension = os.path.splitext(transcript['file_name'])
-        basename, file_format = name_and_extension[0], name_and_extension[1][1:]
-        transcript_filename = f'{basename}.{Transcript.SRT}'
-        transcript_content = Transcript.convert(
-            content=transcript['content'],
-            input_format=file_format,
-            output_format=Transcript.SRT
-        )
-        # Construct an HTTP response
-        response = HttpResponse(transcript_content, content_type=Transcript.mime_types[Transcript.SRT])
-        response['Content-Disposition'] = f'attachment; filename="{transcript_filename}"'
-    else:
-        response = HttpResponseNotFound()
-
-    return response
+    return handle_transcript_download(request)
 
 
-def upload_transcript(request):
-    """
-    Upload a transcript file
-
-    Arguments:
-        request: A WSGI request object
-
-        Transcript file in SRT format
-    """
-    edx_video_id = request.POST['edx_video_id']
-    language_code = request.POST['language_code']
-    new_language_code = request.POST['new_language_code']
-    transcript_file = request.FILES['file']
-    try:
-        # Convert SRT transcript into an SJSON format
-        # and upload it to S3.
-        sjson_subs = Transcript.convert(
-            content=transcript_file.read().decode('utf-8'),
-            input_format=Transcript.SRT,
-            output_format=Transcript.SJSON
-        ).encode()
-        create_or_update_video_transcript(
-            video_id=edx_video_id,
-            language_code=language_code,
-            metadata={
-                'provider': TranscriptProvider.CUSTOM,
-                'file_format': Transcript.SJSON,
-                'language_code': new_language_code
-            },
-            file_data=ContentFile(sjson_subs),
-        )
-        response = JsonResponse(status=201)
-    except (TranscriptsGenerationException, UnicodeDecodeError):
-        LOGGER.error("Unable to update transcript on edX video %s for language %s", edx_video_id, new_language_code)
-        response = JsonResponse(
-            {'error': _('There is a problem with this transcript file. Try to upload a different file.')},
-            status=400
-        )
-    finally:
-        LOGGER.info("Updated transcript on edX video %s for language %s", edx_video_id, new_language_code)
-    return response
-
-
-def validate_transcript_upload_data(data, files):
-    """
-    Validates video transcript file.
-    Arguments:
-        data: A request's data part.
-        files: A request's files part.
-    Returns:
-        None or String
-        If there is error returns error message otherwise None.
-    """
-    error = None
-    # Validate the must have attributes - this error is unlikely to be faced by common users.
-    must_have_attrs = ['edx_video_id', 'language_code', 'new_language_code']
-    missing = [attr for attr in must_have_attrs if attr not in data]
-    if missing:
-        error = _('The following parameters are required: {missing}.').format(missing=', '.join(missing))
-    elif (
-        data['language_code'] != data['new_language_code'] and
-        data['new_language_code'] in get_available_transcript_languages(video_id=data['edx_video_id'])
-    ):
-        error = _('A transcript with the "{language_code}" language code already exists.'.format(  # lint-amnesty, pylint: disable=translation-of-non-string
-            language_code=data['new_language_code']
-        ))
-    elif 'file' not in files:
-        error = _('A transcript file is required.')
-
-    return error
-
-
+# New version of this transcript upload API in contentstore/rest_api/transcripts.py
+# Keeping the old API for backward compatibility
 @api_view(['POST'])
 @view_auth_classes()
 @expect_json
 def transcript_upload_api(request):
     """
-    API View for uploading transcript files.
+    (Old) API View for uploading transcript files.
 
     Arguments:
         request: A WSGI request object

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -21,7 +21,7 @@ from edxval.api import create_external_video, create_or_update_video_transcript
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
 
-from cms.djangoapps.contentstore.views.videos import TranscriptProvider
+from cms.djangoapps.contentstore.video_storage_handlers import TranscriptProvider
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.util.json_request import JsonResponse
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -5,7 +5,6 @@ Views related to the video upload feature
 
 import logging
 from django.contrib.auth.decorators import login_required
-from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from edx_toggles.toggles import WaffleSwitch
 from rest_framework.decorators import api_view

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -3,51 +3,14 @@ Views related to the video upload feature
 """
 
 
-import codecs
-import csv
-import io
-import json
 import logging
-from contextlib import closing
-from datetime import datetime, timedelta
-from uuid import uuid4
-from boto.s3.connection import S3Connection
-from boto import s3
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.contrib.staticfiles.storage import staticfiles_storage
-from django.http import FileResponse, HttpResponseNotFound
-from django.shortcuts import redirect
-from django.urls import reverse
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_noop
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from edx_toggles.toggles import WaffleSwitch
-from edxval.api import (
-    SortDirection,
-    VideoSortField,
-    create_or_update_transcript_preferences,
-    create_video,
-    get_3rd_party_transcription_plans,
-    get_available_transcript_languages,
-    get_video_transcript_url,
-    get_transcript_credentials_state_for_org,
-    get_transcript_preferences,
-    get_videos_for_course,
-    remove_transcript_preferences,
-    remove_video_for_course,
-    update_video_image,
-    update_video_status
-)
-from opaque_keys.edx.keys import CourseKey
-from pytz import UTC
-from rest_framework import status as rest_status
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 
 from cms.djangoapps.contentstore.video_storage_handlers import (
-    TranscriptProvider,
-    StatusDisplayStrings,
     handle_videos,
     handle_generate_video_upload_link,
     handle_video_images,
@@ -66,23 +29,10 @@ from cms.djangoapps.contentstore.video_storage_handlers import (
     send_video_status_update as send_video_status_update_source_function,
     is_status_update_request as is_status_update_request_source_function,
 )
-from common.djangoapps.edxmako.shortcuts import render_to_response
-from common.djangoapps.util.json_request import JsonResponse, expect_json
-from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
-from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
-from openedx.core.djangoapps.video_pipeline.config.waffle import (
-    DEPRECATE_YOUTUBE,
-    ENABLE_DEVSTACK_VIDEO_UPLOADS,
-)
+
+from common.djangoapps.util.json_request import expect_json
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from openedx.core.lib.api.view_utils import view_auth_classes
-from xmodule.video_block.transcripts_utils import Transcript  # lint-amnesty, pylint: disable=wrong-import-order
-
-from ..models import VideoUploadConfig
-from ..toggles import use_new_video_uploads_page
-from ..utils import reverse_course_url, get_video_uploads_url
-from ..video_utils import validate_video_image
-from .course import get_course_and_check_access
 
 __all__ = [
     'videos_handler',

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -126,7 +126,6 @@ MAX_UPLOAD_HOURS = 24
 VIDEOS_PER_PAGE = 100
 
 
-
 @expect_json
 @login_required
 @require_http_methods(("GET", "POST", "DELETE"))
@@ -194,8 +193,8 @@ def validate_transcript_preferences(provider, cielo24_fidelity, cielo24_turnarou
     Exposes helper method without breaking existing bindings/dependencies
     """
     return validate_transcript_preferences_source_function(provider, cielo24_fidelity, cielo24_turnaround,
-                                                              three_play_turnaround, video_source_language,
-                                                              preferred_languages)
+                                                           three_play_turnaround, video_source_language,
+                                                           preferred_languages)
 
 
 @expect_json

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -142,7 +142,13 @@ def videos_handler(request, course_key_string, edx_video_id=None):
     POST
         json: create a new video upload; the actual files should not be provided
             to this endpoint but rather PUT to the respective upload_url values
-            contained in the response
+            contained in the response. Example payload:
+                {
+                    "files": [{
+                        "file_name": "video.mp4",
+                        "content_type": "video/mp4"
+                    }]
+                }
     DELETE
         soft deletes a video for particular course
     """

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -328,7 +328,7 @@ from openedx.core.djangoapps.plugins.constants import ProjectType  # isort:skip
 
 urlpatterns.extend(get_plugin_url_patterns(ProjectType.CMS))
 
-# Contentstore
+# Contentstore REST APIs
 urlpatterns += [
     path('api/contentstore/', include('cms.djangoapps.contentstore.rest_api.urls'))
 ]


### PR DESCRIPTION
## Description

https://2u-internal.atlassian.net/browse/TNL-10897

The purpose of this is to expose endpoints related to video uploads as public endpoint sas part of the studio content API MVP.

## Included refactorings

It was necessary to extract business logic from the video views for reuse to a service layer.
I did the same thing for transcripts, in preparation for the next upcoming PR that will expose transcript endpoints.

The files holding the service layer logic are cms/djangoapps/contentstore/transcript_storage_handlers.py and cms/djangoapps/contentstore/video_storage_handlers.py

## On the topic of unit tests

I did not include any unit tests for these reasons:
- We are working on an experimental MVP and these do not have priority. The new APIs are not yet enabled on prod but hidden behind a waffle flag. We do have some time constraints here.
- We can add tests in a later-stage PR before releasing the API MVP to prod.
- The actual functionality is all exhaustively tested. The untested code are only the urls.py and view files directly responsible for the new API. Endpoints have been manually tested to work, though.

## Out of scope

- Tests
- Swagger

## How to test

### Add an oauth-app to LMS django admin (instructions copied from[this opencraft article]( https://opencraft.com/use-the-open-edx-lms-for-authentication)):

Note: Everything we'll be doing is OAuth2, not OAuth1, which has been deprecated for quite some time.

We begin by registering a new application within the LMS. Log into [LMS admin panel](http://localhost:18000/) as the administrator. The default email and password for the admin on the devstack is edx@example.com and edx. From here, find the section with the header 'Django Oauth Toolkit.' Click 'Add' next to 'Applications':

![django-oauth-toolkit](https://github.com/openedx/edx-platform/assets/19345795/915d7632-9ab9-4443-9eff-b6d66331081b)

Every tool that needs to log into the LMS and perform actions on behalf of the user using OAuth has to be registered as an application. The form will initially populate with a unique client id and client secret. Save these and put them aside-- we'll need them later!

Leave 'User' blank, and set the Redirect URIs as below. Then, set the client type as 'Confidential' and the authorization grant type as 'Authorization Code'.

![oauth-example-app](https://github.com/openedx/edx-platform/assets/19345795/5bec06cf-2497-4a4f-9469-138bed8bf85c)


### Config

For this to work, you need to make a couple of changes in django-admin.
- To test video upload post endpoint without full AWS setup, add waffle flag "contentstore.mock_video_uploads" to studio django admin and set it to true. This will replace with some mock data.
- Waffle Flag `contentstore.enable_studio_content_api` must be set to true.
- Go to `<your_studio_base_url/admin/video_pipeline/videouploadsenabledbydefault/add/`, check the `enabled` checkbox, and save.
- Waffle Flag `contentstore.video_upload_pipeline` should be set to **False**.

### Testing requests with Insomnia

- Create an insomnia environment with this value, and fill in the client id and secret you copied from the django-admin oauth app:
```json
{
	"clientId": <your clientId>,
	"clientSecret": <your clientSecret
}
```
- Import this course to studio for testing:
[course.czpej34u.tar.gz](https://github.com/openedx/edx-platform/files/12174667/course.czpej34u.tar.gz)
- Go to insomnia, click the top breadcrumbs at the top center (Should say something like "Insomnia / My Collection" - click on Insomnia, which should bring you to a home page where you can create a new collection. Create a new collection.
- Again, on the breadcrumbs, click on the dropdown and select import
- Unzip and Import this file to your collection:
[Insomnia_video_api.json.zip](https://github.com/openedx/edx-platform/files/12174695/Insomnia_video_api.json.zip)
- Now you should have the relevant requests.
- You need to replace `course-v1:MITx+aga+adg` with your course ID for every request.
- To test the `videos/features` endpoint, you can add a new Waffle **Switch** `videos.video_image_upload_enabled`, which should switch the return value of the corresponding JSON key for the endpoint; and add a Waffle **Flag** `video_config.public_video_share`.