### PR TITLE
feat: make notification type info translatable

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -83,7 +83,8 @@ COURSE_NOTIFICATION_TYPES = {
 COURSE_NOTIFICATION_APPS = {
     'discussion': {
         'enabled': True,
-        'core_info': '',
+        'core_info': _('Notifications for responses and comments on your posts, and the ones you’re '
+                       'following, including endorsements to your responses and on your posts.'),
         'core_web': True,
         'core_email': True,
         'core_push': True,
@@ -206,7 +207,7 @@ class NotificationTypeManager:
         Returns notification types for the given notification app.
         """
         return [
-            notification_type for _, notification_type in self.notification_types.items()
+            notification_type.copy() for _, notification_type in self.notification_types.items()
             if notification_type.get('notification_app', None) == notification_app
         ]
 
@@ -247,7 +248,6 @@ class NotificationTypeManager:
                 'web': notification_type.get('web', False),
                 'email': notification_type.get('email', False),
                 'push': notification_type.get('push', False),
-                'info': notification_type.get('info', ''),
             }
         return non_core_notification_type_preferences
 
@@ -279,7 +279,6 @@ class NotificationAppManager:
             'web': notification_app_attrs.get('core_web', False),
             'email': notification_app_attrs.get('core_email', False),
             'push': notification_app_attrs.get('core_push', False),
-            'info': notification_app_attrs.get('core_info', ''),
         }
 
     def add_core_notification_non_editable(self, notification_app_attrs, non_editable_channels):

--- a/openedx/core/djangoapps/notifications/serializers.py
+++ b/openedx/core/djangoapps/notifications/serializers.py
@@ -11,6 +11,7 @@ from openedx.core.djangoapps.notifications.models import (
     Notification,
     get_notification_channels
 )
+from .base_notification import COURSE_NOTIFICATION_APPS, COURSE_NOTIFICATION_TYPES
 
 
 class CourseOverviewSerializer(serializers.ModelSerializer):
@@ -45,6 +46,22 @@ class UserCourseNotificationPreferenceSerializer(serializers.ModelSerializer):
         fields = ('id', 'course_name', 'course_id', 'notification_preference_config',)
         read_only_fields = ('id', 'course_name', 'course_id',)
         write_only_fields = ('notification_preference_config',)
+
+    def to_representation(self, instance):
+        """
+        Override to_representation to add info of all notification types
+        """
+        value = super().to_representation(instance)
+        config = value['notification_preference_config']
+        for notification_app, app_prefs in config.items():
+            notification_types = app_prefs.get('notification_types', {})
+            for notification_type, type_prefs in notification_types.items():
+                if notification_type == "core":
+                    type_info = COURSE_NOTIFICATION_APPS.get(notification_app, {}).get('core_info', '')
+                else:
+                    type_info = COURSE_NOTIFICATION_TYPES.get(notification_type, {}).get('info', '')
+                type_prefs['info'] = type_info
+        return value
 
     def get_course_name(self, obj):
         """

--- a/openedx/core/djangoapps/notifications/tests/test_base_notification.py
+++ b/openedx/core/djangoapps/notifications/tests/test_base_notification.py
@@ -220,19 +220,6 @@ class NotificationPreferenceSyncManagerTest(ModuleStoreTestCase):
         preference_non_editable = preferences[self.default_app_name]['non_editable'].get('core', [])
         assert preference_non_editable == []
 
-    def test_notification_type_info_updates(self):
-        """
-        Preference info updates when default info is update
-        """
-        current_config_version = get_course_notification_preference_config_version()
-        new_info = "NEW INFO"
-        base_notification.COURSE_NOTIFICATION_TYPES[self.default_type_name]['info'] = new_info
-        self._set_notification_config_version(current_config_version + 1)
-        new_config = CourseNotificationPreference.get_updated_user_course_preferences(self.user, self.course.id)
-        preferences = new_config.notification_preference_config
-        notification_type = preferences[self.default_app_name]['notification_types'][self.default_type_name]
-        assert notification_type['info'] == new_info
-
     def test_notification_type_in_core(self):
         """
         Tests addition/removal of core in notification type
@@ -266,7 +253,7 @@ class NotificationPreferenceValidationTest(ModuleStoreTestCase):
         notification_apps = base_notification.COURSE_NOTIFICATION_APPS
         assert "" not in notification_apps.keys()
         for app_data in notification_apps.values():
-            assert isinstance(app_data['core_info'], str)
+            assert 'core_info' in app_data.keys()
             assert isinstance(app_data['non_editable'], list)
             for key in bool_keys:
                 assert isinstance(app_data[key], bool)

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -24,7 +24,7 @@ from openedx.core.djangoapps.notifications.serializers import NotificationCourse
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from ..base_notification import COURSE_NOTIFICATION_APPS
+from ..base_notification import COURSE_NOTIFICATION_APPS, NotificationAppManager
 
 
 @ddt.ddt
@@ -223,7 +223,8 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'web': True,
                             'email': True,
                             'push': True,
-                            'info': ''
+                            'info': 'Notifications for responses and comments on your posts, and the ones you’re '
+                                    'following, including endorsements to your responses and on your posts.'
                         },
                         'new_discussion_post': {'web': False, 'email': False, 'push': False, 'info': ''},
                         'new_question_post': {'web': False, 'email': False, 'push': False, 'info': ''}
@@ -304,6 +305,12 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
             self.assertEqual(event_data['notification_type'], notification_type or '')
             self.assertEqual(event_data['notification_channel'], notification_channel or '')
             self.assertEqual(event_data['value'], value)
+
+    def test_info_is_not_saved_in_json(self):
+        default_prefs = NotificationAppManager().get_notification_app_preferences()
+        for notification_app, app_prefs in default_prefs.items():
+            for _, type_prefs in app_prefs.get('notification_types', {}).items():
+                assert 'info' not in type_prefs.keys()
 
 
 class NotificationListAPIViewTest(APITestCase):


### PR DESCRIPTION
Make `info` in notifications translatable. `info` will not be saved in model (json field). It will be added in response when request will be made

Ticket Link: [INF-1004](https://2u-internal.atlassian.net/browse/INF-1004)