### PR TITLE
feat: add email support to the enrollment post and get methods

### DIFF
--- a/openedx/core/djangoapps/enrollments/forms.py
+++ b/openedx/core/djangoapps/enrollments/forms.py
@@ -15,9 +15,10 @@ class CourseEnrollmentsApiListForm(Form):
     """
     A form that validates the query string parameters for the CourseEnrollmentsApiListView.
     """
-    MAX_USERNAME_COUNT = 100
+    MAX_INPUT_COUNT = 100
     username = CharField(required=False)
     course_id = CharField(required=False)
+    email = CharField(required=False)
 
     def clean_course_id(self):
         """
@@ -38,14 +39,31 @@ class CourseEnrollmentsApiListForm(Form):
         usernames_csv_string = self.cleaned_data.get('username')
         if usernames_csv_string:
             usernames = usernames_csv_string.split(',')
-            if len(usernames) > self.MAX_USERNAME_COUNT:
+            if len(usernames) > self.MAX_INPUT_COUNT:
                 raise ValidationError(
                     "Too many usernames in a single request - {}. A maximum of {} is allowed".format(
                         len(usernames),
-                        self.MAX_USERNAME_COUNT,
+                        self.MAX_INPUT_COUNT,
                     )
                 )
             for username in usernames:
                 validate_username(username)
             return usernames
         return usernames_csv_string
+
+    def clean_email(self):
+        """
+        Validate a string of comma-separated emails and return a list of emails.
+        """
+        emails_csv_string = self.cleaned_data.get('email')
+        if emails_csv_string:
+            emails = emails_csv_string.split(',')
+            if len(emails) > self.MAX_INPUT_COUNT:
+                raise ValidationError(
+                    "Too many emails in a single request - {}. A maximum of {} is allowed".format(
+                        len(emails),
+                        self.MAX_INPUT_COUNT,
+                    )
+                )
+            return emails
+        return emails_csv_string

--- a/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
+++ b/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
@@ -115,6 +115,63 @@
 
     ],
     [
+        {
+            "email": "student1@example.com"
+        },
+        [
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student1",
+                "created": "2018-01-01T00:00:01Z"
+            }
+        ]
+    ],
+    [
+        {
+            "email": "student1@example.com,student2@example.com"
+        },
+        [
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student1",
+                "created": "2018-01-01T00:00:01Z"
+            },
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
+            },
+            {
+                "course_id": "course-v1:x+y+Z",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
+            }
+        ]
+    ],
+    [
+        {
+            "email": "student2@example.com",
+            "course_id": "course-v1:e+d+X"
+        },
+        [
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
+            }
+        ]
+    ],
+    [
         null,
         [
             {

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -407,6 +407,24 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
         assert data['is_active']
 
+    def test_get_enrollment_by_email(self):
+        # Create an enrollment
+        self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.user.username
+            },
+            format='json'
+        )
+        # Get the enrollment with an email
+        resp = self.client.get(
+            reverse('courseenrollment', kwargs={"username": str(self.user.email), "course_id": str(self.course.id)})
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
     def test_user_not_authenticated(self):
         # Log out, so we're no longer authenticated
         self.client.logout()

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -236,7 +236,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                 'course_details': {
                     'course_id': str(self.course.id)
                 },
-                'user_email': self.user.email
+                'email': self.user.email
             },
             format='json'
         )
@@ -251,7 +251,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                     'course_id': str(self.course.id)
                 },
                 'user': self.user.username,
-                'user_email': 'another_email@example.com'
+                'email': 'another_email@example.com'
             },
             format='json'
         )

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -407,24 +407,6 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
         assert data['is_active']
 
-    def test_get_enrollment_by_email(self):
-        # Create an enrollment
-        self.client.post(
-            reverse('courseenrollments'),
-            {
-                'course_details': {
-                    'course_id': str(self.course.id)
-                },
-                'user': self.user.username
-            },
-            format='json'
-        )
-        # Get the enrollment with an email
-        resp = self.client.get(
-            reverse('courseenrollment', kwargs={"username": str(self.user.email), "course_id": str(self.course.id)})
-        )
-        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
-
     def test_user_not_authenticated(self):
         # Log out, so we're no longer authenticated
         self.client.logout()

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -295,6 +295,46 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         )
         self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
 
+    def test_enroll_with_user_without_permissions_and_email(self):
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.other_user.username,
+                'email': self.user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_enroll_with_user_as_self_user(self):
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.user.username
+            },
+            format='json'
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
+    def test_enroll_without_user(self):
+        # To check if it takes the request.user.
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                }
+            },
+            format='json'
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
     @ddt.data(
         # Default (no course modes in the database)
         # Expect that users are automatically enrolled as the default

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -229,7 +229,13 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert is_active
         assert course_mode == enrollment_mode
 
-    def test_enroll_with_email(self):
+    def test_enroll_with_email_staff(self):
+        # Create enrollments with email are allowed if you are staff.
+
+        self.client.logout()
+        AdminFactory.create(username='global_staff', email='global_staff@example.com', password=self.PASSWORD)
+        self.client.login(username="global_staff", password=self.PASSWORD)
+
         resp = self.client.post(
             reverse('courseenrollments'),
             {
@@ -242,8 +248,40 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         )
         assert resp.status_code == status.HTTP_200_OK
 
+    @patch('openedx.core.djangoapps.enrollments.views.EnrollmentListView.has_api_key_permissions')
+    def test_enroll_with_email_server(self, has_api_key_permissions_mock):
+        # Create enrollments with email are allowed if it is a server-to-server request.
+
+        has_api_key_permissions_mock.return_value = True
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'email': self.user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+    def test_enroll_with_email_without_staff(self):
+        # If you are not staff or server request you can't create enrollments with email.
+
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'email': self.other_user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
     def test_enroll_with_user_and_email(self):
-        # The user has priority over the email.
+        # Creating enrollments the user has priority over the email.
         resp = self.client.post(
             reverse('courseenrollments'),
             {
@@ -251,7 +289,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                     'course_id': str(self.course.id)
                 },
                 'user': self.user.username,
-                'email': 'another_email@example.com'
+                'email': self.other_user.email
             },
             format='json'
         )

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -229,6 +229,34 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert is_active
         assert course_mode == enrollment_mode
 
+    def test_enroll_with_email(self):
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user_email': self.user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+    def test_enroll_with_user_and_email(self):
+        # The user has priority over the email.
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.user.username,
+                'user_email': 'another_email@example.com'
+            },
+            format='json'
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
     @ddt.data(
         # Default (no course modes in the database)
         # Expect that users are automatically enrolled as the default

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -699,17 +699,17 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
 
         has_api_key_permissions = self.has_api_key_permissions(request)
 
-        # Check if the user or user_email was defined.
+        # Check if the user or email was defined.
         if not username:
-            user_email = request.data.get('user_email')
-            if user_email:
+            email = request.data.get('email')
+            if email:
                 try:
-                    username = User.objects.get(email=user_email).username
+                    username = User.objects.get(email=email).username
                 except ObjectDoesNotExist:
                     return Response(
                         status=status.HTTP_406_NOT_ACCEPTABLE,
                         data={
-                            'message': f'The user with the email address {user_email} does not exist.'
+                            'message': f'The user with the email address {email} does not exist.'
                         }
                     )
             else:

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -925,12 +925,17 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
 
             GET /api/enrollment/v1/enrollments?course_id={course_id}&username={username}
 
+            GET /api/enrollment/v1/enrollments?email={email},{email}
+
         **Query Parameters for GET**
 
             * course_id: Filters the result to course enrollments for the course corresponding to the
               given course ID. The value must be URL encoded. Optional.
 
             * username: List of comma-separated usernames. Filters the result to the course enrollments
+              of the given users. Optional.
+
+            * email: List of comma-separated emails. Filters the result to the course enrollments
               of the given users. Optional.
 
             * page_size: Number of results to return per page. Optional.
@@ -995,9 +1000,12 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         queryset = CourseEnrollment.objects.all()
         course_id = form.cleaned_data.get('course_id')
         usernames = form.cleaned_data.get('username')
+        emails = form.cleaned_data.get('email')
 
         if course_id:
             queryset = queryset.filter(course_id=course_id)
         if usernames:
             queryset = queryset.filter(user__username__in=usernames)
+        if emails:
+            queryset = queryset.filter(user__email__in=emails)
         return queryset

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -6,7 +6,6 @@ consist primarily of authentication, request validation, and serialization.
 
 
 import logging
-from re import match
 
 from django.core.exceptions import (  # lint-amnesty, pylint: disable=wrong-import-order
     ObjectDoesNotExist,
@@ -202,17 +201,6 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
 
         """
         username = username or request.user.username
