### PR TITLE
chore: remove duplicate apt dependencies from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,9 +91,6 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends \
         curl \
         libssl-dev \
-        libxml2-dev \
-        libxmlsec1-dev \
-        libxslt1-dev \
         libffi-dev \
         libfreetype6-dev \
         libgeos-dev \


### PR DESCRIPTION
The following dependencies were duplicated in the same command:
 - libxml2-dev
 - libxmlsec1-dev
 - libxslt1-dev

Now the requirements are sorted to help spot duplicate dependencies in the future.

First occurrence on `master`:

https://github.com/openedx/edx-platform/blob/5d11db24c4028c928dc0cce8a7eeff903bd58fb6/Dockerfile#L91-L93

Second occurence on `master`:
https://github.com/openedx/edx-platform/blob/5d11db24c4028c928dc0cce8a7eeff903bd58fb6/Dockerfile#L104-L106


-----

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
