### PR TITLE
feat: upgrade edx-i18n-tools to v1.2.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -490,7 +490,7 @@ edx-event-bus-kafka==5.4.0
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.3.1
     # via -r requirements/edx/kernel.in
-edx-i18n-tools==1.1.0
+edx-i18n-tools==1.2.0
     # via ora2
 edx-milestones==0.5.0
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -761,7 +761,7 @@ edx-event-bus-redis==0.3.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-i18n-tools==1.1.0
+edx-i18n-tools==1.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -564,7 +564,7 @@ edx-event-bus-kafka==5.4.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.3.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.1.0
+edx-i18n-tools==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -594,7 +594,7 @@ edx-event-bus-kafka==5.4.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.3.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.1.0
+edx-i18n-tools==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in


### PR DESCRIPTION
### Description

Upgrade to use the `--combine-po-files` parameter in future [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification) work.

This upgrade brings the following feature:

 - https://github.com/openedx/i18n-tools/pull/134 which is released in https://github.com/openedx/i18n-tools/releases/tag/v1.2.0

## Testing instructions

 - [x] Test the release itself extensively: https://gist.github.com/OmarIthawi/3de2704804401a58c01aca1ef5ab3fb5
 - [x] Ensure the upgrade is backward compatible with existing `extract_translations`

<details><summary>Test details</summary>

```
$ pip freeze | grep edx-i18n-tools
edx-i18n-tools==1.1.0
$ make extract_translations
$ cp -r conf/locale/en/LC_MESSAGES/en /tmp/en-v1.1.0

$ rm conf/locale/en/LC_MESSAGES/*
$ git checkout HEAD -- conf/locale/en/LC_MESSAGES/

$ pip install -r requirements/edx/development.txt
$ pip freeze | grep edx-i18n-tools
edx-i18n-tools==1.2.0

$ make extract_translations
$ cp -r conf/locale/en/LC_MESSAGES/en /tmp/en-v1.2.0

$ /bin/diff --report-identical-files -r /tmp/en-v1.{1,2}.0
Files en-v1.1.0/LC_MESSAGES/djangojs-account-settings-view.po and en-v1.2.0/LC_MESSAGES/djangojs-account-settings-view.po are identical
Files en-v1.1.0/LC_MESSAGES/djangojs-partial.po and en-v1.2.0/LC_MESSAGES/djangojs-partial.po are identical
Files en-v1.1.0/LC_MESSAGES/djangojs.po and en-v1.2.0/LC_MESSAGES/djangojs.po are identical
Files en-v1.1.0/LC_MESSAGES/djangojs-studio.po and en-v1.2.0/LC_MESSAGES/djangojs-studio.po are identical
Files en-v1.1.0/LC_MESSAGES/django-partial.po and en-v1.2.0/LC_MESSAGES/django-partial.po are identical
Files en-v1.1.0/LC_MESSAGES/django.po and en-v1.2.0/LC_MESSAGES/django.po are identical
Files en-v1.1.0/LC_MESSAGES/django-studio.po and en-v1.2.0/LC_MESSAGES/django-studio.po are identical
Files en-v1.1.0/LC_MESSAGES/edx_proctoring_proctortrack.po and en-v1.2.0/LC_MESSAGES/edx_proctoring_proctortrack.po are identical
Files en-v1.1.0/LC_MESSAGES/mako.po and en-v1.2.0/LC_MESSAGES/mako.po are identical
Files en-v1.1.0/LC_MESSAGES/mako-studio.po and en-v1.2.0/LC_MESSAGES/mako-studio.po are identical
Files en-v1.1.0/LC_MESSAGES/underscore.po and en-v1.2.0/LC_MESSAGES/underscore.po are identical
Files en-v1.1.0/LC_MESSAGES/underscore-studio.po and en-v1.2.0/LC_MESSAGES/underscore-studio.po are identical
Files en-v1.1.0/LC_MESSAGES/wiki.po and en-v1.2.0/LC_MESSAGES/wiki.po are identical
```
</details> 

 - [x] Rebuild devstack image on the `uprade-i18n-tools` branch and test
 - [x] Generate new pofiles and compare to existing ones

<details><summary>Diff</summary>
**Note:** There are some differences which has been neglected due to the fact `en/LC_MESSAGES/django{,js}.po` might be stale.

