### PR TITLE
feat: handle exam events for credit state

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -256,7 +256,7 @@ def update_special_exams_and_publish(course_key_str):
     """
     from cms.djangoapps.contentstore.exams import register_exams
     from cms.djangoapps.contentstore.proctoring import register_special_exams as register_exams_legacy
-    from openedx.core.djangoapps.credit.signals import on_course_publish
+    from openedx.core.djangoapps.credit.signals.handlers import on_course_publish
 
     course_key = CourseKey.from_string(course_key_str)
     LOGGER.info('Attempting to register exams for course %s', course_key_str)

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -195,7 +195,7 @@ class RegisterExamsTaskTestCase(CourseTestCase):  # pylint: disable=missing-clas
     @mock.patch('cms.djangoapps.contentstore.proctoring.register_special_exams')
     def test_register_exams_failure(self, _mock_register_exams_proctoring, _mock_register_exams_service):
         """ credit requirements update signal fires even if exam registration fails """
-        with mock.patch('openedx.core.djangoapps.credit.signals.on_course_publish') as course_publish:
+        with mock.patch('openedx.core.djangoapps.credit.signals.handlers.on_course_publish') as course_publish:
             _mock_register_exams_proctoring.side_effect = Exception('boom!')
             update_special_exams_and_publish(str(self.course.id))
             course_publish.assert_called()

--- a/cms/djangoapps/contentstore/views/tests/test_credit_eligibility.py
+++ b/cms/djangoapps/contentstore/views/tests/test_credit_eligibility.py
@@ -9,7 +9,7 @@ from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
 from openedx.core.djangoapps.credit.api import get_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse
-from openedx.core.djangoapps.credit.signals import on_course_publish
+from openedx.core.djangoapps.credit.signals.handlers import on_course_publish
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 

--- a/openedx/core/djangoapps/credit/apps.py
+++ b/openedx/core/djangoapps/credit/apps.py
@@ -15,7 +15,7 @@ class CreditConfig(AppConfig):
     name = 'openedx.core.djangoapps.credit'
 
     def ready(self):
-        from . import signals  # lint-amnesty, pylint: disable=unused-import
+        from .signals import handlers  # lint-amnesty, pylint: disable=unused-import
         if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
             from .services import CreditService
             set_runtime_service('credit', CreditService())

--- a/openedx/core/djangoapps/credit/signals.py
+++ b/openedx/core/djangoapps/credit/signals.py
@@ -10,14 +10,72 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.dispatch import receiver
 from django.utils import timezone
 from opaque_keys.edx.keys import CourseKey
-from openedx_events.learning.signals import EXAM_ATTEMPT_RESET
+from openedx_events.learning.signals import (
+    EXAM_ATTEMPT_ERRORED,
+    EXAM_ATTEMPT_REJECTED,
+    EXAM_ATTEMPT_RESET,
+    EXAM_ATTEMPT_SUBMITTED,
+    EXAM_ATTEMPT_VERIFIED
+)
 
-from openedx.core.djangoapps.credit.api.eligibility import is_credit_course, remove_credit_requirement_status
+from openedx.core.djangoapps.credit.api.eligibility import (
+    is_credit_course,
+    remove_credit_requirement_status,
+    set_credit_requirement_status
+)
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_CHANGED
 
 User = get_user_model()
 
 log = logging.getLogger(__name__)
+
+
+def handle_exam_event(signal, event_data, credit_status=None):
+    """
+    update credit requirements based on exam event
+    """
+    user_data = event_data.student_user
+    course_key = event_data.course_key
+    usage_key = event_data.usage_key
+    request_namespace = 'exam'
+
+    # quick exit, if course is not credit enabled
+    if not is_credit_course(course_key):
+        return
+
+    # log any activity to the credit requirements table
+    log_msg = (
+        f'recieved {signal} signal, changing credit requirement for '
+        f'user_id={user_data.id}, course_key_or_id={course_key} '
+        f'content_id={usage_key}'
+    )
+    log.info(log_msg)
+
+    try:
+        user = User.objects.get(id=user_data.id)
+    except ObjectDoesNotExist:
+        log.error(
+            'Error occurred while handling exam event for '
+            f'{user_data.id} and content_id {usage_key}. '
+            'User does not exist!'
+        )
+        return
+
+    if signal == EXAM_ATTEMPT_RESET:
+        remove_credit_requirement_status(
+            user.username,
+            course_key,
+            request_namespace,
+            str(usage_key),
+        )
+    else:
+        set_credit_requirement_status(
+            user.username,
+            course_key,
+            request_namespace,
+            str(usage_key),
+            credit_status
+        )
 
 
 def on_course_publish(course_key):
@@ -103,43 +161,45 @@ def listen_for_grade_calculation(sender, user, course_grade, course_key, deadlin
 
 
 @receiver(EXAM_ATTEMPT_RESET)
-def handle_exam_reset(sender, signal, **kwargs):
+def listen_for_exam_reset(sender, signal, **kwargs):
     """
     exam reset event from the event bus
     """
     event_data = kwargs.get('exam_attempt')
-    user_data = event_data.student_user
-    course_key = event_data.course_key
-    usage_key = event_data.usage_key
-    request_namespace = 'special_exam'
- 
-    # quick exit, if course is not credit enabled
-    if not is_credit_course(course_key):
-        return
+    handle_exam_event(signal, event_data)
 
-    # always log any deleted activity to the credit requirements
-    # table. This will be to help debug any issues that might
-    # arise in production
-    log_msg = (
-        'recieved EXAM_ATTEMPT_RESET signal, resetting credit requirement for '
-        f'user_id={user_data.id}, course_key_or_id={course_key} '
-        f'content_id={usage_key}'
-    )
-    log.info(log_msg)
 
-    try:
-        user = User.objects.get(id=user_data.id)
-    except ObjectDoesNotExist:
-        log.error(
-            'Error occurred while handling EXAM_ATTEMPT_RESET signal for '
-            f'{user_data.id} and content_id {usage_key}. '
-            'User does not exist!'
-        )
-        return
+@receiver(EXAM_ATTEMPT_SUBMITTED)
+def listen_for_exam_submitted(sender, signal, **kwargs):
+    """
+    exam submission event from the event bus
+    """
+    event_data = kwargs.get('exam_attempt')
+    handle_exam_event(signal, event_data, credit_status='submitted')
 
-    remove_credit_requirement_status(
-        user.username,
-        course_key,
-        request_namespace,
-        str(usage_key),
-    )
+
+@receiver(EXAM_ATTEMPT_VERIFIED)
+def listen_for_exam_verified(sender, signal, **kwargs):
+    """
+    exam verification event from the event bus
+    """
+    event_data = kwargs.get('exam_attempt')
+    handle_exam_event(signal, event_data, credit_status='satisfied')
+
+
+@receiver(EXAM_ATTEMPT_REJECTED)
+def listen_for_exam_rejected(sender, signal, **kwargs):
+    """
+    exam rejection event from the event bus
+    """
+    event_data = kwargs.get('exam_attempt')
+    handle_exam_event(signal, event_data, credit_status='failed')
+
+
+@receiver(EXAM_ATTEMPT_ERRORED)
+def listen_for_exam_errored(sender, signal, **kwargs):
+    """
+    exam error event from the event bus
+    """
+    event_data = kwargs.get('exam_attempt')
+    handle_exam_event(signal, event_data, credit_status='failed')

--- a/openedx/core/djangoapps/credit/signals/handlers.py
+++ b/openedx/core/djangoapps/credit/signals/handlers.py
@@ -44,12 +44,11 @@ def handle_exam_event(signal, event_data, credit_status=None):
         return
 
     # log any activity to the credit requirements table
-    log_msg = (
-        f'recieved {signal} signal, changing credit requirement for '
+    log.info(
+        f'Recieved {signal} signal, changing credit requirement for '
         f'user_id={user_data.id}, course_key_or_id={course_key} '
         f'content_id={usage_key}'
     )
-    log.info(log_msg)
 
     try:
         user = User.objects.get(id=user_data.id)

--- a/openedx/core/djangoapps/credit/tests/test_signals.py
+++ b/openedx/core/djangoapps/credit/tests/test_signals.py
@@ -25,7 +25,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.credit.api import get_credit_requirement_status, set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
-from openedx.core.djangoapps.credit.signals import (
+from openedx.core.djangoapps.credit.signals.handlers import (
     listen_for_exam_errored,
     listen_for_exam_rejected,
     listen_for_exam_reset,
@@ -208,7 +208,7 @@ class TestExamEvents(ModuleStoreTestCase):
             time=datetime.now(timezone.utc)
         )
 
-    @mock.patch('openedx.core.djangoapps.credit.signals.remove_credit_requirement_status', autospec=True)
+    @mock.patch('openedx.core.djangoapps.credit.signals.handlers.remove_credit_requirement_status', autospec=True)
     def test_exam_reset(self, mock_remove_credit_status):
         """
         Test exam reset event
