### PR TITLE
fix: redirection issue with enterprise selection page flow

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -469,7 +469,7 @@ def enterprise_selection_page(request, user, next_url):
 
     response = get_enterprise_learner_data_from_api(user)
     if response and len(response) > 1:
-        redirect_url = reverse('enterprise_select_active') + '/?success_url=' + next_url
+        redirect_url = reverse('enterprise_select_active') + '/?success_url=' + urllib.parse.quote(next_url)
 
         # Check to see if next url has an enterprise in it. In this case if user is associated with
         # that enterprise, activate that enterprise and bypass the selection page.


### PR DESCRIPTION
[VAN-1511](https://2u-internal.atlassian.net/browse/VAN-1511)

## Description

Next Url was not getting encoded in the enterprise selection page flow hence redirecting to an unquoted invalid URL showing an error page. This PR fixes this issue.

## Supporting information

https://2u-internal.atlassian.net/browse/VAN-1511

## Screen recordings 

### Before fix (local setup)

https://github.com/openedx/edx-platform/assets/52817156/ea1a23f1-0b2e-47f7-91fe-6c677ab4974d

### After fix (local setup)

https://github.com/openedx/edx-platform/assets/52817156/0c70c927-c805-4221-abea-d28b060bd5ce

