### PR TITLE
fix: fix django.utils.translations warnings

### DIFF
--- a/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
@@ -7,7 +7,7 @@
 <%!
 import json
 
-from django.utils.translation import gettext as _, ungettext
+from django.utils.translation import gettext as _, ngettext
 from django.template.defaultfilters import escapejs
 from django.urls import reverse
 
@@ -52,8 +52,8 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                     <span class="user-roles">${", ".join(_(role_name) for role_name in django_user_roles)}</span>
                 </span>
                 <div class="discussion-profile-count">
-                    <span class="discussion-profile-info threads-count">${ungettext('%s discussion started', '%s discussions started', profiled_user['threads_count']) % span(profiled_user['threads_count'])}</span>
-                    <span class="discussion-profile-info  comments-count">${ungettext('%s comment', '%s comments', profiled_user['comments_count']) % span(profiled_user['comments_count'])}</span>
+                    <span class="discussion-profile-info threads-count">${ngettext('%s discussion started', '%s discussions started', profiled_user['threads_count']) % span(profiled_user['threads_count'])}</span>
+                    <span class="discussion-profile-info  comments-count">${ngettext('%s comment', '%s comments', profiled_user['comments_count']) % span(profiled_user['comments_count'])}</span>
                 </div>
             </div>
         </div>

--- a/lms/templates/library-block-author-preview-header.html
+++ b/lms/templates/library-block-author-preview-header.html
@@ -1,10 +1,10 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ungettext %>
+<%! from django.utils.translation import ngettext %>
 <div class="wrapper-xblock-message">
     <div class="xblock-message information">
         <p>
             <span class="message-text">
