### PR TITLE
fix: replace ugettext with gettext

### DIFF
--- a/cms/templates/html_error.html
+++ b/cms/templates/html_error.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%! from django.urls import reverse %>
 
 <%block name="content">

--- a/cms/templates/widgets/html-edit.html
+++ b/cms/templates/widgets/html-edit.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div class="wrapper-comp-editor" id="editor-tab" data-base-asset-url="${base_asset_url}" data-editor="${editor}">
     <section class="html-editor editor">

--- a/cms/templates/widgets/metadata-edit.html
+++ b/cms/templates/widgets/metadata-edit.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%namespace name='static' file='../static_content.html'/>
 
 <%

--- a/cms/templates/widgets/tabs-aggregator.html
+++ b/cms/templates/widgets/tabs-aggregator.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <div class="wrapper-comp-editor" id="editor-tab-${html_id}" data-html_id="${html_id}">
     <section class="editor-with-tabs">
      <div class="edit-header">

--- a/common/templates/edxnotes_wrapper.html
+++ b/common/templates/edxnotes_wrapper.html
@@ -3,7 +3,7 @@
 
 <%!
 import json
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from common.djangoapps.student.models import anonymous_id_for_user
 from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>

--- a/common/templates/emails/contact_us_feedback_email_body.txt
+++ b/common/templates/emails/contact_us_feedback_email_body.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 ${_("Feedback Form")}
 
 ${_("Email: {email}").format(email=email)}

--- a/common/templates/emails/contact_us_feedback_email_subject.txt
+++ b/common/templates/emails/contact_us_feedback_email_subject.txt
@@ -1,1 +1,1 @@
-<%! from django.utils.translation import ugettext as _ %>${_("Feedback from user")}
+<%! from django.utils.translation import gettext as _ %>${_("Feedback from user")}

--- a/common/templates/emails/sync_learner_profile_data_email_change_body.txt
+++ b/common/templates/emails/sync_learner_profile_data_email_change_body.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
 
 <p>

