### PR TITLE
[FC-0009] fix: Copy/Paste unit with python_lib.zip

### DIFF
--- a/openedx/core/lib/xblock_serializer/block_serializer.py
+++ b/openedx/core/lib/xblock_serializer/block_serializer.py
@@ -38,7 +38,7 @@ class XBlockSerializer:
             if path not in [sf.name for sf in self.static_files]:
                 self.static_files.append(StaticFile(name=path, url=asset['url'], data=None))
 
-        if block.scope_ids.usage_id.block_type == 'problem':
+        if block.scope_ids.usage_id.block_type in ['problem', 'vertical']:
             py_lib_zip_file = utils.get_python_lib_zip_if_using(self.olx_str, course_key)
             if py_lib_zip_file:
                 self.static_files.append(py_lib_zip_file)


### PR DESCRIPTION
## Description

This fixes the issue when pasting a copied unit that contains python_lib.zip file into another course. The python_lib.zip file was not being correctly copied over to the new course's Files & Uploads page.

**Note:** There is a bug with the new files notification banner not showing up, that is fixed as part of a separate PR https://github.com/openedx/edx-platform/pull/33197

## Supporting information

Related Ticket:
- Fixes https://github.com/openedx/modular-learning/issues/94

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_units` flag is set
4. Navigate to Studio: http://localhost:18010/
5. Make sure you have **2** courses created
6. Click on one of the courses and navigate to the **Files & Uploads** page
7. Upload a `python_lib.zip` file. You can use this one here: https://github.com/openedx/edx-platform/blob/6e28ba329e0a5354d7264ea834861bf0cae4ceb3/common/test/data/uploads/python_lib.zip 
8. Create a unit or use an existing one in a subsection in the same course you uploaded the python_lib.zip file to
9. Click on the unit to add a new a new **Problem** -> **Advanced** -> **Custom Python-Evaluated Input** component
10. Navigate back to the course outline, click on the 3 vertical dots on the unit you added the python problem component to
11. Click on **Copy to Clipboard**
12. Navigate to the other course you have in Studio
13. Paste the unit in one of the subsections, confirm that it pasted properly
14. Navigate to the **Files & Uploads** page of that course and confirm that the `python_lib.zip` file has been copied over

---
Private ref: [FAL-3489](https://tasks.opencraft.com/browse/FAL-3489)