### PR TITLE
fix  cms api route details

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -74,7 +74,7 @@ urlpatterns = [
 
     # CMS API
     re_path(
-        fr'^file_assets/{settings.COURSE_ID_PATTERN}$',
+        fr'^file_assets/{settings.COURSE_ID_PATTERN}/$',
         assets.AssetsCreateRetrieveView.as_view(), name='cms_api_create_retrieve_assets'
     ),
     re_path(
@@ -94,15 +94,19 @@ urlpatterns = [
         videos.VideoImagesView.as_view(), name='cms_api_videos_images'
     ),
     re_path(
-        fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
-        videos.VideosView.as_view(), name='cms_api_videos_uploads'
+        fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/$',
+        videos.VideosCreateUploadView.as_view(), name='cms_api_create_videos_upload'
+    ),
+    re_path(
+        fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}$',
+        videos.VideosUploadsView.as_view(), name='cms_api_videos_uploads'
     ),
     re_path(
         fr'^video_transcripts/{settings.COURSE_ID_PATTERN}$',
         transcripts.TranscriptView.as_view(), name='cms_api_video_transcripts'
     ),
     re_path(
-        fr'^xblock/{settings.COURSE_ID_PATTERN}$',
+        fr'^xblock/{settings.COURSE_ID_PATTERN}/$',
         xblock.XblockCreateView.as_view(), name='cms_api_create_xblock'
     ),
     re_path(

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -75,11 +75,11 @@ urlpatterns = [
     # CMS API
     re_path(
         fr'^file_assets/{settings.COURSE_ID_PATTERN}$',
-        assets.AssetsReadPostView.as_view(), name='cms_api_create_read_assets'
+        assets.AssetsCreateRetrieveView.as_view(), name='cms_api_create_retrieve_assets'
     ),
     re_path(
         fr'^file_assets/{settings.COURSE_ID_PATTERN}/{settings.ASSET_KEY_PATTERN}$',
-        assets.AssetsView.as_view(), name='cms_api_update_delete_assets'
+        assets.AssetsUpdateDestroyView.as_view(), name='cms_api_update_destroy_assets'
     ),
     re_path(
         fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
@@ -103,7 +103,7 @@ urlpatterns = [
     ),
     re_path(
         fr'^xblock/{settings.COURSE_ID_PATTERN}$',
-        xblock.XblockPostView.as_view(), name='cms_api_post_xblock'
+        xblock.XblockCreateView.as_view(), name='cms_api_create_xblock'
     ),
     re_path(
         fr'^xblock/{settings.COURSE_ID_PATTERN}/{settings.USAGE_KEY_PATTERN}$',

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -23,7 +23,7 @@ from .views import (
 
 app_name = 'v1'
 
-VIDEO_ID_PATTERN = r'(?:(?P<edx_video_id>[-\w]+))'
+VIDEO_ID_PATTERN = r'(?P<edx_video_id>[-\w]+)'
 
 urlpatterns = [
     path(
@@ -74,8 +74,12 @@ urlpatterns = [
 
     # CMS API
     re_path(
-        fr'^file_assets/{settings.COURSE_ID_PATTERN}/{settings.ASSET_KEY_PATTERN}?$',
-        assets.AssetsView.as_view(), name='cms_api_assets'
+        fr'^file_assets/{settings.COURSE_ID_PATTERN}$',
+        assets.AssetsReadPostView.as_view(), name='cms_api_create_read_assets'
+    ),
+    re_path(
+        fr'^file_assets/{settings.COURSE_ID_PATTERN}/{settings.ASSET_KEY_PATTERN}$',
+        assets.AssetsView.as_view(), name='cms_api_update_delete_assets'
     ),
     re_path(
         fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
@@ -92,10 +96,6 @@ urlpatterns = [
     re_path(
         fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
         videos.VideosView.as_view(), name='cms_api_videos_uploads'
-    ),
-    re_path(
-        fr'^videos/upload_link/{settings.COURSE_ID_PATTERN}$',
-        videos.UploadLinkView.as_view(), name='cms_api_videos_upload_link'
     ),
     re_path(
         fr'^video_transcripts/{settings.COURSE_ID_PATTERN}$',

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -61,38 +61,6 @@ urlpatterns = [
         CourseGradingView.as_view(),
         name="course_grading"
     ),
-    re_path(
-        fr'^xblock/{settings.COURSE_ID_PATTERN}/{settings.USAGE_KEY_PATTERN}?$',
-        xblock.XblockView.as_view(), name='studio_content'
-    ),
-    re_path(
-        fr'^file_assets/{settings.COURSE_ID_PATTERN}/{settings.ASSET_KEY_PATTERN}?$',
-        assets.AssetsView.as_view(), name='studio_content_assets'
-    ),
-    re_path(
-        fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
-        videos.VideosView.as_view(), name='studio_content_videos_uploads'
-    ),
-    re_path(
-        fr'^videos/images/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}$',
-        videos.VideoImagesView.as_view(), name='studio_content_videos_images'
-    ),
-    re_path(
-        fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
-        videos.VideoEncodingsDownloadView.as_view(), name='studio_content_videos_encodings'
-    ),
-    path(
-        'videos/features/',
-        videos.VideoFeaturesView.as_view(), name='studio_content_videos_features'
-    ),
-    re_path(
-        fr'^videos/upload_link/{settings.COURSE_ID_PATTERN}$',
-        videos.UploadLinkView.as_view(), name='studio_content_videos_upload_link'
-    ),
-    re_path(
-        fr'^video_transcripts/{settings.COURSE_ID_PATTERN}$',
-        transcripts.TranscriptView.as_view(), name='studio_content_video_transcripts'
-    ),
     path(
         'help_urls',
         HelpUrlsView.as_view(),
@@ -102,5 +70,43 @@ urlpatterns = [
         fr'^course_rerun/{COURSE_ID_PATTERN}$',
         CourseRerunView.as_view(),
         name="course_rerun"
+    ),
+
+    # CMS API
+    re_path(
+        fr'^file_assets/{settings.COURSE_ID_PATTERN}/{settings.ASSET_KEY_PATTERN}?$',
+        assets.AssetsView.as_view(), name='cms_api_assets'
+    ),
+    re_path(
+        fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
+        videos.VideoEncodingsDownloadView.as_view(), name='cms_api_videos_encodings'
+    ),
+    path(
+        'videos/features/',
+        videos.VideoFeaturesView.as_view(), name='cms_api_videos_features'
+    ),
+    re_path(
+        fr'^videos/images/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}$',
+        videos.VideoImagesView.as_view(), name='cms_api_videos_images'
+    ),
+    re_path(
+        fr'^videos/uploads/{settings.COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}?$',
+        videos.VideosView.as_view(), name='cms_api_videos_uploads'
+    ),
+    re_path(
+        fr'^videos/upload_link/{settings.COURSE_ID_PATTERN}$',
+        videos.UploadLinkView.as_view(), name='cms_api_videos_upload_link'
+    ),
+    re_path(
+        fr'^video_transcripts/{settings.COURSE_ID_PATTERN}$',
+        transcripts.TranscriptView.as_view(), name='cms_api_video_transcripts'
+    ),
+    re_path(
+        fr'^xblock/{settings.COURSE_ID_PATTERN}$',
+        xblock.XblockPostView.as_view(), name='cms_api_post_xblock'
+    ),
+    re_path(
+        fr'^xblock/{settings.COURSE_ID_PATTERN}/{settings.USAGE_KEY_PATTERN}$',
+        xblock.XblockView.as_view(), name='cms_api_xblock'
     ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -8,7 +8,7 @@ from .grading import CourseGradingView
 from .proctoring import ProctoredExamSettingsView, ProctoringErrorsView
 from .home import HomePageView
 from .settings import CourseSettingsView
-from .xblock import XblockView
-from .assets import AssetsView
-from .videos import VideosView
+from .xblock import XblockView, XblockCreateView
+from .assets import AssetsCreateRetrieveView, AssetsUpdateDestroyView
+from .videos import VideosView, VideoImagesView, VideoEncodingsDownloadView, VideoFeaturesView
 from .help_urls import HelpUrlsView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -11,10 +11,10 @@ from .settings import CourseSettingsView
 from .xblock import XblockView, XblockCreateView
 from .assets import AssetsCreateRetrieveView, AssetsUpdateDestroyView
 from .videos import (
-  VideosUploadsView,
-  VideosCreateUploadView,
-  VideoImagesView,
-  VideoEncodingsDownloadView,
-  VideoFeaturesView
+    VideosUploadsView,
+    VideosCreateUploadView,
+    VideoImagesView,
+    VideoEncodingsDownloadView,
+    VideoFeaturesView
 )
 from .help_urls import HelpUrlsView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -10,5 +10,5 @@ from .home import HomePageView
 from .settings import CourseSettingsView
 from .xblock import XblockView, XblockCreateView
 from .assets import AssetsCreateRetrieveView, AssetsUpdateDestroyView
-from .videos import VideosView, VideoImagesView, VideoEncodingsDownloadView, VideoFeaturesView
+from .videos import VideosUploadsView, VideosCreateUploadView, VideoImagesView, VideoEncodingsDownloadView, VideoFeaturesView
 from .help_urls import HelpUrlsView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -10,5 +10,11 @@ from .home import HomePageView
 from .settings import CourseSettingsView
 from .xblock import XblockView, XblockCreateView
 from .assets import AssetsCreateRetrieveView, AssetsUpdateDestroyView
-from .videos import VideosUploadsView, VideosCreateUploadView, VideoImagesView, VideoEncodingsDownloadView, VideoFeaturesView
+from .videos import (
+  VideosUploadsView,
+  VideosCreateUploadView,
+  VideoImagesView,
+  VideoEncodingsDownloadView,
+  VideoFeaturesView
+)
 from .help_urls import HelpUrlsView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/assets.py
@@ -24,7 +24,7 @@ toggles = contentstore_toggles
 
 
 @view_auth_classes()
-class AssetsReadPostView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView):
+class AssetsCreateRetrieveView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView):
     """
     public rest API endpoints for the CMS API Assets.
     course_key: required argument, needed to authorize course authors and identify the asset.
@@ -57,7 +57,7 @@ class AssetsReadPostView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView
 
 
 @view_auth_classes()
-class AssetsView(DeveloperErrorViewMixin, UpdateAPIView, DestroyAPIView):
+class AssetsUpdateDestroyView(DeveloperErrorViewMixin, UpdateAPIView, DestroyAPIView):
     """
     public rest API endpoints for the CMS API Assets.
     course_key: required argument, needed to authorize course authors and identify the asset.

--- a/cms/djangoapps/contentstore/rest_api/v1/views/assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/assets.py
@@ -2,7 +2,7 @@
 Public rest API endpoints for the CMS API Assets.
 """
 import logging
-from rest_framework.generics import RetrieveUpdateDestroyAPIView, CreateAPIView
+from rest_framework.generics import CreateAPIView, RetrieveAPIView, UpdateAPIView, DestroyAPIView
 from django.views.decorators.csrf import csrf_exempt
 from django.http import Http404
 
@@ -24,7 +24,7 @@ toggles = contentstore_toggles
 
 
 @view_auth_classes()
-class AssetsView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView, CreateAPIView):
+class AssetsReadPostView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView):
     """
     public rest API endpoints for the CMS API Assets.
     course_key: required argument, needed to authorize course authors and identify the asset.
@@ -44,16 +44,38 @@ class AssetsView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView, CreateAP
             raise Http404
         return super().dispatch(request, *args, **kwargs)
 
-    @course_author_access_required
-    @expect_json_in_class_view
-    def retrieve(self, request, course_key):  # pylint: disable=arguments-differ
-        return handle_assets(request, course_key.html_id())
-
     @csrf_exempt
     @course_author_access_required
     @validate_request_with_serializer
     def create(self, request, course_key):  # pylint: disable=arguments-differ
         return handle_assets(request, course_key.html_id())
+
+    @course_author_access_required
+    @expect_json_in_class_view
+    def retrieve(self, request, course_key):  # pylint: disable=arguments-differ
+        return handle_assets(request, course_key.html_id())
+
+
+@view_auth_classes()
+class AssetsView(DeveloperErrorViewMixin, UpdateAPIView, DestroyAPIView):
+    """
+    public rest API endpoints for the CMS API Assets.
+    course_key: required argument, needed to authorize course authors and identify the asset.
+    asset_key_string: required argument, needed to identify the asset.
+    """
+    serializer_class = AssetSerializer
+    parser_classes = (JSONParser, MultiPartParser, FormParser, TypedFileUploadParser)
+
+    def dispatch(self, request, *args, **kwargs):
+        # TODO: probably want to refactor this to a decorator.
+        """
+        The dispatch method of a View class handles HTTP requests in general
+        and calls other methods to handle specific HTTP methods.
+        We use this to raise a 404 if the content api is disabled.
+        """
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
 
     @course_author_access_required
     @expect_json_in_class_view

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
@@ -44,7 +44,7 @@ class AssetsViewTestCase(AuthorizeStaffTestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:cms_api_assets",
+            "cms.djangoapps.contentstore:v1:cms_api_update_delete_assets",
             kwargs=self.get_url_params(),
         )
 
@@ -102,6 +102,12 @@ class AssetsViewGetTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase):
     def get_url_params(self):
         return {"course_id": self.get_course_key_string()}
 
+    def get_url(self, _course_id=None):
+        return reverse(
+            "cms.djangoapps.contentstore:v1:cms_api_create_read_assets",
+            kwargs=self.get_url_params(),
+        )
+
     def get_test_data(self):
         return None
 
@@ -147,6 +153,12 @@ class AssetsViewPostTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase):
 
     def get_url_params(self):
         return {"course_id": self.get_course_key_string()}
+
+    def get_url(self, _course_id=None):
+        return reverse(
+            "cms.djangoapps.contentstore:v1:cms_api_create_read_assets",
+            kwargs=self.get_url_params(),
+        )
 
     def get_test_data(self):
         return {

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
@@ -44,7 +44,7 @@ class AssetsViewTestCase(AuthorizeStaffTestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:studio_content_assets",
+            "cms.djangoapps.contentstore:v1:cms_api_assets",
             kwargs=self.get_url_params(),
         )
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
@@ -44,7 +44,7 @@ class AssetsViewTestCase(AuthorizeStaffTestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:cms_api_update_delete_assets",
+            "cms.djangoapps.contentstore:v1:cms_api_update_destroy_assets",
             kwargs=self.get_url_params(),
         )
 
@@ -104,7 +104,7 @@ class AssetsViewGetTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:cms_api_create_read_assets",
+            "cms.djangoapps.contentstore:v1:cms_api_create_retrieve_assets",
             kwargs=self.get_url_params(),
         )
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_assets.py
@@ -156,7 +156,7 @@ class AssetsViewPostTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:cms_api_create_read_assets",
+            "cms.djangoapps.contentstore:v1:cms_api_create_retrieve_assets",
             kwargs=self.get_url_params(),
         )
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock.py
@@ -38,7 +38,7 @@ class XBlockViewTestCase(AuthorizeStaffTestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:studio_content",
+            "cms.djangoapps.contentstore:v1:cms_api_xblock",
             kwargs=self.get_url_params(),
         )
 
@@ -140,7 +140,7 @@ class XBlockViewPostTest(XBlockViewTestCase, ModuleStoreTestCase, APITestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:studio_content",
+            "cms.djangoapps.contentstore:v1:cms_api_post_xblock",
             kwargs=self.get_url_params(),
         )
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock.py
@@ -140,7 +140,7 @@ class XBlockViewPostTest(XBlockViewTestCase, ModuleStoreTestCase, APITestCase):
 
     def get_url(self, _course_id=None):
         return reverse(
-            "cms.djangoapps.contentstore:v1:cms_api_post_xblock",
+            "cms.djangoapps.contentstore:v1:cms_api_create_xblock",
             kwargs=self.get_url_params(),
         )
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -143,29 +143,3 @@ class VideoFeaturesView(DeveloperErrorViewMixin, RetrieveAPIView):
     @csrf_exempt
     def retrieve(self, request):  # pylint: disable=arguments-differ
         return enabled_video_features(request)
-
-
-@view_auth_classes()
-class UploadLinkView(DeveloperErrorViewMixin, CreateAPIView):
-    """
-    public rest API endpoint providing a list of enabled video features.
-    """
-    serializer_class = VideoUploadSerializer
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
-
-    @csrf_exempt
-    @course_author_access_required
-    @expect_json_in_class_view
-    @validate_request_with_serializer
-    def create(self, request, course_key):  # pylint: disable=arguments-differ
-        return handle_videos(request, course_key.html_id())

--- a/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
@@ -68,7 +68,7 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
 
 
 @view_auth_classes()
-class XblockPostView(DeveloperErrorViewMixin, CreateAPIView):
+class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
     """
     Public rest API endpoints for the CMS API.
     course_key: required argument, needed to authorize course authors.

--- a/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
@@ -88,6 +88,7 @@ class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
             raise Http404
         return super().dispatch(request, *args, **kwargs)
 
+    # pylint: disable=arguments-differ
     @csrf_exempt
     @course_author_access_required
     @expect_json_in_class_view

--- a/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
@@ -23,7 +23,7 @@ handle_xblock = view_handlers.handle_xblock
 
 
 @view_auth_classes()
-class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView, CreateAPIView):
+class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
     """
     Public rest API endpoints for the CMS API.
     course_key: required argument, needed to authorize course authors.
@@ -65,6 +65,28 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView, CreateAP
     @expect_json_in_class_view
     def destroy(self, request, course_key, usage_key_string=None):
         return handle_xblock(request, usage_key_string)
+
+
+@view_auth_classes()
+class XblockPostView(DeveloperErrorViewMixin, CreateAPIView):
+    """
+    Public rest API endpoints for the CMS API.
+    course_key: required argument, needed to authorize course authors.
+    usage_key_string (optional):
+    xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"
+    """
+    serializer_class = XblockSerializer
+
+    def dispatch(self, request, *args, **kwargs):
+        # TODO: probably want to refactor this to a decorator.
+        """
+        The dispatch method of a View class handles HTTP requests in general
+        and calls other methods to handle specific HTTP methods.
+        We use this to raise a 404 if the content api is disabled.
+        """
+        if not toggles.use_studio_content_api():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
 
     @csrf_exempt
     @course_author_access_required


### PR DESCRIPTION
[TNL-11048](https://2u-internal.atlassian.net/browse/TNL-11048)
This fixes some swagger details:
- POST xblock/ should only take one parameter
- POST file_assets/ should only take one parameter
- GET and POST videos/uploads/ should only take one parameter
- you should see no more "/{var}" in the urls in the swagger ui

How to test:
- Demo app still needs to work completely (I can screen share to demonstrate, no need to set it up) - [necessary demo app PR](https://github.com/2uinc/xblock-api-experiments/pull/23)
- Go to localhost:18010/cms-api/ui/ and just verify the points above (you can just look at the urls. No need to test in further detail.)

Currently not working: Demo app uses POST to update blocks. We need to make it use PUT (even if that is not formally correct for REST) so there is no problem with routes.