### PR TITLE
Refactors content_tagging tests

### DIFF
--- a/openedx/features/content_tagging/tests/test_rules.py
+++ b/openedx/features/content_tagging/tests/test_rules.py
@@ -74,127 +74,151 @@ class TestRulesTaxonomy(TestTaxonomyMixin, TestCase):
             email="learner@example.com",
         )
 
-    def _expected_users_have_perm(
-        self, perm, obj, learner_perm=False, learner_obj=False, user_org2=True
-    ):
-        """
-        Checks that all users have the given permission on the given object.
-
-        If learners_too, then the learner user should have it too.
-        """
-        # Global Taxonomy Admins can do pretty much anything
-        assert self.superuser.has_perm(perm)
-        assert self.superuser.has_perm(perm, obj)
-        assert self.staff.has_perm(perm)
-        assert self.staff.has_perm(perm, obj)
-        assert self.user_all_orgs.has_perm(perm)
-        assert self.user_all_orgs.has_perm(perm, obj)
-
-        # Org content creators are bound by a taxonomy's org restrictions
-        assert self.user_both_orgs.has_perm(perm) == learner_perm
-        assert self.user_both_orgs.has_perm(perm, obj)
-        assert self.user_org2.has_perm(perm) == learner_perm
-        # user_org2 does not have course creator access for org 1
-        assert self.user_org2.has_perm(perm, obj) == user_org2
-
-        # Learners can't do much but view
-        assert self.learner.has_perm(perm) == learner_perm
-        assert self.learner.has_perm(perm, obj) == learner_obj
+        # No one can change or delete system taxonomy data
+        self.taxonomy_system = api.create_taxonomy(
+            name="System Languages",
+        )
+        self.taxonomy_system.taxonomy_class = UserSystemDefinedTaxonomy
+        self.taxonomy_system.save()
+        self.taxonomy_system = self.taxonomy_system.cast()
+        self.tag_system = Tag.objects.create(
+            taxonomy=self.taxonomy_system,
+            value="Spanish",
+        )
+        self.object_tag_system = api.tag_content_object(
+            taxonomy=self.taxonomy_system,
+            tags=[self.tag_system.id],
+            object_id=self.both_orgs_block_tag.object_id,
+        )[0]
 
     # Taxonomy
 
