### PR TITLE
fix: fix middleware get_response parameter deprecation warning

### DIFF
--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -30,7 +30,7 @@ class TestLoginHelper(TestCase):
     @staticmethod
     def _add_session(request):
         """Annotate the request object with a session"""
-        middleware = SessionMiddleware()
+        middleware = SessionMiddleware(get_response=lambda request: None)
         middleware.process_request(request)
         request.session.save()
 

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -145,7 +145,7 @@ class HelperMixin:
         middleware.ExceptionMiddleware makes sure the user ends up in the right
         place when they cancel authentication via the provider's UX.
         """
-        exception_middleware = middleware.ExceptionMiddleware()
+        exception_middleware = middleware.ExceptionMiddleware(get_response=lambda request: None)
         request, _ = self.get_request_and_strategy(auth_entry=auth_entry)
         response = exception_middleware.process_exception(
             request, exceptions.AuthCanceled(request.backend))
@@ -730,7 +730,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
 
         # Monkey-patch storage for messaging; pylint: disable=protected-access
         post_request._messages = fallback.FallbackStorage(post_request)
-        middleware.ExceptionMiddleware().process_exception(
+        middleware.ExceptionMiddleware(get_response=lambda request: None).process_exception(
             post_request,
             exceptions.AuthAlreadyAssociated(self.provider.backend_name, 'account is already in use.'))
 

--- a/common/djangoapps/third_party_auth/tests/test_middleware.py
+++ b/common/djangoapps/third_party_auth/tests/test_middleware.py
@@ -34,8 +34,8 @@ class ThirdPartyAuthMiddlewareTestCase(TestCase):
         exception.response = HttpResponse(status=502)
 
         # Add error message for error in auth pipeline
-        MessageMiddleware().process_request(request)
-        response = ExceptionMiddleware().process_exception(
+        MessageMiddleware(get_response=lambda request: None).process_request(request)
+        response = ExceptionMiddleware(get_response=lambda request: None).process_exception(
             request, exception
         )
         target_url = response.url

--- a/common/djangoapps/track/tests/test_middleware.py
+++ b/common/djangoapps/track/tests/test_middleware.py
@@ -19,7 +19,7 @@ class TrackMiddlewareTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.track_middleware = TrackMiddleware()
+        self.track_middleware = TrackMiddleware(get_response=lambda request: None)
         self.request_factory = RequestFactory()
 
         patcher = patch('common.djangoapps.track.views.server_track')
@@ -156,7 +156,7 @@ class TrackMiddlewareTestCase(TestCase):
 
     def test_request_with_session(self):
         request = self.request_factory.get('/courses/')
-        SessionMiddleware().process_request(request)
+        SessionMiddleware(get_response=lambda request: None).process_request(request)
         request.session.save()
         session_key = request.session.session_key
         expected_session_key = self.track_middleware.substitute_session_key(session_key)

--- a/common/djangoapps/track/views/tests/test_segmentio.py
+++ b/common/djangoapps/track/views/tests/test_segmentio.py
@@ -118,7 +118,7 @@ class SegmentIOTrackingTestCase(SegmentIOTrackingTestCaseBase):
 
     @data('foo/bar/baz', 'course-v1:foo+bar+baz')
     def test_success(self, course_id):
-        middleware = TrackMiddleware()
+        middleware = TrackMiddleware(get_response=lambda request: None)
 
         request = self.create_request(
             data=self.create_segmentio_event_json(data={'foo': 'bar'}, course_id=course_id),
@@ -278,7 +278,7 @@ class SegmentIOTrackingTestCase(SegmentIOTrackingTestCaseBase):
     @unpack
     def test_video_event(self, name, event_type):
         course_id = 'foo/bar/baz'
-        middleware = TrackMiddleware()
+        middleware = TrackMiddleware(get_response=lambda request: None)
 
         input_payload = {
             'current_time': 132.134456,
@@ -414,7 +414,7 @@ class SegmentIOTrackingTestCase(SegmentIOTrackingTestCaseBase):
         was sent instead of edx.video.position.changed
         """
         course_id = 'foo/bar/baz'
