### PR TITLE
temp: added logs to test notification creation

### DIFF
--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -2,6 +2,7 @@
 Utils for discussion API.
 """
 from datetime import datetime
+import logging
 from pytz import UTC
 from typing import List, Dict
 
@@ -28,6 +29,9 @@ from openedx.core.djangoapps.django_comment_common.models import (
 from openedx_events.learning.signals import USER_NOTIFICATION_REQUESTED
 from openedx_events.learning.data import UserNotificationData
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
+
+
+log = logging.getLogger(__name__)
 
 
 class AttributeDict(dict):
@@ -374,6 +378,7 @@ def send_response_notifications(thread, course, creator, parent_id=None):
     """
     Send notifications to users who are subscribed to the thread.
     """
+    log.info(f'Temp Logs: Creating Notification {thread.id} - start')
     notification_sender = DiscussionNotificationSender(thread, course, creator, parent_id)
     notification_sender.send_new_comment_notification()
     notification_sender.send_new_response_notification()
@@ -496,6 +501,8 @@ class DiscussionNotificationSender:
         """
         if not self.parent_id and self.creator.id != int(self.thread.user_id):
             self._send_notification([self.thread.user_id], "new_response")
+            log.info(f'Temp Logs: Creating Notification {self.thread.id} - new_response - '
+                     f'created {self.thread.user_id}')
 
     def _response_and_thread_has_same_creator(self) -> bool:
         """
@@ -531,6 +538,8 @@ class DiscussionNotificationSender:
                 "author_name": str(author_name),
             }
             self._send_notification([self.thread.user_id], "new_comment", extra_context=context)
+            log.info(f'Temp Logs: Creating Notification {self.thread.id} - new_comment - '
+                     f'created {self.thread.user_id}')
 
     def send_new_comment_on_response_notification(self):
         """
@@ -543,6 +552,8 @@ class DiscussionNotificationSender:
             self._response_and_thread_has_same_creator()
         ):
             self._send_notification([self.parent_response.user_id], "new_comment_on_response")
+            log.info(f'Temp Logs: Creating Notification {self.thread.id} - new_comment_on_response - created '
+                     f'{self.parent_response.user_id}')
 
     def send_new_thread_created_notification(self):
         """

--- a/openedx/core/djangoapps/notifications/tasks.py
+++ b/openedx/core/djangoapps/notifications/tasks.py
@@ -86,6 +86,9 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
     """
     Send notifications to the users.
     """
+    add_logs = notification_type in ['new_response', 'new_comment', 'new_comment_on_response']
+    if add_logs:
+        logger.info(f'Temp Logs: Creating Notification Task {notification_type} {course_key} - {user_ids} - Creating')
     course_key = CourseKey.from_string(course_key)
     if not ENABLE_NOTIFICATIONS.is_enabled(course_key):
         return
@@ -120,6 +123,9 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
     # send notification to users but use bulk_create
     notifications_generated = Notification.objects.bulk_create(notifications)
     if notifications_generated:
+        if add_logs:
+            logger.info(f'Temp Logs: Creating Notification Task {notification_type} {course_key} - {audience}'
+                        ' - Created')
         notification_content = notifications_generated[0].content
         notification_generated_event(
             audience, app_name, notification_type, course_key, content_url, notification_content,


### PR DESCRIPTION
Added temporary logs to test if `new_response,` `new_comment` and `new_comment_on_response` notification are being created