### PR TITLE
build: Only build and push ci-runner Docker image on origin repo

### DIFF
--- a/.github/workflows/publish-ci-docker-image.yml
+++ b/.github/workflows/publish-ci-docker-image.yml
@@ -13,6 +13,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # This has to happen after checkout in order for gh to work.
+      - name: "Cancel scheduled job on forks"
+        if: github.repository != 'openedx/edx-platform' && github.event_name == 'schedule'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh run cancel "${{ github.run_id }}"
+          gh run watch "${{ github.run_id }}"
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
I get a weekly CI failure email due to this scheduled workflow running on my fork of edx-platform. Cancelling the job when it runs on a fork prevents this.
