### PR TITLE
fix: fix notification generated event to include only users with preferences enabled

### DIFF
--- a/openedx/core/djangoapps/notifications/tasks.py
+++ b/openedx/core/djangoapps/notifications/tasks.py
@@ -98,6 +98,7 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
     )
     preferences = create_notification_pref_if_not_exists(user_ids, list(preferences), course_key)
     notifications = []
+    audience = []
     for preference in preferences:
         preference = update_user_preference(preference, preference.user, course_key)
         if (
@@ -115,12 +116,13 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
                     course_id=course_key,
                 )
             )
+            audience.append(preference.user_id)
     # send notification to users but use bulk_create
     notifications_generated = Notification.objects.bulk_create(notifications)
     if notifications_generated:
         notification_content = notifications_generated[0].content
         notification_generated_event(
-            user_ids, app_name, notification_type, course_key, content_url, notification_content,
+            audience, app_name, notification_type, course_key, content_url, notification_content,
         )
 
 


### PR DESCRIPTION
### Description

Update the notification generated event to have filtered `user_ids`, that have preferences enabled for the notification being sent out.
Currently, all the `user_ids` requested from the notification are being sent to the event, this fix limits the `user_ids` to those who have preferences for notification enabled!