### PR TITLE
fix: update dashboard recommendations API endpoint

### DIFF
--- a/lms/djangoapps/learner_recommendations/views.py
+++ b/lms/djangoapps/learner_recommendations/views.py
@@ -48,6 +48,9 @@ log = logging.getLogger(__name__)
 
 class AboutPageRecommendationsView(APIView):
     """
+    IMPORTANT: Please do not update or use this API. This code has been moved to edx-recommendations plugin.
+    Please use that plugin for further code changes. This API will be removed as part of VAN-1427.
+
     **Example Request**
 
     GET api/learner_recommendations/amplitude/{course_id}/

--- a/lms/static/js/learner_dashboard/RecommendationsPanel.jsx
+++ b/lms/static/js/learner_dashboard/RecommendationsPanel.jsx
@@ -26,7 +26,7 @@ class RecommendationsPanel extends React.Component {
     };
 
     getCourseList = async () => {
-        const coursesRecommendationData = await fetch(`${this.props.lmsRootUrl}/api/learner_recommendations/courses/`)
+        const coursesRecommendationData = await fetch(`${this.props.lmsRootUrl}/api/edx_recommendations/learner_dashboard/amplitude/`)
             .then(response => response.json())
             .catch(() => ({
                 courses: this.props.generalRecommendations,


### PR DESCRIPTION
Added docstring to tell contributors that the recommendations-related code has been moved to `edx-recommendations` plugin.

VAN-1596

