### PR TITLE
fix: replaced mysql57 hosts with mysql80

### DIFF
--- a/.github/workflows/docker-compose.yml.mysqldbdump
+++ b/.github/workflows/docker-compose.yml.mysqldbdump
@@ -2,7 +2,7 @@ version: '3'
 services:
   mysql:
     image: mysql:5.7
-    container_name: edx.devstack.mysql57
+    container_name: edx.devstack.mysql80
     ports:
       - '3306:3306'
     environment:

--- a/cms/envs/bok_choy_docker.auth.json
+++ b/cms/envs/bok_choy_docker.auth.json
@@ -24,7 +24,7 @@
     "DATABASES": {
         "default": {
             "ENGINE": "django.db.backends.mysql",
-            "HOST": "edx.devstack.mysql57",
+            "HOST": "edx.devstack.mysql80",
             "NAME": "edxtest",
             "PASSWORD": "",
             "PORT": "3306",
@@ -32,7 +32,7 @@
         },
         "student_module_history": {
             "ENGINE": "django.db.backends.mysql",
-            "HOST": "edx.devstack.mysql57",
+            "HOST": "edx.devstack.mysql80",
             "NAME": "student_module_history_test",
             "PASSWORD": "",
             "PORT": "3306",

--- a/cms/envs/bok_choy_docker.yml
+++ b/cms/envs/bok_choy_docker.yml
@@ -75,9 +75,9 @@ CONTENTSTORE:
     host: [edx.devstack.mongo]
     port: 27017
 DATABASES:
-  default: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql57, NAME: edxtest,
+  default: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql80, NAME: edxtest,
     PASSWORD: '', PORT: '3306', USER: root}
-  student_module_history: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql57,
+  student_module_history: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql80,
     NAME: student_module_history_test, PASSWORD: '', PORT: '3306', USER: root}
 DEFAULT_FEEDBACK_EMAIL: feedback@example.com
 DEFAULT_FROM_EMAIL: registration@example.com

--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -208,7 +208,7 @@ DATABASES:
         ATOMIC_REQUESTS: true
         CONN_MAX_AGE: 0
         ENGINE: django.db.backends.mysql
-        HOST: edx.devstack.mysql57
+        HOST: edx.devstack.mysql80
         NAME: edxapp
         OPTIONS:
             isolation_level: read committed
@@ -218,7 +218,7 @@ DATABASES:
     read_replica:
         CONN_MAX_AGE: 0
         ENGINE: django.db.backends.mysql
-        HOST: edx.devstack.mysql57
+        HOST: edx.devstack.mysql80
         NAME: edxapp
         OPTIONS:
             isolation_level: read committed
@@ -228,7 +228,7 @@ DATABASES:
     student_module_history:
         CONN_MAX_AGE: 0
         ENGINE: django.db.backends.mysql
-        HOST: edx.devstack.mysql57
+        HOST: edx.devstack.mysql80
         NAME: edxapp_csmh
         OPTIONS:
             isolation_level: read committed

--- a/lms/envs/bok_choy_docker.yml
+++ b/lms/envs/bok_choy_docker.yml
@@ -75,9 +75,9 @@ CONTENTSTORE:
     host: [edx.devstack.mongo]
     port: 27017
 DATABASES:
-  default: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql57, NAME: edxtest,
+  default: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql80, NAME: edxtest,
     PASSWORD: '', PORT: '3306', USER: root}
-  student_module_history: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql57,
+  student_module_history: {ENGINE: django.db.backends.mysql, HOST: edx.devstack.mysql80,
     NAME: student_module_history_test, PASSWORD: '', PORT: '3306', USER: root}
 DEFAULT_FEEDBACK_EMAIL: feedback@example.com
 DEFAULT_FROM_EMAIL: registration@example.com

--- a/lms/envs/devstack-experimental.yml
+++ b/lms/envs/devstack-experimental.yml
@@ -228,7 +228,7 @@ DATABASES:
         ATOMIC_REQUESTS: true
         CONN_MAX_AGE: 0
         ENGINE: django.db.backends.mysql
-        HOST: edx.devstack.mysql57
+        HOST: edx.devstack.mysql80
         NAME: edxapp
         OPTIONS:
             isolation_level: read committed
@@ -238,7 +238,7 @@ DATABASES:
     read_replica:
         CONN_MAX_AGE: 0
         ENGINE: django.db.backends.mysql
-        HOST: edx.devstack.mysql57
+        HOST: edx.devstack.mysql80
         NAME: edxapp
         OPTIONS:
             isolation_level: read committed
@@ -248,7 +248,7 @@ DATABASES:
     student_module_history:
         CONN_MAX_AGE: 0
         ENGINE: django.db.backends.mysql
-        HOST: edx.devstack.mysql57
+        HOST: edx.devstack.mysql80
         NAME: edxapp_csmh
         OPTIONS:
             isolation_level: read committed

--- a/scripts/reset-test-db.sh
+++ b/scripts/reset-test-db.sh
@@ -31,7 +31,7 @@ if [[ -z "$BOK_CHOY_HOSTNAME" ]]; then
     MYSQL_HOST=""
     SETTINGS="bok_choy"
 else
-    MYSQL_HOST="--host=edx.devstack.mysql57"
+    MYSQL_HOST="--host=edx.devstack.mysql80"
     SETTINGS="bok_choy_docker"
 fi
 


### PR DESCRIPTION
As we going to use mysql80 for LMS and CMS in devstack, that's why created this PR that is using mysql80 now.

**Related PR**
- https://github.com/openedx/devstack/pull/1189