### PR TITLE
chore: ORA bump to 5.5.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -792,7 +792,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==5.5.1
+ora2==5.5.2
     # via -r requirements/edx/bundled.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1330,7 +1330,7 @@ optimizely-sdk==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==5.5.1
+ora2==5.5.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -932,7 +932,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.5.1
+ora2==5.5.2
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -999,7 +999,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.5.1
+ora2==5.5.2
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via


### PR DESCRIPTION
## Description
Bump ORA from 5.5.1 to 5.5.2 ([Changelog](https://github.com/openedx/edx-ora2/compare/v5.5.1...5.5.2))

## Testing instructions
Daily workflow update job gets executed at 1am. After execution we should verify `Error:<class 'opaque_keys.edx.locator.BlockUsageLocator'>` is not present. 

Splunk query:
```
index="stage-edx" "service_variant=lms"  "openassessment.workflow.workflow_batch_update" "Error:<class 'opaque_keys.edx.locator.BlockUsageLocator'>"
``` 
