### PR TITLE
build: Fix the docs build.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.8"
 
 sphinx:
-  configuration: source/conf.py
+  configuration: docs/conf.py
 
 python:
   install:


### PR DESCRIPTION
We were pointing to the wrong location for the conf.py file previously.
Correct this so that the docs build works.
