### PR TITLE
fix: error on course outline in Studio due to browser caching old JS file [FC-0009]

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -169,7 +169,7 @@ if (is_proctored_exam) {
                         </a>
                     </li>
                 <% } %>
-                <% if (enableCopyPasteUnits) { %>
+                <% if (typeof enableCopyPasteUnits !== "undefined" && enableCopyPasteUnits) { %>
                     <!--
                         If the ENABLE_COPY_PASTE_UNITS feature flag is enabled, all these actions (besides "Publish")
                         appear in a menu. We use .nav-dd on the parent element and .nav-item on this button to get the


### PR DESCRIPTION
## Description

This is a follow-up to #32891

This fixes a bug where some users would see an error that prevented the course outline page in Studio from loading, for any course:

```
VM409:222 Uncaught ReferenceError: enableCopyPasteUnits is not defined
    at child.eval (eval at _.template (cms-base-vendor.7fdf2ee29320.js:12214:20), <anonymous>:222:2)
    at child.template (cms-base-vendor.7fdf2ee29320.js:12221:21)
    at child.renderTemplate (outline.js:1670:29)
    at child.render (outline.js:1647:18)
    at child.render (outline.js:7172:67)
    at child.<anonymous> (outline.js:768:17)
    at executeBound (cms-base-vendor.7fdf2ee29320.js:11461:67)
    at child.bound [as render] (cms-base-vendor.7fdf2ee29320.js:11493:14)
    at outline.js:1724:38
    at _.each._.forEach (cms-base-vendor.7fdf2ee29320.js:10913:9)
```

Reason: When viewing a course outline on [edx.org](http://edx.org/), the templates like `course_outline.underscore` (which expects `enableCopyPasteUnits` to be defined) are [embedded directly into the HTML on the server side](https://github.com/openedx/edx-platform/blob/b9134c64ff35b2b14825c5e58a69735ceb0a4fd3/cms/templates/course_outline.html#L32-L36), so users were definitely getting the latest version of the template which expects that variable to be defined. But the JS view code which renders the template and [provides the context](https://github.com/openedx/edx-platform/blob/b9134c64ff35b2b14825c5e58a69735ceb0a4fd3/cms/static/js/views/xblock_outline.js#L116) (hopefully including `enableCopyPasteUnits`) is bundled into the file `https://studio.edx.org/static/studio/js/factories/outline.js` which as you can see is not a versioned URL, unlike many other JS static assets. Some users saw the page with an old (cached) version of the view code, but the new template, resulting in this error.

Simply refreshing the page should also solve the bug, but we are implementing this fix anyways to reduce the impact even further so hopefully nobody else will encounter the error at all, regardless of their cache.

## Supporting information

n/a

## Testing instructions

Try accessing a course in Studio without the `contentstore.enable_copy_paste_units` waffle flag defined at all, and also with it set to True.

## Deadline

ASAP - CAT-1 issue, although there is a workaround in place and it doesn't seem to be ongoing.

## Other information