@@ -229,7 +229,7 @@ class TestExamEvents(ModuleStoreTestCase):
         (EXAM_ATTEMPT_SUBMITTED, 'submitted'),
     )
     @ddt.unpack
-    @mock.patch('openedx.core.djangoapps.credit.signals.set_credit_requirement_status', autospec=True)
+    @mock.patch('openedx.core.djangoapps.credit.signals.handlers.set_credit_requirement_status', autospec=True)
     def test_exam_update_event(self, event_signal, expected_status, mock_set_credit_status):
         """
         Test exam events that update credit status
@@ -260,7 +260,7 @@ class TestExamEvents(ModuleStoreTestCase):
         event_metadata = self._get_exam_event_metadata(event_signal)
         handler = self.HANDLERS.get(event_signal)
 
-        with mock.patch('openedx.core.djangoapps.credit.signals.log.error') as mock_log:
+        with mock.patch('openedx.core.djangoapps.credit.signals.handlers.log.error') as mock_log:
             handler(None, event_signal, event_metadata=event_metadata, exam_attempt=event_data)
             mock_log.assert_called_once_with(
                 'Error occurred while handling exam event for '
@@ -275,8 +275,8 @@ class TestExamEvents(ModuleStoreTestCase):
         EXAM_ATTEMPT_VERIFIED,
         EXAM_ATTEMPT_SUBMITTED,
     )
-    @mock.patch('openedx.core.djangoapps.credit.signals.remove_credit_requirement_status', autospec=True)
-    @mock.patch('openedx.core.djangoapps.credit.signals.set_credit_requirement_status', autospec=True)
+    @mock.patch('openedx.core.djangoapps.credit.signals.handlers.remove_credit_requirement_status', autospec=True)
+    @mock.patch('openedx.core.djangoapps.credit.signals.handlers.set_credit_requirement_status', autospec=True)
     def test_exam_event_non_credit_course(self, event_signal, mock_remove_credit_status, mock_set_credit_status):
         """
         Credit credit logic should not run on non-credit courses

