### PR TITLE
feat: allow to prefetch xblock aside fields

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -784,7 +784,18 @@ class FieldDataCache:
         for block in blocks:
             for field in block.fields.values():
                 scope_map[field.scope].add(field)
-        return scope_map
+
+        try:
+            block = blocks[0]
+            from openedx.core.lib.xblock_utils import get_aside_from_xblock  # pylint: disable=import-outside-toplevel
+            for aside in self.asides:
+                xblock_aside = get_aside_from_xblock(block, aside)
+                for field in xblock_aside.fields.values():
+                    scope_map[field.scope].add(field)
+            return scope_map
+        except IndexError:
+            # No blocks to cache
+            return scope_map
 
     def get(self, key):
         """


### PR DESCRIPTION
## Description

This PR fixes a compatibility issue between XBlockAside and the scope `user_summary_state` in which the fields of the asides were not cached.

This PR updates the implementation of the `field_to_cache` method to also read aside fields information

## Testing instructions

- Install feedbackxblock as an editable requirement and add checkout this PR: https://github.com/openedx/FeedbackXBlock/pull/31 (it creates an aside for the feedback xblock)
- Go to the admin and enable XBlock Asides in http://local.overhang.io:8000/admin/lms_xblock/xblockasidesconfig/
- Before this change, the XBlock runtime will try to create a record in the courseware user summary table and will succeed the first time and fail in later attempts as the record already exists and it's not found in the cache.
- After this change, the XBlock runtime will be able to cache the fields and all requests will work.

Author concern: After this fix, another issue was raised about invalid scopes after using the handlers. This makes me question if is this was the right approach and this contribution requires a different approach
