### PR TITLE
build: don't exclude lms/static/css/vendor from Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -103,6 +103,7 @@ common/test/data/badges/*.png
 ### Static assets pipeline artifacts
 **/*.scssc
 lms/static/css/
+!lms/static/css/vendor
 lms/static/certificates/css/
 cms/static/css/
 common/static/common/js/vendor/


### PR DESCRIPTION
The .dockerignore file smartly excludes lms/static/css from the Docker build, as most of its contents are generated CSS.

However, there is one version-controlled subdirectory of lms/static/css: lms/static/css/vendor.

In order to correctly build a Docker image using a bind-mounted edx-platform repository, we need this vendor directory to be included.