### PR TITLE
fix: turn off atomic requests for course api get views

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -5,6 +5,7 @@ Tests for the Course Home Course Metadata API in the Course Home API
 import ddt
 import json
 import mock
+from django.db import transaction
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 from unittest.mock import patch
@@ -86,7 +87,9 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
 
     def test_get_unknown_course(self):
         url = reverse('course-home:course-metadata', args=['course-v1:unknown+course+2T2020'])
-        response = self.client.get(url)
+        # Django TestCase wraps every test in a transaction, so we must specifically wrap this when we expect an error
+        with transaction.atomic():
+            response = self.client.get(url)
         assert response.status_code == 404
 
     def _assert_course_access_response(self, response, expect_course_access, expected_error_code):

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -2,6 +2,8 @@
 General view for the Course Home that contains metadata every page needs.
 """
 
+from django.db import transaction
+from django.utils.decorators import method_decorator
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.response import Response
@@ -23,6 +25,7 @@ from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 
 
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
 class CourseHomeMetadataView(RetrieveAPIView):
     """
     **Use Cases**

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -4,6 +4,8 @@ Course API Views
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
 from django.conf import settings
+from django.db import transaction
+from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from edx_django_utils.cache import TieredCache
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
@@ -368,6 +370,7 @@ class CoursewareMeta:
         return learning_assistant_is_active(self.course_key)
 
 
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
 class CoursewareInformation(RetrieveAPIView):
     """
     **Use Cases**


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/AU-1450

Deadlock errors for `lms.djangoapps.course_home_api.course_metadata.views:CourseHomeMetadataView.get` and `openedx.core.djangoapps.courseware_api.views:CoursewareInformation.get` are the number 2 and 5 most common error we see. 

The views do no writing besides some minor user tracking, so we can simply mark them as nonatomic

