### PR TITLE
feat: FC-0012 - add (--no-segment) option to extract_translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,20 @@ technical-docs:  ## build the technical docs
 guides:	swagger ## build the developer guide docs
 	cd docs/guides; make clean html
 
+# (IS_OPENEDX_TRANSLATIONS_WORKFLOW) is set to "yes" in the `extract-translation-source-files` GitHub actions
+# workflow on the `openedx-translations` repository. See (extract translation source files) step here:
+# https://github.com/openedx/openedx-translations/blob/main/.github/workflows/extract-translation-source-files.yml
+# Related doc: https://docs.openedx.org/en/latest/developers/how-tos/enable-translations-new-repo.html
+ifeq ($(IS_OPENEDX_TRANSLATIONS_WORKFLOW),yes)
 extract_translations: ## extract localizable strings from sources
-	i18n_tool extract -v
+	i18n_tool extract --no-segment -v
+	cd conf/locale/en/LC_MESSAGES && msgcat djangojs.po underscore.po -o djangojs.po
+	cd conf/locale/en/LC_MESSAGES && msgcat django.po wiki.po edx_proctoring_proctortrack.po mako.po -o django.po
+	cd conf/locale/en/LC_MESSAGES && rm wiki.po edx_proctoring_proctortrack.po mako.po underscore.po
+else
+extract_translations: ## extract localizable strings from sources
+	i18n_tool extract -v;
+endif
 
 push_translations: ## push source strings to Transifex for translation
 	i18n_tool transifex push


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Add `--no-segment` option to `extract_translations`. The flag is added if and only if `IS_OPENEDX_TRANSLATIONS_WORKFLOW` is set to `yes`. This a follow-up work to [Decision to standardize django/djangojs po files](https://github.com/openedx/edx-platform/pull/32994)

`IS_OPENEDX_TRANSLATIONS_WORKFLOW` flag is introduced and used by [openedx-translations](https://github.com/openedx/openedx-translations)

- [x] Tested with and without the flag. Working fine
- [x] Tested with openedx-translation fork https://github.com/Zeit-Labs/openedx-translations/pull/89/files#diff-dca191d363b47b36a676551d004f32d72595eb6bd57096aff82794c40e6d4c87

References
----------

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being re-architected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you notice any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes
