### PR TITLE
chore: update content_tagging for compatibility with new openedx-learning [FC-0036]

### DIFF
--- a/openedx/core/djangoapps/content_tagging/tests/test_api.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_api.py
@@ -210,7 +210,12 @@ class TestAPITaxonomy(TestTaxonomyMixin, TestCase):
         assert valid_tags[0].id == object_tag.id
 
     def test_get_tags(self):
-        assert api.get_tags(self.taxonomy_all_orgs) == [self.tag_all_orgs]
+        result = list(api.get_tags(self.taxonomy_all_orgs))
+        assert len(result) == 1
+        assert result[0]["value"] == self.tag_all_orgs.value
+        assert result[0]["_id"] == self.tag_all_orgs.id
+        assert result[0]["parent_value"] is None
+        assert result[0]["depth"] == 0
 
     def test_cannot_tag_across_orgs(self):
         """

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -121,7 +121,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.2.6
+openedx-learning==0.3.0
 
 # lti-consumer-xblock 9.6.2 contains a breaking change that makes
 # existing custom parameter configurations unusable.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -785,7 +785,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.2.6
+openedx-learning==0.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1318,7 +1318,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.2.6
+openedx-learning==0.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -925,7 +925,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.2.6
+openedx-learning==0.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -992,7 +992,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.2.6
+openedx-learning==0.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This updates edx-platform to be compatible with the changes I made to how tags are retrieved from taxonomies in https://github.com/openedx/openedx-learning/pull/92 . The actual changes required are trivial, just updating one test.

## Supporting information

See linked PR for details of this change, which makes the APIs for retrieving tags from a taxonomy much more flexible and optimized.

## Testing instructions

Just run the tests.

## Deadline

None

## Other information

- [x] Version bump needs to happen first in openedx-learning