### PR TITLE
fix: incorrect type hints in a few places

### DIFF
--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
@@ -1,11 +1,12 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
+from __future__ import annotations
+
 import logging
 from collections import defaultdict  # lint-amnesty, pylint: disable=unused-import
 from datetime import datetime, timedelta
-from typing import Dict
 
 from edx_when.api import get_dates_for_course
-from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=unused-import
+from opaque_keys.edx.keys import UsageKey, CourseKey  # lint-amnesty, pylint: disable=unused-import
 from openedx.core import types
 
 from common.djangoapps.student.auth import user_has_role
@@ -37,7 +38,7 @@ class ScheduleOutlineProcessor(OutlineProcessor):
     def __init__(self, course_key: CourseKey, user: types.User, at_time: datetime):
         super().__init__(course_key, user, at_time)
         self.dates = None
-        self.keys_to_schedule_fields: Dict[str, Dict[str, datetime]] = defaultdict(dict)
+        self.keys_to_schedule_fields: dict[UsageKey, dict[str, datetime]] = defaultdict(dict)
         self._course_start = None
         self._course_end = None
         self._is_beta_tester = False

--- a/openedx/core/djangoapps/content_staging/data.py
+++ b/openedx/core/djangoapps/content_staging/data.py
@@ -63,4 +63,4 @@ class StagedContentFileData:
 class UserClipboardData:
     """ Read-only data model for User Clipboard data (copied OLX) """
     content: StagedContentData = field(validator=validators.instance_of(StagedContentData))
-    source_usage_key: UsageKey = field(validator=validators.instance_of(UsageKey))
+    source_usage_key: UsageKey = field(validator=validators.instance_of(UsageKey))  # type: ignore[type-abstract]

--- a/xmodule/partitions/partitions_service.py
+++ b/xmodule/partitions/partitions_service.py
@@ -3,13 +3,12 @@ This is a service-like API that assigns tracks which groups users are in for var
 user partitions.  It uses the user_service key/value store provided by the LMS runtime to
 persist the assignments.
 """
-
-
 import logging
 from typing import Dict
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.cache_utils import request_cached
 from openedx.core.lib.dynamic_partitions_generators import DynamicPartitionGeneratorsPluginManager
 
@@ -44,7 +43,7 @@ def get_all_partitions_for_course(course, active_only=False):
     return all_partitions
 
 
-def get_user_partition_groups(course_key: str, user_partitions: list, user: User,
+def get_user_partition_groups(course_key: CourseKey, user_partitions: list, user: User,
                               partition_dict_key: str = 'name') -> Dict[str, Group]:
     """
     Collect group ID for each partition in this course for this user.


### PR DESCRIPTION
## Description

As part of my Core Contributor role, I have been working on rolling out type hint declarations and checking in more parts of the codebase. I am about to "turn on" type hints for opaque-keys, but before I can do so I need to fix some minor type errors that exist in `learning_sequences`. These weren't detected before because all opaque keys were being type-checked as `Any`, but once https://github.com/openedx/opaque-keys/pull/259 merges, opaque-keys become distinct types and mypy will catch errors like this.

The errors:

```
openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py:131: error: Invalid index type "UsageKey" for "Dict[str, Dict[str, datetime]]"; expected type "str"  [index]
openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py:132: error: Invalid index type "UsageKey" for "Dict[str, Dict[str, datetime]]"; expected type "str"  [index]
openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py:145: error: Invalid index type "UsageKey" for "Dict[str, Dict[str, datetime]]"; expected type "str"  [index]
openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py:160: error: Invalid index type "UsageKey" for "Dict[str, Dict[str, datetime]]"; expected type "str"  [index]
openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py:42: error: Argument 1 to "get_user_partition_groups" has incompatible type "CourseKey"; expected "str"  [arg-type]
```

Note that in this case these aren't runtime bugs, just errors with the type annotations.

## Supporting information

See https://github.com/openedx/opaque-keys/pull/259 , https://github.com/openedx/opaque-keys/pull/256 , https://github.com/openedx/edx-platform/pull/32591 for more context.

## Testing instructions

The CI should be sufficient, but if you really want:

1. Run `mypy` for edx-platform without this change. No errors, but that's because opaque key types are not really being checked.
2. Check out https://github.com/openedx/opaque-keys/pull/259 and use `pip install -e .` to install the newer type hints into your virtual env.
3. Run `mypy` for edx-platform again - you see the errors I mentioned.
4. Check out this branch and run `mypy` one final time - the errors are gone.

## Deadline

None

## Other information

This needs to merge before the corresponding opaque-keys PR.

Private-ref: MNG-3826