### PR TITLE
feat: added notifications in legacy discussion experience

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -37,7 +37,6 @@ from lms.djangoapps.course_api.blocks.api import get_blocks
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
-from lms.djangoapps.discussion.rest_api.tasks import send_thread_created_notification
 from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE, ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE
 from lms.djangoapps.discussion.toggles_utils import reported_content_email_notification_enabled
 from lms.djangoapps.discussion.views import is_privileged_user
@@ -129,7 +128,6 @@ from .utils import (
     get_usernames_for_course,
     get_usernames_from_search_string,
     is_posting_allowed,
-    send_response_notifications,
     set_attribute,
 )
 
@@ -1469,8 +1467,6 @@ def create_thread(request, thread_data):
     track_thread_created_event(request, course, cc_thread, actions_form.cleaned_data["following"],
                                from_mfe_sidebar)
 
-    thread_id = cc_thread.attributes['id']
-    send_thread_created_notification.apply_async(args=[thread_id, str(course.id), request.user.id])
     return api_thread
 
 
@@ -1517,8 +1513,6 @@ def create_comment(request, comment_data):
 
     track_comment_created_event(request, course, cc_comment, cc_thread["commentable_id"], followed=False,
                                 from_mfe_sidebar=from_mfe_sidebar)
-    send_response_notifications(thread=cc_thread, course=course, creator=request.user,
-                                parent_id=comment_data.get("parent_id"))
     return api_comment
 
 

--- a/lms/djangoapps/discussion/rest_api/tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tasks.py
@@ -28,3 +28,21 @@ def send_thread_created_notification(thread_id, course_key_str, user_id):
     course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
     notification_sender = DiscussionNotificationSender(thread, course, user)
     notification_sender.send_new_thread_created_notification()
+
+
+@shared_task
+@set_code_owner_attribute
+def send_response_notifications(thread_id, course_key_str, user_id, parent_id=None):
+    """
+    Send notifications to users who are subscribed to the thread.
+    """
+    course_key = CourseKey.from_string(course_key_str)
+    if not ENABLE_NOTIFICATIONS.is_enabled(course_key):
+        return
+    thread = Thread(id=thread_id).retrieve()
+    user = User.objects.get(id=user_id)
+    course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
+    notification_sender = DiscussionNotificationSender(thread, course, user, parent_id)
+    notification_sender.send_new_comment_notification()
+    notification_sender.send_new_response_notification()
+    notification_sender.send_new_comment_on_response_notification()

