### PR TITLE
[Django 4.2]: Fix: got both positional and keyword arguments for field

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -164,7 +164,8 @@ class CohortTarget(Target):
         app_label = "bulk_email"
 
     def __init__(self, *args, **kwargs):
-        kwargs['target_type'] = SEND_TO_COHORT
+        if not args:
+            kwargs['target_type'] = SEND_TO_COHORT
         super().__init__(*args, **kwargs)
 
     def __str__(self):
@@ -209,7 +210,8 @@ class CourseModeTarget(Target):
         app_label = "bulk_email"
 
     def __init__(self, *args, **kwargs):
-        kwargs['target_type'] = SEND_TO_TRACK
+        if not args:
+            kwargs['target_type'] = SEND_TO_TRACK
         super().__init__(*args, **kwargs)
 
     def __str__(self):


### PR DESCRIPTION
## Description

Fixes this error when updating to Django 4.2

```
lms/djangoapps/bulk_email/tests/test_models.py:152: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lms/djangoapps/bulk_email/models.py:92: in short_display
    return self.cohorttarget.short_display()  # lint-amnesty, pylint: disable=no-member
/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py:481: in __get__
    rel_obj = self.get_queryset(instance=instance).get(**filter_args)
/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py:633: in get
    num = len(clone)
/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py:380: in __len__
    self._fetch_all()
/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py:1881: in _fetch_all
    self._result_cache = list(self._iterable_class(self))
/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py:122: in __iter__
    obj = model_cls.from_db(
/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py:582: in from_db
    new = cls(*values)
lms/djangoapps/bulk_email/models.py:168: in __init__
    super().__init__(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'NoneType' object has no attribute 'attname'") raised in repr()] CohortTarget object at 0x7f913667c5b0>
args = (1, 'cohort', 1, 1), kwargs = {}
cls = <class 'lms.djangoapps.bulk_email.models.CohortTarget'>
opts = <Options for CohortTarget>, _setattr = <built-in function setattr>
_DEFERRED = <Deferred field>
fields_iter = <tuple_iterator object at 0x7f913667c160>, val = 'cohort'
field = <django.db.models.fields.CharField: target_type>

    def __init__(self, *args, **kwargs):
        # Alias some things as locals to avoid repeat global lookups
        cls = self.__class__
        opts = self._meta
        _setattr = setattr
        _DEFERRED = DEFERRED
        if opts.abstract:
            raise TypeError("Abstract models cannot be instantiated.")
    
        pre_init.send(sender=cls, args=args, kwargs=kwargs)
    
        # Set up the storage for instance state
        self._state = ModelState()
    
        # There is a rather weird disparity here; if kwargs, it's set, then args
        # overrides it. It should be one or the other; don't duplicate the work
        # The reason for the kwargs check is that standard iterator passes in by
        # args, and instantiation for iteration is 33% faster.
        if len(args) > len(opts.concrete_fields):
            # Daft, but matches old exception sans the err msg.
            raise IndexError("Number of args exceeds number of fields")
    
        if not kwargs:
            fields_iter = iter(opts.concrete_fields)
            # The ordering of the zip calls matter - zip throws StopIteration
            # when an iter throws it. So if the first iter throws it, the second
            # is *not* consumed. We rely on this, so don't change the order
            # without changing the logic.
            for val, field in zip(args, fields_iter):
                if val is _DEFERRED:
                    continue
                _setattr(self, field.attname, val)
        else:
            # Slower, kwargs-ready version.
            fields_iter = iter(opts.fields)
            for val, field in zip(args, fields_iter):
                if val is _DEFERRED:
                    continue
                _setattr(self, field.attname, val)
                if kwargs.pop(field.name, NOT_PROVIDED) is not NOT_PROVIDED:
>                   raise TypeError(
                        f"{cls.__qualname__}() got both positional and "
                        f"keyword arguments for field '{field.name}'."
                    )
E                   TypeError: CohortTarget() got both positional and keyword arguments for field 'target_type'.

```

Fix for this error was suggested here https://stackoverflow.com/a/70677745

Django Reference:
https://github.com/django/django/pull/14059