### PR TITLE
fix: added new_comment and new_response to core notification

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -25,10 +25,7 @@ COURSE_NOTIFICATION_TYPES = {
     'new_comment': {
         'notification_app': 'discussion',
         'name': 'new_comment',
-        'is_core': False,
-        'web': True,
-        'email': True,
-        'push': True,
+        'is_core': True,
         'info': 'Comment on post',
         'non_editable': ['web', 'email'],
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on <{strong}>{author_name}\'s'
@@ -43,10 +40,7 @@ COURSE_NOTIFICATION_TYPES = {
     'new_response': {
         'notification_app': 'discussion',
         'name': 'new_response',
-        'is_core': False,
-        'web': True,
-        'email': True,
-        'push': True,
+        'is_core': True,
         'info': 'Response on post',
         'non_editable': [],
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> responded to your '
@@ -66,7 +60,7 @@ COURSE_NOTIFICATION_APPS = {
         'core_web': True,
         'core_email': True,
         'core_push': True,
-        'non_editable': []
+        'non_editable': ['web']
     }
 }
 

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 NOTIFICATION_CHANNELS = ['web', 'push', 'email']
 
 # Update this version when there is a change to any course specific notification type or app.
-COURSE_NOTIFICATION_CONFIG_VERSION = 1
+COURSE_NOTIFICATION_CONFIG_VERSION = 2
 
 
 def get_course_notification_preference_config():

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -217,20 +217,8 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
             'notification_preference_config': {
                 'discussion': {
                     'enabled': True,
-                    'core_notification_types': ['new_comment_on_response'],
+                    'core_notification_types': ['new_comment_on_response', 'new_comment', 'new_response'],
                     'notification_types': {
-                        'new_comment': {
-                            'web': True,
-                            'email': True,
-                            'push': True,
-                            'info': 'Comment on post'
-                        },
-                        'new_response': {
-                            'web': True,
-                            'email': True,
-                            'push': True,
-                            'info': 'Response on post'
-                        },
                         'core': {
                             'web': True,
                             'email': True,
@@ -239,7 +227,7 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                         }
                     },
                     'non_editable': {
-                        'new_comment': ['web', 'email']
+                        'core': ['web']
                     }
                 }
             }
@@ -268,9 +256,6 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
         ('discussion', None, None, True, status.HTTP_200_OK, 'app_update'),
         ('discussion', None, None, False, status.HTTP_200_OK, 'app_update'),
         ('invalid_notification_app', None, None, True, status.HTTP_400_BAD_REQUEST, None),
-
-        ('discussion', 'new_comment', 'web', True, status.HTTP_200_OK, 'type_update'),
-        ('discussion', 'new_response', 'web', False, status.HTTP_200_OK, 'type_update'),
 
         ('discussion', 'core', 'email', True, status.HTTP_200_OK, 'type_update'),
         ('discussion', 'core', 'email', False, status.HTTP_200_OK, 'type_update'),


### PR DESCRIPTION
Added new_comment and new_response to core. Moved web to non-editable for core notification

Ticket: [INF-989](https://2u-internal.atlassian.net/browse/INF-989)