-        # If You send an email:
-        if bool(match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', username)):
-            try:
-                username = User.objects.get(email=username).username
-            except ObjectDoesNotExist:
-                return Response(
-                    status=status.HTTP_406_NOT_ACCEPTABLE,
-                    data={
-                        'message': f'The user with the email address {username} does not exist.'
-                    }
-                )
 
         # TODO Implement proper permissions
         if request.user.username != username and not self.has_api_key_permissions(request) \

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -700,7 +700,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         has_api_key_permissions = self.has_api_key_permissions(request)
 
         # Check that the user specified is either the same user, or this is a server-to-server request.
-        if username != request.user.username and not has_api_key_permissions \
+        if username and username != request.user.username and not has_api_key_permissions \
                 and not GlobalStaff().has_user(request.user):
             # Return a 404 instead of a 403 (Unauthorized). If one user is looking up
             # other users, do not let them deduce the existence of an enrollment.
@@ -711,6 +711,9 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         if not username:
             email = request.data.get('email')
             if email:
+                # Only server-to-server or staff users can use the email for the request.
+                if not has_api_key_permissions and not GlobalStaff().has_user(request.user):
+                    return Response(status=status.HTTP_404_NOT_FOUND)
                 try:
                     username = User.objects.get(email=email).username
                 except ObjectDoesNotExist:


### PR DESCRIPTION
## Description
This PR adds email support to the get and post method of the enrollments in the API.

The logic I proposed for the POST method is:
- In the request, Do I have "user"?
    - Yes: Continue the normal flow.
    - No: Check if I have "user_email."
        - Yes, try to obtain the username and continue the normal flow.
        - No, set the `request.username` and continue the normal flow.

And for the GET:
-  Does the username match with an email regex?
    - Yes, try to obtain the username and continue the normal flow.
    - No, trying to use the username passed or the `request.username`.

## Supporting information

We want to add this support to allow requests with email for the WooCommerce Plugin we are building to integrate third-party e-commerce with Open edX. (It is easier to remember your email over your username in a platform, and we want to make the buy easier for the customer)

## Testing instructions

Requisites:

- Have a platform with this PR.
- Have a user for the test and a course with a mode specified in "mode" (You can add it in the admin in Course Modes).
- Have an Authorization token (For example, a JWT token).

### POST /api/enrollment/v1/enrollment
Header:
> Authorization: JWT YOUR_JWT_TOKEN

Body:
```json
{
  "user_email": "user-1@example.com",
  "mode": "honor",
  "course_details": {
    "course_id": "course-v1:edX+DemoX+Demo_Course"
  }
}
```
Expected result: 200 and show the enrollment information.

### GET /api/enrollment/v1/enrollment/USER_EMAIL,COURSE_ID
Header:
> Authorization: JWT YOUR_JWT_TOKEN

Expected result: 200 and show the enrollment information.

## Deadline

We would like to have this merged by 08/22/2023

## Other information

ADR when we discuss these additions: https://github.com/eduNEXT/platform-plugin-ecommerce-api/pull/1#issuecomment-1661343634

### How to have a JWT Token
POST /oauth2/access_token
Body in Form:

```
client_id="CLIENT_ID"
client_secret="CLIENT_SECRET"
grant_type="client_credentials"
token_type="jwt"
```
