### PR TITLE
build: Short-circuit the consistency check when no requirements changes

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -7,13 +7,6 @@ name: Consistent Python dependencies
 
 on:
   pull_request:
-    paths:
-      - 'requirements/**'
-  push:
-    branches:
-      - master
-    paths:
-      - 'requirements/**'
 
 defaults:
   run:
@@ -25,16 +18,37 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      # Only run remaining steps if there are changes to requirements/**
+      - name: "Decide whether to short-circuit"
+        env:
+          GH_TOKEN: "${{ github.token }}"
+          PR_URL: "${{ github.event.pull_request.html_url }}"
+        run: |
+          paths=$(gh pr diff "$PR_URL" --name-only)
+          echo $'Paths touched in PR:\n'"$paths"
+
+          # The ^"? is because git may quote weird file paths
+          matched="$(echo "$paths" | grep -P '^"?requirements/' || true)"
+          echo $'Relevant paths:\n'"$matched"
+          if [[ -n "$matched" ]]; then
+              echo "RELEVANT=true" >> "$GITHUB_ENV"
+          fi
+
       - uses: actions/checkout@v3
+        if: ${{ env.RELEVANT == 'true' }}
 
       - uses: actions/setup-python@v4
+        if: ${{ env.RELEVANT == 'true' }}
         with:
           python-version: '3.8'
 
-      - run: |
+      - name: "Recompile requirements"
+        if: ${{ env.RELEVANT == 'true' }}
+        run: |
           make compile-requirements
 
       - name: Fail if compiling requirements caused changes
+        if: ${{ env.RELEVANT == 'true' }}
         run: |
           SUMMARY_HELP=$(cat <<'EOMARKDOWN'
           # Inconsistent Python dependencies


### PR DESCRIPTION
This skips the `make compile-requirements` check when there have been no changes under `requirements/**`, but it does so in a way that still registers the action as having passed, not skipped. By doing so, we can make it a required check while also avoiding the 5-6 minutes of wasted worker time.

This commit also removes the activation on push-to-master, since we really just need to check PRs. I don't expect there to be silent merge conflicts with this check, so if it passes on a branch it should also pass on a successful simple rebase or merge.

It would be nice if there was a way to declare success and exit early, but GH hasn't implemented it: https://github.com/actions/runner/issues/662 Alternatively, it would be great if skipped checks could count as fulfilling the branch protection rules, but no luck there.

The only alternative that uses GH's built-in paths/paths-ignore feature would be to add a second workflow with the same job name and the opposite path triggers and that always passes. It's not clear that this would be any less fragile or confusing than the `git diff | grep` and step-conditionals approach.