--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -3,16 +3,13 @@ Tests for Discussion REST API utils.
 """
 
 from datetime import datetime, timedelta
-from unittest.mock import Mock
 
 import ddt
-from django.conf import settings
-from httpretty import httpretty
 from pytz import UTC
 import unittest
 from common.djangoapps.student.roles import CourseStaffRole, CourseInstructorRole
 from lms.djangoapps.discussion.django_comment_client.tests.utils import ForumsEnableMixin
-from lms.djangoapps.discussion.rest_api.tests.utils import CommentsServiceMockMixin, ThreadMock
+from lms.djangoapps.discussion.rest_api.tests.utils import CommentsServiceMockMixin
 from openedx.core.djangoapps.discussions.models import PostingRestriction, DiscussionsConfiguration
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -26,9 +23,8 @@ from lms.djangoapps.discussion.rest_api.utils import (
     get_moderator_users_list,
     get_archived_topics,
     remove_empty_sequentials,
-    send_response_notifications, is_posting_allowed
+    is_posting_allowed
 )
-from openedx_events.learning.signals import USER_NOTIFICATION_REQUESTED
 
 
 class DiscussionAPIUtilsTestCase(ModuleStoreTestCase):
@@ -163,185 +159,6 @@ class TestRemoveEmptySequentials(unittest.TestCase):
         ]
         result = remove_empty_sequentials(data)
         self.assertEqual(result, expected_output)
-
-
-def _get_mfe_url(course_id, post_id):
-    """
-    get discussions mfe url to specific post.
-    """
-    return f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(course_id)}/posts/{post_id}"
-
-
-class TestSendResponseNotifications(ForumsEnableMixin, CommentsServiceMockMixin, ModuleStoreTestCase):
-    """
-    Test for the send_response_notifications function
-    """
-
-    def setUp(self):
-        super().setUp()
-        httpretty.reset()
-        httpretty.enable()
-
-        self.user_1 = UserFactory.create()
-        self.user_2 = UserFactory.create()
-        self.user_3 = UserFactory.create()
-        self.thread = ThreadMock(thread_id=1, creator=self.user_1, title='test thread')
-        self.thread_2 = ThreadMock(thread_id=2, creator=self.user_2, title='test thread 2')
-        self.thread_3 = ThreadMock(thread_id=2, creator=self.user_1, title='test thread 3')
-        self.course = CourseFactory.create()
-
-    def test_send_notification_to_thread_creator(self):
-        """
-        Test that the notification is sent to the thread creator
-        """
-        handler = Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
-
-        # Post the form or do what it takes to send the signal
-
-        send_response_notifications(self.thread, self.course, self.user_2, parent_id=None)
-        self.assertEqual(handler.call_count, 1)
-        args = handler.call_args[1]['notification_data']
-        self.assertEqual([int(user_id) for user_id in args.user_ids], [self.user_1.id])
-        self.assertEqual(args.notification_type, 'new_response')
-        expected_context = {
-            'replier_name': self.user_2.username,
-            'post_title': 'test thread',
-            'course_name': self.course.display_name,
-        }
-        self.assertDictEqual(args.context, expected_context)
-        self.assertEqual(
-            args.content_url,
-            _get_mfe_url(self.course.id, self.thread.id)
-        )
-        self.assertEqual(args.app_name, 'discussion')
-
-    def test_send_notification_to_parent_threads(self):
-        """
-        Test that the notification signal is sent to the parent response creator and
-        parent thread creator, it checks signal is sent with correct arguments for both
-        types of notifications.
-        """
-        handler = Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
-
-        self.register_get_comment_response({
-            'id': self.thread_2.id,
-            'thread_id': self.thread.id,
-            'user_id': self.thread_2.user_id
-        })
-
-        send_response_notifications(self.thread, self.course, self.user_3, parent_id=self.thread_2.id)
-        # check if 2 call are made to the handler i.e. one for the response creator and one for the thread creator
-        self.assertEqual(handler.call_count, 2)
-
-        # check if the notification is sent to the thread creator
-        args_comment = handler.call_args_list[0][1]['notification_data']
-        args_comment_on_response = handler.call_args_list[1][1]['notification_data']
-        self.assertEqual([int(user_id) for user_id in args_comment.user_ids], [self.user_1.id])
-        self.assertEqual(args_comment.notification_type, 'new_comment')
-        expected_context = {
-            'replier_name': self.user_3.username,
-            'post_title': self.thread.title,
-            'author_name': 'dummy\'s',
-            'course_name': self.course.display_name,
-        }
-        self.assertDictEqual(args_comment.context, expected_context)
-        self.assertEqual(
-            args_comment.content_url,
-            _get_mfe_url(self.course.id, self.thread.id)
-        )
-        self.assertEqual(args_comment.app_name, 'discussion')
-
-        # check if the notification is sent to the parent response creator
-        self.assertEqual([int(user_id) for user_id in args_comment_on_response.user_ids], [self.user_2.id])
-        self.assertEqual(args_comment_on_response.notification_type, 'new_comment_on_response')
-        expected_context = {
-            'replier_name': self.user_3.username,
-            'post_title': self.thread.title,
-            'course_name': self.course.display_name,
-        }
-        self.assertDictEqual(args_comment_on_response.context, expected_context)
-        self.assertEqual(
-            args_comment_on_response.content_url,
-            _get_mfe_url(self.course.id, self.thread.id)
-        )
-        self.assertEqual(args_comment_on_response.app_name, 'discussion')
-
-    def test_no_signal_on_creators_own_thread(self):
-        """
-        Makes sure that no signal is emitted if user creates response on
-        their own thread.
-        """
-        handler = Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
-        send_response_notifications(self.thread, self.course, self.user_1, parent_id=None)
-        self.assertEqual(handler.call_count, 0)
-
-    def test_comment_creators_own_response(self):
-        """
-        Check incase post author and response auther is same only send
-        new comment signal , with your as author_name.
-        """
-        handler = Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
-
-        self.register_get_comment_response({
-            'id': self.thread_3.id,
-            'thread_id': self.thread.id,
-            'user_id': self.thread_3.user_id
-        })
-
-        send_response_notifications(self.thread, self.course, self.user_3, parent_id=self.thread_2.id)
-        # check if 1 call is made to the handler i.e. for the thread creator
-        self.assertEqual(handler.call_count, 1)
-
-        # check if the notification is sent to the thread creator
-        args_comment = handler.call_args_list[0][1]['notification_data']
-        self.assertEqual(args_comment.user_ids, [self.user_1.id])
-        self.assertEqual(args_comment.notification_type, 'new_comment')
-        expected_context = {
-            'replier_name': self.user_3.username,
-            'post_title': self.thread.title,
-            'author_name': 'your',
-            'course_name': self.course.display_name,
-        }
-        self.assertDictEqual(args_comment.context, expected_context)
-        self.assertEqual(
-            args_comment.content_url,
-            _get_mfe_url(self.course.id, self.thread.id)
-        )
-        self.assertEqual(args_comment.app_name, 'discussion')
-
-
-class TestSendCommentNotification(ForumsEnableMixin, CommentsServiceMockMixin, ModuleStoreTestCase):
-    """
-    Test case to send new_comment notification
-    """
-    def setUp(self):
-        super().setUp()
-        httpretty.reset()
-        httpretty.enable()
-
-        self.course = CourseFactory.create()
-        self.user_1 = UserFactory.create()
-        self.user_2 = UserFactory.create()
-
-    def test_new_comment_notification(self):
-        handler = Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
-
-        thread = ThreadMock(thread_id=1, creator=self.user_1, title='test thread')
-        response = ThreadMock(thread_id=2, creator=self.user_2, title='test response')
-        self.register_get_comment_response({
-            'id': response.id,
-            'thread_id': 'abc',
-            'user_id': response.user_id
-        })
-        send_response_notifications(thread, self.course, self.user_2, parent_id=response.id)
-        handler.assert_called_once()
-        context = handler.call_args[1]['notification_data'].context
-        self.assertEqual(context['author_name'], 'their')
 
 
 @ddt.ddt

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1360,10 +1360,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         super().setUp()
         self.url = reverse("thread-list")
 
-    @mock.patch(
-        'lms.djangoapps.discussion.rest_api.tasks.send_thread_created_notification.apply_async'
-    )
-    def test_basic(self, mock_notification_task):
+    def test_basic(self):
         self.register_get_user_response(self.user)
         cs_thread = make_minimal_cs_thread({
             "id": "test_thread",
@@ -1384,7 +1381,6 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             content_type="application/json"
         )
         assert response.status_code == 200
-        mock_notification_task.assert_called_once()
         response_data = json.loads(response.content.decode('utf-8'))
         assert response_data == self.expected_thread_data({
             "read": True,


### PR DESCRIPTION
Added the following notifications in teams and legacy discussion
- new_discussion_post
- new_question_post
- new_comment
- new_response
- new_comment_on_response

Moved response and comment notifications to task

Ticket Link: [INF-1072](https://2u-internal.atlassian.net/browse/INF-1072)