### PR TITLE
fix: five package has been bumped has django42 support

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -520,7 +520,7 @@ edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/kernel.in
 edx-rbac==1.7.0
     # via edx-enterprise
-edx-rest-api-client==5.5.2
+edx-rest-api-client==5.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -561,9 +561,9 @@ elasticsearch==7.13.4
     #   edx-search
 enmerkar==0.7.1
     # via enmerkar-underscore
-enmerkar-underscore==2.1.0
+enmerkar-underscore==2.2.0
     # via -r requirements/edx/kernel.in
-event-tracking==2.1.0
+event-tracking==2.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
@@ -594,7 +594,7 @@ glob2==0.7
     # via -r requirements/edx/kernel.in
 gunicorn==21.2.0
     # via -r requirements/edx/kernel.in
-help-tokens==2.2.0
+help-tokens==2.3.0
     # via -r requirements/edx/kernel.in
 html5lib==1.1
     # via
@@ -1108,7 +1108,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.0.1
+super-csv==3.1.0
     # via edx-bulk-grades
 sympy==1.12
     # via openedx-calc

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -813,7 +813,7 @@ edx-rbac==1.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-edx-rest-api-client==5.5.2
+edx-rest-api-client==5.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -876,11 +876,11 @@ enmerkar==0.7.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   enmerkar-underscore
-enmerkar-underscore==2.1.0
+enmerkar-underscore==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-event-tracking==2.1.0
+event-tracking==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -969,7 +969,7 @@ h11==0.14.0
     #   -r requirements/edx/testing.txt
     #   httpcore
     #   uvicorn
-help-tokens==2.2.0
+help-tokens==2.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1983,7 +1983,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.0.1
+super-csv==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -600,7 +600,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.5.2
+edx-rest-api-client==5.6.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -646,9 +646,9 @@ enmerkar==0.7.1
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar-underscore
-enmerkar-underscore==2.1.0
+enmerkar-underscore==2.2.0
     # via -r requirements/edx/base.txt
-event-tracking==2.1.0
+event-tracking==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
@@ -690,7 +690,7 @@ glob2==0.7
     # via -r requirements/edx/base.txt
 gunicorn==21.2.0
     # via -r requirements/edx/base.txt
-help-tokens==2.2.0
+help-tokens==2.3.0
     # via -r requirements/edx/base.txt
 html5lib==1.1
     # via
@@ -1350,7 +1350,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.0.1
+super-csv==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -632,7 +632,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.5.2
+edx-rest-api-client==5.6.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -678,9 +678,9 @@ enmerkar==0.7.1
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar-underscore
-enmerkar-underscore==2.1.0
+enmerkar-underscore==2.2.0
     # via -r requirements/edx/base.txt
-event-tracking==2.1.0
+event-tracking==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
@@ -740,7 +740,7 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-help-tokens==2.2.0
+help-tokens==2.3.0
     # via -r requirements/edx/base.txt
 html5lib==1.1
     # via
@@ -1463,7 +1463,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.0.1
+super-csv==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades


### PR DESCRIPTION
As we have added support for Django 4.2 for few edx-platform dependent packages, so those packages has been bumped in the PR.

Supporting information
Issue for the bumped packages: https://github.com/openedx/public-engineering/issues/199

Bumped packages:
- edx-rest-api-client changes from 5.5.2 to 5.6.0
- enmerkar-underscore changes from 2.1.0 to 2.2.0
- event-tracking changes from 2.1.0 to 2.2.0
- help-tokens changes from 2.2.0 to 2.3.0
- super-csv changes from 3.0.1 to 3.1.0