### PR TITLE
fix: for the Wiki page translation

### DIFF
--- a/lms/templates/wiki/includes/editor_widget.html
+++ b/lms/templates/wiki/includes/editor_widget.html
@@ -1,9 +1,9 @@
 {% load i18n %}
+{% load django_markup %}
 <p id="hint_id_content" class="help-block">
-    {% filter force_escape %}
-    {% blocktrans with start_link="<a id='cheatsheetLink' href='#cheatsheetModal' rel='leanModal'>" end_link="</a>" trimmed %}
-        Markdown syntax is allowed. See the {{ start_link }}cheatsheet{{ end_link }} for help.
+    {% blocktrans trimmed asvar tmsg %}
+        Markdown syntax is allowed. See the {start_link}cheatsheet{end_link} for help.
     {% endblocktrans %}
-    {% endfilter %}
+    {% interpolate_html tmsg start_link='<a id="cheatsheetLink" href="#cheatsheetModal" rel="leanModal">'|safe end_link='</a>'|safe %}
 </p>
 <textarea {{ attrs }}>{{ content }}</textarea>


### PR DESCRIPTION
## Description

This is the fix for `http://localhost:18000/wiki/_create/`

Before:
<img width="1339" alt="screen_56" src="https://github.com/openedx/edx-platform/assets/98233552/1de35f27-f8b4-4f3e-a398-a990776e2a28">

After:
<img width="1268" alt="screen_55" src="https://github.com/openedx/edx-platform/assets/98233552/5701f7c7-d6a1-44dd-95f6-d942b7a6c7c2">
