### PR TITLE
feat: add hook to modify courserun data for executive education courses

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import serializers
-from openedx_filters.learning.filters import CourseEnrollmentAPIRenderStarted
+from openedx_filters.learning.filters import CourseEnrollmentAPIRenderStarted, CourseRunAPIRenderStarted
 
 from common.djangoapps.course_modes.models import CourseMode
 from openedx.features.course_experience import course_home_url
@@ -135,6 +135,14 @@ class CourseRunSerializer(serializers.Serializer):
 
     def get_resumeUrl(self, instance):
         return self.context.get("resume_course_urls", {}).get(instance.course_id)
+
+    def to_representation(self, instance):
+        """Serialize the courserun instance to be able to update the values before the API finishes rendering."""
+        serialized_courserun = super().to_representation(instance)
+        serialized_courserun = CourseRunAPIRenderStarted().run_filter(
+            serialized_courserun=serialized_courserun,
+        )
+        return serialized_courserun
 
 
 class CoursewareAccessSerializer(serializers.Serializer):


### PR DESCRIPTION
## Description
JIRA -> [ENT-7542](https://2u-internal.atlassian.net/browse/ENT-7542)


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
