### PR TITLE
feat: upgrading django-history.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -125,4 +125,4 @@ djangorestframework-stubs==3.14.0  # Pinned to match django-stubs. Remove this w
 libsass==0.10.0
 
 # incremental upgrade
-django-simple-history<=3.2.0
+django-simple-history<3.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -125,4 +125,4 @@ djangorestframework-stubs==3.14.0  # Pinned to match django-stubs. Remove this w
 libsass==0.10.0
 
 # incremental upgrade
-django-simple-history<=3.1.1
+django-simple-history<=3.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -125,4 +125,4 @@ djangorestframework-stubs==3.14.0  # Pinned to match django-stubs. Remove this w
 libsass==0.10.0
 
 # incremental upgrade
-django-simple-history<3.3.0
+django-simple-history==3.2.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -338,7 +338,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==3.5.0
     # via -r requirements/edx/bundled.in
-django-simple-history==3.1.1
+django-simple-history==3.2.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -548,7 +548,7 @@ django-ses==3.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-simple-history==3.1.1
+django-simple-history==3.2.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -402,7 +402,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==3.5.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.1.1
+django-simple-history==3.2.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -434,7 +434,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==3.5.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.1.1
+django-simple-history==3.2.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Upgrading to django-history to 3.2.0.
https://github.com/jazzband/django-simple-history/blob/master/CHANGES.rst#320-2022-09-28

```
3.2.0 (2022-09-28)
Fixed typos in the docs
Removed n+1 query from bulk_create_with_history utility (gh-975)
Started using exists query instead of count in populate_history command (gh-982)
Add basic support for many-to-many fields (gh-399)
Added support for Django 4.1 (gh-1021)

3.1.1 (2022-04-23)
Full list of changes:

Fix py36 references in pyproject.toml (gh-960)
Fix local setup.py install versioning issue (gh-960)
Remove py2 universal wheel cfg - only py3 needed now (gh-960)
```