### PR TITLE
feat: add python apis to agreements models

### DIFF
--- a/openedx/core/djangoapps/agreements/api.py
+++ b/openedx/core/djangoapps/agreements/api.py
@@ -78,28 +78,36 @@ def get_integrity_signatures_for_course(course_id):
 def create_lti_pii_signature(username, course_id, lti_tools):
     """
     Creates an lti pii tool signature. If the signature already exist, do not create a new one.
+
     Arguments:
         * course_key (str)
         * lti_tools (dict)
         * lti_tools_hash (int)
     Returns:
-        * True or False depending on if the write was successful
+        * An LTIPIISignature, or None if a signature already exists.
     """
     user = User.objects.get(username=username)
     course_key = CourseKey.from_string(course_id)
     lti_tools_hash = hash(str(lti_tools))
 
-    signature, created = LTIPIISignature.objects.get_or_create(
-        user=user,
-        course_key=course_key,
-        lti_tools=lti_tools,
-        lti_tools_hash=lti_tools_hash)
-    if not created:
-        log.warning(
-            'LTI PII signature already exists for user_id={user_id} and '
-            'course_id={course_id}'.format(user_id=user.id, course_id=course_id)
-        )
-    return signature
+    # if user and course exists, update, otherwise create a new signature
+    try:
+        LTIPIISignature.objects.get(user=user, course_key=course_key)
+    except ObjectDoesNotExist:
+        #create
+        signature = LTIPIISignature.objects.create(
+            user=user,
+            course_key=course_key,
+            lti_tools=lti_tools,
+            lti_tools_hash=lti_tools_hash)
+        return signature
+    else:
+        signature = LTIPIISignature.objects.update(
+            user=user,
+            course_key=course_key,
+            lti_tools=lti_tools,
+            lti_tools_hash=lti_tools_hash)
+        return signature
 
 
 def get_lti_pii_signature(username, course_id):
@@ -114,13 +122,15 @@ def get_lti_pii_signature(username, course_id):
         * An LTIPIISignature object, or None if one does not exist for the
           user + course combination.
     """
-    user = User.objects.get(username=username)
     course_key = CourseKey.from_string(course_id)
     try:
+        user = User.objects.get(username=username)
         signature = LTIPIISignature.objects.get(user=user, course_key=course_key)
-        return LTIPIISignatureData(lti_pii_signature=signature)
     except ObjectDoesNotExist:
         return None
+    else:
+        return LTIPIISignatureData(user=signature.user, course_id=str(signature.course_key),
+                                   lti_tools=signature.lti_tools, lti_tools_hash=signature.lti_tools_hash)
 
 
 def get_pii_receiving_lti_tools(course_id):
@@ -135,11 +145,13 @@ def get_pii_receiving_lti_tools(course_id):
     """
 
     course_key = CourseKey.from_string(course_id)
-    course_ltipiitools = LTIPIITool.objects.get(course_key=course_key).lti_tools
-
-    return LTIToolsReceivingPIIData(
-        lii_tools_receiving_pii=course_ltipiitools,
-    )
+    try:
+        course_ltipiitools = LTIPIITool.objects.get(course_key=course_key).lti_tools
+        return LTIToolsReceivingPIIData(
+            lii_tools_receiving_pii=course_ltipiitools,
+        )
+    except ObjectDoesNotExist:
+        return None
 
 
 def user_lti_pii_signature_needed(username, course_id):
@@ -180,10 +192,10 @@ def _course_has_lti_pii_tools(course_id):
         * False if the course does not.
     """
     course_key = CourseKey.from_string(course_id)
-    course_lti_pii_tools = LTIPIITool.objects.get(course_key)
-
-    if not course_lti_pii_tools:
-        # empty queryset, meaning no tools
+    try:
+        LTIPIITool.objects.get(course_key)
+    except ObjectDoesNotExist:
+        # no entry in the database
         return False
     else:
         return True
@@ -201,14 +213,15 @@ def _user_lti_pii_signature_exists(username, course_id):
         * True if user has a signature for the given course.
         * False if the user does not have a signature for the given course.
     """
-    user = User.objects.get(username=username)
     course_key = CourseKey.from_string(course_id)
 
-    signature = LTIPIISignature.objects.get(user=user, course_key=course_key)
-    if not signature:
-        return False
+    try:
+        user = User.objects.get(username=username)
+        LTIPIISignature.objects.get(user=user, course_key=course_key)
+    except ObjectDoesNotExist:
+        return None
     else:
-        return True
+        return True  # signature exist
 
 
 def _user_needs_signature_update(username, course_id):
@@ -220,18 +233,20 @@ def _user_needs_signature_update(username, course_id):
             * course_id (str)
 
         Returns:
