### PR TITLE
fix: Don't set default_app_config.

### DIFF
--- a/openedx/core/djangoapps/programs/__init__.py
+++ b/openedx/core/djangoapps/programs/__init__.py
@@ -10,8 +10,6 @@ this package should be kept small, thin, and stateless.
 """
 from edx_toggles.toggles import WaffleSwitch
 
-default_app_config = 'openedx.core.djangoapps.programs.apps.ProgramsConfig'
-
 PROGRAMS_WAFFLE_SWITCH_NAMESPACE = 'programs'
 
 # This is meant to be enabled until https://openedx.atlassian.net/browse/LEARNER-5573 needs to be resolved

--- a/openedx/core/djangoapps/schedules/__init__.py
+++ b/openedx/core/djangoapps/schedules/__init__.py
@@ -1,2 +1,0 @@
-# lint-amnesty, pylint: disable=missing-module-docstring
-default_app_config = 'openedx.core.djangoapps.schedules.apps.SchedulesConfig'


### PR DESCRIPTION
From the warning: Django now detects this configuration automatically.
You can remove default_app_config.

This also removes two warnings from shell startup.
