### PR TITLE
fix: fix django4 deprecation warnings

### DIFF
--- a/cms/djangoapps/api/__init__.py
+++ b/cms/djangoapps/api/__init__.py
@@ -1,2 +1,1 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
-default_app_config = 'cms.djangoapps.api.apps.ApiConfig'

--- a/cms/djangoapps/api/urls.py
+++ b/cms/djangoapps/api/urls.py
@@ -3,7 +3,7 @@ URLs for the Studio API app
 """
 
 
-from django.conf.urls import include
+from django.urls import include
 from django.urls import path
 
 app_name = 'cms.djangoapps.api'

--- a/cms/djangoapps/contentstore/rest_api/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/urls.py
@@ -2,7 +2,8 @@
 Contentstore API URLs.
 """
 
-from django.urls import include, re_path
+from django.urls import path
+from django.urls import include
 
 from .v0 import urls as v0_urls
 from .v1 import urls as v1_urls
@@ -10,6 +11,6 @@ from .v1 import urls as v1_urls
 app_name = 'cms.djangoapps.contentstore'
 
 urlpatterns = [
-    re_path(r'^v0/', include(v0_urls)),
-    re_path(r'^v1/', include(v1_urls)),
+    path('v0/', include(v0_urls)),
+    path('v1/', include(v1_urls)),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -1,5 +1,6 @@
 """ Contenstore API v1 URLs. """
 
+from django.urls import path
 from django.urls import re_path
 from django.conf import settings
 
@@ -67,8 +68,8 @@ urlpatterns = [
         fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
         videos.VideoEncodingsDownloadView.as_view(), name='studio_content_videos_encodings'
     ),
-    re_path(
-        r'^videos/features/$',
+    path(
+        'videos/features/',
         videos.VideoFeaturesView.as_view(), name='studio_content_videos_features'
     ),
     re_path(

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -3,9 +3,9 @@ Urls of Studio.
 """
 
 from django.conf import settings
-from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib.admin import autodiscover as django_autodiscover
+from django.urls import include
 from django.urls import path, re_path
 from django.utils.translation import gettext_lazy as _
 from auth_backends.urls import oauth2_urlpatterns


### PR DESCRIPTION
### Description
- Fixed Django 4.0 and Django 4.1 deprecation warnings in order to prepare for `Django 4.2` upgrade.
- Creating PR under the effort of issue https://github.com/openedx/public-engineering/issues/198