+    def test_superuser_taxonomy_perms(self):
+        assert self.superuser.has_perm('oel_tagging.add_taxonomy')
+        assert self.superuser.has_perm('oel_tagging.change_taxonomy')
+        assert self.superuser.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.superuser.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.superuser.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert self.superuser.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert self.superuser.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert self.superuser.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert self.superuser.has_perm('oel_tagging.delete_taxonomy')
+        assert self.superuser.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.superuser.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.superuser.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert self.superuser.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert self.superuser.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert self.superuser.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
+
+    def test_staff_taxonomy_perms(self):
+        assert self.staff.has_perm('oel_tagging.add_taxonomy')
+        assert self.staff.has_perm('oel_tagging.change_taxonomy')
+        assert self.staff.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.staff.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.staff.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert self.staff.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert self.staff.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.staff.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert self.staff.has_perm('oel_tagging.delete_taxonomy')
+        assert self.staff.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.staff.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.staff.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert self.staff.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert self.staff.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.staff.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
+
+    def test_user_all_orgs_taxonomy_perms(self):
+        assert self.user_all_orgs.has_perm('oel_tagging.add_taxonomy')
+        assert self.user_all_orgs.has_perm('oel_tagging.change_taxonomy')
+        assert self.user_all_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert not self.user_all_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_all_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_taxonomy')
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert not self.user_all_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_all_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
+
+    def test_user_both_orgs_taxonomy_perms(self):
+        assert not self.user_both_orgs.has_perm('oel_tagging.add_taxonomy')
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_taxonomy')
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy')
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
+
+    def test_user_org2_taxonomy_perms(self):
+        assert not self.user_org2.has_perm('oel_tagging.add_taxonomy')
+        assert not self.user_org2.has_perm('oel_tagging.change_taxonomy')
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert not self.user_org2.has_perm('oel_tagging.delete_taxonomy')
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
+
+    def test_learner_taxonomy_perms(self):
+        assert not self.learner.has_perm('oel_tagging.add_taxonomy')
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy')
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy')
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
+
     @ddt.data(
-        ("oel_tagging.add_taxonomy", "taxonomy_all_orgs"),
-        ("oel_tagging.add_taxonomy", "taxonomy_both_orgs"),
-        ("oel_tagging.add_taxonomy", "taxonomy_disabled"),
         ("oel_tagging.change_taxonomy", "taxonomy_all_orgs"),
         ("oel_tagging.change_taxonomy", "taxonomy_both_orgs"),
         ("oel_tagging.change_taxonomy", "taxonomy_disabled"),
+        ("oel_tagging.change_taxonomy", "taxonomy_one_org"),
+        ("oel_tagging.change_taxonomy", "taxonomy_no_orgs"),
         ("oel_tagging.delete_taxonomy", "taxonomy_all_orgs"),
         ("oel_tagging.delete_taxonomy", "taxonomy_both_orgs"),
         ("oel_tagging.delete_taxonomy", "taxonomy_disabled"),
-    )
-    @ddt.unpack
-    def test_change_taxonomy_all_orgs(self, perm, taxonomy_attr):
-        """Taxonomy administrators with course creator access for the taxonomy org"""
-        taxonomy = getattr(self, taxonomy_attr)
-        self._expected_users_have_perm(perm, taxonomy)
-
-    @ddt.data(
-        ("oel_tagging.add_taxonomy", "taxonomy_one_org"),
-        ("oel_tagging.change_taxonomy", "taxonomy_one_org"),
         ("oel_tagging.delete_taxonomy", "taxonomy_one_org"),
-    )
-    @ddt.unpack
-    def test_change_taxonomy_org1(self, perm, taxonomy_attr):
-        taxonomy = getattr(self, taxonomy_attr)
-        self._expected_users_have_perm(perm, taxonomy, user_org2=False)
-
-    @ddt.data(
-        "oel_tagging.add_taxonomy",
-        "oel_tagging.change_taxonomy",
-        "oel_tagging.delete_taxonomy",
-    )
-    def test_system_taxonomy(self, perm):
-        """Taxonomy administrators cannot edit system taxonomies"""
-        system_taxonomy = api.create_taxonomy(
-            name="System Languages",
-        )
-        system_taxonomy.taxonomy_class = UserSystemDefinedTaxonomy
-        system_taxonomy = system_taxonomy.cast()
-        assert self.superuser.has_perm(perm, system_taxonomy)
-        assert not self.staff.has_perm(perm, system_taxonomy)
-        assert not self.user_all_orgs.has_perm(perm, system_taxonomy)
-        assert not self.user_both_orgs.has_perm(perm, system_taxonomy)
-        assert not self.user_org2.has_perm(perm, system_taxonomy)
-        assert not self.learner.has_perm(perm, system_taxonomy)
-
-    @ddt.data(
-        (True, "taxonomy_all_orgs"),
-        (False, "taxonomy_all_orgs"),
-        (True, "taxonomy_both_orgs"),
-        (False, "taxonomy_both_orgs"),
-    )
-    @ddt.unpack
-    def test_view_taxonomy_enabled(self, enabled, taxonomy_attr):
-        """Anyone can see enabled taxonomies, but learners cannot see disabled taxonomies"""
-        taxonomy = getattr(self, taxonomy_attr)
-        taxonomy.enabled = enabled
-        perm = "oel_tagging.view_taxonomy"
-        self._expected_users_have_perm(perm, taxonomy, learner_obj=enabled)
-
-    @ddt.data(
-        (True, "taxonomy_no_orgs"),
-        (False, "taxonomy_no_orgs"),
-    )
-    @ddt.unpack
-    def test_view_taxonomy_no_orgs(self, enabled, taxonomy_attr):
-        """
-        Enabled taxonomies with no org can be viewed by anyone.
-        Disabled taxonomies with no org can only be viewed by staff/superusers.
-        """
-        taxonomy = getattr(self, taxonomy_attr)
-        taxonomy.enabled = enabled
-        perm = "oel_tagging.view_taxonomy"
-        assert self.superuser.has_perm(perm, taxonomy)
-        assert self.staff.has_perm(perm, taxonomy)
-        assert self.user_all_orgs.has_perm(perm, taxonomy) == enabled
-        assert self.user_both_orgs.has_perm(perm, taxonomy) == enabled
-        assert self.user_org2.has_perm(perm, taxonomy) == enabled
-        assert self.learner.has_perm(perm, taxonomy) == enabled
-
-    @ddt.data(
-        ("oel_tagging.change_taxonomy", "taxonomy_no_orgs"),
         ("oel_tagging.delete_taxonomy", "taxonomy_no_orgs"),
     )
     @ddt.unpack
