### PR TITLE
fix: Update notification sending logic for discussions

### DIFF
--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -422,19 +422,36 @@ class DiscussionNotificationSender:
         if not self.parent_id and self.creator.id != int(self.thread.user_id):
             self._send_notification([self.thread.user_id], "new_response")
 
+    def _response_and_thread_has_same_creator(self) -> bool:
+        """
+        Check if response and main thread have same author.
+        """
+        return int(self.parent_response.user_id) == int(self.thread.user_id)
+
     def send_new_comment_notification(self):
         """
         Send notification to parent thread creator i.e. comment on the response.
         """
-        if self.parent_response and self.creator.id != int(self.thread.user_id):
+        #
+        if (
+            self.parent_response and
+            self.creator.id != int(self.thread.user_id)
+        ):
+            # use your if author of response is same as author of post.
+            author_name = "your" if self._response_and_thread_has_same_creator() else self.parent_response.username
             context = {
-                "author_name": self.parent_response.username,
+                "author_name": author_name,
             }
             self._send_notification([self.thread.user_id], "new_comment", extra_context=context)
 
     def send_new_comment_on_response_notification(self):
         """
         Send notification to parent response creator i.e. comment on the response.
+        Do not send notification if author of response is same as author of post.
         """
-        if self.parent_response and self.creator.id != int(self.parent_response.user_id):
+        if (
+            self.parent_response and
+            self.creator.id != int(self.parent_response.user_id) and not
+            self._response_and_thread_has_same_creator()
+        ):
             self._send_notification([self.parent_response.user_id], "new_comment_on_response")

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -391,7 +391,7 @@ class DiscussionNotificationSender:
             extra_context = {}
 
         notification_data = UserNotificationData(
-            user_ids=user_ids,
+            user_ids=[int(user_id) for user_id in user_ids],
             context={
                 "replier_name": self.creator.username,
                 "post_title": self.thread.title,

--- a/openedx/core/djangoapps/notifications/handlers.py
+++ b/openedx/core/djangoapps/notifications/handlers.py
@@ -32,7 +32,7 @@ def course_enrollment_post_save(signal, sender, enrollment, metadata, **kwargs):
             )
         except IntegrityError:
             log.info(f'CourseNotificationPreference already exists for user {enrollment.user} '
-                     f'and course {enrollment.course_id}')
+                     f'and course {enrollment.course.course_key}')
 
 
 @receiver(COURSE_UNENROLLMENT_COMPLETED)


### PR DESCRIPTION
# Ticket 
https://2u-internal.atlassian.net/browse/INF-974

# Description 

1. Skip `comment_on_response` when author of the response is also the author of the post.
2. Modify the notification {username} replied on {response author} response to your post {post title} to {username} replied on your response to your post {post title}. Just replace “{response author}” with “your”.