### PR TITLE
fix: library ref management cmds course id call

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/replace_v1_lib_refs_with_v2_in_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/replace_v1_lib_refs_with_v2_in_courses.py
@@ -34,8 +34,7 @@ class Command(BaseCommand):
     def replace_all_library_source_blocks_ids(self, v1_to_v2_lib_map):
         """A method to replace 'source_library_id' in all relevant blocks."""
 
-        courses = CourseOverview.get_all_courses()
-        course_id_strings = [str(course.id) for course in courses]
+        course_id_strings = CourseOverview.get_all_course_keys()
 
         # Use Celery to distribute the workload
         tasks = group(
@@ -58,8 +57,7 @@ class Command(BaseCommand):
 
     def validate(self, v1_to_v2_lib_map):
         """ Validate that replace_all_library_source_blocks_ids was successful"""
-        courses = CourseOverview.get_all_courses()
-        course_id_strings = [str(course.id) for course in courses]
+        course_id_strings = CourseOverview.get_all_course_keys()
         tasks = group(validate_all_library_source_blocks_ids_for_course.s(course_id, v1_to_v2_lib_map) for course_id in course_id_strings)  # lint-amnesty, pylint: disable=line-too-long
         results = tasks.apply_async()
 
@@ -81,8 +79,7 @@ class Command(BaseCommand):
 
     def undo(self, v1_to_v2_lib_map):
         """ undo the changes made by replace_all_library_source_blocks_ids"""
-        courses = CourseOverview.get_all_courses()
-        course_id_strings = [str(course.id) for course in courses]
+        course_id_strings = CourseOverview.get_all_course_keys()
 
         # Use Celery to distribute the workload
         tasks = group(


### PR DESCRIPTION
This should fixes the error `AttributeError: 'str' object has no attribute 'id'` when running `replace_v1_lib_refs_with_v2_in_courses`