### PR TITLE
Bszabo/tnl 10766 gaps

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -555,7 +555,7 @@ def update_asset(request, course_key, asset_key):
 
         # update existing asset
         try:
-            modified_asset = json.loads(request.data.decode('utf8'))
+            modified_asset = json.loads(request.body.decode('utf8'))
         except ValueError:
             return HttpResponseBadRequest()
         contentstore().set_attr(asset_key, 'locked', modified_asset['locked'])

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -555,7 +555,7 @@ def update_asset(request, course_key, asset_key):
 
         # update existing asset
         try:
-            modified_asset = json.loads(request.body.decode('utf8'))
+            modified_asset = json.loads(request.data.decode('utf8'))
         except ValueError:
             return HttpResponseBadRequest()
         contentstore().set_attr(asset_key, 'locked', modified_asset['locked'])

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -185,14 +185,13 @@ def handle_xblock(request, usage_key_string=None):
                     )
                     return JsonResponse(ancestor_info)
                 # TODO: pass fields to get_block_info and only return those
-                include_children_predicate=NEVER
                 with modulestore().bulk_operations(usage_key.course_key):
                     data = request.data
                     if ("customReadToken" in data["fields"]):
                         log.info("*** customReadToken detected ***")
-                        include_children_predicate=ALWAYS
-                    #response = get_block_info(get_xblock(usage_key, request.user), include_children_predicate = include_children_predicate)
-                    response = _get_block_parent_children(get_xblock(usage_key, request.user))
+                    response = get_block_info(get_xblock(usage_key, request.user))
+                    parent_children = _get_block_parent_children(get_xblock(usage_key, request.user))
+                    response.update(parent_children)
                 return JsonResponse(response)
             else:
                 return HttpResponse(status=406)

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -206,12 +206,10 @@ def handle_xblock(request, usage_key_string=None):
                     return JsonResponse(ancestor_info)
                 # TODO: pass fields to get_block_info and only return those
                 with modulestore().bulk_operations(usage_key.course_key):
-                    data = request.data
-                    if "customReadToken" in data["fields"]:
-                        log.info("*** customReadToken detected ***")
                     response = get_block_info(get_xblock(usage_key, request.user))
-                    parent_children = _get_block_parent_children(get_xblock(usage_key, request.user))
-                    response.update(parent_children)
+                    if "customReadToken" in fields:
+                        parent_children = _get_block_parent_children(get_xblock(usage_key, request.user))
+                        response.update(parent_children)
                 return JsonResponse(response)
             else:
                 return HttpResponse(status=406)

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -146,10 +146,11 @@ def _is_library_component_limit_reached(usage_key):
 
 def _get_block_parent_children(xblock):
     response = {}
