### PR TITLE
Feat  studio content api transcripts

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -14,6 +14,7 @@ from .views import (
     xblock,
     assets,
     videos,
+    transcripts,
 )
 
 app_name = 'v1'
@@ -56,22 +57,26 @@ urlpatterns = [
     ),
     re_path(
         fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
-        videos.VideosView.as_view(), name='studio_content_videos'
+        videos.VideosView.as_view(), name='studio_content_videos_uploads'
     ),
     re_path(
         fr'^videos/images/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
-        videos.VideoImagesView.as_view(), name='studio_content_videos'
+        videos.VideoImagesView.as_view(), name='studio_content_videos_images'
     ),
     re_path(
         fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
-        videos.VideoEncodingsDownloadView.as_view(), name='studio_content_videos'
+        videos.VideoEncodingsDownloadView.as_view(), name='studio_content_videos_encodings'
     ),
     re_path(
         r'^videos/features/$',
-        videos.VideoFeaturesView.as_view(), name='studio_content_videos'
+        videos.VideoFeaturesView.as_view(), name='studio_content_videos_features'
     ),
     re_path(
         fr'^videos/upload_link/{settings.COURSE_ID_PATTERN}$',
-        videos.UploadLinkView.as_view(), name='studio_content_videos'
+        videos.UploadLinkView.as_view(), name='studio_content_videos_upload_link'
+    ),
+    re_path(
+        fr'^video_transcripts/{settings.COURSE_ID_PATTERN}$',
+        transcripts.TranscriptView.as_view(), name='studio_content_video_transcripts'
     ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v1/views/transcripts.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/transcripts.py
@@ -11,20 +11,20 @@ from django.views.decorators.csrf import csrf_exempt
 from django.http import Http404
 
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
-from common.djangoapps.util.json_request import expect_json_in_class_view, JsonResponse
+from common.djangoapps.util.json_request import expect_json_in_class_view
 
 from ....api import course_author_access_required
 
 from cms.djangoapps.contentstore.transcript_storage_handlers import (
     upload_transcript,
     delete_video_transcript_or_404,
-    handle_transcript_credentials,
     handle_transcript_download,
 )
 import cms.djangoapps.contentstore.toggles as contentstore_toggles
 
 log = logging.getLogger(__name__)
 toggles = contentstore_toggles
+
 
 @view_auth_classes()
 class TranscriptView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, DestroyAPIView):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/transcripts.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/transcripts.py
@@ -1,0 +1,62 @@
+"""
+Public rest API endpoints for the Studio Content API video assets.
+"""
+import logging
+from rest_framework.generics import (
+    CreateAPIView,
+    RetrieveAPIView,
+    DestroyAPIView
+)
+from django.views.decorators.csrf import csrf_exempt
+from django.http import Http404
+
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
+from common.djangoapps.util.json_request import expect_json_in_class_view, JsonResponse
+
+from ....api import course_author_access_required
+
+from cms.djangoapps.contentstore.transcript_storage_handlers import (
+    upload_transcript,
+    delete_video_transcript_or_404,
+    handle_transcript_credentials,
+    handle_transcript_download,
+)
+import cms.djangoapps.contentstore.toggles as contentstore_toggles
+
+log = logging.getLogger(__name__)
+toggles = contentstore_toggles
+
+@view_auth_classes()
+class TranscriptView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, DestroyAPIView):
+    """
+    public rest API endpoints for the Studio Content API video transcripts.
+    course_key: required argument, needed to authorize course authors and identify the video.
+    edx_video_id: optional query parameter, needed to identify the transcript.
+    language_code: optional query parameter, needed to identify the transcript.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+    @csrf_exempt
+    @course_author_access_required
+    @expect_json_in_class_view
+    def create(self, request, course_key_string):  # pylint: disable=arguments-differ
+        return upload_transcript(request)
+
+    @course_author_access_required
+    def retrieve(self, request, course_key_string):  # pylint: disable=arguments-differ
+        """
+        Get a video transcript. edx_video_id and language_code query parameters are required.
+        """
+        return handle_transcript_download(request)
+
+    @course_author_access_required
+    def destroy(self, request, course_key_string):  # pylint: disable=arguments-differ
+        """
+        Delete a video transcript. edx_video_id and language_code query parameters are required.
+        """
+
+        return delete_video_transcript_or_404(request)

--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -257,9 +257,9 @@ def delete_video_transcript_or_404(request):
     video_id = request.GET.get('edx_video_id')
     language_code = request.GET.get('language_code')
 
-    if not get_video_transcript(video_id, language_code):
+    if not get_video_transcript(video_id=video_id, language_code=language_code):
         return HttpResponseNotFound()
 
-    delete_video_transcript(video_id, language_code)
+    delete_video_transcript(video_id=video_id, language_code=language_code)
 
     return JsonResponse(status=200)

--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -166,6 +166,7 @@ def _create_or_update_video_transcript(**kwargs):
 
     return create_or_update_video_transcript(**kwargs)
 
+
 def upload_transcript(request):
     """
     Upload a transcript file

