### PR TITLE
[FC-0009] feat: Add subsection grading policy mismatch validation

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -78,8 +78,14 @@ if (staffOnlyMessage) {
 }
 
 var gradingType = gettext('Ungraded');
+var gradingPolicyMismatch = false;
 if (xblockInfo.get('graded')) {
     gradingType = xblockInfo.get('format')
+    if (gradingType) {
+        gradingPolicyMismatch = (
+            xblockInfo.get('course_graders').filter((cg) => cg.toLowerCase() === gradingType.toLowerCase())
+        ).length === 0;
+    }
 }
 
 var is_proctored_exam = xblockInfo.get('is_proctored_exam');
@@ -269,7 +275,7 @@ if (is_proctored_exam) {
                                     )
                                 %>
                             </span>
-                        <p>
+                        </p>
                     </div>
                 <% } %>
             <% } else if ((xblockInfo.get('due_date') && !course.get('self_paced')) || xblockInfo.get('graded')) { %>
@@ -299,7 +305,7 @@ if (is_proctored_exam) {
                                     )
                                 %>
                             </span>
-                        <p>
+                        </p>
                     </div>
                 <% } %>
             <% } else if (course.get('self_paced') && course.get('is_custom_relative_dates_active') && xblockInfo.get('relative_weeks_due')) { %>
@@ -325,7 +331,7 @@ if (is_proctored_exam) {
                                 )
                             %>
                         </span>
-                    <p>
+                    </p>
                 </div>
             <% } %>
             <div class="status-hide-after-due">
@@ -350,6 +356,22 @@ if (is_proctored_exam) {
                     <p class="status-message-copy"><%- statusMessages[i].text %></p>
                 </div>
             <% } %>
+            </div>
+        <% } %>
+        <% if (gradingPolicyMismatch) { %>
+            <div class="status-messages">
+                <div class="container-message wrapper-message">
+                    <div class="message has-warnings">
+                        <p class="warning">
+                            <span class="icon fa fa-warning" aria-hidden="true"></span>
+                            <%- interpolate(
+                                gettext("This subsection is configured as \"%(gradingType)s\", which doesn't exist in the current grading policy."),
+                                { gradingType: gradingType },
+                                true
+                            ) %>
+                        </p>
+                    </div>
+                </div>
             </div>
         <% } %>
     </div>


### PR DESCRIPTION
## Description

This implements https://github.com/openedx/modular-learning/issues/20, it  adds validation for the grading assignment and grading policy in subsections, showing a warning in Studio if there is a mismatch.

## Testing instructions

1. Login to Studio: http://localhost:18010/
2. Click on an existing course or create a new one
3. Navigate to the Grading Settings of the selected course: eg: http://localhost:18010/settings/grading/<course_key>
4. Create a new Assignment Type by click on **"+ New Assignment Type"**
    1. Give it a name and weight
    2. Save
5. Navigate back to the Course Outline page in Studio: http://localhost:18010/course/<course_key>
6. Click **configure** on a Subsection and select the newly created Grading Assignment type from the "Grade as" dropdown menu in the Subsection Settings modal, and save it
7. After the change is reflected, navigate back to the Grading Settings http://localhost:18010/settings/grading/<course_key>
    1. Delete the newly created Grading Assignment Type
    2. Save
8. Navigate back to the Course Outline page you should see a warning message under the subsection that looks like this:
![Screen Shot 2023-07-23 at 2 00 01 PM](https://github.com/openedx/edx-platform/assets/6829768/101eb64c-6a65-45b9-874d-5cf01fa99ce5)

-----

Private ref: FAL-3464