### PR TITLE
feat: Update the minimum password length.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -51,7 +51,7 @@ class TestCourseListing(ModuleStoreTestCase):
         self.factory = RequestFactory()
         self.global_admin = AdminFactory()
         self.client = AjaxEnabledTestClient()
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.course_create_rerun_url = reverse('course_handler')
         self.course_start = datetime.datetime.utcnow()
         self.course_end = self.course_start + datetime.timedelta(days=30)

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -56,12 +56,12 @@ class TestCourseListing(ModuleStoreTestCase):
         super().setUp()
         # create and log in a staff user.
         # create and log in a non-staff user
-        self.user = UserFactory()
+        self.user = UserFactory(password=self.TEST_PASSWORD)
         self.factory = RequestFactory()
         self.request = self.factory.get('/course')
         self.request.user = self.user
         self.client = AjaxEnabledTestClient()
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     def _create_course_with_access_groups(self, course_location, user=None):
         """

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1866,10 +1866,10 @@ id=\"course-enrollment-end-time\" value=\"\" placeholder=\"HH:MM\" autocomplete=
         """
         Return the course details page as either global or non-global staff
         """
-        user = UserFactory(is_staff=global_staff)
+        user = UserFactory(is_staff=global_staff, password=self.TEST_PASSWORD)
         CourseInstructorRole(self.course.id).add_users(user)
 
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
 
         return self.client.get_html(self.course_details_url)
 

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -184,7 +184,7 @@ class InternationalizationTest(ModuleStoreTestCase):
 
         self.uname = 'testuser'
         self.email = 'test+courses@edx.org'
-        self.password = 'foo'
+        self.password = 'password'
 
         # Create the use so we can log them in.
         self.user = UserFactory.create(username=self.uname, email=self.email, password=self.password)

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -184,7 +184,7 @@ class InternationalizationTest(ModuleStoreTestCase):
 
         self.uname = 'testuser'
         self.email = 'test+courses@edx.org'
-        self.password = 'password'
+        self.password = 'Password1234'
 
         # Create the use so we can log them in.
         self.user = UserFactory.create(username=self.uname, email=self.email, password=self.password)

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -184,7 +184,7 @@ class InternationalizationTest(ModuleStoreTestCase):
 
         self.uname = 'testuser'
         self.email = 'test+courses@edx.org'
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
 
         # Create the use so we can log them in.
         self.user = UserFactory.create(username=self.uname, email=self.email, password=self.password)

--- a/cms/djangoapps/contentstore/tests/test_users_default_role.py
+++ b/cms/djangoapps/contentstore/tests/test_users_default_role.py
@@ -27,7 +27,7 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
         # create and log in a staff user.
         self.user = UserFactory(is_staff=True)
         self.client = AjaxEnabledTestClient()
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # create a course via the view handler to create course
         self.course_key = self.store.make_course_key('Org_1', 'Course_1', 'Run_1')

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -95,7 +95,7 @@ class AuthTestCase(ContentStoreTestCase):
         super().setUp()
 
         self.email = 'a@b.com'
-        self.pw = 'xyz'
+        self.pw = 'password1234'
         self.username = 'testuser'
         self.client = AjaxEnabledTestClient()
         # clear the cache so ratelimiting won't affect these tests

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -249,7 +249,7 @@ class CertificatesListHandlerTestCase(
         Tests user without write permissions on course should not able to create certificate
         """
         user = UserFactory()
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.ajax_post(
             self._url(),
             data=CERTIFICATE_JSON
@@ -635,7 +635,7 @@ class CertificatesDetailHandlerTestCase(
         """
         self._add_course_certificates(count=2, signatory_count=1, asset_path_format=signatory_path)
         user = UserFactory()
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.delete(
             self._url(cid=1),
             content_type="application/json",
@@ -653,7 +653,7 @@ class CertificatesDetailHandlerTestCase(
         user = UserFactory()
         for role in [CourseInstructorRole, CourseStaffRole]:
             role(self.course.id).add_users(user)
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.delete(
             self._url(cid=1),
             content_type="application/json",
@@ -681,7 +681,7 @@ class CertificatesDetailHandlerTestCase(
         user = UserFactory()
         for role in [CourseInstructorRole, CourseStaffRole]:
             role(self.course.id).add_users(user)
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.put(
             self._url(cid=1),
             data=json.dumps(cert_data),
@@ -799,7 +799,7 @@ class CertificatesDetailHandlerTestCase(
         test_url = reverse_course_url('certificate_activation_handler', self.course.id)
         self._add_course_certificates(count=1, signatory_count=2, asset_path_format=signatory_path)
         user = UserFactory()
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.post(
             test_url,
             data=json.dumps({"is_active": activate}),

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -14,8 +14,9 @@ class TestOrganizationListing(TestCase):
     """Verify Organization listing behavior."""
     def setUp(self):
         super().setUp()
-        self.staff = UserFactory(is_staff=True)
-        self.client.login(username=self.staff.username, password='test')
+        self.password = "password1234"
+        self.staff = UserFactory(is_staff=True, password=self.password)
+        self.client.login(username=self.staff.username, password=self.password)
         self.org_names_listing_url = reverse('organizations')
         self.org_short_names = ["alphaX", "betaX", "orgX"]
         for index, short_name in enumerate(self.org_short_names):

--- a/cms/djangoapps/maintenance/tests.py
+++ b/cms/djangoapps/maintenance/tests.py
@@ -30,7 +30,7 @@ class TestMaintenanceIndex(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='test')
+        login_success = self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.assertTrue(login_success)
         self.view_url = reverse('maintenance:maintenance_index')
 
@@ -56,7 +56,7 @@ class MaintenanceViewTestCase(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='test')
+        login_success = self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.assertTrue(login_success)
 
     def verify_error_message(self, data, error_message):
@@ -110,8 +110,8 @@ class MaintenanceViewAccessTests(MaintenanceViewTestCase):
         """
         Test that all maintenance app views are not accessible to non-global-staff user.
         """
-        user = UserFactory(username='test', email='test@example.com', password='test')
-        login_success = self.client.login(username=user.username, password='test')
+        user = UserFactory(username='test', email='test@example.com', password=self.TEST_PASSWORD)
+        login_success = self.client.login(username=user.username, password=self.TEST_PASSWORD)
         self.assertTrue(login_success)
 
         response = self.client.get(url)
@@ -245,13 +245,13 @@ class TestAnnouncementsViews(MaintenanceViewTestCase):
         self.admin = AdminFactory.create(
             email='staff@edx.org',
             username='admin',
-            password='pass'
+            password=self.TEST_PASSWORD
         )
-        self.client.login(username=self.admin.username, password='pass')
+        self.client.login(username=self.admin.username, password=self.TEST_PASSWORD)
         self.non_staff_user = UserFactory.create(
             email='test@edx.org',
             username='test',
-            password='pass'
+            password=self.TEST_PASSWORD
         )
 
     def test_index(self):
@@ -301,7 +301,7 @@ class TestAnnouncementsViews(MaintenanceViewTestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_authorization(self):
-        self.client.login(username=self.non_staff_user, password='pass')
+        self.client.login(username=self.non_staff_user, password=self.TEST_PASSWORD)
         announcement = Announcement.objects.create(content="Test Delete")
         announcement.save()
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -121,6 +121,9 @@ from lms.envs.common import (
     # Methods to derive settings
     _make_mako_template_dirs,
     _make_locale_paths,
+
+    # Password Validator Settings
+    AUTH_PASSWORD_VALIDATORS
 )
 from path import Path as path
 from django.urls import reverse_lazy
@@ -1878,24 +1881,6 @@ EVENT_TRACKING_PROCESSORS = []
 EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST = []
 
 #### PASSWORD POLICY SETTINGS #####
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
-        "NAME": "common.djangoapps.util.password_policy_validators.MinimumLengthValidator",
-        "OPTIONS": {
-            "min_length": 2
-        }
-    },
-    {
-        "NAME": "common.djangoapps.util.password_policy_validators.MaximumLengthValidator",
-        "OPTIONS": {
-            "max_length": 75
-        }
-    },
-]
-
 PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG = {
     'ENFORCE_COMPLIANCE_ON_LOGIN': False
 }

--- a/common/djangoapps/course_modes/tests/test_admin.py
+++ b/common/djangoapps/course_modes/tests/test_admin.py
@@ -54,7 +54,7 @@ class AdminCourseModePageTest(ModuleStoreTestCase):
             '_expiration_datetime_1': expiration.time(),
         }
 
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
 
         # Create a new course mode from django admin page
         response = self.client.post(reverse('admin:course_modes_coursemode_add'), data=data)

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -35,7 +35,7 @@ from common.djangoapps.student.roles import OrgStaffRole
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
-TEST_PASSWORD = 'password'
+TEST_PASSWORD = 'Password1234'
 
 
 class GroupFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -81,7 +81,7 @@ class UserFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-
         model = User
         django_get_or_create = ('email', 'username')
 
-    _DEFAULT_PASSWORD = 'password'
+    _DEFAULT_PASSWORD = 'Password1234'
 
     username = factory.Sequence('robot{}'.format)
     email = factory.Sequence('robot+test+{}@edx.org'.format)

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -35,7 +35,7 @@ from common.djangoapps.student.roles import OrgStaffRole
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
-TEST_PASSWORD = 'test'
+TEST_PASSWORD = 'password'
 
 
 class GroupFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -81,7 +81,7 @@ class UserFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-
         model = User
         django_get_or_create = ('email', 'username')
 
-    _DEFAULT_PASSWORD = 'test'
+    _DEFAULT_PASSWORD = 'password'
 
     username = factory.Sequence('robot{}'.format)
     email = factory.Sequence('robot+test+{}@edx.org'.format)

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -324,9 +324,9 @@ class LoginFailuresAdminTest(TestCase):
     def setUpClass(cls):
         """Setup class"""
         super().setUpClass()
-        cls.user = UserFactory.create(username='§', is_staff=True, is_superuser=True)
+        cls.TEST_PASSWORD = 'Password1234'
+        cls.user = UserFactory.create(username='§', password=cls.TEST_PASSWORD, is_staff=True, is_superuser=True)
         cls.user.save()
-        cls.TEST_PASSWORD = 'password'
 
     def setUp(self):
         """Setup."""

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -53,7 +53,7 @@ class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
             'email': self.user.email
         }
 
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # # adding new role from django admin page
         response = self.client.post(reverse('admin:student_courseaccessrole_add'), data=data)
@@ -78,7 +78,7 @@ class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
             'course_id': str(self.course.id)
         }
 
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # # adding new role from django admin page
         response = self.client.post(reverse('admin:student_courseaccessrole_add'), data=data)
@@ -96,7 +96,7 @@ class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
 
         }
 
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # # adding new role from django admin page
         response = self.client.post(reverse('admin:student_courseaccessrole_add'), data=data)
@@ -115,7 +115,7 @@ class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
 
         }
 
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # # adding new role from django admin page
         response = self.client.post(reverse('admin:student_courseaccessrole_add'), data=data)
@@ -136,7 +136,7 @@ class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
             'email': email
         }
 
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Adding new role with invalid data
         response = self.client.post(reverse('admin:student_courseaccessrole_add'), data=data)
@@ -163,7 +163,7 @@ class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
             'email': self.user.email
         }
 
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # # adding new role from django admin page
         response = self.client.post(reverse('admin:student_courseaccessrole_add'), data=data)
@@ -230,7 +230,7 @@ class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
             user=self.user,
             course_id=self.course.id,  # pylint: disable=no-member
         )
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     @ddt.data(*ADMIN_URLS)
     @ddt.unpack
@@ -326,11 +326,12 @@ class LoginFailuresAdminTest(TestCase):
         super().setUpClass()
         cls.user = UserFactory.create(username='§', is_staff=True, is_superuser=True)
         cls.user.save()
+        cls.TEST_PASSWORD = 'password'
 
     def setUp(self):
         """Setup."""
         super().setUp()
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.user2 = UserFactory.create(username='Zażółć gęślą jaźń')
         self.user_lockout_until = datetime.datetime.now(UTC)
         LoginFailures.objects.create(user=self.user, failure_count=10, lockout_until=self.user_lockout_until)

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -33,7 +33,7 @@ class TestStudentDashboardEmailView(SharedModuleStoreTestCase):
         # Create student account
         student = UserFactory.create()
         CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
-        self.client.login(username=student.username, password="test")
+        self.client.login(username=student.username, password=self.TEST_PASSWORD)
 
         self.url = reverse('dashboard')
         # URL for email settings modal

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -136,7 +136,7 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
         params = {
             'username': 'test_user',
             'email': 'test_user@example.com',
-            'password': 'edx',
+            'password': 'long_password',
             'name': 'Test User',
             'honor_code': True,
             'terms_of_service': True

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -136,7 +136,7 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
         params = {
             'username': 'test_user',
             'email': 'test_user@example.com',
-            'password': 'long_password',
+            'password': 'Password1234',
             'name': 'Test User',
             'honor_code': True,
             'terms_of_service': True
@@ -319,7 +319,7 @@ class EmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, CacheIsolat
         self.new_email = 'new.email@edx.org'
         self.req_factory = RequestFactory()
         self.request = self.req_factory.post('unused_url', data={
-            'password': 'test',
+            'password': 'Password1234',
             'new_email': self.new_email
         })
         self.request.user = self.user
@@ -628,7 +628,7 @@ class SecondaryEmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, Ca
         self.new_secondary_email = 'new.secondary.email@edx.org'
         self.req_factory = RequestFactory()
         self.request = self.req_factory.post('unused_url', data={
-            'password': 'test',
+            'password': 'Password1234',
             'new_email': self.new_secondary_email
         })
         self.request.user = self.user

--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -316,7 +316,7 @@ class StudentDashboardFiltersTest(ModuleStoreTestCase):
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password="test")
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.dashboard_url = reverse("dashboard")
         self.first_course = CourseFactory.create(
             org="test1", course="course1", display_name="run1",

--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -260,7 +260,7 @@ class TestRegisterRetiredUsername(TestCase):
             'username': 'username',
             'email': 'foo_bar' + '@bar.com',
             'name': 'foo bar',
-            'password': '123',
+            'password': '12345678',
             'terms_of_service': 'true',
             'honor_code': 'true',
         }

--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -260,7 +260,7 @@ class TestRegisterRetiredUsername(TestCase):
             'username': 'username',
             'email': 'foo_bar' + '@bar.com',
             'name': 'foo bar',
-            'password': '12345678',
+            'password': 'Password1234',
             'terms_of_service': 'true',
             'honor_code': 'true',
         }

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -43,7 +43,7 @@ class UserStandingTest(TestCase):
             (self.non_staff, self.non_staff_client),
             (self.admin, self.admin_client),
         ]:
-            client.login(username=user.username, password='test')
+            client.login(username=user.username, password='password')
 
         UserStandingFactory.create(
             user=self.bad_user,

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -43,7 +43,7 @@ class UserStandingTest(TestCase):
             (self.non_staff, self.non_staff_client),
             (self.admin, self.admin_client),
         ]:
-            client.login(username=user.username, password='password')
+            client.login(username=user.username, password='Password1234')
 
         UserStandingFactory.create(
             user=self.bad_user,

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -49,7 +49,6 @@ from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: d
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
-PASSWORD = 'test'
 TOMORROW = now() + timedelta(days=1)
 ONE_WEEK_AGO = now() - timedelta(weeks=1)
 THREE_YEARS_FROM_NOW = now() + timedelta(days=(365 * 3))
@@ -81,7 +80,7 @@ class TestStudentDashboardUnenrollments(SharedModuleStoreTestCase):
         self.user = UserFactory()
         self.enrollment = CourseEnrollmentFactory(course_id=self.course.id, user=self.user)
         self.cert_status = 'processing'
-        self.client.login(username=self.user.username, password=PASSWORD)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     def mock_cert(self, _user, _course_overview):
         """ Return a preset certificate status. """
@@ -212,7 +211,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         """
         super().setUp()
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=PASSWORD)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.path = reverse('dashboard')
 
     def set_course_sharing_urls(self, set_marketing, set_social_sharing):
@@ -1018,7 +1017,7 @@ class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=PASSWORD)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.path = reverse('dashboard')
 
     def test_check_for_unacknowledged_notices(self):

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -278,7 +278,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
-        self.user = UserFactory.create(username="jack", email="jack@fake.edx.org", password='test')
+        self.user = UserFactory.create(username="jack", email="jack@fake.edx.org", password=self.TEST_PASSWORD)
         self.client = Client()
         cache.clear()
 
@@ -307,7 +307,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         """
         Test that the certificate verification status for courses is visible on the dashboard.
         """
-        self.client.login(username="jack", password="test")
+        self.client.login(username="jack", password=self.TEST_PASSWORD)
         self._check_verification_status_on('verified', 'You&#39;re enrolled as a verified student')
         self._check_verification_status_on('honor', 'You&#39;re enrolled as an honor code student')
         self._check_verification_status_off('audit', '')
