### PR TITLE
fix: do not instantiate the PartitionService during XBlock validation in Studio [FC-0026]

### DIFF
--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -3287,7 +3287,11 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         Create the proper runtime for this course
         """
         services = self.services
-        services["partitions"] = PartitionService(course_entry.course_key)
+        # Only the CourseBlock can have user partitions. Therefore, creating the PartitionService with the library key
+        # instead of the course key does not work. The XBlock validation in Studio fails with the following message:
+        # "This component's access settings refer to deleted or invalid group configurations.".
+        if not isinstance(course_entry.course_key, LibraryLocator):
+            services["partitions"] = PartitionService(course_entry.course_key)
 
         return CachingDescriptorSystem(
             modulestore=self,


### PR DESCRIPTION
## Description

This is a follow-up fix to #32779. This is the alternative approach I was considering there.

## Testing instructions

1. Create a Library in Studio.
2. Create a new unit in the course. Create two Randomized Content Blocks. Use the library from the previous point in both of them.
3. Click "Manage Access" on the second XBlock and restrict access to a content group.
4. Refresh the page and check that the "This component has validation issues." message is not displayed.