--- a/common/templates/emails/sync_learner_profile_data_email_change_subject.txt
+++ b/common/templates/emails/sync_learner_profile_data_email_change_subject.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
 
 ${_("Your {platform_name} account email has been updated").format(

--- a/common/test/test-theme/lms/templates/static_templates/embargo.html
+++ b/common/test/test-theme/lms/templates/static_templates/embargo.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/annotatable.html
+++ b/lms/templates/annotatable.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div class="annotatable-wrapper">
 	<div class="annotatable-header">

--- a/lms/templates/api_admin/catalogs/edit.html
+++ b/lms/templates/api_admin/catalogs/edit.html
@@ -3,7 +3,7 @@
 <%inherit file="../../main.html"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/lms/templates/api_admin/catalogs/search.html
+++ b/lms/templates/api_admin/catalogs/search.html
@@ -3,7 +3,7 @@
 <%inherit file="../../main.html"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <%block name="pagetitle">${_("Catalog search")}</%block>

--- a/lms/templates/certificates/_about-edx.html
+++ b/lms/templates/certificates/_about-edx.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <section class="about-item about-edx">
     <h2 class="about-edx-title hd-4">${company_about_title}</h2>
 

--- a/lms/templates/certificates/_accomplishment-banner.html
+++ b/lms/templates/certificates/_accomplishment-banner.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/certificates/_accomplishment-header.html
+++ b/lms/templates/certificates/_accomplishment-header.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div class="wrapper-header">
 

--- a/lms/templates/certificates/_edx-accomplishment-print-help.html
+++ b/lms/templates/certificates/_edx-accomplishment-print-help.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%! 
-from django.utils.translation import ugettext as _ 
+from django.utils.translation import gettext as _ 
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <div class="wrapper-accomplishment-support">

--- a/lms/templates/certificates/invalid.html
+++ b/lms/templates/certificates/invalid.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%inherit file="accomplishment-base.html" />
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div class="wrapper-content status status-invalid">
     <div class="wrapper-content-grid">

--- a/lms/templates/certificates/url_unsupported.html
+++ b/lms/templates/certificates/url_unsupported.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%inherit file="accomplishment-base.html" />
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div class="wrapper-content status status-invalid">
     <div class="wrapper-content-grid">

--- a/lms/templates/certificates/valid.html
+++ b/lms/templates/certificates/valid.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%inherit file="accomplishment-base.html" />
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 % if user.is_authenticated and user.id == int(accomplishment_user_id):
 <%include file="_accomplishment-banner.html" />

--- a/lms/templates/conditional_block.html
+++ b/lms/templates/conditional_block.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/course_modes/_upgrade_button.html
+++ b/lms/templates/course_modes/_upgrade_button.html
@@ -1,7 +1,7 @@
 <%page args="content_gating_enabled, course_duration_limit_enabled, min_price, price_before_discount" expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/course_modes/choose.html
+++ b/lms/templates/course_modes/choose.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text

--- a/lms/templates/course_modes/error.html
+++ b/lms/templates/course_modes/error.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string

--- a/lms/templates/course_modes/fbe.html
+++ b/lms/templates/course_modes/fbe.html
@@ -6,7 +6,7 @@
 <%page expression_filter="h"/>
 <%inherit file="track_selection.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%block name="track_selection_certificate_bullets">

--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string

--- a/lms/templates/course_modes/unfbe.html
+++ b/lms/templates/course_modes/unfbe.html
@@ -10,7 +10,7 @@
 <%page expression_filter="h"/>
 <%inherit file="track_selection.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%block name="track_selection_certificate_bullets">

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
     from django.urls import reverse
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
     from django.conf import settings
     from openedx.core.djangolib.markup import HTML, Text
 %>

--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -3,7 +3,7 @@
 <%!
 import six
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 from django.conf import settings
 %>

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -10,7 +10,7 @@ from lms.djangoapps.course_goals.models import UserActivity
 
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <%

--- a/lms/templates/courseware/course_updates.html
+++ b/lms/templates/courseware/course_updates.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <div class="recent-updates">
   % for index, update in enumerate(visible_updates):
     <article class="updates-article">

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
   import json
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -2,7 +2,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from openedx.core.djangolib.markup import HTML
 from openedx.core.djangolib.js_utils import js_escaped_string

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -7,7 +7,7 @@ import waffle
 
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from lms.djangoapps.edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 from openedx.core.djangolib.js_utils import js_escaped_string

--- a/lms/templates/courseware/error-message.html
+++ b/lms/templates/courseware/error-message.html
@@ -2,7 +2,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/courseware/gradebook.html
+++ b/lms/templates/courseware/gradebook.html
@@ -2,7 +2,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 %>
 

--- a/lms/templates/courseware/program_marketing.html
+++ b/lms/templates/courseware/program_marketing.html
@@ -6,7 +6,7 @@
 from datetime import datetime
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from mako import exceptions
 
 from openedx.core.djangolib.markup import HTML, Text

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -8,7 +8,7 @@ from datetime import datetime
 from django.conf import settings
 from django.urls import reverse
 from django.utils.http import urlquote_plus
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from pytz import UTC
 
 from common.djangoapps.course_modes.models import CourseMode

--- a/lms/templates/courseware/tab-view.html
+++ b/lms/templates/courseware/tab-view.html
@@ -6,7 +6,7 @@
 <%! main_css = "css/bootstrap/lms-main.css" %>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 

--- a/lms/templates/courseware/tabs.html
+++ b/lms/templates/courseware/tabs.html
@@ -2,7 +2,7 @@
 
 <%namespace name='static' file='/static_content.html'/>
 <%!
- from django.utils.translation import ugettext as _
+ from django.utils.translation import gettext as _
  from django.urls import reverse
  %>
 <%page args="tab_list, active_page, default_tab, tab_image" expression_filter="h" />

--- a/lms/templates/courseware/welcome-back.html
+++ b/lms/templates/courseware/welcome-back.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/credit_notifications/credit_eligibility_email.html
+++ b/lms/templates/credit_notifications/credit_eligibility_email.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
   from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/credit_notifications/credit_eligibility_email.txt
+++ b/lms/templates/credit_notifications/credit_eligibility_email.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 % if full_name is not UNDEFINED and full_name is not None:
 ${_(u"Hi {name},").format(name=full_name)}
 % else:

--- a/lms/templates/dashboard/_dashboard_credit_info.html
+++ b/lms/templates/dashboard/_dashboard_credit_info.html
@@ -1,6 +1,6 @@
 <%page args="credit_status" expression_filter="h"/>
 <%!
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
     from openedx.core.djangolib.markup import HTML, Text
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/dashboard/_dashboard_third_party_error.html
+++ b/lms/templates/dashboard/_dashboard_third_party_error.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <div class="wrapper-msg urgency-high">
     <div class="msg">
         <div class="msg-content">

--- a/lms/templates/dashboard/_entitlement_reason_survey.html
+++ b/lms/templates/dashboard/_entitlement_reason_survey.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 <div class="reasons_survey">
   <div class="slide1 hidden">

--- a/lms/templates/discussion/_discussion_inline.html
+++ b/lms/templates/discussion/_discussion_inline.html
@@ -4,7 +4,7 @@
 <%include file="_thread_list_template.html" />
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from json import dumps as json_dumps
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>

--- a/lms/templates/discussion/_discussion_inline_studio.html
+++ b/lms/templates/discussion/_discussion_inline_studio.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%page expression_filter="h"/>
 
 <div class="discussion-module" data-discussion-id="${discussion_id}">

--- a/lms/templates/discussion/_filter_dropdown.html
+++ b/lms/templates/discussion/_filter_dropdown.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY
 from openedx.core.djangolib.markup import HTML
 %>

--- a/lms/templates/discussion/_thread_list_template.html
+++ b/lms/templates/discussion/_thread_list_template.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <script type="text/template" id="thread-list-template">
     <div class="forum-nav-thread-list-wrapper" id="sort-filter-wrapper" tabindex="-1">
         <div class="forum-nav-refine-bar">

--- a/lms/templates/discussion/_user_profile.html
+++ b/lms/templates/discussion/_user_profile.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _, ungettext %>
+<%! from django.utils.translation import gettext as _, ungettext %>
 <%def name="span(num)"><span>${num}</span></%def>
 <div class="user-profile">
   <div class="sidebar-username"><a class="learner-profile-link" href="${learner_profile_page_url}">${django_user.username | h}</a></div>

--- a/lms/templates/enrollment/course_enrollment_message.html
+++ b/lms/templates/enrollment/course_enrollment_message.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%page expression_filter="h"/>
 <div class="wrapper-msg urgency-high">
     <div class="msg">

--- a/lms/templates/financial-assistance/financial-assistance.html
+++ b/lms/templates/financial-assistance/financial-assistance.html
@@ -2,7 +2,7 @@
 <%inherit file="../main.html"/>
 <%
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from common.djangoapps.edxmako.shortcuts import marketing_link
 

--- a/lms/templates/hidden_content.html
+++ b/lms/templates/hidden_content.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/index_overlay.html
+++ b/lms/templates/index_overlay.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='../../static_content.html'/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/cohort_management.html
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort_management.html
@@ -2,7 +2,7 @@
 
 <%namespace name='static' file='../../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 from lms.djangoapps.courseware.courses import get_studio_url
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -1,6 +1,6 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/certificates.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/grading.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/grading.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/problem_report.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/problem_report.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/reports.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/reports.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/discussions_management.html
+++ b/lms/templates/instructor/instructor_dashboard_2/discussions_management.html
@@ -2,7 +2,7 @@
 
 <%namespace name='static' file='../../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 from lms.djangoapps.courseware.courses import get_studio_url
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition

--- a/lms/templates/instructor/instructor_dashboard_2/extensions.html
+++ b/lms/templates/instructor/instructor_dashboard_2/extensions.html
@@ -1,6 +1,6 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <div id="set-extension">

--- a/lms/templates/instructor/instructor_dashboard_2/generate_registarion_codes_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/generate_registarion_codes_modal.html
@@ -1,6 +1,6 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 %>
 <section id="registration_code_generation_modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-registration-code">

--- a/lms/templates/instructor/instructor_dashboard_2/invalidate_registration_code_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/invalidate_registration_code_modal.html
@@ -1,5 +1,5 @@
 <%page args="section_data" expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%! from django.urls import reverse %>
 <section id="invalidate_registration_code_modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-enrollment-code-status">
     <h2 id="header-enrollment-code-status" class="hd hd-2">${_("Enrollment Code Status")}</h2>

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
 %>

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -1,6 +1,6 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -1,6 +1,6 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from datetime import datetime, timedelta
 import pytz
 %>

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -1,5 +1,5 @@
 <%page args="section_data" expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 %if section_data['access']['staff'] or section_data['access']['instructor']:
 <div class="action-type-container">
     %if section_data.get('writable_gradebook_url') or section_data.get('is_small_course'):

--- a/lms/templates/learner_dashboard/_dashboard_navigation_courses.html
+++ b/lms/templates/learner_dashboard/_dashboard_navigation_courses.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <header class="wrapper-header-courses">

--- a/lms/templates/learner_dashboard/program_details.html
+++ b/lms/templates/learner_dashboard/program_details.html
@@ -4,7 +4,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 

--- a/lms/templates/learner_dashboard/programs.html
+++ b/lms/templates/learner_dashboard/programs.html
@@ -4,7 +4,7 @@
 <%inherit file="../main.html" />
 <%def name="online_help_token()"><% return "programs" %></%def>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -6,7 +6,7 @@
 <%namespace file='../../main.html' import="login_query"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <div class="collapse navbar-collapse" id="navbarSupportedContent">

--- a/lms/templates/navigation/bootstrap/navbar-logo-header.html
+++ b/lms/templates/navigation/bootstrap/navbar-logo-header.html
@@ -4,7 +4,7 @@
 
 <%namespace name='static' file='../../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 # App that handles subdomain specific branding
 from lms.djangoapps.branding import api as branding_api

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -6,7 +6,7 @@
 <%namespace file='../main.html' import="login_query"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <ol class="left nav-global list-inline authenticated">

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 

--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -6,7 +6,7 @@
 <%namespace file='../main.html' import="login_query"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <ol class="left list-inline nav-global">

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -10,7 +10,7 @@
 <%namespace file='../main.html' import="login_query"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangolib.markup import HTML, Text

--- a/lms/templates/peer_grading/peer_grading.html
+++ b/lms/templates/peer_grading/peer_grading.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _
+<%! from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%

--- a/lms/templates/peer_grading/peer_grading_closed.html
+++ b/lms/templates/peer_grading/peer_grading_closed.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <section class="container peer-grading-container">
 <h2>${_("Peer Grading")}</h2>
     % if use_for_single_location:

--- a/lms/templates/peer_grading/peer_grading_problem.html
+++ b/lms/templates/peer_grading/peer_grading_problem.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <section class="container peer-grading-container">
     <div class="peer-grading" data-ajax-url="${ajax_url}" data-location="${problem_location}" data-use-single-location="${use_single_location}">
         <div class="error-container"></div>

--- a/lms/templates/registration/account_activation_sidebar_notice.html
+++ b/lms/templates/registration/account_activation_sidebar_notice.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <div class="profile-sidebar" role="region" aria-labelledby="account-activation-title">

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -3,7 +3,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -3,7 +3,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
 %>

--- a/lms/templates/registration/password_reset_done.html
+++ b/lms/templates/registration/password_reset_done.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <header>
   <h2>${_("Password reset successful")}</h2>
   <hr>

--- a/lms/templates/split_test_staff_view.html
+++ b/lms/templates/split_test_staff_view.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div class="split-test-view">
     <select class="split-test-select">

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/static_templates/429.html
+++ b/lms/templates/static_templates/429.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/static_templates/about.html
+++ b/lms/templates/static_templates/about.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("About")}</%block>

--- a/lms/templates/static_templates/blog.html
+++ b/lms/templates/static_templates/blog.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Blog")}</%block>

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Contact")}</%block>

--- a/lms/templates/static_templates/donate.html
+++ b/lms/templates/static_templates/donate.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Donate")}</%block>

--- a/lms/templates/static_templates/embargo.html
+++ b/lms/templates/static_templates/embargo.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/static_templates/faq.html
+++ b/lms/templates/static_templates/faq.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("FAQ")}</%block>

