### PR TITLE
autofilling user details from sso pipeline

### DIFF
--- a/openedx/core/djangoapps/user_authn/api/tests/test_data.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_data.py
@@ -1,0 +1,141 @@
+""" Mocked data for testing """
+
+mfe_context_data_keys = {
+    'contextData',
+    'registrationFields',
+    'optionalFields'
+}
+
+mock_mfe_context_data = {
+    'context_data': {
+        'currentProvider': 'edX',
+        'platformName': 'edX',
+        'providers': [
+            {
+                'id': 'oa2-facebook',
+                'name': 'Facebook',
+                'iconClass': 'fa-facebook',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://facebook.com/login',
+                'registerUrl': 'https://facebook.com/register'
+            },
+            {
+                'id': 'oa2-google-oauth2',
+                'name': 'Google',
+                'iconClass': 'fa-google-plus',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://google.com/login',
+                'registerUrl': 'https://google.com/register'
+            }
+        ],
+        'secondaryProviders': [],
+        'finishAuthUrl': 'https://edx.com/auth/finish',
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipeline_user_details': {
+            'username': 'test123',
+            'email': 'test123@edx.com',
+            'fullname': 'Test Test',
+            'first_name': 'Test',
+            'last_name': 'Test'
+        }
+    },
+    'registration_fields': {},
+    'optional_fields': {
+        'extended_profile': []
+    }
+}
+
+mock_default_mfe_context_data = {
+    'context_data': {
+        'currentProvider': None,
+        'platformName': 'édX',
+        'providers': [],
+        'secondaryProviders': [],
+        'finishAuthUrl': None,
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipeline_user_details': {}
+    },
+    'registration_fields': {},
+    'optional_fields': {
+        'extended_profile': []
+    }
+}
+
+expected_mfe_context_data = {
+    'contextData': {
+        'currentProvider': 'edX',
+        'platformName': 'edX',
+        'providers': [
+            {
+                'id': 'oa2-facebook',
+                'name': 'Facebook',
+                'iconClass': 'fa-facebook',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://facebook.com/login',
+                'registerUrl': 'https://facebook.com/register'
+            },
+            {
+                'id': 'oa2-google-oauth2',
+                'name': 'Google',
+                'iconClass': 'fa-google-plus',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://google.com/login',
+                'registerUrl': 'https://google.com/register'
+            }
+        ],
+        'secondaryProviders': [],
+        'finishAuthUrl': 'https://edx.com/auth/finish',
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipelineUserDetails': {
+            'username': 'test123',
+            'email': 'test123@edx.com',
+            'name': 'Test Test',
+            'firstName': 'Test',
+            'lastName': 'Test'
+        }
+    },
+    'registrationFields': {},
+    'optionalFields': {
+        'extended_profile': []
+    }
+}
+
+default_expected_mfe_context_data = {
+    'contextData': {
+        'currentProvider': None,
+        'platformName': 'édX',
+        'providers': [],
+        'secondaryProviders': [],
+        'finishAuthUrl': None,
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipelineUserDetails': {}
+    },
+    'registrationFields': {},
+    'optionalFields': {
+        'extended_profile': []
+    }
+}

--- a/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
@@ -2,6 +2,12 @@
 
 from django.test import TestCase
 
+from openedx.core.djangoapps.user_authn.api.tests.test_data import (
+    mock_mfe_context_data,
+    expected_mfe_context_data,
+    mock_default_mfe_context_data,
+    default_expected_mfe_context_data,
+)
 from openedx.core.djangoapps.user_authn.serializers import MFEContextSerializer
 
 
