### PR TITLE
[Django4.2]: fix:: middleware get_response parameter deprecation warning

### DIFF
--- a/common/test/pacts/middleware.py
+++ b/common/test/pacts/middleware.py
@@ -18,7 +18,7 @@ class AuthenticationMiddleware(MiddlewareMixin):
     See https://docs.pact.io/faq#how-do-i-test-oauth-or-other-security-headers
     """
     def __init__(self, get_response):
-        super().__init__()
+        super().__init__(get_response)
 
         username = getattr(settings, 'MOCK_USERNAME', 'Mock User')
         self.auth_user = UserFactory.create(username=username)


### PR DESCRIPTION
## Description

- Fixes get_response middleware warning
- More details can be found in associated PR
  - https://github.com/openedx/edx-platform/pull/33067