### PR TITLE
chore: Adding condition to pick values in case of django42.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -831,6 +831,7 @@ CSRF_COOKIE_SECURE = False
 CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = ''
 CROSS_DOMAIN_CSRF_COOKIE_NAME = ''
 CSRF_TRUSTED_ORIGINS = []
+CSRF_TRUSTED_ORIGINS_WITH_SCHEME = []
 
 #################### CAPA External Code Evaluation #############################
 XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -14,6 +14,7 @@ import warnings
 import yaml
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from edx_django_utils.plugins import add_plugins
@@ -235,6 +236,11 @@ SHARED_COOKIE_DOMAIN = ENV_TOKENS.get('SHARED_COOKIE_DOMAIN', SESSION_COOKIE_DOM
 # but it is highly recommended that this is True for environments accessed
 # by end users.
 CSRF_COOKIE_SECURE = ENV_TOKENS.get('CSRF_COOKIE_SECURE', False)
+
+# values are already updated above with default CSRF_TRUSTED_ORIGINS values but in
+# case of new django version these values will override.
+if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
+    CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS_WITH_SCHEME', [])
 
 #Email overrides
 MKTG_URL_LINK_MAP.update(ENV_TOKENS.get('MKTG_URL_LINK_MAP', {}))


### PR DESCRIPTION
This override needed here as well. Sandbox fails with django42 branch.

```
changed: [awais786.sandbox.edx.org] => (item=lms)
15:48:45 failed: [awais786.sandbox.edx.org] (item=cms) => {"ansible_loop_var": "item",
 "changed": true, "cmd": ["/edx/bin/edxapp-migrate-cms"], "
```
```
changed: [awais786.sandbox.edx.org] => (item=lms)
15:48:45 failed: [awais786.sandbox.edx.org] (item=cms) => {"ansible_loop_var": "item",
 "changed": true, "cmd": ["/edx/bin/edxapp-migrate-cms"], "
```