### PR TITLE
chore: ORA bump to 5.4.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -782,7 +782,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==5.3.0
+ora2==5.4.0
     # via -r requirements/edx/bundled.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1321,7 +1321,7 @@ optimizely-sdk==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==5.3.0
+ora2==5.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -923,7 +923,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.3.0
+ora2==5.4.0
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -993,7 +993,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.3.0
+ora2==5.4.0
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via


### PR DESCRIPTION
## Description

Bump ORA from 5.3.0 to 5.4.0 ([Changelog](https://github.com/openedx/edx-ora2/compare/v5.3.0...v5.4.0))

## Testing instructions

These are mostly ORA refactors so no behavior should change. If an issue is identified, please contact @openedx/content-aurora.

## Deadline

ASAP