### PR TITLE
fix: fix django4 deprecation warnings

### DIFF
--- a/common/djangoapps/course_modes/rest_api/urls.py
+++ b/common/djangoapps/course_modes/rest_api/urls.py
@@ -3,7 +3,7 @@ URL definitions for the course_modes API.
 """
 
 
-from django.conf.urls import include
+from django.urls import include
 from django.urls import path
 
 app_name = 'common.djangoapps.course_modes.rest_api'

--- a/common/djangoapps/entitlements/rest_api/urls.py
+++ b/common/djangoapps/entitlements/rest_api/urls.py
@@ -2,7 +2,7 @@
 URLs file for the Entitlements API.
 """
 
-from django.conf.urls import include
+from django.urls import include
 from django.urls import path
 
 app_name = 'entitlements'

--- a/common/djangoapps/entitlements/rest_api/v1/urls.py
+++ b/common/djangoapps/entitlements/rest_api/v1/urls.py
@@ -2,7 +2,7 @@
 URLs for the V1 of the Entitlements API.
 """
 
-from django.conf.urls import include
+from django.urls import include
 from django.urls import path, re_path
 from rest_framework.routers import DefaultRouter
 

--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -3,8 +3,6 @@
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
-default_app_config = 'common.djangoapps.third_party_auth.apps.ThirdPartyAuthConfig'
-
 
 def is_enabled():
     """Check whether third party authentication has been enabled. """

--- a/common/djangoapps/third_party_auth/urls.py
+++ b/common/djangoapps/third_party_auth/urls.py
@@ -1,6 +1,6 @@
 """Url configuration for the auth module."""
 
-from django.conf.urls import include
+from django.urls import include
 from django.urls import path, re_path
 
 from .views import (


### PR DESCRIPTION
### Description
- Fixed Django 4.0 and Django 4.1 deprecation warnings in order to prepare for `Django 4.2` upgrade.
- Creating PR under the effort of issue https://github.com/openedx/public-engineering/issues/198