### PR TITLE
feat: [FC-0031] Add new endpoint BlocksInfoInCourseView 

### DIFF
--- a/lms/djangoapps/mobile_api/course_info/serializers.py
+++ b/lms/djangoapps/mobile_api/course_info/serializers.py
@@ -1,0 +1,36 @@
+"""
+Course Info serializers
+"""
+from rest_framework import serializers
+
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+
+class CourseInfoOverviewSerializer(serializers.ModelSerializer):
+    """
+    Serializer for serialize additional fields in BlocksInfoInCourseView.
+    """
+
+    name = serializers.CharField(source='display_name')
+    number = serializers.CharField(source='display_number_with_default')
+    org = serializers.CharField(source='display_org_with_default')
+    is_self_paced = serializers.BooleanField(source='self_paced')
+    media = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CourseOverview
+        fields = (
+            'name',
+            'number',
+            'org',
+            'start',
+            'start_display',
+            'start_type',
+            'end',
+            'is_self_paced',
+            'media',
+        )
+
+    @staticmethod
+    def get_media(obj):
+        return {'image': obj.image_urls}

--- a/lms/djangoapps/mobile_api/course_info/tests.py
+++ b/lms/djangoapps/mobile_api/course_info/tests.py
@@ -294,7 +294,7 @@ class TestBlocksInfoInCourseView(TestBlocksInCourseView):  # lint-amnesty, pylin
         assert response.data['name'] == self.course.display_name
         assert response.data['number'] == self.course.display_number_with_default
         assert response.data['org'] == self.course.display_org_with_default
-        assert response.data['start'] == self.course.start
+        assert response.data['start'] == self.course.start.strftime('%Y-%m-%dT%H:%M:%SZ')
         assert response.data['start_display'] == 'July 17, 2015'
         assert response.data['start_type'] == 'timestamp'
         assert response.data['end'] == self.course.end

--- a/lms/djangoapps/mobile_api/course_info/urls.py
+++ b/lms/djangoapps/mobile_api/course_info/urls.py
@@ -6,7 +6,7 @@ URLs for course_info API
 from django.conf import settings
 from django.urls import path, re_path
 
