### PR TITLE
feat: FC-0012 - add atlas pull behind a flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,9 @@ COPY . .
 # Install Python requirements again in order to capture local projects
 RUN pip install -e .
 
+# Setting edx-platform directory as safe for git commands
+RUN git config --global --add safe.directory /edx/app/edxapp/edx-platform
+
 # Production target
 FROM base as production
 

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ push_translations: ## push source strings to Transifex for translation
 
 pull_translations:  ## pull translations from Transifex
 	git clean -fdX conf/locale
+ifeq ($(OPENEDX_ATLAS_PULL),)
 	i18n_tool transifex pull
 	i18n_tool extract
 	i18n_tool dummy
@@ -65,6 +66,12 @@ pull_translations:  ## pull translations from Transifex
 	git clean -fdX conf/locale/eo
 	i18n_tool validate --verbose
 	paver i18n_compilejs
+else
+	find conf/locale -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
+	atlas pull $(OPENEDX_ATLAS_ARGS) translations/edx-platform/conf/locale:conf/locale
+	i18n_tool generate
+	paver i18n_compilejs
+endif
 
 
 detect_changed_source_translations: ## check if translation files are up-to-date


### PR DESCRIPTION
(atlas pull) will be performed only if `OPENEDX_ATLAS_PULL` environment variable is set

### Tests:

- [x] in devstack, lms-shell: `OPENEDX_ATLAS_PULL=yes make pull_translations` is working fine
- [x] in devstack, lms-shell: `OPENEDX_ATLAS_PULL=yes make pull_translations` is deleting old translations and pulling the latest translations

### Note:

I had to run the following command in the container before the test
```
git config --global --add safe.directory /edx/app/edxapp/edx-platform
```

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For XBlocks:**
 - The standard translation path must be `conf/locale`. Therefore, we are creating a link from `conf/locale` to `translations` so Atlas can find the path without disrupting the current way of having translations locally within the XBlocks
 - [openedx-translations](https://github.com/openedx/openedx-translations) will have a related PR that adds the XBlock to the pipeline. This will not affect the current way of managing/updating translations
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo within the version bump
 - A notification for the community will be published to ensure that everyone knows why translations directories are removed from all repos