-    def test_change_taxonomy_no_orgs(self, perm, taxonomy_attr):
+    def test_no_orgs_no_perms(self, perm, taxonomy_attr):
         """
-        Taxonomies with no org can only be changed by staff and superusers.
+        Org-level permissions are revoked when there are no orgs.
         """
+        Organization.objects.all().delete()
         taxonomy = getattr(self, taxonomy_attr)
+        # Superusers & Staff always have access
         assert self.superuser.has_perm(perm, taxonomy)
         assert self.staff.has_perm(perm, taxonomy)
+
+        # But everyone else's object-level access is removed
         assert not self.user_all_orgs.has_perm(perm, taxonomy)
         assert not self.user_both_orgs.has_perm(perm, taxonomy)
         assert not self.user_org2.has_perm(perm, taxonomy)
@@ -202,138 +226,211 @@ class TestRulesTaxonomy(TestTaxonomyMixin, TestCase):
 
     # Tag
 
-    @ddt.data(
-        ("oel_tagging.add_tag", "tag_all_orgs"),
-        ("oel_tagging.add_tag", "tag_both_orgs"),
-        ("oel_tagging.add_tag", "tag_disabled"),
-        ("oel_tagging.change_tag", "tag_all_orgs"),
-        ("oel_tagging.change_tag", "tag_both_orgs"),
-        ("oel_tagging.change_tag", "tag_disabled"),
-        ("oel_tagging.delete_tag", "tag_all_orgs"),
-        ("oel_tagging.delete_tag", "tag_both_orgs"),
-        ("oel_tagging.delete_tag", "tag_disabled"),
-    )
-    @ddt.unpack
-    def test_change_tag_all_orgs(self, perm, tag_attr):
-        """Taxonomy administrators can modify tags on non-free-text taxonomies"""
-        tag = getattr(self, tag_attr)
-        self._expected_users_have_perm(perm, tag)
+    def test_superuser_tag_perms(self):
+        assert self.superuser.has_perm('oel_tagging.add_tag')
+        assert self.superuser.has_perm('oel_tagging.change_tag')
+        assert self.superuser.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.superuser.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.superuser.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert self.superuser.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert self.superuser.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert self.superuser.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert self.superuser.has_perm('oel_tagging.delete_tag')
+        assert self.superuser.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.superuser.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.superuser.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert self.superuser.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert self.superuser.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert self.superuser.has_perm('oel_tagging.delete_tag', self.tag_system)
 
-    @ddt.data(
-        ("oel_tagging.add_tag", "tag_one_org"),
-        ("oel_tagging.change_tag", "tag_one_org"),
-        ("oel_tagging.delete_tag", "tag_one_org"),
-    )
-    @ddt.unpack
-    def test_change_tag_org1(self, perm, tag_attr):
-        """Taxonomy administrators can modify tags on non-free-text taxonomies"""
-        tag = getattr(self, tag_attr)
-        self._expected_users_have_perm(perm, tag, user_org2=False)
+    def test_staff_tag_perms(self):
+        assert self.staff.has_perm('oel_tagging.add_tag')
+        assert self.staff.has_perm('oel_tagging.change_tag')
+        assert self.staff.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.staff.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.staff.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert self.staff.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert self.staff.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.staff.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert self.staff.has_perm('oel_tagging.delete_tag')
+        assert self.staff.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.staff.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.staff.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert self.staff.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert self.staff.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.staff.has_perm('oel_tagging.delete_tag', self.tag_system)
 
