### PR TITLE
Fixing Video Repeating Issue

### DIFF
--- a/xmodule/js/src/video/03_video_player.js
+++ b/xmodule/js/src/video/03_video_player.js
@@ -480,7 +480,9 @@
                     // finish bufferization and then rewind the video.
                     if (this.isYoutubeType() && this.videoPlayer.isBuffering()) {
                         this.el.on('play.seek', function() {
+                            if (this.videoPlayer.isBuffering()){
                             this.videoPlayer.player.seekTo(time, true);
+                            }
                         }.bind(this));
                     } else {
                         // Otherwise, just seek the video


### PR DESCRIPTION
## Description

This PR fixes an issue that causes the video to loop for a specific few seconds. The issue is caused when the video buffer completes and this.el.on('play.seek',) calls back to player.seekTo. To prevent this behavior, a check has been added before invoking player.seekTo.

## Supporting information

https://github.com/openedx/edx-platform/issues/36822

## Testing instructions

Play a video and seek multiple times to different points in the video before the buffering process completes.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
