### PR TITLE
[FC-0009] fix: Vertically center align Unit paste spinner

### DIFF
--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -314,7 +314,11 @@ function(
                         </span>
                     </h3>
                     <div class="${category}-header-actions" style="width: 50%; text-align: right;">
-                        <span class="icon fa fa-spinner fa-pulse fa-spin" aria-hidden="true"></span>
+                        <ul class="actions-list nav-dd ui-right">
+                            <li class="action-item">
+                                <span class="icon fa fa-spinner fa-pulse fa-spin" aria-hidden="true"></span>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             `;


### PR DESCRIPTION
## Description

This vertically center aligns the spinner animation that appears when pasting a Unit.

## Supporting information

Related Ticket:
- https://github.com/openedx/modular-learning/issues/92

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_units` flag is set
4. Navigate to Studio: http://localhost:18010/
5. Create a unit or use an existing one in a subsection
6. Click on the 3 vertical dots on the unit
7. Click on **Copy to Clipboard**
8. Paste the unit in one of the subsections, confirm that the paste spinner is centered
![Screen Shot 2023-09-05 at 1 31 12 PM](https://github.com/openedx/edx-platform/assets/6829768/4c007440-e485-4760-aacb-b66308951251)

---
Private ref: [FAL-3492](https://tasks.opencraft.com/browse/FAL-3492)