### PR TITLE
feat: [FC-0031] Add new endpoint CourseInfoDetailView

### DIFF
--- a/lms/djangoapps/mobile_api/course_info/serializers.py
+++ b/lms/djangoapps/mobile_api/course_info/serializers.py
@@ -1,0 +1,22 @@
+"""
+Serializer for course_info API
+"""
+
+
+from common.djangoapps.student.models import CourseEnrollment
+from lms.djangoapps.course_api.serializers import CourseDetailSerializer
+
+
+class CourseInfoDetailSerializer(CourseDetailSerializer):
+    """
+        Serializer for Course objects providing additional details about the
+        course.
+
+        This serializer returns more data - 'is_enrolled' user's status.
+    """
+    def to_representation(self, instance):
+        response = super().to_representation(instance)
+
+        if self.context['request'].user.is_authenticated:
+            response['is_enrolled'] = CourseEnrollment.is_enrolled(self.context['request'].user, instance.id)
+        return response

--- a/lms/djangoapps/mobile_api/course_info/urls.py
+++ b/lms/djangoapps/mobile_api/course_info/urls.py
@@ -5,8 +5,13 @@ URLs for course_info API
 
 from django.conf import settings
 from django.urls import path, re_path
+from .views import (
+    CourseHandoutsList,
+    CourseUpdatesList,
+    CourseGoalsRecordUserActivity,
+    CourseInfoDetailView,
+)
 
-from .views import CourseHandoutsList, CourseUpdatesList, CourseGoalsRecordUserActivity
 
 urlpatterns = [
     re_path(
@@ -18,6 +23,11 @@ urlpatterns = [
         fr'^{settings.COURSE_ID_PATTERN}/updates$',
         CourseUpdatesList.as_view(),
         name='course-updates-list'
+    ),
+    re_path(
+        fr'^{settings.COURSE_KEY_PATTERN}/info$',
+        CourseInfoDetailView.as_view(),
+        name="course-info-detail"
     ),
     path('record_user_activity', CourseGoalsRecordUserActivity.as_view(), name='record_user_activity'),
 ]

--- a/lms/djangoapps/mobile_api/utils.py
+++ b/lms/djangoapps/mobile_api/utils.py
@@ -5,6 +5,7 @@ Common utility methods for Mobile APIs.
 API_V05 = 'v0.5'
 API_V1 = 'v1'
 API_V2 = 'v2'
+API_V3 = 'v3'
 
 
 def parsed_version(version):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -224,7 +224,7 @@ urlpatterns = [
 
 if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
     urlpatterns += [
-        re_path(r'^api/mobile/(?P<api_version>v(2|1|0.5))/', include('lms.djangoapps.mobile_api.urls')),
+        re_path(r'^api/mobile/(?P<api_version>v(3|2|1|0.5))/', include('lms.djangoapps.mobile_api.urls')),
     ]
 
 if settings.FEATURES.get('ENABLE_OPENBADGES'):


### PR DESCRIPTION
## Description

Add a new mobile endpoint that is based on the CourseDetailView endpoint 
but extends it with information about user enrolment.

## Supporting information

This contribution is done as a part of the project [FC-0031](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3844505604/FC-0031+-+Mobile+API+Migration)

## Testing instructions

GET /api/mobile/v3/course_info/{course_key}/info

See that  `"is_enrolled"` is present in the response