### PR TITLE
feat: Adds disable_progress_graph attribute to the returned course_me…

### DIFF
--- a/lms/djangoapps/course_home_api/progress/serializers.py
+++ b/lms/djangoapps/course_home_api/progress/serializers.py
@@ -145,3 +145,4 @@ class ProgressTabSerializer(VerifiedModeSerializer):
     username = serializers.CharField()
     user_has_passing_grade = serializers.BooleanField()
     verification_data = VerificationDataSerializer()
+    disable_progress_graph = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -230,6 +230,7 @@ class ProgressTabView(RetrieveAPIView):
 
         block = modulestore().get_course(course_key)
         grading_policy = block.grading_policy
+        disable_progress_graph = block.disable_progress_graph
         verification_status = IDVerificationService.user_status(student)
         verification_link = None
         if verification_status['status'] is None or verification_status['status'] == 'expired':
@@ -259,6 +260,7 @@ class ProgressTabView(RetrieveAPIView):
             'username': username,
             'user_has_passing_grade': user_has_passing_grade,
             'verification_data': verification_data,
+            'disable_progress_graph': disable_progress_graph,
         }
         context = self.get_serializer_context()
         context['staff_access'] = is_staff


### PR DESCRIPTION
Closes [#517](https://github.com/openedx/frontend-app-course-authoring/issues/517)

Adds disable_progress_graph attribute to the returned course_metadata response

## Description

Currently, [#517](https://github.com/openedx/frontend-app-course-authoring/issues/517) faces an issue when the progress graph toggle is enabled/disabled but the settings are not respected, this PR enables the disable_progress_graph attribute to be sent in the response so the [front-end](https://github.com/openedx/frontend-app-learning) can be allowed to display/hide the graph based on the defined course-wide settings. 

## Testing Instructions:

[Please follow instructions from the this PR](https://github.com/openedx/frontend-app-learning/pull/1194)

## Results:

![CleanShot 2023-09-21 at 17 47 17@2x](https://github.com/openedx/edx-platform/assets/20343475/84de0b0e-dab3-441a-915d-cfe4fa10a83e)


