### PR TITLE
feat: use new event_bus_producer_config

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import transaction
 from django.dispatch import receiver
-from edx_django_utils.monitoring import set_custom_attribute
 from edx_toggles.toggles import SettingToggle
 from opaque_keys.edx.keys import CourseKey
 from openedx_events.content_authoring.data import CourseCatalogData, CourseScheduleData
@@ -20,6 +19,7 @@ from openedx_events.content_authoring.signals import (
     XBLOCK_DUPLICATED,
     XBLOCK_PUBLISHED,
 )
+from openedx.core.lib.events import determine_producer_config_for_signal_and_topic
 from openedx_events.event_bus import get_producer
 from pytz import UTC
 
@@ -160,38 +160,14 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
     transaction.on_commit(lambda: emit_catalog_info_changed_signal(course_key))
 
 
-def _determine_producer_config_for_signal_and_topic(signal, topic):
-    """
-    Utility method to determine the setting for the given signal and topic in EVENT_BUS_PRODUCER_CONFIG
-
-    Records to New Relic for later analysis.
-
-    Parameters
-        signal (OpenEdxPublicSignal): The signal being sent to the event bus
-        topic (string): The topic to which the signal is being sent (without environment prefix)
-
-    Returns
-        True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
-        False if the signal is explicitly disabled for that topic in EVENT_BUS_PRODUCER_CONFIG
-        None if the signal/topic pair is not present in EVENT_BUS_PRODUCER_CONFIG
-    """
-    event_type_producer_configs = getattr(settings, "EVENT_BUS_PRODUCER_CONFIG",
-                                          {}).get(signal.event_type, {})
-    topic_config = event_type_producer_configs.get(topic, {})
-    topic_setting = topic_config.get('enabled', None)
-    set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
-                         topic_setting if topic_setting is not None else 'Unset')
-    return topic_setting
-
-
 @receiver(COURSE_CATALOG_INFO_CHANGED)
 def listen_for_course_catalog_info_changed(sender, signal, **kwargs):
     """
     Publish COURSE_CATALOG_INFO_CHANGED signals onto the event bus.
     """
     # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
-    producer_config_setting = _determine_producer_config_for_signal_and_topic(COURSE_CATALOG_INFO_CHANGED,
-                                                                              'course-catalog-info-changed')
+    producer_config_setting = determine_producer_config_for_signal_and_topic(COURSE_CATALOG_INFO_CHANGED,
+                                                                             'course-catalog-info-changed')
     if producer_config_setting is True:
         log.info("Producing course-catalog-info-changed event via config")
         return
@@ -210,7 +186,7 @@ def listen_for_xblock_published(sender, signal, **kwargs):
     """
     # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
     topic = getattr(settings, "EVENT_BUS_XBLOCK_LIFECYCLE_TOPIC", "course-authoring-xblock-lifecycle")
-    producer_config_setting = _determine_producer_config_for_signal_and_topic(XBLOCK_PUBLISHED, topic)
+    producer_config_setting = determine_producer_config_for_signal_and_topic(XBLOCK_PUBLISHED, topic)
     if producer_config_setting is True:
         log.info("Producing xblock-published event via config")
         return
@@ -230,7 +206,7 @@ def listen_for_xblock_deleted(sender, signal, **kwargs):
     """
     # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
     topic = getattr(settings, "EVENT_BUS_XBLOCK_LIFECYCLE_TOPIC", "course-authoring-xblock-lifecycle")
-    producer_config_setting = _determine_producer_config_for_signal_and_topic(XBLOCK_DELETED, topic)
+    producer_config_setting = determine_producer_config_for_signal_and_topic(XBLOCK_DELETED, topic)
     if producer_config_setting is True:
         log.info("Producing xblock-deleted event via config")
         return
