### PR TITLE
fix: updated discussions notifications templates

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -14,7 +14,7 @@ COURSE_NOTIFICATION_TYPES = {
         'name': 'new_comment_on_response',
         'is_core': True,
         'info': 'Comment on response',
-        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> replied on your response in '
+        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on your response to the post '
                               '<{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',
@@ -31,7 +31,7 @@ COURSE_NOTIFICATION_TYPES = {
         'push': True,
         'info': 'Comment on post',
         'non_editable': ['web', 'email'],
-        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> replied on <{strong}>{author_name}'
+        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on <{strong}>{author_name}\'s'
                               '</{strong}> response to your post <{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',


### PR DESCRIPTION
## Ticket 
https://2u-internal.atlassian.net/browse/INF-975
## Description
Updated  notification templates as per ticket .
## After updates : 

<img width="538" alt="Screenshot 2023-07-24 at 4 11 08 PM" src="https://github.com/openedx/edx-platform/assets/26253150/5e393af8-cbbb-46e6-a515-217a817c1476">
