### PR TITLE
Replace learning_assistant_launch_url with learning_assistant_enabled in courseware API.

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -114,7 +114,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     linkedin_add_to_profile_url = serializers.URLField()
     is_integrity_signature_enabled = serializers.BooleanField()
     user_needs_integrity_signature = serializers.BooleanField()
-    learning_assistant_launch_url = serializers.CharField()
+    learning_assistant_enabled = serializers.BooleanField()
 
     def __init__(self, *args, **kwargs):
         """

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -47,7 +47,7 @@ from lms.djangoapps.gating.api import get_entrance_exam_score, get_entrance_exam
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.agreements.api import get_integrity_signature
-from openedx.core.djangoapps.courseware_api.utils import get_celebrations_dict, get_learning_assistant_launch_url
+from openedx.core.djangoapps.courseware_api.utils import get_celebrations_dict
 from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
@@ -360,19 +360,11 @@ class CoursewareMeta:
             return enrollment_active and CourseMode.is_eligible_for_certificate(enrollment_mode)
 
     @property
-    def learning_assistant_launch_url(self):
+    def learning_assistant_enabled(self):
         """
-        Returns a URL for the learning assistant LTI launch if applicable, otherwise None
+        Returns a boolean representing whether the requesting user should have access to the Xpert Learning Assistant.
         """
-        if learning_assistant_is_active(self.course_key):
-            lti_url = get_learning_assistant_launch_url(
-                self.effective_user,
-                self.course_key,
-                self.enrollment_object,
-                self.overview,
-            )
-            return lti_url
-        return None
+        return learning_assistant_is_active(self.course_key)
 
 
 class CoursewareInformation(RetrieveAPIView):
@@ -463,7 +455,7 @@ class CoursewareInformation(RetrieveAPIView):
             verified mode. Will update to reverify URL if necessary.
         * linkedin_add_to_profile_url: URL to add the effective user's certificate to a LinkedIn Profile.
         * user_needs_integrity_signature: Whether the user needs to sign the integrity agreement for the course
-        * learning_assistant_launch_url: URL for the LTI launch of a learning assistant
+        * learning_assistant_enabled: Whether the Xpert Learning Assistant is enabled for the requesting user
 
     **Parameters:**
 


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This commit replaces the `learning_assistant_launch_url` field of the `CoursewareInformation` view of the courseware API with a `learning_assistant_enabled` field. `learning_assistant_enabled` is a boolean that represents whether the Xpert Learning Assistant is enabled for the requesting user, based on the associated `CourseWaffleFlag`. This change is necessary because we are no longer leveraging the Learning Assistant LTI tool.

## Supporting information

JIRA: [MST-2038](https://2u-internal.atlassian.net/browse/MST-2038) (private)