@@ -250,7 +226,7 @@ def listen_for_xblock_duplicated(sender, signal, **kwargs):
     """
     # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
     topic = getattr(settings, "EVENT_BUS_XBLOCK_LIFECYCLE_TOPIC", "course-authoring-xblock-lifecycle")
-    producer_config_setting = _determine_producer_config_for_signal_and_topic(XBLOCK_DUPLICATED, topic)
+    producer_config_setting = determine_producer_config_for_signal_and_topic(XBLOCK_DUPLICATED, topic)
     if producer_config_setting is True:
         log.info("Producing xblock-duplicated event via config")
         return

--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -168,7 +168,7 @@ def _determine_producer_config_for_signal_and_topic(signal, topic):
 
     Parameters
         signal (OpenEdxPublicSignal): The signal being sent to the event bus
-        topic (string): The topic to which the signal is being sent
+        topic (string): The topic to which the signal is being sent (without environment prefix)
 
     Returns
         True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
@@ -179,12 +179,8 @@ def _determine_producer_config_for_signal_and_topic(signal, topic):
                                           {}).get(signal.event_type, {})
     topic_config = event_type_producer_configs.get(topic, {})
     topic_setting = topic_config.get('enabled', None)
-    if topic_setting is True:
-        set_custom_attribute('producer_config_setting', 'True')
-    if topic_setting is False:
-        set_custom_attribute('producer_config_setting', 'False')
-    if topic_setting is None:
-        set_custom_attribute('producer_config_setting', 'Unset')
+    set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
+                         topic_setting if topic_setting is not None else 'Unset')
     return topic_setting
 
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1808,7 +1808,7 @@ INSTALLED_APPS = [
 
     # alternative swagger generator for CMS API
     'drf_spectacular',
-    'openedx_events'
+    'openedx_events',
 ]
 
 
@@ -2805,8 +2805,10 @@ SPECTACULAR_SETTINGS = {
 
 
 #### Event bus producing ####
+def _should_send_xblock_events(settings):
+    return settings.FEATURES['ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS']
+
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
-# .. setting_default: {}
 # .. setting_description: Dictionary of event_types mapped to dictionaries of topic to topic-related configuration.
 #    Each topic configuration dictionary contains
 #    * `enabled`: a toggle denoting whether the event will be published to the topic. These should be annotated
@@ -2815,15 +2817,13 @@ SPECTACULAR_SETTINGS = {
 #    * `event_key_field` which is a period-delimited string path to event data field to use as event key.
 #    Note: The topic names should not include environment prefix as it will be dynamically added based on
 #    EVENT_BUS_TOPIC_PREFIX setting.
-def _should_send_xblock_events(settings):
-    return settings.FEATURES['ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS']
-
 
 EVENT_BUS_PRODUCER_CONFIG = {
     'org.openedx.content_authoring.course.catalog_info.changed.v1': {
         'course-catalog-info-changed':
             {'event_key_field': 'catalog_info.course_key',
-             # .. toggle_name: ENABLE_SEND_COURSE_CATALOG_INFO_CHANGED_EVENTS_OVER_BUS
+             # .. toggle_name: EVENT_BUS_PRODUCER_CONFIG['org.openedx.content_authoring.course.catalog_info.changed.v1']
+             #    ['course-catalog-info-changed']['enabled']
              # .. toggle_implementation: DjangoSetting
              # .. toggle_default: False
              # .. toggle_description: if enabled, will publish COURSE_CATALOG_INFO_CHANGED events to the event bus on
@@ -2857,6 +2857,7 @@ EVENT_BUS_PRODUCER_CONFIG = {
             {'event_key_field': 'certificate.course.course_key', 'enabled': False},
     },
 }
+
 
 derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.content_authoring.xblock.published.v1',
                          'course-authoring-xblock-lifecycle', 'enabled')

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2809,6 +2809,7 @@ def _should_send_xblock_events(settings):
     return settings.FEATURES['ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS']
 
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
+# .. setting_default: all events disabled
 # .. setting_description: Dictionary of event_types mapped to dictionaries of topic to topic-related configuration.
 #    Each topic configuration dictionary contains
 #    * `enabled`: a toggle denoting whether the event will be published to the topic. These should be annotated

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -309,6 +309,7 @@ CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:18150'
 # .. toggle_creation_date: 2023-02-21
 # .. toggle_warning: For consistency in user experience, keep the value in sync with the setting of the same name
 #   in the LMS and CMS.
+#   This will be deprecated in favor of ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS
 # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/31813'
 FEATURES['ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS'] = True
 FEATURES['ENABLE_SEND_ENROLLMENT_EVENTS_OVER_BUS'] = True

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -18,8 +18,8 @@ import django
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from edx_django_utils.plugins import add_plugins
+from openedx_events.event_bus import merge_producer_configs
 from path import Path as path
-
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 
@@ -85,6 +85,7 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
         'MKTG_URL_LINK_MAP',
         'MKTG_URL_OVERRIDES',
         'REST_FRAMEWORK',
+        'EVENT_BUS_PRODUCER_CONFIG',
     ]
     for key in KEYS_WITH_MERGED_VALUES:
         if key in __config_copy__:
@@ -670,3 +671,7 @@ COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = {
 }
 
 INACTIVE_USER_URL = f'http{"s" if HTTPS == "on" else ""}://{CMS_BASE}'
+
+############## Event bus producer ##############
+EVENT_BUS_PRODUCER_CONFIG = merge_producer_configs(EVENT_BUS_PRODUCER_CONFIG,
+                                                   ENV_TOKENS.get('EVENT_BUS_PRODUCER_CONFIG', {}))

--- a/common/djangoapps/student/handlers.py
+++ b/common/djangoapps/student/handlers.py
@@ -3,11 +3,43 @@ Handlers for student
 """
 from django.conf import settings
 from django.dispatch import receiver
