### PR TITLE
fix: get registration fields from site configuration

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -190,10 +190,9 @@ def create_account_with_params(request, params):  # pylint: disable=too-many-sta
         set_custom_attribute('register_user_tpa', pipeline.running(request))
     extended_profile_fields = configuration_helpers.get_value('extended_profile_fields', [])
     # Can't have terms of service for certain SHIB users, like at Stanford
-    registration_fields = getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})
     tos_required = (
-        registration_fields.get('terms_of_service') != 'hidden' or
-        registration_fields.get('honor_code') != 'hidden'
+        extra_fields.get('terms_of_service') != 'hidden' or
+        extra_fields.get('honor_code') != 'hidden'
     )
 
     form = AccountCreationForm(


### PR DESCRIPTION
## Description

There is currently no way to control the `REGISTRATION_EXTRA_FIELDS` setting in Site Configuration.
<img width="787" alt="screen_80" src="https://github.com/openedx/edx-platform/assets/98233552/08b61f24-adad-4b29-a062-622904c0068f">

This fix adds the ability to control whether or not this field is displayed on the legacy registration page.

<img width="1288" alt="screen_81" src="https://github.com/openedx/edx-platform/assets/98233552/0b0c6f16-c22d-4044-b5e9-038ba58975a9">

<img width="785" alt="screen_78" src="https://github.com/openedx/edx-platform/assets/98233552/33dfaef6-b24c-47b9-b2e7-132d7cbdfcf3">

By default, data is taken from the settings.

Changes in the admin panel do not affect the behavior of this field in the Authn MFE:
<img width="811" alt="screen_79" src="https://github.com/openedx/edx-platform/assets/98233552/5e5e293a-ead7-43a1-8e7c-73d809ca8655">