### PR TITLE
chore: add maintainership documentation 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ platform.  Functionally, the edx-platform repository provides two services:
 * CMS (Content Management Service), which powers Open edX Studio, the platform's learning content authoring environment; and
 * LMS (Learning Management Service), which delivers learning content.
 
-Installation
-************
+Getting Started
+***************
 
 Installing and running an Open edX instance is not simple.  We strongly
 recommend that you use a service provider to run the software for you.  They
@@ -122,6 +122,13 @@ Contributions are welcome! The first step is to submit a signed
 information – it also contains guidelines for how to maintain high code
 quality, which will make your contribution more likely to be accepted.
 
+New features accepted. Discussing your new ideas with the maintainers
+before you write code will also increase the chances that features are accepted.
+
+Code of Conduct
+***************
+
+Please read the `Community Code of Conduct`_ for interacting with this repository.
 
 Reporting Security Issues
 *************************
@@ -131,3 +138,4 @@ security@edx.org.
 
 .. _individual contributor agreement: https://openedx.org/cla
 .. _CONTRIBUTING: https://github.com/openedx/.github/blob/master/CONTRIBUTING.md
+.. _Community Code of Conduct: https://openedx.org/code-of-conduct/

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ information – it also contains guidelines for how to maintain high code
 quality, which will make your contribution more likely to be accepted.
 
 New features are accepted. Discussing your new ideas with the maintainers
-before you write code will also increase the chances that features are accepted.
+before you write code will also increase the chances that your work is accepted.
 
 Code of Conduct
 ***************

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Contributions are welcome! The first step is to submit a signed
 information – it also contains guidelines for how to maintain high code
 quality, which will make your contribution more likely to be accepted.
 
-New features accepted. Discussing your new ideas with the maintainers
+New features are accepted. Discussing your new ideas with the maintainers
 before you write code will also increase the chances that features are accepted.
 
 Code of Conduct

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'edx-platform'
+  description: "The monolith at the center of the Open edX platform"
+  links:
+    - url: "https://docs.openedx.org"
+      title: "Documentation"
+      icon: "Web"
+spec:
+  owner: group:arch-bom
+  type: 'service'
+  lifecycle: 'production'


### PR DESCRIPTION
Adds catalog-info.yaml and updates the README to be in compliance with https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055/decisions/0003-readme-specification.html .

The only section left out is People, which will contain a link to the backstage page once it has been created.

