### PR TITLE
build: bumped the package have django42 support now

### DIFF
--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -58,7 +58,7 @@ pillow==9.5.0
     #   matplotlib
 pycparser==2.21
     # via cffi
-pyparsing==3.1.0
+pyparsing==3.1.1
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -529,13 +529,13 @@ edx-search==3.6.0
     # via -r requirements/edx/kernel.in
 edx-sga==0.22.0
     # via -r requirements/edx/bundled.in
-edx-submissions==3.5.6
+edx-submissions==3.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
 edx-tincan-py35==1.0.0
     # via edx-enterprise
-edx-toggles==5.0.0
+edx-toggles==5.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-completion
@@ -553,7 +553,7 @@ edx-when==2.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-edxval==2.3.0
+edxval==2.4.0
     # via -r requirements/edx/kernel.in
 elasticsearch==7.13.4
     # via
@@ -669,7 +669,7 @@ libsass==0.10.0
     #   -r requirements/edx/paver.txt
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.5.5
+lti-consumer-xblock==9.6.0
     # via -r requirements/edx/kernel.in
 lxml==4.9.3
     # via

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-chardet==5.1.0
+chardet==5.2.0
     # via diff-cover
 coverage==7.2.7
     # via -r requirements/edx/coverage.in
@@ -16,5 +16,5 @@ markupsafe==2.1.3
     # via jinja2
 pluggy==1.2.0
     # via diff-cover
-pygments==2.15.1
+pygments==2.16.1
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -827,7 +827,7 @@ edx-sga==0.22.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-submissions==3.5.6
+edx-submissions==3.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -837,7 +837,7 @@ edx-tincan-py35==1.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-edx-toggles==5.0.0
+edx-toggles==5.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -861,7 +861,7 @@ edx-when==2.4.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-edxval==2.3.0
+edxval==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1136,7 +1136,7 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.5.5
+lti-consumer-xblock==9.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -609,7 +609,7 @@ edx-search==3.6.0
     # via -r requirements/edx/base.txt
 edx-sga==0.22.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.5.6
+edx-submissions==3.6.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -617,7 +617,7 @@ edx-tincan-py35==1.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-toggles==5.0.0
+edx-toggles==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion
@@ -635,7 +635,7 @@ edx-when==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==2.3.0
+edxval==2.4.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.13.4
     # via
@@ -797,7 +797,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.5.5
+lti-consumer-xblock==9.6.0
     # via -r requirements/edx/base.txt
 lxml==4.9.3
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -641,7 +641,7 @@ edx-search==3.6.0
     # via -r requirements/edx/base.txt
 edx-sga==0.22.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.5.6
+edx-submissions==3.6.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -649,7 +649,7 @@ edx-tincan-py35==1.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-toggles==5.0.0
+edx-toggles==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion
@@ -667,7 +667,7 @@ edx-when==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==2.3.0
+edxval==2.4.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.13.4
     # via
@@ -864,7 +864,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.5.5
+lti-consumer-xblock==9.6.0
     # via -r requirements/edx/base.txt
 lxml==4.9.3
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -12,7 +12,7 @@ click==8.1.6
     #   pip-tools
 packaging==23.1
     # via build
-pip-tools==7.1.0
+pip-tools==7.2.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
@@ -21,7 +21,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.0
+wheel==0.41.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.41.0
+wheel==0.41.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
As we have added support for Django 4.2 for few `edx-platform` dependent packages, so those packages has been bumped in the PR.

## Supporting information
Issue for the bumped packages: https://github.com/openedx/public-engineering/issues/199
Bumped packages:
edx-toggles, edx-submissions, edxval, lti-consumer-xblock