--- a/cms/djangoapps/contentstore/transcript_storage_handlers.py
+++ b/cms/djangoapps/contentstore/transcript_storage_handlers.py
@@ -15,7 +15,8 @@ from edxval.api import (
     get_3rd_party_transcription_plans,
     get_available_transcript_languages,
     get_video_transcript_data,
-    update_transcript_credentials_state_for_org
+    update_transcript_credentials_state_for_org,
+    get_video_transcript
 )
 from opaque_keys.edx.keys import CourseKey
 
@@ -24,6 +25,7 @@ from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFl
 from openedx.core.djangoapps.video_pipeline.api import update_3rd_party_transcription_service_credentials
 from xmodule.video_block.transcripts_utils import Transcript, TranscriptsGenerationException  # lint-amnesty, pylint: disable=wrong-import-order
 
+from .toggles import use_mock_video_uploads
 from .video_storage_handlers import TranscriptProvider
 
 LOGGER = logging.getLogger(__name__)
@@ -158,6 +160,12 @@ def handle_transcript_download(request):
     return response
 
 
+def _create_or_update_video_transcript(**kwargs):
+    if use_mock_video_uploads():
+        return True
+
+    return create_or_update_video_transcript(**kwargs)
+
 def upload_transcript(request):
     """
     Upload a transcript file
@@ -179,7 +187,7 @@ def upload_transcript(request):
             input_format=Transcript.SRT,
             output_format=Transcript.SJSON
         ).encode()
-        create_or_update_video_transcript(
+        _create_or_update_video_transcript(
             video_id=edx_video_id,
             language_code=language_code,
             metadata={
@@ -232,3 +240,25 @@ def validate_transcript_upload_data(data, files):
 
 def delete_video_transcript(video_id=None, language_code=None):
     return delete_video_transcript_source_function(video_id=video_id, language_code=language_code)
+
+
+def delete_video_transcript_or_404(request):
+    """
+    Delete a video transcript or return 404 if it doesn't exist.
+    """
+    missing = [attr for attr in ['edx_video_id', 'language_code'] if attr not in request.GET]
+    if missing:
+        return JsonResponse(
+            {'error': _('The following parameters are required: {missing}.').format(missing=', '.join(missing))},
+            status=400
+        )
+
+    video_id = request.GET.get('edx_video_id')
+    language_code = request.GET.get('language_code')
+
+    if not get_video_transcript(video_id, language_code):
+        return HttpResponseNotFound()
+
+    delete_video_transcript(video_id, language_code)
+
+    return JsonResponse(status=200)


### PR DESCRIPTION
## Description

https://2u-internal.atlassian.net/browse/TNL-10893

This branch is based on [#32803](https://github.com/openedx/edx-platform/pull/32803), and it should be merged into that base branch before the base branch is merged into master.

The purpose of this is to expose endpoints related to video transcripts as public endpoints as part of the studio content API MVP.

## Included refactorings

Transcript view refactorings necessary for this are found in the PR linked above, on which this is based.

## On the topic of unit tests

I did not include any unit tests for these reasons:
- We are working on an experimental MVP and these do not have priority. The new APIs are not yet enabled on prod but hidden behind a waffle flag. We do have some time constraints here.
- We can add tests in a later-stage PR before releasing the API MVP to prod.
- The actual functionality is all exhaustively tested. The untested code are only the urls.py and view files directly responsible for the new API. Endpoints have been manually tested to work, though.

## Out of scope

- Tests
- Swagger
- Transcript credentials

### Config

For this to work, you need to make a couple of changes in django-admin.
- To test video upload post endpoint without full AWS setup, add waffle flag "contentstore.mock_video_uploads" to studio django admin and set it to true. This will replace with some mock data.
- Waffle Flag `contentstore.enable_studio_content_api` must be set to true.
- Go to `<your_studio_base_url/admin/video_pipeline/videouploadsenabledbydefault/add/`, check the `enabled` checkbox, and save.
- Waffle Flag `contentstore.video_upload_pipeline` should be set to **False**.

## How to test

Please follow the instructions in #32803 on which this is based, and then continue here for the tests specific to the transcript endpoints.

Unzip and Import this file to your insomnia collection:

[Insomnia-transcripts.json.zip](https://github.com/openedx/edx-platform/files/12177848/Insomnia-transcripts.json.zip)

Now posting transcripts is also not possible without S3 access. So the same waffle flag used for the previous PR also mocks out the transcript post. To test the endpoint, you can use this rst file, for example: (unzip first)

[awesome-example-transcript.srt.zip](https://github.com/openedx/edx-platform/files/12177856/awesome-example-transcript.srt.zip)

There are two additional requests for deleting transcripts in the insomnia export. They serve to test that when you add either no query params or add query params and the transcripts don't exist, there is no server error, but a 400 or 404 response, and also you don't get a misleading 200.