### PR TITLE
fix: include the correct SCSS file for lti_block

### DIFF
--- a/xmodule/lti_block.py
+++ b/xmodule/lti_block.py
@@ -383,7 +383,6 @@ class LTIBlock(
         fragment = Fragment(
             self.runtime.service(self, 'mako').render_cms_template(self.mako_template, context)
         )
-        add_sass_to_fragment(fragment, 'LTIBlockEditor.scss')
         add_webpack_js_to_fragment(fragment, 'LTIBlockEditor')
         shim_xmodule_js(fragment, self.studio_js_module_name)
         return fragment
@@ -499,6 +498,7 @@ class LTIBlock(
         """
         fragment = Fragment()
         fragment.add_content(self.runtime.service(self, 'mako').render_lms_template('lti.html', self.get_context()))
+        add_sass_to_fragment(fragment, 'LTIBlockDisplay.scss')
         add_webpack_js_to_fragment(fragment, 'LTIBlockDisplay')
         shim_xmodule_js(fragment, 'LTI')
         return fragment


### PR DESCRIPTION
### Testing

I confirmed this fix using Tutor and an export of the course from the original (private) bug report. Here's how I tested.

Setup:
* Running instance of Studio & LMS
* Course exists with "lti" added as an Advanced Module Type (in Advanced Settings) and a unit containing an "LTI" component (not an "LTI Consumer" component -- that is a newer implementation of the block, which didn't suffer from this bug).
* LTI component should be pre-configured with an external resource.
* Logged-in user can edit course

Bug reproduction (master)
* Go to unit in Studio
* Hit "Edit" on LTI component
* Editor should show error message containing `Error: Sass not found: /edx/app/edxapp/edx-platform/xmodule/assets/LTIBlockEditor.scss`
* Hit "View Live"
* LTI contents should be squished into a very small frame in LMS -- about 300x400, by my guess.
* Open network log, hard-refresh, and confirm that `LTIBlockDisplay.css` is NOT loaded.

Bug fix confirmation (this branch):
* Go to unit in Studio
* Hit "Edit" on LTI component
* Confirm that editor displays and works.
* Hit "View Live"
* LTI contents should display in LMS in a frame of appropriate size.
* Open network log, hard-refresh, and confirm that `LTIBlockDisplay.css` IS loaded.

### Description

lti_block has Sass for its display, but not for its editor.

During the `add_sass_to_fragment` refactoring, I mixed this up: I added a non-existent scss file to the studio_view but didn't add the actual scss file to the student_view.

Course authors using the (deprecated) lti_block saw:

    We're having trouble rendering your component
    Students will not be able to access this component. Re-edit your component to fix the error.

    Error: Sass not found: /edx/app/edxapp/edx-platform/xmodule/assets/LTIBlockEditor.scss

as a result of this bug.

Original PR: https://github.com/openedx/edx-platform/pull/32592

Private-ref: https://2u-internal.atlassian.net/browse/TNL-11029