### PR TITLE
Unpin tox, tox-battery and pytest-metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,8 @@ $(COMMON_CONSTRAINTS_TXT):
 
 compile-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade
 compile-requirements: pre-requirements $(COMMON_CONSTRAINTS_TXT) ## Re-compile *.in requirements to *.txt
+	sed 's/tox<4.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	@# Bootstrapping: Rebuild pip and pip-tools first, and then install them
 	@# so that if there are any failures we'll know now, rather than the next
 	@# time someone tries to use the outputs.
@@ -143,9 +145,7 @@ $(COMMON_CONSTRAINTS_TXT):
 	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
 	echo "$(COMMON_CONSTRAINTS_TEMP_COMMENT)" | cat - $(@) > temp && mv temp $(@)
 
-upgrade: $(COMMON_CONSTRAINTS_TXT) ## update the pip requirements files to use the latest releases satisfying our constraints
-	sed 's/tox<4.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
-	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+upgrade:  ## update the pip requirements files to use the latest releases satisfying our constraints
 	$(MAKE) compile-requirements COMPILE_OPTS="--upgrade"
 
 upgrade-package: ## update just one package to the latest usable release

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,15 @@ compile-requirements: pre-requirements $(COMMON_CONSTRAINTS_TXT) ## Re-compile *
 		export REBUILD=''; \
 	done
 
-upgrade:  ## update the pip requirements files to use the latest releases satisfying our constraints
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+	echo "$(COMMON_CONSTRAINTS_TEMP_COMMENT)" | cat - $(@) > temp && mv temp $(@)
+
+upgrade: $(COMMON_CONSTRAINTS_TXT) ## update the pip requirements files to use the latest releases satisfying our constraints
+	sed 's/tox<4.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	$(MAKE) compile-requirements COMPILE_OPTS="--upgrade"
 
 upgrade-package: ## update just one package to the latest usable release

--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,6 @@ compile-requirements: pre-requirements $(COMMON_CONSTRAINTS_TXT) ## Re-compile *
 		export REBUILD=''; \
 	done
 
-COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
-.PHONY: $(COMMON_CONSTRAINTS_TXT)
-$(COMMON_CONSTRAINTS_TXT):
-	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
-	echo "$(COMMON_CONSTRAINTS_TEMP_COMMENT)" | cat - $(@) > temp && mv temp $(@)
-
 upgrade:  ## update the pip requirements files to use the latest releases satisfying our constraints
 	$(MAKE) compile-requirements COMPILE_OPTS="--upgrade"
 

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -27,4 +27,4 @@ elasticsearch<7.14.0
 
 # tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
 # Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0
+

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -79,13 +79,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
-boto3==1.28.65
+boto3==1.28.66
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.65
+botocore==1.31.66
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -1084,7 +1084,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==3.3.0
+snowflake-connector-python==3.3.1
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -79,13 +79,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
-boto3==1.28.62
+boto3==1.28.64
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.64
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -169,7 +169,7 @@ cryptography==38.0.4
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.7.1
+cssutils==2.9.0
     # via pynliner
 defusedxml==0.7.1
     # via
@@ -265,7 +265,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via -r requirements/edx/kernel.in
 django-countries==7.5.1
     # via
@@ -323,7 +323,7 @@ django-mptt==0.14.0
     #   openedx-django-wiki
 django-multi-email-field==0.7.0
     # via edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via -r requirements/edx/kernel.in
 django-oauth-toolkit==1.7.1
     # via
@@ -452,7 +452,7 @@ edx-django-release-util==1.3.0
     #   -r requirements/edx/kernel.in
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/kernel.in
 edx-django-utils==5.7.0
     # via
@@ -520,7 +520,7 @@ edx-proctoring==4.16.1
     #   edx-proctoring-proctortrack
 edx-rbac==1.8.0
     # via edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -841,7 +841,7 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.39
     # via click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
@@ -1015,7 +1015,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/kernel.in
     #   social-auth-core
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   jsonschema
     #   referencing