+from edx_django_utils.monitoring import set_custom_attribute
 
 from openedx_events.event_bus import get_producer
 from openedx_events.learning.signals import (
     COURSE_UNENROLLMENT_COMPLETED,
 )
+import logging
+log = logging.getLogger(__name__)
+
+
+def _determine_producer_config_for_signal_and_topic(signal, topic):
+    """
+    Utility method to determine the setting for the given signal and topic in EVENT_BUS_PRODUCER_CONFIG
+
+    Records to New Relic for later analysis.
+
+    Parameters
+        signal (OpenEdxPublicSignal): The signal being sent to the event bus
+        topic (string): The topic to which the signal is being sent
+
+    Returns
+        True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
+        False if the signal is explicitly disabled for that topic in EVENT_BUS_PRODUCER_CONFIG
+        None if the signal/topic pair is not present in EVENT_BUS_PRODUCER_CONFIG
+    """
+    event_type_producer_configs = getattr(settings, "EVENT_BUS_PRODUCER_CONFIG",
+                                          {}).get(signal.event_type, {})
+    topic_config = event_type_producer_configs.get(topic, {})
+    topic_setting = topic_config.get('enabled', None)
+    if topic_setting is True:
+        set_custom_attribute('producer_config_setting', 'True')
+        return
+    if topic_setting is False:
+        set_custom_attribute('producer_config_setting', 'False')
+    if topic_setting is None:
+        set_custom_attribute('producer_config_setting', 'Unset')
+    return topic_setting
 
 
 @receiver(COURSE_UNENROLLMENT_COMPLETED)
@@ -15,10 +47,16 @@ def course_unenrollment_receiver(sender, signal, **kwargs):
     """
     Removes user notification preference when user un-enrolls from the course
     """
+    topic = getattr(settings, "EVENT_BUS_ENROLLMENT_LIFECYCLE_TOPIC", "course-unenrollment-lifecycle")
+    producer_config_setting = _determine_producer_config_for_signal_and_topic(COURSE_UNENROLLMENT_COMPLETED, topic)
+    if producer_config_setting is True:
+        log.info("Producing unenrollment-event event via config")
+        return
     if settings.FEATURES.get("ENABLE_SEND_ENROLLMENT_EVENTS_OVER_BUS"):
+        log.info("Producing unenrollment-event event via manual send")
         get_producer().send(
             signal=COURSE_UNENROLLMENT_COMPLETED,
-            topic=getattr(settings, "EVENT_BUS_ENROLLMENT_LIFECYCLE_TOPIC", "course-unenrollment-lifecycle"),
+            topic=topic,
             event_key_field='enrollment.course.course_key',
             event_data={'enrollment': kwargs.get('enrollment')},
             event_metadata=kwargs.get('metadata')

--- a/common/djangoapps/student/handlers.py
+++ b/common/djangoapps/student/handlers.py
@@ -3,38 +3,15 @@ Handlers for student
 """
 from django.conf import settings
 from django.dispatch import receiver
-from edx_django_utils.monitoring import set_custom_attribute
 
 from openedx_events.event_bus import get_producer
 from openedx_events.learning.signals import (
     COURSE_UNENROLLMENT_COMPLETED,
 )
+from openedx.core.lib.events import determine_producer_config_for_signal_and_topic
 import logging
 log = logging.getLogger(__name__)
 
-
-def _determine_producer_config_for_signal_and_topic(signal, topic):
-    """
-    Utility method to determine the setting for the given signal and topic in EVENT_BUS_PRODUCER_CONFIG
-
-    Records to New Relic for later analysis.
-
-    Parameters
-        signal (OpenEdxPublicSignal): The signal being sent to the event bus
-        topic (string): The topic to which the signal is being sent (without environment prefix)
-
-    Returns
-        True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
-        False if the signal is explicitly disabled for that topic in EVENT_BUS_PRODUCER_CONFIG
-        None if the signal/topic pair is not present in EVENT_BUS_PRODUCER_CONFIG
-    """
-    event_type_producer_configs = getattr(settings, "EVENT_BUS_PRODUCER_CONFIG",
-                                          {}).get(signal.event_type, {})
-    topic_config = event_type_producer_configs.get(topic, {})
-    topic_setting = topic_config.get('enabled', None)
-    set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
-                         topic_setting if topic_setting is not None else 'Unset')
-    return topic_setting
 
 @receiver(COURSE_UNENROLLMENT_COMPLETED)
 def course_unenrollment_receiver(sender, signal, **kwargs):
@@ -42,7 +19,7 @@ def course_unenrollment_receiver(sender, signal, **kwargs):
     Removes user notification preference when user un-enrolls from the course
     """
     topic = getattr(settings, "EVENT_BUS_ENROLLMENT_LIFECYCLE_TOPIC", "course-unenrollment-lifecycle")
-    producer_config_setting = _determine_producer_config_for_signal_and_topic(COURSE_UNENROLLMENT_COMPLETED, topic)
+    producer_config_setting = determine_producer_config_for_signal_and_topic(COURSE_UNENROLLMENT_COMPLETED, topic)
     if producer_config_setting is True:
         log.info("Producing unenrollment-event event via config")
         return

--- a/common/djangoapps/student/handlers.py
+++ b/common/djangoapps/student/handlers.py
@@ -21,7 +21,7 @@ def _determine_producer_config_for_signal_and_topic(signal, topic):
 
     Parameters
         signal (OpenEdxPublicSignal): The signal being sent to the event bus
-        topic (string): The topic to which the signal is being sent
+        topic (string): The topic to which the signal is being sent (without environment prefix)
 
     Returns
         True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
@@ -32,15 +32,9 @@ def _determine_producer_config_for_signal_and_topic(signal, topic):
                                           {}).get(signal.event_type, {})
     topic_config = event_type_producer_configs.get(topic, {})
     topic_setting = topic_config.get('enabled', None)
