### PR TITLE
chore: version bump

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,7 +27,7 @@ django-storages==1.10.1
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==4.1.0
+edx-enterprise==4.1.1
 
 # 1. django-oauth-toolkit version >=2.0.0 has breaking changes. More details
 #    mentioned on this issue https://github.com/openedx/edx-platform/issues/32884

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -481,7 +481,7 @@ edx-drf-extensions==8.9.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.1.0
+edx-enterprise==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -747,7 +747,7 @@ edx-drf-extensions==8.9.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.1.0
+edx-enterprise==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -555,7 +555,7 @@ edx-drf-extensions==8.9.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.1.0
+edx-enterprise==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -584,7 +584,7 @@ edx-drf-extensions==8.9.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.1.0
+edx-enterprise==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
[Related PR](https://github.com/openedx/edx-enterprise/pull/1853)
[JIRA Ticket](https://2u-internal.atlassian.net/browse/ENT-7583)
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
