### PR TITLE
feat: add file size length to returned json

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -361,6 +361,7 @@ def _get_assets_in_json_format(assets, course_key):
             thumbnail_asset_key,
             asset_is_locked,
             course_key,
+            asset['length'],
         )
 
         assets_in_json_format.append(asset_in_json)
@@ -435,6 +436,7 @@ def _upload_asset(request, course_key):
             content.thumbnail_location,
             locked,
             course_key,
+            content.length,
         ),
         'msg': _('Upload completed')
     })
@@ -491,12 +493,13 @@ def _get_file_too_large_error_message(filename):
 def _get_file_content_and_path(file_metadata, course_key):
     """returns contents of the uploaded file and path for temporary uploaded file"""
     content_location = StaticContent.compute_location(course_key, file_metadata['filename'])
+    upload_file_size = str(file_metadata['upload_file_size'])
     upload_file = file_metadata['upload_file']
 
     file_can_be_chunked = upload_file.multiple_chunks()
 
     static_content_partial = partial(StaticContent, content_location, file_metadata['filename'],
-                                     file_metadata['mime_type'])
+                                     file_metadata['mime_type'], length=upload_file_size)
 
     if file_can_be_chunked:
         content = static_content_partial(upload_file.chunks())
@@ -599,7 +602,7 @@ def _delete_thumbnail(thumbnail_location, course_key, asset_key):  # lint-amnest
             logging.warning('Could not delete thumbnail: %s', thumbnail_location)
 
 
-def get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key):
+def get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key, file_size):
     '''
     Helper method for formatting the asset information to send to client.
     '''
@@ -617,5 +620,6 @@ def get_asset_json(display_name, content_type, date, location, thumbnail_locatio
         'locked': locked,
         'static_full_url': StaticContent.get_canonicalized_asset_path(course_key, portable_url, '', []),
         # needed for Backbone delete/update.
-        'id': str(location)
+        'id': str(location),
+        'file_size': file_size,
     }

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -352,6 +352,7 @@ def _get_assets_in_json_format(assets, course_key):
     for asset in assets:
         thumbnail_asset_key = _get_thumbnail_asset_key(asset, course_key)
         asset_is_locked = asset.get('locked', False)
+        asset_file_size = asset.get('length', None)
 
         asset_in_json = get_asset_json(
             asset['displayname'],
@@ -361,7 +362,7 @@ def _get_assets_in_json_format(assets, course_key):
             thumbnail_asset_key,
             asset_is_locked,
             course_key,
-            asset['length'],
+            asset_file_size,
         )
 
         assets_in_json_format.append(asset_in_json)
@@ -427,6 +428,7 @@ def _upload_asset(request, course_key):
     # readback the saved content - we need the database timestamp
     readback = contentstore().find(content.location)
     locked = getattr(content, 'locked', False)
+    length = getattr(content, 'length', None)
     return JsonResponse({
         'asset': get_asset_json(
             content.name,
@@ -436,7 +438,7 @@ def _upload_asset(request, course_key):
             content.thumbnail_location,
             locked,
             course_key,
-            content.length,
+            length,
         ),
         'msg': _('Upload completed')
     })
@@ -602,7 +604,7 @@ def _delete_thumbnail(thumbnail_location, course_key, asset_key):  # lint-amnest
             logging.warning('Could not delete thumbnail: %s', thumbnail_location)
 
 
-def get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key, file_size):
+def get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key, file_size=None):
     '''
     Helper method for formatting the asset information to send to client.
     '''


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds an assets's length (aka file size) to the returned assets json. This change impacts Course Authors.

## Supporting information

JIRA Ticket: [TNL-10962](https://2u-internal.atlassian.net/browse/TNL-10962)

The file size of an asset needs to be returned with the asset info json. The file size will be used in the asset info modal.

<img width="756" alt="Screenshot 2023-08-21 at 8 40 33 AM" src="https://github.com/openedx/edx-platform/assets/42981026/a7162797-8a29-4959-926e-85c8c28b8a61">

## Testing instructions

Use [this branch](https://github.com/openedx/frontend-app-course-authoring/pull/573) of frontend-app-course-authoring for testing

1. Navigate to the course authoring assets page
2. Click on the vertical three dots on an assets and select info
3. Check that the asset's file size section is populated

## Deadline

None

## Other information

frontend-app-course-authoring[ PR #573](https://github.com/openedx/frontend-app-course-authoring/pull/573) is dependent on this PR.
