### PR TITLE
feat: Get video_uuid, user_uuid and language for request

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -151,7 +151,7 @@ from openedx.core.djangolib.js_utils import (
         </div>
         % endif
         % if transcript_feedback_enabled:
-            <div class="wrapper-transcript-feedback">
+            <div class="wrapper-transcript-feedback" data-video-id='${video_id}' data-user-id='${user_id}'>
                 <h4 class="hd hd-5">${_('How is the transcript quality ?')}</h4>
                 <div class="transcript-feedback-buttons">
                     <div class="transcript-feedback-btn-wrapper">

--- a/openedx/core/djangoapps/video_config/toggles.py
+++ b/openedx/core/djangoapps/video_config/toggles.py
@@ -15,3 +15,14 @@ WAFFLE_FLAG_NAMESPACE = 'video_config'
 PUBLIC_VIDEO_SHARE = CourseWaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.public_video_share', __name__
 )
+
+# .. toggle_name: video_config.transcript_feedback
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Gates access to the transcript feedback widget feature.
+# .. toggle_use_cases: temporary, opt_in
+# .. toggle_creation_date: 2023-05-10
+# .. toggle_target_removal_date: None
+TRANSCRIPT_FEEDBACK = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.transcript_feedback', __name__
+)

--- a/xmodule/js/src/video/037_video_transcript_feedback.js
+++ b/xmodule/js/src/video/037_video_transcript_feedback.js
@@ -1,31 +1,38 @@
 (function(define) {
-    // eslint-disable-next-line lines-around-directive
-    'use strict';
-
     // VideoTranscriptFeedbackHandler module.
-    define(
-        'video/037_video_transcript_feedback.js', ['underscore'],
-        function(_) {
-            var VideoTranscriptFeedbackHandler;
 
+        'use strict';
+
+        define('video/037_video_caption.js', ['underscore'],
+        function(_) {
             /**
-             * Video Transcript Feedback control module.
-             * @exports video/037_video_transcript_feedback.js
-             * @constructor
-             * @param {jquery Element} element
-             * @param {Object} options
+             * @desc VideoTranscriptFeedbackHandler module exports a function.
+             *
+             * @type {function}
+             * @access public
+             *
+             * @param {object} state - The object containing the state of the video
+             *     player. All other modules, their parameters, public variables, etc.
+             *     are available via this object.
+             *
+             * @this {object} The global window object.
+             *
              */
-            VideoTranscriptFeedbackHandler = function(element, options) {
+
+            var VideoTranscriptFeedbackHandler = function(state) {
                 if (!(this instanceof VideoTranscriptFeedbackHandler)) {
-                    return new VideoTranscriptFeedbackHandler(element, options);
+                    return new VideoTranscriptFeedbackHandler(state);
                 }
 
-                _.bindAll(this, 'sendPositiveFeedback');
-                _.bindAll(this, 'sendNegativeFeedback');
+                _.bindAll(this, 'sendPositiveFeedback', 'sendNegativeFeedback', 'onHideLanguageMenu',
+                    'destroy'
+                );
 
-                this.container = element;
+                this.state = state;
+                this.currentTranscriptLanguage = this.state.lang;
+                this.transcriptLanguages = this.state.config.transcriptLanguages;
 
-                if (this.container.find('.wrapper-downloads .wrapper-transcript-feedback')) {
+                if (this.state.el.find('.wrapper-downloads .wrapper-transcript-feedback')) {
                     this.initialize();
                 }
 
@@ -34,13 +41,31 @@
 
             VideoTranscriptFeedbackHandler.prototype = {
 
+                destroy: function() {
+                    this.state.el.off(this.events);
+                },
+
                 // Initializes the module.
                 initialize: function() {
-                    this.el = this.container.find('.wrapper-transcript-feedback');
+                    this.el = this.state.el.find('.wrapper-transcript-feedback');
+
+                    this.video_id = this.el.data('video-id');
+                    this.user_id = this.el.data('user-id');
+
                     this.thumbsUpButton = this.el.find('.thumbs-up-btn');
                     this.thumbsDownButton = this.el.find('.thumbs-down-btn');
                     this.thumbsUpButton.on('click', this.sendPositiveFeedback);
                     this.thumbsDownButton.on('click', this.sendNegativeFeedback);
+
+                    this.events = {
+                        'language_menu:hide': this.onHideLanguageMenu,
+                        destroy: this.destroy
+                    };
+                    this.bindHandlers();
+                },
+
+                bindHandlers: function() {
+                    this.state.el.on(this.events);
                 },
 
                 sendPositiveFeedback: function() {
@@ -65,6 +90,15 @@
                         this.thumbsDownIcon[0].classList.add("fa-thumbs-o-down");
                     }
                     // Send request
+                },
+
+                onHideLanguageMenu: function() {
+                    this.currentTranscriptLanguage = this.getCurrentLanguage();
+                },
+
+                getCurrentLanguage: function() {
+                    var language = this.state.lang;
+                    return language;
                 },
             };
 

--- a/xmodule/js/src/video/10_main.js
+++ b/xmodule/js/src/video/10_main.js
@@ -93,10 +93,10 @@
                         FocusGrabber, VideoControl, VideoPlayPlaceholder,
                         VideoPlayPauseControl, VideoProgressSlider, VideoSpeedControl,
                         VideoVolumeControl, VideoQualityControl, VideoFullScreen, VideoCaption, VideoCommands,
-                        VideoContextMenu, VideoSaveStatePlugin, VideoEventsPlugin, VideoCompletionHandler
+                        VideoContextMenu, VideoSaveStatePlugin, VideoEventsPlugin, VideoCompletionHandler, VideoTranscriptFeedback
                     ].concat(autoAdvanceEnabled ? [VideoAutoAdvanceControl] : []),
                     bumperVideoModules = [VideoControl, VideoPlaySkipControl, VideoSkipControl,
-                        VideoVolumeControl, VideoCaption, VideoCommands, VideoSaveStatePlugin,
+                        VideoVolumeControl, VideoCaption, VideoCommands, VideoSaveStatePlugin, VideoTranscriptFeedback,
                         VideoEventsBumperPlugin, VideoCompletionHandler],
                     state = {
                         el: el,
@@ -138,7 +138,6 @@
                 });
 
                 VideoSocialSharing(el);
-                VideoTranscriptFeedback(el);
 
                 if (bumperMetadata) {
                     VideoPoster(el, {


### PR DESCRIPTION
[NOVA-94](https://2u-internal.atlassian.net/browse/NOVA-94)

## Description
This PR adds to the `video_block`'s `template_context` the current `video_id` and `user_id` so that they can be used inside the feedback widget handler. Also adds a listener to the `language_menu:hide` to fetch the current transcript language being used in the `video_block`. These 3 values will be used to make requests to `ai-translations` services.