-            * True if user has a signature for the given course.
-            * False if the user does not have a signature for the given course.
+            * True if user needs a new signature
+            * False if the user has an up-to-date signature.
         """
-
-    user = User.objects.get(username=username)
     course_key = CourseKey.from_string(course_id)
 
-    user_lti_pii_signature_hash = LTIPIISignature.objects.get(course_key=course_key, user=user).lti_tools_hash
-    course_lti_pii_tools_hash = LTIPIITool.objects.get(course_key=course_key).lti_tools_hash
-
-    if user_lti_pii_signature_hash == course_lti_pii_tools_hash:
-        # Hashes are equal, therefor update is not need
-        return False
+    try:
+        user = User.objects.get(username=username)
+        user_lti_pii_signature_hash = LTIPIISignature.objects.get(course_key=course_key, user=user).lti_tools_hash
+        course_lti_pii_tools_hash = LTIPIITool.objects.get(course_key=course_key).lti_tools_hash
+    except ObjectDoesNotExist:
+        return None
     else:
-        return True
+        if user_lti_pii_signature_hash == course_lti_pii_tools_hash:
+            # Hashes are equal, therefore update is not need
+            return False
+        else:
+            return True

--- a/openedx/core/djangoapps/agreements/api.py
+++ b/openedx/core/djangoapps/agreements/api.py
@@ -9,6 +9,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.agreements.models import IntegritySignature
+from openedx.core.djangoapps.agreements.models import LTIPIITool
+from openedx.core.djangoapps.agreements.models import LTIPIISignature
 
 log = logging.getLogger(__name__)
 User = get_user_model()
@@ -68,3 +70,76 @@ def get_integrity_signatures_for_course(course_id):
     """
     course_key = CourseKey.from_string(course_id)
     return IntegritySignature.objects.filter(course_key=course_key)
+
+
+def get_ltipiitool(course_id):
+    """
+    Get a course's LTI tools that share PII.
+
+    Arguments:
+        * course_id (str)
+
+    Returns:
+        * A QuerySet of LTIPIITool object.
+    """
+    course_key = CourseKey.from_string(course_id)
+    course_ltipiitools = LTIPIITool.objects.get(course_key=course_key)
+    return course_ltipiitools
+
+
+def set_ltipiitool(course_id, lti_tools, lti_tools_hash):
+    """
+    Creates or updates a course's list of LTI tools that share PII.
+
+    Arguments:
+        * course_key (str)
+        * lti_tools (str)
+        * lti_tools_hash (int)
+
+    Returns:
+        * True or False depending on if the write was successful
+    """
+    course_key = CourseKey.from_string(course_id)
+    LTIPIITool.objects.update_or_create(
+        course_key=course_key,
+        lti_tools=lti_tools,
+        lti_tools_hash=lti_tools_hash)
+    
+
+def get_ltipiisignature(username, course_id):
+    """
+    Get a lti pii signature for a specific user.
+
+    Arguments:
+        * course_key (str)
+        * user (User)
+
+    Returns:
+        * An IntegritySignature object, or None if one does not exist for the
+        user + course combination.
+    """
+    course_key = CourseKey.from_string(course_id)
+    user = User.objects.get(username=username)
+    try:
+        return LTIPIISignature.objects.get(user=user, course_key=course_key)
+    except ObjectDoesNotExist:
+        return None
+
+
+def set_ltipiisignature(course_id, lti_tools, lti_tools_hash):
+    """
+    Creates or updates a user's acknowledgement of sharing PII via LTI tools.
+
+    Arguments:
+        * course_key (str)
+        * lti_tools (str)
+        * lti_tools_hash (int)
+
+    Returns:
+        * True or False depending on if the write was successful
+    """
+    course_key = CourseKey.from_string(course_id)
+    LTIPIITool.objects.update_or_create(
+        course_key=course_key,
+        lti_tools=lti_tools,
+        lti_tools_hash=lti_tools_hash)

--- a/openedx/core/djangoapps/agreements/api.py
+++ b/openedx/core/djangoapps/agreements/api.py
@@ -169,13 +169,8 @@ def user_lti_pii_signature_needed(username, course_id):
     signature_exists = _user_lti_pii_signature_exists(username, course_id)
     signature_out_of_date = _user_signature_out_of_date(username, course_id)
 
-    if ((course_has_lti_pii_tools and (not signature_exists)) or
-            (course_has_lti_pii_tools and signature_exists and signature_out_of_date)):
-        # write a new signature, or update an existing signature
-        return True
-    else:
-        # course does not have lti pii tools, or signature is up to date
-        return False
+    return ((course_has_lti_pii_tools and (not signature_exists)) or
+            (course_has_lti_pii_tools and signature_exists and signature_out_of_date))
 
 
 def _course_has_lti_pii_tools(course_id):