-from .views import CourseHandoutsList, CourseUpdatesList, CourseGoalsRecordUserActivity
+from .views import CourseHandoutsList, CourseUpdatesList, CourseGoalsRecordUserActivity, BlocksInfoInCourseView
 
 urlpatterns = [
     re_path(
@@ -20,4 +20,5 @@ urlpatterns = [
         name='course-updates-list'
     ),
     path('record_user_activity', CourseGoalsRecordUserActivity.as_view(), name='record_user_activity'),
+    path('blocks/', BlocksInfoInCourseView.as_view(), name="blocks_info_in_course"),
 ]

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -12,8 +12,12 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.djangoapps.static_replace import make_static_urls_absolute
+from lms.djangoapps.certificates.api import certificate_downloadable_status
 from lms.djangoapps.courseware.courses import get_course_info_section_block
 from lms.djangoapps.course_goals.models import UserActivity
+from lms.djangoapps.course_api.blocks.views import BlocksInCourseView
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.lib.api.view_utils import view_auth_classes
 from openedx.core.lib.xblock_utils import get_course_update_items
 from openedx.features.course_experience import ENABLE_COURSE_GOALS
 from ..decorators import mobile_course_access, mobile_view
@@ -166,3 +170,119 @@ class CourseGoalsRecordUserActivity(APIView):
         # Populate user activity for tracking progress towards a user's course goals
         UserActivity.record_user_activity(user, course_key)
         return Response(status=(200))
+
+
+@view_auth_classes(is_authenticated=False)
+class BlocksInfoInCourseView(BlocksInCourseView):
+    """
+    **Use Case**
+
+        Returns the blocks in the course according to the requesting user's access level.
+        Add to response info fields with information about course
+
+    **Example requests**:
+
+        This api works with all versions {api_version}, you can use: v0.5, v1, v2 or v3
+
+        GET /api/mobile/{api_version}/course_info/blocks/?course_id=<course_id>
+        GET /api/mobile/{api_version}/course_info/blocks/?course_id=<course_id>
+            &username=anjali
+            &depth=all
+            &requested_fields=graded,format,student_view_multi_device,lti_url
+            &block_counts=video
+            &student_view_data=video
+            &block_types_filter=problem,html
+
+    **Response example**
+
+        Body consists of the following fields:
+
+        root: (str) The ID of the root node of the requested course block structure.\
+        blocks: (dict) A dictionary or list, based on the value of the
+            "return_type" parameter. Maps block usage IDs to a collection of
+            information about each block. Each block contains the following
+            fields.
+
+        id: (str) The Course's id (Course Run key)
+        name: (str) The course's name
+        number: (str) The course's number
+        org: (str) The course's organisation
+        start: (str) Date the course begins, in ISO 8601 notation
+        start_display: (str) Readably formatted start of the course
+        start_type: (str) Hint describing how `start_display` is set. One of:
+            * `"string"`: manually set by the course author
+            * `"timestamp"`: generated from the `start` timestamp
+            * `"empty"`: no start date is specified
+        end: (str) Date the course ends, in ISO 8601 notation
+        media: (dict) An object that contains named media items. Included here:
+            * course_image: An image to show for the course.  Represented
+              as an object with the following fields:
+                * uri: The location of the image
+        certificate: (dict) Information about the user's earned certificate in the course.
+            Included here:
+                * uri: The location of the user's certificate
+        is_self_paced: (bool) Indicates if the course is self paced
+
+    **Returns**
+
+        * 200 on success with above fields.
+        * 400 if an invalid parameter was sent or the username was not provided
+        * 401 unauthorized, the provided access token has expired and is no longer valid
+          for an authenticated request.
+        * 403 if a user who does not have permission to masquerade as
+          another user specifies a username other than their own.
+        * 404 if the course is not available or cannot be seen.
+    """
+
+    def get_certificate(self, request, course_id):
+        """Returns the information about the user's certificate in the course."""
+        if request.user.is_authenticated:
+            certificate_info = certificate_downloadable_status(request.user, course_id)
+            if certificate_info['is_downloadable']:
+                return {
+                    'url': request.build_absolute_uri(
+                        certificate_info['download_url']
+                    ),
+                }
+        return {}
+
+    # pylint: disable=arguments-differ
+    def list(self, request, **kwargs):
+        """
+        REST API endpoint for listing all the blocks information in the course and
+        information about the course while regarding user access and roles.
+
+        Arguments:
+            request - Django request object
+        """
+
+        response = super().list(request, kwargs)
+
+        if request.GET.get('return_type', 'dict') == 'dict':
+            course_id = request.query_params.get('course_id', None)
+            course_key = CourseKey.from_string(course_id)
+            course_overview = CourseOverview.get_from_id(course_key)
+
+            course_data = {
+                # identifiers
+                'id': course_id,
+                'name': course_overview.display_name,
+                'number': course_overview.display_number_with_default,
+                'org': course_overview.display_org_with_default,
+
+                # dates
+                'start': course_overview.start,
+                'start_display': course_overview.start_display,
+                'start_type': course_overview.start_type,
+                'end': course_overview.end,
+
+                # various URLs
+                'media': {
+                    'image': course_overview.image_urls,
+                },
+                'certificate': self.get_certificate(request, course_key),
+                'is_self_paced': course_overview.self_paced
+            }
+
+            response.data.update(course_data)
+        return response

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -178,8 +178,10 @@ class BlocksInfoInCourseView(BlocksInCourseView):
     """
     **Use Case**
 
-        Returns the blocks in the course according to the requesting user's access level.
-        Add to response info fields with information about course
+        This API endpoint is specifically optimized for the course homepage on Mobile Apps.
+        The endpoint returns the blocks in the course according to the requesting user's access level.
+        Additionally, response encompasses info fields with information about the course,
+        including certificate URL, media dictionary with course image URLs, start and end dates for the course.
 
     **Example requests**:
 


### PR DESCRIPTION
## Description

Add a new mobile endpoint that extends [BlocksInCourseView](https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/course_api/blocks/views.py#L253 "https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/course_api/blocks/views.py#L253"), and add more data about a course as `media`, `course dates`, `certificate` etc.

This endpoint was added into mobile_api LMS application. In the future, this endpoint can be extended to be, for example, a coursee home endpoint for a mobile.

 
## Supporting information

This contribution is done as a part of the project [FC-0031](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3844505604/FC-0031+-+Mobile+API+Migration)

## Testing instructions

GET /api/mobile/{api_version}/course_info/blocks/?course_id=<course_id>
Check that fields `start`, `media`, `certificate` are in the reponse.