### PR TITLE
fix: fix Django 4.1 Deprecation Warnings

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1451,7 +1451,6 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.course = CourseFactory.create()
         cls.password = "test password"
         seed_permissions_roles(cls.course.id)
 

--- a/lms/djangoapps/verify_student/management/commands/tests/test_manual_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_manual_verify_student.py
@@ -77,7 +77,7 @@ class TestVerifyStudentCommand(TestCase):
             created_at__gte=earliest_allowed_verification_date()
         )
 
-        self.assertQuerysetEqual(verification1, [repr(r) for r in verification2])
+        self.assertQuerysetEqual(verification1, [repr(r) for r in verification2], transform=repr)
 
     def test_user_doesnot_exist_log(self):
         """


### PR DESCRIPTION
### Description
Fixed following `Django41DeprecationWarnings` [[Django 4.1 Release notes](https://docs.djangoproject.com/en/4.2/releases/4.1/#features-removed-in-4-1)]


- Support for assigning objects which don’t support creating deep copies with copy.deepcopy() to class attributes in TestCase.setUpTestData() is removed.

- TransactionTestCase.assertQuerysetEqual() no longer calls repr() on a queryset when compared to string values.