@@ -345,7 +345,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         Test that the certificate verification status for courses is not visible on the dashboard
         if the verified certificates setting is off.
         """
-        self.client.login(username="jack", password="test")
+        self.client.login(username="jack", password=self.TEST_PASSWORD)
         self._check_verification_status_off('verified', 'You\'re enrolled as a verified student')
         self._check_verification_status_off('honor', 'You\'re enrolled as an honor code student')
         self._check_verification_status_off('audit', '')
@@ -371,7 +371,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
     @skip_unless_lms
     def test_linked_in_add_to_profile_btn_not_appearing_without_config(self):
         # Without linked-in config don't show Add Certificate to LinkedIn button
-        self.client.login(username="jack", password="test")
+        self.client.login(username="jack", password=self.TEST_PASSWORD)
 
         CourseModeFactory.create(
             course_id=self.course.id,
@@ -409,7 +409,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
     def test_linked_in_add_to_profile_btn_with_certificate(self):
         # If user has a certificate with valid linked-in config then Add Certificate to LinkedIn button
         # should be visible. and it has URL value with valid parameters.
-        self.client.login(username="jack", password="test")
+        self.client.login(username="jack", password=self.TEST_PASSWORD)
 
         linkedin_config = LinkedInAddToProfileConfiguration.objects.create(company_identifier='1337', enabled=True)
         CourseModeFactory.create(
@@ -480,7 +480,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         # Create a course and log in the user.
         # Creating a new course will trigger a publish event and the course will be cached
         test_course = CourseFactory.create(emit_signals=True)
-        self.client.login(username="jack", password="test")
+        self.client.login(username="jack", password=self.TEST_PASSWORD)
 
         with check_mongo_calls(0):
             CourseEnrollment.enroll(self.user, test_course.id)
@@ -495,7 +495,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
 
     @skip_unless_lms
     def test_dashboard_header_nav_has_find_courses(self):
-        self.client.login(username="jack", password="test")
+        self.client.login(username="jack", password=self.TEST_PASSWORD)
         response = self.client.get(reverse("dashboard"))
 
         # "Explore courses" is shown in the side panel
@@ -542,7 +542,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
         super().setUp()
         self.org = 'fakeX'
         self.course = CourseFactory.create(org=self.org)
-        self.user = UserFactory.create(username='jack', email='jack@fake.edx.org', password='test')
+        self.user = UserFactory.create(username='jack', email='jack@fake.edx.org', password=self.TEST_PASSWORD)
         CourseModeFactory.create(mode_slug='no-id-professional', course_id=self.course.id)
         CourseEnrollment.enroll(self.user, self.course.location.course_key, mode='no-id-professional')
         cache.clear()
@@ -564,7 +564,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
             'course_org_filter': self.org
         })
         self.set_up_site(site_domain, site_configuration_values)
-        self.client.login(username='jack', password='test')
+        self.client.login(username='jack', password=self.TEST_PASSWORD)
         response = self.client.get(reverse('dashboard'))
         self.assertContains(response, 'class="course professional"')
 
@@ -585,7 +585,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
             'course_org_filter': self.org
         })
         self.set_up_site(site_domain, site_configuration_values)
-        self.client.login(username='jack', password='test')
+        self.client.login(username='jack', password=self.TEST_PASSWORD)
         response = self.client.get(reverse('dashboard'))
         self.assertNotContains(response, 'class="course professional"')
 
@@ -899,8 +899,8 @@ class ChangeEnrollmentViewTest(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
-        self.user = UserFactory.create(password='secret')
-        self.client.login(username=self.user.username, password='secret')
+        self.user = UserFactory.create(password=self.TEST_PASSWORD)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.url = reverse('change_enrollment')
 
     def _enroll_through_view(self, course):
@@ -1056,14 +1056,13 @@ class AnonymousLookupTable(ModuleStoreTestCase):
 class RelatedProgramsTests(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
     """Tests verifying that related programs appear on the course dashboard."""
     maxDiff = None
-    password = 'test'
     related_programs_preface = 'Related Programs'
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.user = UserFactory()
+        cls.user = UserFactory(password=cls.TEST_PASSWORD)
         cls.course = CourseFactory()
         cls.enrollment = CourseEnrollmentFactory(user=cls.user, course_id=cls.course.id)  # pylint: disable=no-member
 
@@ -1073,7 +1072,7 @@ class RelatedProgramsTests(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
         self.url = reverse('dashboard')
 
         self.create_programs_config()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         course_run = CourseRunFactory(key=str(self.course.id))  # pylint: disable=no-member
         course = CatalogCourseFactory(course_runs=[course_run])

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -481,7 +481,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
         # The AJAX on the page will log them in:
         ajax_login_response = self.client.post(
             reverse('user_api_login_session', kwargs={'api_version': 'v1'}),
-            {'email': self.user.email, 'password': 'password'}
+            {'email': self.user.email, 'password': 'Password1234'}
         )
         assert ajax_login_response.status_code == 200
         # Then the AJAX will finish the third party auth:

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -481,7 +481,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
         # The AJAX on the page will log them in:
         ajax_login_response = self.client.post(
             reverse('user_api_login_session', kwargs={'api_version': 'v1'}),
-            {'email': self.user.email, 'password': 'test'}
+            {'email': self.user.email, 'password': 'password'}
         )
         assert ajax_login_response.status_code == 200
         # Then the AJAX will finish the third party auth:

--- a/common/djangoapps/third_party_auth/tests/test_admin.py
+++ b/common/djangoapps/third_party_auth/tests/test_admin.py
@@ -14,7 +14,7 @@ from common.djangoapps.third_party_auth.tests import testutil
 from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
 
 
-TEST_PASSWORD = 'password'
+TEST_PASSWORD = 'Password1234'
 
 
 # This is necessary because cms does not implement third party auth

--- a/common/djangoapps/third_party_auth/tests/test_admin.py
+++ b/common/djangoapps/third_party_auth/tests/test_admin.py
@@ -14,6 +14,9 @@ from common.djangoapps.third_party_auth.tests import testutil
 from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
 
 
+TEST_PASSWORD = 'password'
+
+
 # This is necessary because cms does not implement third party auth
 @skip_unless_thirdpartyauth()
 class Oauth2ProviderConfigAdminTest(testutil.TestCase):
@@ -36,9 +39,9 @@ class Oauth2ProviderConfigAdminTest(testutil.TestCase):
         prepopulated correctly, and that we can clear and update the image.
         """
         # Login as a super user
-        user = UserFactory.create(is_staff=True, is_superuser=True)
+        user = UserFactory.create(is_staff=True, is_superuser=True, password=TEST_PASSWORD)
         user.save()
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=TEST_PASSWORD)
 
         # Get baseline provider count
         providers = OAuth2ProviderConfig.objects.all()

--- a/common/djangoapps/util/tests/test_password_policy_validators.py
+++ b/common/djangoapps/util/tests/test_password_policy_validators.py
@@ -45,6 +45,11 @@ class PasswordPolicyValidatorsTestCase(unittest.TestCase):
                 validate_password(password, user)
             assert msg in ' '.join(cm.value.messages)
 
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[
+        create_validator_config(
+            'common.djangoapps.util.password_policy_validators.MinimumLengthValidator', {'min_length': 4}
+        )
+    ])
     def test_unicode_password(self):
         """ Tests that validate_password enforces unicode """
         unicode_str = '𤭮'
@@ -55,12 +60,17 @@ class PasswordPolicyValidatorsTestCase(unittest.TestCase):
         assert len(unicode_str) == 1
 
         # Test length check
-        self.validation_errors_checker(byte_str, 'This password is too short. It must contain at least 2 characters.')
-        self.validation_errors_checker(byte_str + byte_str, None)
+        self.validation_errors_checker(byte_str, 'This password is too short. It must contain at least 4 characters.')
+        self.validation_errors_checker(byte_str * 4, None)
 
         # Test badly encoded password
         self.validation_errors_checker(b'\xff\xff', 'Invalid password.')
 
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[
+        create_validator_config(
+            'common.djangoapps.util.password_policy_validators.MinimumLengthValidator', {'min_length': 4}
+        )
+    ])
     def test_password_unicode_normalization(self):
         """ Tests that validate_password normalizes passwords """
         # s ̣ ̇ (s with combining dot below and combining dot above)
@@ -70,7 +80,7 @@ class PasswordPolicyValidatorsTestCase(unittest.TestCase):
         # When we normalize we expect the not_normalized password to fail
         # because it should be normalized to '\u1E69' -> ṩ
         self.validation_errors_checker(not_normalized_password,
-                                       'This password is too short. It must contain at least 2 characters.')
+                                       'This password is too short. It must contain at least 4 characters.')
 
     @data(
         ([create_validator_config('common.djangoapps.util.password_policy_validators.MinimumLengthValidator', {'min_length': 2})],  # lint-amnesty, pylint: disable=line-too-long

--- a/lms/djangoapps/badges/api/tests.py
+++ b/lms/djangoapps/badges/api/tests.py
@@ -29,7 +29,7 @@ class UserAssertionTestCase(UrlResetMixin, ModuleStoreTestCase, ApiTestCase):
         self.course = CourseFactory.create()
         self.user = UserFactory.create()
         # Password defined by factory.
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     def url(self):
         """

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -40,7 +40,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
         # load initial content (since we don't run migrations as part of tests):
         call_command("loaddata", "course_email_template.json")
 
-        self.client.login(username=self.student.username, password="test")
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
 
         self.send_mail_url = reverse('send_email', kwargs={'course_id': str(self.course.id)})
         self.success_content = {
@@ -70,7 +70,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
 
         self.client.logout()
 
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self.navigate_to_email_view()
 
         test_email = {
@@ -92,7 +92,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
         """
         self.client.logout()
 
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         unsubscribe_link = get_unsubscribed_link(self.student.username, str(self.course.id))
         response = self.client.post(unsubscribe_link, {'unsubscribe': True})
@@ -122,7 +122,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
 
         assert CourseEnrollment.is_enrolled(self.student, self.course.id)
 
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self.navigate_to_email_view()
 
         test_email = {
@@ -155,7 +155,7 @@ class TestACEOptoutCourseEmails(ModuleStoreTestCase):
         self.student = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
 
-        self.client.login(username=self.student.username, password="test")
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
 
         self._set_email_optout(False)
         self.policy = CourseEmailOptout()

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -87,7 +87,7 @@ class EmailSendFromDashboardTestCase(SharedModuleStoreTestCase):
         """
         Log in self.client as user.
         """
-        self.client.login(username=user.username, password="test")
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
 
     def goto_instructor_dash_email_view(self):
         """

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -53,7 +53,7 @@ class TestEmailErrors(ModuleStoreTestCase):
         course_title = "ẗëṡẗ title ｲ乇丂ｲ ﾶ乇丂丂ﾑg乇 ｷo尺 ﾑﾚﾚ тэѕт мэѕѕаБэ"
         self.course = CourseFactory.create(display_name=course_title)
         self.instructor = AdminFactory.create()
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         # load initial content (since we don't run migrations as part of tests):
         call_command("loaddata", "course_email_template.json")

--- a/lms/djangoapps/bulk_email/tests/test_signals.py
+++ b/lms/djangoapps/bulk_email/tests/test_signals.py
@@ -33,7 +33,7 @@ class TestOptoutCourseEmailsBySignal(ModuleStoreTestCase):
         # load initial content (since we don't run migrations as part of tests):
         call_command("loaddata", "course_email_template.json")
 
-        self.client.login(username=self.student.username, password="test")
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
 
         self.send_mail_url = reverse('send_email', kwargs={'course_id': str(self.course.id)})
         self.success_content = {
@@ -78,7 +78,7 @@ class TestOptoutCourseEmailsBySignal(ModuleStoreTestCase):
         force_optout_all(sender=self.__class__, user=self.student)
 
         # Try to send a bulk course email
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self.send_test_email()
 
         # Assert that self.student.email not in mail.to, outbox should only contain "myself" target

--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -33,7 +33,7 @@ from lms.djangoapps.instructor.access import allow_access, list_with_level
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params
 from openedx.core.lib.courses import get_course_by_id
 
-USER_PASSWORD = 'test'
+USER_PASSWORD = 'password'
 
 
 class CcxRestApiTest(CcxTestCase, APITestCase):
@@ -760,7 +760,7 @@ class CcxDetailTest(CcxRestApiTest):
         """
         # create a staff user
         staff_user = UserFactory.create(
-            username='test_staff_user', email='test_staff_user@openedx.org', password='test',
+            username='test_staff_user', email='test_staff_user@openedx.org', password=USER_PASSWORD,
         )
         # add staff role to the staff user
         CourseStaffRole(self.master_course_key).add_users(staff_user)
@@ -779,7 +779,7 @@ class CcxDetailTest(CcxRestApiTest):
         """
         # create an instructor user
         instructor_user = UserFactory.create(
-            username='test_instructor_user', email='test_instructor_user@openedx.org', password='test',
+            username='test_instructor_user', email='test_instructor_user@openedx.org', password=USER_PASSWORD,
         )
         # add instructor role to the instructor user
         CourseInstructorRole(self.master_course_key).add_users(instructor_user)
@@ -798,7 +798,7 @@ class CcxDetailTest(CcxRestApiTest):
         """
         # create an coach user
         coach_user = UserFactory.create(
-            username='test_coach_user', email='test_coach_user@openedx.org', password='test',
+            username='test_coach_user', email='test_coach_user@openedx.org', password=USER_PASSWORD,
         )
         # add coach role to the coach user
         CourseCcxCoachRole(self.master_course_key).add_users(coach_user)

--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -33,7 +33,7 @@ from lms.djangoapps.instructor.access import allow_access, list_with_level
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params
 from openedx.core.lib.courses import get_course_by_id
 
-USER_PASSWORD = 'password'
+USER_PASSWORD = 'Password1234'
 
 
 class CcxRestApiTest(CcxTestCase, APITestCase):

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -129,7 +129,7 @@ class TestAdminAccessCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         ccx = self.make_ccx()
         ccx_key = CCXLocator.from_course_locator(self.course.id, ccx.id)
         self.url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_key})
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
 
     def test_staff_access_coach_dashboard(self):
         """

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -129,13 +129,14 @@ class TestAdminAccessCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         ccx = self.make_ccx()
         ccx_key = CCXLocator.from_course_locator(self.course.id, ccx.id)
         self.url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_key})
+        self.TEST_PASSWORD = 'password'
 
     def test_staff_access_coach_dashboard(self):
         """
         User is staff, should access coach dashboard.
         """
         staff = self.make_staff()
-        self.client.login(username=staff.username, password="test")
+        self.client.login(username=staff.username, password=self.TEST_PASSWORD)
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -145,7 +146,7 @@ class TestAdminAccessCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         User is instructor, should access coach dashboard.
         """
         instructor = self.make_instructor()
-        self.client.login(username=instructor.username, password="test")
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
 
         # Now access URL
         response = self.client.get(self.url)
@@ -155,8 +156,8 @@ class TestAdminAccessCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         """
         Assert user with no access must not see dashboard.
         """
-        user = UserFactory.create(password="test")
-        self.client.login(username=user.username, password="test")
+        user = UserFactory.create(password=self.TEST_PASSWORD)
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         assert response.status_code == 403
 
@@ -211,12 +212,12 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         """
         assert signal and schedule update.
         """
-        student = UserFactory.create(is_staff=False, password="test")
+        student = UserFactory.create(is_staff=False, password=self.TEST_PASSWORD)
         CourseEnrollment.enroll(student, ccx_course_key)
         assert CourseEnrollment.objects.filter(course_id=ccx_course_key, user=student).exists()
 
         # login as student
-        self.client.login(username=student.username, password="test")
+        self.client.login(username=student.username, password=self.TEST_PASSWORD)
         progress_page_response = self.client.get(
             reverse('progress', kwargs={'course_id': ccx_course_key})
         )
@@ -236,7 +237,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         self.make_coach()
         ccx = self.make_ccx()
         ccx_course_key = CCXLocator.from_course_locator(self.course.id, str(ccx.id))
-        self.client.login(username=self.coach.username, password="test")
+        self.client.login(username=self.coach.username, password=self.TEST_PASSWORD)
 
         url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_course_key})
         response = self.client.get(url)
@@ -295,7 +296,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         """
         super().setUp()
         # Login with the instructor account
-        self.client.login(username=self.coach.username, password="test")
+        self.client.login(username=self.coach.username, password=self.TEST_PASSWORD)
 
         # adding staff to master course.
         staff = UserFactory()
@@ -315,8 +316,8 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         ccx = self.make_ccx()
 
         # create session of non-coach user
-        user = UserFactory.create(password="test")
-        self.client.login(username=user.username, password="test")
+        user = UserFactory.create(password=self.TEST_PASSWORD)
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         url = reverse(
             'ccx_coach_dashboard',
             kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)})
@@ -841,7 +842,7 @@ class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleSto
         self.mstore = modulestore()
 
         # Login with the instructor account
-        self.client.login(username=self.coach.username, password="test")
+        self.client.login(username=self.coach.username, password=self.TEST_PASSWORD)
 
         # adding staff to master course.
         staff = UserFactory()
@@ -981,7 +982,7 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
 
         # Create instructor account
         self.coach = coach = AdminFactory.create()
-        self.client.login(username=coach.username, password="test")
+        self.client.login(username=coach.username, password=self.TEST_PASSWORD)
 
         # Create CCX
         role = CourseCcxCoachRole(self._course.id)
@@ -1009,7 +1010,7 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
         self.course = get_course_by_id(self.ccx_key, depth=None)
         CourseOverview.load_from_module_store(self.course.id)
         setup_students_and_grades(self)
-        self.client.login(username=coach.username, password="test")
+        self.client.login(username=coach.username, password=self.TEST_PASSWORD)
         self.addCleanup(RequestCache.clear_all_namespaces)
         from xmodule.modulestore.django import SignalHandler
 
@@ -1068,7 +1069,7 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
         get_course.return_value = self.course
         self.addCleanup(patch_context.stop)
 
-        self.client.login(username=self.student.username, password="test")  # lint-amnesty, pylint: disable=no-member
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)  # lint-amnesty, pylint: disable=no-member
         url = reverse(
             'progress',
             kwargs={'course_id': self.ccx_key}
@@ -1194,7 +1195,7 @@ class TestStudentViewsWithCCX(ModuleStoreTestCase):
 
         # Create a Split Mongo course and enroll a student user in it.
         self.student_password = "foobar"
-        self.student = UserFactory.create(username="test", password=self.student_password, is_staff=False)
+        self.student = UserFactory.create(username=self.TEST_PASSWORD, password=self.student_password, is_staff=False)
         self.split_course = SampleCourseFactory.create(default_store=ModuleStoreEnum.Type.split)
         CourseEnrollment.enroll(self.student, self.split_course.id)
 

--- a/lms/djangoapps/ccx/tests/utils.py
+++ b/lms/djangoapps/ccx/tests/utils.py
@@ -68,7 +68,7 @@ class CcxTestCase(EmailTemplateTagMixin, SharedModuleStoreTestCase):
         """
         super().setUp()
         # Create instructor account
-        self.coach = UserFactory.create(password="test")
+        self.coach = UserFactory.create()
         # create an instance of modulestore
         self.mstore = modulestore()
 
@@ -76,7 +76,7 @@ class CcxTestCase(EmailTemplateTagMixin, SharedModuleStoreTestCase):
         """
         create staff user.
         """
-        staff = UserFactory.create(password="test")
+        staff = UserFactory.create()
         role = CourseStaffRole(self.course.id)
         role.add_users(staff)
 
