### PR TITLE
fix: load user preference for notes visibility in courseware API and toggle_notes.html template

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1636,6 +1636,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
         context = {
             'fragment': fragment,
             'course': course,
+            'block': block,
             'disable_accordion': True,
             'allow_iframing': True,
             'disable_header': True,

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -100,7 +100,7 @@ ${HTML(fragment.foot_html())}
     <nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
       ## Utility: Notes
       % if edx_notes_enabled:
-        <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+        <%include file="/edxnotes/toggle_notes.html" args="course=course, block=block"/>
       % endif
 
       ## Utility: Calc
@@ -111,7 +111,7 @@ ${HTML(fragment.foot_html())}
   % endif
 % else:
   % if edx_notes_enabled:
-    <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+    <%include file="/edxnotes/toggle_notes.html" args="course=course, block=block"/>
   % endif
 % endif
 

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -308,7 +308,7 @@ ${HTML(fragment.foot_html())}
     <nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
       ## Utility: Notes
       % if is_edxnotes_enabled(course, request.user):
-        <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+        <%include file="/edxnotes/toggle_notes.html" args="course=course, block=course"/>
       % endif
 
       ## Utility: Calc

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -1,4 +1,4 @@
-<%page args="course" expression_filter="h"/>
+<%page args="course, block" expression_filter="h"/>
 <%!
 from django.utils.translation import gettext as _
 from django.urls import reverse
@@ -7,7 +7,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 <%namespace name='static' file='/static_content.html'/>
 
 <%
-  edxnotes_visibility = course.edxnotes_visibility
+  edxnotes_visibility = getattr(block, 'edxnotes_visibility', course.edxnotes_visibility)
   edxnotes_visibility_url = reverse("edxnotes_visibility", kwargs={"course_id": course.id})
   if is_learning_mfe is UNDEFINED:
     hide_ui = False

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -89,6 +89,7 @@ class CoursewareMeta:
             staff_access=original_user_is_staff,
         )
         self.request.user = self.effective_user
+        self.overview.bind_course_for_student(self.request)
         self.enrollment_object = CourseEnrollment.get_enrollment(self.effective_user, self.course_key,
                                                                  select_related=['celebration', 'user__celebration'])
 


### PR DESCRIPTION
## Description

* Add method to bind course overview model to a student, so that user preferences correctly override course defaults, and use this in courseware API to return correct notes visibility, so that the MFE is initialised with the correct visibility state.
* Add block argument (for user-bound block) to toggle_notes.html template (used by course block iframe) so notes visibility can be loaded from it instead of course default.

Impacts Learner users.

Fixes openedx/wg-build-test-release#227

## Supporting information

openedx/wg-build-test-release#227
openedx/frontend-app-learning#1005

## Testing instructions

(Parts from openedx/wg-build-test-release#227)

1. Enable Notes in a Course Advanced settings
2. Open Course as a Student
3. Check Notes tab
4. Open any Unit in a subsection
5. Select text to note
6. Save the note
7. Check the Note tab
8. Return to the Course Subsection
9. Check that notes are visible and that the previously noted text is highlighted
10. Check that the button state corresponds to the visibility of notes (i.e. "Hide Notes" when notes are visible and "Show Notes" when notes are not visible)
11. Toggle note visibility until they are hidden (or visible, if openedx/frontend-app-learning#1170 is not applied)\*
12. Reload page and check that notes are hidden
13. Toggle note visibility until they are visible (or hidden, if openedx/frontend-app-learning#1170 is not applied)\*
14. Reload page and check that notes are visible

\*Due to the issue documented at openedx/frontend-app-learning#1170, the "Show/Hide Notes" button persists the state that is opposite to the one applied. I.e., if the button is used and notes are hidden, they will be visible when the page is reloaded and vice-versa. Running the MFE with the branch from that pull request should allow observing the correct non-reversed behaviour. This is independent of this issue.