-                ${ungettext(
+                ${ngettext(
                     'Showing all matching content eligible to be added into {display_name}. Each student will be assigned {max_count} component drawn randomly from this list.',
                     'Showing all matching content eligible to be added into {display_name}. Each student will be assigned {max_count} components drawn randomly from this list.',
                     max_count

--- a/lms/templates/seq_block.html
+++ b/lms/templates/seq_block.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-  from django.utils.translation import pgettext, ugettext as _
+  from django.utils.translation import pgettext, gettext as _
   from django.conf import settings
 %>
 

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -59,7 +59,7 @@ log = logging.getLogger("edx.courseware")
 
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
-#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
+#  `django.utils.translation.gettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 # Generate this many different variants of problems with rerandomize=per_student
@@ -388,7 +388,7 @@ class ProblemBlock(
             'ungraded_response': self.handle_ungraded_response
         }
 
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
 
         generic_error_message = _(
             "We're sorry, there was an error with processing your request. "
@@ -661,7 +661,7 @@ class ProblemBlock(
             xqueue=None,
             matlab_api_key=None,
         )
-        _ = capa_system.i18n.ugettext
+        _ = capa_system.i18n.gettext
 
         count = 0
         for user_state in user_state_iterator:
@@ -928,7 +928,7 @@ class ProblemBlock(
         """
         # The logic flow is a little odd so that _('xxx') strings can be found for
         # translation while also running _() just once for each string.
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
         submit = _('Submit')
 
         return submit
@@ -941,7 +941,7 @@ class ProblemBlock(
         display the value returned by this function until a response is
         received by the server.
         """
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
         return _('Submitting')
 
     def should_enable_submit_button(self):
@@ -1071,7 +1071,7 @@ class ProblemBlock(
             self.set_state_from_lcp()
             self.set_score(self.score_from_lcp(self.lcp))
             # Prepend a scary warning to the student
-            _ = self.runtime.service(self, "i18n").ugettext
+            _ = self.runtime.service(self, "i18n").gettext
             warning_msg = Text(_("Warning: The problem has been reset to its initial state!"))
             warning = HTML('<div class="capa_reset"> <h2>{}</h2>').format(warning_msg)
 
@@ -1130,7 +1130,7 @@ class ProblemBlock(
         demand_hints = self.lcp.tree.xpath("//problem/demandhint/hint")
         hint_index = hint_index % len(demand_hints)
 
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
 
         counter = 0
         total_text = ''
@@ -1195,7 +1195,7 @@ class ProblemBlock(
             html = self.handle_problem_html_error(err)
 
         html = self.remove_tags_from_html(html)
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
 
         # Enable/Disable Submit button if should_enable_submit_button returns True/False.
         submit_button = self.submit_button_name()
@@ -1292,11 +1292,11 @@ class ProblemBlock(
                         break
 
             # Build the notification message based on the notification type and translate it.
-            ungettext = self.runtime.service(self, "i18n").ungettext
-            _ = self.runtime.service(self, "i18n").ugettext
+            ngettext = self.runtime.service(self, "i18n").ngettext
+            _ = self.runtime.service(self, "i18n").gettext
             if answer_notification_type == 'incorrect':
                 if progress is not None:
-                    answer_notification_message = ungettext(
+                    answer_notification_message = ngettext(
                         "Incorrect ({progress} point)",
                         "Incorrect ({progress} points)",
                         progress.frac()[1]
@@ -1305,7 +1305,7 @@ class ProblemBlock(
                     answer_notification_message = _('Incorrect')
             elif answer_notification_type == 'correct':
                 if progress is not None:
-                    answer_notification_message = ungettext(
+                    answer_notification_message = ngettext(
                         "Correct ({progress} point)",
                         "Correct ({progress} points)",
                         progress.frac()[1]
@@ -1314,7 +1314,7 @@ class ProblemBlock(
                     answer_notification_message = _('Correct')
             elif answer_notification_type == 'partially-correct':
                 if progress is not None:
-                    answer_notification_message = ungettext(
+                    answer_notification_message = ngettext(
                         "Partially correct ({progress} point)",
                         "Partially correct ({progress} points)",
                         progress.frac()[1]
@@ -1550,7 +1550,7 @@ class ProblemBlock(
             'answers': new_answers,
             'correct_status_html': self.runtime.service(self, 'mako').render_template(
                 'status_span.html',
-                {'status': Status('correct', self.runtime.service(self, "i18n").ugettext)}
+                {'status': Status('correct', self.runtime.service(self, "i18n").gettext)}
             )
         }
 
@@ -1690,7 +1690,7 @@ class ProblemBlock(
         if override_time is not False:
             current_time = override_time
 
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
 
         # Too late. Cannot submit
         if self.closed():
@@ -1879,25 +1879,25 @@ class ProblemBlock(
         Returns time duration nicely formated, e.g. "3 minutes 4 seconds"
         """
         # Here _ is the N variant ungettext that does pluralization with a 3-arg call
-        ungettext = self.runtime.service(self, "i18n").ungettext
+        ngettext = self.runtime.service(self, "i18n").ngettext
         hours = num_seconds // 3600
         sub_hour = num_seconds % 3600
         minutes = sub_hour // 60
         seconds = sub_hour % 60
         display = ""
         if hours > 0:
-            display += ungettext("{num_hour} hour", "{num_hour} hours", hours).format(num_hour=hours)
+            display += ngettext("{num_hour} hour", "{num_hour} hours", hours).format(num_hour=hours)
         if minutes > 0:
             if display != "":
                 display += " "
             # translators: "minute" refers to a minute of time
-            display += ungettext("{num_minute} minute", "{num_minute} minutes", minutes).format(num_minute=minutes)
+            display += ngettext("{num_minute} minute", "{num_minute} minutes", minutes).format(num_minute=minutes)
         # Taking care to make "0 seconds" instead of "" for 0 time
         if seconds > 0 or (hours == 0 and minutes == 0):
             if display != "":
                 display += " "
             # translators: "second" refers to a second of time
-            display += ungettext("{num_second} second", "{num_second} seconds", seconds).format(num_second=seconds)
+            display += ngettext("{num_second} second", "{num_second} seconds", seconds).format(num_second=seconds)
         return display
 
     def get_submission_metadata_safe(self, answers, correct_map):
@@ -1996,7 +1996,7 @@ class ProblemBlock(
 
         answers = self.make_dict_of_responses(data)
         event_info['answers'] = answers
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
 
         # Too late. Cannot submit
         if self.closed() and not self.max_attempts == 0:
@@ -2053,7 +2053,7 @@ class ProblemBlock(
         event_info = {}
         event_info['old_state'] = self.lcp.get_state()
         event_info['problem_id'] = str(self.location)
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
 
         if self.closed():
             event_info['failure'] = 'closed'
@@ -2119,7 +2119,7 @@ class ProblemBlock(
         """
         event_info = {'state': self.lcp.get_state(), 'problem_id': str(self.location)}
 
-        _ = self.runtime.service(self, "i18n").ugettext
+        _ = self.runtime.service(self, "i18n").gettext
 
         if not self.lcp.supports_rescoring():
             event_info['failure'] = 'unsupported'

--- a/xmodule/video_block/transcripts_utils.py
+++ b/xmodule/video_block/transcripts_utils.py
@@ -203,7 +203,7 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
 
     Returns (status, transcripts): bool, dict.
     """
-    _ = i18n.ugettext
+    _ = i18n.gettext
 
     utf8_parser = etree.XMLParser(encoding='utf-8')
 
@@ -259,7 +259,7 @@ def download_youtube_subs(youtube_id, video_block, settings):  # lint-amnesty, p
         GetTranscriptsFromYouTubeException, if fails.
     """
     i18n = video_block.runtime.service(video_block, "i18n")
-    _ = i18n.ugettext
+    _ = i18n.gettext
 
     subs = get_transcripts_from_youtube(youtube_id, settings, i18n)
     return json.dumps(subs, indent=2)
@@ -285,7 +285,7 @@ def generate_subs_from_source(speed_subs, subs_type, subs_filedata, block, langu
     :param language: str, language of translation of transcripts
     :returns: True, if all subs are generated and saved successfully.
     """
-    _ = block.runtime.service(block, "i18n").ugettext
+    _ = block.runtime.service(block, "i18n").gettext
     if subs_type.lower() != 'srt':
         raise TranscriptsGenerationException(_("We support only SubRip (*.srt) transcripts format."))
     try:
@@ -434,7 +434,7 @@ def manage_video_subtitles_save(item, user, old_metadata=None, generate_translat
         (To avoid confusing situation if you attempt to correct a translation by uploading
         a new version of the SRT file with same name).
     """
-    _ = item.runtime.service(item, "i18n").ugettext
+    _ = item.runtime.service(item, "i18n").gettext
 
     # # 1.
     # html5_ids = get_html5_ids(item.html5_sources)
@@ -519,7 +519,7 @@ def generate_sjson_for_all_speeds(block, user_filename, result_subs_dict, lang):
     """
     Generates sjson from srt for given lang.
     """
-    _ = block.runtime.service(block, "i18n").ugettext
+    _ = block.runtime.service(block, "i18n").gettext
 
     try:
         srt_transcripts = contentstore().find(Transcript.asset_location(block.location, user_filename))


### PR DESCRIPTION
### Description
- Fix following deprecation warnings and fixes issue https://github.com/openedx/edx-platform/issues/33037

- `django.utils.translation.ugettext() is deprecated in favor of django.utils.translation.gettext()`
- `django.utils.translation.ungettext() is deprecated in favor of django.utils.translation.ngettext()`

- Some instances of these methods are still remaining but they are not producing any deprecation warnings and we need to update both `i18n` and `openedx/Xblock` repos first before refactoring those instances to avoid test failures. So these will be refactored in a later PR if needed. 