-    @ddt.data(
-        "oel_tagging.add_tag",
-        "oel_tagging.change_tag",
-        "oel_tagging.delete_tag",
-    )
-    def test_tag_no_taxonomy(self, perm):
-        """Taxonomy administrators can modify any Tag, even those with no Taxonnmy."""
-        tag = Tag()
+    def test_user_all_orgs_tag_perms(self):
+        assert self.user_all_orgs.has_perm('oel_tagging.add_tag')
+        assert self.user_all_orgs.has_perm('oel_tagging.change_tag')
+        assert self.user_all_orgs.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert not self.user_all_orgs.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.user_all_orgs.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_tag')
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert not self.user_all_orgs.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.user_all_orgs.has_perm('oel_tagging.delete_tag', self.tag_system)
 
-        # Global Taxonomy Admins can do pretty much anything
-        assert self.superuser.has_perm(perm, tag)
-        assert self.staff.has_perm(perm, tag)
-        assert self.user_all_orgs.has_perm(perm, tag)
+    def test_user_both_orgs_tag_perms(self):
+        assert not self.user_both_orgs.has_perm('oel_tagging.add_tag')
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_tag')
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_tag')
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_system)
 
-        # Org content creators are bound by a taxonomy's org restrictions,
-        # so if there's no taxonomy, they can't do anything to it.
-        assert not self.user_both_orgs.has_perm(perm, tag)
-        assert not self.user_org2.has_perm(perm, tag)
-        assert not self.learner.has_perm(perm, tag)
+    def test_user_org2_tag_perms(self):
+        assert not self.user_org2.has_perm('oel_tagging.add_tag')
+        assert not self.user_org2.has_perm('oel_tagging.change_tag')
+        assert self.user_org2.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.user_org2.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert not self.user_org2.has_perm('oel_tagging.delete_tag')
+        assert self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_system)
 
-    @ddt.data(
-        "tag_all_orgs",
-        "tag_both_orgs",
-        "tag_one_org",
-        "tag_disabled",
-        "tag_no_orgs",
-    )
-    def test_view_tag(self, tag_attr):
-        """Anyone can view any Tag"""
-        tag = getattr(self, tag_attr)
-        self._expected_users_have_perm(
-            "oel_tagging.view_tag", tag, learner_perm=True, learner_obj=True
-        )
+    def test_learner_tag_perms(self):
+        assert not self.learner.has_perm('oel_tagging.add_tag')
+        assert not self.learner.has_perm('oel_tagging.change_tag')
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert not self.learner.has_perm('oel_tagging.delete_tag')
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_system)
 
     # ObjectTag
 
-    @ddt.data(
-        ("oel_tagging.add_object_tag", "disabled_course_tag"),
-        ("oel_tagging.change_object_tag", "disabled_course_tag"),
-        ("oel_tagging.delete_object_tag", "disabled_course_tag"),
-    )
-    @ddt.unpack
-    def test_object_tag_disabled_taxonomy(self, perm, tag_attr):
-        """Taxonomy administrators cannot create/edit an ObjectTag with a disabled Taxonomy"""
-        object_tag = getattr(self, tag_attr)
-        assert self.superuser.has_perm(perm, object_tag)
-        assert not self.staff.has_perm(perm, object_tag)
-        assert not self.user_all_orgs.has_perm(perm, object_tag)
-        assert not self.user_both_orgs.has_perm(perm, object_tag)
-        assert not self.user_org2.has_perm(perm, object_tag)
-        assert not self.learner.has_perm(perm, object_tag)
+    def test_superuser_object_tag_perms(self):
+        assert self.superuser.has_perm('oel_tagging.add_object_tag')
+        assert self.superuser.has_perm('oel_tagging.change_object_tag')
+        assert self.superuser.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.superuser.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.superuser.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert self.superuser.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert self.superuser.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert self.superuser.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert self.superuser.has_perm('oel_tagging.delete_object_tag')
+        assert self.superuser.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.superuser.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.superuser.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert self.superuser.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert self.superuser.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert self.superuser.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
 
