### PR TITLE
fix: Fix Apple registration during migration

### DIFF
--- a/common/djangoapps/third_party_auth/appleid.py
+++ b/common/djangoapps/third_party_auth/appleid.py
@@ -228,11 +228,12 @@ class AppleIdAuth(BaseOAuth2):
                 # belonging to already signed-in users.
                 AppleMigrationUserIdInfo = apps.get_model('third_party_auth', 'AppleMigrationUserIdInfo')
                 user_apple_id_info = AppleMigrationUserIdInfo.objects.filter(transfer_id=transfer_sub).first()
-                old_apple_id = user_apple_id_info.old_apple_id
-                if social_django.models.DjangoStorage.user.get_social_auth(provider=self.name, uid=old_apple_id):
-                    user_apple_id_info.new_apple_id = response.get(self.ID_KEY)
-                    user_apple_id_info.save()
-                    return user_apple_id_info.old_apple_id
+                if user_apple_id_info:
+                    old_apple_id = user_apple_id_info.old_apple_id
+                    if social_django.models.DjangoStorage.user.get_social_auth(provider=self.name, uid=old_apple_id):
+                        user_apple_id_info.new_apple_id = response.get(self.ID_KEY)
+                        user_apple_id_info.save()
+                        return user_apple_id_info.old_apple_id
 
         return apple_id
 

--- a/common/djangoapps/third_party_auth/management/commands/generate_and_store_new_apple_ids.py
+++ b/common/djangoapps/third_party_auth/management/commands/generate_and_store_new_apple_ids.py
@@ -151,7 +151,7 @@ class Command(BaseCommand):
             new_apple_id = ''
         except (requests.exceptions.JSONDecodeError, AttributeError):
             log.info('JSONDecodeError/AttributeError for transfer_id %s.', transfer_id)
-            transfer_id = ''
+            new_apple_id = ''
 
         return new_apple_id
 


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

1. Handle the case where `transfer_sub` claim is sent by Apple on Login/Registration but the mathcing value is not found in the Database. 
New relic trace: https://onenr.io/0bRKpKkqOjE
3. Fix typo in Management command to create and store New Apple IDs

## Supporting information

https://github.com/openedx/edx-platform/blob/master/common/djangoapps/third_party_auth/docs/how_tos/migrating_apple_users_in_teams.rst

## Deadline

Asap

