### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ build==0.9.0
 click==8.1.3
 importlib==1.0.4
 importlib-resources==5.10.0
-packaging==21.3
 pep517==0.13.0
 pip-tools==6.9.0
 pyparsing==3.0.9

--- a/requirements/edx/coverage.in
+++ b/requirements/edx/coverage.in
@@ -13,4 +13,3 @@
 -c ../constraints.txt
 
 coverage                            # Code coverage testing for Python
-diff-cover                          # Automatically find diff lines that need test coverage

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,17 +4,5 @@
 #
 #    make upgrade
 #
-chardet==5.2.0
-    # via diff-cover
 coverage==7.3.1
     # via -r requirements/edx/coverage.in
-diff-cover==7.7.0
-    # via -r requirements/edx/coverage.in
-jinja2==3.1.2
-    # via diff-cover
-markupsafe==2.1.3
-    # via jinja2
-pluggy==1.3.0
-    # via diff-cover
-pygments==2.16.1
-    # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -200,7 +200,6 @@ chardet==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   diff-cover
     #   pysrt
 charset-normalizer==2.0.12
     # via
@@ -327,8 +326,6 @@ deprecated==1.2.14
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jwcrypto
-diff-cover==7.7.0
-    # via -r requirements/edx/testing.txt
 dill==0.3.7
     # via
     #   -r requirements/edx/testing.txt
@@ -1062,7 +1059,6 @@ jinja2==3.1.2
     #   -r requirements/edx/testing.txt
     #   code-annotations
     #   coreschema
-    #   diff-cover
     #   sphinx
 jmespath==0.10.0
     # via
@@ -1424,7 +1420,6 @@ platformdirs==3.8.1
 pluggy==1.3.0
     # via
     #   -r requirements/edx/testing.txt
-    #   diff-cover
     #   pytest
     #   tox
 polib==1.2.0
@@ -1496,7 +1491,6 @@ pygments==2.16.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   accessible-pygments
-    #   diff-cover
     #   py2neo
     #   pydata-sphinx-theme
     #   sphinx

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -153,8 +153,6 @@ cffi==1.15.1
 chardet==5.2.0
     # via
     #   -r requirements/edx/base.txt
-    #   -r requirements/edx/coverage.txt
-    #   diff-cover
     #   pysrt
 charset-normalizer==2.0.12
     # via
@@ -254,8 +252,6 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/base.txt
     #   jwcrypto
-diff-cover==7.7.0
-    # via -r requirements/edx/coverage.txt
 dill==0.3.7
     # via pylint
 distlib==0.3.7
@@ -806,10 +802,8 @@ itypes==1.2.0
 jinja2==3.1.2
     # via
     #   -r requirements/edx/base.txt
-    #   -r requirements/edx/coverage.txt
     #   code-annotations
     #   coreschema
-    #   diff-cover
 jmespath==0.10.0
     # via
     #   -r requirements/edx/base.txt
@@ -909,7 +903,6 @@ markey==0.8
 markupsafe==2.1.3
     # via
     #   -r requirements/edx/base.txt
-    #   -r requirements/edx/coverage.txt
     #   chem
     #   jinja2
     #   mako
@@ -1069,8 +1062,6 @@ platformdirs==3.8.1
     #   virtualenv
 pluggy==1.3.0
     # via
-    #   -r requirements/edx/coverage.txt
-    #   diff-cover
     #   pytest
     #   tox
 polib==1.2.0
@@ -1122,8 +1113,6 @@ pydantic-core==2.6.3
 pygments==2.16.1
     # via
     #   -r requirements/edx/base.txt
-    #   -r requirements/edx/coverage.txt
-    #   diff-cover
     #   py2neo
 pyjwkest==1.4.2
     # via


### PR DESCRIPTION
## Description
We ran [depslorer](https://github.com/Nathan-Furnal/depslorer) on the edx-platform and found a few dependencies that are no longer needed in the repo. This PR aims to remove those dependencies from edx-platform.

## Supporting information
Closes #32604 
Please check above issue for information on the output from Depslorer.

## Testing instructions
Please ensure that all tests should still pass after removing these dependencies.

## Deadline
None