### PR TITLE
fix: add missing target_username attribute to discussion thread followed event

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1878,14 +1878,15 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
 
         assert mock_emit.called
         event_name, event_data = mock_emit.call_args[0]
-        action_name = 'followed' if view_name == 'follow_thread' else 'unfollowed'
+        expected_action_name = 'followed' if view_name == 'follow_thread' else 'unfollowed'
         expected_action_value = True if view_name == 'follow_thread' else False
-        assert event_name == f'edx.forum.thread.{action_name}'
+        assert event_name == f'edx.forum.thread.{expected_action_name}'
         assert event_data['commentable_id'] == 'test_commentable_id'
         assert event_data['id'] == 'thread_id'
         assert event_data['followed'] == expected_action_value
         assert event_data['user_forums_roles'] == ['Student']
         assert event_data['user_course_roles'] == ['Wizard']
+        assert event_data['target_username'] == ['test_user']
 
 
 class UsersEndpointTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -145,6 +145,8 @@ def track_thread_followed_event(request, course, thread, followed):
         'id': thread.id,
         'followed': followed,
     }
+    if hasattr(thread, 'username'):
+        event_data['target_username'] = thread.get('username', '')
     track_forum_event(request, event_name, course, thread, event_data)
 
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2747,6 +2747,7 @@ class UpdateThreadTest(
             assert event_data['id'] == 'test_thread'
             assert event_data['followed'] == new_following
             assert event_data['user_forums_roles'] == ['Student']
+            assert event_data['target_username'] == [self.user.username]
 
     @ddt.data(*itertools.product([True, False], [True, False]))
     @ddt.unpack


### PR DESCRIPTION
### [INF-1047](https://2u-internal.atlassian.net/browse/INF-1047)

### Description

Add missing `target_username` field to followed/unfollowed event for discussion thread.