### PR TITLE
feat: publish `CERTIFICATE_REVOKED` events to the event bus

### DIFF
--- a/lms/djangoapps/certificates/config.py
+++ b/lms/djangoapps/certificates/config.py
@@ -34,8 +34,8 @@ SEND_CERTIFICATE_CREATED_SIGNAL = SettingToggle('SEND_CERTIFICATE_CREATED_SIGNAL
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: When True, the system will publish `CERTIFICATE_REVOKED` signals to the event bus. The
-#   `CERTIFICATE_REVOKED` signal is emit when a certificate has been awarded to a learner and the creation process has
-#   completed.
+#   `CERTIFICATE_REVOKED` signal is emit when a certificate has been revoked from a learner and the revocation process
+#   has completed.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2023-09-15
 # .. toggle_target_removal_date: 2024-01-01

--- a/lms/djangoapps/certificates/config.py
+++ b/lms/djangoapps/certificates/config.py
@@ -28,3 +28,16 @@ AUTO_CERTIFICATE_GENERATION = WaffleSwitch(f"{WAFFLE_NAMESPACE}.auto_certificate
 # .. toggle_target_removal_date: 2023-07-31
 # .. toggle_tickets: TODO
 SEND_CERTIFICATE_CREATED_SIGNAL = SettingToggle('SEND_CERTIFICATE_CREATED_SIGNAL', default=False, module_name=__name__)
+
+
+# .. toggle_name: SEND_CERTIFICATE_REVOKED_SIGNAL
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: When True, the system will publish `CERTIFICATE_REVOKED` signals to the event bus. The
+#   `CERTIFICATE_REVOKED` signal is emit when a certificate has been awarded to a learner and the creation process has
+#   completed.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-09-15
+# .. toggle_target_removal_date: 2024-01-01
+# .. toggle_tickets: TODO
+SEND_CERTIFICATE_REVOKED_SIGNAL = SettingToggle('SEND_CERTIFICATE_REVOKED_SIGNAL', default=False, module_name=__name__)

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -378,6 +378,10 @@ class GeneratedCertificate(models.Model):
 
         if not grade:
             grade = ''
+        # the grade can come through revocation as a float, so we must convert it to a string to be compatible with the
+        # `CERTIFICATE_REVOKED` event definition
+        elif isinstance(grade, float):
+            grade = str(grade)
 
         if not mode:
             mode = self.mode


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds the ability for the LMS to publish `CERTIFICATE_REVOKED` events to the Event Bus. There is also work in progress for Credentials to consume these events.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
