### PR TITLE
fix: Four packages has been bumped has Django 42 support

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1162,7 +1162,7 @@ watchdog==3.0.0
     # via -r requirements/edx/paver.txt
 wcwidth==0.2.6
     # via prompt-toolkit
-web-fragments==2.0.0
+web-fragments==2.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   crowdsourcehinter-xblock
@@ -1201,11 +1201,11 @@ xblock[django]==1.6.2
     #   xblock-utils
 xblock-drag-and-drop-v2==3.2.0
     # via -r requirements/edx/bundled.in
-xblock-google-drive==0.3.0
+xblock-google-drive==0.4.0
     # via -r requirements/edx/bundled.in
 xblock-poll==1.13.0
     # via -r requirements/edx/bundled.in
-xblock-utils==3.3.0
+xblock-utils==3.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   done-xblock
@@ -1216,7 +1216,7 @@ xblock-utils==3.3.0
     #   xblock-google-drive
 xmlsec==1.3.13
     # via python3-saml
-xss-utils==0.4.0
+xss-utils==0.5.0
     # via -r requirements/edx/kernel.in
 yarl==1.9.2
     # via aiohttp

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2146,7 +2146,7 @@ wcwidth==0.2.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   prompt-toolkit
-web-fragments==2.0.0
+web-fragments==2.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2198,7 +2198,7 @@ xblock-drag-and-drop-v2==3.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock-google-drive==0.3.0
+xblock-google-drive==0.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2206,7 +2206,7 @@ xblock-poll==1.13.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock-utils==3.3.0
+xblock-utils==3.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2221,7 +2221,7 @@ xmlsec==1.3.13
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml
-xss-utils==0.4.0
+xss-utils==0.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1427,7 +1427,7 @@ wcwidth==0.2.6
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==2.0.0
+web-fragments==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   crowdsourcehinter-xblock
@@ -1467,11 +1467,11 @@ xblock[django]==1.6.2
     #   xblock-utils
 xblock-drag-and-drop-v2==3.2.0
     # via -r requirements/edx/base.txt
-xblock-google-drive==0.3.0
+xblock-google-drive==0.4.0
     # via -r requirements/edx/base.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
-xblock-utils==3.3.0
+xblock-utils==3.4.0
     # via
     #   -r requirements/edx/base.txt
     #   done-xblock
@@ -1484,7 +1484,7 @@ xmlsec==1.3.13
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
-xss-utils==0.4.0
+xss-utils==0.5.0
     # via -r requirements/edx/base.txt
 yarl==1.9.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1575,7 +1575,7 @@ wcwidth==0.2.6
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==2.0.0
+web-fragments==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   crowdsourcehinter-xblock
@@ -1616,11 +1616,11 @@ xblock[django]==1.6.2
     #   xblock-utils
 xblock-drag-and-drop-v2==3.2.0
     # via -r requirements/edx/base.txt
-xblock-google-drive==0.3.0
+xblock-google-drive==0.4.0
     # via -r requirements/edx/base.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
-xblock-utils==3.3.0
+xblock-utils==3.4.0
     # via
     #   -r requirements/edx/base.txt
     #   done-xblock
@@ -1633,7 +1633,7 @@ xmlsec==1.3.13
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
-xss-utils==0.4.0
+xss-utils==0.5.0
     # via -r requirements/edx/base.txt
 yarl==1.9.2
     # via


### PR DESCRIPTION
As we have added support for Django 4.2 for few edx-platform dependent packages, so those packages has been bumped in the PR.

Supporting information
Issue for the bumped packages: https://github.com/openedx/public-engineering/issues/199
Bumped packages:

- web-fragments changes from 2.0.0 to 2.1.0
- xblock-google-drive changes from 0.3.0 to 0.4.0
- xblock-utils changes from 3.3.0 to 3.4.0
- xss-utils changes from 0.4.0 to 0.5.0