### PR TITLE
[Django 4.2]: Fix: Expected query log count

### DIFF
--- a/openedx/core/djangoapps/external_user_ids/tests/test_batch_generate_id.py
+++ b/openedx/core/djangoapps/external_user_ids/tests/test_batch_generate_id.py
@@ -2,6 +2,7 @@
 Test batch_get_or_create in ExternalId model
 """
 
+import django
 from django.test import TransactionTestCase
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.external_user_ids.models import ExternalId
@@ -19,7 +20,7 @@ class TestBatchGenerateExternalIds(TransactionTestCase):
     # 3 - Get external ids that already exists
     # 4 - BEGIN (from bulk_create)
     # 5 - Create new external ids
-    EXPECTED_NUM_OF_QUERIES = 5
+    EXPECTED_NUM_OF_QUERIES = 5 if django.VERSION < (4, 2) else 6
 
     def test_batch_get_or_create_user_ids(self):
         """


### PR DESCRIPTION
# Description

Fixes this issue when upgrading to Django 4.2

```
openedx/core/djangoapps/external_user_ids/tests/test_batch_generate_id.py::TestBatchGenerateExternalIds::test_batch_get_or_create_user_ids - AssertionError: 6 != 5 : 6 queries executed, 5 expected
Captured queries were:
1. SELECT "external_user_ids_externalidtype"."id", "external_user_ids_externalidtype"."created", "external_user_ids_externalidtype"."modified", "external_user_ids_externalidtype"."name", "external_user_ids_externalidtype"."description" FROM "external_user_ids_externalidtype" WHERE "external_user_ids_externalidtype"."name" = 'test' LIMIT 21
2. SELECT "external_user_ids_externalid"."id", "external_user_ids_externalid"."created", "external_user_ids_externalid"."modified", "external_user_ids_externalid"."external_user_id", "external_user_ids_externalid"."external_id_type_id", "external_user_ids_externalid"."user_id" FROM "external_user_ids_externalid" WHERE ("external_user_ids_externalid"."external_id_type_id" = 1 AND "external_user_ids_externalid"."user_id" IN (31, 32, 33, 34, 35, 36, 37, 38, 39, 40))
3. SELECT "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name", "auth_user"."email", "auth_user"."is_staff", "auth_user"."is_active", "auth_user"."date_joined", COUNT("external_user_ids_externalid"."id") FILTER (WHERE "external_user_ids_externalid"."external_id_type_id" = 1) AS "externalid_count" FROM "auth_user" LEFT OUTER JOIN "external_user_ids_externalid" ON ("auth_user"."id" = "external_user_ids_externalid"."user_id") WHERE "auth_user"."id" IN (32, 33, 34, 35, 36, 37, 38, 39, 40, 31) GROUP BY "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name", "auth_user"."email", "auth_user"."is_staff", "auth_user"."is_active", "auth_user"."date_joined" HAVING COUNT("external_user_ids_externalid"."id") FILTER (WHERE ("external_user_ids_externalid"."external_id_type_id" = 1)) = 0
4. BEGIN
5. INSERT INTO "external_user_ids_externalid" ("created", "modified", "external_user_id", "external_id_type_id", "user_id") VALUES ('2023-09-01 09:56:48.419272', '2023-09-01 09:56:48.419272', '9e8d1f80a3974bb1aa1c08b00f9e259e', 1, 31), ('2023-09-01 09:56:48.419363', '2023-09-01 09:56:48.419363', '306dec5b72b24ac9a95d72f0418a3518', 1, 32), ('2023-09-01 09:56:48.419417', '2023-09-01 09:56:48.419417', '1471dd390af1434f852bd35e10b891ed', 1, 33), ('2023-09-01 09:56:48.419466', '2023-09-01 09:56:48.419466', '6394e6f30f644d919262bfcb38b1e9be', 1, 34), ('2023-09-01 09:56:48.419536', '2023-09-01 09:56:48.419536', 'fb57fa59a7af42b5866af196ed384c76', 1, 35), ('2023-09-01 09:56:48.419585', '2023-09-01 09:56:48.419585', 'a9e101f97b284ec39aba4524a5df64c3', 1, 36), ('2023-09-01 09:56:48.419632', '2023-09-01 09:56:48.419632', 'd0cba7c791884645a26dbdf23892efd0', 1, 37), ('2023-09-01 09:56:48.419677', '2023-09-01 09:56:48.419677', '56b9ed9760654a23a490f98c227a89bb', 1, 38), ('2023-09-01 09:56:48.419723', '2023-09-01 09:56:48.419723', 'a5ad0e4fb3be4d6aab86cce08aec4fc7', 1, 39), ('2023-09-01 09:56:48.419767', '2023-09-01 09:56:48.419767', '018848f3cf5a478485c86e2360263cce', 1, 40)
6. COMMIT
```

This error occurs due to change in logging queries in Django 4.2
https://docs.djangoproject.com/en/4.2/releases/4.2/#logging
