### PR TITLE
Update DRF endpoints to use default authentication

### DIFF
--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -164,7 +164,6 @@ class BasketOrderView(APIView):
     Retrieve the order associated with a basket.
     """
 
-    authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, *_args, **kwargs):

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -9,7 +9,6 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import HTTPError
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.status import HTTP_406_NOT_ACCEPTABLE, HTTP_409_CONFLICT
 from rest_framework.views import APIView

--- a/lms/djangoapps/support/views/feature_based_enrollments.py
+++ b/lms/djangoapps/support/views/feature_based_enrollments.py
@@ -43,6 +43,9 @@ class FeatureBasedEnrollmentSupportAPIView(GenericAPIView):
     Support-only API View for getting feature based enrollment configuration details
     for a course.
     """
+    authentication_classes = (
+        JwtAuthentication, SessionAuthentication
+    )
     permission_classes = (IsAuthenticated,)
 
     @method_decorator(require_support_permission)

--- a/lms/djangoapps/support/views/feature_based_enrollments.py
+++ b/lms/djangoapps/support/views/feature_based_enrollments.py
@@ -43,9 +43,6 @@ class FeatureBasedEnrollmentSupportAPIView(GenericAPIView):
     Support-only API View for getting feature based enrollment configuration details
     for a course.
     """
-    authentication_classes = (
-        JwtAuthentication, SessionAuthentication
-    )
     permission_classes = (IsAuthenticated,)
 
     @method_decorator(require_support_permission)

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -31,7 +31,6 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     """
     DRF class for interacting with the User ORM object
     """
-    authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (ApiKeyHeaderPermission,)
     queryset = User.objects.all().prefetch_related("preferences").select_related("profile")
     serializer_class = UserSerializer
@@ -43,7 +42,6 @@ class ForumRoleUsersListView(generics.ListAPIView):
     """
     Forum roles are represented by a list of user dicts
     """
-    authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (ApiKeyHeaderPermission,)
     serializer_class = UserSerializer
     paginate_by = 10
@@ -67,7 +65,6 @@ class UserPreferenceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     DRF class for interacting with the UserPreference ORM
     """
-    authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (ApiKeyHeaderPermission,)
     queryset = UserPreference.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -81,7 +78,6 @@ class PreferenceUsersListView(generics.ListAPIView):
     """
     DRF class for listing a user's preferences
     """
-    authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (ApiKeyHeaderPermission,)
     serializer_class = UserSerializer
     paginate_by = 10

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -10,7 +10,7 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx import locator
 from opaque_keys.edx.keys import CourseKey
-from rest_framework import authentication, generics, status, viewsets
+from rest_framework import generics, status, viewsets
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView


### PR DESCRIPTION
**Description**

In this PR i update all API views that explicitly accept only SessionAuth to use the DEFAULT_AUTHENTICATION_CLASSES instead.

Ticket: https://github.com/orgs/openedx/projects/55/views/1?pane=issue&itemId=39276438
