### PR TITLE
feat: install `atlas` translations tool

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -755,6 +755,8 @@ olxcleaner==0.2.1
     # via -r requirements/edx/kernel.in
 openai==0.28.0
     # via edx-enterprise
+openedx-atlas==0.5.0
+    # via -r requirements/edx/kernel.in
 openedx-blockstore==1.4.0
     # via -r requirements/edx/kernel.in
 openedx-calc==3.0.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1277,6 +1277,10 @@ openai==0.28.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
+openedx-atlas==0.5.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
 openedx-blockstore==1.4.0
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -895,6 +895,8 @@ openai==0.28.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+openedx-atlas==0.5.0
+    # via -r requirements/edx/base.txt
 openedx-blockstore==1.4.0
     # via -r requirements/edx/base.txt
 openedx-calc==3.0.1

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -111,6 +111,7 @@ mysqlclient                         # Driver for the default production relation
 nodeenv                             # Utility for managing Node.js environments; we use this for deployments and testing
 oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services
 olxcleaner
+openedx-atlas                       # CLI tool to manage translations
 openedx-calc                        # Library supporting mathematical calculations for Open edX
 openedx-django-require
 openedx-events>=8.3.0               # Open edX Events from Hooks Extension Framework (OEP-50)

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -965,6 +965,8 @@ openai==0.28.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+openedx-atlas==0.5.0
+    # via -r requirements/edx/base.txt
 openedx-blockstore==1.4.0
     # via -r requirements/edx/base.txt
 openedx-calc==3.0.1


### PR DESCRIPTION
## Description

Add the [openedx-atlas](https://github.com/openedx/openedx-atlas) to the kernel.in so it's available in all environments including Atlas, Devstack and Native installation.

This is part 1 out of several other steps to eventually let `make pull_translations` pull from https://github.com/openedx/openedx-translations instead of Transifex, which has been concluded by [OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

This has been generated with the following command:

```
$ cd edx-platform
$ make upgrade-package package=openedx-atlas
```

Which is inspired by the [upgrade-one-python-dependency.yml](https://github.com/openedx/edx-platform/blob/master/.github/workflows/upgrade-one-python-dependency.yml) workflow which I suppose I cannot run due to the lack of GitHub permission.


## Testing instructions

 - [x] Build the image on my fork
 - [x] Upgrade to `openedx-atlas==0.5.0` 
 - [x] Test again

```
$ DOCKER_BUILDKIT=1 docker build . --build-arg SERVICE_VARIANT=lms --build-arg SERVICE_PORT=8000 --target development -t openedx/lms-dev
...
$ docker run -it docker.io/openedx/lms-dev atlas --version
v0.5.0

...

devstack $ make dev.up.lms
devstack $ make dev.shell.lms
root@lms:/edx/app/edxapp/edx-platform# atlas --version
v0.5.0


```


 - [x] Run atlas and pull translations on `edx-platform`


<details><summary>Testing atlas pull with --expand-glob</summary>

```
$ docker run -it docker.io/openedx/lms-dev bash
root@c8b826df60ce:/edx/app/edxapp/edx-platform# rm -rf conf/plugins-locale
root@c8b826df60ce:/edx/app/edxapp/edx-platform# atlas pull --expand-glob 'translations/*/done/conf/locale:conf/plugins-locale/done'
Pulling translation files
 - directory: translations/*/done/conf/locale:conf/plugins-locale/done
 - repository: openedx/openedx-translations
 - branch: main
 - filter: Not Specified
 - expand-glob: 1
Creating a temporary Git repository to pull translations into "./translations_TEMP"...
Done.
Setting git sparse-checkout rules...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 4 (delta 3), reused 1 (delta 1), pack-reused 0
Receiving objects: 100% (4/4), 2.78 KiB | 2.78 MiB/s, done.
Resolving deltas: 100% (3/3), done.
Done.
Pulling translation files from the repository...
Your branch is up to date with 'origin/main'.
Done.
Copying translations from "./translations_TEMP/translations/DoneXBlock/done/conf/locale" to "./conf/plugins-locale/done"...
Done.
Removing temporary directory...
Done.

Translations pulled successfully!
root@c8b826df60ce:/edx/app/edxapp/edx-platform# find conf/plugins-locale/ -type f
conf/plugins-locale/done/fr_CA/LC_MESSAGES/django.po
conf/plugins-locale/done/en/LC_MESSAGES/django.po
conf/plugins-locale/done/de/LC_MESSAGES/django.po
conf/plugins-locale/done/ar/LC_MESSAGES/django.po

```


</details> 


## Supporting information

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