@@ -86,7 +86,7 @@ class CcxTestCase(EmailTemplateTagMixin, SharedModuleStoreTestCase):
         """
         create instructor user.
         """
-        instructor = UserFactory.create(password="test")
+        instructor = UserFactory.create()
         role = CourseInstructorRole(self.course.id)
         role.add_users(instructor)
 

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 from ....tests.mocks import mock_order_endpoint
 from ....tests.test_views import UserMixin
 
-PASSWORD = 'test'
+PASSWORD = 'password'
 JSON_CONTENT_TYPE = 'application/json'
 
 

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 from ....tests.mocks import mock_order_endpoint
 from ....tests.test_views import UserMixin
 
-PASSWORD = 'password'
+PASSWORD = 'Password1234'
 JSON_CONTENT_TYPE = 'application/json'
 
 

--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -3,7 +3,7 @@
 from common.djangoapps.student.tests.factories import UserFactory
 
 
-TEST_PASSWORD = "password"
+TEST_PASSWORD = "Password1234"
 
 
 class UserMixin:

--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -3,6 +3,9 @@
 from common.djangoapps.student.tests.factories import UserFactory
 
 
+TEST_PASSWORD = "password"
+
+
 class UserMixin:
     """ Mixin for tests involving users. """
 
@@ -12,4 +15,4 @@ class UserMixin:
 
     def _login(self):
         """ Log into LMS. """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=TEST_PASSWORD)

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -60,7 +60,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         self.admin_user = AdminFactory.create()
         self.data_researcher = UserFactory.create()
         CourseDataResearcherRole(self.course_key).add_users(self.data_researcher)
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course_key)
 
         # default values for url and query_params
@@ -248,7 +248,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         self.client.logout()
         self.verify_response(403, cacheable=False)
         # Verify response for a staff user.
-        self.client.login(username=self.admin_user.username, password='test')
+        self.client.login(username=self.admin_user.username, password=self.TEST_PASSWORD)
         self.verify_response(cacheable=False)
 
     def test_non_existent_course(self):
@@ -269,7 +269,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         self.verify_response(400)
 
     def test_no_user_staff_all_blocks(self):
-        self.client.login(username=self.admin_user.username, password='test')
+        self.client.login(username=self.admin_user.username, password=self.TEST_PASSWORD)
         self.query_params.pop('username')
         self.query_params['all_blocks'] = True
         self.verify_response()
@@ -319,7 +319,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
             - other_course_settings
             - course_visibility
         """
-        self.client.login(username=self.admin_user.username, password='test')
+        self.client.login(username=self.admin_user.username, password=self.TEST_PASSWORD)
         response = self.verify_response(params={
             'all_blocks': True,
             'requested_fields': ['other_course_settings', 'course_visibility'],
@@ -351,7 +351,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
             - other_course_settings
             - course_visibility
         """