@@ -10,128 +16,29 @@ class TestMFEContextSerializer(TestCase):
     High-level unit tests for MFEContextSerializer
     """
 
-    @staticmethod
-    def get_mock_mfe_context_data():
-        """
-        Helper function to generate mock data for the MFE Context API view.
-        """
-
-        mock_context_data = {
-            'context_data': {
-                'currentProvider': 'edX',
-                'platformName': 'edX',
-                'providers': [
-                    {
-                        'id': 'oa2-facebook',
-                        'name': 'Facebook',
-                        'iconClass': 'fa-facebook',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://facebook.com/login',
-                        'registerUrl': 'https://facebook.com/register'
-                    },
-                    {
-                        'id': 'oa2-google-oauth2',
-                        'name': 'Google',
-                        'iconClass': 'fa-google-plus',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://google.com/login',
-                        'registerUrl': 'https://google.com/register'
-                    }
-                ],
-                'secondaryProviders': [],
-                'finishAuthUrl': 'https://edx.com/auth/finish',
-                'errorMessage': None,
-                'registerFormSubmitButtonText': 'Create Account',
-                'autoSubmitRegForm': False,
-                'syncLearnerProfileData': False,
-                'countryCode': '',
-                'pipeline_user_details': {
-                    'username': 'test123',
-                    'email': 'test123@edx.com',
-                    'fullname': 'Test Test',
-                    'first_name': 'Test',
-                    'last_name': 'Test'
-                }
-            },
-            'registration_fields': {},
-            'optional_fields': {
-                'extended_profile': []
-            }
-        }
-
-        return mock_context_data
-
-    @staticmethod
-    def get_expected_data():
-        """
-        Helper function to generate expected data for the MFE Context API view serializer.
-        """
-
-        expected_data = {
-            'contextData': {
-                'currentProvider': 'edX',
-                'platformName': 'edX',
-                'providers': [
-                    {
-                        'id': 'oa2-facebook',
-                        'name': 'Facebook',
-                        'iconClass': 'fa-facebook',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://facebook.com/login',
-                        'registerUrl': 'https://facebook.com/register'
-                    },
-                    {
-                        'id': 'oa2-google-oauth2',
-                        'name': 'Google',
-                        'iconClass': 'fa-google-plus',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://google.com/login',
-                        'registerUrl': 'https://google.com/register'
-                    }
-                ],
-                'secondaryProviders': [],
-                'finishAuthUrl': 'https://edx.com/auth/finish',
-                'errorMessage': None,
-                'registerFormSubmitButtonText': 'Create Account',
-                'autoSubmitRegForm': False,
-                'syncLearnerProfileData': False,
-                'countryCode': '',
-                'pipelineUserDetails': {
-                    'username': 'test123',
-                    'email': 'test123@edx.com',
-                    'name': 'Test Test',
-                    'firstName': 'Test',
-                    'lastName': 'Test'
-                }
-            },
-            'registrationFields': {},
-            'optionalFields': {
-                'extended_profile': []
-            }
-        }
-
-        return expected_data
-
     def test_mfe_context_serializer(self):
         """
         Test MFEContextSerializer with mock data that serializes data correctly
         """
 
-        mfe_context_data = self.get_mock_mfe_context_data()
-        expected_data = self.get_expected_data()
         output_data = MFEContextSerializer(
-            mfe_context_data
+            mock_mfe_context_data
         ).data
 
         self.assertDictEqual(
             output_data,
-            expected_data
+            expected_mfe_context_data
+        )
+
+    def test_mfe_context_serializer_default_response(self):
+        """
+        Test MFEContextSerializer with default data
+        """
+        serialized_data = MFEContextSerializer(
+            mock_default_mfe_context_data
+        ).data
+
+        self.assertDictEqual(
+            serialized_data,
+            default_expected_mfe_context_data
         )

--- a/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
@@ -1,0 +1,137 @@
+"""Tests for serializers for the MFE Context"""
+
+from django.test import TestCase
+
+from openedx.core.djangoapps.user_authn.serializers import MFEContextSerializer
+
+
+class TestMFEContextSerializer(TestCase):
+    """
+    High-level unit tests for MFEContextSerializer
+    """
+
+    @staticmethod
+    def get_mock_mfe_context_data():
+        """
+        Helper function to generate mock data for the MFE Context API view.
+        """
+
+        mock_context_data = {
+            'context_data': {
+                'currentProvider': 'edX',
+                'platformName': 'edX',
+                'providers': [
+                    {
+                        'id': 'oa2-facebook',
+                        'name': 'Facebook',
+                        'iconClass': 'fa-facebook',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://facebook.com/login',
+                        'registerUrl': 'https://facebook.com/register'
+                    },
+                    {
+                        'id': 'oa2-google-oauth2',
+                        'name': 'Google',
+                        'iconClass': 'fa-google-plus',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://google.com/login',
+                        'registerUrl': 'https://google.com/register'
+                    }
+                ],
+                'secondaryProviders': [],
+                'finishAuthUrl': 'https://edx.com/auth/finish',
+                'errorMessage': None,
+                'registerFormSubmitButtonText': 'Create Account',
+                'autoSubmitRegForm': False,
+                'syncLearnerProfileData': False,
+                'countryCode': '',
+                'pipeline_user_details': {
+                    'username': 'test123',
+                    'email': 'test123@edx.com',
+                    'fullname': 'Test Test',
+                    'first_name': 'Test',
+                    'last_name': 'Test'
+                }
+            },
+            'registration_fields': {},
+            'optional_fields': {
+                'extended_profile': []
+            }
+        }
+
+        return mock_context_data
+
+    @staticmethod
+    def get_expected_data():
+        """
+        Helper function to generate expected data for the MFE Context API view serializer.
+        """
+
+        expected_data = {
+            'contextData': {
+                'currentProvider': 'edX',
+                'platformName': 'edX',
+                'providers': [
+                    {
+                        'id': 'oa2-facebook',
+                        'name': 'Facebook',
+                        'iconClass': 'fa-facebook',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://facebook.com/login',
+                        'registerUrl': 'https://facebook.com/register'
+                    },
+                    {
+                        'id': 'oa2-google-oauth2',
+                        'name': 'Google',
+                        'iconClass': 'fa-google-plus',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://google.com/login',
+                        'registerUrl': 'https://google.com/register'
+                    }
+                ],
+                'secondaryProviders': [],
+                'finishAuthUrl': 'https://edx.com/auth/finish',
+                'errorMessage': None,
+                'registerFormSubmitButtonText': 'Create Account',
+                'autoSubmitRegForm': False,
+                'syncLearnerProfileData': False,
+                'countryCode': '',
+                'pipelineUserDetails': {
+                    'username': 'test123',
+                    'email': 'test123@edx.com',
+                    'name': 'Test Test',
+                    'firstName': 'Test',
+                    'lastName': 'Test'
+                }
+            },
+            'registrationFields': {},
+            'optionalFields': {
+                'extended_profile': []
+            }
+        }
+
+        return expected_data
+
+    def test_mfe_context_serializer(self):
+        """
+        Test MFEContextSerializer with mock data that serializes data correctly
+        """
+
+        mfe_context_data = self.get_mock_mfe_context_data()
+        expected_data = self.get_expected_data()
+        output_data = MFEContextSerializer(
+            mfe_context_data
+        ).data
+
+        self.assertDictEqual(
+            output_data,
+            expected_data
+        )

--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -16,9 +16,10 @@ from common.djangoapps.student.models import Registration
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth import pipeline
 from common.djangoapps.third_party_auth.tests.testutil import ThirdPartyAuthTestMixin, simulate_running_pipeline
-from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
+from openedx.core.djangoapps.user_authn.api.tests.test_data import mfe_context_data_keys
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
@@ -343,6 +344,32 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
         response = self.client.get(self.url, self.query_params)
         assert response.data == self.get_context()
+
+    def test_mfe_context_api_serialized_response(self):
+        """
+        Test MFE Context API serialized response
+        """
+        response = self.client.get(self.url, self.query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        params = {
+            'next': self.query_params['next']
+        }
+
+        self.assertEqual(
+            response.data,
+            self.get_context(params)
+        )
+
+    def test_mfe_context_api_response_keys(self):
+        """
+        Test MFE Context API response keys
+        """
+        response = self.client.get(self.url, self.query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_keys = set(response.data.keys())
+        self.assertSetEqual(response_keys, mfe_context_data_keys)
 
 
 @skip_unless_lms

--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -43,8 +43,7 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         hostname = socket.gethostname()
         ip_address = socket.gethostbyname(hostname)
         self.country_code = country_code_from_ip(ip_address)
-        self.pipeline_user_details = {'username': None, 'email': None, 'name': None,
-                                      'firstName': None, 'lastName': None}
+        self.pipeline_user_details = {}
 
         # Several third party auth providers are created for these tests:
         self.configure_google_provider(enabled=True, visible=True)
@@ -98,7 +97,15 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
 
         if add_user_details:
-            self.pipeline_user_details.update({'email': 'test@test.com'})
+            self.pipeline_user_details.update(
+                {
+                    'username': None,
+                    'email': 'test@test.com',
+                    'name': None,
+                    'firstName': None,
+                    'lastName': None
+                }
+            )
 
         return {
             'contextData': {

--- a/openedx/core/djangoapps/user_authn/api/views.py
+++ b/openedx/core/djangoapps/user_authn/api/views.py
@@ -15,6 +15,7 @@ from common.djangoapps.student.helpers import get_next_url_for_login_page
 from common.djangoapps.student.views import compose_and_send_activation_email
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.api.helper import RegistrationFieldsContext
+from openedx.core.djangoapps.user_authn.serializers import MFEContextSerializer
 from openedx.core.djangoapps.user_authn.views.utils import get_mfe_context
 
 
@@ -65,6 +66,7 @@ class MFEContextView(APIView):
             context['registration_fields'].update({
                 'fields': registration_fields,
             })
+
             optional_fields = RegistrationFieldsContext('optional').get_fields()
             if optional_fields:
                 context['optional_fields'].update({
@@ -74,7 +76,9 @@ class MFEContextView(APIView):
 
         return Response(
             status=status.HTTP_200_OK,
-            data=context
+            data=MFEContextSerializer(
+                context
+            ).data
         )
 
 

--- a/openedx/core/djangoapps/user_authn/serializers.py
+++ b/openedx/core/djangoapps/user_authn/serializers.py
@@ -53,7 +53,12 @@ class ContextDataSerializer(serializers.Serializer):
     autoSubmitRegForm = serializers.BooleanField(default=False)
     syncLearnerProfileData = serializers.BooleanField(default=False)
     countryCode = serializers.CharField(allow_null=True)
-    pipelineUserDetails = PipelineUserDetailsSerializer(source='pipeline_user_details', allow_null=True)
+    pipelineUserDetails = serializers.SerializerMethodField()
+
+    def get_pipelineUserDetails(self, obj):
+        if obj.get('pipeline_user_details'):
+            return PipelineUserDetailsSerializer(obj.get('pipeline_user_details')).data
+        return {}
 
 
 class MFEContextSerializer(serializers.Serializer):

--- a/openedx/core/djangoapps/user_authn/serializers.py
+++ b/openedx/core/djangoapps/user_authn/serializers.py
@@ -1,0 +1,77 @@
+"""
+MFE Context API Serializers
+"""
+
+from rest_framework import serializers
+
+
+class ProvidersSerializer(serializers.Serializer):
+    """
+    Providers Serializers
+    """
+
+    id = serializers.CharField(allow_null=True)
+    name = serializers.CharField(allow_null=True)
+    iconClass = serializers.CharField(allow_null=True)
+    iconImage = serializers.CharField(allow_null=True)
+    skipHintedLogin = serializers.BooleanField(default=False)
+    skipRegistrationForm = serializers.BooleanField(default=False)
+    loginUrl = serializers.CharField(allow_null=True)
+    registerUrl = serializers.CharField(allow_null=True)
+
+
+class PipelineUserDetailsSerializer(serializers.Serializer):
+    """
+    Pipeline User Details Serializers
+    """
+
+    username = serializers.CharField(allow_null=True)
+    email = serializers.CharField(allow_null=True)
+    name = serializers.CharField(source='fullname', allow_null=True)
+    firstName = serializers.CharField(source='first_name', allow_null=True)
+    lastName = serializers.CharField(source='last_name', allow_null=True)
+
+
+class ContextDataSerializer(serializers.Serializer):
+    """
+    Context Data Serializers
+    """
+
+    currentProvider = serializers.CharField(allow_null=True)
+    platformName = serializers.CharField(allow_null=True)
+    providers = serializers.ListField(
+        child=ProvidersSerializer(),
+        allow_null=True
+    )
+    secondaryProviders = serializers.ListField(
+        child=ProvidersSerializer(),
+        allow_null=True
+    )
+    finishAuthUrl = serializers.CharField(allow_null=True)
+    errorMessage = serializers.CharField(allow_null=True)
+    registerFormSubmitButtonText = serializers.CharField(allow_null=True)
+    autoSubmitRegForm = serializers.BooleanField(default=False)
+    syncLearnerProfileData = serializers.BooleanField(default=False)
+    countryCode = serializers.CharField(allow_null=True)
+    pipelineUserDetails = PipelineUserDetailsSerializer(source='pipeline_user_details', allow_null=True)
+
+
+class MFEContextSerializer(serializers.Serializer):
+    """
+    Serializer class to convert the keys of MFE Context Response dict object to camelCase format.
+    """
+
+    contextData = ContextDataSerializer(
+        source='context_data',
+        default={}
+    )
+    registrationFields = serializers.DictField(
+        source='registration_fields',
+        default={}
+    )
+    optionalFields = serializers.DictField(
+        source='optional_fields',
+        default={
+            'extended_profile': []
+        }
+    )


### PR DESCRIPTION
We released some changes related to SSO pipeline user details for` frontend-app-authn` for `palm.master` but were not released for `edx-platform`. Now we are backporting these changes for `edx-platform`too. 