-        middleware = TrackMiddleware()
+        middleware = TrackMiddleware(get_response=lambda request: None)
         input_payload = {
             "code": "mobile",
             "new_time": 89.699177437,

--- a/common/djangoapps/track/views/tests/test_views.py
+++ b/common/djangoapps/track/views/tests/test_views.py
@@ -173,7 +173,7 @@ class TestTrackViews(EventTrackingTestCase):  # lint-amnesty, pylint: disable=mi
     def test_user_track_with_middleware_and_processors(self):
         self.recreate_tracker()
 
-        middleware = TrackMiddleware()
+        middleware = TrackMiddleware(get_response=lambda request: None)
         payload = '{"foo": "bar"}'
         user_id = 1
         request = self.request_factory.get('/event', {
@@ -238,7 +238,7 @@ class TestTrackViews(EventTrackingTestCase):  # lint-amnesty, pylint: disable=mi
         assert_event_matches(expected_event, actual_event)
 
     def test_server_track_with_middleware(self):
-        middleware = TrackMiddleware()
+        middleware = TrackMiddleware(get_response=lambda request: None)
         request = self.request_factory.get(self.path_with_course)
         middleware.process_request(request)
         # The middleware emits an event, reset the mock to ignore it since we aren't testing that feature.
@@ -279,7 +279,7 @@ class TestTrackViews(EventTrackingTestCase):  # lint-amnesty, pylint: disable=mi
         )
 
     def test_server_track_with_middleware_and_google_analytics_cookie(self):
-        middleware = TrackMiddleware()
+        middleware = TrackMiddleware(get_response=lambda request: None)
         request = self.request_factory.get(self.path_with_course)
         request.COOKIES['_ga'] = 'GA1.2.1033501218.1368477899'
         middleware.process_request(request)

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -754,7 +754,7 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
     """
     # In this case, we are using Session based authentication, so we need to check CSRF token.
     if request.user.is_authenticated:
-        error = CsrfViewMiddleware().process_view(request, None, (), {})
+        error = CsrfViewMiddleware(get_response=lambda request: None).process_view(request, None, (), {})
         if error:
             return error
 

--- a/lms/djangoapps/courseware/tests/test_middleware.py
+++ b/lms/djangoapps/courseware/tests/test_middleware.py
@@ -36,7 +36,7 @@ class CoursewareMiddlewareTestCase(SharedModuleStoreTestCase):
     def test_process_404(self):
         """A 404 should not trigger anything"""
         request = RequestFactory().get("dummy_url")
-        response = RedirectMiddleware().process_exception(
+        response = RedirectMiddleware(get_response=lambda request: None).process_exception(
             request, Http404()
         )
         assert response is None
@@ -48,7 +48,7 @@ class CoursewareMiddlewareTestCase(SharedModuleStoreTestCase):
         request = RequestFactory().get("dummy_url")
         test_url = '/test_url'
         exception = Redirect(test_url)
-        response = RedirectMiddleware().process_exception(
+        response = RedirectMiddleware(get_response=lambda request: None).process_exception(
             request, exception
         )
         assert response.status_code == 302

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1952,7 +1952,7 @@ class UsersEndpointTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockRe
 class SegmentIOForumThreadViewedEventTestCase(SegmentIOTrackingTestCaseBase):
 
     def _raise_navigation_event(self, label, include_name):
-        middleware = TrackMiddleware()
+        middleware = TrackMiddleware(get_response=lambda request: None)
         kwargs = {'label': label}
         if include_name:
             kwargs['name'] = 'edx.bi.app.navigation.screen'

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_middleware.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_middleware.py
@@ -12,7 +12,7 @@ class AjaxExceptionTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-
 
     def setUp(self):
         super().setUp()
-        self.a = middleware.AjaxExceptionMiddleware()
+        self.a = middleware.AjaxExceptionMiddleware(get_response=lambda request: None)
         self.request1 = django.http.HttpRequest()
         self.request0 = django.http.HttpRequest()
         self.exception1 = comment_client.CommentClientRequestError('{}', 401)

--- a/lms/djangoapps/mobile_api/tests/test_middleware.py
+++ b/lms/djangoapps/mobile_api/tests/test_middleware.py
@@ -26,7 +26,7 @@ class TestAppVersionUpgradeMiddleware(CacheIsolationTestCase):
 
     def setUp(self):
         super().setUp()
-        self.middleware = AppVersionUpgrade()
+        self.middleware = AppVersionUpgrade(get_response=lambda request: None)
         self.set_app_version_config()
 
     def set_app_version_config(self):

--- a/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
@@ -28,7 +28,7 @@ class AccessTokenExchangeFormTest(AccessTokenExchangeTestMixin):
         super().setUp()
         self.request = RequestFactory().post("dummy_url")
         redirect_uri = 'dummy_redirect_url'
-        SessionMiddleware().process_request(self.request)
+        SessionMiddleware(get_response=lambda request: None).process_request(self.request)
         self.request.social_strategy = social_utils.load_strategy(self.request)
         # pylint: disable=no-member
         self.request.backend = social_utils.load_backend(self.request.social_strategy, self.BACKEND, redirect_uri)

--- a/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
@@ -67,7 +67,7 @@ class CachedAuthMiddlewareTestCase(TestCase):
         self.request.COOKIES[settings.SESSION_COOKIE_NAME] = str(safe_cookie_data)
         self.client.response.cookies[settings.SESSION_COOKIE_NAME] = session_id
         self.client.response.cookies['edx-jwt-cookie-header-payload'] = 'test-jwt-payload'
-        SafeSessionMiddleware().process_request(self.request)
+        SafeSessionMiddleware(get_response=lambda request: None).process_request(self.request)
 
         # asserts that user, session, and JWT cookies exist
         assert self.request.session.get(SESSION_KEY) is not None
@@ -76,8 +76,10 @@ class CachedAuthMiddlewareTestCase(TestCase):
         assert self.client.response.cookies.get('edx-jwt-cookie-header-payload').value == 'test-jwt-payload'
 
         with patch.object(User, 'get_session_auth_hash', return_value='abc123'):
-            CacheBackedAuthenticationMiddleware().process_request(self.request)
-            SafeSessionMiddleware().process_response(self.request, self.client.response)
+            CacheBackedAuthenticationMiddleware(get_response=lambda request: None).process_request(self.request)
+            SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                self.request, self.client.response
+            )
 
         # asserts that user, session, and JWT cookies do not exist
         assert self.request.session.get(SESSION_KEY) is None

--- a/openedx/core/djangoapps/cors_csrf/authentication.py
+++ b/openedx/core/djangoapps/cors_csrf/authentication.py
@@ -26,7 +26,7 @@ class SessionAuthenticationCrossDomainCsrf(authentication.SessionAuthentication)
     it can be mixed in with other `SessionAuthentication` subclasses.
     """
     def _process_enforce_csrf(self, request):
-        CsrfViewMiddleware().process_request(request)
+        CsrfViewMiddleware(get_response=lambda request: None).process_request(request)
         return super().enforce_csrf(request)
 
     def enforce_csrf(self, request):

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -35,7 +35,7 @@ class TestCorsMiddlewareProcessRequest(TestCase):
     @override_settings(FEATURES={'ENABLE_CORS_HEADERS': True})
     def setUp(self):
         super().setUp()
-        self.middleware = CorsCSRFMiddleware()
+        self.middleware = CorsCSRFMiddleware(get_response=lambda request: None)
 
     def check_not_enabled(self, request):
         """
@@ -83,7 +83,7 @@ class TestCorsMiddlewareProcessRequest(TestCase):
     )
     def test_disabled_no_cors_headers(self):
         with pytest.raises(MiddlewareNotUsed):
-            CorsCSRFMiddleware()
+            CorsCSRFMiddleware(get_response=lambda request: None)
 
     @override_settings(CORS_ORIGIN_WHITELIST=['https://bar.com'])
     def test_disabled_wrong_cors_domain(self):
@@ -122,12 +122,12 @@ class TestCsrfCrossDomainCookieMiddleware(TestCase):
     )
     def setUp(self):
         super().setUp()
-        self.middleware = CsrfCrossDomainCookieMiddleware()
+        self.middleware = CsrfCrossDomainCookieMiddleware(get_response=lambda request: None)
 
     @override_settings(FEATURES={'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': False})
     def test_disabled_by_feature_flag(self):
         with pytest.raises(MiddlewareNotUsed):
-            CsrfCrossDomainCookieMiddleware()
+            CsrfCrossDomainCookieMiddleware(get_response=lambda request: None)
 
     @ddt.data('CROSS_DOMAIN_CSRF_COOKIE_NAME', 'CROSS_DOMAIN_CSRF_COOKIE_DOMAIN')
     def test_improperly_configured(self, missing_setting):
@@ -140,7 +140,7 @@ class TestCsrfCrossDomainCookieMiddleware(TestCase):
 
         with override_settings(**settings):
             with pytest.raises(ImproperlyConfigured):
-                CsrfCrossDomainCookieMiddleware()
+                CsrfCrossDomainCookieMiddleware(get_response=lambda request: None)
 
     @override_settings(
         CROSS_DOMAIN_CSRF_COOKIE_NAME=COOKIE_NAME,

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -72,7 +72,7 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         )
 
         # Process it through the Middleware to ensure the language is available as expected.
-        assert DarkLangMiddleware().process_request(request) is None
+        assert DarkLangMiddleware(get_response=lambda request: None).process_request(request) is None
         return request
 
     def assertAcceptEquals(self, value, request):

--- a/openedx/core/djangoapps/geoinfo/tests/test_middleware.py
+++ b/openedx/core/djangoapps/geoinfo/tests/test_middleware.py
@@ -21,8 +21,8 @@ class CountryMiddlewareTests(TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.country_middleware = CountryMiddleware()
-        self.session_middleware = SessionMiddleware()
+        self.country_middleware = CountryMiddleware(get_response=lambda request: None)
+        self.session_middleware = SessionMiddleware(get_response=lambda request: None)
         self.authenticated_user = UserFactory.create()
         self.anonymous_user = AnonymousUserFactory.create()
         self.request_factory = RequestFactory()

--- a/openedx/core/djangoapps/header_control/tests/test_middleware.py
+++ b/openedx/core/djangoapps/header_control/tests/test_middleware.py
@@ -12,7 +12,7 @@ class TestHeaderControlMiddlewareProcessResponse(TestCase):
     """Test the `header_control` middleware. """
     def setUp(self):
         super().setUp()
-        self.middleware = HeaderControlMiddleware()
+        self.middleware = HeaderControlMiddleware(get_response=lambda request: None)
 
     def test_doesnt_barf_if_not_modifying_anything(self):
         fake_request = HttpRequest()

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -37,8 +37,8 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
 
     def setUp(self):
         super().setUp()
-        self.middleware = LanguagePreferenceMiddleware()
-        self.session_middleware = SessionMiddleware()
+        self.middleware = LanguagePreferenceMiddleware(get_response=lambda request: None)
+        self.session_middleware = SessionMiddleware(get_response=lambda request: None)
         self.user = UserFactory.create()
         self.anonymous_user = AnonymousUserFactory()
         self.request = RequestFactory().get('/somewhere')

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -50,7 +50,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
         """
         if safe_cookie_data:
             self.request.COOKIES[settings.SESSION_COOKIE_NAME] = str(safe_cookie_data)
-        response = SafeSessionMiddleware().process_request(self.request)
+        response = SafeSessionMiddleware(get_response=lambda request: None).process_request(self.request)
         if success:
             assert response is None
             assert getattr(self.request, 'need_to_delete_cookie', None) is None
@@ -174,7 +174,9 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
         if set_session_cookie:
             self.client.response.cookies[settings.SESSION_COOKIE_NAME] = "some_session_id"
 
-        response = SafeSessionMiddleware().process_response(self.request, self.client.response)
+        response = SafeSessionMiddleware(get_response=lambda request: None).process_response(
+            self.request, self.client.response
+        )
         assert response.status_code == 200
 
     def assert_response_with_delete_cookie(
@@ -275,7 +277,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         self.request.COOKIES[settings.SESSION_COOKIE_NAME] = str(safe_cookie_data)
 
         with self.assert_not_logged():
-            response = SafeSessionMiddleware().process_request(self.request)
+            response = SafeSessionMiddleware(get_response=lambda request: None).process_request(self.request)
             # Note: setting the user here is later than it really happens, but it enables a
             #   semi-accurate user change tracking. The only issue is that it changes from
             #   None to user, rather than being logged as the first time request.user is set,
@@ -293,7 +295,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         self.set_up_for_success()
 
         with self.assert_not_logged():
-            response = SafeSessionMiddleware().process_response(self.request, self.client.response)
+            response = SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                self.request, self.client.response
+            )
         assert response.status_code == 200
 
     def test_success(self):
@@ -316,14 +320,18 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         self.request.session = self.client.session
 
         with self.assert_parse_error():
-            request_response = SafeSessionMiddleware().process_request(self.request)
+            request_response = SafeSessionMiddleware(get_response=lambda request: None).process_request(
+                self.request
+            )
             assert request_response.status_code == expected_response_status
 
         assert self.request.need_to_delete_cookie
         self.cookies_from_request_to_response()
 
         with patch('django.http.HttpResponse.delete_cookie') as mock_delete_cookie:
-            SafeSessionMiddleware().process_response(self.request, self.client.response)
+            SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                self.request, self.client.response
+            )
             assert {'sessionid', 'edx-jwt-cookie-header-payload'} \
                 <= {call.args[0] for call in mock_delete_cookie.call_args_list}
 
@@ -355,7 +363,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
 
         with self.assert_logged_for_request_user_mismatch(self.user.id, self.request.user.id, 'warning', '/', False):
             with patch('openedx.core.djangoapps.safe_sessions.middleware.set_custom_attribute') as mock_attr:
-                response = SafeSessionMiddleware().process_response(self.request, self.client.response)
+                response = SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                    self.request, self.client.response
+                )
         assert response.status_code == 200
         set_attr_call_args = [call.args for call in mock_attr.call_args_list]
         assert ("safe_sessions.user_mismatch", "request-response-mismatch") in set_attr_call_args
