### PR TITLE
build: Install wget in development docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,10 +147,11 @@ COPY . .
 # Install Python requirements again in order to capture local projects
 RUN pip install -e .
 
-USER app
-
 # Production target
 FROM base as production
+
+USER app
+
 ENV EDX_PLATFORM_SETTINGS='docker-production'
 ENV SERVICE_VARIANT "${SERVICE_VARIANT}"
 ENV SERVICE_PORT "${SERVICE_PORT}"
@@ -167,9 +168,15 @@ CMD gunicorn \
 # Development target
 FROM base as development
 
-COPY --from=builder-development /edx/app/edxapp/venvs/edxapp /edx/app/edxapp/venvs/edxapp
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        # wget is used in Makefile for common_constraints.txt
+        wget \
+    && \
+    apt-get clean all && \
+    rm -rf /var/lib/apt/*
 
-USER root
+COPY --from=builder-development /edx/app/edxapp/venvs/edxapp /edx/app/edxapp/venvs/edxapp
 
 RUN ln -s "$(pwd)/lms/envs/devstack-experimental.yml" "$LMS_CFG"
 RUN ln -s "$(pwd)/cms/envs/devstack-experimental.yml" "$CMS_CFG"


### PR DESCRIPTION
It's needed by `make common_constraints.txt`. We're starting to see
failures running this command in lms-shell in devstack. This has probably
been going on the entire time, but the error suppression was only removed
recently in <https://github.com/openedx/edx-platform/pull/33271>.

The new RUN instruction for installing wget is added to the development
layer only, partly to limit image sizes and partly to make life harder for
any attacker who manages to gain code execution in production.

I've moved `USER app` from the end of the `base` layer to the start of the
`production` layer, since the only other layer (in this file) that builds
on `base` is `development`, which more or less immediately switches back
to root. (The intervening COPY instruction is not affected by the current
user.)

Ticket: https://github.com/openedx/edx-platform/issues/33287
