### PR TITLE
build: Fix common-constraints override to prevent doubled comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endef
 COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
 .PHONY: $(COMMON_CONSTRAINTS_TXT)
 $(COMMON_CONSTRAINTS_TXT):
-	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 	printf "$(COMMON_CONSTRAINTS_TEMP_COMMENT)" | cat - $(@) > temp && mv temp $(@)
 
 compile-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade


### PR DESCRIPTION
Sometimes this make target doubles or even triples the comment. I think this is due to a temporary failure in the wget call, which is then ignored and an additional comment is added onto the top. If this happens multiple times in a row, you get multiple additions.

Removing the `|| touch` should fix this, and surface any errors that are happening.