@@ -374,7 +384,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
 
         with self.assert_logged_for_request_user_mismatch(self.user.id, self.request.user.id, 'warning', '/', False):
             with patch('openedx.core.djangoapps.safe_sessions.middleware.set_custom_attribute') as mock_attr:
-                response = SafeSessionMiddleware().process_response(self.request, self.client.response)
+                response = SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                    self.request, self.client.response
+                )
         assert response.status_code == 401
         assert SafeSessionMiddleware.get_user_id_from_session(self.request) is None  # session cleared
         set_attr_call_args = [call.args for call in mock_attr.call_args_list]
@@ -392,7 +404,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         with self.assert_logged_for_session_user_mismatch(self.user.id, different_user.id, self.request.path,
                                                           False):
             with patch('openedx.core.djangoapps.safe_sessions.middleware.set_custom_attribute') as mock_attr:
-                response = SafeSessionMiddleware().process_response(self.request, self.client.response)
+                response = SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                    self.request, self.client.response
+                )
         assert response.status_code == 200
         set_attr_call_args = [call.args for call in mock_attr.call_args_list]
         assert ("safe_sessions.user_mismatch", "request-session-mismatch") in set_attr_call_args
@@ -410,7 +424,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         with self.assert_logged_for_both_mismatch(self.user.id, different_user.id,
                                                   self.request.user.id, self.request.path, False):
             with patch('openedx.core.djangoapps.safe_sessions.middleware.set_custom_attribute') as mock_attr:
