### PR TITLE
feat: use feature setting for beta tester notify

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -118,7 +118,8 @@ from openedx.core.djangolib.markup import HTML, Text
     </div>
     <div class="enroll-option">
         <label class="has-hint">
-            <input type="checkbox" name="email-students-beta" id="email-students-beta" value="Notify-students-by-email" checked="yes" aria-describedby="heading-batch-beta-testers">
+            <input type="checkbox" name="email-students-beta" id="email-students-beta" value="Notify-students-by-email" aria-describedby="heading-batch-beta-testers"
+                   ${'checked="yes"' if settings.FEATURES.get('BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT') else ''}>
             <span class="label-text">${_("Notify users by email")}</span>
             <div class="hint email-students-beta-hint">
                 <span class="hint-caret"></span>


### PR DESCRIPTION
## Description

Use the `BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT` feature setting for the default value of the "notify users by email" checkbox under Batch Beta Tester Addition in a course's instructor dashboard (membership tab).

## Testing instructions

1. Set `BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT` to True
2. Ensure the notify users checkbox is ticked by default
3. Set `BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT` to False
4. Ensure the notify users checkbox is unticked by default

Private-ref: [BB-7751](https://tasks.opencraft.com/browse/BB-7751)