@@ -1040,7 +1040,7 @@ scipy==1.7.3
     #   openedx-calc
 semantic-version==2.10.0
     # via edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via -r requirements/edx/kernel.in
 simplejson==3.19.2
     # via
@@ -1084,7 +1084,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==3.2.1
+snowflake-connector-python==3.3.0
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via
@@ -1221,7 +1221,7 @@ xblock[django]==1.8.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.2.1
     # via -r requirements/edx/bundled.in
 xblock-google-drive==0.4.0
     # via -r requirements/edx/bundled.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -79,13 +79,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
-boto3==1.28.64
+boto3==1.28.65
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.64
+botocore==1.31.65
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -793,7 +793,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==5.5.5
+ora2==5.5.6
     # via -r requirements/edx/bundled.in
 oscrypto==1.3.0
     # via snowflake-connector-python
@@ -1161,7 +1161,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.txt

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -8,7 +8,7 @@ chardet==5.2.0
     # via diff-cover
 coverage==7.3.2
     # via -r requirements/edx/coverage.in
-diff-cover==7.7.0
+diff-cover==8.0.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.2
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -151,14 +151,14 @@ boto==2.39.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.28.65
+boto3==1.28.66
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.65
+botocore==1.31.66
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -596,7 +596,7 @@ django-stubs==1.16.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
     #   djangorestframework-stubs
-django-stubs-ext==4.2.2
+django-stubs-ext==4.2.5
     # via django-stubs
 django-user-tasks==3.1.0
     # via
@@ -906,11 +906,11 @@ execnet==2.0.2
     #   pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.txt
-faker==19.10.0
+faker==19.11.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.103.2
+fastapi==0.104.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -959,7 +959,7 @@ gitdb==4.0.10
     # via
     #   -r requirements/edx/doc.txt
     #   gitpython
-gitpython==3.1.38
+gitpython==3.1.40
     # via -r requirements/edx/doc.txt
 glob2==0.7
     # via
@@ -1903,7 +1903,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==3.3.0
+snowflake-connector-python==3.3.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -151,14 +151,14 @@ boto==2.39.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.28.64
+boto3==1.28.65
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.64
+botocore==1.31.65
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1242,7 +1242,7 @@ multidict==6.0.4
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.6.0
+mypy==1.6.1
     # via
     #   -r requirements/edx/development.in
     #   django-stubs
@@ -1344,7 +1344,7 @@ optimizely-sdk==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==5.5.5
+ora2==5.5.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1635,7 +1635,7 @@ pytest-django==4.5.2
     # via -r requirements/edx/testing.txt
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.txt
-pytest-metadata==1.8.0
+pytest-metadata==3.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-json-report
@@ -2126,7 +2126,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -118,6 +118,7 @@ backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   backports-zoneinfo
     #   celery
     #   icalendar
     #   kombu
@@ -136,6 +137,7 @@ bleach[css]==6.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   bleach
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-django-wiki
@@ -149,14 +151,14 @@ boto==2.39.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.28.62
+boto3==1.28.64
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.64
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -170,6 +172,10 @@ build==1.0.3
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   pip-tools
+cachetools==5.3.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   tox
 celery==5.3.4
     # via
     #   -c requirements/edx/../constraints.txt
@@ -204,6 +210,7 @@ chardet==5.2.0
     #   -r requirements/edx/testing.txt
     #   diff-cover
     #   pysrt
+    #   tox
 charset-normalizer==2.0.12
     # via
     #   -c requirements/edx/../constraints.txt
@@ -268,6 +275,10 @@ codejail-includes==1.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+colorama==0.4.6
+    # via
+    #   -r requirements/edx/testing.txt
+    #   tox
 coreapi==2.3.3
     # via
     #   -r requirements/edx/doc.txt
@@ -282,6 +293,7 @@ coreschema==0.0.4
 coverage[toml]==7.3.2
     # via
     #   -r requirements/edx/testing.txt
+    #   coverage
     #   pytest-cov
 crowdsourcehinter-xblock==0.6
     # via
