### PR TITLE
chore: upgrade dot

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -33,7 +33,7 @@ edx-enterprise==4.2.0
 #    mentioned on this issue https://github.com/openedx/edx-platform/issues/32884
 # 2. Versions from 1.5.0 to 2.0.0 have some migrations related changes.
 #    so we're upgrading minor versions one by one.
-django-oauth-toolkit==1.5.0
+django-oauth-toolkit==1.6.2
 
 
 # constrained in opaque_keys. migration guide here: https://pymongo.readthedocs.io/en/4.0/migrate-to-pymongo4.html

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -325,7 +325,7 @@ django-multi-email-field==0.7.0
     # via edx-enterprise
 django-mysql==4.11.0
     # via -r requirements/edx/kernel.in
-django-oauth-toolkit==1.5.0
+django-oauth-toolkit==1.6.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -1062,7 +1062,6 @@ six==1.16.0
     #   chem
     #   codejail-includes
     #   crowdsourcehinter-xblock
-    #   django-oauth-toolkit
     #   edx-ace
     #   edx-auth-backends
     #   edx-ccx-keys

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -524,7 +524,7 @@ django-mysql==4.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-oauth-toolkit==1.5.0
+django-oauth-toolkit==1.6.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
@@ -1841,7 +1841,6 @@ six==1.16.0
     #   chem
     #   codejail-includes
     #   crowdsourcehinter-xblock
-    #   django-oauth-toolkit
     #   edx-ace
     #   edx-auth-backends
     #   edx-ccx-keys

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -386,7 +386,7 @@ django-multi-email-field==0.7.0
     #   edx-enterprise
 django-mysql==4.11.0
     # via -r requirements/edx/base.txt
-django-oauth-toolkit==1.5.0
+django-oauth-toolkit==1.6.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -1256,7 +1256,6 @@ six==1.16.0
     #   chem
     #   codejail-includes
     #   crowdsourcehinter-xblock
-    #   django-oauth-toolkit
     #   edx-ace
     #   edx-auth-backends
     #   edx-ccx-keys

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -419,7 +419,7 @@ django-multi-email-field==0.7.0
     #   edx-enterprise
 django-mysql==4.11.0
     # via -r requirements/edx/base.txt
-django-oauth-toolkit==1.5.0
+django-oauth-toolkit==1.6.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -1399,7 +1399,6 @@ six==1.16.0
     #   chem
     #   codejail-includes
     #   crowdsourcehinter-xblock
-    #   django-oauth-toolkit
     #   edx-ace
     #   edx-auth-backends
     #   edx-ccx-keys


### PR DESCRIPTION
Upgrading DOT

---
Result of `python manage.py lms sqlmigrate oauth2_provider 0005_auto_20211222_2352` 

```
--
-- Alter field user on accesstoken
--
--
-- Alter field user on application
--
--
-- Alter field user on grant
--
--
-- Alter field user on idtoken
--
--
-- Alter field user on refreshtoken
--
```

- `0005_auto_20211222_2352` migration file is from version [1.6.2](https://github.com/jazzband/django-oauth-toolkit/blob/1.6.2/oauth2_provider/migrations/0005_auto_20211222_2352.py)
- This migration file is the result of this change ([django 4.0 release notes](https://docs.djangoproject.com/en/4.0/releases/4.0/#migrations-autodetector-changes:~:text=makemigrations%20might%20generate%20no%2Dop%20AlterField%20operations)) as mentioned in [DOT 1.6.2 release notes](https://github.com/jazzband/django-oauth-toolkit/blob/6911c81af3de15e4175a033e0dd17df6295fee1d/CHANGELOG.md#fixed)
- It only generates no-op AlterField operations which have no impact on database.