### PR TITLE
fix: api for schedule and details page MFE page

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
@@ -34,6 +34,7 @@ class CourseSettingsSerializer(serializers.Serializer):
     is_prerequisite_courses_enabled = serializers.BooleanField()
     language_options = serializers.ListField(child=serializers.ListField(child=serializers.CharField()))
     lms_link_for_about_page = serializers.URLField()
+    licensing_enabled = serializers.BooleanField()
     marketing_enabled = serializers.BooleanField()
     mfe_proctored_exam_settings_url = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     platform_name = serializers.CharField()

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
@@ -36,6 +36,7 @@ class CourseSettingsSerializer(serializers.Serializer):
     lms_link_for_about_page = serializers.URLField()
     marketing_enabled = serializers.BooleanField()
     mfe_proctored_exam_settings_url = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    platform_name = serializers.CharField()
     possible_pre_requisite_courses = PossiblePreRequisiteCourseSerializer(required=False, many=True)
     short_description_editable = serializers.BooleanField()
     show_min_grade_warning = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
@@ -74,6 +74,7 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
                 ],
                 ...
             ],
+            "licensing_enabled": false,
             "lms_link_for_about_page": "http://localhost:18000/courses/course-v1:edX+E2E-101+course/about",
             "marketing_enabled": true,
             "mfe_proctored_exam_settings_url": "",
@@ -110,6 +111,7 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
                 'course_display_name': course_block.display_name,
                 'course_display_name_with_default': course_block.display_name_with_default,
                 'platform_name': settings.PLATFORM_NAME,
+                'licensing_enabled': settings.FEATURES.get("LICENSING", False),
                 'use_v2_cert_display_settings': settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False),
             })
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
@@ -77,6 +77,7 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
             "lms_link_for_about_page": "http://localhost:18000/courses/course-v1:edX+E2E-101+course/about",
             "marketing_enabled": true,
             "mfe_proctored_exam_settings_url": "",
+            "platform_name": "edX",
             "possible_pre_requisite_courses": [
                 {
                 "course_key": "course-v1:edX+M12+2T2023",
@@ -108,6 +109,7 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
                 'can_show_certificate_available_date_field': can_show_certificate_available_date_field(course_block),
                 'course_display_name': course_block.display_name,
                 'course_display_name_with_default': course_block.display_name_with_default,
+                'platform_name': settings.PLATFORM_NAME,
                 'use_v2_cert_display_settings': settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False),
             })
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
@@ -53,6 +53,7 @@ class CourseSettingsViewTest(CourseTestCase, PermissionAccessMixin):
             "sidebar_html_enabled": False,
             "show_min_grade_warning": False,
             "upgrade_deadline": None,
+            "licensing_enabled": False,
             "use_v2_cert_display_settings": False,
         }
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
@@ -48,6 +48,7 @@ class CourseSettingsViewTest(CourseTestCase, PermissionAccessMixin):
             "mfe_proctored_exam_settings_url": get_proctored_exam_settings_url(
                 self.course.id
             ),
+            "platform_name": settings.PLATFORM_NAME,
             "short_description_editable": True,
             "sidebar_html_enabled": False,
             "show_min_grade_warning": False,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -882,7 +882,6 @@ def _duplicate_block(
 
 
 @login_required
-@expect_json
 def delete_item(request, usage_key):
     """
     Exposes internal helper method without breaking existing bindings/dependencies

--- a/common/test/data/course_after_rename/about/overview.html
+++ b/common/test/data/course_after_rename/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #1">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #2">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/course_before_rename/about/overview.html
+++ b/common/test/data/course_before_rename/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #1">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #2">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/course_info_updates/about/overview.html
+++ b/common/test/data/course_info_updates/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #1">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #2">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/manual-testing-complete/about/overview.html
+++ b/common/test/data/manual-testing-complete/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #1">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #2">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/scoreable/about/overview.html
+++ b/common/test/data/scoreable/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #1">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #2">
+      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/xmodule/templates/about/overview.yaml
+++ b/xmodule/templates/about/overview.yaml
@@ -19,7 +19,7 @@ data: |
       <h2>Course Staff</h2>
       <article class="teacher">
         <div class="teacher-image">
-          <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #1">
+          <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
         </div>
 
         <h3>Staff Member #1</h3>
@@ -28,7 +28,7 @@ data: |
 
       <article class="teacher">
         <div class="teacher-image">
-          <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0" alt="Course Staff Image #2">
+          <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
         </div>
 
         <h3>Staff Member #2</h3>


### PR DESCRIPTION
## Description
#### This is part of Schedule & Details [PR](https://github.com/openedx/frontend-app-course-authoring/pull/547) on `2U-Studio-MFE`
- added `platform_name`, `licensing_enabled` to course settings DRF endpoint
- fixed error when a user disables the Entrance exam on MFE schedule and details page
- change syntax of image tag for templates overview.html

#### Please merge it before
- `frontend-app-course-authoring` [PR](https://github.com/openedx/frontend-app-course-authoring/pull/547)