### PR TITLE
feat: toggle to enable/disable lti pii acknowledgement

### DIFF
--- a/openedx/core/djangoapps/agreements/toggles.py
+++ b/openedx/core/djangoapps/agreements/toggles.py
@@ -1,0 +1,27 @@
+"""
+Toggle for lti pii acknowledgement feature.
+"""
+
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+# .. toggle_name: agreements.enable_lti_pii_acknowledgement
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables the lti pii acknowledgement feature for a course
+# .. toggle_warning: None
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2023-10
+# .. toggle_tickets: MST-2055
+
+
+ENABLE_LTI_PII_ACKNOWLEDGEMENT = CourseWaffleFlag('agreements.enable_lti_pii_acknowledgement', __name__)
+
+
+def lti_pii_acknowledgment_enabled(course_key):
+    """
+    Returns a boolean if lti pii acknowledgements are enabled for a course.
+    """
+    if isinstance(course_key, str):
+        course_key = CourseKey.from_string(course_key)
+    return ENABLE_LTI_PII_ACKNOWLEDGEMENT.is_enabled(course_key)

--- a/openedx/core/djangoapps/agreements/toggles.py
+++ b/openedx/core/djangoapps/agreements/toggles.py
@@ -12,6 +12,7 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 # .. toggle_warning: None
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2023-10
+# .. toggle_target_removal_date: None
 # .. toggle_tickets: MST-2055
 
 


### PR DESCRIPTION
## Description

Add a toggle to the agreements application to enable/disable the LTI PII Acknowledgement feature. Use the [CourseWaffleFlag](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/waffle_utils/__init__.py) class to create a toggle. CourseWaffleFlag is a edx-platform specific extension of the [django-waffle](https://waffle.readthedocs.io/en/stable/) library to allow per-course toggles.