-    @ddt.data(
-        ("oel_tagging.add_object_tag", "no_orgs_invalid_tag"),
-        ("oel_tagging.change_object_tag", "no_orgs_invalid_tag"),
-        ("oel_tagging.delete_object_tag", "no_orgs_invalid_tag"),
-    )
-    @ddt.unpack
-    def test_object_tag_no_orgs(self, perm, tag_attr):
-        """Only staff & superusers can create/edit an ObjectTag with a no-org Taxonomy"""
-        object_tag = getattr(self, tag_attr)
-        assert self.superuser.has_perm(perm, object_tag)
-        assert self.staff.has_perm(perm, object_tag)
-        assert not self.user_all_orgs.has_perm(perm, object_tag)
-        assert not self.user_both_orgs.has_perm(perm, object_tag)
-        assert not self.user_org2.has_perm(perm, object_tag)
-        assert not self.learner.has_perm(perm, object_tag)
+    def test_staff_object_tag_perms(self):
+        assert self.staff.has_perm('oel_tagging.add_object_tag')
+        assert self.staff.has_perm('oel_tagging.change_object_tag')
+        assert not self.staff.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.staff.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.staff.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert self.staff.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert self.staff.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert self.staff.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert self.staff.has_perm('oel_tagging.delete_object_tag')
+        assert not self.staff.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.staff.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.staff.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert self.staff.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert self.staff.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert self.staff.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
 
-    @ddt.data(
-        ("oel_tagging.add_object_tag", "all_orgs_course_tag"),
-        ("oel_tagging.add_object_tag", "all_orgs_block_tag"),
-        ("oel_tagging.add_object_tag", "both_orgs_course_tag"),
-        ("oel_tagging.add_object_tag", "both_orgs_block_tag"),
-        ("oel_tagging.add_object_tag", "all_orgs_invalid_tag"),
-        ("oel_tagging.change_object_tag", "all_orgs_course_tag"),
-        ("oel_tagging.change_object_tag", "all_orgs_block_tag"),
-        ("oel_tagging.change_object_tag", "both_orgs_course_tag"),
-        ("oel_tagging.change_object_tag", "both_orgs_block_tag"),
-        ("oel_tagging.change_object_tag", "all_orgs_invalid_tag"),
-        ("oel_tagging.delete_object_tag", "all_orgs_course_tag"),
-        ("oel_tagging.delete_object_tag", "all_orgs_block_tag"),
-        ("oel_tagging.delete_object_tag", "both_orgs_course_tag"),
-        ("oel_tagging.delete_object_tag", "both_orgs_block_tag"),
-        ("oel_tagging.delete_object_tag", "all_orgs_invalid_tag"),
-    )
-    @ddt.unpack
-    def test_change_object_tag_all_orgs(self, perm, tag_attr):
-        """Taxonomy administrators can create/edit an ObjectTag on taxonomies in their org."""
-        object_tag = getattr(self, tag_attr)
-        self._expected_users_have_perm(perm, object_tag)
+    def test_user_all_orgs_object_tag_perms(self):
+        assert self.user_all_orgs.has_perm('oel_tagging.add_object_tag')
+        assert self.user_all_orgs.has_perm('oel_tagging.change_object_tag')
+        assert not self.user_all_orgs.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert self.user_all_orgs.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert not self.user_all_orgs.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_all_orgs.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_object_tag')
+        assert not self.user_all_orgs.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert self.user_all_orgs.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert not self.user_all_orgs.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_all_orgs.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
 
