### PR TITLE
feat: set course for wiki based on the wiki_slug

### DIFF
--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -34,3 +34,10 @@ class TestWikiAccessMiddleware(ModuleStoreTestCase):
         response = self.client.get('/courses/course-v1:edx+math101+2014/wiki/math101/')
         self.assertContains(response, '/courses/course-v1:edx+math101+2014/wiki/math101/_edit/')
         self.assertContains(response, '/courses/course-v1:edx+math101+2014/wiki/math101/_settings/')
+
+    def test_finds_course_by_wiki_slug(self):
+        """Test that finds course by wiki slug, if course id is not present in the url."""
+        response = self.client.get('/wiki/math101/')
+        request = response.wsgi_request
+        self.assertTrue(hasattr(request, 'course'))
+        self.assertEqual(request.course.id, self.course_math101.id)


### PR DESCRIPTION
## Description

Learners want to have the usual course navigation when viewing a wiki, so that they can go back to the course related to the wiki and browse other tabs/sections of the course.

Wiki reads the course from the `request.course`. If it's not present, i.e.  None or not set on the request, it will not show the course navigation UI.

It seems like `WikiAccessMiddleware` already has the code that parses course id from the request (when the request is for a wiki view) and sets the course for the request. However, it doesn't work in most scenarios, because the course id is not in the it's normal format in most requests that go to wiki.

For example, when a leaner clicks on a wiki tab from the course overview, they are redirected to `/wiki/<wiki_slug>/` path. The wiki slug is taken from course's `wiki_slug` field. This slug can be used to figure out what course this wiki belongs to in most (not all) cases.

This commit adds code to the `WikiAccessMiddleware` that attempts to find a course based on wiki slug, and in case of success, sets the course to the `request.course`, so that wiki can display course navigation UI.

## Testing instructions

* Setup `devstack` of latest version
* `make dev.up.lms+cms+frontend-app-learning`
* Log in at `localhost:18000` as `edx@example.com` (`edx` as password)
* Enroll into the demo course
* Go to studio for this course, in the navigation find "Content -> Pages", click on it, and make the Wiki tab visible by clicking the crossed eye icon
* Go back to the course, and click the wiki tab
* You will see that the wiki doesn't have any course tabs, there is no way to go back to the course you came from, etc.
  <details>
    <summary>Screenshot</summary>

    ![image](https://github.com/openedx/edx-platform/assets/30300520/feaa2f37-de00-4b09-9058-94fe1fa7da18)
  </details>
* Now checkout the branch from the PR
* Go back to the wiki page and reload (it might need a minute for the dev server to restart)
* You will now see that the course navigation UI is showing correctly.
  <details>
    <summary>Screenshot</summary>

    ![image](https://github.com/openedx/edx-platform/assets/30300520/af11a5e7-8f1c-4eab-baa1-2759fb89c094)
  </details>
* Check that the links are pointing to the correct course

## Deadline

"None"

## Notes

This solution doesn't work well when there a lot of courses that have the same `wiki_slug`. (https://github.com/openedx/edx-platform/pull/31794#issuecomment-1741504639)

And alternative or complementary solution could be to, when the learners click on the wiki tab, instead of redirecting them to `/wiki/<path>`, redirect them to `/courses/<course_id>/wiki/<path>`. Such urls are supported, and the middleware would be able to pick up the course id from the url. One of the issue with this solution, is that it seems like these views were deliberately made un-reversable, so we would have to hard code the url. Essentially, the solution that would not rely on the `wiki_slug` would only require the following change:
```diff
--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -98,7 +98,7 @@ def course_wiki_redirect(request, course_id, wiki_path=""):
                             'other_write': True,
                             })

-    return redirect("wiki:get", path=urlpath.path)
+    return redirect(f"/courses/{course_id}/wiki/{urlpath.path}")
```