### PR TITLE
fix: Disable reset button until an answer is submitted.

### DIFF
--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -40,7 +40,7 @@ from openedx.core.djangolib.markup import HTML
           </button>
       </span>
       % endif
-      % if reset_button:
+      % if attempts_used and reset_button:
       <span class="problem-action-button-wrapper">
           <button type="button" class="reset problem-action-btn btn-link btn-small" data-value="${_('Reset')}"><span aria-hidden="true">${_('Reset')}</span><span class="sr">${_("Reset your answer")}</span></button>
       </span>


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Reset button should not be visible before a learner has attempted a problem, this MR solves the issue by adding an additional check for attempts used which defaults to 0, when user has not submitted any option. Thus, if attempts used is > 0 (True) meaning user has submitted some answer, the reset button becomes available. 

## Supporting information

Private-ref: [BB-7991](https://tasks.opencraft.com/browse/BB-7991)

TNL-10645

## Testing instructions

Steps to reproduce:

    As an instructor, go to a unit.
    Click to add a problem.
    Select any problem.
    In the advanced settings of problem on the sidebar, select "True" for "Reset".
    Save and publish your problem.

As a learner, go to that problem.

**Desired / expected behavior:**
As a learner, I will not see a "Reset" button until I have clicked on an answer option and submitted it.

**Actual behavior:**
As a learner, I see a "Reset" button even if I have not yet interacted with the problem.

ACs: when course author selects "true" for "reset", student must have answered the question before the "reset" button is visible.