### PR TITLE
[django42] sha1 is removed in django42 version. 

### DIFF
--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -86,7 +86,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import signing
-
 from django.core.cache import cache
 from django.http import HttpResponse
 from django.utils.crypto import get_random_string
@@ -270,7 +269,7 @@ class SafeCookieData:
         data_to_sign = self._compute_digest(user_id)
 
         self.signature = signing.TimestampSigner(
-            key=None, salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
+            salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
         ).sign_object(data_to_sign, serializer=signing.JSONSerializer, compress=False)
 
     def verify(self, user_id):
@@ -281,7 +280,7 @@ class SafeCookieData:
         """
         try:
             unsigned_data = signing.TimestampSigner(
-                key=None, salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
+                salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
             ).unsign_object(self.signature, serializer=signing.JSONSerializer, max_age=settings.SESSION_COOKIE_AGE)
 
             if unsigned_data == self._compute_digest(user_id):

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -86,6 +86,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import signing
+
 from django.core.cache import cache
 from django.http import HttpResponse
 from django.utils.crypto import get_random_string
@@ -267,7 +268,10 @@ class SafeCookieData:
         SHA256(version '|' session_id '|' user_id '|').
         """
         data_to_sign = self._compute_digest(user_id)
-        self.signature = signing.dumps(data_to_sign, salt=self.key_salt)
+
+        self.signature = signing.TimestampSigner(
+            key=None, salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
+        ).sign_object(data_to_sign, serializer=signing.JSONSerializer, compress=False)
 
     def verify(self, user_id):
         """
@@ -276,7 +280,10 @@ class SafeCookieData:
         (not expired) and bound to the given user.
         """
         try:
-            unsigned_data = signing.loads(self.signature, salt=self.key_salt, max_age=settings.SESSION_COOKIE_AGE)
+            unsigned_data = signing.TimestampSigner(
+                key=None, salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
+            ).unsign_object(self.signature, serializer=signing.JSONSerializer, max_age=settings.SESSION_COOKIE_AGE)
+
             if unsigned_data == self._compute_digest(user_id):
                 return True
             log.error("SafeCookieData '%r' is not bound to user '%s'.", str(self), user_id)


### PR DESCRIPTION
edx is using `DEFAULT_HASHING_ALGORITHM = 'sha1` as default.

In [django32](https://github.com/django/django/blob/3.2/django/core/signing.py#L279) its mention about `DEFAULT_HASHING_ALGORITHM` deprecation.
```
# RemovedInDjango40Warning: when the deprecation ends, replace with:
# self.algorithm = algorithm or 'sha256'
self.algorithm = algorithm or settings.DEFAULT_HASHING_ALGORITHM
```
-----

in [django42](https://github.com/django/django/blob/4.2.4/django/core/signing.py#L204) 
```
self.algorithm = algorithm or "sha256"
```
Tests were failing in django42 because now it is using `sha256` since `DEFAULT_HASHING_ALGORITHM` removed.
https://github.com/django/django/blob/3f8dbe267d35f0219277f0fe2d79915a4fb2b045/docs/releases/4.0.txt#L773
