### PR TITLE
fix: removed redundant unit update from task

### DIFF
--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -110,16 +110,6 @@ def get_discussable_units(course, enable_graded_units, discussable_units=None):
                 for unit in get_units(subsection):
                     idx += 1
                     if not is_discussable_unit(unit, store, enable_graded_units, subsection):
-                        # TODO: if and log statement will be removed after testing.
-                        if str(course.id) == "course-v1:NedX+CMH43+2023_Summer":
-                            log.info(f"Checking discussions_enabled for {course.id}")
-                            if unit.discussion_enabled:
-                                unit.discussion_enabled = False
-                                store.update_item(unit, unit.published_by, isPublish=True, emit_signals=False)
-                                log.info(f"Updating discussions_enabled for {course.id}")
-                        else:
-                            unit.discussion_enabled = False
-                            store.update_item(unit, unit.published_by, emit_signals=False)
                         continue
                     # check if discussable_units is type of list and discussable_units is empty
                     # it means if discussable_units is empty then we should not create any topic

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -110,6 +110,9 @@ def get_discussable_units(course, enable_graded_units, discussable_units=None):
                 for unit in get_units(subsection):
                     idx += 1
                     if not is_discussable_unit(unit, store, enable_graded_units, subsection):
+                        if unit.discussion_enabled:
+                            log.info(f"Unit {unit.location} of course {course.id} has discussion enabled "
+                                     f"but is not discussable")
                         continue
                     # check if discussable_units is type of list and discussable_units is empty
                     # it means if discussable_units is empty then we should not create any topic


### PR DESCRIPTION
## Ticket : 
https://2u-internal.atlassian.net/browse/INF-997

## Description
Removed update_item from the task because it was making published content unpublished. This was added for fixing issues related to the course outline display labels but that fix didn't work so this code is redundant.