### PR TITLE
feat: upd batch enrollment email msg

### DIFF
--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -765,7 +765,7 @@ such that the value can be defined later than this assignment (file load order).
             }
             if (allowed.length && emailStudents) {
                 // Translators: A list of users appears after this sentence;
-                renderList(gettext('Successfully sent enrollment emails to the following users. They will be allowed to enroll once they register:'), (function() { // eslint-disable-line max-len
+                renderList(gettext('Email cannot be sent to the following users via batch enrollment. They will be allowed to enroll once they register:'), (function() { // eslint-disable-line max-len
                     var k, len2, results;
                     results = [];
                     for (k = 0, len2 = allowed.length; k < len2; k++) {
@@ -789,7 +789,7 @@ such that the value can be defined later than this assignment (file load order).
             }
             if (autoenrolled.length && emailStudents) {
                 // Translators: A list of users appears after this sentence;
-                renderList(gettext('Successfully sent enrollment emails to the following users. They will be enrolled once they register:'), (function() { // eslint-disable-line max-len
+                renderList(gettext('Email cannot be sent to the following users via batch enrollment. They will be enrolled once they register:'), (function() { // eslint-disable-line max-len
                     var k, len2, results;
                     results = [];
                     for (k = 0, len2 = autoenrolled.length; k < len2; k++) {


### PR DESCRIPTION
## Description
When course authors perform batch enrollment via the instructor dashboard, they are given the message that enrollment email has successfully went out when that isn't the case. When an account has not had their email verified, batch enrollment cannot be performed. This is documented in the following places:  
- https://github.com/openedx/edx-platform/pull/21594
- https://2u-internal.atlassian.net/wiki/spaces/ENGAGE/pages/12025987/Account+Activation#Account-activation-for-enrollment

This PR will change the message from `Successfully sent enrollment emails to the following users. They will be allowed to enroll once they register:` to `Email cannot be sent to the following users via batch enrollment. They will be allowed to enroll once they register:`.

-----

For reference, here were the messages we sent out when 'Notify users by email' are checked:
If user is enrolled:
`Successfully enrolled and sent email to the following users:`

If user is not enrolled and 'Auto enroll' is checked:
`Successfully sent enrollment emails to the following users. They will be enrolled once they register:` (will be changed by this PR)

If user is not enrolled and 'Auto enroll' is not checked, but allowed is true:
`Successfully sent enrollment emails to the following users. They will be allowed to enroll once they register:` (will be changed by this PR)


## Testing instructions
In the instructor dashboard, enter a list of accounts with some emails that have not been verified. You should see the new message.

## Other information
Ticket: https://2u-internal.atlassian.net/browse/TNL-10820
