### PR TITLE
fix: limited staff cohorts and gradebook access [BB-7962]

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -93,9 +93,16 @@ def get_user_permissions(user, course_key, org=None):
         return all_perms
     if course_key and user_has_role(user, CourseInstructorRole(course_key)):
         return all_perms
-    # Limited Course Staff does not have access to Studio.
+    # HACK: Limited Staff should not have studio read access. However, since many LMS views depend on the
+    #  `has_course_author_access` check and `course_author_access_required` decorator, we have to allow write access
+    #  until the permissions become more granular. For example, there could be STUDIO_VIEW_COHORTS and
+    #  STUDIO_EDIT_COHORTS specifically for the cohorts endpoint, which is used to display the "Cohorts" tab of the
+    #  Instructor Dashboard.
+    #  The permissions matrix from the RBAC project (https://github.com/openedx/platform-roadmap/issues/246) shows that
+    #  the LMS and Studio permissions will be separated as a part of this project. Once this is done (and this code is
+    #  not removed during its implementation), we can replace the Limited Staff permissions with more granular ones.
     if course_key and user_has_role(user, CourseLimitedStaffRole(course_key)):
-        return STUDIO_NO_PERMISSIONS
+        return STUDIO_EDIT_CONTENT
     # Staff have all permissions except EDIT_ROLES:
     if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
         return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -285,14 +285,14 @@ class CourseGroupTest(TestCase):
         with pytest.raises(PermissionDenied):
             remove_users(self.staff, CourseStaffRole(self.course_key), another_staff)
 
-    def test_no_limited_staff_read_or_write_access(self):
+    def test_limited_staff_no_studio_read_access(self):
         """
-        Test that course limited staff have no read or write access.
+        Verifies that course limited staff have no read, but have write access.
         """
         add_users(self.global_admin, CourseLimitedStaffRole(self.course_key), self.limited_staff)
 
         assert not has_studio_read_access(self.limited_staff, self.course_key)
-        assert not has_studio_write_access(self.limited_staff, self.course_key)
+        assert has_studio_write_access(self.limited_staff, self.course_key)
 
 
 class CourseOrgGroupTest(TestCase):


### PR DESCRIPTION
## Description

`http://<LMS>/courses/<COURSE_KEY>/cohorts/` responds with 404 status code for users with Limited Staff role. This breaks "Cohorts" instructor dashboard tab, it's just empty.

It happens due to this check:
https://github.com/openedx/edx-platform/blob/bef05ab6649fe9dd7e04f05c445b5cc006c4cd97/openedx/core/djangoapps/course_groups/views.py#L175-L176
https://github.com/openedx/edx-platform/blob/bef05ab6649fe9dd7e04f05c445b5cc006c4cd97/common/djangoapps/student/auth.py#L125-L129
https://github.com/openedx/edx-platform/blob/bef05ab6649fe9dd7e04f05c445b5cc006c4cd97/common/djangoapps/student/auth.py#L109-L122

So currently this endpoint requires Studio write permissions for both GET and POST requests. Unfortunately, the story is the same for many other endpoints that are necessary for LMS, at least: `SubsectionGradeView`, `CourseGradingView`, `GradebookView`, `GradebookBulkUpdateView`.

A proper solution would be to leave Limited Staff without any Studio access and expand this list with new flags:
https://github.com/openedx/edx-platform/blob/bef05ab6649fe9dd7e04f05c445b5cc006c4cd97/common/djangoapps/student/auth.py#L29-L35

However, in this case we'd have to add more decorators like `course_author_access_required` and / or do some refactoring. I don't know whether it's feasible giving the upcoming RBAC.

## Testing instructions

1. Create a user with "Limited Staff" course team access role.
2. Open the "Cohorts" instructor dashboard tab. You should see a checkbox there.