--- a/lms/templates/static_templates/help.html
+++ b/lms/templates/static_templates/help.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Help")}</%block>

--- a/lms/templates/static_templates/honor.html
+++ b/lms/templates/static_templates/honor.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Honor Code")}</%block>

--- a/lms/templates/static_templates/jobs.html
+++ b/lms/templates/static_templates/jobs.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Jobs")}</%block>

--- a/lms/templates/static_templates/media-kit.html
+++ b/lms/templates/static_templates/media-kit.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Media Kit")}</%block>

--- a/lms/templates/static_templates/news.html
+++ b/lms/templates/static_templates/news.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <%inherit file="../main.html" />
 

--- a/lms/templates/static_templates/press.html
+++ b/lms/templates/static_templates/press.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <%inherit file="../main.html" />
 

--- a/lms/templates/static_templates/privacy.html
+++ b/lms/templates/static_templates/privacy.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <%inherit file="../main.html" />
 

--- a/lms/templates/static_templates/server-down.html
+++ b/lms/templates/static_templates/server-down.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/static_templates/server-error.html
+++ b/lms/templates/static_templates/server-error.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/static_templates/server-overloaded.html
+++ b/lms/templates/static_templates/server-overloaded.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/static_templates/tos.html
+++ b/lms/templates/static_templates/tos.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("Terms of Service")}</%block>

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -5,7 +5,7 @@ import json
 
 from django.urls import reverse
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML

