### PR TITLE
feat: remove paver update_db in depr

### DIFF
--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -160,22 +160,6 @@ class TestPaverServerTasks(PaverTestCase):
         assert self.task_messages == [EXPECTED_CELERY_COMMAND.format(settings=settings)]
 
     @ddt.data(
-        [{}],
-        [{"settings": "aws"}],
-    )
-    @ddt.unpack
-    def test_update_db(self, options):
-        """
-        Test the "update_db" task.
-        """
-        settings = options.get("settings", Env.DEVSTACK_SETTINGS)
-        call_task("pavelib.servers.update_db", options=options)
-        # pylint: disable=line-too-long
-        db_command = "NO_EDXAPP_SUDO=1 EDX_PLATFORM_SETTINGS_OVERRIDE={settings} /edx/bin/edxapp-migrate-{server} --traceback --pythonpath=. "
-        assert self.task_messages == [db_command.format(server='lms', settings=settings),
-                                      db_command.format(server='cms', settings=settings)]
-
-    @ddt.data(
         ["lms", {}],
         ["lms", {"settings": "aws"}],
         ["cms", {}],

--- a/pavelib/servers.py
+++ b/pavelib/servers.py
@@ -235,27 +235,6 @@ def run_all_servers(options):
 
 @task
 @needs('pavelib.prereqs.install_prereqs')
-@cmdopts([
-    ("settings=", "s", "Django settings"),
-    ("fake-initial", None, "Fake the initial migrations"),
-])
-@timed
-def update_db(options):
-    """
-    Migrates the lms and cms across all databases
-    """
-    settings = getattr(options, 'settings', DEFAULT_SETTINGS)
-    fake = "--fake-initial" if getattr(options, 'fake_initial', False) else ""
-    for system in ('lms', 'cms'):
-        # pylint: disable=line-too-long
-        sh("NO_EDXAPP_SUDO=1 EDX_PLATFORM_SETTINGS_OVERRIDE={settings} /edx/bin/edxapp-migrate-{system} --traceback --pythonpath=. {fake}".format(
-            settings=settings,
-            system=system,
-            fake=fake))
-
-
-@task
-@needs('pavelib.prereqs.install_prereqs')
 @consume_args
 @timed
 def check_settings(args):


### PR DESCRIPTION
**Description:**
as per original ticker https://github.com/openedx/edx-platform/issues/32683 

We are currently trying to deprecate the paver overall. This method is currently not working in one of our environments, so the best way forward is to delete this method.

We will replace this call with a make migrate command in the Makefile to make it more consistent with other IDAs in the Open edX ecosystem.




