### PR TITLE
fix: `session_language` should be renamed to `update_language`

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -325,7 +325,7 @@
               % if user.is_authenticated:
               <input title="preference api" type="hidden" id="preference-api-url" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
               % else:
-              <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+              <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
               % endif
               <label><span class="sr">${_("Choose Language")}</span>
               <select class="input select language-selector" id="settings-language-value" name="language">

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -90,7 +90,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             % if user.is_authenticated:
                 <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
             % else:
-                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
             % endif
             <label><span class="sr">${_("Choose Language")}</span>
             <select class="input select language-selector" id="settings-language-value" name="language">

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -58,7 +58,7 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
                 % if user.is_authenticated:
                   <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
                 % else:
-                  <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                  <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
                 % endif
                 <label><span class="sr">${_("Choose Language")}</span>
                   <select class="input select language-selector" id="settings-language-value" name="language">


### PR DESCRIPTION
fix: `session_language` should be renamed to `update_language`

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

fix: `session_language` should be renamed to `update_language`

This is a patch to pull request #32578 because the `session_language` was renamed
to `update_language` except in three two locations causing a 500 error

```
Reverse for 'session_language' not found. 'session_language' is not a valid view function or pattern name.

Request Method: 	GET
Request URL: 	http://localhost:18000/
Django Version: 	3.2.21
Exception Type: 	NoReverseMatch
Exception Value: 	

Reverse for 'session_language' not found. 'session_language' is not a valid view function or pattern name.

Exception Location: 	/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/urls/resolvers.py, line 698, in _reverse_with_prefix
Python Executable: 	/edx/app/edxapp/venvs/edxapp/bin/python
Python Version: 	3.8.10
Python Path: 	

['/edx/app/edxapp/edx-platform',
 '/edx/app/edxapp/edx-platform',
 '/usr/lib/python38.zip',
 '/usr/lib/python3.8',
 '/usr/lib/python3.8/lib-dynload',
 '/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages',
 '/edx/app/edxapp/edx-platform']
```
![Screenshot from 2023-09-13 08-39-11](https://github.com/openedx/edx-platform/assets/17448993/7a5033c7-9fd9-4ecf-a895-862fdd30db48)

**Note:** updating assets is needed after the fix

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
