### PR TITLE
Use Open edX as a noun on the default Open edX homepage

### DIFF
--- a/lms/templates/index_overlay.html
+++ b/lms/templates/index_overlay.html
@@ -6,5 +6,5 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <h1>${Text(_(u"Welcome to {platform_name}")).format(platform_name=settings.PLATFORM_NAME)}</h1>
-## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See https://open.edx.org for more information.
-<p>${Text(_("It works! Powered by Open edX{registered_trademark}")).format(registered_trademark=HTML("<sup style='font-size: 65%'>&reg;</sup>"))}</p>
+## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See https://openedx.org for more information.
+<p>${Text(_("It works! Powered by the Open edX{registered_trademark} Platform")).format(registered_trademark=HTML("<sup style='font-size: 65%'>&reg;</sup>"))}</p>


### PR DESCRIPTION
@nedbat or @feanil any thoughts on making this change?