### PR TITLE
temp: pin openedx-events to before publish-by-config

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -2,10 +2,6 @@
 # In edx-lint, until the pyjwt constraint in edx-lint has been removed.
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -2,6 +2,10 @@
 # In edx-lint, until the pyjwt constraint in edx-lint has been removed.
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -123,3 +123,6 @@ libsass==0.10.0
 
 # greater version breaking upgrade builds
 click==8.1.6
+
+# openedx-events 8.6.0 introduces publishing via configuration. Ticket to unpin: https://github.com/edx/edx-arch-experiments/issues/381
+openedx-events<8.6.0               # Open edX Events from Hooks Extension Framework (OEP-50)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -769,6 +769,7 @@ openedx-django-wiki==2.0.1
     # via -r requirements/edx/kernel.in
 openedx-events==8.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-event-bus-kafka
     #   edx-event-bus-redis

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -767,7 +767,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==2.0.1
     # via -r requirements/edx/kernel.in
-openedx-events==8.6.0
+openedx-events==8.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-event-bus-kafka

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1300,6 +1300,7 @@ openedx-django-wiki==2.0.1
     #   -r requirements/edx/testing.txt
 openedx-events==8.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1298,7 +1298,7 @@ openedx-django-wiki==2.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==8.6.0
+openedx-events==8.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -908,7 +908,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.1
     # via -r requirements/edx/base.txt
-openedx-events==8.6.0
+openedx-events==8.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -910,6 +910,7 @@ openedx-django-wiki==2.0.1
     # via -r requirements/edx/base.txt
 openedx-events==8.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -113,8 +113,7 @@ olxcleaner
 openedx-atlas                       # CLI tool to manage translations
 openedx-calc                        # Library supporting mathematical calculations for Open edX
 openedx-django-require
-# openedx-events 8.6.0 introduces publishing via configuration. Ticket to unpin: https://github.com/edx/edx-arch-experiments/issues/381
-openedx-events<8.6.0               # Open edX Events from Hooks Extension Framework (OEP-50)
+openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-learning                    # Open edX Learning core (experimental)
 openedx-mongodbproxy

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -113,7 +113,8 @@ olxcleaner
 openedx-atlas                       # CLI tool to manage translations
 openedx-calc                        # Library supporting mathematical calculations for Open edX
 openedx-django-require
-openedx-events>=8.3.0               # Open edX Events from Hooks Extension Framework (OEP-50)
+# openedx-events 8.6.0 introduces publishing via configuration. Ticket to unpin: https://github.com/edx/edx-arch-experiments/issues/381
+openedx-events<8.6.0               # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-learning                    # Open edX Learning core (experimental)
 openedx-mongodbproxy

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -980,6 +980,7 @@ openedx-django-wiki==2.0.1
     # via -r requirements/edx/base.txt
 openedx-events==8.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -978,7 +978,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.1
     # via -r requirements/edx/base.txt
-openedx-events==8.6.0
+openedx-events==8.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka


### PR DESCRIPTION

## Description
Temporarily pin opeendx-events to <8.6.0 to better control the rollout of the publishing changes.
