### PR TITLE
fix: fix django4 deprecation warnings

### DIFF
--- a/openedx/core/djangoapps/ace_common/__init__.py
+++ b/openedx/core/djangoapps/ace_common/__init__.py
@@ -3,4 +3,3 @@
 ace_common is a Django App that provides common utilities and templates
 for edx-platform applications that use ACE as their messaging framework.
 """
-default_app_config = 'openedx.core.djangoapps.ace_common.apps.AceCommonConfig'  # pylint: disable=invalid-name

--- a/openedx/core/djangoapps/api_admin/api/urls.py
+++ b/openedx/core/djangoapps/api_admin/api/urls.py
@@ -3,7 +3,7 @@ URL definitions for api access request API.
 """
 
 
-from django.conf.urls import include
+from django.urls import include
 from django.urls import path
 
 app_name = 'api_admin'

--- a/openedx/core/djangoapps/catalog/__init__.py
+++ b/openedx/core/djangoapps/catalog/__init__.py
@@ -1,2 +1,1 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
-default_app_config = 'openedx.core.djangoapps.catalog.apps.CatalogConfig'

--- a/openedx/core/djangoapps/course_date_signals/__init__.py
+++ b/openedx/core/djangoapps/course_date_signals/__init__.py
@@ -1,5 +1,3 @@
 """
 Django app to manage course content dates, and ingesting them into edx-when for later use by the LMS.
 """
-
-default_app_config = 'openedx.core.djangoapps.course_date_signals.apps.CourseDatesSignalsConfig'  # pylint: disable=invalid-name

--- a/openedx/core/djangoapps/discussions/__init__.py
+++ b/openedx/core/djangoapps/discussions/__init__.py
@@ -1,4 +1,3 @@
 """
 Handle discussions integrations
 """
-default_app_config = 'openedx.core.djangoapps.discussions.apps.DiscussionsConfig'

--- a/openedx/core/djangoapps/external_user_ids/__init__.py
+++ b/openedx/core/djangoapps/external_user_ids/__init__.py
@@ -4,4 +4,3 @@ edX Platform support for external user IDs.
 This package will be used to support generating external User IDs to be shared
 with outside parties.
 """
-default_app_config = 'openedx.core.djangoapps.external_user_ids.apps.ExternalUserIDConfig'

--- a/openedx/features/calendar_sync/__init__.py
+++ b/openedx/features/calendar_sync/__init__.py
@@ -1,7 +1,6 @@
 """
 Calendar syncing Course dates with a User.
 """
-default_app_config = 'openedx.features.calendar_sync.apps.UserCalendarSyncConfig'
 
 
 def get_calendar_event_id(user, block_key, date_type, hostname):


### PR DESCRIPTION
### Description
- Fixed Django 4.0 and Django 4.1 deprecation warnings in order to prepare for `Django 4.2` upgrade.
- Creating PR under the effort of issue https://github.com/openedx/public-engineering/issues/198