### PR TITLE
[FC-0009] feat: Prepend 'Copy of' to pasted blocks names

### DIFF
--- a/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
+++ b/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
@@ -18,7 +18,7 @@ CLIPBOARD_ENDPOINT = "/api/content-staging/v1/clipboard/"
 SAMPLE_VIDEO_OLX = """
     <video
         url_name="sample_video"
-        display_name="default"
+        display_name="Copy of 'default'"
         youtube="0.75:JMD_ifUUfsU,1.00:OEoXaMPEzfM,1.25:AKqURZnYqpk,1.50:DYpADpL7jAY"
         youtube_id_0_75="JMD_ifUUfsU"
         youtube_id_1_0="OEoXaMPEzfM"
@@ -156,7 +156,7 @@ class ClipboardTestCase(ModuleStoreTestCase):
         # For HTML, we really want to be sure that the OLX is serialized in this exact format (using CDATA), so we check
         # the actual string directly rather than using assertXmlEqual():
         assert olx_response.content.decode() == dedent("""
-            <html url_name="toyhtml" display_name="Text"><![CDATA[
+            <html url_name="toyhtml" display_name="Copy of 'Text'"><![CDATA[
             <a href='/static/handouts/sample_handout.txt'>Sample</a>
             ]]></html>
         """).lstrip()


### PR DESCRIPTION
## Description

Adds "Copy of '[BLOCK_NAME]'" for pasted blocks to make it more obvious that the block was copied and pasted.

## Supporting information

Related Ticket:

- https://github.com/openedx/modular-learning/issues/92

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_feature` and `contentstore.enable_copy_paste_units` flags are set
4. Navigate to Studio: http://localhost:18010/
5. Click on a course
6. Check component functionality:
    1. Click on 3 vertical dots and Copy to Clipboard
    1. Paste it, and check that the newly pasted item is named "Copy of 'NAME'"
7. Check unit functionality 
    1. Click on a unit and click on the 3 vertical dots to open dropdown menu and then Copy to Clipboard
    1. Paste it and check that the newly pasted item is named "Copy of 'NAME'"

<img width="269" alt="Screen Shot 2023-08-17 at 3 53 45 PM" src="https://github.com/openedx/edx-platform/assets/6829768/91934f88-682c-47e5-baf9-54dcc1eb7973">
<img width="513" alt="Screen Shot 2023-08-17 at 3 55 31 PM" src="https://github.com/openedx/edx-platform/assets/6829768/85496ea3-6ed4-4601-8f06-0765f6722ee7">

---
Private ref: [FAL-3479](https://tasks.opencraft.com/browse/FAL-3479)