### PR TITLE
Adding new variable for SafeSessionMiddleware.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1087,6 +1087,9 @@ DATABASES = {
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 DEFAULT_HASHING_ALGORITHM = 'sha1'
 
+# default algorithm for SafeSessionMiddleware
+SAFE_SESSIONS_MAC_ALGO = 'sha1'
+
 #################### Python sandbox ############################################
 
 CODE_JAIL = {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1736,6 +1736,9 @@ DATABASES = {
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 DEFAULT_HASHING_ALGORITHM = 'sha1'
 
+# default algorithm for SafeSessionMiddleware
+SAFE_SESSIONS_MAC_ALGO = 'sha1'
+
 #################### Python sandbox ############################################
 
 CODE_JAIL = {

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -269,7 +269,7 @@ class SafeCookieData:
         data_to_sign = self._compute_digest(user_id)
 
         self.signature = signing.TimestampSigner(
-            salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
+            salt=self.key_salt, algorithm=settings.SAFE_SESSIONS_MAC_ALGO
         ).sign_object(data_to_sign, serializer=signing.JSONSerializer, compress=False)
 
     def verify(self, user_id):
@@ -280,7 +280,7 @@ class SafeCookieData:
         """
         try:
             unsigned_data = signing.TimestampSigner(
-                salt=self.key_salt, algorithm=settings.DEFAULT_HASHING_ALGORITHM
+                salt=self.key_salt, algorithm=settings.SAFE_SESSIONS_MAC_ALGO
             ).unsign_object(self.signature, serializer=signing.JSONSerializer, max_age=settings.SESSION_COOKIE_AGE)
 
             if unsigned_data == self._compute_digest(user_id):


### PR DESCRIPTION
Adding new variable  for SafeSessionMiddleware.
```
SAFE_SESSIONS_MAC_ALGO = 'sha1'
```

In django42 `sha1` will be removed but this middleware will keep continue using this algo `sha1`.

Followup [PR](https://github.com/openedx/edx-platform/pull/33345) will remove `sha1` from settings.