### PR TITLE
feat: added sender_id to notification generated events

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -52,6 +52,7 @@ class DiscussionNotificationSender:
                 "replier_name": self.creator.username,
                 "post_title": self.thread.title,
                 "course_name": self.course.display_name,
+                "sender_id": self.creator.id,
                 **extra_context,
             },
             notification_type=notification_type,

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -307,6 +307,7 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'replier_name': self.user_2.username,
             'post_title': 'test thread',
             'course_name': self.course.display_name,
+            'sender_id': self.user_2.id
         }
         self.assertDictEqual(args.context, expected_context)
         self.assertEqual(
@@ -344,6 +345,7 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'post_title': self.thread.title,
             'author_name': 'dummy\'s',
             'course_name': self.course.display_name,
+            'sender_id': self.user_3.id
         }
         self.assertDictEqual(args_comment.context, expected_context)
         self.assertEqual(
@@ -359,6 +361,7 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'replier_name': self.user_3.username,
             'post_title': self.thread.title,
             'course_name': self.course.display_name,
+            'sender_id': self.user_3.id
         }
         self.assertDictEqual(args_comment_on_response.context, expected_context)
         self.assertEqual(
@@ -404,6 +407,7 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'post_title': self.thread.title,
             'author_name': 'your',
             'course_name': self.course.display_name,
+            'sender_id': self.user_3.id,
         }
         self.assertDictEqual(args_comment.context, expected_context)
         self.assertEqual(
@@ -440,6 +444,7 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'replier_name': self.user_2.username,
             'post_title': 'test thread',
             'course_name': self.course.display_name,
+            'sender_id': self.user_2.id,
         }
         if parent_id:
             expected_context['author_name'] = 'dummy'

--- a/openedx/core/djangoapps/notifications/events.py
+++ b/openedx/core/djangoapps/notifications/events.py
@@ -62,7 +62,8 @@ def notification_preferences_viewed_event(request, course_id):
         )
 
 
-def notification_generated_event(user_ids, app_name, notification_type, course_key, content_url, content):
+def notification_generated_event(user_ids, app_name, notification_type, course_key,
+                                 content_url, content, sender_id=None):
     """
     Emit an event when a notification is generated.
     """
@@ -78,6 +79,7 @@ def notification_generated_event(user_ids, app_name, notification_type, course_k
         'notification_app': app_name,
         'content_url': content_url,
         'notification_content': content,
+        'sender_id': sender_id,
     }
     with tracker.get_tracker().context(NOTIFICATION_GENERATED, context):
         tracker.emit(

--- a/openedx/core/djangoapps/notifications/tasks.py
+++ b/openedx/core/djangoapps/notifications/tasks.py
@@ -97,6 +97,7 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
 
     notifications_generated = False
     notification_content = ''
+    sender_id = context.pop('sender_id', None)
     default_web_config = get_default_values_of_preference(app_name, notification_type).get('web', True)
     for batch_user_ids in get_list_in_batches(user_ids, batch_size):
         # check if what is preferences of user and make decision to send notification or not
@@ -146,6 +147,7 @@ def send_notifications(user_ids, course_key: str, app_name, notification_type, c
         if notifications_generated:
             notification_generated_event(
                 batch_user_ids, app_name, notification_type, course_key, content_url, notification_content,
+                sender_id=sender_id
             )
 
 


### PR DESCRIPTION
Added `sender_id` field to notification generated event

Ticket Link: [INF-1097](https://2u-internal.atlassian.net/browse/INF-1097)