### PR TITLE
feat: adds endpoint for downloading the taxonomy templates [FC-0036]

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/urls.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/urls.py
@@ -6,7 +6,10 @@ from rest_framework.routers import DefaultRouter
 
 from django.urls.conf import path, include
 
-from openedx_tagging.core.tagging.rest_api.v1 import views as oel_tagging_views
+from openedx_tagging.core.tagging.rest_api.v1 import (
+    views as oel_tagging_views,
+    views_import as oel_tagging_views_import,
+)
 
 from . import views
 
@@ -15,5 +18,10 @@ router.register("taxonomies", views.TaxonomyOrgView, basename="taxonomy")
 router.register("object_tags", oel_tagging_views.ObjectTagView, basename="object_tag")
 
 urlpatterns = [
+    path(
+        "taxonomies/import/template.<str:file_ext>",
+        oel_tagging_views_import.TemplateView.as_view(),
+        name="taxonomy-import-template",
+    ),
     path('', include(router.urls))
 ]


### PR DESCRIPTION
## Description

This PR adds a Studio endpoint for downloading the CSV and JSON templates added to oel_tagging by https://github.com/openedx/openedx-learning/pull/89

Will be used by Taxonomy Admins/Course Authors once the Taxonomy Admin UI is built.

## Supporting information

Closes https://github.com/openedx/modular-learning/issues/137
Private-ref: [FAL-3520](https://tasks.opencraft.com/browse/FAL-3520)

## Testing instructions

Using this branch in your devstack's `cms-shell`:

1. Update requirements: `paver install_prereqs`
1. Update migrations: `./manage.py lms migrate`
2. Download the template files:
    http://localhost:18010/api/content_tagging/v1/taxonomies/import/template.csv
    http://localhost:18010/api/content_tagging/v1/taxonomies/import/template.json
3. Check that the files download as expected.

## Deadline

None