@@ -192,7 +187,7 @@ def _course_has_lti_pii_tools(course_id):
     course_key = CourseKey.from_string(course_id)
     try:
         course_lti_pii_tools = LTIPIITool.objects.get(course_key=course_key)
-    except (LTIPIITool.DoesNotExist):
+    except LTIPIITool.DoesNotExist:
         # no entry in the database
         return False
     else:

--- a/openedx/core/djangoapps/agreements/api.py
+++ b/openedx/core/djangoapps/agreements/api.py
@@ -167,9 +167,10 @@ def user_lti_pii_signature_needed(username, course_id):
     """
     course_has_lti_pii_tools = _course_has_lti_pii_tools(course_id)
     signature_exists = _user_lti_pii_signature_exists(username, course_id)
-    signature_out_of_date = _user_signature_out_of_date(course_id)
+    signature_out_of_date = _user_signature_out_of_date(username, course_id)
 
-    if course_has_lti_pii_tools and (not signature_exists) or (course_has_lti_pii_tools and signature_exists and signature_out_of_date):
+    if (course_has_lti_pii_tools and (not signature_exists) or 
+        (course_has_lti_pii_tools and signature_exists and signature_out_of_date)):
         # write a new signature, or update an existing signature
         return True
     else:

--- a/openedx/core/djangoapps/agreements/data.py
+++ b/openedx/core/djangoapps/agreements/data.py
@@ -1,0 +1,9 @@
+import attr
+
+
+@attr.s(frozen=True, auto_attribs=True)
+class LTIToolsReceivingPIIData:
+    """
+    Class that stores data about the list of LTI tools sharing PII
+    """
+    lii_tools_receiving_pii: dict()

--- a/openedx/core/djangoapps/agreements/data.py
+++ b/openedx/core/djangoapps/agreements/data.py
@@ -1,3 +1,6 @@
+"""
+Public data structures for this app. 
+"""
 import attr
 
 
@@ -6,7 +9,7 @@ class LTIToolsReceivingPIIData:
     """
     Class that stores data about the list of LTI tools sharing PII
     """
-    lii_tools_receiving_pii: dict()
+    lii_tools_receiving_pii: {}
 
 
 @attr.s(frozen=True, auto_attribs=True)

--- a/openedx/core/djangoapps/agreements/data.py
+++ b/openedx/core/djangoapps/agreements/data.py
@@ -1,4 +1,5 @@
 import attr
+from openedx.core.djangoapps.agreements.models import LTIPIISignature
 
 
 @attr.s(frozen=True, auto_attribs=True)
@@ -7,3 +8,11 @@ class LTIToolsReceivingPIIData:
     Class that stores data about the list of LTI tools sharing PII
     """
     lii_tools_receiving_pii: dict()
+
+
+@attr.s(frozen=True, auto_attribs=True)
+class LTIPIISignatureData:
+    """
+    Class that stores an lti pii signature
+    """
+    lti_pii_signature: LTIPIISignature

--- a/openedx/core/djangoapps/agreements/data.py
+++ b/openedx/core/djangoapps/agreements/data.py
@@ -1,5 +1,4 @@
 import attr
-from openedx.core.djangoapps.agreements.models import LTIPIISignature
 
 
 @attr.s(frozen=True, auto_attribs=True)
@@ -15,4 +14,7 @@ class LTIPIISignatureData:
     """
     Class that stores an lti pii signature
     """
-    lti_pii_signature: LTIPIISignature
+    user: str
+    course_id: str
+    lti_tools: str
+    lti_tools_hash: str

--- a/openedx/core/djangoapps/agreements/data.py
+++ b/openedx/core/djangoapps/agreements/data.py
@@ -1,5 +1,5 @@
 """
-Public data structures for this app. 
+Public data structures for this app.
 """
 import attr
 

--- a/openedx/core/djangoapps/agreements/tests/test_api.py
+++ b/openedx/core/djangoapps/agreements/tests/test_api.py
@@ -18,7 +18,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from ..models import (
-    LTIPIITool, LTIPIISignature,
+    LTIPIITool,
 )
 from opaque_keys.edx.keys import CourseKey
 
@@ -143,9 +143,9 @@ class TestLTIPIISignatureApi(SharedModuleStoreTestCase):
 
         create_lti_pii_signature(self.user.username, self.course_id, self.lti_tools)  # first signature
         s1 = get_lti_pii_signature(self.user.username, self.course_id)  # retrieve the database entry
