### PR TITLE
fix: Remove rendering of the subs upsell on dashboard sidebar

### DIFF
--- a/lms/static/js/learner_dashboard/spec/sidebar_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/sidebar_view_spec.js
@@ -32,33 +32,8 @@ describe('Sidebar View', () => {
         expect(view).toBeDefined();
     });
 
-    it('should not render the subscription upsell section if B2CSubscriptions are disabled', () => {
-        view.remove();
-        view = new SidebarView({
-            el: '.sidebar',
-            context: {
-                ...context,
-                isUserB2CSubscriptionsEnabled: false,
-            },
-        });
-        view.render();
+    it('should not render the subscription upsell section', () => {
         expect(view.$('.js-subscription-upsell')[0]).not.toBeInDOM();
-    });
-
-    it('should render the subscription upsell section', () => {
-        expect(view.$('.js-subscription-upsell')[0]).toBeInDOM();
-        expect(view.$('.js-subscription-upsell .badge').html().trim())
-            .toEqual('New');
-        expect(view.$('.js-subscription-upsell h4').html().trim())
-            .toMatch(/^Monthly program subscriptions . more flexible, more affordable$/);
-        expect(view.$('.js-subscription-upsell .advertise-message').html().trim())
-            .toEqual(
-                'Now available for many popular programs, affordable monthly subscription pricing can help you manage your budget more effectively. Subscriptions start at $39/month USD per program, after a 7-day full access free trial. Cancel at any time.',
-            );
-        expect(view.$('.js-subscription-upsell a span:last').html().trim())
-            .toEqual('Explore subscription options');
-        expect(view.$('.js-subscription-upsell a').attr('href'))
-            .toEqual('https://www.example.org/program-subscriptions');
     });
 
     it('should load the exploration panel given a marketing URL', () => {

--- a/lms/static/js/learner_dashboard/views/sidebar_view.js
+++ b/lms/static/js/learner_dashboard/views/sidebar_view.js
@@ -3,7 +3,6 @@ import Backbone from 'backbone';
 import HtmlUtils from 'edx-ui-toolkit/js/utils/html-utils';
 
 import NewProgramsView from './explore_new_programs_view';
-import SubscriptionUpsellView from './subscription_upsell_view';
 
 import sidebarTpl from '../../../templates/learner_dashboard/sidebar.underscore';
 
@@ -30,12 +29,6 @@ class SidebarView extends Backbone.View {
     }
 
     postRender() {
-        if (this.context.isUserB2CSubscriptionsEnabled) {
-            this.subscriptionUpsellView = new SubscriptionUpsellView({
-                subscriptionUpsellData: this.context.subscriptionUpsellData,
-            });
-        }
-
         this.newProgramsView = new NewProgramsView({
             context: this.context,
         });

--- a/lms/templates/learner_dashboard/sidebar.underscore
+++ b/lms/templates/learner_dashboard/sidebar.underscore
@@ -1,4 +1,1 @@
-<% if (isUserB2CSubscriptionsEnabled) { %>
-	<aside class="aside js-subscription-upsell"></aside>
-<% } %>
 <div class="aside program-advertise"></div>


### PR DESCRIPTION
[REV-3705](https://2u-internal.atlassian.net/browse/REV-3705).

Removing the subscription upsell on the program dashboard sidebar from being rendered. Learners who have an active subscription will still see subscription related alerts.

The CSS added in https://github.com/openedx/edx-platform/pull/31943 will not be reverted as they were general CSS improvements.

_Pls note_: this PR should not be merged until 10/2/23.