### PR TITLE
fix: remove django-ipware constraint

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -2,10 +2,6 @@
 # In edx-lint, until the pyjwt constraint in edx-lint has been removed.
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -2,6 +2,10 @@
 # In edx-lint, until the pyjwt constraint in edx-lint has been removed.
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -86,7 +86,6 @@ social-auth-core==4.3.0
 babel==2.11.0
 social-auth-app-django==5.0.0
 algoliasearch==2.6.3
-django-ipware==4.0.2
 
 # pytz>2022 has major changes which are causing test failures.
 # Pinning this version for now so this could be fixed in a separate PR later on

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -289,9 +289,8 @@ django-filter==23.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==4.0.2
+django-ipware==5.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -475,9 +475,8 @@ django-filter==23.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==4.0.2
+django-ipware==5.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -346,9 +346,8 @@ django-filter==23.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==4.0.2
+django-ipware==5.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -379,9 +379,8 @@ django-filter==23.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==4.0.2
+django-ipware==5.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring


### PR DESCRIPTION
## Description
- Removed the `django-ipware==4.0.2` constraint which was added to avoid upgrading multiple packages at once when upgrading boto to boto3
- No breaking change in the updated version `django-ipware==5.0.0` [[CHANGELOG](https://github.com/un33k/django-ipware/blob/master/CHANGELOG.md#500)]