-                response = SafeSessionMiddleware().process_response(self.request, self.client.response)
+                response = SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                    self.request, self.client.response
+                )
         assert response.status_code == 200
         set_attr_call_args = [call.args for call in mock_attr.call_args_list]
         assert ("safe_sessions.user_mismatch", "request-response-and-session-mismatch") in set_attr_call_args
@@ -421,7 +437,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         self.set_up_for_success()
         self.request.user = UserFactory.create()
         with self.assert_logged('SafeCookieData: Changing request user. ', log_level='warning'):
-            SafeSessionMiddleware().process_response(self.request, self.client.response)
+            SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                self.request, self.client.response
+            )
         mock_set_custom_attribute.assert_has_calls([call('safe_sessions.user_id_list', '1,2')])
 
     @patch("openedx.core.djangoapps.safe_sessions.middleware.LOG_REQUEST_USER_CHANGES", False)
@@ -429,7 +447,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         self.set_up_for_success()
         self.request.user = UserFactory.create()
         with self.assert_regex_not_logged('SafeCookieData: Changing request user. ', log_level='warning'):
-            SafeSessionMiddleware().process_response(self.request, self.client.response)
+            SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                self.request, self.client.response
+            )
 
     @override_settings(LOG_REQUEST_USER_CHANGE_HEADERS=True)
     @patch("openedx.core.djangoapps.safe_sessions.middleware.LOG_REQUEST_USER_CHANGES", True)