--- a/openedx/core/djangoapps/credit/tests/test_signals.py
+++ b/openedx/core/djangoapps/credit/tests/test_signals.py
@@ -1,7 +1,6 @@
 """
-Tests for minimum grade requirement status
+Tests for minimum grade and credit requirement status
 """
-
 
 from datetime import datetime, timedelta, timezone
 from unittest import mock
@@ -13,14 +12,27 @@ from django.test.client import RequestFactory
 from opaque_keys.edx.keys import UsageKey
 from openedx_events.data import EventsMetadata
 from openedx_events.learning.data import ExamAttemptData, UserData, UserPersonalData
-from openedx_events.learning.signals import EXAM_ATTEMPT_RESET
+from openedx_events.learning.signals import (
+    EXAM_ATTEMPT_ERRORED,
+    EXAM_ATTEMPT_REJECTED,
+    EXAM_ATTEMPT_RESET,
+    EXAM_ATTEMPT_SUBMITTED,
+    EXAM_ATTEMPT_VERIFIED
+)
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.credit.api import get_credit_requirement_status, set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
-from openedx.core.djangoapps.credit.signals import handle_exam_reset, listen_for_grade_calculation
+from openedx.core.djangoapps.credit.signals import (
+    listen_for_exam_errored,
+    listen_for_exam_rejected,
+    listen_for_exam_reset,
+    listen_for_exam_submitted,
+    listen_for_exam_verified,
+    listen_for_grade_calculation
+)
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import \
     ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
@@ -138,10 +150,18 @@ class TestMinGradedRequirementStatus(ModuleStoreTestCase):
 
 
 @skip_unless_lms
+@ddt.ddt
 class TestExamEvents(ModuleStoreTestCase):
     """
     Test exam events
     """
+    HANDLERS = {
+        EXAM_ATTEMPT_ERRORED: listen_for_exam_errored,
+        EXAM_ATTEMPT_REJECTED: listen_for_exam_rejected,
+        EXAM_ATTEMPT_RESET: listen_for_exam_reset,
+        EXAM_ATTEMPT_SUBMITTED: listen_for_exam_submitted,
+        EXAM_ATTEMPT_VERIFIED: listen_for_exam_verified,
+    }
 
     def setUp(self):
         super().setUp()
@@ -196,37 +216,77 @@ class TestExamEvents(ModuleStoreTestCase):
         event_data = self._get_exam_event_data(self.user, self.course, self.subsection_key)
         event_metadata = self._get_exam_event_metadata(EXAM_ATTEMPT_RESET)
 
-        handle_exam_reset(None, EXAM_ATTEMPT_RESET, event_metadata=event_metadata, exam_attempt=event_data)
+        listen_for_exam_reset(None, EXAM_ATTEMPT_RESET, event_metadata=event_metadata, exam_attempt=event_data)
 
         mock_remove_credit_status.assert_called_once_with(
-            self.user.username, self.course.id, 'special_exam', str(self.subsection_key)
+            self.user.username, self.course.id, 'exam', str(self.subsection_key)
         )
 
