### PR TITLE
feat!: Django 4.0 and above, CSRF_TRUSTED_ORIGINS must include scheme.

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -14,7 +14,6 @@ import warnings
 import yaml
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
-import django
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from edx_django_utils.plugins import add_plugins
@@ -591,13 +590,6 @@ derive_settings(__name__)
 # This is at the bottom because it is going to load more settings after base settings are loaded
 
 add_plugins(__name__, ProjectType.CMS, SettingsType.PRODUCTION)
-
-# Determines which origins are trusted for unsafe requests eg. POST requests.
-CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS', [])
-# values are already updated above with default CSRF_TRUSTED_ORIGINS values but in
-# case of new django version these values will override.
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS_WITH_SCHEME', [])
 
 ############# CORS headers for cross-domain requests #################
 if FEATURES.get('ENABLE_CORS_HEADERS'):

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -14,6 +14,7 @@ import warnings
 import yaml
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from edx_django_utils.plugins import add_plugins
@@ -590,6 +591,13 @@ derive_settings(__name__)
 # This is at the bottom because it is going to load more settings after base settings are loaded
 
 add_plugins(__name__, ProjectType.CMS, SettingsType.PRODUCTION)
+
+# Determines which origins are trusted for unsafe requests eg. POST requests.
+CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS', [])
+# values are already updated above with default CSRF_TRUSTED_ORIGINS values but in
+# case of new django version these values will override.
+if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
+    CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS_WITH_SCHEME', [])
 
 ############# CORS headers for cross-domain requests #################
 if FEATURES.get('ENABLE_CORS_HEADERS'):

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -345,4 +345,3 @@ class ExperimentUserMetaDataViewTests(APITestCase, ModuleStoreTestCase):
         response = self.client.get(reverse('api_experiments:user_metadata', args=call_args_with_bogus_course))
         assert response.status_code == 404
         assert response.json()['message'] == 'Provided course is not found'
-

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -166,6 +166,10 @@ class ExperimentDataViewSetTests(APITestCase, ModuleStoreTestCase):  # lint-amne
         response = self.client.patch(url, data)
         assert response.status_code == 404
 
+    def test_loads_valid_csrf_trusted_origins_list(self):
+        """checking CSRF_TRUSTED_ORIGINS here. in django4.2 they will require schemes"""
+        assert settings.CSRF_TRUSTED_ORIGINS == ['.example.com']
+
 
 def cross_domain_config(func):
     """Decorator for configuring a cross-domain request. """
@@ -341,3 +345,4 @@ class ExperimentUserMetaDataViewTests(APITestCase, ModuleStoreTestCase):
         response = self.client.get(reverse('api_experiments:user_metadata', args=call_args_with_bogus_course))
         assert response.status_code == 404
         assert response.json()['message'] == 'Provided course is not found'
+

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import six.moves.urllib.parse
 from datetime import timedelta
+import django
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
 from django.test.utils import override_settings
@@ -168,7 +169,10 @@ class ExperimentDataViewSetTests(APITestCase, ModuleStoreTestCase):  # lint-amne
 
     def test_loads_valid_csrf_trusted_origins_list(self):
         """checking CSRF_TRUSTED_ORIGINS here. in django4.2 they will require schemes"""
-        assert settings.CSRF_TRUSTED_ORIGINS == ['.example.com']
+        if django.VERSION[0] < 4:  # for greater than django 3.2 use schemes.
+            assert settings.CSRF_TRUSTED_ORIGINS == ['.example.com']
+        else:
+            assert settings.CSRF_TRUSTED_ORIGINS == ['https://*.example.com']
 
 
 def cross_domain_config(func):

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -23,6 +23,7 @@ import os
 
 import yaml
 from corsheaders.defaults import default_headers as corsheaders_default_headers
+import django
 from django.core.exceptions import ImproperlyConfigured
 from edx_django_utils.plugins import add_plugins
 from path import Path as path
@@ -366,6 +367,8 @@ CSRF_COOKIE_SECURE = ENV_TOKENS.get('CSRF_COOKIE_SECURE', False)
 
 # Determines which origins are trusted for unsafe requests eg. POST requests.
 CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS', [])
+if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
+    CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS_WITH_SCHEME', [])
 
 ############# CORS headers for cross-domain requests #################
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -367,6 +367,8 @@ CSRF_COOKIE_SECURE = ENV_TOKENS.get('CSRF_COOKIE_SECURE', False)
 
 # Determines which origins are trusted for unsafe requests eg. POST requests.
 CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS', [])
+# values are already updated above with default CSRF_TRUSTED_ORIGINS values but in
+# case of new django version these values will override.
 if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
     CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS_WITH_SCHEME', [])
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -681,7 +681,7 @@ SUBSCRIPTIONS_TRIAL_LENGTH = 7
 CSRF_TRUSTED_ORIGINS = ['.example.com']
 CSRF_TRUSTED_ORIGINS_WITH_SCHEME = ['https://example.com']
 
-# values are already updated above with default CORS_ORIGIN_WHITELIST values but in
-# case of new version django_cors_headers they will get override.
+# values are already updated above with default CSRF_TRUSTED_ORIGINS values but in
+# case of new django version these values will override.
 if django.VERSION[0] >= 4:  # for greater than django 3.2 use with schemes.
     CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -18,6 +18,7 @@ from collections import OrderedDict
 from uuid import uuid4
 
 import openid.oidutil
+import django
 from django.utils.translation import gettext_lazy
 from edx_django_utils.plugins import add_plugins
 from path import Path as path
@@ -677,3 +678,10 @@ SUBSCRIPTIONS_BUY_SUBSCRIPTION_URL = f"{SUBSCRIPTIONS_ROOT_URL}/api/v1/stripe-su
 SUBSCRIPTIONS_MANAGE_SUBSCRIPTION_URL = None
 SUBSCRIPTIONS_MINIMUM_PRICE = '$39'
 SUBSCRIPTIONS_TRIAL_LENGTH = 7
+CSRF_TRUSTED_ORIGINS = ['.example.com']
+CSRF_TRUSTED_ORIGINS_WITH_SCHEME = ['https://example.com']
+
+# values are already updated above with default CORS_ORIGIN_WHITELIST values but in
+# case of new version django_cors_headers they will get override.
+if django.VERSION[0] >= 4:  # for greater than django 3.2 use with schemes.
+    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -679,7 +679,7 @@ SUBSCRIPTIONS_MANAGE_SUBSCRIPTION_URL = None
 SUBSCRIPTIONS_MINIMUM_PRICE = '$39'
 SUBSCRIPTIONS_TRIAL_LENGTH = 7
 CSRF_TRUSTED_ORIGINS = ['.example.com']
-CSRF_TRUSTED_ORIGINS_WITH_SCHEME = ['https://example.com']
+CSRF_TRUSTED_ORIGINS_WITH_SCHEME = ['https://*.example.com']
 
 # values are already updated above with default CSRF_TRUSTED_ORIGINS values but in
 # case of new django version these values will override.


### PR DESCRIPTION
PR created under issue https://github.com/openedx/edx-platform/issues/33228

django4.0 = https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins

django3.2 = https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins

Right now doing this for sandbox only.

1. https://github.com/edx/sandbox-internal/pull/326/files
3. https://github.com/edx/edx-internal/pull/9206/files
4. https://github.com/edx/edge-internal/pull/581/files