### PR TITLE
fix: fix course_id param for generated event

### DIFF
--- a/openedx/core/djangoapps/notifications/events.py
+++ b/openedx/core/djangoapps/notifications/events.py
@@ -69,7 +69,7 @@ def notification_generated_event(user_ids, app_name, notification_type, course_k
     context = contexts.course_context_from_course_id(course_key)
     event_data = {
         'recipients_id': user_ids,
-        'course_id': course_key,
+        'course_id': str(course_key),
         'notification_type': notification_type,
         'notification_app': app_name,
     }


### PR DESCRIPTION
### [INF-1019](https://2u-internal.atlassian.net/browse/INF-1019)

### Description

This PR addresses the issue raised by sending CourseLocator object instead of course_id when emitting generated event for notifications.

Fixes the following issue in the events pipeline:

```python
raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type CourseLocator is not JSON serializable
```