@@ -305,7 +317,7 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
-cssutils==2.7.1
+cssutils==2.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -329,7 +341,7 @@ deprecated==1.2.14
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jwcrypto
-diff-cover==7.7.0
+diff-cover==8.0.0
     # via -r requirements/edx/testing.txt
 dill==0.3.7
     # via
@@ -440,7 +452,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -522,7 +534,7 @@ django-multi-email-field==0.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -720,7 +732,7 @@ edx-django-release-util==1.3.0
     #   -r requirements/edx/testing.txt
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -792,6 +804,7 @@ edx-opaque-keys[django]==2.5.1
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-milestones
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-when
@@ -812,7 +825,7 @@ edx-rbac==1.8.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -893,7 +906,7 @@ execnet==2.0.2
     #   pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.txt
-faker==19.9.0
+faker==19.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -946,13 +959,13 @@ gitdb==4.0.10
     # via
     #   -r requirements/edx/doc.txt
     #   gitpython
-gitpython==3.1.37
+gitpython==3.1.38
     # via -r requirements/edx/doc.txt
 glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-grimp==3.0
+grimp==3.1
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
@@ -1350,6 +1363,7 @@ packaging==23.2
     #   gunicorn
     #   py2neo
     #   pydata-sphinx-theme
+    #   pyproject-api
     #   pytest
     #   snowflake-connector-python
     #   sphinx
@@ -1417,6 +1431,7 @@ platformdirs==3.11.0
     #   -r requirements/edx/testing.txt
     #   pylint
     #   snowflake-connector-python
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -1434,17 +1449,13 @@ prompt-toolkit==3.0.39
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
     #   pact-python
     #   pytest-xdist
-py==1.11.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   tox
 py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
@@ -1513,6 +1524,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
+    #   pyjwt
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core
@@ -1584,6 +1596,10 @@ pyparsing==3.1.1
     #   -r requirements/edx/testing.txt
     #   chem
     #   openedx-calc
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/edx/../pip-tools.txt
@@ -1626,7 +1642,9 @@ pytest-metadata==1.8.0
 pytest-randomly==3.15.0
     # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==3.3.1
-    # via -r requirements/edx/testing.txt
+    # via
+    #   -r requirements/edx/testing.txt
+    #   pytest-xdist
 python-dateutil==2.8.2
     # via
     #   -r requirements/edx/doc.txt
@@ -1766,7 +1784,8 @@ rfc3986[idna2008]==1.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   httpx
-rpds-py==0.10.4
+    #   rfc3986
+rpds-py==0.10.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1815,7 +1834,7 @@ semantic-version==2.10.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1863,7 +1882,6 @@ six==1.16.0
     #   python-dateutil
     #   python-memcached
     #   sphinxcontrib-httpdomain
-    #   tox
 slumber==0.7.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1885,7 +1903,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==3.2.1
+snowflake-connector-python==3.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1959,7 +1977,9 @@ sphinxcontrib-jsmath==1.0.1
     #   -r requirements/edx/doc.txt
     #   sphinx
 sphinxcontrib-openapi[markdown]==0.8.1
-    # via -r requirements/edx/doc.txt
+    # via
+    #   -r requirements/edx/doc.txt
+    #   sphinxcontrib-openapi
 sphinxcontrib-qthelp==1.0.3
     # via
     #   -r requirements/edx/doc.txt
@@ -2032,6 +2052,7 @@ tomli==2.0.1
     #   mypy
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
@@ -2041,12 +2062,7 @@ tomlkit==0.12.1
     #   -r requirements/edx/testing.txt
     #   pylint
     #   snowflake-connector-python
-tox==3.28.0
-    # via
-    #   -c requirements/edx/../common_constraints.txt
-    #   -r requirements/edx/testing.txt
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.3
     # via -r requirements/edx/testing.txt
 tqdm==4.66.1
     # via
@@ -2207,10 +2223,11 @@ xblock[django]==1.8.1
     #   lti-consumer-xblock
     #   ora2
     #   staff-graded-xblock
