### PR TITLE
fix: chardet bumped to 5.2.0 in all the requirements files

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -110,7 +110,7 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-chardet==5.1.0
+chardet==5.2.0
     # via pysrt
 charset-normalizer==2.0.12
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -192,7 +192,7 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-chardet==5.1.0
+chardet==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -138,7 +138,7 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-chardet==5.1.0
+chardet==5.2.0
     # via
     #   -r requirements/edx/base.txt
     #   pysrt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -146,7 +146,7 @@ cffi==1.15.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-chardet==5.1.0
+chardet==5.2.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt


### PR DESCRIPTION
Create this PR in the followup of this [PR](https://github.com/openedx/edx-platform/pull/32921). Bumped `chardet` to 5.2.0 only in coverage.txt, soo now I've bumped it in all requirements files.
**Reason:**
It was causing conflicts when trying to run make requirements