### PR TITLE
chore: upgrading deprecated import.

### DIFF
--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -8,7 +8,8 @@ from datetime import datetime
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.files.storage import DefaultStorage, get_valid_filename
+from django.core.files.storage import DefaultStorage
+from django.utils.text import get_valid_filename
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 from pytz import UTC


### PR DESCRIPTION
This method is removed in django42. 
For django upgrade we can use the different import.

This django [PR](https://github.com/django/django/pull/16282/files#diff-2f8524035203a28c596eb210d5b886a12d5a46215a649bee85f9987cc335d128R8) Show the change. They are using the same import also.