--- a/lms/templates/student_account/finish_auth.html
+++ b/lms/templates/student_account/finish_auth.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%namespace name='static' file='/static_content.html'/>
 <%inherit file="/main.html" />
 

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
     import json
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
     from openedx.core.djangolib.js_utils import dump_js_escaped_json
 %>

--- a/lms/templates/studio_render_paged_children_view.html
+++ b/lms/templates/studio_render_paged_children_view.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <%namespace name='static' file='static_content.html'/>
 

--- a/lms/templates/support/certificates.html
+++ b/lms/templates/support/certificates.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -2,7 +2,7 @@
 
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>

--- a/lms/templates/support/enrollment.html
+++ b/lms/templates/support/enrollment.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/lms/templates/support/entitlement.html
+++ b/lms/templates/support/entitlement.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/lms/templates/support/link_program_enrollments.html
+++ b/lms/templates/support/link_program_enrollments.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/lms/templates/support/manage_user.html
+++ b/lms/templates/support/manage_user.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/lms/templates/support/program_enrollments_inspector.html
+++ b/lms/templates/support/program_enrollments_inspector.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/lms/templates/verify_student/_verification_help.html
+++ b/lms/templates/verify_student/_verification_help.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/verify_student/incourse_reverify.html
+++ b/lms/templates/verify_student/incourse_reverify.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 <%namespace name='static' file='../static_content.html'/>
 

