### PR TITLE
Revert "feat!: upgrading django-storages to 1.10.1"""

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -389,7 +389,7 @@ class S3Boto3TestCase(TestCase):
     @override_settings(VIDEO_IMAGE_SETTINGS={
         'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
         'STORAGE_KWARGS':
-            {'bucket_name': 'test', 'default_acl': None, 'location': 'abc/def'}}
+            {'bucket_name': 'test', 'default_acl': None, 'base_url': '/', 'location': 'abc/def'}}
     )
     def test_boto3_backend_with_params(self):
         storage = get_storage_class(
@@ -417,6 +417,7 @@ class S3Boto3TestCase(TestCase):
         obj.upload_fileobj.assert_called_with(
             content,
             ExtraArgs={
+                'ACL': 'public-read',   # it will come from 1.9.1
                 'ContentType': 'text/plain',
             }
         )

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2504,9 +2504,9 @@ VIDEO_IMAGE_SETTINGS = dict(
     # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
     ),
     DIRECTORY_PREFIX='video-images/',
-    BASE_URL=MEDIA_URL,
 )
 
 VIDEO_IMAGE_MAX_AGE = 31536000
@@ -2519,9 +2519,9 @@ VIDEO_TRANSCRIPTS_SETTINGS = dict(
     # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
     ),
     DIRECTORY_PREFIX='video-transcripts/',
-    BASE_URL=MEDIA_URL,
 )
 
 VIDEO_TRANSCRIPTS_MAX_AGE = 31536000

--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -512,17 +512,17 @@ VIDEO_IMAGE_MAX_AGE: 31536000
 VIDEO_IMAGE_SETTINGS:
     DIRECTORY_PREFIX: video-images/
     STORAGE_KWARGS:
+        base_url: /media/
         location: /edx/var/edxapp/media//
     VIDEO_IMAGE_MAX_BYTES: 2097152
     VIDEO_IMAGE_MIN_BYTES: 2048
-    BASE_URL: /media/
 VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 VIDEO_TRANSCRIPTS_SETTINGS:
     DIRECTORY_PREFIX: video-transcripts/
     STORAGE_KWARGS:
-        location: edx/var/edxapp/media//
+        base_url: /media/
+        location: /edx/var/edxapp/media//
     VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728
-    BASE_URL: /media/
 VIDEO_UPLOAD_PIPELINE:
     BUCKET: ''
     ROOT_PATH: ''

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -303,9 +303,9 @@ VIDEO_IMAGE_SETTINGS = dict(
     VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
     ),
     DIRECTORY_PREFIX='video-images/',
-    BASE_URL=MEDIA_URL,
 )
 VIDEO_IMAGE_DEFAULT_FILENAME = 'default_video_image.png'
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -277,12 +277,12 @@ if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
     urlpatterns += static(
-        settings.VIDEO_IMAGE_SETTINGS['BASE_URL'],
+        settings.VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['base_url'],
         document_root=settings.VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location']
     )
 
     urlpatterns += static(
-        settings.VIDEO_TRANSCRIPTS_SETTINGS['BASE_URL'],
+        settings.VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['base_url'],
         document_root=settings.VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location']
     )
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3801,10 +3801,9 @@ VIDEO_IMAGE_SETTINGS = dict(
     # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
     ),
     DIRECTORY_PREFIX='video-images/',
-    BASE_URL=MEDIA_URL,
-
 )
 
 VIDEO_IMAGE_MAX_AGE = 31536000
@@ -3818,9 +3817,9 @@ VIDEO_TRANSCRIPTS_SETTINGS = dict(
     # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
     ),
     DIRECTORY_PREFIX='video-transcripts/',
-    BASE_URL=MEDIA_URL,
 )
 
 VIDEO_TRANSCRIPTS_MAX_AGE = 31536000

--- a/lms/envs/devstack-experimental.yml
+++ b/lms/envs/devstack-experimental.yml
@@ -614,17 +614,17 @@ VIDEO_IMAGE_MAX_AGE: 31536000
 VIDEO_IMAGE_SETTINGS:
     DIRECTORY_PREFIX: video-images/
     STORAGE_KWARGS:
-        location: edx/var/edxapp/media//
+        base_url: /media/
+        location: /edx/var/edxapp/media//
     VIDEO_IMAGE_MAX_BYTES: 2097152
     VIDEO_IMAGE_MIN_BYTES: 2048
-    BASE_URL: /media/
 VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 VIDEO_TRANSCRIPTS_SETTINGS:
     DIRECTORY_PREFIX: video-transcripts/
     STORAGE_KWARGS:
-        location: edx/var/edxapp/media//
+        base_url: /media/
+        location: /edx/var/edxapp/media//
     VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728
-    BASE_URL: /media/
 VIDEO_UPLOAD_PIPELINE:
     BUCKET: ''
     ROOT_PATH: ''

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,8 +20,9 @@ celery>=5.2.2,<6.0.0
 # required for celery>=5.2.0;<5.3.0
 click>=8.0,<9.0
 
-# django-storages version 1.10.1 is major upgrade and require multiple settings changes.
-django-storages==1.10.1
+# django-storages version 1.9 drops support for boto storage backend.
+# 1.9 gives an error for details https://github.com/jschneier/django-storages/issues/831
+django-storages==1.9.1
 
 
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -357,7 +357,7 @@ django-statici18n==2.4.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.10.1
+django-storages==1.9.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -570,7 +570,7 @@ django-statici18n==2.4.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.10.1
+django-storages==1.9.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -420,7 +420,7 @@ django-statici18n==2.4.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.10.1
+django-storages==1.9.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -452,7 +452,7 @@ django-statici18n==2.4.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   xblock-drag-and-drop-v2
-django-storages==1.10.1
+django-storages==1.9.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
[scorm-xblock ](https://github.com/overhangio/openedx-scorm-xblock/pull/39)  functionality implemented but new release is not available.  I have requested author for new version. 

In edxo-internal it has following entry and nothing to change here to get new version it will pick the new release.
```
 name: openedx-scorm-xblock
 version: <16.1.0
```

Reverts openedx/edx-platform#33111