### PR TITLE
[FC-0009] fix: Pasting unit with LibraryContentBlock error

### DIFF
--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -714,10 +714,7 @@ class LibraryContentBlock(
                 if system.error_tracker is not None:
                     system.error_tracker(msg)
 
-        definition = {
-            attr_name: json.loads(attr_value)
-            for attr_name, attr_value in xml_object.attrib.items()
-        }
+        definition = dict(xml_object.attrib.items())
         return definition, children
 
     def definition_to_xml(self, resource_fs):


### PR DESCRIPTION
## Description

This fixes the error that occurs when trying to paste a unit that contains a `LibraryContentBlock`.

## Supporting information

Related Ticket:
- Fixes https://github.com/openedx/modular-learning/issues/93

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_units` flag is set
4. Navigate to Studio: http://localhost:18010/
5. Create a new Library by clicking on the **New Library** button the top right
6. After creating a new Library, click on a course
7. Create a unit or use an existing one in a subsection
8. Click on the unit to add a new a new Content Library component
9. After the component is added, click on **Select a Library** and select the Library created in the previous step then hit save
10. Navigate back to the course outline, click on the 3 vertical dots on the unit with the Content Library component
11. Click on **Copy to Clipboard**
12. Paste it, and confirm that is pasted properly without any errors

---
Private ref: [FAL-3488](https://tasks.opencraft.com/browse/FAL-3488)