-        create_lti_pii_signature(self.user.username, self.course_id, self.lti_tools_2)  # signature with updated lti pii tools
+        create_lti_pii_signature(self.user.username, self.course_id, self.lti_tools_2)  # signature with updated tools
         s2 = get_lti_pii_signature(self.user.username, self.course_id)  # retrieve the updated database entry
-        self.assertTrue(s1 != s2)  # the signatue retrieved from the database should be the updated version
+        self.assertNotEqual(s1, s2)  # the signatue retrieved from the database should be the updated version
 
     def _assert_lti_pii_signature(self, signature):
         """
@@ -181,8 +181,8 @@ class TestLTIPIIToolsApi(SharedModuleStoreTestCase):
         data = get_pii_receiving_lti_tools(self.course_id)
         self._assert_ltitools(data.lii_tools_receiving_pii)
 
-    def _assert_ltitools(self, list):
+    def _assert_ltitools(self, lti_list):
         """
         Helper function to assert the returned list has the correct tools
         """
-        self.assertEqual(self.lti_tools, list)
+        self.assertEqual(self.lti_tools, lti_list)

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -119,26 +119,3 @@ class IntegritySignatureView(AuthenticatedAPIView):
         signature = create_integrity_signature(username, course_id)
         serializer = IntegritySignatureSerializer(signature)
         return Response(serializer.data)
-
-
-class LTIPIISignatureView(AuthenticatedAPIView):
-    """
-    Endpoint for an PII sharing LTI Signature
-    /integrity_signature/{course_id}
-
-    HTTP POST
-        * If an integrity signature does not exist for the user + course, creates one and
-          returns it. If one does exist, returns the existing signature.
-    """
-
-    def post(self, request, course_id):
-        """
-        Create an LTI PII signature for the requesting user and course. If a signature
-        already exists, returns the existing signature instead of creating a new one.
-
-        /api/agreements/v1/lti_pii_signature/{course_id}
-        """
-        username = request.user.username
-        #signature = create_lti_pii_signature(username, course_id, lti_tools)
-        #serializer = IntegritySignatureSerializer(signature)
-        #return Response(serializer.data)

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -16,6 +16,7 @@ from common.djangoapps.student.roles import CourseStaffRole
 from openedx.core.djangoapps.agreements.api import (
     create_integrity_signature,
     get_integrity_signature,
+    create_lti_pii_signature,
 )
 from openedx.core.djangoapps.agreements.serializers import IntegritySignatureSerializer
 
@@ -119,3 +120,26 @@ class IntegritySignatureView(AuthenticatedAPIView):
         signature = create_integrity_signature(username, course_id)
         serializer = IntegritySignatureSerializer(signature)
         return Response(serializer.data)
+
+
+class LTIPIISignatureView(AuthenticatedAPIView):
+    """
+    Endpoint for an PII sharing LTI Signature
+    /integrity_signature/{course_id}
+
+    HTTP POST
+        * If an integrity signature does not exist for the user + course, creates one and
+          returns it. If one does exist, returns the existing signature.
+    """
+
+    def post(self, request, course_id):
+        """
+        Create an LTI PII signature for the requesting user and course. If a signature
+        already exists, returns the existing signature instead of creating a new one.
+
+        /api/agreements/v1/lti_pii_signature/{course_id}
+        """
+        username = request.user.username
+        signature = create_lti_pii_signature(username, course_id, lti_tools)
+        #serializer = IntegritySignatureSerializer(signature)
+        #return Response(serializer.data)

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -140,6 +140,6 @@ class LTIPIISignatureView(AuthenticatedAPIView):
         /api/agreements/v1/lti_pii_signature/{course_id}
         """
         username = request.user.username
-        signature = create_lti_pii_signature(username, course_id, lti_tools)
+        #signature = create_lti_pii_signature(username, course_id, lti_tools)
         #serializer = IntegritySignatureSerializer(signature)
         #return Response(serializer.data)

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -16,7 +16,6 @@ from common.djangoapps.student.roles import CourseStaffRole
 from openedx.core.djangoapps.agreements.api import (
     create_integrity_signature,
     get_integrity_signature,
-    create_lti_pii_signature,
 )
 from openedx.core.djangoapps.agreements.serializers import IntegritySignatureSerializer
 


### PR DESCRIPTION
## Description

JIRA: https://2u-internal.atlassian.net/browse/MST-2014

In order to support the asynchronous Celery task and the courseware API view, we need to add Python APIs to read from and write to the new agreements models LTIPIITool, LTIPIISignature, and ProctoringPIISignature.

Create a Python API to read from and write to these models. Use the guidance documented in [OEP-49: Django App Patterns](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0049-django-app-patterns.html).