### PR TITLE
[django4.2]: fix: requires_system_checks deprecation warning

### DIFF
--- a/openedx/core/djangoapps/theming/management/commands/compile_sass.py
+++ b/openedx/core/djangoapps/theming/management/commands/compile_sass.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
     help = 'Compile and collect themed assets...'
 
     # NOTE (CCB): This allows us to compile static assets in Docker containers without database access.
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         """


### PR DESCRIPTION
## Description

- Fixes requires_system_checks boolean value deprecation warning.

> WARNING 4319 [py.warnings] [user None] [ip None] warnings.py:109 - /opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/django/core/management/base.py:254: RemovedInDjango41Warning: Using a boolean value for requires_system_checks is deprecated. Use '__all__' instead of True, and [] (an empty list) instead of False.

- For details, see [logs](https://github.com/openedx/edx-platform/actions/runs/5956396347/job/16157083739#step:12:328)

- Reference from Django release notes:

  - https://docs.djangoproject.com/en/4.2/releases/4.1/#features-removed-in-4-1

      >Support for using a boolean value in [BaseCommand.requires_system_checks](https://docs.djangoproject.com/en/4.2/howto/custom-management-commands/#django.core.management.BaseCommand.requires_system_checks) is removed.

  - https://django.readthedocs.io/en/stable/releases/3.2.html#id3
       >Using a boolean value in [BaseCommand.requires_system_checks](https://django.readthedocs.io/en/stable/howto/custom-management-commands.html#django.core.management.BaseCommand.requires_system_checks) is deprecated. Use '__all__' instead of True, and [] (an empty list) instead of False.