+    #   xblock
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -107,13 +107,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.65
+boto3==1.28.66
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.65
+botocore==1.31.66
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -685,7 +685,7 @@ geoip2==4.7.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.38
+gitpython==3.1.40
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
@@ -1290,7 +1290,7 @@ smmap==5.0.1
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.3.0
+snowflake-connector-python==3.3.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -80,6 +80,7 @@ backoff==1.10.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/base.txt
+    #   backports-zoneinfo
     #   celery
     #   icalendar
     #   kombu
@@ -95,6 +96,7 @@ billiard==4.1.0
 bleach[css]==6.1.0
     # via
     #   -r requirements/edx/base.txt
+    #   bleach
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-django-wiki
@@ -105,13 +107,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.62
+boto3==1.28.64
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.64
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -210,7 +212,7 @@ cryptography==38.0.4
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.7.1
+cssutils==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
@@ -318,7 +320,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via -r requirements/edx/base.txt
 django-countries==7.5.1
     # via
@@ -384,7 +386,7 @@ django-multi-email-field==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
@@ -528,7 +530,7 @@ edx-django-release-util==1.3.0
     #   -r requirements/edx/base.txt
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/base.txt
 edx-django-utils==5.7.0
     # via
@@ -583,6 +585,7 @@ edx-opaque-keys[django]==2.5.1
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-milestones
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-when
@@ -599,7 +602,7 @@ edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -682,7 +685,7 @@ geoip2==4.7.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.37
+gitpython==3.1.38
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
@@ -1000,7 +1003,7 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1048,6 +1051,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
+    #   pyjwt
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core
@@ -1200,7 +1204,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -1237,7 +1241,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via -r requirements/edx/base.txt
 simplejson==3.19.2
     # via
@@ -1286,7 +1290,7 @@ smmap==5.0.1
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.2.1
+snowflake-connector-python==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1483,10 +1487,11 @@ xblock[django]==1.8.1
     #   lti-consumer-xblock
     #   ora2
     #   staff-graded-xblock
+    #   xblock
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.2.1
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.4.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -107,13 +107,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.64
+boto3==1.28.65
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.64
+botocore==1.31.65
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -936,7 +936,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.5.5
+ora2==5.5.6
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via
@@ -1422,7 +1422,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -54,7 +54,7 @@ stevedore==5.1.0
     #   edx-opaque-keys
 typing-extensions==4.8.0
     # via edx-opaque-keys
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -30,7 +30,7 @@ paver==1.3.4
     # via -r requirements/edx/paver.in
 pbr==5.11.1
     # via stevedore
-psutil==5.9.5
+psutil==5.9.6
     # via -r requirements/edx/paver.in
 pymemcache==4.0.0
     # via -r requirements/edx/paver.in

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -54,7 +54,7 @@ mdurl==0.1.2
     # via markdown-it-py
 packaging==23.2
     # via semgrep
-peewee==3.16.3
+peewee==3.17.0
     # via semgrep
 pkgutil-resolve-name==1.3.10
     # via jsonschema
@@ -70,7 +70,7 @@ requests==2.31.0
     # via semgrep
 rich==13.6.0
     # via semgrep
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   jsonschema
     #   referencing
@@ -78,7 +78,7 @@ ruamel-yaml==0.17.35
     # via semgrep
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-semgrep==1.43.0
+semgrep==1.44.0
     # via -r requirements/edx/semgrep.in
 tomli==2.0.1
     # via semgrep

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -88,7 +88,7 @@ typing-extensions==4.8.0
     #   semgrep
 ujson==5.8.0
     # via python-lsp-jsonrpc
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -78,7 +78,7 @@ ruamel-yaml==0.17.35
     # via semgrep
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-semgrep==1.44.0
+semgrep==1.45.0
     # via -r requirements/edx/semgrep.in
 tomli==2.0.1
     # via semgrep

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -45,7 +45,6 @@ selenium                  # Browser automation library, used for acceptance test
 singledispatch            # Backport of functools.singledispatch from Python 3.4+, used in tests of XBlock rendering
 testfixtures              # Provides a LogCapture utility used by several tests
 tox                       # virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes
 unidiff                   # Required by coverage_pytest_plugin
 pylint-pytest==0.3.0      # A Pylint plugin to suppress pytest-related false positives.
 pact-python               # Library for contract testing

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -38,7 +38,7 @@ pytest-attrib             # Select tests based on attributes
 pytest-cov                # pytest plugin for measuring code coverage
 pytest-django             # Django support for pytest
 pytest-json-report        # Output json formatted warnings after running pytest
