### PR TITLE
fix: set isPublish as True when creating topics in incontext discussion

### DIFF
--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -111,7 +111,12 @@ def get_discussable_units(course, enable_graded_units, discussable_units=None):
                     idx += 1
                     if not is_discussable_unit(unit, store, enable_graded_units, subsection):
                         unit.discussion_enabled = False
-                        store.update_item(unit, unit.published_by, emit_signals=False)
+                        # TODO: if and log statement will be removed after testing.
+                        if str(course.id) == "course-v1:NedX+CMH43+2023_Summer":
+                            log.info(f"Updating discussions_enabled for {course.id}")
+                            store.update_item(unit, unit.published_by, isPublish=True, emit_signals=False)
+                        else:
+                            store.update_item(unit, unit.published_by, emit_signals=False)
                         continue
                     # check if discussable_units is type of list and discussable_units is empty
                     # it means if discussable_units is empty then we should not create any topic


### PR DESCRIPTION
Set `isPublish` as True while setting `discussion_enabled` as source of truth

[isPublish DocString](https://github.com/openedx/edx-platform/blob/b97007e1823320c3d97b5a84b0c988d888250e84/xmodule/modulestore/mongo/base.py#L1394C14-L1394C14)

Ticket: [INF-997](https://2u-internal.atlassian.net/browse/INF-997)