### PR TITLE
fix: handle new_comment notification edge case

### DIFF
--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.paginator import Paginator
 from django.db.models.functions import Length
+from django.utils.translation import gettext_lazy as _
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseStaffRole, CourseInstructorRole
@@ -502,19 +503,32 @@ class DiscussionNotificationSender:
         """
         return int(self.parent_response.user_id) == int(self.thread.user_id)
 
+    def _response_and_comment_has_same_creator(self):
+        return int(self.parent_response.attributes['user_id']) == self.creator.id
+
     def send_new_comment_notification(self):
         """
         Send notification to parent thread creator i.e. comment on the response.
         """
-        #
         if (
             self.parent_response and
             self.creator.id != int(self.thread.user_id)
         ):
             # use your if author of response is same as author of post.
-            author_name = "your" if self._response_and_thread_has_same_creator() else self.parent_response.username
+            # use 'their' if comment author is also response author.
+            author_name = (
+                # Translators: Replier commented on "your" response to your post
+                _("your")
+                if self._response_and_thread_has_same_creator()
+                else (
+                    # Translators: Replier commented on "their" response to your post
+                    _("their")
+                    if self._response_and_comment_has_same_creator()
+                    else f"{self.parent_response.username}'s"
+                )
+            )
             context = {
-                "author_name": author_name,
+                "author_name": str(author_name),
             }
             self._send_notification([self.thread.user_id], "new_comment", extra_context=context)
 

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -25,7 +25,7 @@ COURSE_NOTIFICATION_TYPES = {
         'notification_app': 'discussion',
         'name': 'new_comment',
         'is_core': True,
-        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on <{strong}>{author_name}\'s'
+        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on <{strong}>{author_name}'
                               '</{strong}> response to your post <{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',


### PR DESCRIPTION
Handled edge case when response author is comment author in new_comment notification. The notification should use `their` as author name in context

Ticket: [INF-1013](https://2u-internal.atlassian.net/browse/INF-1013)