-pytest-metadata==1.8.0     # To prevent 'make upgrade' failure, dependency of pytest-json-report
+pytest-metadata
 pytest-randomly           # pytest plugin to randomly order tests
 pytest-xdist[psutil]      # Parallel execution of tests on multiple CPU cores or hosts
 selenium                  # Browser automation library, used for acceptance tests

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -38,7 +38,6 @@ pytest-attrib             # Select tests based on attributes
 pytest-cov                # pytest plugin for measuring code coverage
 pytest-django             # Django support for pytest
 pytest-json-report        # Output json formatted warnings after running pytest
-pytest-metadata
 pytest-randomly           # pytest plugin to randomly order tests
 pytest-xdist[psutil]      # Parallel execution of tests on multiple CPU cores or hosts
 selenium                  # Browser automation library, used for acceptance tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -114,13 +114,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.64
+boto3==1.28.65
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.64
+botocore==1.31.65
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1008,7 +1008,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.5.5
+ora2==5.5.6
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via
@@ -1226,7 +1226,7 @@ pytest-django==4.5.2
     # via -r requirements/edx/testing.in
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.in
-pytest-metadata==1.8.0
+pytest-metadata==3.0.0
     # via
     #   -r requirements/edx/testing.in
     #   pytest-json-report
@@ -1563,7 +1563,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -85,6 +85,7 @@ backoff==1.10.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/base.txt
+    #   backports-zoneinfo
     #   celery
     #   icalendar
     #   kombu
@@ -100,6 +101,7 @@ billiard==4.1.0
 bleach[css]==6.1.0
     # via
     #   -r requirements/edx/base.txt
+    #   bleach
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-django-wiki
@@ -112,19 +114,21 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.62
+boto3==1.28.64
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.64
     # via
     #   -r requirements/edx/base.txt
     #   boto3
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
+cachetools==5.3.1
+    # via tox
 celery==5.3.4
     # via
     #   -c requirements/edx/../constraints.txt
@@ -156,6 +160,7 @@ chardet==5.2.0
     #   -r requirements/edx/coverage.txt
     #   diff-cover
     #   pysrt
+    #   tox
 charset-normalizer==2.0.12
     # via
     #   -c requirements/edx/../constraints.txt
@@ -205,6 +210,8 @@ code-annotations==1.5.0
     #   edx-toggles
 codejail-includes==1.0.0
     # via -r requirements/edx/base.txt
+colorama==0.4.6
+    # via tox
 coreapi==2.3.3
     # via
     #   -r requirements/edx/base.txt
@@ -237,7 +244,7 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
-cssutils==2.7.1
+cssutils==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
@@ -254,7 +261,7 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/base.txt
     #   jwcrypto
-diff-cover==7.7.0
+diff-cover==8.0.0
     # via -r requirements/edx/coverage.txt
 dill==0.3.7
     # via pylint
@@ -351,7 +358,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via -r requirements/edx/base.txt
 django-countries==7.5.1
     # via
@@ -417,7 +424,7 @@ django-multi-email-field==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
@@ -555,7 +562,7 @@ edx-django-release-util==1.3.0
     #   -r requirements/edx/base.txt
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/base.txt
 edx-django-utils==5.7.0
     # via
@@ -613,6 +620,7 @@ edx-opaque-keys[django]==2.5.1
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-milestones
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-when
@@ -629,7 +637,7 @@ edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -689,7 +697,7 @@ execnet==2.0.2
     # via pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.in
-faker==19.9.0
+faker==19.10.0
     # via factory-boy
 fastapi==0.103.2
     # via pact-python