-    response["parent"] = {
-        "block_type": xblock.parent.block_type,
-        "block_id": xblock.parent.block_id
-    }
+    if (xblock.parent):
+        response["parent"] = {
+            "block_type": xblock.parent.block_type,
+            "block_id": xblock.parent.block_id
+        }
     if xblock.children:
         response["children"] = [
             {

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -146,6 +146,14 @@ def _is_library_component_limit_reached(usage_key):
 
 
 def _get_block_parent_children(xblock):
+    '''
+    Extract parent ID information from the given xblock and report it in the response
+    Extract child ID information from the given xblock and report it in the response
+
+    Note that no effort is made to look up all settings for this xblock's parent or childrent;
+    the blocks are merely identified. If further informaiton regarding them is required, another
+    call with those blocks as subjects may be made into this handler.
+    '''
     response = {}
     if hasattr(xblock, "parent") and xblock.parent:
         response["parent"] = {
@@ -199,7 +207,7 @@ def handle_xblock(request, usage_key_string=None):
                 # TODO: pass fields to get_block_info and only return those
                 with modulestore().bulk_operations(usage_key.course_key):
                     data = request.data
-                    if ("customReadToken" in data["fields"]):
+                    if "customReadToken" in data["fields"]:
                         log.info("*** customReadToken detected ***")
                     response = get_block_info(get_xblock(usage_key, request.user))
                     parent_children = _get_block_parent_children(get_xblock(usage_key, request.user))

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -144,6 +144,7 @@ def _is_library_component_limit_reached(usage_key):
     total_children = len(parent.children)
     return total_children + 1 > settings.MAX_BLOCKS_PER_CONTENT_LIBRARY
 
+
 def _get_block_parent_children(xblock):
     response = {}
     if hasattr(xblock, "parent") and xblock.parent:
@@ -156,10 +157,11 @@ def _get_block_parent_children(xblock):
             {
                 "block_type": child.block_type,
                 "block_id": child.block_id
-             }
+            }
             for child in xblock.children
         ]
     return response
+
 
 def handle_xblock(request, usage_key_string=None):
     """

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -146,12 +146,12 @@ def _is_library_component_limit_reached(usage_key):
 
 def _get_block_parent_children(xblock):
     response = {}
-    if (xblock.parent):
+    if hasattr(xblock, "parent"):
         response["parent"] = {
             "block_type": xblock.parent.block_type,
             "block_id": xblock.parent.block_id
         }
-    if xblock.children:
+    if hasattr(xblock, "children"):
         response["children"] = [
             {
                 "block_type": child.block_type,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -180,7 +180,10 @@ def handle_xblock(request, usage_key_string=None):
                     return JsonResponse(ancestor_info)
                 # TODO: pass fields to get_block_info and only return those
                 with modulestore().bulk_operations(usage_key.course_key):
-                    response = get_block_info(get_xblock(usage_key, request.user))
+                    data = request.data
+                    if ("customReadToken" in data["fields"]):
+                        log.info("*** customReadToken detected ***")
+                        response = get_block_info(get_xblock(usage_key, request.user))
                 return JsonResponse(response)
             else:
                 return HttpResponse(status=406)
@@ -267,6 +270,7 @@ def handle_xblock(request, usage_key_string=None):
 
 def modify_xblock(usage_key, request):
     request_data = request.json
+    print(f'In modify_xblock with data = {request_data.get("data")}, fields = {request_data.get("fields")}')
     return _save_xblock(
         request.user,
         get_xblock(usage_key, request.user),

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -146,12 +146,12 @@ def _is_library_component_limit_reached(usage_key):
 
 def _get_block_parent_children(xblock):
     response = {}
-    if hasattr(xblock, "parent"):
+    if hasattr(xblock, "parent") and xblock.parent:
         response["parent"] = {
             "block_type": xblock.parent.block_type,
             "block_id": xblock.parent.block_id
         }
-    if hasattr(xblock, "children"):
+    if hasattr(xblock, "children") and xblock.children:
         response["children"] = [
             {
                 "block_type": child.block_type,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1608,8 +1608,6 @@ def _create_xblock_child_info(
             ),
         }
     if xblock.has_children and include_children_predicate(xblock):
-        child_info["parent descriptor"] = (xblock.parent.block_type, xblock.parent.block_id)
-        child_info["child descriptors"] = [(child.block_type, child.block_id) for child in xblock.children]
         child_info["children"] = [
             create_xblock_info(
                 child,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -146,9 +146,18 @@ def _is_library_component_limit_reached(usage_key):
 
 def _get_block_parent_children(xblock):
     response = {}
-    response["parent"] = (xblock.parent.block_type, xblock.parent.block_id)
+    response["parent"] = {
+        "block_type": xblock.parent.block_type,
+        "block_id": xblock.parent.block_id
+    }
     if xblock.children:
-        response["children"] = [(child.block_type, child.block_id) for child in xblock.children]
+        response["children"] = [
+            {
+                "block_type": child.block_type,
+                "block_id": child.block_id
+             }
+            for child in xblock.children
+        ]
     return response
 
 def handle_xblock(request, usage_key_string=None):


### PR DESCRIPTION



## Description

These changes support Jira task [TNL-10766](https://2u-internal.atlassian.net/browse/TNL-10766)

XBlock handlers already provide the ability to retrieve information about a given XBlock, the principal objeçtive of this task, but they do not easily convey which block is the parent of the designated block, or which blocks are its children. This PR remedies that.

## Supporting information



## Testing instructions

Host this version of edx-platform on devstack.

Get the course ID for a course on your devstack environment (e.g., course-v1:edX+DemoX+Demo_Course)

Set up an OAuth Django toolkit application on your devstack environment, noting the cliend id and client secret. Specify the redirect ULR to be `http://127.0.0.1:8000/authorize/`

Set up a GET request on Insomnia
Request: 
http://127.0.0.1:18010/api/contentstore/v1/xblock/course-v1:{course ID}/block-v1:{course ID}+type@course+block@course

Body (JSON): 
{
		"fields" : ["ancestorInfo", "customReadToken"]
}

Success = lots of info for the course-level block returned. If the course is empty, no information is returned for either parent (the course-level object has no parent) nor children (the course is empty).

Add a section to the course and repeat. The info returned now identifies the block ID for that child at the bottom of the description, but does not further describe the child. This should look like

	"children": [
		{
			"block_type": "chapter",
			"block_id": "f2dba65571ba466f8227c3ae6609cc82"
		}

Change the request to be like 
GET http://127.0.0.1:18010/api/contentstore/v1/xblock/course-v1:{course ID}/block-v1:{course ID}+type@chapter+block@{chapter block ID}

You'll now get plenty of info for this chapter block. At the bottom of that you'll see the course block as this chapter's parent

	"parent": {
		"block_type": "course",
		"block_id": "course"
	}

