### PR TITLE
fix: move notification generation event within task

### DIFF
--- a/openedx/core/djangoapps/notifications/events.py
+++ b/openedx/core/djangoapps/notifications/events.py
@@ -62,16 +62,16 @@ def notification_preferences_viewed_event(request, course_id):
         )
 
 
-def notification_generated_event(notification_data):
+def notification_generated_event(user_ids, app_name, notification_type, course_key):
     """
     Emit an event when a notification is generated.
     """
-    context = contexts.course_context_from_course_id(notification_data.get('course_key', ''))
+    context = contexts.course_context_from_course_id(course_key)
     event_data = {
-        'recipients_id': notification_data.get('user_ids', []),
-        'course_id': notification_data.get('course_key', ''),
-        'notification_type': notification_data.get('notification_type', ''),
-        'notification_app': notification_data.get('notification_app', ''),
+        'recipients_id': user_ids,
+        'course_id': course_key,
+        'notification_type': notification_type,
+        'notification_app': app_name,
     }
     with tracker.get_tracker().context(NOTIFICATION_GENERATED, context):
         tracker.emit(

--- a/openedx/core/djangoapps/notifications/handlers.py
+++ b/openedx/core/djangoapps/notifications/handlers.py
@@ -13,7 +13,6 @@ from openedx_events.learning.signals import (
 )
 
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
-from openedx.core.djangoapps.notifications.events import notification_generated_event
 from openedx.core.djangoapps.notifications.models import CourseNotificationPreference
 
 log = logging.getLogger(__name__)
@@ -59,4 +58,3 @@ def generate_user_notifications(signal, sender, notification_data, metadata, **k
     notification_data = notification_data.__dict__
     notification_data['course_key'] = str(notification_data['course_key'])
     send_notifications.delay(**notification_data)
-    notification_generated_event(notification_data)

--- a/openedx/core/djangoapps/notifications/tasks.py
+++ b/openedx/core/djangoapps/notifications/tasks.py
@@ -14,6 +14,7 @@ from pytz import UTC
 
 from common.djangoapps.student.models import CourseEnrollment
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
+from openedx.core.djangoapps.notifications.events import notification_generated_event
 from openedx.core.djangoapps.notifications.models import (
     CourseNotificationPreference,
     Notification,
@@ -116,6 +117,7 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
             )
     # send notification to users but use bulk_create
     Notification.objects.bulk_create(notifications)
+    notification_generated_event(user_ids, app_name, notification_type, course_key)
 
 
 def update_user_preference(preference: CourseNotificationPreference, user, course_id):


### PR DESCRIPTION
### [INF-1019](https://2u-internal.atlassian.net/browse/INF-1019)

### Description

The notification generated event was not part of the task of notification creation. This PR moves the event to be part of the task responsible of handling notification creation.