-    if topic_setting is True:
-        set_custom_attribute('producer_config_setting', 'True')
-        return
-    if topic_setting is False:
-        set_custom_attribute('producer_config_setting', 'False')
-    if topic_setting is None:
-        set_custom_attribute('producer_config_setting', 'Unset')
+    set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
+                         topic_setting if topic_setting is not None else 'Unset')
     return topic_setting
-
 
 @receiver(COURSE_UNENROLLMENT_COMPLETED)
 def course_unenrollment_receiver(sender, signal, **kwargs):

--- a/lms/djangoapps/certificates/config.py
+++ b/lms/djangoapps/certificates/config.py
@@ -23,6 +23,7 @@ AUTO_CERTIFICATE_GENERATION = WaffleSwitch(f"{WAFFLE_NAMESPACE}.auto_certificate
 # .. toggle_description: When True, the system will publish `CERTIFICATE_CREATED` signals to the event bus. The
 #   `CERTIFICATE_CREATED` signal is emit when a certificate has been awarded to a learner and the creation process has
 #   completed.
+# .. toggle_warning: Will be deprecated in favor of SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2023-04-11
 # .. toggle_target_removal_date: 2023-07-31
@@ -36,6 +37,7 @@ SEND_CERTIFICATE_CREATED_SIGNAL = SettingToggle('SEND_CERTIFICATE_CREATED_SIGNAL
 # .. toggle_description: When True, the system will publish `CERTIFICATE_REVOKED` signals to the event bus. The
 #   `CERTIFICATE_REVOKED` signal is emit when a certificate has been revoked from a learner and the revocation process
 #   has completed.
+# .. toggle_warning: Will be deprecated in favor of SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2023-09-15
 # .. toggle_target_removal_date: 2024-01-01

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -3,10 +3,12 @@ Signal handler for enabling/disabling self-generated certificates based on the c
 """
 
 import logging
+from django.conf import settings
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from openedx_events.event_bus import get_producer
+from edx_django_utils.monitoring import set_custom_attribute
 
 from common.djangoapps.course_modes import api as modes_api
 from common.djangoapps.student.models import CourseEnrollment
@@ -161,12 +163,47 @@ def _listen_for_enrollment_mode_change(sender, user, course_key, mode, **kwargs)
             return False
 
 
+def _determine_producer_config_for_signal_and_topic(signal, topic):
+    """
+    Utility method to determine the setting for the given signal and topic in EVENT_BUS_PRODUCER_CONFIG
+
+    Records to New Relic for later analysis.
+
+    Parameters
+        signal (OpenEdxPublicSignal): The signal being sent to the event bus
+        topic (string): The topic to which the signal is being sent
+
+    Returns
+        True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
+        False if the signal is explicitly disabled for that topic in EVENT_BUS_PRODUCER_CONFIG
+        None if the signal/topic pair is not present in EVENT_BUS_PRODUCER_CONFIG
+    """
+    event_type_producer_configs = getattr(settings, "EVENT_BUS_PRODUCER_CONFIG",
+                                          {}).get(signal.event_type, {})
+    topic_config = event_type_producer_configs.get(topic, {})
+    topic_setting = topic_config.get('enabled', None)
+    if topic_setting is True:
+        set_custom_attribute('producer_config_setting', 'True')
+    if topic_setting is False:
+        set_custom_attribute('producer_config_setting', 'False')
+    if topic_setting is None:
+        set_custom_attribute('producer_config_setting', 'Unset')
+    return topic_setting
+
+
 @receiver(CERTIFICATE_CREATED)
 def listen_for_certificate_created_event(sender, signal, **kwargs):  # pylint: disable=unused-argument
     """
     Publish `CERTIFICATE_CREATED` events to the event bus.
     """
+    # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
+    producer_config_setting = _determine_producer_config_for_signal_and_topic(CERTIFICATE_CREATED,
+                                                                              'learning-certificate-lifecycle')
+    if producer_config_setting is True:
+        log.info("Producing certificate-created event via config")
+        return
     if SEND_CERTIFICATE_CREATED_SIGNAL.is_enabled():
+        log.info("Producing certificate-created event via manual send")
         get_producer().send(
             signal=CERTIFICATE_CREATED,
             topic='learning-certificate-lifecycle',
@@ -181,7 +218,14 @@ def listen_for_certificate_revoked_event(sender, signal, **kwargs):  # pylint: d
     """
     Publish `CERTIFICATE_REVOKED` events to the event bus.
     """
+    # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
+    producer_config_setting = _determine_producer_config_for_signal_and_topic(CERTIFICATE_REVOKED,
+                                                                              'learning-certificate-lifecycle')
+    if producer_config_setting is True:
+        log.info("Producing certificate-revoked event via config")
+        return
     if SEND_CERTIFICATE_REVOKED_SIGNAL.is_enabled():
+        log.info("Producing certificate-revoked event via manual send")
         get_producer().send(
             signal=CERTIFICATE_REVOKED,
             topic='learning-certificate-lifecycle',

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -29,6 +29,7 @@ from lms.djangoapps.certificates.models import (
 from lms.djangoapps.certificates.api import auto_certificate_generation_enabled
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.content.course_overviews.signals import COURSE_PACING_CHANGED
+from openedx.core.lib.events import determine_producer_config_for_signal_and_topic
 from openedx.core.djangoapps.signals.signals import (
     COURSE_GRADE_NOW_FAILED,
     COURSE_GRADE_NOW_PASSED,
@@ -193,8 +194,8 @@ def listen_for_certificate_created_event(sender, signal, **kwargs):  # pylint: d
     Publish `CERTIFICATE_CREATED` events to the event bus.
     """
     # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
-    producer_config_setting = _determine_producer_config_for_signal_and_topic(CERTIFICATE_CREATED,
-                                                                              'learning-certificate-lifecycle')
+    producer_config_setting = determine_producer_config_for_signal_and_topic(CERTIFICATE_CREATED,
+                                                                             'learning-certificate-lifecycle')
     if producer_config_setting is True:
         log.info("Producing certificate-created event via config")
         return
@@ -215,8 +216,8 @@ def listen_for_certificate_revoked_event(sender, signal, **kwargs):  # pylint: d
     Publish `CERTIFICATE_REVOKED` events to the event bus.
     """
     # temporary: defer to EVENT_BUS_PRODUCER_CONFIG if present
-    producer_config_setting = _determine_producer_config_for_signal_and_topic(CERTIFICATE_REVOKED,
-                                                                              'learning-certificate-lifecycle')
+    producer_config_setting = determine_producer_config_for_signal_and_topic(CERTIFICATE_REVOKED,
+                                                                             'learning-certificate-lifecycle')
     if producer_config_setting is True:
         log.info("Producing certificate-revoked event via config")
         return

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -171,7 +171,7 @@ def _determine_producer_config_for_signal_and_topic(signal, topic):
 
     Parameters
         signal (OpenEdxPublicSignal): The signal being sent to the event bus
-        topic (string): The topic to which the signal is being sent
+        topic (string): The topic to which the signal is being sent (without environment prefix)
 
     Returns
         True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
@@ -182,12 +182,8 @@ def _determine_producer_config_for_signal_and_topic(signal, topic):
                                           {}).get(signal.event_type, {})
     topic_config = event_type_producer_configs.get(topic, {})
     topic_setting = topic_config.get('enabled', None)
-    if topic_setting is True:
-        set_custom_attribute('producer_config_setting', 'True')
-    if topic_setting is False:
-        set_custom_attribute('producer_config_setting', 'False')
-    if topic_setting is None:
-        set_custom_attribute('producer_config_setting', 'Unset')
+    set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
+                         topic_setting if topic_setting is not None else 'Unset')
     return topic_setting
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1039,6 +1039,18 @@ FEATURES = {
     # .. toggle_creation_date: 2022-06-06
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/29538'
     'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': False,
+
+    # .. toggle_name: SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS
+    # .. toggle_implementation: SettingToggle
+    # .. toggle_default: False
+    # .. toggle_description: When True, the system will publish certificate lifecycle signals to the event bus.
+    #    This toggle is used to create the EVENT_BUS_PRODUCER_CONFIG setting.
+    # .. toggle_warning: The default may be changed in a later release. See
+    #    https://github.com/openedx/openedx-events/issues/265
+    # .. toggle_use_cases: opt_in
+    # .. toggle_creation_date: 2023-10-10
+    # .. toggle_tickets: https://github.com/openedx/openedx-events/issues/210
+    'SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS': False
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
@@ -5386,6 +5398,73 @@ NOTIFICATION_CREATION_BATCH_SIZE = 99
 # disable indexing on date field its coming from django-simple-history.
 SIMPLE_HISTORY_DATE_INDEX = False
 
-#### Event bus publishing ####
-## Will be more filled out as part of https://github.com/edx/edx-arch-experiments/issues/381
-EVENT_BUS_PRODUCER_CONFIG = {}
+
+def _should_send_certificate_events(settings):
+    return settings.FEATURES['SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS']
+#### Event bus producing ####
+# .. setting_name: EVENT_BUS_PRODUCER_CONFIG
+# .. setting_default: {}
+# .. setting_description: Dictionary of event_types mapped to dictionaries of topic to topic-related configuration.
+#    Each topic configuration dictionary contains
+#    * `enabled`: a toggle denoting whether the event will be published to the topic. These should be annotated
+#       according to
+#       https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html
+#    * `event_key_field` which is a period-delimited string path to event data field to use as event key.
+#    Note: The topic names should not include environment prefix as it will be dynamically added based on
+#    EVENT_BUS_TOPIC_PREFIX setting.
+EVENT_BUS_PRODUCER_CONFIG = {
+    'org.openedx.learning.certificate.created.v1': {
+        'learning-certificate-lifecycle':
+            {'event_key_field': 'certificate.course.course_key', 'enabled': _should_send_certificate_events},
+    },
+    'org.openedx.learning.certificate.revoked.v1': {
+        'learning-certificate-lifecycle':
+            {'event_key_field': 'certificate.course.course_key', 'enabled': _should_send_certificate_events},
+    },
+    'org.openedx.learning.course.unenrollment.completed.v1': {
+        'course-unenrollment-lifecycle':
+            {'event_key_field': 'enrollment.course.course_key',
+             # .. toggle_name: ENABLE_SEND_COURSE_UNENROLLMENT_COMPLETED_EVENTS_OVER_BUS
+             # .. toggle_implementation: DjangoSetting
+             # .. toggle_default: False
+             # .. toggle_description: Enables sending COURSE_UNENROLLMENT_COMPLETED events over the event bus.
+             # .. toggle_use_cases: opt_in
+             # .. toggle_creation_date: 2023-09-18
+             # .. toggle_warning: The default may be changed in a later release. See
+             #   https://github.com/openedx/openedx-events/issues/265
+             # .. toggle_tickets: https://github.com/openedx/openedx-events/issues/210
+             'enabled': False},
+    },
+    'org.openedx.learning.xblock.skill.verified.v1': {
+        'learning-xblock-skill-verified':
+            {'event_key_field': 'xblock_info.usage_key',
+             # .. toggle_name: ENABLE_SEND_XBLOCK_SKILL_VERIFIED_EVENTS_OVER_BUS
+             # .. toggle_implementation: DjangoSetting
+             # .. toggle_default: False
+             # .. toggle_description: Enables sending xblock_skill_verified events over the event bus.
+             # .. toggle_use_cases: opt_in
+             # .. toggle_creation_date: 2023-09-18
+             # .. toggle_warning: The default may be changed in a later release. See
+             #   https://github.com/openedx/openedx-events/issues/265
+             # .. toggle_tickets: https://github.com/openedx/openedx-events/issues/210
+             'enabled': False}
+    },
+    # CMS events. These have to be copied over here because cms.common adds some derived entries as well,
+    # and the derivation fails if the keys are missing. If we ever remove the import of cms.common, we can remove these.
+    'org.openedx.content_authoring.xblock.published.v1': {
+        'course-authoring-xblock-lifecycle':
+            {'event_key_field': 'xblock_info.usage_key', 'enabled': False},
+    },
+    'org.openedx.content_authoring.xblock.deleted.v1': {
+        'course-authoring-xblock-lifecycle':
+            {'event_key_field': 'xblock_info.usage_key', 'enabled': False},
+    },
+    'org.openedx.content_authoring.xblock.duplicated.v1': {
+        'course-authoring-xblock-lifecycle':
+            {'event_key_field': 'xblock_info.usage_key', 'enabled': False},
+    },
+}
+derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.learning.certificate.created.v1',
+                         'learning-certificate-lifecycle', 'enabled')
+derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.learning.certificate.revoked.v1',
+                         'learning-certificate-lifecycle', 'enabled')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1040,7 +1040,7 @@ FEATURES = {
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/29538'
     'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': False,
 
-    # .. toggle_name: SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS
+    # .. toggle_name: FEATURES['SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS']
     # .. toggle_implementation: SettingToggle
     # .. toggle_default: False
     # .. toggle_description: When True, the system will publish certificate lifecycle signals to the event bus.
@@ -3316,6 +3316,7 @@ INSTALLED_APPS = [
 
     # Notifications
     'openedx.core.djangoapps.notifications',
+    'openedx_events',
 ]
 
 ######################### CSRF #########################################

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5401,9 +5401,9 @@ SIMPLE_HISTORY_DATE_INDEX = False
 
 def _should_send_certificate_events(settings):
     return settings.FEATURES['SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS']
+
 #### Event bus producing ####
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
-# .. setting_default: {}
 # .. setting_description: Dictionary of event_types mapped to dictionaries of topic to topic-related configuration.
 #    Each topic configuration dictionary contains
 #    * `enabled`: a toggle denoting whether the event will be published to the topic. These should be annotated
@@ -5424,7 +5424,8 @@ EVENT_BUS_PRODUCER_CONFIG = {
     'org.openedx.learning.course.unenrollment.completed.v1': {
         'course-unenrollment-lifecycle':
             {'event_key_field': 'enrollment.course.course_key',
-             # .. toggle_name: ENABLE_SEND_COURSE_UNENROLLMENT_COMPLETED_EVENTS_OVER_BUS
+             # .. toggle_name: EVENT_BUS_PRODUCER_CONFIG['org.openedx.learning.course.unenrollment.completed.v1']
+             #    ['course-unenrollment-lifecycle']['enabled']
              # .. toggle_implementation: DjangoSetting
              # .. toggle_default: False
              # .. toggle_description: Enables sending COURSE_UNENROLLMENT_COMPLETED events over the event bus.
@@ -5438,7 +5439,8 @@ EVENT_BUS_PRODUCER_CONFIG = {
     'org.openedx.learning.xblock.skill.verified.v1': {
         'learning-xblock-skill-verified':
             {'event_key_field': 'xblock_info.usage_key',
-             # .. toggle_name: ENABLE_SEND_XBLOCK_SKILL_VERIFIED_EVENTS_OVER_BUS
+             # .. toggle_name: EVENT_BUS_PRODUCER_CONFIG['org.openedx.learning.xblock.skill.verified.v1']
+             #    ['learning-xblock-skill-verified']['enabled']
              # .. toggle_implementation: DjangoSetting
              # .. toggle_default: False
              # .. toggle_description: Enables sending xblock_skill_verified events over the event bus.
@@ -5450,7 +5452,8 @@ EVENT_BUS_PRODUCER_CONFIG = {
              'enabled': False}
     },
     # CMS events. These have to be copied over here because cms.common adds some derived entries as well,
-    # and the derivation fails if the keys are missing. If we ever remove the import of cms.common, we can remove these.
+    # and the derivation fails if the keys are missing. If we ever fully decouple the lms and cms settings,
+    # we can remove these.
     'org.openedx.content_authoring.xblock.published.v1': {
         'course-authoring-xblock-lifecycle':
             {'event_key_field': 'xblock_info.usage_key', 'enabled': False},

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5404,6 +5404,7 @@ def _should_send_certificate_events(settings):
 
 #### Event bus producing ####
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
+# .. setting_default: all events disabled
 # .. setting_description: Dictionary of event_types mapped to dictionaries of topic to topic-related configuration.
 #    Each topic configuration dictionary contains
 #    * `enabled`: a toggle denoting whether the event will be published to the topic. These should be annotated

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -26,6 +26,7 @@ from corsheaders.defaults import default_headers as corsheaders_default_headers
 import django
 from django.core.exceptions import ImproperlyConfigured
 from edx_django_utils.plugins import add_plugins
+from openedx_events.event_bus import merge_producer_configs
 from path import Path as path
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
@@ -1133,3 +1134,7 @@ AVAILABLE_DISCUSSION_TOURS = ENV_TOKENS.get('AVAILABLE_DISCUSSION_TOURS', [])
 
 ############## NOTIFICATIONS EXPIRY ##############
 NOTIFICATIONS_EXPIRY = ENV_TOKENS.get('NOTIFICATIONS_EXPIRY', NOTIFICATIONS_EXPIRY)
+
+############## Event bus producer ##############
+EVENT_BUS_PRODUCER_CONFIG = merge_producer_configs(EVENT_BUS_PRODUCER_CONFIG,
+                                                   ENV_TOKENS.get('EVENT_BUS_PRODUCER_CONFIG', {}))

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -85,6 +85,7 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
         'MKTG_URL_LINK_MAP',
         'MKTG_URL_OVERRIDES',
         'REST_FRAMEWORK',
+        'EVENT_BUS_PRODUCER_CONFIG',
     ]
     for key in KEYS_WITH_MERGED_VALUES:
         if key in __config_copy__:

--- a/openedx/core/lib/events.py
+++ b/openedx/core/lib/events.py
@@ -25,3 +25,4 @@ def determine_producer_config_for_signal_and_topic(signal, topic):
     topic_setting = topic_config.get('enabled', None)
     set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
                          topic_setting if topic_setting is not None else 'Unset')
+    return topic_config

--- a/openedx/core/lib/events.py
+++ b/openedx/core/lib/events.py
@@ -1,0 +1,27 @@
+"""Temporary method for use in rolling out a new event producer configuration."""
+
+from django.conf import settings
+from edx_django_utils.monitoring import set_custom_attribute
+
+
+def determine_producer_config_for_signal_and_topic(signal, topic):
+    """
+    Utility method to determine the setting for the given signal and topic in EVENT_BUS_PRODUCER_CONFIG
+
+    Records to New Relic for later analysis.
+
+    Parameters
+        signal (OpenEdxPublicSignal): The signal being sent to the event bus
+        topic (string): The topic to which the signal is being sent (without environment prefix)
+
+    Returns
+        True if the signal is enabled for that topic in EVENT_BUS_PRODUCER_CONFIG
+        False if the signal is explicitly disabled for that topic in EVENT_BUS_PRODUCER_CONFIG
+        None if the signal/topic pair is not present in EVENT_BUS_PRODUCER_CONFIG
+    """
+    event_type_producer_configs = getattr(settings, "EVENT_BUS_PRODUCER_CONFIG",
+                                          {}).get(signal.event_type, {})
+    topic_config = event_type_producer_configs.get(topic, {})
+    topic_setting = topic_config.get('enabled', None)
+    set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
+                         topic_setting if topic_setting is not None else 'Unset')

--- a/openedx/core/lib/events.py
+++ b/openedx/core/lib/events.py
@@ -25,4 +25,4 @@ def determine_producer_config_for_signal_and_topic(signal, topic):
     topic_setting = topic_config.get('enabled', None)
     set_custom_attribute(f'producer_config_setting_{topic}_{signal.event_type}',
                          topic_setting if topic_setting is not None else 'Unset')
-    return topic_config
+    return topic_setting


### PR DESCRIPTION
This PR replaces https://github.com/openedx/edx-platform/pull/32874 and https://github.com/openedx/edx-platform/pull/33269

## Description

Update edx-platform to use the new event bus producer configuration format specified in openedx-events@9.0.0. In order to better control the rollout, we are doing an expand-contract. For this PR, all manual sends in the lms and cms will first check to see if the new configuration is present for the given event/topic combination. If the event/topic is enabled in the new configuration, the manual send will not occur. Otherwise the logic for the manual send will continue as before.

How we use the new config is a little complex in order to account for a few use cases:
1. Multiple events being enabled/disabled as a group. This is useful for multiple events that go on a single lifecycle topic. To accomplish that, we add the config to derived_settings so the `enabled` flags of the relevant events can be set according to the value of a single feature flag. 
2. Enabling/disabling a single known event from yml. To accomplish this, we add the config to KEYS_WITH_MERGED_VALUES and call `merge_producer_configs` from openedx-events to combine the base config and the yml config. This means that operators don't need to copy over the whole configuration from edx-platform to enable/disable a single event while keeping everything else the same as the base config.



## Supporting information

Roll out plan: https://openedx.atlassian.net/wiki/spaces/AC/pages/3886120980/Rollout+plan+for+publish-via-config

GH isssue: https://github.com/edx/edx-arch-experiments/issues/381

## Testing instructions

We can test by firing all the relevant events on stage and making sure nothing is duplicated or lost.

Tested locally to the best of my ability by trying to fire CMS events with combinations of both the old ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS flag and the new config. I was unable to figure out how to fire the LMS events locally but am reasonably confident they will behave the same.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

