### PR TITLE
chore: upgrading ora2 version.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -775,7 +775,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==5.2.1
+ora2==5.2.3
     # via -r requirements/edx/bundled.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1315,7 +1315,7 @@ optimizely-sdk==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==5.2.1
+ora2==5.2.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -918,7 +918,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.2.1
+ora2==5.2.3
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -987,7 +987,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.2.1
+ora2==5.2.3
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via


### PR DESCRIPTION
upgrade ora2==5.2.3

It will bring 1 migration related with django-history.