@@ -438,7 +458,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         self.set_up_for_success()
         self.request.user = UserFactory.create()
         with self.assert_logged('SafeCookieData: Changing request user. ', log_level='warning'):
-            SafeSessionMiddleware().process_response(self.request, self.client.response)
+            SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                self.request, self.client.response
+            )
         # Note: Since the test cache is not retaining its values for some reason, we'll
         #   simply assert that the cache is set (here) and checked (below).
         mock_cache.set_many.assert_called_with(
@@ -450,7 +472,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
 
         # send successful request; request header should be logged for earlier mismatched user id
         self.set_up_for_success()
-        SafeSessionMiddleware().process_response(self.request, self.client.response)
+        SafeSessionMiddleware(get_response=lambda request: None).process_response(self.request, self.client.response)
         # Note: The test cache is not returning True because it is not retaining its values
         #   for some reason. Rather than asserting that we log the header appropriately, we'll
         #   simply verify that we are checking the cache.
@@ -472,7 +494,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         self.request.session = MagicMock()
         del self.request.user
         with self.assert_not_logged():
-            SafeSessionMiddleware().process_response(self.request, self.client.response)
+            SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                self.request, self.client.response
+            )
 
     def test_no_warn_on_expected_user_change(self):
         """
@@ -489,7 +513,9 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
 
         with self.assert_no_warning_logged():
             with patch('openedx.core.djangoapps.safe_sessions.middleware.set_custom_attribute') as mock_attr:
-                response = SafeSessionMiddleware().process_response(self.request, self.client.response)
+                response = SafeSessionMiddleware(get_response=lambda request: None).process_response(
+                    self.request, self.client.response
+                )
         assert response.status_code == 200
         assert 'safe_sessions.user_mismatch' not in [call.args[0] for call in mock_attr.call_args_list]
 

--- a/openedx/core/djangoapps/theming/tests/test_middleware.py
+++ b/openedx/core/djangoapps/theming/tests/test_middleware.py
@@ -26,7 +26,7 @@ class TestCurrentSiteThemeMiddleware(TestCase):
         """
         super().setUp()
 
