### PR TITLE
[DEPR] Remove Matlab API key from Studio Problem settings

### DIFF
--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -504,6 +504,11 @@ class ProblemBlock(
             ProblemBlock.markdown,
             ProblemBlock.use_latex_compiler,
             ProblemBlock.show_correctness,
+
+            # Temporarily remove the ability to see MATLAB API key in Studio, as
+            # a pre-cursor to removing it altogether.
+            #   https://github.com/openedx/public-engineering/issues/192
+            ProblemBlock.matlab_api_key,
         ])
         return non_editable_fields
 


### PR DESCRIPTION
## Description

The Matlab-specific code is coupled with XQueue in places, making its removal a little tricky. But we at least want to hide this now-useless field from course authors before we cut the Quince release.

### Before:

![with-matlab-api-setting](https://github.com/openedx/edx-platform/assets/41625/204c4d25-9abc-470d-bda6-7ec4900a68af)

### After:

![matlab-api-setting-removed](https://github.com/openedx/edx-platform/assets/41625/1b78791e-13f8-4d55-8085-37a616ffdcc0)

## Supporting information

* https://github.com/openedx/public-engineering/issues/192
* https://github.com/openedx/edx-platform/pull/33337
