### PR TITLE
feat: receiver for invalidate certificate

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -20,6 +20,8 @@ from eventtracking import tracker
 from opaque_keys.edx.django.models import CourseKeyField
 from organizations.api import get_course_organization_id
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.api import is_user_enrolled_in_course
 from common.djangoapps.student.models import CourseEnrollment
@@ -49,6 +51,8 @@ from lms.djangoapps.certificates.utils import (
     certificate_status_for_student as _certificate_status_for_student,
 )
 from lms.djangoapps.instructor import access
+from lms.djangoapps.utils import _get_key
+from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: disable=wrong-import-order
@@ -920,3 +924,36 @@ def _has_passed_or_is_allowlisted(course, student, course_grade):
     has_passed = course_grade and course_grade.passed
 
     return has_passed or is_allowlisted
+
+
+def invalidate_certificate_legacy_and_new(user_id, course_key_or_id):
+    """
+    Invalidate the user certificate in a given course if it exists and the user is not on the allowlist for this
+    course run.
+
+    This function is called in services.py and handlers.py within the certificates folder. As of now,
+    The call in services.py occurs when an exam attempt is rejected in the legacy exams backend, edx-proctoring.
+    The call in handlers.py is occurs when an exam attempt is rejected in the newer exams backend, edx-exams.
+    """
+    print("YUH")
+
+    course_key = _get_key(course_key_or_id, CourseKey)
+    if _is_on_certificate_allowlist(user_id, course_key):
+        log.info(f'User {user_id} is on the allowlist for {course_key}. The certificate will not be invalidated.')
+        return False
+
+    try:
+        generated_certificate = GeneratedCertificate.objects.get(
+            user=user_id,
+            course_id=course_key
+        )
+        generated_certificate.invalidate(source='certificate_service')
+    except ObjectDoesNotExist:
+        log.warning(
+            'Invalidation failed because a certificate for user %d in course %s does not exist.',
+            user_id,
+            course_key
+        )
+        return False
+
+    return True

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -20,8 +20,6 @@ from eventtracking import tracker
 from opaque_keys.edx.django.models import CourseKeyField
 from organizations.api import get_course_organization_id
 
-from django.core.exceptions import ObjectDoesNotExist
-
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.api import is_user_enrolled_in_course
 from common.djangoapps.student.models import CourseEnrollment
@@ -935,8 +933,6 @@ def invalidate_certificate_legacy_and_new(user_id, course_key_or_id):
     The call in services.py occurs when an exam attempt is rejected in the legacy exams backend, edx-proctoring.
     The call in handlers.py is occurs when an exam attempt is rejected in the newer exams backend, edx-exams.
     """
-    print("YUH")
-
     course_key = _get_key(course_key_or_id, CourseKey)
     if _is_on_certificate_allowlist(user_id, course_key):
         log.info(f'User {user_id} is on the allowlist for {course_key}. The certificate will not be invalidated.')

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -924,7 +924,7 @@ def _has_passed_or_is_allowlisted(course, student, course_grade):
     return has_passed or is_allowlisted
 
 
-def invalidate_certificate_legacy_and_new(user_id, course_key_or_id):
+def invalidate_certificate(user_id, course_key_or_id, source):
     """
     Invalidate the user certificate in a given course if it exists and the user is not on the allowlist for this
     course run.
@@ -943,7 +943,7 @@ def invalidate_certificate_legacy_and_new(user_id, course_key_or_id):
             user=user_id,
             course_id=course_key
         )
