### PR TITLE
fix: User retirement 404 for state RETIRING_FORUMS

### DIFF
--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -64,7 +64,11 @@ urlpatterns = [
         CourseView.as_view(),
         name="discussion_course"
     ),
-    path('v1/accounts/retire_forum', RetireUserView.as_view(), name="retire_discussion_user"),
+    re_path(
+        r"^v1/accounts/retire_forum/?$",
+        RetireUserView.as_view(),
+        name="retire_discussion_user"
+    ),
     path('v1/accounts/replace_username', ReplaceUsernamesView.as_view(), name="replace_discussion_username"),
     re_path(
         fr"^v1/course_topics/{settings.COURSE_ID_PATTERN}",


### PR DESCRIPTION
This is a [backport](https://github.com/openedx/edx-platform/pull/33024) from the master branch

## Description

We ran into a problem when running the `retire_users.sh` command. The user must first delete their account from the platform. After that, the `/edx/app/retirement_service/retire_users.sh` command is launched. However, for one step, an error appears
```
sudo -sHu edx_retirement_worker
edx_retirement_worker@lms-palm:/home/company$ cd
edx_retirement_worker@lms-palm:~$ /edx/app/retirement_service/retire_users.sh
=== [Tue Aug  1 07:19:04 UTC 2023] /edx/app/retirement_service/retire_users.sh: Started
Writing logs to: /edx/var/log/retirement_service/edx.log
Deleting user: test_user_5...
b'Learner Retirement: Starting learner retirement for test_user_5 using config file /edx/app/retirement_service/config.yml'
b'Learner Retirement: Starting state RETIRING_FORUMS'
ERROR:tubular.edx_api:API Error: 404 Client Error: Not Found for url: https://lms-palm-dev.raccoongang.com/api/discussion/v1/accounts/retire_forum/ with status code: 404
INFO:tubular.edx_api:No information about learner retirement
b'Learner Retirement: State RETIRING_FORUMS completed in 0.36619019508361816 seconds'
b'Learner Retirement: Progressing to state FORUMS_COMPLETE'
b'Learner Retirement: Starting state RETIRING_ENROLLMENTS'
b'Learner Retirement: State RETIRING_ENROLLMENTS completed in 3.4557716846466064 seconds'
b'Learner Retirement: Progressing to state ENROLLMENTS_COMPLETE'
b'Learner Retirement: Starting state RETIRING_LMS_MISC'
b'Learner Retirement: State RETIRING_LMS_MISC completed in 0.11767053604125977 seconds'
b'Learner Retirement: Progressing to state LMS_MISC_COMPLETE'
b'Learner Retirement: Starting state RETIRING_LMS'
b'Learner Retirement: State RETIRING_LMS completed in 0.18668651580810547 seconds'
b'Learner Retirement: Progressing to state LMS_COMPLETE'
b'Learner Retirement: Retirement complete for learner test_user_5'
edx_retirement_worker@lms-palm:~$
```
At the same time, all user actions for the forum remain, since this retirement stage is not completed.
A problem was detected with the WALL of this endpoint.
URL looks like:
`https://lms-palm.com/api/discussion/v1/accounts/retire_forum/`
However, this URL is expected on the platform:
`https://lms-palm.com/api/discussion/v1/accounts/retire_forum`

The URL is created in [LmsApi](https://github.com/openedx/tubular/blob/467cdcc40dedb83dc8ccde7d71963924fc6a1754/tubular/edx_api.py#L268), and the [append_slash](https://github.com/openedx/tubular/blob/467cdcc40dedb83dc8ccde7d71963924fc6a1754/tubular/edx_api.py#L34C5-L34C17) argument is responsible for adding a slash at the end of the URL. This addition of a slash is carried out for all retirement steps.

After fixing, the entire flow passes without errors:
```
=== [Wed Aug 16 10:18:31 UTC 2023] /edx/app/retirement_service/retire_users.sh: Started
Writing logs to: /edx/var/log/retirement_service/edx.log
Deleting user: test_user_5...
b'Learner Retirement: Starting learner retirement for test_user_5 using config file /edx/app/retirement_service/config.yml'
b'Learner Retirement: Starting state RETIRING_FORUMS'
b'Learner Retirement: State RETIRING_FORUMS completed in 0.40157532691955566 seconds'
b'Learner Retirement: Progressing to state FORUMS_COMPLETE'
b'Learner Retirement: Starting state RETIRING_ENROLLMENTS'
b'Learner Retirement: State RETIRING_ENROLLMENTS completed in 0.5397000312805176 seconds'
b'Learner Retirement: Progressing to state ENROLLMENTS_COMPLETE'
b'Learner Retirement: Starting state RETIRING_LMS_MISC'
b'Learner Retirement: State RETIRING_LMS_MISC completed in 0.30715203285217285 seconds'
b'Learner Retirement: Progressing to state LMS_MISC_COMPLETE'
b'Learner Retirement: Starting state RETIRING_LMS'
b'Learner Retirement: State RETIRING_LMS completed in 0.16425585746765137 seconds'
b'Learner Retirement: Progressing to state LMS_COMPLETE'
b'Learner Retirement: Retirement complete for learner test_user_5'
```

User data is deleted in the Discussion:
<img width="1312" alt="screen_53" src="https://github.com/openedx/edx-platform/assets/98233552/4c468ed0-4ba3-420d-b757-175b6afd597a">

#### Note:
We do not have all stages of retirement. Only such:
```
{
    "client_id": "our_client_id",
    "client_secret": "our_client_secret",
    "base_urls": {
        "lms": "https://lms-palm.com/",
        "ecommerce": "https://ecommerce-palm.com/",
        "credentials": "https://credentials-palm.com/",
    },
    "retirement_pipeline": [
        ["RETIRING_FORUMS", "FORUMS_COMPLETE", "LMS", "retirement_retire_forum"],
        ["RETIRING_ENROLLMENTS", "ENROLLMENTS_COMPLETE", "LMS", "retirement_unenroll"],
        ["RETIRING_LMS_MISC", "LMS_MISC_COMPLETE", "LMS", "retirement_lms_retire_misc"],
        ["RETIRING_LMS", "LMS_COMPLETE", "LMS", "retirement_lms_retire"],
    ],
}
```

Might have similar problems for other stages.