### PR TITLE
fix: [FC-0031] Fix count items in pagination for api courses list.

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -100,13 +100,10 @@ def _filter_by_search(course_queryset, search_term):
     )
 
     search_courses_ids = {course['data']['id'] for course in search_courses['results']}
-
+    courses = [course for course in course_queryset if str(course.id) in search_courses_ids]
     return LazySequence(
-        (
-            course for course in course_queryset
-            if str(course.id) in search_courses_ids
-        ),
-        est_len=len(course_queryset)
+        iter(courses),
+        est_len=len(courses)
     )
 
 

--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -65,6 +65,7 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
     active_only = ExtendedNullBooleanField(required=False)
     permissions = MultiValueField(required=False)
     course_keys = MultiValueField(required=False)
+    mobile_search = ExtendedNullBooleanField(required=False)
 
     def clean(self):
         """

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -72,6 +72,7 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
             'permissions': set(),
             'active_only': None,
             'course_keys': set(),
+            'mobile_search': None,
         }
 
     def test_basic(self):

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -449,6 +449,29 @@ class CourseListSearchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase, Sear
                 assert len(response.data['results']) == (30 if (page < 11) else 3)
                 assert [c['id'] for c in response.data['results']] == ordered_course_ids[((page - 1) * 30):(page * 30)]
 
+    def test_count_item_pagination_with_search_term(self):
+        """
+        Test count items in pagination for api courses list - class CourseListView
+        """
+        # Create 15 new courses, courses have the word "new" in the title
+        _ = [self.create_and_index_course(f"numb_{number}", f"new_{number}") for number in range(15)]
+        response = self.verify_response(params={"search_term": "new"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["pagination"]["count"], 15)
+
+    def test_count_item_pagination_with_search_term_and_filter(self):
+        """
+        Test count items in pagination for api courses list
+        with search_term and filter by organisation -
+        class CourseListView
+        """
+        # Create 25 new courses with two different organisations
+        _ = [self.create_and_index_course("Org_N", f"new_{number}") for number in range(10)]
+        _ = [self.create_and_index_course("Org_X", f"new_{number}") for number in range(15)]
+        response = self.verify_response(params={"org": "Org_X", "search_term": "new"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["pagination"]["count"], 15)
+
 
 class CourseIdListViewTestCase(CourseApiTestViewMixin, ModuleStoreTestCase):
     """

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -454,10 +454,12 @@ class CourseListSearchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase, Sear
         Test count items in pagination for api courses list - class CourseListView
         """
         # Create 15 new courses, courses have the word "new" in the title
-        _ = [self.create_and_index_course(f"numb_{number}", f"new_{number}") for number in range(15)]
+        [self.create_and_index_course(f"numb_{number}", f"new_{number}") for number in range(15)]  # pylint: disable=expression-not-assigned
         response = self.verify_response(params={"search_term": "new"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["pagination"]["count"], 15)
+        # We don't have 'count' 15 because 'mobile_search' param is None
+        # And LazySequence contains all courses
+        self.assertEqual(response.json()["pagination"]["count"], 18)
 
     def test_count_item_pagination_with_search_term_and_filter(self):
         """
@@ -466,10 +468,25 @@ class CourseListSearchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase, Sear
         class CourseListView
         """
         # Create 25 new courses with two different organisations
-        _ = [self.create_and_index_course("Org_N", f"new_{number}") for number in range(10)]
-        _ = [self.create_and_index_course("Org_X", f"new_{number}") for number in range(15)]
+        [self.create_and_index_course("Org_N", f"new_{number}") for number in range(10)]  # pylint: disable=expression-not-assigned
+        [self.create_and_index_course("Org_X", f"new_{number}") for number in range(15)]  # pylint: disable=expression-not-assigned
         response = self.verify_response(params={"org": "Org_X", "search_term": "new"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["pagination"]["count"], 15)
+
+    def test_count_item_pagination_with_search_term_and_mobile_search(self):
+        """
+        Test count items in pagination for api courses list
+        with search_term and 'mobile_search' is True
+        """
+        # Create 25 new courses with two different words in titles
+        [self.create_and_index_course("Org_N", f"old_{number}") for number in range(10)]  # pylint: disable=expression-not-assigned
+        [self.create_and_index_course("Org_N", f"new_{number}") for number in range(15)]  # pylint: disable=expression-not-assigned
+        response = self.verify_response(
+            params={"search_term": "new", "mobile_search": True}
+        )
+        self.assertEqual(response.status_code, 200)
+        # We have 'count' 15 because 'mobile_search' param is true
         self.assertEqual(response.json()["pagination"]["count"], 15)
 
 

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -290,6 +290,10 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             If specified, it fetches the `CourseOverview` objects for the
             the specified course keys
 
+        mobile_search (bool):
+            Optional parameter that limits the number of returned courses
+            to MOBILE_SEARCH_COURSE_LIMIT.
+
     **Returns**
 
         * 200 on success, with a list of course discovery objects as returned
@@ -349,6 +353,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             permissions=form.cleaned_data['permissions'],
             active_only=form.cleaned_data.get('active_only', False),
             course_keys=form.cleaned_data['course_keys'],
+            mobile_search=form.cleaned_data.get('mobile_search', False),
         )
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4428,6 +4428,9 @@ MOBILE_APP_USER_AGENT_REGEXES = [
     r'edX/org.edx.mobile',
 ]
 
+# set course limit for mobile search
+MOBILE_SEARCH_COURSE_LIMIT = 100
+
 # cache timeout in seconds for Mobile App Version Upgrade
 APP_UPGRADE_CACHE_TIMEOUT = 3600
 


### PR DESCRIPTION
## Description

This PR is resolving an issue with incorrect count returned from `pagination` object for all pages except for the last page while searching for courses using API `api/courses/v1/courses/` and providing `search_term` query parameter.

## Supporting information

This contribution is done as a part of the project [FC-0031](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3844505604/FC-0031+-+Mobile+API+Migration)

## Testing instructions

GET `api/courses/v1/courses/` specifying query_param `search_term`.
Check that `count` parameter in a response has a correct value. 