-        self.client.login(username=self.admin_user.username, password='test')
+        self.client.login(username=self.admin_user.username, password=self.TEST_PASSWORD)
         response = self.verify_response(params={
             'all_blocks': True,
             'requested_fields': ['course_visibility'],
@@ -370,7 +370,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         """
         Test if data researcher has access to the api endpoint
         """
-        self.client.login(username=self.data_researcher.username, password='test')
+        self.client.login(username=self.data_researcher.username, password=self.TEST_PASSWORD)
 
         self.verify_response(params={
             'all_blocks': True,
@@ -556,7 +556,7 @@ class TestBlockMetadataView(SharedModuleStoreTestCase):  # pylint: disable=test-
     def setUp(self):
         super().setUp()
         self.admin_user = AdminFactory.create()
-        self.client.login(username=self.admin_user.username, password='test')
+        self.client.login(username=self.admin_user.username, password=self.TEST_PASSWORD)
         self.usage_key = list(self.non_orphaned_block_usage_keys)[0]
         self.url = reverse(
             'blocks_metadata',

--- a/lms/djangoapps/course_api/tests/mixins.py
+++ b/lms/djangoapps/course_api/tests/mixins.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from common.djangoapps.student.tests.factories import UserFactory, CourseEnrollmentFactory, CourseAccessRoleFactory
 from xmodule.modulestore.tests.factories import ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
-TEST_PASSWORD = 'edx'
+TEST_PASSWORD = 'Password1234'
 
 
 class CourseApiFactoryMixin:

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -50,7 +50,7 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         """
         super().setUp()
         # Set up users.
-        self.password = 'test'
+        self.password = 'password'
         self.user = UserFactory.create(password=self.password)
         self.staff = UserFactory.create(password=self.password, is_staff=True)
 
@@ -253,7 +253,7 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
                     parent_block.children.append(self.xblock_keys[i])
                     update_block(parent_block)
 
-        self.password = 'test'
+        self.password = 'password'
         self.student = UserFactory.create(is_staff=False, username='test_student', password=self.password)
         self.staff = UserFactory.create(is_staff=True, username='test_staff', password=self.password)
         CourseEnrollmentFactory.create(

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -50,7 +50,7 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         """
         super().setUp()
         # Set up users.
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         self.user = UserFactory.create(password=self.password)
         self.staff = UserFactory.create(password=self.password, is_staff=True)
 
@@ -253,7 +253,7 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
                     parent_block.children.append(self.xblock_keys[i])
                     update_block(parent_block)
 
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         self.student = UserFactory.create(is_staff=False, username='test_student', password=self.password)
         self.staff = UserFactory.create(is_staff=True, username='test_staff', password=self.password)
         CourseEnrollmentFactory.create(

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -50,7 +50,7 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         """
         super().setUp()
         # Set up users.
-        self.password = 'password'
+        self.password = 'Password1234'
         self.user = UserFactory.create(password=self.password)
         self.staff = UserFactory.create(password=self.password, is_staff=True)
 
@@ -253,7 +253,7 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
                     parent_block.children.append(self.xblock_keys[i])
                     update_block(parent_block)
 
-        self.password = 'password'
+        self.password = 'Password1234'
         self.student = UserFactory.create(is_staff=False, username='test_student', password=self.password)
         self.staff = UserFactory.create(is_staff=True, username='test_staff', password=self.password)
         CourseEnrollmentFactory.create(

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -24,7 +24,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         # Create two accounts
         self.student = 'view@test.com'
         self.instructor = 'view2@test.com'
-        self.password = 'foo'
+        self.password = 'password'
         for username, email in [('u1', self.student), ('u2', self.instructor)]:
             self.create_account(username, email, self.password)
             self.activate_user(email)

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -24,7 +24,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         # Create two accounts
         self.student = 'view@test.com'
         self.instructor = 'view2@test.com'
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         for username, email in [('u1', self.student), ('u2', self.instructor)]:
             self.create_account(username, email, self.password)
             self.activate_user(email)

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -24,7 +24,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         # Create two accounts
         self.student = 'view@test.com'
         self.instructor = 'view2@test.com'
-        self.password = 'password'
+        self.password = 'Password1234'
         for username, email in [('u1', self.student), ('u2', self.instructor)]:
             self.create_account(username, email, self.password)
             self.activate_user(email)

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -128,7 +128,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
         self.clients = {user.username: Client() for user in self.users}
         self.login_statuses = [
             self.clients[user.username].login(
-                username=user.username, password='test')
+                username=user.username, password=self.TEST_PASSWORD)
             for user in self.users
         ]
 
@@ -173,7 +173,7 @@ class LoginEnrollmentTestCase(TestCase):
         Create a user account, activate, and log in.
         """
         self.email = 'foo@test.com'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
-        self.password = 'bar'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
+        self.password = 'password'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
         self.username = 'test'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
         self.user = self.create_account(
             self.username,

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -173,7 +173,7 @@ class LoginEnrollmentTestCase(TestCase):
         Create a user account, activate, and log in.
         """
         self.email = 'foo@test.com'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
-        self.password = 'password'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
+        self.password = 'Password1234'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
         self.username = 'test'  # lint-amnesty, pylint: disable=attribute-defined-outside-init
         self.user = self.create_account(
             self.username,

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -284,7 +284,7 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
         # pylint: disable=attribute-defined-outside-init
         # create a new account since the first account is already enrolled in the course
         self.email = 'foo_second@test.com'
-        self.password = 'bar'
+        self.password = 'password'
         self.username = 'test_second'
         self.create_account(self.username, self.email, self.password)
         self.activate_user(self.email)

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -284,7 +284,7 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
         # pylint: disable=attribute-defined-outside-init
         # create a new account since the first account is already enrolled in the course
         self.email = 'foo_second@test.com'
-        self.password = 'password'
+        self.password = 'Password1234'
         self.username = 'test_second'
         self.create_account(self.username, self.email, self.password)
         self.activate_user(self.email)

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -82,8 +82,8 @@ class CoachAccessTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
         super().setUp()
 
         # Create ccx coach account
-        self.coach = AdminFactory.create(password="test")
-        self.client.login(username=self.coach.username, password="test")
+        self.coach = AdminFactory.create(password=self.TEST_PASSWORD)
+        self.client.login(username=self.coach.username, password=self.TEST_PASSWORD)
 
         # assign role to coach
         role = CourseCcxCoachRole(self.course.id)
@@ -152,7 +152,7 @@ class CoachAccessTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
         assert resp.status_code == 200
 
         # Assert access of a student
-        self.client.login(username=student.username, password='test')
+        self.client.login(username=student.username, password=self.TEST_PASSWORD)
         resp = self.client.get(reverse('student_progress', args=[str(ccx_locator), self.coach.id]))
         assert resp.status_code == 404
 

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -362,7 +362,7 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
     def test_session_authentication(self):
         """ Test that the xblock endpoint supports session authentication."""
-        self.client.login(username=self.mock_user.username, password="test")
+        self.client.login(username=self.mock_user.username, password=self.TEST_PASSWORD)
         dispatch_url = self._get_dispatch_url()
         response = self.client.post(dispatch_url)
         assert 200 == response.status_code
@@ -387,7 +387,7 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         """
         Test that sending POST request without or invalid position argument don't raise server error
         """
-        self.client.login(username=self.mock_user.username, password="test")
+        self.client.login(username=self.mock_user.username, password=self.TEST_PASSWORD)
         dispatch_url = self._get_dispatch_url()
         response = self.client.post(dispatch_url)
         assert 200 == response.status_code

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -22,7 +22,7 @@ class SurveyViewsTests(LoginEnrollmentTestCase, SharedModuleStoreTestCase, XssTe
     """
     All tests for the views.py file
     """
-    STUDENT_INFO = [('view@test.com', 'foo')]
+    STUDENT_INFO = [('view@test.com', 'password1234')]
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -22,7 +22,7 @@ class SurveyViewsTests(LoginEnrollmentTestCase, SharedModuleStoreTestCase, XssTe
     """
     All tests for the views.py file
     """
-    STUDENT_INFO = [('view@test.com', 'password1234')]
+    STUDENT_INFO = [('view@test.com', 'Password1234')]
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -366,7 +366,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         """
         Tests that course block api returns student_view_data for discussion xblock
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         url = reverse('blocks_in_block_tree', kwargs={'usage_key_string': str(self.course_usage_key)})
         query_params = {
             'depth': 'all',

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -136,7 +136,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         self.request = get_mock_request(UserFactory())
         self.course = self.update_course(self.course, self.request.user.id)
 
-        self.client.login(username=self.request.user.username, password="test")
+        self.client.login(username=self.request.user.username, password=self.TEST_PASSWORD)
         CourseEnrollment.enroll(self.request.user, self.course.id)
 
         self.expected_locked_toc = (
@@ -257,7 +257,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
 
         # hit skip entrance exam api in instructor app
         instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=instructor.username, password='test')
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
         url = reverse('mark_student_can_skip_entrance_exam', kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.request.user.email,
@@ -277,7 +277,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         self.client.logout()
         staff_user = StaffFactory(course_key=self.course.id)
         staff_user.is_staff = True
-        self.client.login(username=staff_user.username, password='test')
+        self.client.login(username=staff_user.username, password=self.TEST_PASSWORD)
 
         # assert staff has access to all toc
         self.request.user = staff_user

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -88,7 +88,7 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
         super().setUp()
 
         self.test_user = self.create_user()
-        self.login(self.test_user.email, 'test')
+        self.login(self.test_user.email, self.TEST_PASSWORD)
         self.enroll(self.course, True)
 
     def get_courseware_page(self):
@@ -298,12 +298,12 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
     def login_staff(self):
         """ Login as a staff user """
         self.logout()
-        self.login(self.test_user.email, 'test')
+        self.login(self.test_user.email, self.TEST_PASSWORD)
 
     def login_student(self):
         """ Login as a student """
         self.logout()
-        self.login(self.student_user.email, 'test')
+        self.login(self.student_user.email, self.TEST_PASSWORD)
 
     def submit_answer(self, response1, response2):
         """
@@ -351,7 +351,7 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         student = UserFactory.create(username=username)
         CourseEnrollment.enroll(student, self.course.id)
         self.logout()
-        self.login(student.email, 'test')
+        self.login(student.email, self.TEST_PASSWORD)
         # Answer correctly as the student, and check progress.
         self.submit_answer('Correct', 'Correct')
         assert self.get_progress_detail() == '2/2'
@@ -378,7 +378,7 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
 
         # Verify the student state did not change.
         self.logout()
-        self.login(student.email, 'test')
+        self.login(student.email, self.TEST_PASSWORD)
         assert self.get_progress_detail() == '2/2'
 
     def test_masquerading_with_language_preference(self):

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -59,7 +59,7 @@ class SplitTestBase(ModuleStoreTestCase):
 
         self.student = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
-        self.client.login(username=self.student.username, password='test')
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
 
         self.included_usage_keys = None
         self.excluded_usage_keys = None
@@ -309,7 +309,7 @@ class SplitTestPosition(SharedModuleStoreTestCase):
 
         self.student = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
-        self.client.login(username=self.student.username, password='test')
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
 
     def test_changing_position_works(self):
         # Make a mock FieldDataCache for this course, so we can get the course block

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -154,7 +154,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
         # create a test student
         self.course = CourseFactory.create(display_name=self.COURSE_NAME, number=self.COURSE_SLUG)
         self.student = 'view@test.com'
-        self.password = 'foo'
+        self.password = 'password'
         self.create_account('u1', self.student, self.password)
         self.activate_user(self.student)
         self.enroll(self.course)

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -154,7 +154,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
         # create a test student
         self.course = CourseFactory.create(display_name=self.COURSE_NAME, number=self.COURSE_SLUG)
         self.student = 'view@test.com'
-        self.password = 'password'
+        self.password = 'Password1234'
         self.create_account('u1', self.student, self.password)
         self.activate_user(self.student)
         self.enroll(self.course)

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -154,7 +154,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
         # create a test student
         self.course = CourseFactory.create(display_name=self.COURSE_NAME, number=self.COURSE_SLUG)
         self.student = 'view@test.com'
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         self.create_account('u1', self.student, self.password)
         self.activate_user(self.student)
         self.enroll(self.course)

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -404,7 +404,7 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         # login as instructor hit skip entrance exam api in instructor app
         instructor = InstructorFactory(course_key=self.course.id)
         self.client.logout()
-        self.client.login(username=instructor.username, password='test')
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
 
         url = reverse('mark_student_can_skip_entrance_exam', kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url, {
@@ -426,7 +426,7 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         # Login as member of staff
         self.client.logout()
         staff_user = StaffFactory(course_key=self.course.id)
-        self.client.login(username=staff_user.username, password='test')
+        self.client.login(username=staff_user.username, password=self.TEST_PASSWORD)
         course_tab_list = get_course_tab_list(staff_user, self.course)
         assert len(course_tab_list) == 4
 
@@ -685,7 +685,7 @@ class CourseTabListTestCase(TabListTestCase):
         # Login as member of staff
         self.client.logout()
         staff_user = StaffFactory(course_key=self.course.id)
-        self.client.login(username=staff_user.username, password='test')
+        self.client.login(username=staff_user.username, password=self.TEST_PASSWORD)
         course_tab_list_staff = get_course_tab_list(staff_user, self.course)
         name_list_staff = [x.name for x in course_tab_list_staff]
         assert 'Static Tab Free' in name_list_staff

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -29,7 +29,7 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
     Check that view authentication works properly.
     """
 
-    ACCOUNT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
+    ACCOUNT_INFO = [('view@test.com', 'password1234'), ('view2@test.com', 'password1234')]
     ENABLED_SIGNALS = ['course_published']
 
     @staticmethod
@@ -111,7 +111,7 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         self.assert_request_status_code(302, url)
 
     def login(self, user):  # lint-amnesty, pylint: disable=arguments-differ
-        return super().login(user.email, 'test')
+        return super().login(user.email, self.TEST_PASSWORD)
 
     def setUp(self):
         super().setUp()

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -29,7 +29,7 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
     Check that view authentication works properly.
     """
 
-    ACCOUNT_INFO = [('view@test.com', 'password1234'), ('view2@test.com', 'password1234')]
+    ACCOUNT_INFO = [('view@test.com', 'Password1234'), ('view2@test.com', 'Password1234')]
     ENABLED_SIGNALS = ['course_published']
 
     @staticmethod

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -712,7 +712,7 @@ class ViewsTestCase(BaseViewsTestCase):
         # log into a staff account
         admin = AdminFactory()
 
-        assert self.client.login(username=admin.username, password='test')
+        assert self.client.login(username=admin.username, password=TEST_PASSWORD)
 
         url = reverse('submission_history', kwargs={
             'course_id': str(self.course_key),
@@ -727,7 +727,7 @@ class ViewsTestCase(BaseViewsTestCase):
         # log into a staff account
         admin = AdminFactory()
 
-        assert self.client.login(username=admin.username, password='test')
+        assert self.client.login(username=admin.username, password=TEST_PASSWORD)
 
         # try it with an existing user and a malicious location
         url = reverse('submission_history', kwargs={
@@ -751,7 +751,7 @@ class ViewsTestCase(BaseViewsTestCase):
         # log into a staff account
         admin = AdminFactory.create()
 
-        assert self.client.login(username=admin.username, password='test')
+        assert self.client.login(username=admin.username, password=TEST_PASSWORD)
 
         usage_key = self.course_key.make_usage_key('problem', 'test-history')
         state_client = DjangoXBlockUserStateClient(admin)
@@ -814,7 +814,7 @@ class ViewsTestCase(BaseViewsTestCase):
                 course_key = course.id
                 client = Client()
                 admin = AdminFactory.create()
-                assert client.login(username=admin.username, password='test')
+                assert client.login(username=admin.username, password=TEST_PASSWORD)
                 state_client = DjangoXBlockUserStateClient(admin)
                 usage_key = course_key.make_usage_key('problem', 'test-history')
                 state_client.set(
@@ -1253,7 +1253,7 @@ class ProgressPageBaseTests(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
-        assert self.client.login(username=self.user.username, password='test')
+        assert self.client.login(username=self.user.username, password=TEST_PASSWORD)
 
         self.setup_course()
 
@@ -1352,7 +1352,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         # Create a new course, a user which will not be enrolled in course, admin user for staff access
         course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
         admin = AdminFactory.create()
-        assert self.client.login(username=admin.username, password='test')
+        assert self.client.login(username=admin.username, password=TEST_PASSWORD)
 
         # Create and enable Credit course
         CreditCourse.objects.create(course_key=course.id, enabled=True)
@@ -1646,7 +1646,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         """
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         user = UserFactory.create()
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         add_course_mode(self.course, mode_slug=CourseMode.AUDIT)
         add_course_mode(self.course)
         CourseEnrollmentFactory(user=user, course_id=self.course.id, mode=course_mode)
@@ -1679,7 +1679,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         """
         CourseDurationLimitConfig.objects.create(enabled=False)
         user = UserFactory.create()
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         CourseModeFactory.create(
             course_id=self.course.id,
             mode_slug=course_mode
@@ -1698,7 +1698,7 @@ class ProgressPageTests(ProgressPageBaseTests):
          in an ineligible mode.
         """
         user = UserFactory.create()
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
         CourseEnrollmentFactory(user=user, course_id=self.course.id, mode=course_mode)
 
         with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
@@ -2081,7 +2081,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
         self.setup_course(show_correctness=show_correctness, due_date=due_date, graded=graded)
         self.add_problem()
 
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=TEST_PASSWORD)
         resp = self._get_progress_page()
 
         # Ensure that expected text is present
@@ -2133,7 +2133,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
         self.add_problem()
 
         # Login as a course staff user to view the student progress page.
-        self.client.login(username=self.staff_user.username, password='test')
+        self.client.login(username=self.staff_user.username, password=TEST_PASSWORD)
 
         resp = self._get_student_progress_page()
 
@@ -3198,7 +3198,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCa
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
-        assert self.client.login(username=self.user.username, password='test')
+        assert self.client.login(username=self.user.username, password=TEST_PASSWORD)
         self.course = CourseFactory.create()
         CourseOverview.load_from_module_store(self.course.id)
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
@@ -3298,7 +3298,7 @@ class PreviewTests(BaseViewsTestCase):
             # Previews will not redirect to the mfe
             course_staff = UserFactory.create(is_staff=False)
             CourseStaffRole(self.course_key).add_users(course_staff)
-            self.client.login(username=course_staff.username, password='test')
+            self.client.login(username=course_staff.username, password=TEST_PASSWORD)
             assert self.client.get(preview_url).status_code == 200
 
 
@@ -3435,7 +3435,7 @@ class TestCourseWideResources(ModuleStoreTestCase):
         CourseEnrollmentFactory(user=user, course_id=course.id)
         if is_instructor:
             allow_access(course, user, 'instructor')
-        assert self.client.login(username=user.username, password='test')
+        assert self.client.login(username=user.username, password=TEST_PASSWORD)
 
         kwargs = None
         if param == 'course_id':

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -81,7 +81,7 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
         """
         Logs in the test user.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password='password')
 
     def course_options(self):
         """

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -81,7 +81,7 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
         """
         Logs in the test user.
         """
-        self.client.login(username=self.user.username, password='password')
+        self.client.login(username=self.user.username, password='Password1234')
 
     def course_options(self):
         """

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -241,7 +241,7 @@ class ViewsTestCaseMixin:
         with patch('common.djangoapps.student.models.user.cc.User.save'):
             uname = 'student'
             email = 'student@edx.org'
-            self.password = 'test'
+            self.password = 'password'
 
             # Create the user and make them active so we can log them in.
             self.student = UserFactory.create(username=uname, email=email, password=self.password)
@@ -464,7 +464,7 @@ class ViewsTestCase(
         with patch('common.djangoapps.student.models.user.cc.User.save'):
             uname = 'student'
             email = 'student@edx.org'
-            self.password = 'test'
+            self.password = 'password'
 
             # Create the user and make them active so we can log them in.
             self.student = UserFactory.create(username=uname, email=email, password=self.password)

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -241,7 +241,7 @@ class ViewsTestCaseMixin:
         with patch('common.djangoapps.student.models.user.cc.User.save'):
             uname = 'student'
             email = 'student@edx.org'
-            self.password = 'password'
+            self.password = 'Password1234'
 
             # Create the user and make them active so we can log them in.
             self.student = UserFactory.create(username=uname, email=email, password=self.password)
@@ -464,7 +464,7 @@ class ViewsTestCase(
         with patch('common.djangoapps.student.models.user.cc.User.save'):
             uname = 'student'
             email = 'student@edx.org'
-            self.password = 'password'
+            self.password = 'Password1234'
 
             # Create the user and make them active so we can log them in.
             self.student = UserFactory.create(username=uname, email=email, password=self.password)

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -87,7 +87,7 @@ class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, Ur
             start=datetime.now(UTC),
             discussion_topics={"Test Topic": {"id": "test_topic"}}
         )
-        self.password = "password"
+        self.password = "Password1234"
         self.user = UserFactory.create(password=self.password)
         # Ensure that parental controls don't apply to this user
         self.user.profile.year_of_birth = 1970
@@ -168,7 +168,7 @@ class UploadFileViewTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMi
                 content_type="image/jpeg",
             ),
         }
-        self.user = UserFactory.create(password="password")
+        self.user = UserFactory.create(password=self.TEST_PASSWORD)
         self.course = CourseFactory.create(org='a', course='b', run='c', start=datetime.now(UTC))
         self.url = reverse("upload_file", kwargs={"course_id": str(self.course.id)})
 
@@ -176,7 +176,7 @@ class UploadFileViewTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMi
         """
         Authenticates the test client with the example user.
         """
-        self.client.login(username=self.user.username, password="password")
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     def enroll_user_in_course(self):
         """
@@ -320,10 +320,10 @@ class CommentViewSetListByUserTest(
         self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
 
-        self.user = UserFactory.create(password="password")
+        self.user = UserFactory.create(password=self.TEST_PASSWORD)
         self.register_get_user_response(self.user)
 
-        self.other_user = UserFactory.create(password="password")
+        self.other_user = UserFactory.create(password=self.TEST_PASSWORD)
         self.register_get_user_response(self.other_user)
 
         self.course = CourseFactory.create(org="a", course="b", run="c", start=datetime.now(UTC))
@@ -405,7 +405,7 @@ class CommentViewSetListByUserTest(
         they're not either enrolled or staff members.
         """
         self.register_mock_endpoints()
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert json.loads(response.content)["developer_message"] == "Course not found."
@@ -416,7 +416,7 @@ class CommentViewSetListByUserTest(
         comments in that course.
         """
         self.register_mock_endpoints()
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         CourseEnrollmentFactory.create(user=self.other_user, course_id=self.course.id)
         self.assert_successful_response(self.client.get(self.url))
 
@@ -425,7 +425,7 @@ class CommentViewSetListByUserTest(
         Staff users are allowed to get any user's comments.
         """
         self.register_mock_endpoints()
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         GlobalStaff().add_users(self.other_user)
         self.assert_successful_response(self.client.get(self.url))
 
@@ -436,7 +436,7 @@ class CommentViewSetListByUserTest(
         course.
         """
         self.register_mock_endpoints()
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         role(course_key=self.course.id).add_users(self.other_user)
         self.assert_successful_response(self.client.get(self.url))
 
@@ -445,7 +445,7 @@ class CommentViewSetListByUserTest(
         Requests for users that don't exist result in a 404 response.
         """
         self.register_mock_endpoints()
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         GlobalStaff().add_users(self.other_user)
         url = self.build_url("non_existent", self.course.id)
         response = self.client.get(url)
@@ -456,7 +456,7 @@ class CommentViewSetListByUserTest(
         Requests for courses that don't exist result in a 404 response.
         """
         self.register_mock_endpoints()
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         GlobalStaff().add_users(self.other_user)
         url = self.build_url(self.user.username, "course-v1:x+y+z")
         response = self.client.get(url)
@@ -467,7 +467,7 @@ class CommentViewSetListByUserTest(
         Requests with invalid course ID should fail form validation.
         """
         self.register_mock_endpoints()
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         GlobalStaff().add_users(self.other_user)
         url = self.build_url(self.user.username, "an invalid course")
         response = self.client.get(url)
@@ -484,7 +484,7 @@ class CommentViewSetListByUserTest(
         self.register_get_threads_response(threads=[], page=1, num_pages=1)
         self.register_get_comments_response(comments=[], page=1, num_pages=1)
 
-        self.client.login(username=self.other_user.username, password="password")
+        self.client.login(username=self.other_user.username, password=self.TEST_PASSWORD)
         GlobalStaff().add_users(self.other_user)
         url = self.build_url(self.user.username, self.course.id, page=2)
         response = self.client.get(url)
@@ -929,7 +929,7 @@ class CourseTopicsViewV3Test(DiscussionAPIViewTestMixin, CommentsServiceMockMixi
     """
     def setUp(self) -> None:
         super().setUp()
-        self.password = "password"
+        self.password = self.TEST_PASSWORD
         self.user = UserFactory.create(password=self.password)
         self.client.login(username=self.user.username, password=self.password)
         self.staff = AdminFactory.create()
@@ -2758,7 +2758,7 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
             discussion_topics={"Test Topic": {"id": "test_topic"}}
         )
         self.path = reverse('discussion_course_settings', kwargs={'course_id': str(self.course.id)})
-        self.password = 'password'
+        self.password = self.TEST_PASSWORD
         self.user = UserFactory(username='staff', password=self.password, is_staff=True)
 
     def _get_oauth_headers(self, user):
@@ -3056,7 +3056,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
             run="z",
             start=datetime.now(UTC),
         )
-        self.password = 'password'
+        self.password = self.TEST_PASSWORD
         self.user = UserFactory(username='staff', password=self.password, is_staff=True)
         course_key = CourseKey.from_string('course-v1:x+y+z')
         seed_permissions_roles(course_key)
@@ -3264,7 +3264,7 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
             user = UserFactory.create(
                 username=stat['username'],
                 email=f"{stat['username']}@example.com",
-                password='12345'
+                password=self.TEST_PASSWORD
             )
             CourseEnrollment.enroll(user, self.course.id, mode='audit')
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -2758,7 +2758,7 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
             discussion_topics={"Test Topic": {"id": "test_topic"}}
         )
         self.path = reverse('discussion_course_settings', kwargs={'course_id': str(self.course.id)})
-        self.password = 'edx'
+        self.password = 'password'
         self.user = UserFactory(username='staff', password=self.password, is_staff=True)
 
     def _get_oauth_headers(self, user):
@@ -3056,7 +3056,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
             run="z",
             start=datetime.now(UTC),
         )
-        self.password = 'edx'
+        self.password = 'password'
         self.user = UserFactory(username='staff', password=self.password, is_staff=True)
         course_key = CourseKey.from_string('course-v1:x+y+z')
         seed_permissions_roles(course_key)
@@ -3278,7 +3278,7 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
         """
         Tests that for a regular user stats are returned without flag counts
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         data = response.json()
         assert data["results"] == self.stats_without_flags
@@ -3288,7 +3288,7 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
         """
         Tests that for a moderator user stats are returned with flag counts
         """
-        self.client.login(username=self.moderator.username, password='test')
+        self.client.login(username=self.moderator.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         data = response.json()
         assert data["results"] == self.stats
@@ -3308,7 +3308,7 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
         """
         Test valid sorting options and defaults
         """
-        self.client.login(username=username, password='test')
+        self.client.login(username=username, password=self.TEST_PASSWORD)
         params = {}
         if ordering_requested:
             params = {"order_by": ordering_requested}
@@ -3326,7 +3326,7 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
         """
         Test for invalid sorting options for regular users.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url, {"order_by": order_by})
         assert "order_by" in response.json()["field_errors"]
 
@@ -3341,7 +3341,7 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
         Test for endpoint with username param.
         """
         params = {'username': username_search_string}
-        self.client.login(username=self.moderator.username, password='test')
+        self.client.login(username=self.moderator.username, password=self.TEST_PASSWORD)
         self.client.get(self.url, params)
         assert urlparse(
             httpretty.last_request().path  # lint-amnesty, pylint: disable=no-member
@@ -3356,7 +3356,7 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
         Test for endpoint with username param with no matches.
         """
         params = {'username': 'unknown'}
-        self.client.login(username=self.moderator.username, password='test')
+        self.client.login(username=self.moderator.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url, params)
         data = response.json()
         self.assertFalse(data['results'])

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -463,7 +463,7 @@ class SingleThreadTestCase(ForumsEnableMixin, ModuleStoreTestCase):  # lint-amne
         CourseTeamFactory.create(discussion_topic_id=discussion_topic_id)
         user_not_in_team = UserFactory.create()
         CourseEnrollmentFactory.create(user=user_not_in_team, course_id=self.course.id)
-        self.client.login(username=user_not_in_team.username, password='test')
+        self.client.login(username=user_not_in_team.username, password=self.TEST_PASSWORD)
 
         mock_request.side_effect = make_mock_request_impl(
             course=self.course,
@@ -624,7 +624,7 @@ class SingleCohortedThreadTestCase(CohortedTestCase):  # lint-amnesty, pylint: d
     def test_html(self, mock_request):
         _mock_text, mock_thread_id = self._create_mock_cohorted_thread(mock_request)
 
-        self.client.login(username=self.student.username, password='test')
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
         response = self.client.get(
             reverse('single_thread', kwargs={
                 'course_id': str(self.course.id),
@@ -758,7 +758,7 @@ class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixin):  # l
         if is_ajax:
             headers['HTTP_X_REQUESTED_WITH'] = "XMLHttpRequest"
 
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
 
         return self.client.get(
             reverse('single_thread', args=[str(self.course.id), commentable_id, "dummy_thread_id"]),
@@ -824,7 +824,7 @@ class ForumFormDiscussionContentGroupTestCase(ForumsEnableMixin, ContentGroupTes
             text="dummy content",
             thread_list=self.thread_list
         )
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         return self.client.get(
             reverse("forum_form_discussion", args=[str(self.course.id)]),
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
@@ -889,7 +889,7 @@ class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, Content
         verify that the user does not have access to that thread.
         """
         def call_single_thread():
-            self.client.login(username=user.username, password='test')
+            self.client.login(username=user.username, password=self.TEST_PASSWORD)
             return self.client.get(
                 reverse('single_thread', args=[str(self.course.id), discussion_id, thread_id])
             )
@@ -1113,7 +1113,7 @@ class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdT
         if is_ajax:
             headers['HTTP_X_REQUESTED_WITH'] = "XMLHttpRequest"
 
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         return self.client.get(
             reverse("forum_form_discussion", args=[str(self.course.id)]),
             data=request_data,
@@ -1165,7 +1165,7 @@ class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupI
         if is_ajax:
             headers['HTTP_X_REQUESTED_WITH'] = "XMLHttpRequest"
 
-        self.client.login(username=requesting_user.username, password='test')
+        self.client.login(username=requesting_user.username, password=self.TEST_PASSWORD)
         return self.client.get(
             reverse('user_profile', args=[str(self.course.id), profiled_user.id]),
             data=request_data,
@@ -1414,7 +1414,7 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
         mock_request.side_effect = make_mock_request_impl(
             course=self.course, text=self.TEST_THREAD_TEXT, thread_id=self.TEST_THREAD_ID
         )
-        self.client.login(username=self.student.username, password='test')
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
 
         response = self.client.get(
             reverse('user_profile', kwargs={
@@ -2300,7 +2300,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         """
 
         with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, True):
-            self.client.login(username=self.user.username, password='test')
+            self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
             url = reverse("forum_form_discussion", args=[self.course.id])
             response = self.client.get(url)
             assert response.status_code == 302
@@ -2315,7 +2315,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         """
 
         with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, True):
-            self.client.login(username=self.user.username, password='test')
+            self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
             url = reverse("user_profile", args=[self.course.id, self.user.id])
             response = self.client.get(url)
             assert response.status_code == 302
@@ -2330,7 +2330,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         """
 
         with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, True):
-            self.client.login(username=self.user.username, password='test')
+            self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
             url = reverse("single_thread", args=[self.course.id, "test_discussion", "test_thread"])
             response = self.client.get(url)
             assert response.status_code == 302

--- a/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
@@ -97,7 +97,7 @@ class GradeViewTestMixin(SharedModuleStoreTestCase):
 
     def setUp(self):
         super().setUp()
-        self.password = 'test'
+        self.password = 'password'
         self.global_staff = GlobalStaffFactory.create()
         self.student = UserFactory(password=self.password, username='student', email='student@example.com')
         self.other_student = UserFactory(

--- a/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
@@ -97,7 +97,7 @@ class GradeViewTestMixin(SharedModuleStoreTestCase):
 
     def setUp(self):
         super().setUp()
-        self.password = 'password'
+        self.password = self.TEST_PASSWORD
         self.global_staff = GlobalStaffFactory.create()
         self.student = UserFactory(password=self.password, username='student', email='student@example.com')
         self.other_student = UserFactory(

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
@@ -548,7 +548,7 @@ class CourseSubmissionHistoryWithDataTest(TestSubmittingProblems):
     def setUp(self):
         super().setUp()
         self.namespaced_url = 'grades_api:v1:submission_history'
-        self.password = 'test'
+        self.password = 'password'
         self.basic_setup()
         self.global_staff = GlobalStaffFactory.create()
 

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
@@ -548,7 +548,7 @@ class CourseSubmissionHistoryWithDataTest(TestSubmittingProblems):
     def setUp(self):
         super().setUp()
         self.namespaced_url = 'grades_api:v1:submission_history'
-        self.password = 'password'
+        self.password = 'Password1234'
         self.basic_setup()
         self.global_staff = GlobalStaffFactory.create()
 

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
@@ -548,7 +548,7 @@ class CourseSubmissionHistoryWithDataTest(TestSubmittingProblems):
     def setUp(self):
         super().setUp()
         self.namespaced_url = 'grades_api:v1:submission_history'
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         self.basic_setup()
         self.global_staff = GlobalStaffFactory.create()
 

--- a/lms/djangoapps/grades/tests/integration/test_access.py
+++ b/lms/djangoapps/grades/tests/integration/test_access.py
@@ -73,9 +73,9 @@ class GradesAccessIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreT
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
         self.student = self.request.user
-        self.client.login(username=self.student.username, password="test")
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
         CourseEnrollment.enroll(self.student, self.course.id)
-        self.instructor = UserFactory.create(is_staff=True, username='test_instructor', password='test')
+        self.instructor = UserFactory.create(is_staff=True, username='test_instructor', password=self.TEST_PASSWORD)
         self.refresh_course()
 
     def test_subsection_access_changed(self):

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -70,9 +70,9 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
         self.student = self.request.user
-        self.client.login(username=self.student.username, password="test")
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
         CourseEnrollment.enroll(self.student, self.course.id)
-        self.instructor = UserFactory.create(is_staff=True, username='test_instructor', password='test')
+        self.instructor = UserFactory.create(is_staff=True, username='test_instructor', password=self.TEST_PASSWORD)
         self.refresh_course()
 
     @patch('lms.djangoapps.grades.events.tracker')

--- a/lms/djangoapps/grades/tests/integration/test_problems.py
+++ b/lms/djangoapps/grades/tests/integration/test_problems.py
@@ -43,9 +43,8 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
 
     def setUp(self):
         super().setUp()
-        password = 'test'
-        self.student = UserFactory.create(is_staff=False, username='test_student', password=password)
-        self.client.login(username=self.student.username, password=password)
+        self.student = UserFactory.create(is_staff=False, username='test_student', password=self.TEST_PASSWORD)
+        self.client.login(username=self.student.username, password=self.TEST_PASSWORD)
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request(self.student)
         self.course_structure = get_course_blocks(self.student, self.course.location)
@@ -58,8 +57,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
         For details on the contents and structure of the file, see
         `common/test/data/scoreable/README`.
         """
-        password = 'test'
-        user = UserFactory.create(is_staff=False, username='test_student', password=password)
+        user = UserFactory.create(is_staff=False, username='test_student', password=cls.TEST_PASSWORD)
 
         course_items = import_course_from_xml(
             cls.store,
@@ -144,7 +142,7 @@ class TestVariedMetadata(ProblemSubmissionTestMixin, ModuleStoreTestCase):
         '''
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
-        self.client.login(username=self.request.user.username, password="test")
+        self.client.login(username=self.request.user.username, password=self.TEST_PASSWORD)
         CourseEnrollment.enroll(self.request.user, self.course.id)
 
     def _get_altered_metadata(self, alterations):

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -325,7 +325,7 @@ class TestEndpointHttpMethods(SharedModuleStoreTestCase, LoginEnrollmentTestCase
         """
         super().setUp()
         global_user = GlobalStaffFactory()
-        self.client.login(username=global_user.username, password='test')
+        self.client.login(username=global_user.username, password=self.TEST_PASSWORD)
 
     @ddt.data(*INSTRUCTOR_POST_ENDPOINTS)
     def test_endpoints_reject_get(self, data):
@@ -478,7 +478,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
         """
         Ensure that an enrolled student can't access staff or instructor endpoints.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         for endpoint, args in self.staff_level_endpoints:
             self._access_endpoint(
@@ -518,7 +518,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
         CourseEnrollment.enroll(staff_member, self.course.id)
         CourseFinanceAdminRole(self.course.id).add_users(staff_member)
         CourseDataResearcherRole(self.course.id).add_users(staff_member)
-        self.client.login(username=staff_member.username, password='test')
+        self.client.login(username=staff_member.username, password=self.TEST_PASSWORD)
         # Try to promote to forums admin - not working
         # update_forum_role(self.course.id, staff_member, FORUM_ROLE_ADMINISTRATOR, 'allow')
 
@@ -558,7 +558,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
 
         CourseFinanceAdminRole(self.course.id).add_users(inst)
         CourseDataResearcherRole(self.course.id).add_users(inst)
-        self.client.login(username=inst.username, password='test')
+        self.client.login(username=inst.username, password=self.TEST_PASSWORD)
 
         for endpoint, args in self.staff_level_endpoints:
             expected_status = 200
@@ -632,7 +632,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         self.audit_course_instructor = InstructorFactory(course_key=self.audit_course.id)
         self.white_label_course_instructor = InstructorFactory(course_key=self.white_label_course.id)
 
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.not_enrolled_student = UserFactory(
             username='NotEnrolledStudent',
@@ -945,7 +945,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         Test that enrollment mode for audit courses (paid courses) is 'audit'.
         """
         # Login Audit Course instructor
-        self.client.login(username=self.audit_course_instructor.username, password='test')
+        self.client.login(username=self.audit_course_instructor.username, password=self.TEST_PASSWORD)
 
         csv_content = b"test_student_wl@example.com,test_student_wl,Test Student,USA"
         uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
@@ -976,7 +976,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         self.white_label_course_mode.save()
 
         # Login Audit Course instructor
-        self.client.login(username=self.white_label_course_instructor.username, password='test')
+        self.client.login(username=self.white_label_course_instructor.username, password=self.TEST_PASSWORD)
 
         csv_content = b"test_student_wl@example.com,test_student_wl,Test Student,USA"
         uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
@@ -1024,7 +1024,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
         self.request = RequestFactory().request()
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.enrolled_student = UserFactory(username='EnrolledStudent', first_name='Enrolled', last_name='Student')
         CourseEnrollment.enroll(
@@ -1873,7 +1873,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         super().setUp()
 
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.beta_tester = BetaTesterFactory(course_key=self.course.id)
         CourseEnrollment.enroll(
@@ -2218,7 +2218,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         super().setUp()
 
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.other_instructor = InstructorFactory(course_key=self.course.id)
         self.other_staff = StaffFactory(course_key=self.course.id)
@@ -2458,7 +2458,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.course_mode.save()
         self.instructor = InstructorFactory(course_key=self.course.id)
         CourseDataResearcherRole(self.course.id).add_users(self.instructor)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.students = [UserFactory() for _ in range(6)]
         for student in self.students:
@@ -2600,7 +2600,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             }))
             course_instructor = InstructorFactory(course_key=self.course.id)
             CourseDataResearcherRole(self.course.id).add_users(course_instructor)
-            self.client.login(username=course_instructor.username, password='test')
+            self.client.login(username=course_instructor.username, password=self.TEST_PASSWORD)
 
         url = reverse('get_students_features', kwargs={'course_id': str(self.course.id)})
 
@@ -2972,7 +2972,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     def setUp(self):
         super().setUp()
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.student = UserFactory()
         CourseEnrollment.enroll(self.student, self.course.id)
@@ -3158,7 +3158,7 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
         self.instructor = InstructorFactory(course_key=self.course.id)
         # Add instructor to invalid ee course
         CourseInstructorRole(self.course_with_invalid_ee.id).add_users(self.instructor)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.student = UserFactory()
         CourseEnrollment.enroll(self.student, self.course.id)
@@ -3261,7 +3261,7 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
         """ Test entrance exam delete state failure with staff access. """
         self.client.logout()
         staff_user = StaffFactory(course_key=self.course.id)
-        self.client.login(username=staff_user.username, password='test')
+        self.client.login(username=staff_user.username, password=self.TEST_PASSWORD)
         url = reverse('reset_student_attempts_for_entrance_exam',
                       kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url, {
@@ -3414,7 +3414,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         }
 
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
     def tearDown(self):
         super().tearDown()
@@ -3434,7 +3434,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
     def test_send_email_but_not_staff(self):
         self.client.logout()
         student = UserFactory()
-        self.client.login(username=student.username, password='test')
+        self.client.login(username=student.username, password=self.TEST_PASSWORD)
         url = reverse('send_email', kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url, self.full_test_message)
         assert response.status_code == 403
@@ -3631,7 +3631,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
     def setUp(self):
         super().setUp()
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.student = UserFactory()
         CourseEnrollment.enroll(self.student, self.course.id)
@@ -3768,7 +3768,7 @@ class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentT
         super().setUp()
 
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self.tasks = {}
         self.emails = {}
         self.emails_info = {}
@@ -4030,7 +4030,7 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         CourseEnrollmentFactory.create(user=self.user1, course_id=self.course.id)
         CourseEnrollmentFactory.create(user=self.user2, course_id=self.course.id)
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         extract_dates(None, self.course.id)
 
     def test_change_due_date(self):
@@ -4206,7 +4206,7 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
         CourseEnrollmentFactory.create(user=self.user1, course_id=self.course.id)
         CourseEnrollmentFactory.create(user=self.user2, course_id=self.course.id)
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         extract_dates(None, self.course.id)
 
     @override_waffle_flag(RELATIVE_DATES_FLAG, active=True)
@@ -4251,7 +4251,7 @@ class TestCourseIssuedCertificatesData(SharedModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.instructor = InstructorFactory(course_key=self.course.id)
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
     def generate_certificate(self, course_id, mode, status):
         """
@@ -4379,7 +4379,7 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
         """
         Verify that we get the error we expect for a given file input.
         """
-        self.client.login(username=self.staff_user.username, password='test')
+        self.client.login(username=self.staff_user.username, password=self.TEST_PASSWORD)
         response = self.call_add_users_to_cohorts(file_content, suffix=file_suffix)
         assert response.status_code == 400
         result = json.loads(response.content.decode('utf-8'))
@@ -4392,7 +4392,7 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
         background task.
         """
         mock_store_upload.return_value = (None, 'fake_file_name.csv')
-        self.client.login(username=self.staff_user.username, password='test')
+        self.client.login(username=self.staff_user.username, password=self.TEST_PASSWORD)
         response = self.call_add_users_to_cohorts(file_content)
         assert response.status_code == 204
         assert mock_store_upload.called
@@ -4438,7 +4438,7 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
         """
         Verify that we can't access the view when we aren't a staff user.
         """
-        self.client.login(username=self.non_staff_user.username, password='test')
+        self.client.login(username=self.non_staff_user.username, password=self.TEST_PASSWORD)
         response = self.call_add_users_to_cohorts('')
         assert response.status_code == 403
 

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -35,7 +35,7 @@ class TestInstructorAPIEnrollmentEmailLocalization(SharedModuleStoreTestCase):
         # Esperanto.
         self.instructor = InstructorFactory(course_key=self.course.id)
         set_user_preference(self.instructor, LANGUAGE_KEY, 'zh-cn')
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         self.student = UserFactory.create()
         set_user_preference(self.student, LANGUAGE_KEY, 'eo')

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -64,11 +64,11 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
 
     def test_visible_only_to_global_staff(self):
         # Instructors don't see the certificates section
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self._assert_certificates_visible(False)
 
         # Global staff can see the certificates section
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         self._assert_certificates_visible(True)
 
     def test_visible_only_when_feature_flag_enabled(self):
@@ -77,17 +77,17 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         cache.clear()
 
         # Now even global staff can't see the certificates section
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         self._assert_certificates_visible(False)
 
     @ddt.data("started", "error", "success")
     def test_show_certificate_status(self, status):
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         with self._certificate_status("honor", status):
             self._assert_certificate_status("honor", status)
 
     def test_show_enabled_button(self):
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
 
         # Initially, no example certs are generated, so
         # the enable button should be disabled
@@ -104,7 +104,7 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
             self._assert_enable_certs_button(False)
 
     def test_can_disable_even_after_failure(self):
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
 
         with self._certificate_status("honor", "error"):
             # When certs are disabled for a course, then don't allow them
@@ -127,7 +127,7 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         self.course.cert_html_view_enabled = True
         self.course.save()
         self.store.update_item(self.course, self.global_staff.id)
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         self.assertContains(response, 'Enable Student-Generated Certificates')
         self.assertContains(response, 'enable-certificates-submit')
@@ -143,7 +143,7 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         self.course.cert_html_view_enabled = True
         self.course.save()
         self.store.update_item(self.course, self.global_staff.id)
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         self.assertContains(response, 'Enable Student-Generated Certificates')
         self.assertContains(response, 'enable-certificates-submit')
@@ -233,18 +233,18 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         url = reverse(url_name, kwargs={'course_id': self.course.id})
 
         # Instructors do not have access
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         response = self.client.post(url)
         assert response.status_code == 403
 
         # Global staff have access
-        self.client.login(username=self.global_staff.username, password='test')
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         response = self.client.post(url)
         assert response.status_code == 302
 
     @ddt.data(True, False)
     def test_enable_certificate_generation(self, is_enabled):
-        self.client.login(username=self.global_staff.username, password='test')
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         url = reverse(
             'enable_certificate_generation',
             kwargs={'course_id': str(self.course.id)}
@@ -274,7 +274,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         user who made the request is not member of global staff.
         """
         user = UserFactory.create()
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         url = reverse(
             'start_certificate_generation',
             kwargs={'course_id': str(self.course.id)}
@@ -283,7 +283,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         response = self.client.post(url)
         assert response.status_code == 403
 
-        self.client.login(username=self.instructor.username, password='test')
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         response = self.client.post(url)
         assert response.status_code == 403
 
@@ -292,7 +292,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         Test certificates generation api endpoint returns success status when called with
         valid course key
         """
-        self.client.login(username=self.global_staff.username, password='test')
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         url = reverse(
             'start_certificate_generation',
             kwargs={'course_id': str(self.course.id)}
@@ -319,7 +319,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         )
 
         # Login the client and access the url with 'certificate_statuses'
-        self.client.login(username=self.global_staff.username, password='test')
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         url = reverse('start_certificate_regeneration', kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url, data={'certificate_statuses': [CertificateStatuses.downloadable]})
 
@@ -352,7 +352,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         )
 
         # Login the client and access the url without 'certificate_statuses'
-        self.client.login(username=self.global_staff.username, password='test')
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         url = reverse('start_certificate_regeneration', kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url)
 
@@ -419,7 +419,7 @@ class CertificateExceptionViewInstructorApiTest(SharedModuleStoreTestCase):
         # Enable certificate generation
         cache.clear()
         CertificateGenerationConfiguration.objects.create(enabled=True)
-        self.client.login(username=self.global_staff.username, password='test')
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
 
     def test_certificate_exception_added_successfully(self):
         """
@@ -712,7 +712,7 @@ class GenerateCertificatesInstructorApiTest(SharedModuleStoreTestCase):
         # Enable certificate generation
         cache.clear()
         CertificateGenerationConfiguration.objects.create(enabled=True)
-        self.client.login(username=self.global_staff.username, password='test')
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
 
     def test_generate_certificate_exceptions_all_students(self):
         """
@@ -830,7 +830,7 @@ class TestCertificatesInstructorApiBulkAllowlist(SharedModuleStoreTestCase):
         CourseEnrollment.enroll(self.enrolled_user_2, self.course.id)
 
         # Global staff can see the certificates section
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
 
     def test_create_allowlist_exception_record(self):
         """
@@ -1026,7 +1026,7 @@ class CertificateInvalidationViewTests(SharedModuleStoreTestCase):
         )
 
         # Global staff can see the certificates section
-        self.client.login(username=self.global_staff.username, password="test")
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
 
     def test_invalidate_certificate(self):
         """

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -40,7 +40,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
 
         # Create instructor account
         instructor = AdminFactory.create()
-        self.client.login(username=instructor.username, password="test")
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
 
     def tearDown(self):
         super().tearDown()
@@ -148,7 +148,7 @@ class TestNewInstructorDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
 
         # Create instructor account
         instructor = AdminFactory.create()
-        self.client.login(username=instructor.username, password="test")
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
 
         # URL for instructor dash
         self.url = reverse('instructor_dashboard', kwargs={'course_id': str(self.course_key)})

--- a/lms/djangoapps/instructor/tests/test_filters.py
+++ b/lms/djangoapps/instructor/tests/test_filters.py
@@ -99,7 +99,7 @@ class InstructorDashboardFiltersTest(ModuleStoreTestCase):
         """
         super().setUp()
         self.instructor = AdminFactory.create()
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self.course = CourseFactory.create(
             org="test1", course="course1", display_name="run1",
         )

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -36,7 +36,7 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
 
         # Create instructor account
         self.instructor = AdminFactory.create()
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
     def setup_course_url(self, course):
         """

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -56,7 +56,7 @@ class TestGradebook(SharedModuleStoreTestCase):
         super().setUp()
 
         instructor = AdminFactory.create()
-        self.client.login(username=instructor.username, password='test')
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
         self.users = [UserFactory.create() for _ in range(USER_COUNT)]
         for user in self.users:
             CourseEnrollmentFactory.create(user=user, course_id=self.course.id)

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -85,7 +85,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         self.course_mode.save()
         # Create instructor account
         self.instructor = AdminFactory.create()
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
         # URL for instructor dash
         self.url = reverse('instructor_dashboard', kwargs={'course_id': str(self.course.id)})
@@ -169,7 +169,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
                     org=self.course.id.org
                 )
                 set_course_cohorted(self.course.id, True)
-                self.client.login(username=self.user.username, password='test')
+                self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
                 response = self.client.get(self.url).content.decode('utf-8')
                 self.assertEqual(discussion_section in response, is_discussion_tab_available)
 
@@ -192,7 +192,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
                 user = UserFactory.create(is_staff=True)
                 set_course_cohorted(self.course.id, True)
-                self.client.login(username=user.username, password='test')
+                self.client.login(username=user.username, password=self.TEST_PASSWORD)
                 response = self.client.get(self.url).content.decode('utf-8')
                 self.assertEqual(discussion_section in response, is_discussion_tab_available)
 
@@ -224,7 +224,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
                 role=access_role,
                 org=self.course.id.org
             )
-            self.client.login(username=user.username, password="test")
+            self.client.login(username=user.username, password=self.TEST_PASSWORD)
             response = self.client.get(self.url)
             if can_access:
                 self.assertContains(response, download_section)
@@ -244,7 +244,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             role='data_researcher',
             org=self.course.id.org
         )
-        self.client.login(username=user.username, password="test")
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         matches = re.findall(
             rb'<li class="nav-item"><button type="button" class="btn-link .*" data-section=".*">.*',
@@ -320,7 +320,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
         # But staff user can only see specific grades
         staff = StaffFactory(course_key=self.course.id)
-        self.client.login(username=staff.username, password="test")
+        self.client.login(username=staff.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         self.assertNotContains(response, '<h4 class="hd hd-4">Adjust all enrolled learners')
         self.assertContains(response, '<h4 class="hd hd-4">View a specific learner&#39;s grades and progress')
@@ -620,7 +620,7 @@ class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTes
         self.course_mode.save()
         # Create instructor account
         self.instructor = AdminFactory.create()
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
 
     def test_spoc_gradebook_mongo_calls(self):
         """

--- a/lms/djangoapps/instructor_task/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/instructor_task/rest_api/v1/tests/test_views.py
@@ -128,7 +128,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
         Test case that verifies the permissions of the ListScheduledBulkEmailInstructorTasks view. A user without staff,
         instructor, or GlobalStaff access should not be able to retrieve the bulk email schedules for a course.
         """
-        self.client.login(username=username, password="test")
+        self.client.login(username=username, password=self.TEST_PASSWORD)
         response = self.client.get(self._build_api_url(self.course1.id))
         assert response.status_code == expected_status
 
@@ -143,7 +143,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
         # add a "In Progress" task which shouldn't be returned in our results
         self._create_scheduled_course_emails_for_course(self.course1.id, self.instructor_course1, PROGRESS, 1)
 
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.get(self._build_api_url(self.course1.id))
         results = response.data.get("results")
 
@@ -169,7 +169,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
         expected_task_output_msg = "Task revoked before running"
 
         self._create_scheduled_course_emails_for_course(self.course1.id, self.instructor_course1, SCHEDULED, 3)
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.get(self._build_api_url(self.course1.id))
         results = response.data.get("results")
 
@@ -199,7 +199,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
 
         This test verifies the response received when we try to delete a task schedule that does not exist.
         """
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.delete(f"{self._build_api_url(self.course1.id)}123456789")
         assert response.status_code == 404
 
@@ -214,7 +214,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
         task = InstructorTask.objects.get(course_id=self.course1.id)
         schedule = InstructorTaskSchedule.objects.get(task=task)
 
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.delete(f"{self._build_api_url(self.course1.id)}{schedule.id}")
         assert response.status_code == 400
 
@@ -232,7 +232,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
             "schedule": schedule_datetime.strftime('%Y-%m-%dT%H:%M:%SZ'),
             "browser_timezone": "UTC"
         }
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.patch(
             f"{self._build_api_url(self.course1.id)}{task_schedule.id}",
             data=json.dumps(data),
@@ -262,7 +262,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
             }
         }
 
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.patch(
             f"{self._build_api_url(self.course1.id)}{task_schedule.id}",
             data=json.dumps(data),
@@ -296,7 +296,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
             f"Cannot update instructor task schedule '{task_schedule.id}', the updated schedule occurs in the past"
         )
 
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.patch(
             f"{self._build_api_url(self.course1.id)}{task_schedule.id}",
             data=json.dumps(data),
@@ -328,7 +328,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
             f"Subject{email_id}'"
         )
 
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.patch(
             f"{self._build_api_url(self.course1.id)}{task_schedule.id}",
             data=json.dumps(data),
@@ -359,7 +359,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
             "specified in the request does not match the email id associated with the task"
         )
 
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.patch(
             f"{self._build_api_url(self.course1.id)}{task_schedule.id}",
             data=json.dumps(data),
@@ -379,7 +379,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
             "browser_timezone": "UTC"
         }
 
-        self.client.login(username=self.instructor_course1.username, password="test")
+        self.client.login(username=self.instructor_course1.username, password=self.TEST_PASSWORD)
         response = self.client.patch(
             f"{self._build_api_url(self.course1.id)}8675309",
             data=json.dumps(data),

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -161,7 +161,7 @@ class InstructorTaskCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase)
         if self.current_user != username:
             self.logout()
             user_email = User.objects.get(username=username).email
-            self.login(user_email, "test")
+            self.login(user_email, self.TEST_PASSWORD)
             self.current_user = username
 
     def _create_user(self, username, email=None, is_staff=False, mode='honor', enrollment_active=True):

--- a/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
@@ -50,7 +50,6 @@ PROGRAMS_UTILS_MODULE = 'openedx.core.djangoapps.programs.utils'
 class TestProgramProgressDetailView(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
     """Unit tests for the program progress detail page."""
     program_uuid = str(uuid4())
-    password = 'test'
     url = reverse_lazy('learner_dashboard:v0:program_progress_detail', kwargs={'program_uuid': program_uuid})
 
     @classmethod
@@ -71,7 +70,7 @@ class TestProgramProgressDetailView(ProgramsApiConfigMixin, SharedModuleStoreTes
         super().setUp()
 
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     def assert_program_data_present(self, response):
         """Verify that program data is present."""
@@ -144,7 +143,6 @@ class TestProgramsView(SharedModuleStoreTestCase, ProgramCacheMixin):
 
     enterprise_uuid = str(uuid4())
     program_uuid = str(uuid4())
-    password = 'test'
     url = reverse_lazy('learner_dashboard:v0:program_list', kwargs={'enterprise_uuid': enterprise_uuid})
 
     @classmethod
@@ -184,7 +182,7 @@ class TestProgramsView(SharedModuleStoreTestCase, ProgramCacheMixin):
 
     def setUp(self):
         super().setUp()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.set_program_in_catalog_cache(self.program_uuid, self.program)
         ProgramEnrollmentFactory.create(
             user=self.user,

--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -55,7 +55,6 @@ def load_serialized_data(response, key):
 class TestProgramListing(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
     """Unit tests for the program listing page."""
     maxDiff = None
-    password = 'test'
     url = reverse_lazy('program_listing_view')
 
     @classmethod
@@ -75,7 +74,7 @@ class TestProgramListing(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
         super().setUp()
 
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     @classmethod
     def program_sort_key(cls, program):
@@ -112,7 +111,7 @@ class TestProgramListing(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
             '{}?next={}'.format(reverse('signin_user'), self.url)
         )
 
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -224,7 +223,7 @@ class TestProgramDetails(ProgramsApiConfigMixin, CatalogIntegrationMixin, Shared
         super().setUp()
 
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     def assert_program_data_present(self, response):
         """Verify that program data is present."""
@@ -277,7 +276,7 @@ class TestProgramDetails(ProgramsApiConfigMixin, CatalogIntegrationMixin, Shared
             '{}?next={}'.format(reverse('signin_user'), self.url)
         )
 
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         with mock.patch('lms.djangoapps.learner_dashboard.programs.get_certificates') as certs:
             certs.return_value = [{'type': 'program', 'url': '/'}]
@@ -324,7 +323,7 @@ class TestProgramDetailsFragmentView(SharedModuleStoreTestCase, ProgramCacheMixi
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.set_program_in_catalog_cache(self.program_uuid, self.program)
         self.create_programs_config()
 

--- a/lms/djangoapps/learner_dashboard/tests/test_views.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_views.py
@@ -26,7 +26,6 @@ from openedx.core.djangoapps.programs.models import ProgramDiscussionsConfigurat
 class TestProgramDiscussionIframeView(SharedModuleStoreTestCase, ProgramCacheMixin):
     """Unit tests for the program details page."""
     program_uuid = str(uuid4())
-    password = 'test'
     url = reverse_lazy('program_discussion', kwargs={'program_uuid': program_uuid})
 
     @classmethod
@@ -41,7 +40,7 @@ class TestProgramDiscussionIframeView(SharedModuleStoreTestCase, ProgramCacheMix
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.set_program_in_catalog_cache(self.program_uuid, self.program)
         ProgramEnrollmentFactory.create(
             user=self.user,
@@ -103,7 +102,7 @@ class TestProgramDiscussionIframeView(SharedModuleStoreTestCase, ProgramCacheMix
         """
         if staff:
             self.user = UserFactory(is_staff=True)
-            self.client.login(username=self.user.username, password=self.password)
+            self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         discussion_config = ProgramDiscussionsConfiguration.objects.create(
             program_uuid=self.program_uuid,
             enabled=True,
@@ -126,7 +125,7 @@ class TestProgramDiscussionIframeView(SharedModuleStoreTestCase, ProgramCacheMix
         Test if API returns default response in case a non staff user has no enrollment in the program
         """
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password=self.password)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         default_response = {
             'tab_view_enabled': False,

--- a/lms/djangoapps/learner_recommendations/tests/test_views.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_views.py
@@ -26,8 +26,9 @@ class TestRecommendationsBase(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.user = UserFactory()
-        self.client.login(username=self.user.username, password="test")
+        self.TEST_PASSWORD = 'password'
+        self.user = UserFactory(password=self.TEST_PASSWORD)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.recommended_courses = [
             "MITx+6.00.1x",
             "IBM+PY0101EN",
@@ -163,7 +164,7 @@ class TestRecommendationsContextView(APITestCase):
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
-        self.password = "test"
+        self.password = "password"
         self.url = reverse_lazy("learner_recommendations:recommendations_context")
 
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
@@ -369,8 +370,9 @@ class TestProductRecommendationsView(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.user = UserFactory()
-        self.client.login(username=self.user.username, password="test")
+        self.TEST_PASSWORD = 'password'
+        self.user = UserFactory(password=self.TEST_PASSWORD)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.associated_course_keys = ["edx+HL1", "edx+HL2"]
         self.amplitude_keys = [
             "edx+CS0",

--- a/lms/djangoapps/learner_recommendations/tests/test_views.py
+++ b/lms/djangoapps/learner_recommendations/tests/test_views.py
@@ -26,7 +26,7 @@ class TestRecommendationsBase(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory(password=self.TEST_PASSWORD)
         self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.recommended_courses = [
@@ -164,7 +164,7 @@ class TestRecommendationsContextView(APITestCase):
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
-        self.password = "password"
+        self.password = 'Password1234'
         self.url = reverse_lazy("learner_recommendations:recommendations_context")
 
     @mock.patch("lms.djangoapps.learner_recommendations.views.country_code_from_ip")
@@ -370,7 +370,7 @@ class TestProductRecommendationsView(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory(password=self.TEST_PASSWORD)
         self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         self.associated_course_keys = ["edx+HL1", "edx+HL2"]

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -50,7 +50,7 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
             certificate_available_date=datetime.datetime.now(pytz.UTC)
         )
         self.user = UserFactory.create()
-        self.password = 'test'
+        self.password = 'password'
         self.username = self.user.username
         self.api_version = API_V1
         IgnoreMobileAvailableFlagConfig(enabled=False).save()

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -50,7 +50,7 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
             certificate_available_date=datetime.datetime.now(pytz.UTC)
         )
         self.user = UserFactory.create()
-        self.password = 'password'
+        self.password = 'Password1234'
         self.username = self.user.username
         self.api_version = API_V1
         IgnoreMobileAvailableFlagConfig(enabled=False).save()

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -50,7 +50,7 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
             certificate_available_date=datetime.datetime.now(pytz.UTC)
         )
         self.user = UserFactory.create()
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         self.username = self.user.username
         self.api_version = API_V1
         IgnoreMobileAvailableFlagConfig(enabled=False).save()

--- a/lms/djangoapps/staticbook/tests.py
+++ b/lms/djangoapps/staticbook/tests.py
@@ -60,7 +60,7 @@ class StaticBookTest(ModuleStoreTestCase):
         self.course = CourseFactory.create(**kwargs)
         user = UserFactory.create()
         CourseEnrollmentFactory.create(user=user, course_id=self.course.id)
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
 
     def make_url(self, url_name, **kwargs):
         """

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -30,7 +30,7 @@ class SurveyModelsTests(TestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'abc'
+        self.password = 'password'
         self.student = UserFactory.create(
             username='student', email='student@test.com', password=self.password,
         )

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -30,7 +30,7 @@ class SurveyModelsTests(TestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'password'
+        self.password = 'Password1234'
         self.student = UserFactory.create(
             username='student', email='student@test.com', password=self.password,
         )

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -28,7 +28,7 @@ class SurveyModelsTests(ModuleStoreTestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'abc'
+        self.password = 'password'
         self.student = UserFactory.create(
             username='student', email='student@test.com', password=self.password,
         )

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -28,7 +28,7 @@ class SurveyModelsTests(ModuleStoreTestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'password'
+        self.password = 'Password1234'
         self.student = UserFactory.create(
             username='student', email='student@test.com', password=self.password,
         )

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -28,7 +28,7 @@ class SurveyModelsTests(ModuleStoreTestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         self.student = UserFactory.create(
             username='student', email='student@test.com', password=self.password,
         )

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -29,7 +29,7 @@ class SurveyViewsTests(ModuleStoreTestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'abc'
+        self.password = 'password'
         self.student = UserFactory.create(username='student', email='student@test.com', password=self.password)
 
         self.test_survey_name = 'TestSurvey'

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -29,7 +29,7 @@ class SurveyViewsTests(ModuleStoreTestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'Password1234'
+        self.password = self.TEST_PASSWORD
         self.student = UserFactory.create(username='student', email='student@test.com', password=self.password)
 
         self.test_survey_name = 'TestSurvey'

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -29,7 +29,7 @@ class SurveyViewsTests(ModuleStoreTestCase):
         self.client = Client()
 
         # Create two accounts
-        self.password = 'password'
+        self.password = 'Password1234'
         self.student = UserFactory.create(username='student', email='student@test.com', password=self.password)
 
         self.test_survey_name = 'TestSurvey'

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -93,6 +93,8 @@ l8N6+LEIVTMAytPk+/bImHvGHKZkCz5rEMSuYJWOmqKI92rUtI6fz5DUb3XSbrwT
 3W+sdGFUK3GH1NAX71VxbAlFVLUetcMwai1+wXmGkRw6A7YezVFnhw==
 -----END RSA PRIVATE KEY-----"""
 
+TEST_PASSWORD = 'Password1234'
+
 
 def _mock_payment_processors():
     """
@@ -122,8 +124,8 @@ class StartView(TestCase):
         Test the case where the user has no pending `PhotoVerificationAttempts`,
         but is just starting their first.
         """
-        UserFactory.create(username="rusty", password='Password1234')
-        self.client.login(username="rusty", password='Password1234')
+        UserFactory.create(username="rusty", password=TEST_PASSWORD)
+        self.client.login(username="rusty", password=TEST_PASSWORD)
 
     def must_be_logged_in(self):
         self.assertHttpForbidden(self.client.get(self.start_url()))  # lint-amnesty, pylint: disable=no-member
@@ -1055,11 +1057,11 @@ class CheckoutTestMixin:
         """ Create a user and course. """
         super().setUp()
 
-        self.user = UserFactory.create(username="test", password='Password1234')
+        self.user = UserFactory.create(username="test", password=TEST_PASSWORD)
         self.course = CourseFactory.create()
         for mode, min_price in (('audit', 0), ('honor', 0), ('verified', 100)):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id, min_price=min_price, sku=self.make_sku())
-        self.client.login(username="test", password='Password1234')
+        self.client.login(username="test", password=TEST_PASSWORD)
 
     def _assert_checked_out(
         self,
@@ -1868,7 +1870,7 @@ class TestPhotoURLView(TestVerificationBase):
         super().setUp()
 
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='Password1234')
+        login_success = self.client.login(username=self.user.username, password=TEST_PASSWORD)
         assert login_success
         self.attempt = SoftwareSecurePhotoVerification(
             status="submitted",
@@ -1895,7 +1897,7 @@ class TestPhotoURLView(TestVerificationBase):
 
     def test_403_for_non_staff(self):
         self.user = UserFactory()
-        login_success = self.client.login(username=self.user.username, password='Password1234')
+        login_success = self.client.login(username=self.user.username, password=TEST_PASSWORD)
         assert login_success
         url = reverse('verification_photo_urls', kwargs={'receipt_id': str(self.receipt_id)})
         response = self.client.get(url)
@@ -1934,7 +1936,7 @@ class TestDecodeImageViews(MockS3Boto3Mixin, TestVerificationBase):
     def setUp(self):
         super().setUp()
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='Password1234')
+        login_success = self.client.login(username=self.user.username, password=TEST_PASSWORD)
         assert login_success
 
     def _mock_submit_images(self):
@@ -1995,7 +1997,7 @@ class TestDecodeImageViews(MockS3Boto3Mixin, TestVerificationBase):
     @ddt.data("face", "photo_id")
     def test_403_for_non_staff(self, img_type):
         self.user = UserFactory()
-        login_success = self.client.login(username=self.user.username, password='Password1234')
+        login_success = self.client.login(username=self.user.username, password=TEST_PASSWORD)
         assert login_success
 
         self._mock_submit_images()

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -122,8 +122,8 @@ class StartView(TestCase):
         Test the case where the user has no pending `PhotoVerificationAttempts`,
         but is just starting their first.
         """
-        UserFactory.create(username="rusty", password="test")
-        self.client.login(username="rusty", password="test")
+        UserFactory.create(username="rusty", password="password")
+        self.client.login(username="rusty", password="password")
 
     def must_be_logged_in(self):
         self.assertHttpForbidden(self.client.get(self.start_url()))  # lint-amnesty, pylint: disable=no-member
@@ -1055,11 +1055,11 @@ class CheckoutTestMixin:
         """ Create a user and course. """
         super().setUp()
 
-        self.user = UserFactory.create(username="test", password="test")
+        self.user = UserFactory.create(username="test", password="password")
         self.course = CourseFactory.create()
         for mode, min_price in (('audit', 0), ('honor', 0), ('verified', 100)):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id, min_price=min_price, sku=self.make_sku())
-        self.client.login(username="test", password="test")
+        self.client.login(username="test", password="password")
 
     def _assert_checked_out(
         self,
@@ -1868,7 +1868,7 @@ class TestPhotoURLView(TestVerificationBase):
         super().setUp()
 
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='test')
+        login_success = self.client.login(username=self.user.username, password='password')
         assert login_success
         self.attempt = SoftwareSecurePhotoVerification(
             status="submitted",
@@ -1895,7 +1895,7 @@ class TestPhotoURLView(TestVerificationBase):
 
     def test_403_for_non_staff(self):
         self.user = UserFactory()
-        login_success = self.client.login(username=self.user.username, password='test')
+        login_success = self.client.login(username=self.user.username, password='password')
         assert login_success
         url = reverse('verification_photo_urls', kwargs={'receipt_id': str(self.receipt_id)})
         response = self.client.get(url)
@@ -1934,7 +1934,7 @@ class TestDecodeImageViews(MockS3Boto3Mixin, TestVerificationBase):
     def setUp(self):
         super().setUp()
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='test')
+        login_success = self.client.login(username=self.user.username, password='password')
         assert login_success
 
     def _mock_submit_images(self):
@@ -1995,7 +1995,7 @@ class TestDecodeImageViews(MockS3Boto3Mixin, TestVerificationBase):
     @ddt.data("face", "photo_id")
     def test_403_for_non_staff(self, img_type):
         self.user = UserFactory()
-        login_success = self.client.login(username=self.user.username, password='test')
+        login_success = self.client.login(username=self.user.username, password='password')
         assert login_success
 
         self._mock_submit_images()

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -122,8 +122,8 @@ class StartView(TestCase):
         Test the case where the user has no pending `PhotoVerificationAttempts`,
         but is just starting their first.
         """
-        UserFactory.create(username="rusty", password="password")
-        self.client.login(username="rusty", password="password")
+        UserFactory.create(username="rusty", password='Password1234')
+        self.client.login(username="rusty", password='Password1234')
 
     def must_be_logged_in(self):
         self.assertHttpForbidden(self.client.get(self.start_url()))  # lint-amnesty, pylint: disable=no-member
@@ -1055,11 +1055,11 @@ class CheckoutTestMixin:
         """ Create a user and course. """
         super().setUp()
 
-        self.user = UserFactory.create(username="test", password="password")
+        self.user = UserFactory.create(username="test", password='Password1234')
         self.course = CourseFactory.create()
         for mode, min_price in (('audit', 0), ('honor', 0), ('verified', 100)):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id, min_price=min_price, sku=self.make_sku())
-        self.client.login(username="test", password="password")
+        self.client.login(username="test", password='Password1234')
 
     def _assert_checked_out(
         self,
@@ -1868,7 +1868,7 @@ class TestPhotoURLView(TestVerificationBase):
         super().setUp()
 
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='password')
+        login_success = self.client.login(username=self.user.username, password='Password1234')
         assert login_success
         self.attempt = SoftwareSecurePhotoVerification(
             status="submitted",
@@ -1895,7 +1895,7 @@ class TestPhotoURLView(TestVerificationBase):
 
     def test_403_for_non_staff(self):
         self.user = UserFactory()
-        login_success = self.client.login(username=self.user.username, password='password')
+        login_success = self.client.login(username=self.user.username, password='Password1234')
         assert login_success
         url = reverse('verification_photo_urls', kwargs={'receipt_id': str(self.receipt_id)})
         response = self.client.get(url)
@@ -1934,7 +1934,7 @@ class TestDecodeImageViews(MockS3Boto3Mixin, TestVerificationBase):
     def setUp(self):
         super().setUp()
         self.user = AdminFactory()
-        login_success = self.client.login(username=self.user.username, password='password')
+        login_success = self.client.login(username=self.user.username, password='Password1234')
         assert login_success
 
     def _mock_submit_images(self):
@@ -1995,7 +1995,7 @@ class TestDecodeImageViews(MockS3Boto3Mixin, TestVerificationBase):
     @ddt.data("face", "photo_id")
     def test_403_for_non_staff(self, img_type):
         self.user = UserFactory()
-        login_success = self.client.login(username=self.user.username, password='password')
+        login_success = self.client.login(username=self.user.username, password='Password1234')
         assert login_success
 
         self._mock_submit_images()

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3756,7 +3756,7 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "common.djangoapps.util.password_policy_validators.MinimumLengthValidator",
         "OPTIONS": {
-            "min_length": 2
+            "min_length": 8
         }
     },
     {

--- a/openedx/core/djangoapps/contentserver/test/test_contentserver.py
+++ b/openedx/core/djangoapps/contentserver/test/test_contentserver.py
@@ -156,7 +156,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         CourseEnrollment.enroll(self.non_staff_usr, self.course_key)
         assert CourseEnrollment.is_enrolled(self.non_staff_usr, self.course_key)
 
-        self.client.login(username=self.non_staff_usr, password='test')
+        self.client.login(username=self.non_staff_usr, password=self.TEST_PASSWORD)
         resp = self.client.get(self.url_locked_versioned)
         assert resp.status_code == 200
 
@@ -167,7 +167,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         CourseEnrollment.enroll(self.non_staff_usr, self.course_key)
         assert CourseEnrollment.is_enrolled(self.non_staff_usr, self.course_key)
 
-        self.client.login(username=self.non_staff_usr, password='test')
+        self.client.login(username=self.non_staff_usr, password=self.TEST_PASSWORD)
         resp = self.client.get(self.url_locked_versioned_old_style, follow=True)
         assert resp.status_code == 200
 
@@ -185,7 +185,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         Test that locked assets behave appropriately in case user is logged in
         in but not registered for the course.
         """
-        self.client.login(username=self.non_staff_usr, password='test')
+        self.client.login(username=self.non_staff_usr, password=self.TEST_PASSWORD)
         resp = self.client.get(self.url_locked)
         assert resp.status_code == 403
 
@@ -197,7 +197,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         CourseEnrollment.enroll(self.non_staff_usr, self.course_key)
         assert CourseEnrollment.is_enrolled(self.non_staff_usr, self.course_key)
 
-        self.client.login(username=self.non_staff_usr, password='test')
+        self.client.login(username=self.non_staff_usr, password=self.TEST_PASSWORD)
         resp = self.client.get(self.url_locked)
         assert resp.status_code == 200
 
@@ -205,7 +205,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         """
         Test that locked assets behave appropriately in case user is staff.
         """
-        self.client.login(username=self.staff_usr, password='test')
+        self.client.login(username=self.staff_usr, password=self.TEST_PASSWORD)
         resp = self.client.get(self.url_locked)
         assert resp.status_code == 200
 
@@ -320,7 +320,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         CourseEnrollment.enroll(self.non_staff_usr, self.course_key)
         assert CourseEnrollment.is_enrolled(self.non_staff_usr, self.course_key)
 
-        self.client.login(username=self.non_staff_usr, password='test')
+        self.client.login(username=self.non_staff_usr, password=self.TEST_PASSWORD)
         resp = self.client.get(self.url_locked)
         assert resp.status_code == 200
         assert 'Expires' not in resp
@@ -350,7 +350,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         CourseEnrollment.enroll(self.non_staff_usr, self.course_key)
         assert CourseEnrollment.is_enrolled(self.non_staff_usr, self.course_key)
 
-        self.client.login(username=self.non_staff_usr, password='test')
+        self.client.login(username=self.non_staff_usr, password=self.TEST_PASSWORD)
         resp = self.client.get(self.url_locked)
         assert resp.status_code == 200
         assert 'Expires' not in resp

--- a/openedx/core/djangoapps/course_apps/rest_api/tests/test_views.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/tests/test_views.py
@@ -32,7 +32,7 @@ class CourseAppsRestApiTest(SharedModuleStoreTestCase):
         self.instructor = UserFactory()
         self.user = UserFactory()
         self.client = Client()
-        self.client.login(username=self.instructor.username, password="test")
+        self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self.url = reverse("course_apps_api:v1:course_apps", kwargs=dict(course_id=self.course.id))
         CourseStaffRole(self.course.id).add_users(self.instructor)
 

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -73,7 +73,7 @@ class CourseEnrollmentListViewTest(ModuleStoreTestCase):
         """
         Test the CourseEnrollmentListView.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         # Enable or disable the waffle flag based on the test case data
         with override_waffle_flag(SHOW_NOTIFICATIONS_TRAY, active=show_notifications_tray):
             url = reverse('enrollment-list')
@@ -248,7 +248,7 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
         """
         Test get user notification preference.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, self._expected_api_response())
@@ -274,7 +274,7 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
         """
         Test update of user notification preference.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         payload = {
             'notification_app': notification_app,
             'value': value,
@@ -319,7 +319,8 @@ class NotificationListAPIViewTest(APITestCase):
     """
 
     def setUp(self):
-        self.user = UserFactory()
+        self.TEST_PASSWORD = "password"
+        self.user = UserFactory(password=self.TEST_PASSWORD)
         self.url = reverse('notifications-list')
 
     def test_list_notifications(self):
@@ -336,7 +337,7 @@ class NotificationListAPIViewTest(APITestCase):
                 'post_title': 'This is a test post.',
             }
         )
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Make a request to the view.
         response = self.client.get(self.url)
@@ -373,7 +374,7 @@ class NotificationListAPIViewTest(APITestCase):
             app_name='app2',
             notification_type='info',
         )
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Make a request to the view with the app_name query parameter set to 'app1'.
         response = self.client.get(self.url + "?app_name=discussion")
@@ -396,7 +397,7 @@ class NotificationListAPIViewTest(APITestCase):
         """
         Test event emission with tray_opened param is provided.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Make a request to the view with the tray_opened query parameter set to True.
         response = self.client.get(self.url + "?tray_opened=True")
@@ -436,7 +437,7 @@ class NotificationListAPIViewTest(APITestCase):
             notification_type='info',
             created=today - timedelta(days=settings.NOTIFICATIONS_EXPIRY)
         )
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Make a request to the view
         response = self.client.get(self.url)
@@ -463,7 +464,7 @@ class NotificationListAPIViewTest(APITestCase):
             user=self.user,
             notification_type='info',
         )
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Make a request to the view
         response = self.client.get(self.url)
@@ -517,7 +518,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         """
         Test that the endpoint returns the correct count of unseen notifications and show_notifications_tray value.
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Enable or disable the waffle flag based on the test case data
         with override_waffle_flag(SHOW_NOTIFICATIONS_TRAY, active=show_notifications_tray_enabled):
@@ -544,7 +545,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         """
         # Create a user with no notifications.
         user = UserFactory()
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
@@ -556,7 +557,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         Tests if "notification_expiry_days" exists in API response
         """
         user = UserFactory()
-        self.client.login(username=user.username, password='test')
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['notification_expiry_days'], 60)
@@ -568,7 +569,8 @@ class MarkNotificationsSeenAPIViewTestCase(APITestCase):
     """
 
     def setUp(self):
-        self.user = UserFactory()
+        self.TEST_PASSWORD = "password"
+        self.user = UserFactory(password=self.TEST_PASSWORD)
 
         # Create some sample notifications for the user
         Notification.objects.create(user=self.user, app_name='App Name 1', notification_type='Type A')
@@ -580,7 +582,7 @@ class MarkNotificationsSeenAPIViewTestCase(APITestCase):
         # Create a POST request to mark notifications as seen for 'App Name 1'
         app_name = 'App Name 1'
         url = reverse('mark-notifications-seen', kwargs={'app_name': app_name})
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         response = self.client.put(url)
         # Assert the response status code is 200 (OK)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -600,9 +602,10 @@ class NotificationReadAPIViewTestCase(APITestCase):
     """
 
     def setUp(self):
-        self.user = UserFactory()
+        self.TEST_PASSWORD = "password"
+        self.user = UserFactory(password=self.TEST_PASSWORD)
         self.url = reverse('notifications-read')
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         # Create some sample notifications for the user with already existing apps and with invalid app name
         Notification.objects.create(user=self.user, app_name='app_name_2', notification_type='Type A')
@@ -659,7 +662,7 @@ class NotificationReadAPIViewTestCase(APITestCase):
         # Create a PATCH request to mark notification as read for notification_id: 2 through a different user
         self.client.logout()
         self.user = UserFactory()
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         notification_id = 2
         data = {'notification_id': notification_id}

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -319,7 +319,7 @@ class NotificationListAPIViewTest(APITestCase):
     """
 
     def setUp(self):
-        self.TEST_PASSWORD = "password"
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory(password=self.TEST_PASSWORD)
         self.url = reverse('notifications-list')
 
@@ -569,7 +569,7 @@ class MarkNotificationsSeenAPIViewTestCase(APITestCase):
     """
 
     def setUp(self):
-        self.TEST_PASSWORD = "password"
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory(password=self.TEST_PASSWORD)
 
         # Create some sample notifications for the user
@@ -602,7 +602,7 @@ class NotificationReadAPIViewTestCase(APITestCase):
     """
 
     def setUp(self):
-        self.TEST_PASSWORD = "password"
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory(password=self.TEST_PASSWORD)
         self.url = reverse('notifications-read')
         self.client.login(username=self.user.username, password=self.TEST_PASSWORD)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -31,19 +31,20 @@ class AuthenticateTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
+        self.TEST_PASSWORD = 'password'
         self.user = UserFactory.create(
             username='darkhelmet',
-            password='12345',
+            password=self.TEST_PASSWORD,
             email='darkhelmet@spaceball_one.org',
         )
         self.validator = EdxOAuth2Validator()
 
     def test_authenticate_with_username(self):
-        user = self.validator._authenticate(username='darkhelmet', password='12345')
+        user = self.validator._authenticate(username='darkhelmet', password=self.TEST_PASSWORD)
         assert self.user == user
 
     def test_authenticate_with_email(self):
-        user = self.validator._authenticate(username='darkhelmet@spaceball_one.org', password='12345')
+        user = self.validator._authenticate(username='darkhelmet@spaceball_one.org', password=self.TEST_PASSWORD)
         assert self.user == user
 
 
@@ -56,9 +57,10 @@ class CustomValidationTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
+        self.TEST_PASSWORD = "password"
         self.user = UserFactory.create(
             username='darkhelmet',
-            password='12345',
+            password=self.TEST_PASSWORD,
             email='darkhelmet@spaceball_one.org',
         )
         self.validator = EdxOAuth2Validator()
@@ -67,13 +69,13 @@ class CustomValidationTestCase(TestCase):
     def test_active_user_validates(self):
         assert self.user.is_active
         request = self.request_factory.get('/')
-        assert self.validator.validate_user('darkhelmet', '12345', client=None, request=request)
+        assert self.validator.validate_user('darkhelmet', self.TEST_PASSWORD, client=None, request=request)
 
     def test_inactive_user_validates(self):
         self.user.is_active = False
         self.user.save()
         request = self.request_factory.get('/')
-        assert self.validator.validate_user('darkhelmet', '12345', client=None, request=request)
+        assert self.validator.validate_user('darkhelmet', self.TEST_PASSWORD, client=None, request=request)
 
 
 @skip_unless_lms
@@ -87,9 +89,10 @@ class CustomAuthorizationViewTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
+        self.TEST_PASSWORD = 'password'
         self.dot_adapter = adapters.DOTAdapter()
-        self.user = UserFactory()
-        self.client.login(username=self.user.username, password='test')
+        self.user = UserFactory(password=self.TEST_PASSWORD)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         self.restricted_dot_app = self._create_restricted_app()
         self._create_expired_token(self.restricted_dot_app)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -31,7 +31,7 @@ class AuthenticateTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory.create(
             username='darkhelmet',
             password=self.TEST_PASSWORD,
@@ -57,7 +57,7 @@ class CustomValidationTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.TEST_PASSWORD = "password"
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory.create(
             username='darkhelmet',
             password=self.TEST_PASSWORD,
@@ -89,7 +89,7 @@ class CustomAuthorizationViewTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
         self.dot_adapter = adapters.DOTAdapter()
         self.user = UserFactory(password=self.TEST_PASSWORD)
         self.client.login(username=self.user.username, password=self.TEST_PASSWORD)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -86,8 +86,9 @@ class _DispatchingViewTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
+        self.TEST_PASSWORD = "password"
         self.dot_adapter = adapters.DOTAdapter()
-        self.user = UserFactory()
+        self.user = UserFactory(password=self.TEST_PASSWORD)
         self.dot_app = self.dot_adapter.create_public_client(
             name='test dot application',
             user=self.user,
@@ -148,7 +149,7 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
 
         if grant_type == dot_models.Application.GRANT_PASSWORD:
             body['username'] = user.username
-            body['password'] = 'test'
+            body['password'] = self.TEST_PASSWORD
         elif grant_type == dot_models.Application.GRANT_CLIENT_CREDENTIALS:
             body['client_secret'] = client.client_secret
 
@@ -598,7 +599,7 @@ class TestAuthorizationView(_DispatchingViewTestCase):
     @ddt.unpack
     def test_post_authorization_view(self, client_type, allow_field):
         oauth_application = getattr(self, f'{client_type}_app')
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         response = self.client.post(
             '/oauth2/authorize/',
             {
@@ -620,7 +621,7 @@ class TestAuthorizationView(_DispatchingViewTestCase):
         Make sure we get the overridden Authorization page - not
         the default django-oauth-toolkit when we perform a page load
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         response = self.client.get(
             '/oauth2/authorize/',
             {
@@ -787,7 +788,7 @@ class TestRevokeTokenView(AccessTokenLoginMixin, _DispatchingViewTestCase):  # p
             'client_id': self.dot_app.client_id,
             'grant_type': 'password',
             'username': self.user.username,
-            'password': 'test',
+            'password': self.TEST_PASSWORD,
         }
 
     def access_token_post_body_with_refresh_token(self, refresh_token):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -86,7 +86,7 @@ class _DispatchingViewTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.TEST_PASSWORD = "password"
+        self.TEST_PASSWORD = 'Password1234'
         self.dot_adapter = adapters.DOTAdapter()
         self.user = UserFactory(password=self.TEST_PASSWORD)
         self.dot_app = self.dot_adapter.create_public_client(

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -36,6 +36,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
         self.user = UserFactory.create()
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request()
+        self.TEST_PASSWORD = 'password'
 
     def assert_response(self, safe_cookie_data=None, success=True):
         """
@@ -79,7 +80,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
     @patch("openedx.core.djangoapps.safe_sessions.middleware.LOG_REQUEST_USER_CHANGES", False)
     @patch("openedx.core.djangoapps.safe_sessions.middleware.track_request_user_changes")
     def test_success(self, mock_log_request_user_changes):
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         session_id = self.client.session.session_key
         safe_cookie_data = SafeCookieData.create(session_id, self.user.id)
 
@@ -106,7 +107,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
     @patch("openedx.core.djangoapps.safe_sessions.middleware.LOG_REQUEST_USER_CHANGES", True)
     @patch("openedx.core.djangoapps.safe_sessions.middleware.track_request_user_changes")
     def test_log_request_user_on(self, mock_log_request_user_changes):
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         session_id = self.client.session.session_key
         safe_cookie_data = SafeCookieData.create(session_id, self.user.id)
 
@@ -134,7 +135,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
         self.assert_no_session()
 
     def test_invalid_user_at_step_4(self):
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         safe_cookie_data = SafeCookieData.create(self.client.session.session_key, 'no_such_user')
         self.request.META['HTTP_ACCEPT'] = 'text/html'
         with self.assert_incorrect_user_logged():
@@ -250,7 +251,8 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
 
     def setUp(self):
         super().setUp()
-        self.user = UserFactory.create()
+        self.TEST_PASSWORD = 'password'
+        self.user = UserFactory.create(password=self.TEST_PASSWORD)
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request()
         self.client.response = HttpResponse()
@@ -270,7 +272,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
         """
         Set up request for success path -- everything up until process_response().
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
         session_id = self.client.session.session_key
         safe_cookie_data = SafeCookieData.create(session_id, self.user.id)

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -36,7 +36,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
         self.user = UserFactory.create()
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request()
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
 
     def assert_response(self, safe_cookie_data=None, success=True):
         """
@@ -251,7 +251,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, CacheIsolationTestCase
 
     def setUp(self):
         super().setUp()
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory.create(password=self.TEST_PASSWORD)
         self.addCleanup(set_current_request, None)
         self.request = get_mock_request()

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -24,14 +24,15 @@ class TestComprehensiveThemeLMS(TestCase):
         Clear static file finders cache and register cleanup methods.
         """
         super().setUp()
-        self.user = UserFactory()
+        self.TEST_PASSWORD = 'password'
+        self.user = UserFactory(password=self.TEST_PASSWORD)
 
         # Clear the internal staticfiles caches, to get test isolation.
         staticfiles.finders.get_finder.cache_clear()
 
     def _login(self):
         """ Log into LMS. """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
     @with_comprehensive_theme("test-theme")
     def test_footer(self):

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -24,7 +24,7 @@ class TestComprehensiveThemeLMS(TestCase):
         Clear static file finders cache and register cleanup methods.
         """
         super().setUp()
-        self.TEST_PASSWORD = 'password'
+        self.TEST_PASSWORD = 'Password1234'
         self.user = UserFactory(password=self.TEST_PASSWORD)
 
         # Clear the internal staticfiles caches, to get test isolation.

--- a/openedx/core/djangoapps/theming/tests/test_views.py
+++ b/openedx/core/djangoapps/theming/tests/test_views.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.theming.models import SiteTheme
 
 THEMING_ADMIN_URL = '/theming/admin'
 TEST_THEME_NAME = 'test-theme'
-TEST_PASSWORD = 'password'
+TEST_PASSWORD = 'Password1234'
 
 
 class TestThemingViews(TestCase):

--- a/openedx/core/djangoapps/theming/tests/test_views.py
+++ b/openedx/core/djangoapps/theming/tests/test_views.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.theming.models import SiteTheme
 
 THEMING_ADMIN_URL = '/theming/admin'
 TEST_THEME_NAME = 'test-theme'
-TEST_PASSWORD = 'test'
+TEST_PASSWORD = 'password'
 
 
 class TestThemingViews(TestCase):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -88,7 +88,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
     This includes the specific types of error raised, and default behavior when optional arguments
     are not specified.
     """
-    password = "test"
+    password = "password"
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -88,7 +88,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
     This includes the specific types of error raised, and default behavior when optional arguments
     are not specified.
     """
-    password = "password"
+    password = 'Password1234'
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -33,7 +33,7 @@ class UserAPITestCase(ApiTestCase):
     Parent test case for User API workflow coverage
     """
     LIST_URI = USER_LIST_URI
-    TEST_PASSWORD = "password"
+    TEST_PASSWORD = 'Password1234'
 
     def get_uri_for_user(self, target_user):
         """Given a user object, get the URI for the corresponding resource"""

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -33,6 +33,7 @@ class UserAPITestCase(ApiTestCase):
     Parent test case for User API workflow coverage
     """
     LIST_URI = USER_LIST_URI
+    TEST_PASSWORD = "password"
 
     def get_uri_for_user(self, target_user):
         """Given a user object, get the URI for the corresponding resource"""

--- a/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
@@ -23,7 +23,7 @@ class VerificationViewTestsMixinBase:
     """ Base class for the tests on verification views """
     VIEW_NAME = None
     CREATED_AT = datetime.datetime.strptime(FROZEN_TIME, '%Y-%m-%d')
-    PASSWORD = 'password'
+    PASSWORD = 'Password1234'
 
     def setUp(self):
         freezer = freezegun.freeze_time(FROZEN_TIME)

--- a/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
@@ -23,7 +23,7 @@ class VerificationViewTestsMixinBase:
     """ Base class for the tests on verification views """
     VIEW_NAME = None
     CREATED_AT = datetime.datetime.strptime(FROZEN_TIME, '%Y-%m-%d')
-    PASSWORD = 'test'
+    PASSWORD = 'password'
 
     def setUp(self):
         freezer = freezegun.freeze_time(FROZEN_TIME)

--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -421,9 +421,9 @@ class SendAccountActivationEmail(UserAPITestCase):
         Create a user, then log in.
         """
         super().setUp()
-        self.user = UserFactory()
+        self.user = UserFactory(password=self.TEST_PASSWORD)
         Registration().register(self.user)
-        result = self.client.login(username=self.user.username, password="test")
+        result = self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
         assert result, 'Could not log in'
         self.path = reverse('send_account_activation_email')
 

--- a/openedx/core/djangoapps/user_authn/tests/utils.py
+++ b/openedx/core/djangoapps/user_authn/tests/utils.py
@@ -58,7 +58,7 @@ class AuthAndScopesTestMixin:
             self.student.
     """
     default_scopes = None
-    user_password = 'password'
+    user_password = 'Password1234'
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/user_authn/tests/utils.py
+++ b/openedx/core/djangoapps/user_authn/tests/utils.py
@@ -58,7 +58,7 @@ class AuthAndScopesTestMixin:
             self.student.
     """
     default_scopes = None
-    user_password = 'test'
+    user_password = 'password'
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/user_authn/views/tests/test_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_password.py
@@ -99,8 +99,8 @@ class TestPasswordChange(CreateAccountMixin, CacheIsolationTestCase):
 
     USERNAME = "heisenberg"
     ALTERNATE_USERNAME = "walt"
-    OLD_PASSWORD = "ḅḷüëṡḳÿ"
-    NEW_PASSWORD = "B🄸🄶B🄻🅄🄴"
+    OLD_PASSWORD = "ḅḷüëṡḳÿ1"
+    NEW_PASSWORD = "B🄸🄶B🄻🅄🄴1"
     OLD_EMAIL = "walter@graymattertech.com"
     NEW_EMAIL = "walt@savewalterwhite.com"
 
@@ -192,11 +192,11 @@ class TestPasswordChange(CreateAccountMixin, CacheIsolationTestCase):
         UserFactory.create(
             username='edx',
             email='edx@example.com',
-            password='edx',
+            password='password',
             is_superuser=is_superuser,
             is_staff=is_staff,
         )
-        self.client.login(username='edx', password='edx')
+        self.client.login(username='edx', password='password')
 
         response = self._change_password_from_support(email_from_support_tools=self.OLD_EMAIL)
         assert response.status_code == 200

--- a/openedx/core/djangoapps/user_authn/views/tests/test_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_password.py
@@ -192,11 +192,11 @@ class TestPasswordChange(CreateAccountMixin, CacheIsolationTestCase):
         UserFactory.create(
             username='edx',
             email='edx@example.com',
-            password='password',
+            password='Password1234',
             is_superuser=is_superuser,
             is_staff=is_staff,
         )
-        self.client.login(username='edx', password='password')
+        self.client.login(username='edx', password='Password1234')
 
         response = self._change_password_from_support(email_from_support_tools=self.OLD_EMAIL)
         assert response.status_code == 200

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -2689,20 +2689,30 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestM
             {"username": str(USERNAME_INVALID_CHARS_ASCII)}
         )
 
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[
+        create_validator_config(
+            'common.djangoapps.util.password_policy_validators.MinimumLengthValidator', {'min_length': 4}
+        )
+    ])
     def test_password_empty_validation_decision(self):
         # 2 is the default setting for minimum length found in lms/envs/common.py
         # under AUTH_PASSWORD_VALIDATORS.MinimumLengthValidator
-        msg = 'This password is too short. It must contain at least 2 characters.'
+        msg = 'This password is too short. It must contain at least 4 characters.'
         self.assertValidationDecision(
             {'password': ''},
             {"password": msg}
         )
 
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[
+        create_validator_config(
+            'common.djangoapps.util.password_policy_validators.MinimumLengthValidator', {'min_length': 4}
+        )
+    ])
     def test_password_bad_min_length_validation_decision(self):
         password = 'p'
         # 2 is the default setting for minimum length found in lms/envs/common.py
         # under AUTH_PASSWORD_VALIDATORS.MinimumLengthValidator
-        msg = 'This password is too short. It must contain at least 2 characters.'
+        msg = 'This password is too short. It must contain at least 4 characters.'
         self.assertValidationDecision(
             {'password': password},
             {"password": msg}

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -249,7 +249,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
             mode='audit'
         )
         CourseInstructorRole(self.course.id).add_users(instructor)
-        self.client.login(username=instructor.username, password='test')
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
 
         self.update_masquerade(**masquerade_config)
 
@@ -285,7 +285,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
             mode='audit'
         )
         CourseInstructorRole(self.course.id).add_users(instructor)
-        self.client.login(username=instructor.username, password='test')
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
 
         self.update_masquerade(username='audit')
 
@@ -320,7 +320,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
             mode='audit'
         )
         CourseInstructorRole(self.course.id).add_users(instructor)
-        self.client.login(username=instructor.username, password='test')
+        self.client.login(username=instructor.username, password=self.TEST_PASSWORD)
 
         self.update_masquerade(username='audit')
 
@@ -370,7 +370,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
             mode='audit'
         )
 
-        self.client.login(username=staff_user.username, password='test')
+        self.client.login(username=staff_user.username, password=self.TEST_PASSWORD)
 
         self.update_masquerade(username=expired_staff.username)
 
@@ -418,7 +418,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
             mode='audit'
         )
 
-        self.client.login(username=staff_user.username, password='test')
+        self.client.login(username=staff_user.username, password=self.TEST_PASSWORD)
 
         self.update_masquerade(username=expired_staff.username)
 

--- a/openedx/features/course_experience/tests/views/test_course_sock.py
+++ b/openedx/features/course_experience/tests/views/test_course_sock.py
@@ -20,7 +20,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 
 from .helpers import add_course_mode
 
-TEST_PASSWORD = 'password'
+TEST_PASSWORD = 'Password1234'
 TEST_VERIFICATION_SOCK_LOCATOR = '<div class="verification-sock"'
 
 

--- a/openedx/features/course_experience/tests/views/test_course_sock.py
+++ b/openedx/features/course_experience/tests/views/test_course_sock.py
@@ -20,7 +20,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 
 from .helpers import add_course_mode
 
-TEST_PASSWORD = 'test'
+TEST_PASSWORD = 'password'
 TEST_VERIFICATION_SOCK_LOCATOR = '<div class="verification-sock"'
 
 

--- a/openedx/features/course_experience/tests/views/test_masquerade.py
+++ b/openedx/features/course_experience/tests/views/test_masquerade.py
@@ -17,7 +17,7 @@ from xmodule.partitions.partitions_service import PartitionService  # lint-amnes
 from .helpers import add_course_mode
 from .test_course_sock import TEST_VERIFICATION_SOCK_LOCATOR
 
-TEST_PASSWORD = 'password'
+TEST_PASSWORD = 'Password1234'
 
 
 class MasqueradeTestBase(SharedModuleStoreTestCase, MasqueradeMixin):

--- a/openedx/features/course_experience/tests/views/test_masquerade.py
+++ b/openedx/features/course_experience/tests/views/test_masquerade.py
@@ -17,7 +17,7 @@ from xmodule.partitions.partitions_service import PartitionService  # lint-amnes
 from .helpers import add_course_mode
 from .test_course_sock import TEST_VERIFICATION_SOCK_LOCATOR
 
-TEST_PASSWORD = 'test'
+TEST_PASSWORD = 'password'
 
 
 class MasqueradeTestBase(SharedModuleStoreTestCase, MasqueradeMixin):

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -21,8 +21,8 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     Create the test environment with the crowdsourcehinter xblock.
     """
     STUDENTS = [
-        {'email': 'view@test.com', 'password': 'password1234'},
-        {'email': 'view2@test.com', 'password': 'password1234'}
+        {'email': 'view@test.com', 'password': 'Password1234'},
+        {'email': 'view2@test.com', 'password': 'Password1234'}
     ]
     XBLOCK_NAMES = ['crowdsourcehinter']
 

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -21,8 +21,8 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     Create the test environment with the crowdsourcehinter xblock.
     """
     STUDENTS = [
-        {'email': 'view@test.com', 'password': 'Password1234'},
-        {'email': 'view2@test.com', 'password': 'Password1234'}
+        {'email': 'view@test.com', 'password': SharedModuleStoreTestCase.TEST_PASSWORD},
+        {'email': 'view2@test.com', 'password': SharedModuleStoreTestCase.TEST_PASSWORD}
     ]
     XBLOCK_NAMES = ['crowdsourcehinter']
 

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -21,8 +21,8 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     Create the test environment with the crowdsourcehinter xblock.
     """
     STUDENTS = [
-        {'email': 'view@test.com', 'password': 'foo'},
-        {'email': 'view2@test.com', 'password': 'foo'}
+        {'email': 'view@test.com', 'password': 'password1234'},
+        {'email': 'view2@test.com', 'password': 'password1234'}
     ]
     XBLOCK_NAMES = ['crowdsourcehinter']
 

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -27,8 +27,8 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     Check that Recommender state is saved properly
     """
     STUDENTS = [
-        {'email': 'view@test.com', 'password': 'password1234'},
-        {'email': 'view2@test.com', 'password': 'password1234'}
+        {'email': 'view@test.com', 'password': 'Password1234'},
+        {'email': 'view2@test.com', 'password': 'Password1234'}
     ]
     XBLOCK_NAMES = ['recommender', 'recommender_second']
 

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -27,8 +27,8 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     Check that Recommender state is saved properly
     """
     STUDENTS = [
-        {'email': 'view@test.com', 'password': 'foo'},
-        {'email': 'view2@test.com', 'password': 'foo'}
+        {'email': 'view@test.com', 'password': 'password1234'},
+        {'email': 'view2@test.com', 'password': 'password1234'}
     ]
     XBLOCK_NAMES = ['recommender', 'recommender_second']
 
@@ -141,7 +141,7 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         Staff login and enroll for the course
         """
         email = staff.email
-        password = 'test'
+        password = self.TEST_PASSWORD
         self.login(email, password)
         self.enroll(self.course, verify=True)
 

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -282,9 +282,9 @@ class XBlockStudentTestCaseMixin:
     Creates a default set of students for XBlock tests
     '''
     student_list = [
-        {'email': 'alice@test.edx.org', 'password': 'foo'},
-        {'email': 'bob@test.edx.org', 'password': 'foo'},
-        {'email': 'eve@test.edx.org', 'password': 'foo'},
+        {'email': 'alice@test.edx.org', 'password': 'password1234'},
+        {'email': 'bob@test.edx.org', 'password': 'password1234'},
+        {'email': 'eve@test.edx.org', 'password': 'password1234'},
     ]
 
     def setUp(self):

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -282,9 +282,9 @@ class XBlockStudentTestCaseMixin:
     Creates a default set of students for XBlock tests
     '''
     student_list = [
-        {'email': 'alice@test.edx.org', 'password': 'password1234'},
-        {'email': 'bob@test.edx.org', 'password': 'password1234'},
-        {'email': 'eve@test.edx.org', 'password': 'password1234'},
+        {'email': 'alice@test.edx.org', 'password': 'Password1234'},
+        {'email': 'bob@test.edx.org', 'password': 'Password1234'},
+        {'email': 'eve@test.edx.org', 'password': 'Password1234'},
     ]
 
     def setUp(self):

--- a/xmodule/modulestore/tests/django_utils.py
+++ b/xmodule/modulestore/tests/django_utils.py
@@ -369,7 +369,7 @@ class ModuleStoreTestUsersMixin():
     """
     A mixin to help manage test users.
     """
-    TEST_PASSWORD = 'test'
+    TEST_PASSWORD = 'password'
 
     def create_user_for_course(self, course, user_type=CourseUserType.ENROLLED):
         """

--- a/xmodule/modulestore/tests/django_utils.py
+++ b/xmodule/modulestore/tests/django_utils.py
@@ -369,7 +369,7 @@ class ModuleStoreTestUsersMixin():
     """
     A mixin to help manage test users.
     """
-    TEST_PASSWORD = 'password'
+    TEST_PASSWORD = 'Password1234'
 
     def create_user_for_course(self, course, user_type=CourseUserType.ENROLLED):
         """


### PR DESCRIPTION
This changes:

* The default minimum length of passwords from 2 characters to 8 characters. 
* [Updates the CMS password settings](https://github.com/openedx/edx-platform/pull/33373/files#diff-a16fd1c6cf75bdebdf97a2633b533d39e43975c6e98af58787ed6af1282eca71) so that they pull the defaults from the LMS rather than have their own copy.

Operational Impact: None

If you have an existing password, this change along will not force you to update it.  However if you reset your password or go to change it, you'll have to conform to the new guidelines.

If you would like to force people to update their password, you'll probably want to take a look at [the password_policy plugin and its settings](https://github.com/openedx/edx-platform/blob/2033dcf6ace133719aaeb72dc5dd6ee521a7ac42/openedx/core/djangoapps/password_policy/settings/common.py#L13).  