```diff
index 05504dc5..00000000 100644
--- a/LC_MESSAGES/django.po
+++ b/LC_MESSAGES/django.po
@@ -1,8 +1,39 @@
 msgid ""
-msgstr "Project-Id-Version: 0.1a\n"
+msgstr "#-#-#-#-#  django.po (0.1a)  #-#-#-#-#\n"
+"Project-Id-Version: 0.1a\n"
+"Report-Msgid-Bugs-To: openedx-translation@googlegroups.com\n"
+"Last-Translator: \n"
+"Language-Team: openedx-translation <openedx-translation@googlegroups.com>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"#-#-#-#-#  edx_proctoring_proctortrack.po (0.1a)  #-#-#-#-#\n"
+"Project-Id-Version: 0.1a\n"
+"Report-Msgid-Bugs-To: openedx-translation@googlegroups.com\n"
+"Last-Translator: \n"
+"Language-Team: openedx-translation <openedx-translation@googlegroups.com>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.11.0\n"
+"#-#-#-#-#  mako.po (PROJECT VERSION)  #-#-#-#-#\n"
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2023-09-16 10:10+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.11.0\n"
+"#-#-#-#-#  wiki.po (0.1a)  #-#-#-#-#\n"
+"Project-Id-Version: 0.1a\n"
 "Report-Msgid-Bugs-To: openedx-translation@googlegroups.com\n"
-"POT-Creation-Date: 2023-09-05 15:59+0000\n"
-"PO-Revision-Date: 2023-09-05 15:59:41.440074\n"
 "Last-Translator: \n"
 "Language-Team: openedx-translation <openedx-translation@googlegroups.com>\n"
 "Language: en\n"
@@ -10,7 +41,7 @@
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.11.0\n"
 
 msgid ""
 msgstr ""
@@ -1567,7 +1598,7 @@
 msgid "Blank"
 msgstr ""
 
-msgid "Blank Advanced Problem"
+msgid "Blank Problem"
 msgstr ""
 
 msgid "Block type \"{block_type}\" is not compatible with library type "
@@ -2003,9 +2034,6 @@
 "the proctoring software."
 msgstr ""
 
-msgid "Click the link to see my certificate."
-msgstr ""
-
 msgid "Click the {strong_start}Edit{strong_end} icon in a component to edit "
 "its content."
 msgstr ""
@@ -7404,10 +7432,6 @@
 msgid "Open Response Assessment Settings"
 msgstr ""
 
-msgid "Open Response Assessment due dates are set by your instructor and "
-"can't be shifted."
-msgstr ""
-
 msgid "Open Responses"
 msgstr ""
 
@@ -11008,6 +11032,10 @@
 msgid "This Course Unavailable In Your Country"
 msgstr ""
 
+msgid "This Open Response Assessment's due dates are set by your instructor "
+"and can't be shifted."
+msgstr ""
+
 msgid "This account has already been activated."
 msgstr ""
 
index 6e047d84..00000000 100644
--- a/LC_MESSAGES/djangojs.po
+++ b/LC_MESSAGES/djangojs.po
@@ -1,20 +1,41 @@
 msgid ""
-msgstr "Project-Id-Version: 0.1a\n"
+msgstr "#-#-#-#-#  djangojs.po (0.1a)  #-#-#-#-#\n"
+"Project-Id-Version: 0.1a\n"
 "Report-Msgid-Bugs-To: openedx-translation@googlegroups.com\n"
-"POT-Creation-Date: 2023-09-05 15:59+0000\n"
-"PO-Revision-Date: 2023-09-05 15:59:41.261194\n"
 "Last-Translator: \n"
 "Language-Team: openedx-translation <openedx-translation@googlegroups.com>\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Generated-By: Babel 2.8.0\n"
+"#-#-#-#-#  underscore.po (PROJECT VERSION)  #-#-#-#-#\n"
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2023-09-16 10:10+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.11.0\n"
 
 msgid " ${price} {currency} )"
 msgstr ""
 
+msgid " %(enrollmentMode)s "
+msgstr ""
+
+msgid " %(exam_display_name)s "
+msgstr ""
+
+msgid " %(onboardingStatus)s "
+msgstr ""
+
+msgid " %(username)s "
+msgstr ""
+
 msgid " Member"
 msgid_plural " Members"
 msgstr[0] ""
@@ -333,6 +354,9 @@
 msgid "Add Additional Signatory"
 msgstr ""
 
+msgid "Add Allowance"
+msgstr ""
+
 msgid "Add Attachment"
 msgstr ""
 
@@ -351,18 +375,30 @@
 msgid "Add New Component"
 msgstr ""
 
+msgid "Add Policy Exception"
+msgstr ""
+
 msgid "Add Thumbnail"
 msgstr ""
 
 msgid "Add Thumbnail - {videoName}"
 msgstr ""
 
+msgid "Add Time(Minutes)"
+msgstr ""
+
 msgid "Add URLs for additional versions"
 msgstr ""
 
+msgid "Add Usernames or Emails seperated by commas"
+msgstr ""
+
 msgid "Add a Chapter"
 msgstr ""
 
+msgid "Add a New Allowance"
+msgstr ""
+
 msgid "Add a New Cohort"
 msgstr ""
 
@@ -559,6 +595,15 @@
 msgid "Allow students to generate certificates for this course?"
 msgstr ""
 
+msgid "Allowance Type"
+msgstr ""
+
+msgid "Allowance Value"
+msgstr ""
+
+msgid "Allowances"
+msgstr ""
+
 msgid "Already a course team member"
 msgstr ""
 
@@ -797,6 +842,9 @@
 msgid "Automatic transcripts are disabled."
 msgstr ""
 
+msgid "Available Actions"
+msgstr ""
+
 msgid "Average"
 msgstr ""
 
@@ -1062,6 +1110,9 @@
 msgid "Checkout with {processor}"
 msgstr ""
 
+msgid "Choose Exams Below"
+msgstr ""
+
 msgid "Choose File"
 msgstr ""
 
@@ -1211,6 +1262,9 @@
 msgid "Community TA"
 msgstr ""
 
+msgid "Complete Onboarding"
+msgstr ""
+
 msgid "Complete courses on your schedule to ensure you stand out in your "
 "field!"
 msgstr ""
@@ -1218,6 +1272,9 @@
 msgid "Completed"
 msgstr ""
 
+msgid "Completed At"
+msgstr ""
+
 msgid "Component"
 msgstr ""
 
@@ -1464,6 +1521,9 @@
 msgid "Creative Commons licensed content, with terms as follow:"
 msgstr ""
 
+msgid "Current Onboarding Status:"
+msgstr ""
+
 msgid "Current Role:"
 msgstr ""
 
@@ -1785,6 +1845,9 @@
 msgid "Edit %(display_name)s (required)"
 msgstr ""
 
+msgid "Edit Allowance"
+msgstr ""
+
 msgid "Edit HTML"
 msgstr ""
 
@@ -2166,6 +2229,9 @@
 msgid "Everyone who has staff privileges in this course"
 msgstr ""
 
+msgid "Exam Name"
+msgstr ""
+
 msgid "Exam Types"
 msgstr ""
 
@@ -2887,6 +2953,9 @@
 msgid "Last Edited:"
 msgstr ""
 
+msgid "Last Modified"
+msgstr ""
+
 msgid "Last Updated"
 msgstr ""
 
@@ -3451,6 +3520,18 @@
 msgid "Onboarding Exam"
 msgstr ""
 
+msgid "Onboarding Opens"
+msgstr ""
+
+msgid "Onboarding Past Due"
+msgstr ""
+
+msgid "Onboarding Status"
+msgstr ""
+
+msgid "Onboarding profile review can take 2+ business days."
+msgstr ""
+
 msgid "Once in position, use the Take Photo button {icon} to capture your ID"
 msgstr ""
 
@@ -3971,6 +4052,9 @@
 msgid "Read more"
 msgstr ""
 
+msgid "Ready to Resume"
+msgstr ""
+
 msgid "Reason"
 msgstr ""
 
@@ -4129,6 +4213,9 @@
 msgid "Rescore problem '<%- problem_id %>' for all students?"
 msgstr ""
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset My Password"
 msgstr ""
 
@@ -4161,6 +4248,9 @@
 msgid "Restrict access to:"
 msgstr ""
 
+msgid "Resume"
+msgstr ""
+
 msgid "Retake Photo"
 msgstr ""
 
@@ -4194,6 +4284,9 @@
 msgid "Review Your Photos"
 msgstr ""
 
+msgid "Review instructions and system requirements for proctored exams"
+msgstr ""
+
 msgid "Review your info"
 msgstr ""
 
@@ -4291,6 +4384,12 @@
 msgid "Select"
 msgstr ""
 
+msgid "Select Exam Type"
+msgstr ""
+
+msgid "Select Exams"
+msgstr ""
+
 msgid "Select Session"
 msgstr ""
 
@@ -4607,6 +4706,9 @@
 msgid "Source code"
 msgstr ""
 
+msgid "Special Exam"
+msgstr ""
+
 msgid "Special character"
 msgstr ""
 
@@ -4675,6 +4777,9 @@
 msgid "Start {trialLength}-day free trial"
 msgstr ""
 
+msgid "Started At"
+msgstr ""
+
 msgid "Started entrance exam rescore task for student '{student_id}'. Click "
 "the 'Show Task Status' button to see the status of the task."
 msgstr ""
@@ -5376,6 +5481,9 @@
 msgid "This content group is used in one or more units."
 msgstr ""
 
+msgid "This course contains proctored exams"
+msgstr ""
+
 msgid "This discussion could not be loaded. Refresh the page and try again."
 msgstr ""
 
@@ -5532,6 +5640,9 @@
 msgid "Time Allotted (HH:MM):"
 msgstr ""
 
+msgid "Time Limit"
+msgstr ""
+
 msgid "Time Sent"
 msgstr ""
 
@@ -6146,6 +6257,9 @@
 msgid "View Live"
 msgstr ""
 
+msgid "View Onboarding Exam"
+msgstr ""
+
 msgid "View Program Record"
 msgstr ""
 
@@ -6552,6 +6666,9 @@
 "password."
 msgstr ""
 
+msgid "You have successfully submitted your onboarding profile for review."
+msgstr ""
+
 msgid "You have unsaved changes are you sure you want to navigate away?"
 msgstr ""
 
@@ -6605,6 +6722,10 @@
 "member"
 msgstr ""
 
+msgid "You must have a verified onboarding profile prior to taking any "
+"proctored exam."
+msgstr ""
+
 msgid "You must have at least one undroppable <%- types %> assignment."
 msgstr ""
```

</p>
</details> 

## Deadline

As soon as possible, preferably by Monday 18th, 2023 to meet [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) timeline.

References
----------

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being re-architected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern.
