### PR TITLE
fix: update discussion enabled if true

### DIFF
--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -110,12 +110,15 @@ def get_discussable_units(course, enable_graded_units, discussable_units=None):
                 for unit in get_units(subsection):
                     idx += 1
                     if not is_discussable_unit(unit, store, enable_graded_units, subsection):
-                        unit.discussion_enabled = False
                         # TODO: if and log statement will be removed after testing.
                         if str(course.id) == "course-v1:NedX+CMH43+2023_Summer":
-                            log.info(f"Updating discussions_enabled for {course.id}")
-                            store.update_item(unit, unit.published_by, isPublish=True, emit_signals=False)
+                            log.info(f"Checking discussions_enabled for {course.id}")
+                            if unit.discussion_enabled:
+                                unit.discussion_enabled = False
+                                store.update_item(unit, unit.published_by, isPublish=True, emit_signals=False)
+                                log.info(f"Updating discussions_enabled for {course.id}")
                         else:
+                            unit.discussion_enabled = False
                             store.update_item(unit, unit.published_by, emit_signals=False)
                         continue
                     # check if discussable_units is type of list and discussable_units is empty


### PR DESCRIPTION
`discussion_enabled` will only be set to false if its existing value is true. 

Ticket: [INF-997](https://2u-internal.atlassian.net/browse/INF-997)