### PR TITLE
feat: added notification_expiry_days in notification count api

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -550,6 +550,16 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         self.assertEqual(response.data['count'], 0)
         self.assertEqual(response.data['count_by_app_name'], {'discussion': 0})
 
+    def test_get_expiry_days_in_count_view(self):
+        """
+        Tests if "notification_expiry_days" exists in API response
+        """
+        user = UserFactory()
+        self.client.login(username=user.username, password='test')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['notification_expiry_days'], 60)
+
 
 class MarkNotificationsSeenAPIViewTestCase(APITestCase):
     """

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -298,7 +298,8 @@ class NotificationCountView(APIView):
             "count_by_app_name": {
                 (str) app_name: (int) number_of_unseen_notifications,
                 ...
-            }
+            },
+            "notification_expiry_days": 60
         }
         ```
         **Response Error Codes**:
@@ -328,6 +329,7 @@ class NotificationCountView(APIView):
             "show_notifications_tray": show_notifications_tray,
             "count": count_total,
             "count_by_app_name": count_by_app_name_dict,
+            "notification_expiry_days": settings.NOTIFICATIONS_EXPIRY
         })
 
 


### PR DESCRIPTION
Added `notification_expiry_days` in notification count api

Ticket Link: [INF-958](https://2u-internal.atlassian.net/browse/INF-958)