-    @ddt.data(
-        ("oel_tagging.add_object_tag", "one_org_block_tag"),
-        ("oel_tagging.add_object_tag", "one_org_invalid_org_tag"),
-        ("oel_tagging.change_object_tag", "one_org_block_tag"),
-        ("oel_tagging.change_object_tag", "one_org_invalid_org_tag"),
-        ("oel_tagging.delete_object_tag", "one_org_block_tag"),
-        ("oel_tagging.delete_object_tag", "one_org_invalid_org_tag"),
-    )
-    @ddt.unpack
-    def test_change_object_tag_org1(self, perm, tag_attr):
-        """Taxonomy administrators can create/edit an ObjectTag on taxonomies in their org."""
-        object_tag = getattr(self, tag_attr)
-        self._expected_users_have_perm(perm, object_tag, user_org2=False)
+    def test_user_both_orgs_object_tag_perms(self):
+        assert not self.user_both_orgs.has_perm('oel_tagging.add_object_tag')
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_object_tag')
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_object_tag')
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
+
+    def test_user_org2_object_tag_perms(self):
+        assert not self.user_org2.has_perm('oel_tagging.add_object_tag')
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag')
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.user_org2.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.user_org2.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag')
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.user_org2.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.user_org2.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
+
+    def test_learner_object_tag_perms(self):
+        assert not self.learner.has_perm('oel_tagging.add_object_tag')
+        assert not self.learner.has_perm('oel_tagging.change_object_tag')
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag')
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
 
     @ddt.data(
         "oel_tagging.add_object_tag",
@@ -355,27 +452,6 @@ class TestRulesTaxonomy(TestTaxonomyMixin, TestCase):
         assert not self.user_org2.has_perm(perm, object_tag)
         assert not self.learner.has_perm(perm, object_tag)
 
-    @ddt.data(
-        "all_orgs_course_tag",
-        "all_orgs_block_tag",
-        "both_orgs_course_tag",
-        "both_orgs_block_tag",
-        "one_org_block_tag",
-        "all_orgs_invalid_tag",
-        "one_org_invalid_org_tag",
-        "no_orgs_invalid_tag",
-        "disabled_course_tag",
-    )
-    def test_view_object_tag(self, tag_attr):
-        """Anyone can view any ObjectTag"""
-        object_tag = getattr(self, tag_attr)
-        self._expected_users_have_perm(
-            "oel_tagging.view_object_tag",
-            object_tag,
-            learner_perm=True,
-            learner_obj=True,
-        )
-
 
 @ddt.ddt
 @override_settings(FEATURES={"ENABLE_CREATOR_GROUP": False})
@@ -389,39 +465,164 @@ class TestRulesTaxonomyNoCreatorGroup(
     However, if there are no Organizations in the database, then nobody has access to the Tagging models.
     """
 
-    def _expected_users_have_perm(
-        self, perm, obj, learner_perm=False, learner_obj=False, user_org2=True
-    ):
-        """
-        When ENABLE_CREATOR_GROUP is disabled, all users have all permissions.
-        """
-        super()._expected_users_have_perm(
-            perm=perm,
-            obj=obj,
-            learner_perm=True,
-            learner_obj=True,
-            user_org2=True,
-        )
+    # Taxonomy
 
-    @ddt.data(
-        "oel_tagging.add_tag",
-        "oel_tagging.change_tag",
-        "oel_tagging.delete_tag",
-    )
-    def test_tag_no_taxonomy(self, perm):
-        """Taxonomy administrators can modify any Tag, even those with no Taxonnmy."""
-        tag = Tag()
+    def test_user_both_orgs_taxonomy_perms(self):
+        assert self.user_both_orgs.has_perm('oel_tagging.add_taxonomy')
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy')
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy')
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
 
-        # Global Taxonomy Admins can do pretty much anything
-        assert self.superuser.has_perm(perm, tag)
-        assert self.staff.has_perm(perm, tag)
-        assert self.user_all_orgs.has_perm(perm, tag)
+    def test_user_org2_taxonomy_perms(self):
+        assert self.user_org2.has_perm('oel_tagging.add_taxonomy')
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy')
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy')
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
 
-        # Org content creators are bound by a taxonomy's org restrictions,
-        # but since there's no org restrictions enabled, anyone has these permissions.
-        assert self.user_both_orgs.has_perm(perm, tag)
-        assert self.user_org2.has_perm(perm, tag)
-        assert self.learner.has_perm(perm, tag)
+    def test_learner_taxonomy_perms(self):
+        assert self.learner.has_perm('oel_tagging.add_taxonomy')
+        assert self.learner.has_perm('oel_tagging.change_taxonomy')
+        assert self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_disabled)
+        assert self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_all_orgs)
+        assert self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_both_orgs)
+        assert self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_one_org)
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_taxonomy', self.taxonomy_system)
+        assert self.learner.has_perm('oel_tagging.delete_taxonomy')
+        assert self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_disabled)
+        assert self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_all_orgs)
+        assert self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_both_orgs)
+        assert self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_one_org)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_taxonomy', self.taxonomy_system)
+
+    # Tags
+
+    def test_user_both_orgs_tag_perms(self):
+        assert self.user_both_orgs.has_perm('oel_tagging.add_tag')
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag')
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag')
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_tag', self.tag_system)
+
+    def test_user_org2_tag_perms(self):
+        assert self.user_org2.has_perm('oel_tagging.add_tag')
+        assert self.user_org2.has_perm('oel_tagging.change_tag')
+        assert self.user_org2.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.user_org2.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert self.user_org2.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert self.user_org2.has_perm('oel_tagging.delete_tag')
+        assert self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert not self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.user_org2.has_perm('oel_tagging.delete_tag', self.tag_system)
+
+    def test_learner_tag_perms(self):
+        assert self.learner.has_perm('oel_tagging.add_tag')
+        assert self.learner.has_perm('oel_tagging.change_tag')
+        assert self.learner.has_perm('oel_tagging.change_tag', self.tag_disabled)
+        assert self.learner.has_perm('oel_tagging.change_tag', self.tag_all_orgs)
+        assert self.learner.has_perm('oel_tagging.change_tag', self.tag_both_orgs)
+        assert self.learner.has_perm('oel_tagging.change_tag', self.tag_one_org)
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.change_tag', self.tag_system)
+        assert self.learner.has_perm('oel_tagging.delete_tag')
+        assert self.learner.has_perm('oel_tagging.delete_tag', self.tag_disabled)
+        assert self.learner.has_perm('oel_tagging.delete_tag', self.tag_all_orgs)
+        assert self.learner.has_perm('oel_tagging.delete_tag', self.tag_both_orgs)
+        assert self.learner.has_perm('oel_tagging.delete_tag', self.tag_one_org)
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_no_orgs)
+        assert not self.learner.has_perm('oel_tagging.delete_tag', self.tag_system)
+
+    # ObjectTags
+
+    def test_user_both_orgs_object_tag_perms(self):
+        assert self.user_both_orgs.has_perm('oel_tagging.add_object_tag')
+        assert self.user_both_orgs.has_perm('oel_tagging.change_object_tag')
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_object_tag')
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_both_orgs.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
+
+    def test_user_org2_object_tag_perms(self):
+        assert self.user_org2.has_perm('oel_tagging.add_object_tag')
+        assert self.user_org2.has_perm('oel_tagging.change_object_tag')
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.user_org2.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.user_org2.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert self.user_org2.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_org2.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert self.user_org2.has_perm('oel_tagging.delete_object_tag')
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.user_org2.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.user_org2.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert self.user_org2.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert not self.user_org2.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
+
+    def test_learner_object_tag_perms(self):
+        assert self.learner.has_perm('oel_tagging.add_object_tag')
+        assert self.learner.has_perm('oel_tagging.change_object_tag')
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.disabled_course_tag)
+        assert self.learner.has_perm('oel_tagging.change_object_tag', self.all_orgs_block_tag)
+        assert self.learner.has_perm('oel_tagging.change_object_tag', self.both_orgs_course_tag)
+        assert self.learner.has_perm('oel_tagging.change_object_tag', self.one_org_block_tag)
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.no_orgs_invalid_tag)
+        assert not self.learner.has_perm('oel_tagging.change_object_tag', self.object_tag_system)
+        assert self.learner.has_perm('oel_tagging.delete_object_tag')
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.disabled_course_tag)
+        assert self.learner.has_perm('oel_tagging.delete_object_tag', self.all_orgs_block_tag)
+        assert self.learner.has_perm('oel_tagging.delete_object_tag', self.both_orgs_course_tag)
+        assert self.learner.has_perm('oel_tagging.delete_object_tag', self.one_org_block_tag)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.no_orgs_invalid_tag)
+        assert not self.learner.has_perm('oel_tagging.delete_object_tag', self.object_tag_system)
 
     @ddt.data(
         "oel_tagging.add_object_tag",
@@ -442,45 +643,3 @@ class TestRulesTaxonomyNoCreatorGroup(
         assert self.user_both_orgs.has_perm(perm, object_tag)
         assert self.user_org2.has_perm(perm, object_tag)
         assert self.learner.has_perm(perm, object_tag)
-
-    # Taxonomy
-
-    @ddt.data(
-        ("oel_tagging.add_taxonomy", "taxonomy_all_orgs"),
-        ("oel_tagging.add_taxonomy", "taxonomy_both_orgs"),
-        ("oel_tagging.add_taxonomy", "taxonomy_disabled"),
-        ("oel_tagging.add_taxonomy", "taxonomy_one_org"),
-        ("oel_tagging.add_taxonomy", "taxonomy_no_orgs"),
-        ("oel_tagging.change_taxonomy", "taxonomy_all_orgs"),
-        ("oel_tagging.change_taxonomy", "taxonomy_both_orgs"),
-        ("oel_tagging.change_taxonomy", "taxonomy_disabled"),
-        ("oel_tagging.change_taxonomy", "taxonomy_one_org"),
-        ("oel_tagging.change_taxonomy", "taxonomy_no_orgs"),
-        ("oel_tagging.delete_taxonomy", "taxonomy_all_orgs"),
-        ("oel_tagging.delete_taxonomy", "taxonomy_both_orgs"),
-        ("oel_tagging.delete_taxonomy", "taxonomy_disabled"),
-        ("oel_tagging.delete_taxonomy", "taxonomy_one_org"),
-        ("oel_tagging.delete_taxonomy", "taxonomy_no_orgs"),
-    )
-    @ddt.unpack
-    def test_no_orgs_no_perms(self, perm, taxonomy_attr):
-        """
-        Org-level permissions are revoked when there are no orgs.
-        """
-        Organization.objects.all().delete()
-        taxonomy = getattr(self, taxonomy_attr)
-        # Superusers & Staff always have access
-        assert self.superuser.has_perm(perm)
-        assert self.superuser.has_perm(perm, taxonomy)
-        assert self.staff.has_perm(perm)
-        assert self.staff.has_perm(perm, taxonomy)
-
-        # But everyone else's object-level access is removed
-        assert self.user_all_orgs.has_perm(perm)
-        assert not self.user_all_orgs.has_perm(perm, taxonomy)
-        assert self.user_both_orgs.has_perm(perm)
-        assert not self.user_both_orgs.has_perm(perm, taxonomy)
-        assert self.user_org2.has_perm(perm)
-        assert not self.user_org2.has_perm(perm, taxonomy)
-        assert self.learner.has_perm(perm)
-        assert not self.learner.has_perm(perm, taxonomy)


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Refactors the content_tagging rules tests to better demonstrate the access permitted to the different types of users.
My previous implementation covered the functionality, but was very hard to read.

This change makes it easier to see, e.g. Which taxonomies can an org admin modify? Which content tags can a course author create?

## Supporting information

Part of https://github.com/openedx/modular-learning/issues/89

## Testing instructions

This change only refactors tests, so no manual testing is required.

## Deadline

None

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