--- a/lms/templates/verify_student/missed_deadline.html
+++ b/lms/templates/verify_student/missed_deadline.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from lms.djangoapps.verify_student.views import PayAndVerifyView
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/verify_student/pay_and_verify.html
+++ b/lms/templates/verify_student/pay_and_verify.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 import json
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from openedx.core.djangolib.markup import HTML, Text
 from lms.djangoapps.verify_student.views import PayAndVerifyView

--- a/lms/templates/verify_student/reverify.html
+++ b/lms/templates/verify_student/reverify.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 <%namespace name='static' file='../static_content.html'/>
 

--- a/lms/templates/verify_student/reverify_not_allowed.html
+++ b/lms/templates/verify_student/reverify_not_allowed.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
     from django.urls import reverse
 %>
 

--- a/lms/templates/widgets/html-edit.html
+++ b/lms/templates/widgets/html-edit.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div class="wrapper-comp-editor" id="editor-tab" data-editor="${editor}">
     <div class="html-editor editor">

--- a/lms/templates/word_cloud.html
+++ b/lms/templates/word_cloud.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 
 <div
     id="word_cloud_${element_id}"

--- a/openedx/core/djangoapps/dark_lang/templates/dark_lang/preview-language-fragment.html
+++ b/openedx/core/djangoapps/dark_lang/templates/dark_lang/preview-language-fragment.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <%block name="content">

