### PR TITLE
feat: upgrade openedx-events

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2789,4 +2789,5 @@ SPECTACULAR_SETTINGS = {
 }
 
 #### Event bus publishing ####
+## Will be more filled out as part of https://github.com/edx/edx-arch-experiments/issues/381
 EVENT_BUS_PRODUCER_CONFIG = {}

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2787,3 +2787,6 @@ SPECTACULAR_SETTINGS = {
     'SERVE_INCLUDE_SCHEMA': False,
     'PREPROCESSING_HOOKS': ['cms.lib.spectacular.cms_api_filter'],  # restrict spectacular to CMS API endpoints
 }
+
+#### Event bus publishing ####
+EVENT_BUS_PRODUCER_CONFIG = {}

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5384,3 +5384,6 @@ EXPIRED_NOTIFICATIONS_DELETE_BATCH_SIZE = 10000
 #### django-simple-history##
 # disable indexing on date field its coming from django-simple-history.
 SIMPLE_HISTORY_DATE_INDEX = False
+
+#### Event bus publishing ####
+EVENT_BUS_PRODUCER_CONFIG = {}

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5386,4 +5386,5 @@ EXPIRED_NOTIFICATIONS_DELETE_BATCH_SIZE = 10000
 SIMPLE_HISTORY_DATE_INDEX = False
 
 #### Event bus publishing ####
+## Will be more filled out as part of https://github.com/edx/edx-arch-experiments/issues/381
 EVENT_BUS_PRODUCER_CONFIG = {}

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -120,9 +120,6 @@ libsass==0.10.0
 # greater version breaking upgrade builds
 click==8.1.6
 
-# openedx-events 8.6.0 introduces publishing via configuration. Ticket to unpin: https://github.com/edx/edx-arch-experiments/issues/381
-openedx-events<8.6.0               # Open edX Events from Hooks Extension Framework (OEP-50)
-
 # pinning this version to avoid updates while the library is being developed
 openedx-learning==0.1.7
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -776,7 +776,6 @@ openedx-django-wiki==2.0.3
     # via -r requirements/edx/kernel.in
 openedx-events==8.6.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-event-bus-kafka
     #   edx-event-bus-redis

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -774,7 +774,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==2.0.3
     # via -r requirements/edx/kernel.in
-openedx-events==8.5.0
+openedx-events==8.6.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1305,7 +1305,7 @@ openedx-django-wiki==2.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==8.5.0
+openedx-events==8.6.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1307,7 +1307,6 @@ openedx-django-wiki==2.0.3
     #   -r requirements/edx/testing.txt
 openedx-events==8.6.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -916,7 +916,6 @@ openedx-django-wiki==2.0.3
     # via -r requirements/edx/base.txt
 openedx-events==8.6.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -914,7 +914,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.3
     # via -r requirements/edx/base.txt
-openedx-events==8.5.0
+openedx-events==8.6.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -981,7 +981,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.3
     # via -r requirements/edx/base.txt
-openedx-events==8.5.0
+openedx-events==8.6.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -983,7 +983,6 @@ openedx-django-wiki==2.0.3
     # via -r requirements/edx/base.txt
 openedx-events==8.6.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis


### PR DESCRIPTION
- feat: upgrade openedx-events
- fixup!: add empty config

## Description
Unpin openedx-events and upgrade to 8.6.0 (publishing to the event bus via config). Temporarily set the config to empty and keep the manual sends of existing events.

Tested to make sure there aren't duplicate sends as long as the config is empty.

## Deadline

10/6/23. Needed to unblock new events being added to openedx-events

