### PR TITLE
fix: add public video share valid course key check

### DIFF
--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -487,7 +487,6 @@ class VideoBlock(
             'transcript_download_format': transcript_download_format,
             'transcript_download_formats_list': self.fields['transcript_download_format'].values,  # lint-amnesty, pylint: disable=unsubscriptable-object
         }
-
         if self.is_public_sharing_enabled():
             public_video_url = self.get_public_video_url()
             template_context['public_sharing_enabled'] = True
@@ -517,9 +516,12 @@ class VideoBlock(
         """
         Is public sharing enabled for this video?
         """
-
-        # Video share feature must be enabled for sharing settings to take effect
-        feature_enabled = PUBLIC_VIDEO_SHARE.is_enabled(self.location.course_key)
+        try:
+            # Video share feature must be enabled for sharing settings to take effect
+            feature_enabled = PUBLIC_VIDEO_SHARE.is_enabled(self.location.course_key)
+        except Exception as err:  # pylint: disable=broad-except
+            log.exception(f"Error retrieving course for course ID: {self.location.course_key}")
+            return False
         if not feature_enabled:
             return False
 


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR fixes broken student_view for video blocks in the library authoring MFE.  When trying to load the view, the waffle flag check for `PUBLIC_VIDEO_SHARE` would throw the following error:
```
AssertionError: Provided course_key 'lib:krisEdx:krisLibNewTest' is not instance of CourseKey.
```
This PR adds a try/exception block to allow views to still render when the flag check fails. This change impacts "Course Authors".

## Supporting information

JIRA Ticket: [TNL-11024](https://2u-internal.atlassian.net/browse/TNL-11024)

## Testing instructions

1. With the [studio.library_authoring_mfe](http://localhost:18010/admin/waffle/flag/6/change/?_changelist_filters=q%3Dlibrary) flag enabled, navigate to a library and add a new video.
2. Fill out the fields and save
3. Updated page should show video preview

## Deadline

None
