### PR TITLE
[FC-0009] fix: Hide Copy menu button in ContentLibrary

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -313,7 +313,8 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
             'can_move': context.get('can_move', is_course),
-            'language': getattr(course, 'language', None)
+            'language': getattr(course, 'language', None),
+            'is_course': is_course
         }
 
         add_webpack_js_to_fragment(frag, "js/factories/xblock_validation")

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -48,6 +48,7 @@ function($, _, Backbone, gettext, BasePage, ViewUtils, ContainerView, XBlockView
             BasePage.prototype.initialize.call(this, options);
             this.viewClass = options.viewClass || this.defaultViewClass;
             this.isLibraryPage = (this.model.attributes.category === 'library');
+            this.isLibraryContentPage = (this.model.attributes.category === 'library_content');
             this.nameEditor = new XBlockStringFieldEditor({
                 el: this.$('.wrapper-xblock-field'),
                 model: this.model
@@ -154,7 +155,7 @@ function($, _, Backbone, gettext, BasePage, ViewUtils, ContainerView, XBlockView
                     self.delegateEvents();
 
                     // Show/hide the paste button
-                    if (!self.isLibraryPage) {
+                    if (!self.isLibraryPage && !self.isLibraryContentPage) {
                         self.initializePasteButton();
                     }
                 },
@@ -208,32 +209,36 @@ function($, _, Backbone, gettext, BasePage, ViewUtils, ContainerView, XBlockView
          * Given the latest information about the user's clipboard, hide or show the Paste button as appropriate.
          */
         refreshPasteButton(data) {
-            // 'data' is the same data returned by the "get clipboard status" API endpoint
-            // i.e. /api/content-staging/v1/clipboard/
-            if (this.options.canEdit && data.content) {
-                if (["vertical", "sequential", "chapter", "course"].includes(data.content.block_type)) {
-                    // This is not suitable for pasting into a unit.
-                    this.$(".paste-component").hide();
-                } else if (data.content.status === "expired") {
-                    // This has expired and can no longer be pasted.
-                    this.$(".paste-component").hide();
-                } else {
-                    // The thing in the clipboard can be pasted into this unit:
-                    const detailsPopupEl = this.$(".clipboard-details-popup")[0];
-                    detailsPopupEl.querySelector(".detail-block-name").innerText = data.content.display_name;
-                    detailsPopupEl.querySelector(".detail-block-type").innerText = data.content.block_type_display;
-                    detailsPopupEl.querySelector(".detail-course-name").innerText = data.source_context_title;
-                    if (data.source_edit_url) {
-                        detailsPopupEl.setAttribute("href", data.source_edit_url);
-                        detailsPopupEl.classList.remove("no-edit-link");
+            // Do not perform any changes on paste button since they are not
+            // rendered on Library or LibraryContent pages
+            if (!this.isLibraryPage && !this.isLibraryContentPage) {
+                // 'data' is the same data returned by the "get clipboard status" API endpoint
+                // i.e. /api/content-staging/v1/clipboard/
+                if (this.options.canEdit && data.content) {
+                    if (["vertical", "sequential", "chapter", "course"].includes(data.content.block_type)) {
+                        // This is not suitable for pasting into a unit.
+                        this.$(".paste-component").hide();
+                    } else if (data.content.status === "expired") {
+                        // This has expired and can no longer be pasted.
+                        this.$(".paste-component").hide();
                     } else {
-                        detailsPopupEl.setAttribute("href", "#");
-                        detailsPopupEl.classList.add("no-edit-link");
+                        // The thing in the clipboard can be pasted into this unit:
+                        const detailsPopupEl = this.$(".clipboard-details-popup")[0];
+                        detailsPopupEl.querySelector(".detail-block-name").innerText = data.content.display_name;
+                        detailsPopupEl.querySelector(".detail-block-type").innerText = data.content.block_type_display;
+                        detailsPopupEl.querySelector(".detail-course-name").innerText = data.source_context_title;
+                        if (data.source_edit_url) {
+                            detailsPopupEl.setAttribute("href", data.source_edit_url);
+                            detailsPopupEl.classList.remove("no-edit-link");
+                        } else {
+                            detailsPopupEl.setAttribute("href", "#");
+                            detailsPopupEl.classList.add("no-edit-link");
+                        }
+                        this.$(".paste-component").show();
                     }
-                    this.$(".paste-component").show();
+                } else {
+                    this.$(".paste-component").hide();
                 }
-            } else {
-                this.$(".paste-component").hide();
             }
         },
 

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -104,9 +104,15 @@ block_is_unit = is_unit(xblock)
                                 <div class="nav-sub">
                                   <ul>
                                     % if not show_inline:
-                                        <li class="nav-item">
-                                            <a class="copy-button" href="#" role="button">${_("Copy to Clipboard")}</a>
-                                        </li>
+                                        % if is_course:
+                                            <!--
+                                                Only show the "Copy to Clipboard" button for xblocks inside courses since
+                                                the copy/paste functionality is not yet implemented for LibraryContent.
+                                            -->
+                                            <li class="nav-item">
+                                                <a class="copy-button" href="#" role="button">${_("Copy to Clipboard")}</a>
+                                            </li>
+                                        % endif
                                         % if can_add:
                                             <li class="nav-item">
                                                 <a class="duplicate-button" href="#" role="button">${_("Duplicate")}</a>


### PR DESCRIPTION
## Description

Since the Copy/Paste functionality has not been implemented for ContentLibraries yet, the "Copy to Clipboard" button should not appear in both the ContentLibrary page and from the ContentLibrary preview from within the Course unit's component.

## Supporting information

Related Ticket:
- Closes https://github.com/openedx/modular-learning/issues/101

## Testing instructions

1. Run the devstack on this branch
2. Login to Studio Admin and navigate to: http://localhost:18010/admin/waffle/flag/
3. Make sure that the `contentstore.enable_copy_paste_units` flag is set
4. Navigate to Studio: http://localhost:18010/
5. Create a new Library with a few components or use an existing one
6. Confirm that the drop down menu for the components inside the Library do **not** contain the Copy to Clipboard option
![Screen Shot 2023-09-18 at 2 33 06 PM](https://github.com/openedx/edx-platform/assets/6829768/330f0424-ec12-45f3-9022-e7b3368c7a9d)
8. Create a new unit and add a LibraryContent component and select the Library you created earlier
9. Click on the **View** button that appears under the LibraryContentBlock
10. Confirm that there is no 3 dotted menu that appears at the end of the components. (This is because after removing the Copy to clipboard option, there are not actions that can be performed)
![Screen Shot 2023-09-18 at 2 34 01 PM](https://github.com/openedx/edx-platform/assets/6829768/a0f34a69-2a97-49ed-8d64-85db114bbea1)

---
Private ref: [FAL-3507](https://tasks.opencraft.com/browse/FAL-3507)