### PR TITLE
docs: move up docs link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,11 @@ platform.  Functionally, the edx-platform repository provides two services:
 * CMS (Content Management Service), which powers Open edX Studio, the platform's learning content authoring environment; and
 * LMS (Learning Management Service), which delivers learning content.
 
+Documentation
+*************
+
+Documentation can be found at https://docs.openedx.org/projects/edx-platform.
+
 Getting Started
 ***************
 
@@ -80,11 +85,6 @@ addition, the Open edX site provides product announcements, the Open edX blog,
 and other rich community resources.
 
 .. _Open edX site: https://openedx.org
-
-Documentation
-*************
-
-Documentation can be found at https://docs.openedx.org/projects/edx-platform.
 
 
 Getting Help


### PR DESCRIPTION
## Description

The documentation section, which now has an edx-platform specific doc link, was moved closer to the top of the README to make it stand out more.