-        self.site_theme_middleware = CurrentSiteThemeMiddleware()
+        self.site_theme_middleware = CurrentSiteThemeMiddleware(get_response=lambda request: None)
         self.user = UserFactory.create()
 
     def create_mock_get_request(self, qs_theme=None):
@@ -49,7 +49,7 @@ class TestCurrentSiteThemeMiddleware(TestCase):
         request.user = self.user
         request.site, __ = Site.objects.get_or_create(domain='test', name='test')
         request.session = {}
-        MessageMiddleware().process_request(request)
+        MessageMiddleware(get_response=lambda request: None).process_request(request)
 
     @override_settings(DEFAULT_SITE_THEME=TEST_THEME_NAME)
     def test_default_site_theme(self):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -63,7 +63,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         # Python-social saves auth failure notifcations in Django messages.
         # See pipeline.get_duplicate_provider() for details.
         self.request.COOKIES = {}
-        MessageMiddleware().process_request(self.request)
+        MessageMiddleware(get_response=lambda request: None).process_request(self.request)
         messages.error(self.request, 'Facebook is already in use.', extra_tags='Auth facebook')
 
     @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')

--- a/openedx/core/djangoapps/user_api/tests/test_middleware.py
+++ b/openedx/core/djangoapps/user_api/tests/test_middleware.py
@@ -18,7 +18,7 @@ class TagsMiddlewareTest(TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.middleware = UserTagsEventContextMiddleware()
+        self.middleware = UserTagsEventContextMiddleware(get_response=lambda request: None)
         self.user = UserFactory.create()
         self.other_user = UserFactory.create()
 

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -85,7 +85,7 @@ class CookieTests(TestCase):
         If can_recreate is False, verifies that a JWT cannot be recreated.
         """
         self._copy_cookies_to_request(response, self.request)
-        JwtAuthCookieMiddleware().process_view(self.request, None, None, None)
+        JwtAuthCookieMiddleware(get_response=lambda request: None).process_view(self.request, None, None, None)
         assert (cookies_api.jwt_cookies.jwt_cookie_name() in self.request.COOKIES) == can_recreate
         if can_recreate:
             jwt_string = self.request.COOKIES[cookies_api.jwt_cookies.jwt_cookie_name()]

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -337,7 +337,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
     ):
         params = []
         request = RequestFactory().get(reverse(url_name), params, HTTP_ACCEPT='text/html')
-        SessionMiddleware().process_request(request)
+        SessionMiddleware(get_response=lambda request: None).process_request(request)
         request.user = AnonymousUser()
 
         self.enable_saml()
@@ -353,7 +353,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
                               '["invalid_response"] [SAML Response must contain 1 assertion]'
 
         # Add error message for error in auth pipeline
-        MessageMiddleware().process_request(request)
+        MessageMiddleware(get_response=lambda request: None).process_request(request)
         messages.error(request, dummy_error_message, extra_tags='social-auth')
 
         # Simulate a running pipeline

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -49,7 +49,7 @@ ENABLE_AUTHN_MICROFRONTEND['ENABLE_AUTHN_MICROFRONTEND'] = True
 
 
 def process_request(request):
-    middleware = SessionMiddleware()
+    middleware = SessionMiddleware(get_response=lambda request: None)
     middleware.process_request(request)
     request.session.save()
 

--- a/openedx/core/djangoapps/util/tests/test_legacy_ip.py
+++ b/openedx/core/djangoapps/util/tests/test_legacy_ip.py
@@ -46,5 +46,5 @@ class TestClientIP(TestCase):
         assert legacy_ip.get_legacy_ip(self.request) == expected
 
         # Check that it still works after the XFF middleware has done its dirty work
-        XForwardedForMiddleware().process_request(self.request)
+        XForwardedForMiddleware(get_response=lambda request: None).process_request(self.request)
         assert legacy_ip.get_legacy_ip(self.request) == expected

--- a/openedx/core/djangoapps/util/tests/test_ratelimit.py
+++ b/openedx/core/djangoapps/util/tests/test_ratelimit.py
@@ -33,7 +33,7 @@ class TestRateLimiting(TestCase):
         """
         More realistic test since XFF middleware meddles with REMOTE_ADDR.
         """
-        XForwardedForMiddleware().process_request(self.request)
+        XForwardedForMiddleware(get_response=lambda request: None).process_request(self.request)
         assert ratelimit.real_ip(None, self.request) == '1.2.3.4'
 
     @override_waffle_switch(USE_LEGACY_IP, True)
@@ -45,7 +45,7 @@ class TestRateLimiting(TestCase):
         """
         Again, but with XFF Middleware running first.
         """
-        XForwardedForMiddleware().process_request(self.request)
+        XForwardedForMiddleware(get_response=lambda request: None).process_request(self.request)
         assert ratelimit.real_ip(None, self.request) == '7.8.9.0'
 
     def test_request_post_email(self):

--- a/openedx/core/djangoapps/util/tests/test_user_messages.py
+++ b/openedx/core/djangoapps/util/tests/test_user_messages.py
@@ -29,7 +29,7 @@ class UserMessagesTestCase(TestCase):
         self.request = RequestFactory().request()
         self.request.session = {}
         self.request.user = self.student
-        MessageMiddleware().process_request(self.request)
+        MessageMiddleware(get_response=lambda request: None).process_request(self.request)
 
     @ddt.data(
         ('Rock & Roll', '<div class="message-content">Rock &amp; Roll</div>'),

--- a/openedx/core/lib/celery/task_utils.py
+++ b/openedx/core/lib/celery/task_utils.py
@@ -38,7 +38,7 @@ def emulate_http_request(site=None, user=None, middleware_classes=None):
         CurrentRequestUserMiddleware,
         CurrentSiteThemeMiddleware,
     ]
-    middleware_instances = [klass() for klass in middleware_classes]
+    middleware_instances = [klass(get_response=lambda request: None) for klass in middleware_classes]
     response = HttpResponse()
 
     for middleware in middleware_instances:

--- a/openedx/core/lib/x_forwarded_for/tests/test_middleware.py
+++ b/openedx/core/lib/x_forwarded_for/tests/test_middleware.py
@@ -54,7 +54,7 @@ class TestXForwardedForMiddleware(TestCase):
         request = RequestFactory().get('/somewhere')
         request.META.update(add_meta)
 
-        XForwardedForMiddleware().process_request(request)
+        XForwardedForMiddleware(get_response=lambda request: None).process_request(request)
 
         assert request.META.items() >= expected_meta_include.items()
 
@@ -70,7 +70,7 @@ class TestXForwardedForMiddleware(TestCase):
         if xff is not None:
             request.META['HTTP_X_FORWARDED_FOR'] = xff
 
-        XForwardedForMiddleware().process_request(request)
+        XForwardedForMiddleware(get_response=lambda request: None).process_request(request)
 
         mock_set_custom_attribute.assert_has_calls([
             call('ip_chain.raw', expected_raw),

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -152,7 +152,7 @@ class TestLimitConfiguration(unittest.TestCase):
             # middleware is automatically initialized because it's an element of
             # `settings.MIDDLEWARE`).
             try:
-                ConfigureCodeJailMiddleware()
+                ConfigureCodeJailMiddleware(get_response=lambda request: None)
             except MiddlewareNotUsed:
                 pass
 


### PR DESCRIPTION
### Description
- Fixes issue https://github.com/openedx/edx-platform/issues/33038
- Further details on the error and solution are mentioned on the issue. 