### PR TITLE
chore: add constraint for ora2

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -131,3 +131,6 @@ click==8.1.6
 
 # plz upgrade this in separate ticket
 redis==4.6.0
+
+# holding off ora date config feature
+ora2==5.2.4

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -783,7 +783,9 @@ openedx-mongodbproxy==0.2.0
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
 ora2==5.2.4
-    # via -r requirements/edx/bundled.in
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/bundled.in
 oscrypto==1.3.0
     # via snowflake-connector-python
 packaging==23.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1321,6 +1321,7 @@ optimizely-sdk==4.1.1
     #   -r requirements/edx/testing.txt
 ora2==5.2.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 oscrypto==1.3.0

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -924,7 +924,9 @@ openedx-mongodbproxy==0.2.0
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
 ora2==5.2.4
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -993,7 +993,9 @@ openedx-mongodbproxy==0.2.0
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
 ora2==5.2.4
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
constraint ora2 to 5.2.4 to hold the release of date config feature