### PR TITLE
feat: remove 403  for disabled advanced settings

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
@@ -3,7 +3,6 @@
 from django import forms
 import edx_api_doc_tools as apidocs
 from opaque_keys.edx.keys import CourseKey
-from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -12,7 +11,6 @@ from xmodule.modulestore.django import modulestore
 
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 from cms.djangoapps.contentstore.api.views.utils import get_bool_param
-from cms.djangoapps.contentstore.toggles import use_new_advanced_settings_page
 from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
 from ..serializers import CourseAdvancedSettingsSerializer

--- a/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
@@ -117,8 +117,6 @@ class AdvancedCourseSettingsView(DeveloperErrorViewMixin, APIView):
         if not filter_query_data.is_valid():
             raise ValidationError(filter_query_data.errors)
         course_key = CourseKey.from_string(course_id)
-        if not use_new_advanced_settings_page(course_key):
-            return Response(status=status.HTTP_403_FORBIDDEN)
         if not has_studio_read_access(request.user, course_key):
             self.permission_denied(request)
         course_block = modulestore().get_course(course_key)


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This change impacts Authors. To prevent users from accessing the new MFE version of the advanced settings page, a 403 was added to the API. However, the API is not exclusive to the advanced settings page so the other pages, e.i. Pages and resources, dependent on the API were no longer function if the waffle flag was off. The removal of the 403 response restores functionality.

## Testing instructions

1. Confirm that the Advanced Setting's waffle flag, `contentstore.new_studio_mfe.use_new_advanced_settings_page` is off
2. Navigate to Pages and resources
3. Click the gear link on any of the cards
4. Setting modal loads as expected. There should be no error alert.