-        generated_certificate.invalidate(source='certificate_service')
+        generated_certificate.invalidate(source=source)
     except ObjectDoesNotExist:
         log.warning(
             'Invalidation failed because a certificate for user %d in course %s does not exist.',

--- a/lms/djangoapps/certificates/handlers.py
+++ b/lms/djangoapps/certificates/handlers.py
@@ -1,0 +1,31 @@
+"""
+Handlers for credits
+"""
+import logging
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from django.dispatch import receiver
+from openedx_events.learning.signals import EXAM_ATTEMPT_REJECTED
+
+from lms.djangoapps.certificates.services import CertificateService
+
+User = get_user_model()
+
+log = logging.getLogger(__name__)
+
+
+
+
+@receiver(EXAM_ATTEMPT_REJECTED)
+def handle_exam_attempt_rejected_event(sender, signal, **kwargs):
+    """
+    Consume `EXAM_ATTEMPT_REJECTED` events from the event bus.
+    Pass the received data to invalidate_certificate in the services.py file in this folder.
+    """
+    event_data = kwargs.get('exam_attempt')
+    user_data = event_data.student_user
+    usage_key = event_data.usage_key
+
+    # Note that the usage_key is the same as the course_key, and is being passed in as the course_key param
+    CertificateService.invalidate_certificate(user_id=user_data.id, course_key_or_id=usage_key)

--- a/lms/djangoapps/certificates/handlers.py
+++ b/lms/djangoapps/certificates/handlers.py
@@ -8,13 +8,11 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.dispatch import receiver
 from openedx_events.learning.signals import EXAM_ATTEMPT_REJECTED
 
-from lms.djangoapps.certificates.services import CertificateService
+from lms.djangoapps.certificates.api import invalidate_certificate_legacy_and_new
 
 User = get_user_model()
 
 log = logging.getLogger(__name__)
-
-
 
 
 @receiver(EXAM_ATTEMPT_REJECTED)
@@ -25,7 +23,7 @@ def handle_exam_attempt_rejected_event(sender, signal, **kwargs):
     """
     event_data = kwargs.get('exam_attempt')
     user_data = event_data.student_user
-    usage_key = event_data.usage_key
+    course_key = event_data.course_key
 
-    # Note that the usage_key is the same as the course_key, and is being passed in as the course_key param
-    CertificateService.invalidate_certificate(user_id=user_data.id, course_key_or_id=usage_key)
+    # Note that the course_key is the same as the course_key_or_id, and is being passed in as the course_key param
+    invalidate_certificate_legacy_and_new(user_id=user_data.id, course_key_or_id=course_key)

--- a/lms/djangoapps/certificates/handlers.py
+++ b/lms/djangoapps/certificates/handlers.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.dispatch import receiver
 from openedx_events.learning.signals import EXAM_ATTEMPT_REJECTED
 
-from lms.djangoapps.certificates.api import invalidate_certificate_legacy_and_new
+from lms.djangoapps.certificates.api import invalidate_certificate
 
 User = get_user_model()
 
@@ -25,4 +25,4 @@ def handle_exam_attempt_rejected_event(sender, signal, **kwargs):
     course_key = event_data.course_key
 
     # Note that the course_key is the same as the course_key_or_id, and is being passed in as the course_key param
-    invalidate_certificate_legacy_and_new(user_data.id, course_key)
+    invalidate_certificate(user_data.id, course_key, source='exam_event')

--- a/lms/djangoapps/certificates/handlers.py
+++ b/lms/djangoapps/certificates/handlers.py
@@ -4,7 +4,6 @@ Handlers for credits
 import logging
 
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist
 from django.dispatch import receiver
 from openedx_events.learning.signals import EXAM_ATTEMPT_REJECTED
 
@@ -26,4 +25,4 @@ def handle_exam_attempt_rejected_event(sender, signal, **kwargs):
     course_key = event_data.course_key
 
     # Note that the course_key is the same as the course_key_or_id, and is being passed in as the course_key param
-    invalidate_certificate_legacy_and_new(user_id=user_data.id, course_key_or_id=course_key)
+    invalidate_certificate_legacy_and_new(user_data.id, course_key)

--- a/lms/djangoapps/certificates/services.py
+++ b/lms/djangoapps/certificates/services.py
@@ -2,18 +2,7 @@
 Certificate service
 """
 
-
-import logging
-
-from django.core.exceptions import ObjectDoesNotExist
-from opaque_keys.edx.keys import CourseKey
-
-from lms.djangoapps.certificates.generation_handler import is_on_certificate_allowlist
-from lms.djangoapps.certificates.models import GeneratedCertificate
-from lms.djangoapps.utils import _get_key
-
-log = logging.getLogger(__name__)
-
+from lms.djangoapps.certificates.api import invalidate_certificate_legacy_and_new
 
 class CertificateService:
     """
@@ -21,27 +10,6 @@ class CertificateService:
     """
 
     def invalidate_certificate(self, user_id, course_key_or_id):
-        """
-        Invalidate the user certificate in a given course if it exists and the user is not on the allowlist for this
-        course run.
-        """
-        course_key = _get_key(course_key_or_id, CourseKey)
-        if is_on_certificate_allowlist(user_id, course_key):
-            log.info(f'User {user_id} is on the allowlist for {course_key}. The certificate will not be invalidated.')
-            return False
-
-        try:
-            generated_certificate = GeneratedCertificate.objects.get(
-                user=user_id,
-                course_id=course_key
-            )
-            generated_certificate.invalidate(source='certificate_service')
-        except ObjectDoesNotExist:
-            log.warning(
-                'Invalidation failed because a certificate for user %d in course %s does not exist.',
-                user_id,
-                course_key
-            )
-            return False
-
-        return True
+        # The original code for this function was moved to this helper function to be call-able
+        # By both the legacy and current exams backends (edx-proctoring and edx-exams).
+        invalidate_certificate_legacy_and_new(user_id, course_key_or_id)

--- a/lms/djangoapps/certificates/services.py
+++ b/lms/djangoapps/certificates/services.py
@@ -4,6 +4,7 @@ Certificate service
 
 from lms.djangoapps.certificates.api import invalidate_certificate_legacy_and_new
 
+
 class CertificateService:
     """
     User Certificate service
@@ -12,4 +13,4 @@ class CertificateService:
     def invalidate_certificate(self, user_id, course_key_or_id):
         # The original code for this function was moved to this helper function to be call-able
         # By both the legacy and current exams backends (edx-proctoring and edx-exams).
-        invalidate_certificate_legacy_and_new(user_id, course_key_or_id)
+        return invalidate_certificate_legacy_and_new(user_id, course_key_or_id)

--- a/lms/djangoapps/certificates/services.py
+++ b/lms/djangoapps/certificates/services.py
@@ -2,7 +2,7 @@
 Certificate service
 """
 
-from lms.djangoapps.certificates.api import invalidate_certificate_legacy_and_new
+from lms.djangoapps.certificates.api import invalidate_certificate
 
 
 class CertificateService:
@@ -13,4 +13,4 @@ class CertificateService:
     def invalidate_certificate(self, user_id, course_key_or_id):
         # The original code for this function was moved to this helper function to be call-able
         # By both the legacy and current exams backends (edx-proctoring and edx-exams).
-        return invalidate_certificate_legacy_and_new(user_id, course_key_or_id)
+        return invalidate_certificate(user_id, course_key_or_id, source='certificate_service')

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -25,7 +25,6 @@ from lms.djangoapps.certificates.models import (
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.api import auto_certificate_generation_enabled
-from lms.djangoapps.certificates.services import CertificateService
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.content.course_overviews.signals import COURSE_PACING_CHANGED
 from openedx.core.djangoapps.signals.signals import (

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -25,6 +25,7 @@ from lms.djangoapps.certificates.models import (
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.api import auto_certificate_generation_enabled
+from lms.djangoapps.certificates.services import CertificateService
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.content.course_overviews.signals import COURSE_PACING_CHANGED
 from openedx.core.djangoapps.signals.signals import (

--- a/lms/djangoapps/certificates/tests/test_handlers.py
+++ b/lms/djangoapps/certificates/tests/test_handlers.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for certificates signals
+"""
+import json
+from datetime import datetime, timezone
+from unittest import mock
+from uuid import uuid4
+
+from django.test import TestCase
+from opaque_keys.edx.keys import CourseKey, UsageKey
+from openedx_events.data import EventsMetadata
+from openedx_events.learning.data import ExamAttemptData, UserData, UserPersonalData
+from openedx_events.learning.signals import EXAM_ATTEMPT_REJECTED
+
+from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.courseware.models import StudentModule
+from lms.djangoapps.certificates.handlers import handle_exam_attempt_rejected_event
+
+
+class ExamCompletionEventBusTests(TestCase):
+    """
+    Tests completion events from the event bus.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course_key = CourseKey.from_string('course-v1:edX+TestX+Test_Course')
+        cls.subsection_id = 'block-v1:edX+TestX+Test_Course+type@sequential+block@subsection'
+        cls.subsection_key = UsageKey.from_string(cls.subsection_id)
+        cls.student_user = UserFactory(
+            username='student_user',
+        )
+
+    @staticmethod
+    def _get_exam_event_data(student_user, course_key, usage_key, exam_type, requesting_user=None):
+        """ create ExamAttemptData object for exam based event """
+        if requesting_user:
+            requesting_user_data = UserData(
+                id=requesting_user.id,
+                is_active=True,
+                pii=None
+            )
+        else:
+            requesting_user_data = None
+
+        return ExamAttemptData(
+            student_user=UserData(
+                id=student_user.id,
+                is_active=True,
+                pii=UserPersonalData(
+                    username=student_user.username,
+                    email=student_user.email,
+                ),
+            ),
+            course_key=course_key,
+            usage_key=usage_key,
+            requesting_user=requesting_user_data,
+            exam_type=exam_type,
+        )
+
+    @staticmethod
+    def _get_exam_event_metadata(event_signal):
+        """ create metadata object for event """
+        return EventsMetadata(
+            event_type=event_signal.event_type,
+            id=uuid4(),
+            minorversion=0,
+            source='openedx/lms/web',
+            sourcehost='lms.test',
+            time=datetime.now(timezone.utc)
+        )
+
+    @mock.patch('lms.djangoapps.certificates.services.CertificateService.invalidate_certificate', autospec=True)
+    def test_exam_attempt_rejected_event(self, mock_service_function):
+        """
+        Assert that CertificateService.invalidate_certificate is called upon consuming the event
+        """
+        exam_event_data = self._get_exam_event_data(self.student_user,
+                                                    self.course_key,
+                                                    self.subsection_key,
+                                                    exam_type='proctored')
+        event_metadata = self._get_exam_event_metadata(EXAM_ATTEMPT_REJECTED)
+
+        event_kwargs = {
+            'exam_attempt': exam_event_data,
+            'metadata': event_metadata
+        }
+        handle_exam_attempt_rejected_event(None, EXAM_ATTEMPT_REJECTED, **event_kwargs)
+        # TODO: Change params here accordingly
+        mock_service_function.assert_called_once_with((self.student_user, self.course_key))

--- a/lms/djangoapps/certificates/tests/test_handlers.py
+++ b/lms/djangoapps/certificates/tests/test_handlers.py
@@ -26,7 +26,7 @@ class ExamCompletionEventBusTests(TestCase):
         super().setUpClass()
         cls.course_key = CourseKey.from_string('course-v1:edX+TestX+Test_Course')
         cls.subsection_id = 'block-v1:edX+TestX+Test_Course+type@sequential+block@subsection'
-        cls.subsection_key = UsageKey.from_string(cls.subsection_id)
+        cls.usage_key = UsageKey.from_string(cls.subsection_id)
         cls.student_user = UserFactory(
             username='student_user',
         )
@@ -70,15 +70,16 @@ class ExamCompletionEventBusTests(TestCase):
             time=datetime.now(timezone.utc)
         )
 
-    @mock.patch('lms.djangoapps.certificates.services.CertificateService.invalidate_certificate', autospec=True)
-    def test_exam_attempt_rejected_event(self, mock_service_function):
+    @mock.patch('lms.djangoapps.certificates.api.invalidate_certificate_legacy_and_new')
+    def test_exam_attempt_rejected_event(self, mock_api_function):
         """
-        Assert that CertificateService.invalidate_certificate is called upon consuming the event
+        Assert that CertificateService api's invalidate_certificate_legacy_and_new is called upon consuming the event
         """
         exam_event_data = self._get_exam_event_data(self.student_user,
                                                     self.course_key,
-                                                    self.subsection_key,
+                                                    self.usage_key,
                                                     exam_type='proctored')
+        # print("\n\n\nexam_event_data:", exam_event_data)
         event_metadata = self._get_exam_event_metadata(EXAM_ATTEMPT_REJECTED)
 
         event_kwargs = {
@@ -86,5 +87,6 @@ class ExamCompletionEventBusTests(TestCase):
             'metadata': event_metadata
         }
         handle_exam_attempt_rejected_event(None, EXAM_ATTEMPT_REJECTED, **event_kwargs)
-        # TODO: Change params here accordingly
-        mock_service_function.assert_called_once_with((self.student_user, self.course_key))
+        # TODO: THURS MORNING MAKE THIS WORK!!!
+        mock_api_function.assert_called()
+        mock_api_function.assert_called_once_with(self.student_user.id, self.course_key)

--- a/lms/djangoapps/certificates/tests/test_handlers.py
+++ b/lms/djangoapps/certificates/tests/test_handlers.py
@@ -68,10 +68,10 @@ class ExamCompletionEventBusTests(TestCase):
             time=datetime.now(timezone.utc)
         )
 
-    @mock.patch('lms.djangoapps.certificates.handlers.invalidate_certificate_legacy_and_new')
+    @mock.patch('lms.djangoapps.certificates.handlers.invalidate_certificate')
     def test_exam_attempt_rejected_event(self, mock_api_function):
         """
-        Assert that CertificateService api's invalidate_certificate_legacy_and_new is called upon consuming the event
+        Assert that CertificateService api's invalidate_certificate is called upon consuming the event
         """
         exam_event_data = self._get_exam_event_data(self.student_user,
                                                     self.course_key,
@@ -84,4 +84,4 @@ class ExamCompletionEventBusTests(TestCase):
             'metadata': event_metadata
         }
         handle_exam_attempt_rejected_event(None, EXAM_ATTEMPT_REJECTED, **event_kwargs)
-        mock_api_function.assert_called_once_with(self.student_user.id, self.course_key)
+        mock_api_function.assert_called_once_with(self.student_user.id, self.course_key, source='exam_event')

--- a/lms/djangoapps/certificates/tests/test_handlers.py
+++ b/lms/djangoapps/certificates/tests/test_handlers.py
@@ -1,7 +1,6 @@
 """
 Unit tests for certificates signals
 """
-import json
 from datetime import datetime, timezone
 from unittest import mock
 from uuid import uuid4
@@ -13,7 +12,6 @@ from openedx_events.learning.data import ExamAttemptData, UserData, UserPersonal
 from openedx_events.learning.signals import EXAM_ATTEMPT_REJECTED
 
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.certificates.handlers import handle_exam_attempt_rejected_event
 
 
@@ -70,7 +68,7 @@ class ExamCompletionEventBusTests(TestCase):
             time=datetime.now(timezone.utc)
         )
 
-    @mock.patch('lms.djangoapps.certificates.api.invalidate_certificate_legacy_and_new')
+    @mock.patch('lms.djangoapps.certificates.handlers.invalidate_certificate_legacy_and_new')
     def test_exam_attempt_rejected_event(self, mock_api_function):
         """
         Assert that CertificateService api's invalidate_certificate_legacy_and_new is called upon consuming the event
@@ -79,7 +77,6 @@ class ExamCompletionEventBusTests(TestCase):
                                                     self.course_key,
                                                     self.usage_key,
                                                     exam_type='proctored')
-        # print("\n\n\nexam_event_data:", exam_event_data)
         event_metadata = self._get_exam_event_metadata(EXAM_ATTEMPT_REJECTED)
 
         event_kwargs = {
@@ -87,6 +84,4 @@ class ExamCompletionEventBusTests(TestCase):
             'metadata': event_metadata
         }
         handle_exam_attempt_rejected_event(None, EXAM_ATTEMPT_REJECTED, **event_kwargs)
-        # TODO: THURS MORNING MAKE THIS WORK!!!
-        mock_api_function.assert_called()
         mock_api_function.assert_called_once_with(self.student_user.id, self.course_key)


### PR DESCRIPTION
- consumes event of exam attempt rejected
- initial commit, need to make tests

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
