### PR TITLE
feat!: CsrfViewMiddleware now uses `CSRF_COOKIE_NEEDS_UPDATE` in place of`CSRF_COOKIE_USED`

### DIFF
--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -127,7 +127,7 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
 
         if django.VERSION < (4, 2):
             csrf_cookie_usage = request.META.get('CSRF_COOKIE_USED', False)
-        else:  # django 42 has new cookie name
+        else:   # django 42 has new cookie name
             csrf_cookie_usage = request.META.get('CSRF_COOKIE_NEEDS_UPDATE', False)
 
         should_set_cookie = (

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -127,7 +127,7 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
 
         if django.VERSION < (4, 2):
             csrf_cookie_usage = request.META.get('CSRF_COOKIE_USED', False)
-        else:   # django 42 has new cookie name
+        else:  # django 42 has new cookie name
             csrf_cookie_usage = request.META.get('CSRF_COOKIE_NEEDS_UPDATE', False)
 
         should_set_cookie = (

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -45,6 +45,7 @@ CSRF cookie.
 
 import logging
 
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
 from django.middleware.csrf import CsrfViewMiddleware
@@ -123,9 +124,15 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
         # Check whether (a) the CSRF middleware has already set a cookie, and
         # (b) this is a view decorated with `@ensure_cross_domain_csrf_cookie`
         # If so, we can send the cross-domain CSRF cookie.
+
+        if django.VERSION < (4, 2):
+            csrf_cookie_usage = request.META.get('CSRF_COOKIE_USED', False)
+        else:   # django 42 has new cookie name
+            csrf_cookie_usage = request.META.get('CSRF_COOKIE_NEEDS_UPDATE', False)
+
         should_set_cookie = (
             request.META.get('CROSS_DOMAIN_CSRF_COOKIE_USED', False) and
-            request.META.get('CSRF_COOKIE_USED', False) and
+            csrf_cookie_usage and
             request.META.get('CSRF_COOKIE') is not None
         )
 

--- a/openedx/core/djangoapps/cors_csrf/tests/test_decorators.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_decorators.py
@@ -3,6 +3,7 @@
 
 import json
 from unittest import mock
+import django
 from django.http import HttpResponse
 from django.test import TestCase
 
@@ -25,4 +26,8 @@ class TestEnsureCsrfCookieCrossDomain(TestCase):
         response = wrapped_view(request)
         response_meta = json.loads(response.content.decode('utf-8'))
         assert response_meta['CROSS_DOMAIN_CSRF_COOKIE_USED'] is True
-        assert response_meta['CSRF_COOKIE_USED'] is True
+
+        if django.VERSION < (4, 2):
+            assert response_meta['CSRF_COOKIE_USED'] is True
+        else:
+            assert response_meta['CSRF_COOKIE_NEEDS_UPDATE'] is True    # django 42 has new cookie name

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -6,6 +6,7 @@ Tests for the CORS CSRF middleware
 from unittest.mock import patch, Mock
 import ddt
 import pytest
+import django
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.core.exceptions import MiddlewareNotUsed, ImproperlyConfigured
@@ -258,7 +259,10 @@ class TestCsrfCrossDomainCookieMiddleware(TestCase):
             del request.META['HTTP_REFERER']
 
         if csrf_cookie_used:
-            request.META['CSRF_COOKIE_USED'] = True
+            if django.VERSION < (4, 2):
+                request.META['CSRF_COOKIE_USED'] = True
+            else:
+                request.META['CSRF_COOKIE_NEEDS_UPDATE'] = True     # django 42 has new cookie name
             request.META['CSRF_COOKIE'] = self.COOKIE_VALUE
 
         if cross_domain_decorator:


### PR DESCRIPTION
Issue https://github.com/openedx/edx-platform/issues/33207

[CsrfViewMiddleware](https://django.readthedocs.io/en/latest/ref/middleware.html#django.middleware.csrf.CsrfViewMiddleware) 
**now uses request.META['CSRF_COOKIE_NEEDS_UPDATE'] in place of request.META['CSRF_COOKIE_USED'], request.csrf_cookie_needs_reset, and response.csrf_cookie_set to track whether the CSRF cookie should be sent. This is an undocumented, private API.**

https://django.readthedocs.io/en/latest/releases/4.0.html

`This PR will fix following test in django42 env.`

`openedx/core/djangoapps/cors_csrf/tests/test_decorators.py::TestEnsureCsrfCookieCrossDomain::test_ensure_csrf_cookie_cross_domain
`

Related django [PR](https://github.com/django/django/pull/14688) 