### PR TITLE
fix: make updates to notification related events

### DIFF
--- a/openedx/core/djangoapps/notifications/tasks.py
+++ b/openedx/core/djangoapps/notifications/tasks.py
@@ -116,8 +116,12 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
                 )
             )
     # send notification to users but use bulk_create
-    Notification.objects.bulk_create(notifications)
-    notification_generated_event(user_ids, app_name, notification_type, course_key)
+    notifications_generated = Notification.objects.bulk_create(notifications)
+    if notifications_generated:
+        notification_content = notifications_generated[0].content
+        notification_generated_event(
+            user_ids, app_name, notification_type, course_key, content_url, notification_content,
+        )
 
 
 def update_user_preference(preference: CourseNotificationPreference, user, course_id):

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -407,6 +407,7 @@ class NotificationListAPIViewTest(APITestCase):
         event_name, event_data = mock_emit.call_args[0]
         self.assertEqual(event_name, 'edx.notifications.tray_opened')
         self.assertEqual(event_data['user_id'], self.user.id)
+        self.assertEqual(event_data['unseen_notifications_count'], 0)
 
     def test_list_notifications_without_authentication(self):
         """
@@ -652,6 +653,7 @@ class NotificationReadAPIViewTestCase(APITestCase):
         self.assertEqual(event_data.get('notification_metadata').get('notification_id'), notification_id)
         self.assertEqual(event_data['notification_app'], 'discussion')
         self.assertEqual(event_data['notification_type'], 'Type A')
+        self.assertEqual(event_data['first_read'], True)
 
     def test_mark_notification_read_with_other_user_notification_id(self):
         # Create a PATCH request to mark notification as read for notification_id: 2 through a different user


### PR DESCRIPTION
### [INF-1044](https://2u-internal.atlassian.net/browse/INF-1044)
### [INF-1046](https://2u-internal.atlassian.net/browse/INF-1046)
### [INF-1037](https://2u-internal.atlassian.net/browse/INF-1037)


### Description

Updates to notification events. Updated include the following changes:

- `edx.notifications.generated`: added new fields to generated event including `content_url`, `notification_content`, `recipients_count` (number of recipients) and`recipients_truncated`(if recipient_ids list has been truncated).
- `edx.notifications.read`: added new field `first_read` to indicate if the event was the first read of the notification
- `edx.notifications.tray_opened`: added new field `unseen_notification_count` to indicate the number of unseen notification count seen by user when the notification tray is opened