### PR TITLE
fix: include new assets.txt file in make upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ REQ_FILES = \
 	requirements/edx/doc \
 	requirements/edx/testing \
 	requirements/edx/development \
+	requirements/edx/assets \
 	scripts/xblock/requirements
 
 define COMMON_CONSTRAINTS_TEMP_COMMENT

--- a/requirements/edx/assets.txt
+++ b/requirements/edx/assets.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-click==8.1.5
+click==8.1.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/assets.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -436,7 +436,7 @@ edx-bulk-grades==1.0.2
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/kernel.in
-edx-celeryutils==1.2.3
+edx-celeryutils==1.2.2
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -201,6 +201,7 @@ django==3.2.20
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
+    #   django-waffle
     #   djangorestframework
     #   done-xblock
     #   drf-jwt
@@ -362,7 +363,7 @@ django-storages==1.9.1
     #   edxval
 django-user-tasks==3.1.0
     # via -r requirements/edx/kernel.in
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-django-utils
@@ -429,22 +430,22 @@ edx-auth-backends==4.1.0
     #   openedx-blockstore
 edx-braze-client==0.1.7
     # via -r requirements/edx/bundled.in
-edx-bulk-grades==1.0.1
+edx-bulk-grades==1.0.2
     # via
     #   -r requirements/edx/kernel.in
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/kernel.in
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/kernel.in
-edx-completion==4.2.1
+edx-completion==4.3.0
     # via -r requirements/edx/kernel.in
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edxval

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -436,7 +436,7 @@ edx-bulk-grades==1.0.2
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/kernel.in
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
@@ -445,7 +445,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/kernel.in
 edx-completion==4.3.0
     # via -r requirements/edx/kernel.in
-edx-django-release-util==1.3.0
+edx-django-release-util==1.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   edxval

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -697,7 +697,7 @@ edx-ccx-keys==1.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -711,7 +711,7 @@ edx-completion==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-release-util==1.3.0
+edx-django-release-util==1.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -362,6 +362,7 @@ django==3.2.20
     #   django-stubs
     #   django-stubs-ext
     #   django-user-tasks
+    #   django-waffle
     #   djangorestframework
     #   done-xblock
     #   drf-jwt
@@ -586,7 +587,7 @@ django-user-tasks==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -687,7 +688,7 @@ edx-braze-client==0.1.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-bulk-grades==1.0.1
+edx-bulk-grades==1.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -696,7 +697,7 @@ edx-ccx-keys==1.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -706,11 +707,11 @@ edx-codejail==3.3.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-completion==4.2.1
+edx-completion==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1461,11 +1462,11 @@ pycryptodomex==3.18.0
     #   lti-consumer-xblock
     #   pyjwkest
     #   snowflake-connector-python
-pydantic==2.0.3
+pydantic==2.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
-pydantic-core==2.3.0
+pydantic-core==2.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   pydantic
@@ -2023,7 +2024,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.8
+tomlkit==0.12.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -697,7 +697,7 @@ edx-ccx-keys==1.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-celeryutils==1.2.3
+edx-celeryutils==1.2.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -249,6 +249,7 @@ django==3.2.20
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
+    #   django-waffle
     #   djangorestframework
     #   done-xblock
     #   drf-jwt
@@ -426,7 +427,7 @@ django-storages==1.9.1
     #   edxval
 django-user-tasks==3.1.0
     # via -r requirements/edx/base.txt
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -506,22 +507,22 @@ edx-auth-backends==4.1.0
     #   openedx-blockstore
 edx-braze-client==0.1.7
     # via -r requirements/edx/base.txt
-edx-bulk-grades==1.0.1
+edx-bulk-grades==1.0.2
     # via
     #   -r requirements/edx/base.txt
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/base.txt
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
-edx-completion==4.2.1
+edx-completion==4.3.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -555,7 +556,7 @@ edx-drf-extensions==8.8.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==4.0.4
+edx-enterprise==4.0.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -513,7 +513,7 @@ edx-bulk-grades==1.0.2
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/base.txt
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
@@ -522,7 +522,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
 edx-completion==4.3.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.3.0
+edx-django-release-util==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -513,7 +513,7 @@ edx-bulk-grades==1.0.2
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/base.txt
-edx-celeryutils==1.2.3
+edx-celeryutils==1.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -281,6 +281,7 @@ django==3.2.20
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
+    #   django-waffle
     #   djangorestframework
     #   done-xblock
     #   drf-jwt
@@ -458,7 +459,7 @@ django-storages==1.9.1
     #   edxval
 django-user-tasks==3.1.0
     # via -r requirements/edx/base.txt
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -535,22 +536,22 @@ edx-auth-backends==4.1.0
     #   openedx-blockstore
 edx-braze-client==0.1.7
     # via -r requirements/edx/base.txt
-edx-bulk-grades==1.0.1
+edx-bulk-grades==1.0.2
     # via
     #   -r requirements/edx/base.txt
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/base.txt
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
-edx-completion==4.2.1
+edx-completion==4.3.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -1097,9 +1098,9 @@ pycryptodomex==3.18.0
     #   lti-consumer-xblock
     #   pyjwkest
     #   snowflake-connector-python
-pydantic==2.0.3
+pydantic==2.1.1
     # via fastapi
-pydantic-core==2.3.0
+pydantic-core==2.4.0
     # via pydantic
 pygments==2.15.1
     # via
@@ -1490,7 +1491,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.8
+tomlkit==0.12.0
     # via pylint
 tox==3.28.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -542,7 +542,7 @@ edx-bulk-grades==1.0.2
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/base.txt
-edx-celeryutils==1.2.3
+edx-celeryutils==1.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -542,7 +542,7 @@ edx-bulk-grades==1.0.2
     #   staff-graded-xblock
 edx-ccx-keys==1.2.1
     # via -r requirements/edx/base.txt
-edx-celeryutils==1.2.2
+edx-celeryutils==1.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
@@ -551,7 +551,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
 edx-completion==4.3.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.3.0
+edx-django-release-util==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval


### PR DESCRIPTION
## Description

- PR https://github.com/openedx/edx-platform/pull/32823 introduced two new Python requirements files `assets.in` and `assets.txt`. Since these files were not included in the `make upgrade` target, it [broke](https://github.com/openedx/edx-platform/actions/runs/5677973497) both the `Upgrade Requirements` and `Upgrade one dependency` workflows due to requirements conflicts when upgrading packages. 
- Including these files in the `make upgrade` target will fix both of the failing jobs as well as `make upgrade` target running locally. 

## Testing
- Tested the change by successfully running `Requirements Upgrade` workflow [build](https://github.com/openedx/edx-platform/pull/32861) against this branch.