### PR TITLE
fix: loading of underscore and other text assets over CDN

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -353,6 +353,11 @@
             'jquery_extend_patch': {
                 deps: ['jquery']
             }
+        },
+        config: {
+          text: {
+            useXhr: () => true
+          }
         }
     });
 }).call(this, require, define);

--- a/lms/static/lms/js/require-config.js
+++ b/lms/static/lms/js/require-config.js
@@ -226,6 +226,11 @@
             'hls': {
                 exports: 'Hls'
             }
+        },
+        config: {
+          text: {
+            useXhr: () => true
+          }
         }
     });
 }).call(this, require || RequireJS.require, define || RequireJS.define);


### PR DESCRIPTION
## Description
The text plugin for requirejs is used to load text assets such as .underscore files. To avoid CORS issues when loading such assets from a different domain, such as a when a CDN is in use, this plugin loads such assets as .js files by adding a script tag.

What this means in practice is that if you configure the platform to serve static assets from a CDN, it will try to load `file.underscore.js` instead of `file.underscore`. We can override this behaviour by providing a `useXhr` function for the text plugin configuration. The plugin will use this function to determine whether to use XHR or the script tag approach.

In this change we are asking it to always use XHR since the concerns about CORS raised by the plugins documentation don't apply here.

## Supporting information

-  https://github.com/requirejs/text/blob/3f9d4c19b3a1a3c6f35650c5788cbea1db93197a/README.md#xhr-restrictions

## Testing instructions

Testing this is a bit tricky and requires setting up the platform to serve assets from a CDN. Here is a simplified approach:

- Use the tutor-minio plugin to set up a local minio-based S3-compatible service. 
- Install the aws cli app inside the lms and cms containers to upload contents to minio. (You can use the rough script from [here](https://gitlab.com/opencraft/dev/tutor-contrib-grove/-/blob/main/tutorgrove/patches/openedx-dockerfile-post-python-requirements?ref_type=heads#L7)).
- Roughly follow the script [here](https://gitlab.com/opencraft/dev/tutor-contrib-grove/-/blob/main/tutorgrove/templates/grove/tasks/lms/s3?ref_type=heads) to use the installed CLI to upload files to minio. 
- Set the STATIC_URL variable in `$(tutor-nightly config printroot)/env/apps/openedx/settings/{lms,cms}/development.py` to the minio domain. 
  - for LMS  `STATIC_URL = "http://files.local.overhang.io:9000/openedx/static"`
  - for CMS  `STATIC_URL = "http://files.local.overhang.io:9000/openedx/static/studio"`

## Other information
