### PR TITLE
feat: change problem default display name

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -147,7 +147,7 @@ def xblock_type_display_name(xblock, default_display_name=None):
     elif category == 'vertical':
         return _('Unit')
     elif category == 'problem':
-        # The problem XBlock's display_name.default is not helpful ("Blank Advanced Problem") but changing it could have
+        # The problem XBlock's display_name.default is not helpful ("Blank Problem") but changing it could have
         # too many ripple effects in other places, so we have a special case for capa problems here.
         # Note: With a ProblemBlock instance, we could actually check block.problem_types to give a more specific
         # description like "Multiple Choice Problem", but that won't work if our 'block' argument is just the block_type

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -336,7 +336,7 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
                 template_id = "peer-assessment"
             elif category == 'problem':
                 # Override generic "Problem" name to describe this blank template:
-                display_name = _("Blank Advanced Problem")
+                display_name = _("Blank Problem")
             templates_for_category.append(
                 create_template_dict(display_name, category, support_level_without_template, template_id, 'advanced')
             )

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -2779,7 +2779,7 @@ class TestComponentTemplates(CourseTestCase):
         self._verify_basic_component("video", "Video", "us")
         problem_templates = self.get_templates_of_type("problem")
         problem_no_boilerplate = self.get_template(
-            problem_templates, "Blank Advanced Problem"
+            problem_templates, "Blank Problem"
         )
         self.assertIsNotNone(problem_no_boilerplate)
         self.assertEqual("us", problem_no_boilerplate["support_level"])

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -313,7 +313,7 @@ class ContentLibrariesTestMixin:
         block_data = self._add_block_to_library(lib_id, "problem", "problem1")
         self.assertDictContainsEntries(block_data, {
             "id": "lb:CL-TEST:testlib1:problem:problem1",
-            "display_name": "Blank Advanced Problem",
+            "display_name": "Blank Problem",
             "block_type": "problem",
             "has_unpublished_changes": True,
         })

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -168,7 +168,7 @@ class ProblemBlock(
         scope=Scope.settings,
         # it'd be nice to have a useful default but it screws up other things; so,
         # use display_name_with_default for those
-        default=_("Blank Advanced Problem")
+        default=_("Blank Problem")
     )
     attempts = Integer(
         help=_("Number of attempts taken by the student on this problem"),


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR changes the default `display_name` for  problem  xblocks. As the new problem editor is being adopted, there is no need for the word "Advanced" to appear in the default `display_name` because all blank problems are handled the same. This change impacts "Course Authors".

## Supporting information

JIRA Ticket: [TNL-11009](https://2u-internal.atlassian.net/browse/TNL-11009)

> “Advanced” should be removed from the title of newly added problems

## Testing instructions

1. With the new problem editor disabled, add a new problem and navigate to the advanced tab.
2. The first item in the list should read "Blank Problem" and create problem with no issues.
3. With the new problem editor enabled, add a new problem in a course.
4. You should be prompted to select a problem type and select advanced.
5. The first item in the list should read "Blank Problem"
6. Test 3-5 for a library problem block.
7. With the [studio.library_authoring_mfe](http://localhost:18010/admin/waffle/flag/6/change/?_changelist_filters=q%3Dlibrary) flag enabled, navigate to a library and add a new problem.
8. The new block should have the default name "Blank Problem"

## Deadline

None