--- a/openedx/core/lib/license/templates/license.html
+++ b/openedx/core/lib/license/templates/license.html
@@ -1,7 +1,7 @@
 <%page args="license, button=False, button_size='88x31'" expression_filter="h"/>
 ## keep this synchronized with the contents of cms/templates/js/license-selector.underscore
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 def parse_license(lic):
     """

--- a/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
+++ b/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
@@ -12,7 +12,7 @@
 
 <%!
 import json
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.template.defaultfilters import escapejs
 
 from lms.djangoapps.discussion.django_comment_client.permissions import has_permission

--- a/openedx/features/course_experience/templates/course_experience/course-dates-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-dates-fragment.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 % if len(course_date_blocks) > 0:
     <h3 class="hd hd-6 handouts-header">${_("Upcoming Dates")}</h3>

--- a/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
@@ -4,7 +4,7 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
 %>

--- a/openedx/features/course_experience/templates/course_experience/course-updates-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-updates-fragment.html
@@ -4,7 +4,7 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import course_home_page_title

--- a/openedx/features/course_experience/templates/course_experience/dates-summary.html
+++ b/openedx/features/course_experience/templates/course_experience/dates-summary.html
@@ -1,5 +1,5 @@
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 <%page args="course_date" expression_filter="h"/>
 ## The date-summary-container div must stay here because it is used in our

--- a/openedx/features/learner_profile/static/learner_profile/templates/third_party_auth.html
+++ b/openedx/features/learner_profile/static/learner_profile/templates/third_party_auth.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from common.djangoapps.third_party_auth import pipeline
 %>
 

--- a/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
+++ b/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='/static_content.html'/>
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/openedx/features/learner_profile/templates/learner_profile/learner_profile.html
+++ b/openedx/features/learner_profile/templates/learner_profile/learner_profile.html
@@ -8,7 +8,7 @@
 <%!
 import json
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.djangolib.markup import HTML
 %>

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.conf import settings
 
 from datetime import datetime

--- a/themes/stanford-style/lms/templates/courseware/course_about_sidebar_header.html
+++ b/themes/stanford-style/lms/templates/courseware/course_about_sidebar_header.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 %>
 
 <header>

--- a/themes/stanford-style/lms/templates/emails/activation_email.txt
+++ b/themes/stanford-style/lms/templates/emails/activation_email.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 ${_("Thank you for signing up for {platform_name}.").format(platform_name=settings.PLATFORM_NAME)}
 
 ${_("Change your life and start learning today by activating your "

--- a/themes/stanford-style/lms/templates/emails/confirm_email_change.txt
+++ b/themes/stanford-style/lms/templates/emails/confirm_email_change.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 ${_("This is to confirm that you changed the e-mail associated with "
   "{platform_name} from {old_email} to {new_email}. If you "
   "did not make this request, please contact us at").format(platform_name=settings.PLATFORM_NAME, old_email=old_email, new_email=new_email)}

--- a/themes/stanford-style/lms/templates/emails/email_change.txt
+++ b/themes/stanford-style/lms/templates/emails/email_change.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 ${_("We received a request to change the e-mail associated with your "
     "{platform_name} account from {old_email} to {new_email}. "
     "If this is correct, please confirm your new e-mail address by "

--- a/themes/stanford-style/lms/templates/emails/reject_name_change.txt
+++ b/themes/stanford-style/lms/templates/emails/reject_name_change.txt
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%namespace name='static' file='../static_content.html'/>
 (Not currently used)
 

--- a/themes/stanford-style/lms/templates/embargo/default_courseware.html
+++ b/themes/stanford-style/lms/templates/embargo/default_courseware.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("This Course Unavailable In Your Country")}</%block>

--- a/themes/stanford-style/lms/templates/embargo/default_enrollment.html
+++ b/themes/stanford-style/lms/templates/embargo/default_enrollment.html
@@ -1,4 +1,4 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import gettext as _ %>
 <%inherit file="../main.html" />
 
 <%block name="pagetitle">${_("This Course Unavailable In Your Country")}</%block>

--- a/themes/stanford-style/lms/templates/footer.html
+++ b/themes/stanford-style/lms/templates/footer.html
@@ -2,7 +2,7 @@
 <%!
   from datetime import date
   from django.urls import reverse
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
 %>
 <%namespace name='static' file='static_content.html'/>

--- a/themes/stanford-style/lms/templates/index.html
+++ b/themes/stanford-style/lms/templates/index.html
@@ -1,6 +1,6 @@
 <%inherit file="main.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 

--- a/themes/stanford-style/lms/templates/register-form.html
+++ b/themes/stanford-style/lms/templates/register-form.html
@@ -2,7 +2,7 @@
 <%!
 from common.djangoapps import third_party_auth
 from common.djangoapps.third_party_auth import pipeline, provider
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django_countries import countries
 from common.djangoapps.student.models import UserProfile
 %>

--- a/themes/stanford-style/lms/templates/register-shib.html
+++ b/themes/stanford-style/lms/templates/register-shib.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h" />
 <%inherit file="main.html" />
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text

--- a/themes/stanford-style/lms/templates/register-sidebar.html
+++ b/themes/stanford-style/lms/templates/register-sidebar.html
@@ -1,5 +1,5 @@
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 %>
 <%namespace file='main.html' import="login_query"/>

--- a/themes/stanford-style/lms/templates/static_templates/about.html
+++ b/themes/stanford-style/lms/templates/static_templates/about.html
@@ -1,6 +1,6 @@
 ## mako
 <%!
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
 %>
 <%namespace name='static' file='/static_content.html'/>
 

--- a/themes/stanford-style/lms/templates/static_templates/embargo.html
+++ b/themes/stanford-style/lms/templates/static_templates/embargo.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />

--- a/themes/stanford-style/lms/templates/static_templates/tos.html
+++ b/themes/stanford-style/lms/templates/static_templates/tos.html
@@ -1,7 +1,7 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
 %>
 <%inherit file="/main.html" />
 

--- a/xmodule/capa/templates/choicetext.html
+++ b/xmodule/capa/templates/choicetext.html
@@ -1,5 +1,5 @@
 <%! from xmodule.capa.util import remove_markup
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 

--- a/xmodule/capa/templates/codeinput.html
+++ b/xmodule/capa/templates/codeinput.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 <div id="textbox_${id}" class="capa_inputtype textbox cminput">


### PR DESCRIPTION
### Description
- `ugettext()` was deprected in earlier versions and has been removed in `Django 4.0`. 