### PR TITLE
[FC-0009] fix: Prevent multiple dropdowns opening at once

### DIFF
--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -420,6 +420,15 @@ function(
         showActionsMenu(event) {
             const showActionsButton = event.currentTarget;
             const subMenu = showActionsButton.parentElement.querySelector(".wrapper-nav-sub");
+
+            // Close all open dropdowns
+            const elements = document.querySelectorAll("li.action-item.action-actions-menu.nav-item");
+            elements.forEach(element => {
+                if (element !== showActionsButton.parentElement) {
+                    element.querySelector('.wrapper-nav-sub').classList.remove('is-shown');
+                }
+            });
+
             // Code in 'base.js' normally handles toggling these dropdowns but since this one is
             // not present yet during the domReady event, we have to handle displaying it ourselves.
             subMenu.classList.toggle("is-shown");
@@ -452,7 +461,7 @@ function(
                 event.preventDefault();
                 this.pasteUnit(event);
             });
-            element.find('.action-actions-menu').click((event) => {
+            element.find('.show-actions-menu-button').click((event) => {
                 this.showActionsMenu(event);
             });
         },

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -356,6 +356,15 @@ function($, _, Backbone, gettext, BasePage, ViewUtils, ContainerView, XBlockView
         showXBlockActionsMenu: function(event) {
             const showActionsButton = event.currentTarget;
             const subMenu = showActionsButton.parentElement.querySelector('.wrapper-nav-sub');
+
+            // Close all open dropdowns
+            const elements = document.querySelectorAll("li.action-item.action-actions-menu.nav-item");
+            elements.forEach(element => {
+                if (element !== showActionsButton.parentElement) {
+                    element.querySelector('.wrapper-nav-sub').classList.remove('is-shown');
+                }
+            });
+
             // Code in 'base.js' normally handles toggling these dropdowns but since this one is
             // not present yet during the domReady event, we have to handle displaying it ourselves.
             subMenu.classList.toggle('is-shown');


### PR DESCRIPTION
## Description

This closes already open dropdown menus when opening another dropdown menu, to prevent them from overlapping each other.

## Supporting information

Related Ticket:
- https://github.com/openedx/modular-learning/issues/92

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_units` flag is set
4. Navigate to Studio: http://localhost:18010/
5. Click on a course
6. Check component functionality:
    1. Click on the 3 vertical dots to open dropdown menu
    1. Check that it opens
    1. Check that when you click away it closes
    1. Check that when you click on another 3 vertical dots while a dropdown is open, it closes it and opens the new one
7. Check unit functionality 
    1. Create a new unit if none exist
    1. Click on the 3 vertical dots to open dropdown menu
    1. Check that it opens
    1. Check that when you click away it closes
    1. Check that when you click on another 3 vertical dots while a dropdown is open, it closes it and opens the new one

---
Private ref: [FAL-3479](https://tasks.opencraft.com/browse/FAL-3479)