### PR TITLE
build: kickoff the Quince release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,3 @@
-<!--
-
-🌴🌴
-🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
-    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
-🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
-🌴🌴
-
-Please give your pull request a short but descriptive title.
-Use conventional commits to separate and summarize commits logically:
-https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html
-
-Use this template as a guide. Omit sections that don't apply.
-You may link to information rather than copy it, but only if the link is publicly
-readable.  If you must linked information must be private (because it has secrets),
-clearly label the link as private.
-
--->
-
 ## Description
 
 Describe what this pull request changes, and why. Include implications for people using this change.

--- a/.tx/config
+++ b/.tx/config
@@ -67,3 +67,14 @@ source_file = conf/locale/en/LC_MESSAGES/wiki.po
 source_lang = en
 type        = PO
 
+[o:open-edx:p:open-edx-releases:r:release-quince]
+file_filter = conf/locale/<lang>/LC_MESSAGES/django.po
+source_file = conf/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type = PO
+
+[o:open-edx:p:open-edx-releases:r:release-quince-js]
+file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs.po
+source_file = conf/locale/en/LC_MESSAGES/djangojs.po
+source_lang = en
+type = PO

--- a/openedx/core/release.py
+++ b/openedx/core/release.py
@@ -8,7 +8,7 @@ import unittest
 # The release line: an Open edX release name ("ficus"), or "master".
 # This should always be "master" on the master branch, and will be changed
 # manually when we start release-line branches, like open-release/ficus.master.
-RELEASE_LINE = "master"
+RELEASE_LINE = "quince"
 
 
 def doc_version():


### PR DESCRIPTION
This kicks off the Quince release!

We follow the instructions from:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release