### PR TITLE
[FC-0009] fix: Escape CDATA special char on xblock serialize

### DIFF
--- a/openedx/core/lib/xblock_serializer/block_serializer.py
+++ b/openedx/core/lib/xblock_serializer/block_serializer.py
@@ -112,7 +112,10 @@ class XBlockSerializer:
             olx_node.attrib["editor"] = block.editor
         if block.use_latex_compiler:
             olx_node.attrib["use_latex_compiler"] = "true"
-        olx_node.text = etree.CDATA("\n" + block.data + "\n")
+
+        # Escape any CDATA special chars
+        escaped_block_data = block.data.replace("]]>", "]]&gt;")
+        olx_node.text = etree.CDATA("\n" + escaped_block_data + "\n")
         return olx_node
 
 


### PR DESCRIPTION
## Description

This fixes a bug in xblock serialization when trying to copy a unit/component that contains an HTML xblock with the characters "]]>" which is a special character in CDATA.

## Supporting information

Related Ticket:
- Fixes: https://github.com/openedx/modular-learning/issues/100

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_units` flag is set
4. Navigate to Studio: http://localhost:18010/
5. Create a new unit or use an existing one
6. Add an HTML block containing the characters `]]>` anywhere in the HTML, example:
```html
<p>This is a Raw HTML editor that saves your HTML exactly as you enter it.
This means that even malformed HTML tags will ]]> be saved and rendered as-is.
There is no way to switch between Raw and Visual Text editor types, so be
sure this is the editor you should be using!</p>

<script type="text/javascript">// <![CDATA[
	console.log("it was logged!!");
// ]]></script>

<h3>something ]]> el]]>se!!</h3>

```
7. For sake of completeness, add a Zooming Image component to the unit as well (its under Text component)
8. Try copying each of the components (the HTML and the Zooming Image), and confirm that it copies and pastes with no issues
9. Navigate back to the course outline, and copy the unit containing the HTML + Zoom Image components 
10. Confirm that is copies and pastes with not issues

---
Private ref: [FAL-3502](https://tasks.opencraft.com/browse/FAL-3502)