-    def test_exam_reset_bad_user(self):
+    @ddt.data(
+        (EXAM_ATTEMPT_ERRORED, 'failed'),
+        (EXAM_ATTEMPT_REJECTED, 'failed'),
+        (EXAM_ATTEMPT_VERIFIED, 'satisfied'),
+        (EXAM_ATTEMPT_SUBMITTED, 'submitted'),
+    )
+    @ddt.unpack
+    @mock.patch('openedx.core.djangoapps.credit.signals.set_credit_requirement_status', autospec=True)
+    def test_exam_update_event(self, event_signal, expected_status, mock_set_credit_status):
         """
-        Test exam reset event with a user that does not exist in the LMS
+        Test exam events that update credit status
+        """
+        event_data = self._get_exam_event_data(self.user, self.course, self.subsection_key)
+        event_metadata = self._get_exam_event_metadata(event_signal)
+
+        handler = self.HANDLERS.get(event_signal)
+        handler(None, event_signal, event_metadata=event_metadata, exam_attempt=event_data)
+
+        mock_set_credit_status.assert_called_once_with(
+            self.user.username, self.course.id, 'exam', str(self.subsection_key), status=expected_status
+        )
+
+    @ddt.data(
+        EXAM_ATTEMPT_RESET,
+        EXAM_ATTEMPT_REJECTED,
+        EXAM_ATTEMPT_ERRORED,
+        EXAM_ATTEMPT_VERIFIED,
+        EXAM_ATTEMPT_SUBMITTED,
+    )
+    def test_exam_event_bad_user(self, event_signal):
+        """
+        Test exam event with a user that does not exist in the LMS
         """
         self.user.id = 999  # don't save to db so user doesn't exist
         event_data = self._get_exam_event_data(self.user, self.course, self.subsection_key)
-        event_metadata = self._get_exam_event_metadata(EXAM_ATTEMPT_RESET)
+        event_metadata = self._get_exam_event_metadata(event_signal)
+        handler = self.HANDLERS.get(event_signal)
 
         with mock.patch('openedx.core.djangoapps.credit.signals.log.error') as mock_log:
-            handle_exam_reset(None, EXAM_ATTEMPT_RESET, event_metadata=event_metadata, exam_attempt=event_data)
+            handler(None, event_signal, event_metadata=event_metadata, exam_attempt=event_data)
             mock_log.assert_called_once_with(
-                'Error occurred while handling EXAM_ATTEMPT_RESET signal for '
+                'Error occurred while handling exam event for '
                 f'{self.user.id} and content_id {self.subsection_key}. '
                 'User does not exist!'
             )
 
+    @ddt.data(
+        EXAM_ATTEMPT_RESET,
+        EXAM_ATTEMPT_REJECTED,
+        EXAM_ATTEMPT_ERRORED,
+        EXAM_ATTEMPT_VERIFIED,
+        EXAM_ATTEMPT_SUBMITTED,
+    )
     @mock.patch('openedx.core.djangoapps.credit.signals.remove_credit_requirement_status', autospec=True)
-    def test_exam_reset_non_credit_course(self, mock_remove_credit_status):
+    @mock.patch('openedx.core.djangoapps.credit.signals.set_credit_requirement_status', autospec=True)
+    def test_exam_event_non_credit_course(self, event_signal, mock_remove_credit_status, mock_set_credit_status):
         """
-        Credit logic should not run on non-credit courses
+        Credit credit logic should not run on non-credit courses
         """
         non_credit_course = CourseFactory.create()
         event_data = self._get_exam_event_data(self.user, non_credit_course, self.subsection_key)
-        event_metadata = self._get_exam_event_metadata(EXAM_ATTEMPT_RESET)
+        event_metadata = self._get_exam_event_metadata(event_signal)
+        handler = self.HANDLERS.get(event_signal)
 
-        handle_exam_reset(None, EXAM_ATTEMPT_RESET, event_metadata=event_metadata, exam_attempt=event_data)
+        handler(None, event_signal, event_metadata=event_metadata, exam_attempt=event_data)
 
         mock_remove_credit_status.assert_not_called()
+        mock_set_credit_status.assert_not_called()

--- a/openedx/core/djangoapps/credit/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credit/tests/test_tasks.py
@@ -11,7 +11,7 @@ from edx_proctoring.api import create_exam
 from openedx.core.djangoapps.credit.api import get_credit_requirements
 from openedx.core.djangoapps.credit.exceptions import InvalidCreditRequirements
 from openedx.core.djangoapps.credit.models import CreditCourse
-from openedx.core.djangoapps.credit.signals import on_course_publish
+from openedx.core.djangoapps.credit.signals.handlers import on_course_publish
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 


### PR DESCRIPTION
Handles exam related events from the event bus that impact credit state. Functionally this will behave the same as the existing CreditService which is called by edx-proctoring. This enables edx-exams (an IDA) to have the same behavior.

Details on edx-exams: https://github.com/edx/edx-exams/blob/main/docs/decisions/0001-purpose-of-this-repo.rst

### [MST-2118](https://2u-internal.atlassian.net/browse/MST-2118)