### PR TITLE
fix: hide sequences & sections when access is restricted in units 

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -303,9 +303,20 @@ class OutlineTabView(RetrieveAPIView):
             )
             available_seq_ids = {str(usage_key) for usage_key in user_course_outline.sequences}
 
+            available_section_ids = {str(section.usage_key) for section in user_course_outline.sections}
+
+            # course_blocks is a reference to the root of the course,
+            # so we go through the chapters (sections) and keep only those
+            # which are part of the outline.
+            course_blocks['children'] = [
+                chapter_data
+                for chapter_data in course_blocks.get('children', [])
+                if chapter_data['id'] in available_section_ids
+            ]
+
             # course_blocks is a reference to the root of the course, so we go
             # through the chapters (sections) to look for sequences to remove.
-            for chapter_data in course_blocks.get('children', []):
+            for chapter_data in course_blocks['children']:
                 chapter_data['children'] = [
                     seq_data
                     for seq_data in chapter_data['children']

--- a/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
@@ -40,6 +40,7 @@ from ..models import (
     UserPartitionGroup
 )
 from .permissions import can_see_all_content
+from .processors.cohort_partition_groups import CohortPartitionGroupsOutlineProcessor
 from .processors.content_gating import ContentGatingOutlineProcessor
 from .processors.enrollment import EnrollmentOutlineProcessor
 from .processors.enrollment_track_partition_groups import EnrollmentTrackPartitionGroupsOutlineProcessor
@@ -328,6 +329,7 @@ def _get_user_course_outline_and_processors(course_key: CourseKey,  # lint-amnes
         ('visibility', VisibilityOutlineProcessor),
         ('enrollment', EnrollmentOutlineProcessor),
         ('enrollment_track_partitions', EnrollmentTrackPartitionGroupsOutlineProcessor),
+        ('cohorts_partitions', CohortPartitionGroupsOutlineProcessor),
     ]
 
     # Run each OutlineProcessor in order to figure out what items we have to

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/cohort_partition_groups.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/cohort_partition_groups.py
@@ -1,0 +1,88 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
+import logging
+from datetime import datetime
+from typing import Union
+
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.core import types
+from openedx.core.djangoapps.course_groups.cohorts import (
+    get_cohort,
+    get_cohorted_user_partition_id,
+    get_group_info_for_cohort,
+)
+
+from .base import OutlineProcessor
+
+log = logging.getLogger(__name__)
+
+
+class CohortPartitionGroupsOutlineProcessor(OutlineProcessor):
+    """
+    Processor for applying cohort user partition groups.
+
+    """
+    def __init__(self, course_key: CourseKey, user: types.User, at_time: datetime):
+        super().__init__(course_key, user, at_time)
+        self.user_cohort_group_id: Union[int, None] = None
+        self.cohorted_partition_id: Union[int, None] = None
+
+    def load_data(self, full_course_outline) -> None:
+        """
+        Load the cohorted partition id and the user's group id.
+        """
+
+        # It is possible that a cohort is not linked to any content group/partition.
+        # This is why the cohorted_partition_id needs to be set independently
+        # of a particular user's cohort.
+        self.cohorted_partition_id = get_cohorted_user_partition_id(self.course_key)
+
+        if self.cohorted_partition_id:
+            user_cohort = get_cohort(self.user, self.course_key)
+
+            if user_cohort:
+                self.user_cohort_group_id, _ = get_group_info_for_cohort(user_cohort)
+
+    def _is_user_excluded_by_partition_group(self, user_partition_groups) -> bool:
+        """
+        Is the user part of the group to which the block is restricting content?
+        """
+        if not user_partition_groups:
+            return False
+
+        groups = user_partition_groups.get(self.cohorted_partition_id)
+        if not groups:
+            return False
+
+        if self.user_cohort_group_id not in groups:
+            # If the user's group (cohort) does not belong
+            # to the partition of the block or the user's cohort
+            # is not linked to a content group (user_cohort_group_id is None),
+            # the block should be removed
+            return True
+        return False
+
+    def usage_keys_to_remove(self, full_course_outline):
+        """
+        Content group exclusions remove the content entirely.
+
+        Remove sections and sequences inacessible by the user's
+        cohort.
+        """
+        if not self.cohorted_partition_id:
+            return frozenset()
+
+        removed_usage_keys = set()
+        for section in full_course_outline.sections:
+            remove_all_children = False
+            if self._is_user_excluded_by_partition_group(
+                section.user_partition_groups
+            ):
+                removed_usage_keys.add(section.usage_key)
+                remove_all_children = True
+            for seq in section.sequences:
+                if remove_all_children or self._is_user_excluded_by_partition_group(
+                    seq.user_partition_groups
+                ):
+                    removed_usage_keys.add(seq.usage_key)
+        return removed_usage_keys

--- a/openedx/core/djangoapps/content/learning_sequences/data.py
+++ b/openedx/core/djangoapps/content/learning_sequences/data.py
@@ -250,10 +250,16 @@ class CourseOutlineData:
         """
         keys_to_remove = set(usage_keys)
 
-        # If we remove a Section, we also remove all Sequences in that Section.
         for section in self.sections:
+            section_sequences_keys = {seq.usage_key for seq in section.sequences}
+
+            # If we remove a Section, we also remove all Sequences in that Section.
             if section.usage_key in keys_to_remove:
-                keys_to_remove |= {seq.usage_key for seq in section.sequences}
+                keys_to_remove |= section_sequences_keys
+
+            # If a Section is empty or about to be, we remove it.
+            elif section_sequences_keys.issubset(keys_to_remove):
+                keys_to_remove.add(section.usage_key)
 
         return attr.evolve(
             self,

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -619,3 +619,17 @@ def _get_cohort_settings_from_modulestore(course):
         'cohorted_discussions': list(course.cohorted_discussions),
         'always_cohort_inline_discussions': course.always_cohort_inline_discussions
     }
+
+
+def get_cohorted_user_partition_id(course_key):
+    """
+    Returns the partition id to which cohorts are linked or None if there is no cohort linked
+    to a content group.
+    """
+    course_user_group_partition_group = CourseUserGroupPartitionGroup.objects.filter(
+        course_user_group__course_id=course_key
+    ).first()
+
+    if course_user_group_partition_group:
+        return course_user_group_partition_group.partition_id
+    return None


### PR DESCRIPTION
### [ISSUE #32892](https://github.com/openedx/edx-platform/issues/32892)

## Description

This PR addresses [Issue#32892](https://github.com/openedx/edx-platform/issues/32892). The problem is that users who don't have access to any units in a sequence, because their cohort lacks the permission, can still see the sequence in their outline in the `frontend-app-learning`.  The same applies to sections. If a user doesn't have access to all the section's sequences, the section should not be part of the outline.


~~As the issue mentions, there is a [function ](https://github.com/openedx/edx-platform/blob/b97007e1823320c3d97b5a84b0c988d888250e84/cms/djangoapps/contentstore/outlines.py#L106-L153) that bubbles up access groups from Units to the parent Sequence in case all Units have the same access. This PR generalizes the function and applies it to bubble up access groups from Sequences to the parent Section in case all Sequences have the same access.~~  => [No bubbling to avoid performance issues](https://github.com/openedx/edx-platform/issues/32892#issuecomment-1712945092)

To get the outline, we rely on a list of [processors](https://github.com/openedx/edx-platform/blob/b97007e1823320c3d97b5a84b0c988d888250e84/openedx/core/djangoapps/content/learning_sequences/api/outlines.py#L323-L332). From what I can tell, only [EnrollmentTrackPartitionGroupsOutlineProcessor](https://github.com/openedx/edx-platform/blob/e480a79d9cbb0f653e3ea48a0f89d66c8a04bca9/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py#L23) removes inaccessible Sections/Sequences by relying on `User Partitions`, but as the name implies, only in the case of Enrollment Track restrictions, not cohorts.  That's why this PR introduces a new `CohortPartitionGroupsOutlineProcessor`.


## Supporting information

- I created `get_cohorted_user_partition_id` in  `openedx/core/djangoapps/course_groups/cohorts.py` because there is a need to retrieve the course's cohorted partition id, to check cohorted access. The function must solely rely on a Django Model (MySql) unlike other functions in the same file which in multiple cases lead to an interaction with the `modulestore`, and this is [prohibited in all OutlineProcessor](https://github1s.com/openedx/edx-platform/blob/b97007e1823320c3d97b5a84b0c988d888250e84/openedx/core/djangoapps/content/learning_sequences/api/processors/base.py#L56-L57).

## Testing instructions

- Launch DevStack
- Login/Sign up as a non-staff user (`user2` for example) and enroll in the Demo Course.
- The user can access all Sections/Sequences/Units. (e.g. **Introduction** > **Demo Course Overview** > **Introduction: Video and Sequences**)
- In another session (Incognito/ different browser), log in as admin 
- Head to the [course studio group settings
](http://localhost:18010/group_configurations/course-v1:edX+DemoX+Demo_Course)  and create a Content Group `group1`.
- [create a cohort](http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-cohort_management)  `cohort1`  in **Instructor** Tab > **Cohorts** Tab in the LMS and link it to `group1`. 
-
- We create another cohort `cohort2` without assigning it to any group. Assign `user2` to `cohort2` in the same tab.
- In the [studio course outline](http://localhost:18010/course/course-v1:edX+DemoX+Demo_Course), we choose a Section with a single Sequence that has a Single Unit and restrict its access to `group2`  for instance, [**Introduction: Video and Sequences**](http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@edx_introduction/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc)
- Upon accessing the[ frontend-app outline](http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/home), `user2` will be able to see the Section & Sequence even if he doesn't have access to the underlying Unit.

The video below recreates the problem. At the end, `user2` should not be able to see the **Introduction**  Section, nor the  **Demo Course Overview** Sequence.

https://github.com/openedx/edx-platform/assets/28169169/031597d2-9a12-40dc-9c22-68ccfe7391a8


After applying this PR, the Sequences whose Units are inaccessible will not show in the outline. Neither will the Sections whose Sequences are inaccessible.



