### PR TITLE
fix: null email in identify calls

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -344,7 +344,7 @@ def _track_user_login(user, request):
     segment.identify(
         user.id,
         {
-            'email': request.POST.get('email'),
+            'email': user.email,
             'username': user.username
         },
         {


### PR DESCRIPTION
We encountered an issue where a high number of the segment `identify` calls from LMS were triggered with `email=null` thus clearing user email addresses in their segment and braze profiles.  As a result, they were not able to receive emails.

**Fix details:**

An `identify` is called when the user logs in. In the v2 of login API and we pass email and username in this identify call, the `username` or `email` used for login is available in the `email_or_username` key for V2 of API and `email` key for V1 of API. In the code, the email was being retrieved from the `email` key only (`request.POST.get('email')`) thus returning `None` for V2 API calls. 

We are now getting the user's email from the user object making it consistent with username data and resolving the bug.