### PR TITLE
[FC-0009] feat: Prompt user to rename unit after it's pasted

### DIFF
--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -340,7 +340,16 @@ function(
                     parent_locator: parentLocator,
                     staged_content: "clipboard",
                 }).then((data) => {
-                    this.refresh(); // Update this and replace the placeholder with the actual pasted unit.
+                    // Update this and replace the placeholder with the actual pasted unit.
+                    this.refresh().done(() => {
+                        // Prompt the user to rename unit after it's pasted
+                        const newUnitLocator = data.locator;
+                        const newUnitEditNameBtn = $(`li.outline-unit[data-locator="${newUnitLocator}"]`).find(
+                            '.xblock-field-value-edit'
+                        );
+                        newUnitEditNameBtn && newUnitEditNameBtn[0] && newUnitEditNameBtn[0].click();
+                    });
+
                     return data;
                 }).fail(() => {
                     $placeholderEl.remove();


### PR DESCRIPTION
## Description

This change prompts the user to rename the newly copied/pasted unit.

## Supporting Information

- Related Ticket: https://github.com/openedx/modular-learning/issues/92

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_units` flag is set
4. Navigate to Studio: http://localhost:18010/
5. Click on a course
6. Create a new unit if none exist
7. Copy the unit, by clicking on the 3 vertical dots and selecting "Copy to Clipboard"
8. Paste the unit, and verify that the name of the newly pasted unit is automatically highlighted and editable like the screenshot below:

![Screen Shot 2023-08-15 at 3 00 52 PM](https://github.com/openedx/edx-platform/assets/6829768/2a1869e1-3159-40af-bc96-ff8f4652cd29)
9. Set a new name, click away, and confirm that the new name unit name is saved

---
Private ref: [FAL-3479](https://tasks.opencraft.com/browse/FAL-3479)