### PR TITLE
chore: update pymemcache settings

### DIFF
--- a/cms/envs/bok_choy.env.json
+++ b/cms/envs/bok_choy.env.json
@@ -4,6 +4,11 @@
     "CACHES": {
         "celery": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_celery",
             "LOCATION": [
@@ -12,6 +17,11 @@
         },
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_default",
             "LOCATION": [
@@ -20,6 +30,11 @@
         },
         "general": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_general",
             "LOCATION": [
@@ -28,6 +43,11 @@
         },
         "mongo_metadata_inheritance": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_mongo_metadata_inheritance",
             "LOCATION": [
@@ -36,6 +56,11 @@
         },
         "staticfiles": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_static_files",
             "LOCATION": [

--- a/cms/envs/bok_choy.yml
+++ b/cms/envs/bok_choy.yml
@@ -7,26 +7,46 @@ BULK_EMAIL_DEFAULT_FROM_EMAIL: no-reply@example.com
 CACHES:
   celery:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      ignore_exc: true
+      no_delay: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_celery
     LOCATION: ['localhost:11211']
   default:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      ignore_exc: true
+      no_delay: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_default
     LOCATION: ['localhost:11211']
   general:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      ignore_exc: true
+      no_delay: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_general
     LOCATION: ['localhost:11211']
   mongo_metadata_inheritance:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      ignore_exc: true
+      no_delay: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_mongo_metadata_inheritance
     LOCATION: ['localhost:11211']
   staticfiles:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      ignore_exc: true
+      no_delay: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_static_files
     LOCATION: ['localhost:11211']

--- a/cms/envs/bok_choy_docker.env.json
+++ b/cms/envs/bok_choy_docker.env.json
@@ -4,6 +4,11 @@
     "CACHES": {
         "celery": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_celery",
             "LOCATION": [
@@ -12,6 +17,11 @@
         },
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_default",
             "LOCATION": [
@@ -20,6 +30,11 @@
         },
         "general": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_general",
             "LOCATION": [
@@ -28,6 +43,11 @@
         },
         "mongo_metadata_inheritance": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_mongo_metadata_inheritance",
             "LOCATION": [
@@ -36,6 +56,11 @@
         },
         "staticfiles": {
             "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "OPTIONS": {
+                "no_delay": true,
+                "ignore_exc": true,
+                "use_pooling": true
+            },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_static_files",
             "LOCATION": [

--- a/cms/envs/bok_choy_docker.yml
+++ b/cms/envs/bok_choy_docker.yml
@@ -7,26 +7,46 @@ BULK_EMAIL_DEFAULT_FROM_EMAIL: no-reply@example.com
 CACHES:
   celery:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_celery
     LOCATION: ['edx.devstack.memcached:11211']
   default:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_default
     LOCATION: ['edx.devstack.memcached:11211']
   general:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_general
     LOCATION: ['edx.devstack.memcached:11211']
   mongo_metadata_inheritance:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_mongo_metadata_inheritance
     LOCATION: ['edx.devstack.memcached:11211']
   staticfiles:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_static_files
     LOCATION: ['edx.devstack.memcached:11211']

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2171,6 +2171,11 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': '86400',  # This data should be long-lived for performance, BundleCache handles invalidation
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'course_structure_cache': {
         'KEY_PREFIX': 'course_structure',
@@ -2178,6 +2183,11 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': '7200',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'celery': {
         'KEY_PREFIX': 'celery',
@@ -2185,6 +2195,11 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': '7200',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'mongo_metadata_inheritance': {
         'KEY_PREFIX': 'mongo_metadata_inheritance',
@@ -2192,12 +2207,22 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': 300,
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'staticfiles': {
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'staticfiles_general',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'default': {
         'VERSION': '1',
@@ -2205,18 +2230,33 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'default',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'configuration': {
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'configuration',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'general': {
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'general',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
 }
 

--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -54,6 +54,10 @@ BULK_EMAIL_LOG_SENT_EMAILS: false
 CACHES:
     celery:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: celery
         LOCATION:
@@ -61,12 +65,20 @@ CACHES:
         TIMEOUT: '7200'
     configuration:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce
         LOCATION:
         - edx.devstack.memcached:11211
     course_structure_cache:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: course_structure
         LOCATION:
@@ -74,6 +86,10 @@ CACHES:
         TIMEOUT: '7200'
     default:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            ignore_exc: true
+            no_delay: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: default
         LOCATION:
@@ -81,12 +97,20 @@ CACHES:
         VERSION: '1'
     general:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: general
         LOCATION:
         - edx.devstack.memcached:11211
     mongo_metadata_inheritance:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: mongo_metadata_inheritance
         LOCATION:
@@ -94,6 +118,10 @@ CACHES:
         TIMEOUT: 300
     staticfiles:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce_general
         LOCATION:

--- a/lms/envs/bok_choy.yml
+++ b/lms/envs/bok_choy.yml
@@ -20,26 +20,46 @@ BLOCK_STRUCTURES_SETTINGS:
 CACHES:
   celery:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_celery
     LOCATION: ['localhost:11211']
   default:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_default
     LOCATION: ['localhost:11211']
   general:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_general
     LOCATION: ['localhost:11211']
   mongo_metadata_inheritance:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_mongo_metadata_inheritance
     LOCATION: ['localhost:11211']
   staticfiles:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_static_files
     LOCATION: ['localhost:11211']

--- a/lms/envs/bok_choy_docker.yml
+++ b/lms/envs/bok_choy_docker.yml
@@ -12,26 +12,46 @@ CACHES:
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_celery
     LOCATION: ['edx.devstack.memcached:11211']
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
   default:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_default
     LOCATION: ['edx.devstack.memcached:11211']
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
   general:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_general
     LOCATION: ['edx.devstack.memcached:11211']
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
   mongo_metadata_inheritance:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_mongo_metadata_inheritance
     LOCATION: ['edx.devstack.memcached:11211']
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
   staticfiles:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_static_files
     LOCATION: ['edx.devstack.memcached:11211']
+    OPTIONS:
+      no_delay: true
+      ignore_exc: true
+      use_pooling: true
 CELERY_BROKER_HOSTNAME: localhost
 CELERY_BROKER_PASSWORD: celery
 CELERY_BROKER_TRANSPORT: amqp

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1114,6 +1114,11 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': '86400',  # This data should be long-lived for performance, BundleCache handles invalidation
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'course_structure_cache': {
         'KEY_PREFIX': 'course_structure',
@@ -1121,6 +1126,11 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': '7200',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'celery': {
         'KEY_PREFIX': 'celery',
@@ -1128,6 +1138,11 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': '7200',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'mongo_metadata_inheritance': {
         'KEY_PREFIX': 'mongo_metadata_inheritance',
@@ -1135,12 +1150,22 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'TIMEOUT': 300,
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'staticfiles': {
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'staticfiles_general',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'default': {
         'VERSION': '1',
@@ -1148,18 +1173,33 @@ CACHES = {
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'default',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'configuration': {
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'configuration',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
     'general': {
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
         'KEY_PREFIX': 'general',
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+        }
     },
 }
 

--- a/lms/envs/devstack-experimental.yml
+++ b/lms/envs/devstack-experimental.yml
@@ -73,6 +73,10 @@ BULK_EMAIL_ROUTING_KEY_SMALL_JOBS: edx.lms.core.default
 CACHES:
     celery:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: celery
         LOCATION:
@@ -80,12 +84,20 @@ CACHES:
         TIMEOUT: '7200'
     configuration:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce
         LOCATION:
         - edx.devstack.memcached:11211
     course_structure_cache:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: course_structure
         LOCATION:
@@ -93,6 +105,10 @@ CACHES:
         TIMEOUT: '7200'
     default:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: default
         LOCATION:
@@ -100,12 +116,20 @@ CACHES:
         VERSION: '1'
     general:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: general
         LOCATION:
         - edx.devstack.memcached:11211
     mongo_metadata_inheritance:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: mongo_metadata_inheritance
         LOCATION:
@@ -113,6 +137,10 @@ CACHES:
         TIMEOUT: 300
     staticfiles:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce_general
         LOCATION:


### PR DESCRIPTION
**Description**
- Pymemcahe's default backend isn't thread-safe. To make it thread-safe we're enabling pooling in this PR.

**Related Comment**
- https://github.com/pinterest/pymemcache/issues/405#issuecomment-1169853211

**Django Doc Reference**
- [click here](https://docs.djangoproject.com/en/3.2/topics/cache/#top:~:text=Here%E2%80%99s%20an%20example%20configuration%20for%20a%20pymemcache%20based%20backend%20that%20enables%20client%20pooling%20(which%20may%20improve%20performance%20by%20keeping%20clients%20connected)%2C%20treats%20memcache/network%20errors%20as%20cache%20misses%2C%20and%20sets%20the%20TCP_NODELAY%20flag%20on%20the%20connection%E2%80%99s%20socket%3A)