### PR TITLE
feat: Add url that exposes taxonomy tags CRUD API

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -339,7 +339,7 @@ urlpatterns += [
 
 # Content tagging
 urlpatterns += [
-    path('api/content_tagging/', include(('openedx.core.djangoapps.content_tagging.urls'))),
+    path('api/content_tagging/', include(('openedx.core.djangoapps.content_tagging.urls', 'content_tagging'))),
 ]
 
 # studio-content-api specific API docs (using drf-spectacular and openapi-v3)

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/urls.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/urls.py
@@ -7,6 +7,7 @@ from rest_framework.routers import DefaultRouter
 from django.urls.conf import path, include
 
 from openedx_tagging.core.tagging.rest_api.v1 import (
+    views as oel_tagging_views,
     views_import as oel_tagging_views_import,
 )
 
@@ -17,6 +18,11 @@ router.register("taxonomies", views.TaxonomyOrgView, basename="taxonomy")
 router.register("object_tags", views.ObjectTagOrgView, basename="object_tag")
 
 urlpatterns = [
+    path(
+        "taxonomies/<str:pk>/tags/",
+        oel_tagging_views.TaxonomyTagsView.as_view(),
+        name="taxonomy-tags",
+    ),
     path(
         "taxonomies/import/template.<str:file_ext>",
         oel_tagging_views_import.TemplateView.as_view(),

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -121,7 +121,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.2.5
+openedx-learning==0.2.6
 
 # lti-consumer-xblock 9.6.2 contains a breaking change that makes
 # existing custom parameter configurations unusable.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -785,7 +785,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.2.5
+openedx-learning==0.2.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1318,7 +1318,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.2.5
+openedx-learning==0.2.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -925,7 +925,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.2.5
+openedx-learning==0.2.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -992,7 +992,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.2.5
+openedx-learning==0.2.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This PR exposes the CRUD API for Taxonomy Tags implemented in 

## Supporting information

Related tickets:
- Depends on https://github.com/openedx/openedx-learning/pull/96

## Testing instructions

1. Run this branch in your local devstack
2. Make sure you have some sample/test taxonomy data populated in your db, you generate some by following the instructions from this repo: https://github.com/open-craft/taxonomy-sample-data
3. Check that the endpoint is available, example:
    1. You should be able to access the tags of a taxonomy by going to the following URL (replace PK with an actual PK): http://localhost:18010/api/content_tagging/v1/taxonomies/[PK]/tags/

---
Private-ref: [FAL-3519](https://tasks.opencraft.com/browse/FAL-3519)