### PR TITLE
chore: rename files and uploads page

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -7,7 +7,7 @@
   from openedx.core.djangolib.markup import HTML, Text
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>
-<%block name="title">${_("Files & Uploads")}</%block>
+<%block name="title">${_("Files")}</%block>
 <%block name="bodyclass">is-signedin course uploads view-uploads</%block>
 
 <%namespace name='static' file='static_content.html'/>
@@ -25,7 +25,7 @@
     <header class="mast has-actions has-subtitle">
         <h2 class="page-header">
             <small class="subtitle">${_("Content")}</small>
-            <span class="sr">- </span>${_("Files & Uploads")}
+            <span class="sr">- </span>${_("Files")}
         </h2>
     </header>
 </div>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -125,12 +125,12 @@
                   % endif
                   %if not files_uploads_mfe_enabled:
                   <li class="nav-item nav-course-courseware-uploads">
-                    <a href="${assets_url}">${_("Files & Uploads")}</a>
+                    <a href="${assets_url}">${_("Files")}</a>
                   </li>
                   %endif
                   %if files_uploads_mfe_enabled:
                   <li class="nav-item nav-course-courseware-uploads">
-                    <a href="${get_files_uploads_url(course_key)}">${_("Files & Uploads")}</a>
+                    <a href="${get_files_uploads_url(course_key)}">${_("Files")}</a>
                   </li>
                   %endif
                   % if not pages_and_resources_mfe_enabled:


### PR DESCRIPTION
Apparently, at least how it was in the past, nothing further needs to be done to get translations updated.