### PR TITLE
Five packages has been bumped has django42 support

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -424,7 +424,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.1.0
+edx-auth-backends==4.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-blockstore
@@ -445,7 +445,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/kernel.in
 edx-completion==4.3.0
     # via -r requirements/edx/kernel.in
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
@@ -487,7 +487,7 @@ edx-event-bus-kafka==5.2.0
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.3.1
     # via -r requirements/edx/kernel.in
-edx-i18n-tools==1.0.0
+edx-i18n-tools==1.1.0
     # via ora2
 edx-milestones==0.5.0
     # via -r requirements/edx/kernel.in
@@ -518,7 +518,7 @@ edx-proctoring==4.16.1
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/kernel.in
-edx-rbac==1.7.0
+edx-rbac==1.8.0
     # via edx-enterprise
 edx-rest-api-client==5.5.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -679,7 +679,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.1.0
+edx-auth-backends==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -711,7 +711,7 @@ edx-completion==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -763,7 +763,7 @@ edx-event-bus-redis==0.3.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-i18n-tools==1.0.0
+edx-i18n-tools==1.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -808,7 +808,7 @@ edx-proctoring-proctortrack==1.0.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-rbac==1.7.0
+edx-rbac==1.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -501,7 +501,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.1.0
+edx-auth-backends==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
@@ -522,7 +522,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
 edx-completion==4.3.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -564,7 +564,7 @@ edx-event-bus-kafka==5.2.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.3.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.0.0
+edx-i18n-tools==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -596,7 +596,7 @@ edx-proctoring==4.16.1
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-rbac==1.7.0
+edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests
-edx-opaque-keys==2.3.0
+edx-opaque-keys==2.4.0
     # via -r requirements/edx/paver.in
 idna==3.4
     # via requests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -530,7 +530,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.1.0
+edx-auth-backends==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
@@ -551,7 +551,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
 edx-completion==4.3.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -593,7 +593,7 @@ edx-event-bus-kafka==5.2.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.3.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.0.0
+edx-i18n-tools==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -628,7 +628,7 @@ edx-proctoring==4.16.1
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-rbac==1.7.0
+edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
As we have added support for Django 4.2 for few edx-platform dependent packages, so those packages has been bumped in the PR.

Supporting information
Issue for the bumped packages: https://github.com/openedx/public-engineering/issues/199

Bumped packages:
- edx-auth-backends changes from 4.1.0 to 4.2.0
- edx-django-release-util changes from 1.2.0 to 1.3.0
- edx-i18n-tools changes from 1.0.0 to 1.1.0
- edx-opaque-keys changes from 2.3.0 to 2.4.0
- edx-rbac changes from 1.7.0 to 1.8.0