### PR TITLE
test: run ./xmodule/ tests with CMS settings too

### DIFF
--- a/.github/workflows/unit-test-shards.json
+++ b/.github/workflows/unit-test-shards.json
@@ -78,7 +78,7 @@
       "lms/tests.py"
     ]
   },
-  "openedx-1": {
+  "openedx-1-with-lms": {
     "settings": "lms.envs.test",
     "paths": [
       "openedx/core/djangoapps/ace_common/",
@@ -116,7 +116,7 @@
       "openedx/core/djangoapps/external_user_ids/"
     ]
   },
-  "openedx-2": {
+  "openedx-2-with-lms": {
     "settings": "lms.envs.test",
     "paths": [
       "openedx/core/djangoapps/geoinfo/",
@@ -159,7 +159,7 @@
       "openedx/tests/"
     ]
   },
-  "openedx-3": {
+  "openedx-1-with-cms": {
     "settings": "cms.envs.test",
     "paths": [
       "openedx/core/djangoapps/ace_common/",
@@ -197,7 +197,7 @@
       "openedx/core/djangoapps/external_user_ids/"
     ]
   },
-  "openedx-4": {
+  "openedx-2-with-cms": {
     "settings": "cms.envs.test",
     "paths": [
       "openedx/core/djangoapps/content_tagging/",
@@ -258,20 +258,26 @@
       "cms/djangoapps/contentstore/"
     ]
   },
-  "common-1": {
+  "common-with-lms": {
     "settings": "lms.envs.test",
     "paths": [
       "common/djangoapps/"
     ]
   },
-  "common-2": {
+  "common-with-cms": {
     "settings": "cms.envs.test",
     "paths": [
       "common/djangoapps/"
     ]
   },
-  "xmodule-1": {
+  "xmodule-with-lms": {
     "settings": "lms.envs.test",
+    "paths": [
+      "xmodule/"
+    ]
+  },
+  "xmodule-with-cms": {
+    "settings": "cms.envs.test",
     "paths": [
       "xmodule/"
     ]

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -26,15 +26,16 @@ jobs:
           - "lms-4"
           - "lms-5"
           - "lms-6"
-          - "openedx-1"
-          - "openedx-2"
-          - "openedx-3"
-          - "openedx-4"
+          - "openedx-1-with-lms"
+          - "openedx-2-with-lms"
+          - "openedx-1-with-cms"
+          - "openedx-2-with-cms"
           - "cms-1"
           - "cms-2"
-          - "common-1"
-          - "common-2"
-          - "xmodule-1"
+          - "common-with-lms"
+          - "common-with-cms"
+          - "xmodule-with-lms"
+          - "xmodule-with-cms"
     name: gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,15 +27,16 @@ jobs:
           - "lms-4"
           - "lms-5"
           - "lms-6"
-          - "openedx-1"
-          - "openedx-2"
-          - "openedx-3"
-          - "openedx-4"
+          - "openedx-1-with-lms"
+          - "openedx-2-with-lms"
+          - "openedx-1-with-cms"
+          - "openedx-2-with-cms"
           - "cms-1"
           - "cms-2"
-          - "common-1"
-          - "common-2"
-          - "xmodule-1"
+          - "common-with-lms"
+          - "common-with-cms"
+          - "xmodule-with-lms"
+          - "xmodule-with-cms"
     # We expect Django 4.0 to fail, so don't stop when it fails.
     continue-on-error: ${{ matrix.django-version == '4.0' }}
 

--- a/xmodule/capa/tests/test_xqueue_interface.py
+++ b/xmodule/capa/tests/test_xqueue_interface.py
@@ -8,9 +8,11 @@ from django.test.utils import override_settings
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.fields import ScopeIds
 
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.capa.xqueue_interface import XQueueInterface, XQueueService
 
 
+@skip_unless_lms
 class XQueueServiceTest(TestCase):
     """Test the XQueue service methods."""
     def setUp(self):

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -29,6 +29,7 @@ from xblock.fields import ScopeIds
 from xblock.scorable import Score
 
 import xmodule
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.capa import responsetypes
 from xmodule.capa.correctmap import CorrectMap
 from xmodule.capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
@@ -182,6 +183,7 @@ if submission[0] == '':
 
 
 @ddt.ddt
+@skip_unless_lms
 class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     def setUp(self):
@@ -2898,6 +2900,7 @@ class ComplexEncoderTest(unittest.TestCase):  # lint-amnesty, pylint: disable=mi
         # ignore quotes
 
 
+@skip_unless_lms
 class ProblemCheckTrackingTest(unittest.TestCase):
     """
     Ensure correct tracking information is included in events emitted during problem checks.


### PR DESCRIPTION
Currently, ./xmodule/ unit tests are only run with LMS settings. However, ./common/ and ./xmodule/ are run twice: once with LMS settings and once with CMS settings.

Just like ./common/ and ./openedx/, the unit tests in ./xmodule/ validate behavior in both LMS and CMS. So, order to fully test ./xmodule/, we should to run its tests with CMS settings too.

This will enable us to better validate certain LibraryContentBlocks behaviors being touched by https://github.com/openedx/edx-platform/pull/33263 which can't be expressed under LMS settings.

Also in this commit:

* refactor: rename the shards to be clear whether they're running under LMS or CMS.
* docs: correct comments regarding conditions under which codejail's test_cant_do_something_forbidden is skipped.

* test: update a unit test which was using the now-deleted block to use library_content block instead.

Before and after merging, I will update branch protection settings to account for the shard changes.