@@ -728,7 +736,7 @@ geoip2==4.7.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-grimp==3.0
+grimp==3.1
     # via import-linter
 gunicorn==21.2.0
     # via -r requirements/edx/base.txt
@@ -1012,6 +1020,7 @@ packaging==23.2
     #   drf-yasg
     #   gunicorn
     #   py2neo
+    #   pyproject-api
     #   pytest
     #   snowflake-connector-python
     #   tox
@@ -1060,6 +1069,7 @@ platformdirs==3.11.0
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -1076,14 +1086,12 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
     #   pact-python
     #   pytest-xdist
-py==1.11.0
-    # via tox
 py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
@@ -1132,6 +1140,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
+    #   pyjwt
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core
@@ -1186,6 +1195,8 @@ pyparsing==3.1.1
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc
+pyproject-api==1.6.1
+    # via tox
 pyquery==2.0.0
     # via -r requirements/edx/testing.in
 pyrsistent==0.19.3
@@ -1333,8 +1344,10 @@ requests-oauthlib==1.3.1
     #   -r requirements/edx/base.txt
     #   social-auth-core
 rfc3986[idna2008]==1.5.0
-    # via httpx
-rpds-py==0.10.4
+    # via
+    #   httpx
+    #   rfc3986
+rpds-py==0.10.6
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -1375,7 +1388,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via -r requirements/edx/base.txt
 simplejson==3.19.2
     # via
@@ -1417,7 +1430,6 @@ six==1.16.0
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
-    #   tox
 slumber==0.7.1
     # via
     #   -r requirements/edx/base.txt
@@ -1429,7 +1441,7 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-snowflake-connector-python==3.2.1
+snowflake-connector-python==3.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1499,6 +1511,7 @@ tomli==2.0.1
     #   coverage
     #   import-linter
     #   pylint
+    #   pyproject-api
     #   pytest
     #   tox
 tomlkit==0.12.1
@@ -1506,12 +1519,7 @@ tomlkit==0.12.1
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
-tox==3.28.0
-    # via
-    #   -c requirements/edx/../common_constraints.txt
-    #   -r requirements/edx/testing.in
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.3
     # via -r requirements/edx/testing.in
 tqdm==4.66.1
     # via
@@ -1627,10 +1635,11 @@ xblock[django]==1.8.1
     #   lti-consumer-xblock
     #   ora2
     #   staff-graded-xblock
+    #   xblock
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.2.1
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.4.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -114,13 +114,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.65
+boto3==1.28.66
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.65
+botocore==1.31.66
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -697,9 +697,9 @@ execnet==2.0.2
     # via pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.in
-faker==19.10.0
+faker==19.11.0
     # via factory-boy
-fastapi==0.103.2
+fastapi==0.104.0
     # via pact-python
 fastavro==1.8.4
     # via
@@ -1227,9 +1227,7 @@ pytest-django==4.5.2
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.in
 pytest-metadata==3.0.0
-    # via
-    #   -r requirements/edx/testing.in
-    #   pytest-json-report
+    # via pytest-json-report
 pytest-randomly==3.15.0
     # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==3.3.1
@@ -1441,7 +1439,7 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-snowflake-connector-python==3.3.0
+snowflake-connector-python==3.3.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.41.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.2.1
+pip==23.3
     # via -r requirements/pip.in
 setuptools==68.2.2
     # via -r requirements/pip.in

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -12,5 +12,5 @@ idna==3.4
     # via requests
 requests==2.31.0
     # via -r scripts/xblock/requirements.in
-urllib3==2.0.6
+urllib3==2.0.7
     # via requests


### PR DESCRIPTION
**Description:**
We [pinned tox](https://github.com/openedx/edx-lint/blob/master/edx_lint/files/common_constraints.txt#L25-L27) back in December because the 4.0.0 release broke most of our CI runs. It has been resolved by now, so we should attempt to remove this pin. I have removed `tox` and `tox-battery` and `pytest-metadata` pins.

Issue: https://github.com/openedx/edx-lint/issues/336