### PR TITLE
feat: [FC-0031] Add DefaultPagination in UserCourseEnrollmentsList

### DIFF
--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -386,8 +386,9 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
     @property
     def paginator(self):
         """
-        Overrides API View paginator property to dynamically determine pagination class 
-        based on the provided api_version. Implements solutions from the discussion at 
+        Override API View paginator property to dynamically determine pagination class
+
+        Implements solutions from the discussion at
         https://www.github.com/encode/django-rest-framework/issues/6397.
         """
         super().paginator  # pylint: disable=expression-not-assigned

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -385,6 +385,11 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
     # pylint: disable=attribute-defined-outside-init
     @property
     def paginator(self):
+        """
+        Overrides API View paginator property to dynamically determine pagination class 
+        based on the provided api_version. Implements solutions from the discussion at 
+        https://www.github.com/encode/django-rest-framework/issues/6397.
+        """
         super().paginator  # pylint: disable=expression-not-assigned
         api_version = self.kwargs.get('api_version')
 

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -21,6 +21,7 @@ from rest_framework.permissions import SAFE_METHODS
 from rest_framework.response import Response
 from xblock.fields import Scope
 from xblock.runtime import KeyValueStore
+from edx_rest_framework_extensions.paginators import DefaultPagination
 
 from common.djangoapps.student.models import CourseEnrollment, User  # lint-amnesty, pylint: disable=reimported
 from lms.djangoapps.courseware.access import is_mobile_available_for_user
@@ -30,7 +31,7 @@ from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.block_render import get_block_for_descriptor
 from lms.djangoapps.courseware.views.index import save_positions_recursively_up
 from lms.djangoapps.mobile_api.models import MobileConfig
-from lms.djangoapps.mobile_api.utils import API_V1, API_V05, API_V2
+from lms.djangoapps.mobile_api.utils import API_V1, API_V05, API_V2, API_V3
 from openedx.features.course_duration_limits.access import check_course_expired
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -372,7 +373,7 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
         response = super().list(request, *args, **kwargs)
         api_version = self.kwargs.get('api_version')
 
-        if api_version == API_V2:
+        if api_version in (API_V2, API_V3):
             enrollment_data = {
                 'configs': MobileConfig.get_structured_configs(),
                 'enrollments': response.data
@@ -380,6 +381,17 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
             return Response(enrollment_data)
 
         return response
+
+    # pylint: disable=attribute-defined-outside-init
+    @property
+    def paginator(self):
+        super().paginator  # pylint: disable=expression-not-assigned
+        api_version = self.kwargs.get('api_version')
+
+        if self._paginator is None and api_version == API_V3:
+            self._paginator = DefaultPagination()
+
+        return self._paginator
 
 
 @api_view(["GET"])

--- a/lms/djangoapps/mobile_api/utils.py
+++ b/lms/djangoapps/mobile_api/utils.py
@@ -5,6 +5,7 @@ Common utility methods for Mobile APIs.
 API_V05 = 'v0.5'
 API_V1 = 'v1'
 API_V2 = 'v2'
+API_V3 = 'v3'
 
 
 def parsed_version(version):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -224,7 +224,7 @@ urlpatterns = [
 
 if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
     urlpatterns += [
-        re_path(r'^api/mobile/(?P<api_version>v(2|1|0.5))/', include('lms.djangoapps.mobile_api.urls')),
+        re_path(r'^api/mobile/(?P<api_version>v(3|2|1|0.5))/', include('lms.djangoapps.mobile_api.urls')),
     ]
 
 urlpatterns += [


### PR DESCRIPTION
## Description

The pagination is necessary for UserCourseEnrollmentsList to optimize course loading in the mobile app.
The pagination for this endpoint was introduced along with a new version (v3) of the mobile API. 
## Supporting information

This contribution is done as a part of the project [FC-0031](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3844505604/FC-0031+-+Mobile+API+Migration)

## Testing instructions

`api/mobile` endpoints are now available with v3 api version.

GET `/api/mobile/v3/users/<user_name>/course_enrollments/`, and see the Default Pagination fields, as count, num_pages, current_page, results in the response.