### PR TITLE
docs: fix the EnrollmentAllowedView doc to be right

### DIFF
--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -1066,7 +1066,9 @@ class EnrollmentAllowedView(APIView):
 
         **Example Request**
 
-        POST /api/enrollment/v1/enrollment_allowed
+        POST /api/enrollment/v1/enrollment_allowed/
+
+        Note: The URL for this request must finish with /
 
         Example request data:
         ```
@@ -1086,7 +1088,6 @@ class EnrollmentAllowedView(APIView):
         - `auto_enroll` (optional, bool: default=false, _body_)
 
         **Responses**
-        - 200: Success, enrollment allowed found.
         - 400: Bad request, missing data.
         - 403: Forbidden, you need to be staff.
         - 409: Conflict, enrollment allowed already exists.
@@ -1122,7 +1123,9 @@ class EnrollmentAllowedView(APIView):
 
         **Example Request**
 
-        DELETE /api/enrollment/v1/enrollment_allowed
+        DELETE /api/enrollment/v1/enrollment_allowed/
+
+        Note: The URL for this request must finish with /
 
         Example request data:
         ```


### PR DESCRIPTION
## Description

At the last moment of this PR #33059, we added "/" at the end of the URL. This PR fixes the doc of EnrollmentAllowedView, adding that change and removing the 200 status of the post method from the doc.

## Note
When I use the POST or DELETE without the "/" at the end, the API uses the GET method by default; is there a way to avoid that behavior? I want to fix that if it is possible.