### PR TITLE
[Django 4.2]: Fix: object has no attribute 'is_ajax'

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -265,24 +265,24 @@ class TestCommonExceptions400(TestCase):
         assert resp.status_code == 200
 
     def test_user_doesnotexist(self):
-        self.request.is_ajax.return_value = False
+        self.request.accepts("application/json").return_value = False
         resp = view_user_doesnotexist(self.request)
         self.assertContains(resp, "User does not exist", status_code=400)
 
     def test_user_doesnotexist_ajax(self):
-        self.request.is_ajax.return_value = True
+        self.request.accepts("application/json").return_value = True
         resp = view_user_doesnotexist(self.request)
         self.assertContains(resp, "User does not exist", status_code=400)
 
     @ddt.data(True, False)
     def test_alreadyrunningerror(self, is_ajax):
-        self.request.is_ajax.return_value = is_ajax
+        self.request.accepts("application/json").return_value = is_ajax
         resp = view_alreadyrunningerror(self.request)
         self.assertContains(resp, "Requested task is already running", status_code=400)
 
     @ddt.data(True, False)
     def test_alreadyrunningerror_with_unicode(self, is_ajax):
-        self.request.is_ajax.return_value = is_ajax
+        self.request.accepts("application/json").return_value = is_ajax
         resp = view_alreadyrunningerror_unicode(self.request)
         self.assertContains(
             resp,
@@ -295,7 +295,7 @@ class TestCommonExceptions400(TestCase):
         """
         Tests that QueueConnectionError exception is handled in common_exception_400.
         """
-        self.request.is_ajax.return_value = is_ajax
+        self.request.accepts("application/json").return_value = is_ajax
         resp = view_queue_connection_error(self.request)
         self.assertContains(
             resp,


### PR DESCRIPTION
## Description

Fixes issue when upgrading to Django 4.2

```
/usr/lib/python3.8/unittest/mock.py:637: AttributeError
___________ TestCommonExceptions400.test_alreadyrunningerror_2_False ___________

self = <lms.djangoapps.instructor.tests.test_api.TestCommonExceptions400 testMethod=test_alreadyrunningerror_2_False>
is_ajax = False

    @ddt.data(True, False)
    def test_alreadyrunningerror(self, is_ajax):
>       self.request.is_ajax.return_value = is_ajax

lms/djangoapps/instructor/tests/test_api.py:279: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Mock spec='HttpRequest' id='140253030049632'>, name = 'is_ajax'

    def __getattr__(self, name):
        if name in {'_mock_methods', '_mock_unsafe'}:
            raise AttributeError(name)
        elif self._mock_methods is not None:
            if name not in self._mock_methods or name in _all_magics:
>               raise AttributeError("Mock object has no attribute %r" % name)
E               AttributeError: Mock object has no attribute 'is_ajax'
```

Django docs
https://docs.djangoproject.com/en/3.1/releases/3.1/#id2
> The HttpRequest.is_ajax() method is deprecated as it relied on a jQuery-specific way of signifying AJAX calls, while current usage tends to use the JavaScript [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). Depending on your use case, you can either write your own AJAX detection method, or use the new [HttpRequest.accepts()](https://docs.djangoproject.com/en/3.1/ref/request-response/#django.http.HttpRequest.accepts) method if your code depends on the client Accept HTTP header.

Reference
https://github.com/openedx/edx-platform/pull/33055