### PR TITLE
chore: Adding test to verify s3boto3 storages with invalid params.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -4,7 +4,7 @@ Unit tests for video utils.
 
 
 from datetime import datetime
-from unittest import TestCase, mock
+from unittest import TestCase
 from unittest.mock import patch
 
 import ddt

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -382,7 +382,7 @@ class S3Boto3TestCase(TestCase):
     @override_settings(VIDEO_IMAGE_SETTINGS={
         'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
         'STORAGE_KWARGS':
-            {'bucket_name': 'awaisqureshi', 'default_acl': None, 'base_url': '/', 'location': 'abc/def'}}
+            {'bucket_name': 'test', 'default_acl': None, 'base_url': '/', 'location': 'abc/def'}}
     )
     def test_boto3_backend_with_params(self):
         storage = get_storage_class(

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -381,7 +381,7 @@ class S3Boto3TestCase(TestCase):
 
     def test_no_video_thumbnail_downloaded(self):
         self.assertEqual(
-            'S3Boto3Storage',
+            S3Boto3Storage,
             get_storage_class(
                 'storages.backends.s3boto3.S3Boto3Storage',
             )(**settings.VIDEO_IMAGE_SETTINGS.get('STORAGE_KWARGS', {})).__class__

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -371,13 +371,22 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
 
 class S3Boto3TestCase(TestCase):
     """ verify s3boto3 returns valid backend."""
-    def setUp(self):
-        self.storage = S3Boto3Storage()
-
-    def test_valid_backend_returns(self):
+    def test_video_backend(self):
         self.assertEqual(
             S3Boto3Storage,
             get_storage_class(
                 'storages.backends.s3boto3.S3Boto3Storage',
             )(**settings.VIDEO_IMAGE_SETTINGS.get('STORAGE_KWARGS', {})).__class__
         )
+
+    @override_settings(VIDEO_IMAGE_SETTINGS={
+        'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
+        'STORAGE_KWARGS':
+            {'bucket_name': 'awaisqureshi', 'default_acl': None, 'base_url': '/', 'location': 'abc/def'}}
+    )
+    def test_boto3_backend_with_params(self):
+        storage = get_storage_class(
+            settings.VIDEO_IMAGE_SETTINGS.get('STORAGE_CLASS', {})
+        )(**settings.VIDEO_IMAGE_SETTINGS.get('STORAGE_KWARGS', {}))
+
+        self.assertEqual(S3Boto3Storage, storage.__class__)

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -375,6 +375,7 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class S3Boto3TestCase(TestCase):
+    """ verify s3boto3 returns valid backend."""
     def setUp(self):
         self.storage = S3Boto3Storage()
         self.storage._connections.connection = mock.MagicMock()

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -373,9 +373,8 @@ class S3Boto3TestCase(TestCase):
     """ verify s3boto3 returns valid backend."""
     def setUp(self):
         self.storage = S3Boto3Storage()
-        self.storage._connections.connection = mock.MagicMock()
 
-    def test_no_video_thumbnail_downloaded(self):
+    def test_valid_backend_returns(self):
         self.assertEqual(
             S3Boto3Storage,
             get_storage_class(

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -4,16 +4,18 @@ Unit tests for video utils.
 
 
 from datetime import datetime
-from unittest import TestCase
+from unittest import TestCase, mock
 from unittest.mock import patch
 
 import ddt
 import pytz
 import requests
 from django.conf import settings
+from django.core.files.storage import get_storage_class
 from django.core.files.uploadedfile import UploadedFile
 from django.test.utils import override_settings
 from edxval.api import create_profile, create_video, get_course_video_image_url, update_video_image
+from storages.backends.s3boto3 import S3Boto3Storage
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.video_utils import (
@@ -365,3 +367,22 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
         # Verify that no image is attached to video1.
         video1_image_url = get_course_video_image_url(course_id=course_id, edx_video_id=video1_edx_video_id)
         self.assertIsNone(video1_image_url)
+
+from unittest import mock
+
+from django.core.files.storage import get_storage_class
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class S3Boto3TestCase(TestCase):
+    def setUp(self):
+        self.storage = S3Boto3Storage()
+        self.storage._connections.connection = mock.MagicMock()
+
+    def test_no_video_thumbnail_downloaded(self):
+        self.assertEqual(
+            'S3Boto3Storage',
+            get_storage_class(
+                'storages.backends.s3boto3.S3Boto3Storage',
+            )(**settings.VIDEO_IMAGE_SETTINGS.get('STORAGE_KWARGS', {})).__class__
+        )

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -368,11 +368,6 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
         video1_image_url = get_course_video_image_url(course_id=course_id, edx_video_id=video1_edx_video_id)
         self.assertIsNone(video1_image_url)
 
-from unittest import mock
-
-from django.core.files.storage import get_storage_class
-from storages.backends.s3boto3 import S3Boto3Storage
-
 
 class S3Boto3TestCase(TestCase):
     """ verify s3boto3 returns valid backend."""


### PR DESCRIPTION
https://github.com/jschneier/django-storages/blob/d547bb645cdbf5c414a76526a894d98acd13b43f/storages/base.py#L23

It will help us to validate `1.10.1` because it will verify the all params and if any unknown param appear it will raise error.