### PR TITLE
feat: Show active subscriptions on Program Details apart from eligibility

### DIFF
--- a/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
@@ -544,6 +544,28 @@ describe('Program Details View', () => {
             .toContainText(body);
     };
 
+    const testSubscriptionSunsetting = (state, heading, body) => {
+        const subscriptionData = {
+            ...options.subscriptionData[0],
+            subscription_state: state,
+        };
+        // eslint-disable-next-line no-use-before-define
+        view = initView({
+            // eslint-disable-next-line no-undef
+            programData: $.extend({}, options.programData, {
+                subscription_eligible: false,
+            }),
+            isUserB2CSubscriptionsEnabled: true,
+            subscriptionData: [subscriptionData],
+        });
+        view.render();
+        expect(view.$('.upgrade-subscription')[0]).not.toBeInDOM();
+        expect(view.$('.upgrade-subscription .upgrade-button')).not
+            .toContainText(heading);
+        expect(view.$('.upgrade-subscription .subscription-info-brief')).not
+            .toContainText(body);
+    };
+
     const initView = (updates) => {
         // eslint-disable-next-line no-undef
         const viewOptions = $.extend({}, options, updates);
@@ -709,8 +731,8 @@ describe('Program Details View', () => {
         );
     });
 
-    it('should render the get subscription link if program is subscription eligible', () => {
-        testSubscriptionState(
+    it('should not render the get subscription link if program is not active', () => {
+        testSubscriptionSunsetting(
             'pre',
             'Start 7-day free trial',
             '$100/month USD subscription after trial ends. Cancel anytime.',
@@ -734,8 +756,8 @@ describe('Program Details View', () => {
         );
     });
 
-    it('should render appropriate subscription text when subscription is inactive', () => {
-        testSubscriptionState(
+    it('should not render appropriate subscription text when subscription is inactive', () => {
+        testSubscriptionSunsetting(
             'inactive',
             'Restart my subscription',
             '$100/month USD subscription. Cancel anytime.',

--- a/lms/static/js/learner_dashboard/views/program_details_view.js
+++ b/lms/static/js/learner_dashboard/views/program_details_view.js
@@ -215,9 +215,13 @@ class ProgramDetailsView extends Backbone.View {
             && this.remainingCourseCollection.length === 0
         );
 
+        const isSubscriptionActiveSunsetting = (
+            this.subscriptionModel.get('subscriptionState') === 'active'
+        )
+
         return (
             this.options.isUserB2CSubscriptionsEnabled
-            && this.options.programData.subscription_eligible
+            && isSubscriptionActiveSunsetting
             && !programPurchasedWithoutSubscription
         );
     }


### PR DESCRIPTION
[REV-3704](https://2u-internal.atlassian.net/browse/REV-3704).

We're untagging all programs that were subscription eligible as ineligible in course-discovery, but we still want to show B2C subscriptions CTAs and messaging on Program Details page for learners that have an active subscription (trial and non-trial).

This does not affect non-subscription Programs.

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->


