### PR TITLE
fix: duplicate import dropdown for export page

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -56,7 +56,6 @@
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': str(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
             pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
-            studio_home_mfe_enabled = toggles.use_new_home_page()
             course_outline_mfe_enabled = toggles.use_new_course_outline_page(context_course.id)
             updates_mfe_enabled = toggles.use_new_updates_page(context_course.id)
             files_uploads_mfe_enabled = toggles.use_new_files_uploads_page(context_course.id)
@@ -245,7 +244,7 @@
                   % endif
                   % if export_mfe_enabled:
                   <li class="nav-item nav-course-tools-import">
-                    <a href="${get_export_url(course_key)}">${_("Import")}</a>
+                    <a href="${get_export_url(course_key)}">${_("Export")}</a>
                   </li>
                   % endif
                   % if toggles.EXPORT_GIT.is_enabled() and context_course.giturl:


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR removes the unused variable definition for `studio_home_mfe_url` and fixes the duplicate import options in the Tools dropdown when the waffle flag for the export mfe page is enabled.


Before
![image](https://github.com/openedx/edx-platform/assets/42981026/ec49bf69-c60c-4dab-8cea-bc8af8b9acf5)

After
<img width="1053" alt="Screenshot 2023-09-26 at 3 40 43 PM" src="https://github.com/openedx/edx-platform/assets/42981026/bba1ddfc-348e-4c5e-8907-1f33b9c990e9">


## Supporting information

JIRA Ticket: [TNL-11052](https://2u-internal.atlassian.net/browse/TNL-11052)

>When I view from legacy page, the tools dropdown shows import twice but no export
> However, from any new course auth page, the dropdown includes import and export

## Testing instructions

1. Enable `contentstore.new_studio_mfe.use_new_export_page` in django admin.
2. Open a course in studio.
3. Click on the tool dropdown.
4. Should have Import, Export, Checklist

## Deadline

None