### PR TITLE
[FC-0036] feat: Display Units Taxonomy Tags in drawer

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -45,7 +45,12 @@ from xmodule.video_block import VideoBlock
 
 from cms.djangoapps.contentstore.config import waffle
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, get_url, parse_json
-from cms.djangoapps.contentstore.utils import delete_course, reverse_course_url, reverse_url
+from cms.djangoapps.contentstore.utils import (
+    delete_course,
+    reverse_course_url,
+    reverse_url,
+    get_taxonomy_tags_widget_url,
+)
 from cms.djangoapps.contentstore.views.component import ADVANCED_COMPONENT_TYPES
 from common.djangoapps.course_action_state.managers import CourseActionStateItemNotFoundError
 from common.djangoapps.course_action_state.models import CourseRerunState, CourseRerunUIStateManager
@@ -1410,12 +1415,16 @@ class ContentStoreTest(ContentStoreTestCase):
             'assets_handler',
             course.location.course_key
         )
+
+        taxonomy_tags_widget_url = get_taxonomy_tags_widget_url(course.id)
+
         self.assertContains(
             resp,
-            '<article class="outline outline-complex outline-course" data-locator="{locator}" data-course-key="{course_key}" data-course-assets="{assets_url}">'.format(  # lint-amnesty, pylint: disable=line-too-long
+            '<article class="outline outline-complex outline-course" data-locator="{locator}" data-course-key="{course_key}" data-course-assets="{assets_url}" data-taxonomy-tags-widget-url="{taxonomy_tags_widget_url}" >'.format(  # lint-amnesty, pylint: disable=line-too-long
                 locator=str(course.location),
                 course_key=str(course.id),
                 assets_url=assets_url,
+                taxonomy_tags_widget_url=taxonomy_tags_widget_url,
             ),
             status_code=200,
             html=True

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -446,6 +446,21 @@ def get_taxonomy_list_url():
     return taxonomy_list_url
 
 
+def get_taxonomy_tags_widget_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for taxonomy tags drawer widget view.
+
+    The `content_id` needs to be appended to the end of the URL when using it.
+    """
+    taxonomy_tags_widget_url = None
+    # Uses the same waffle flag as taxonomy list page
+    if use_tagging_taxonomy_list_page():
+        mfe_base_url = get_course_authoring_url(course_locator)
+        if mfe_base_url:
+            taxonomy_tags_widget_url = f'{mfe_base_url}/tagging/components/widget/'
+    return taxonomy_tags_widget_url
+
+
 def course_import_olx_validation_is_enabled():
     """
     Check if course olx validation is enabled on course import.

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -105,6 +105,7 @@ from ..utils import (
     get_lms_link_for_item,
     get_proctored_exam_settings_url,
     get_course_outline_url,
+    get_taxonomy_tags_widget_url,
     get_studio_home_url,
     get_updates_url,
     get_advanced_settings_url,
@@ -688,6 +689,7 @@ def course_index(request, course_key):
             'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_block.id),
             'advance_settings_url': reverse_course_url('advanced_settings_handler', course_block.id),
             'proctoring_errors': proctoring_errors,
+            'taxonomy_tags_widget_url': get_taxonomy_tags_widget_url(course_block.id),
         })
 
 

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -38,7 +38,7 @@ from xblock.core import XBlock
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
-from cms.djangoapps.contentstore.toggles import ENABLE_COPY_PASTE_UNITS
+from cms.djangoapps.contentstore.toggles import ENABLE_COPY_PASTE_UNITS, use_tagging_taxonomy_list_page
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.lib.ai_aside_summary_config import AiAsideSummaryConfig
 from common.djangoapps.edxmako.services import MakoService
@@ -1396,6 +1396,10 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
 
             # If the ENABLE_COPY_PASTE_UNITS feature flag is enabled, we show the newer menu that allows copying/pasting
             xblock_info["enable_copy_paste_units"] = ENABLE_COPY_PASTE_UNITS.is_enabled()
+
+            # If the ENABLE_TAGGING_TAXONOMY_LIST_PAGE feature flag is enabled, we show the "Manage Tags" options
+            if use_tagging_taxonomy_list_page():
+                xblock_info["use_tagging_taxonomy_list_page"] = True
 
             xblock_info[
                 "has_partition_group_components"

--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -487,7 +487,7 @@ function(
             $(drawerCover).css('display', 'block');
             // xss-lint: disable=javascript-jquery-html
             $(drawer).html(
-                `<iframe src="${taxonomyTagsWidgetUrl}${contentId}" frameborder="0" style="width: 100%; height: 100%;"></iframe>`
+                `<iframe src="${taxonomyTagsWidgetUrl}${contentId}" onload="this.contentWindow.focus()" frameborder="0" style="width: 100%; height: 100%;"></iframe>`
             );
             $(drawer).css('display', 'block');
 

--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -458,6 +458,43 @@ function(
             event.stopPropagation();
         },
 
+        closeManageTagsDrawer(drawer, drawerCover) {
+            $(drawerCover).css('display', 'none');
+            $(drawer).empty();
+            $(drawer).css('display', 'none');
+            $('body').removeClass('drawer-open');
+        },
+
+        openManageTagsDrawer(event) {
+            const drawer = document.querySelector("#manage-tags-drawer");
+            const drawerCover = document.querySelector(".drawer-cover")
+            const article = document.querySelector('[data-taxonomy-tags-widget-url]');
+            const taxonomyTagsWidgetUrl = $(article).attr('data-taxonomy-tags-widget-url');
+            const contentId = this.model.get('id');
+
+            // Add handler to close drawer when dark background is clicked
+            $(drawerCover).click(function() {
+                this.closeManageTagsDrawer(drawer, drawerCover);
+            }.bind(this));
+
+            // Add event listen to close drawer when close button is clicked from within the Iframe
+            window.addEventListener("message", function (event) {
+                if (event.data === 'closeManageTagsDrawer') {
+                    this.closeManageTagsDrawer(drawer, drawerCover)
+                }
+            }.bind(this));
+
+            $(drawerCover).css('display', 'block');
+            // xss-lint: disable=javascript-jquery-html
+            $(drawer).html(
+                `<iframe src="${taxonomyTagsWidgetUrl}${contentId}" frameborder="0" style="width: 100%; height: 100%;"></iframe>`
+            );
+            $(drawer).css('display', 'block');
+
+            // Prevent background from being scrollable when drawer is open
+            $('body').addClass('drawer-open');
+        },
+
         addButtonActions: function(element) {
             XBlockOutlineView.prototype.addButtonActions.apply(this, arguments);
             element.find('.configure-button').click(function(event) {
@@ -477,6 +514,10 @@ function(
             element.find('.copy-button').click((event) => {
                 event.preventDefault();
                 this.copyXBlock();
+            });
+            element.find('.manage-tags-button').click((event) => {
+                event.preventDefault();
+                this.openManageTagsDrawer();
             });
             element.find('.paste-component-button').click((event) => {
                 event.preventDefault();

--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -114,6 +114,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, XBlockStringFieldE
                 staffOnlyMessage: this.model.get('staff_only_message'),
                 course: course,
                 enableCopyPasteUnits: this.model.get("enable_copy_paste_units"), // ENABLE_COPY_PASTE_UNITS waffle flag
+                useTaggingTaxonomyListPage: this.model.get("use_tagging_taxonomy_list_page"), // ENABLE_TAGGING_TAXONOMY_LIST_PAGE waffle flag
             };
         },
 

--- a/cms/static/sass/_build-v1.scss
+++ b/cms/static/sass/_build-v1.scss
@@ -55,6 +55,7 @@
 @import 'elements/uploaded-assets'; // layout for asset tables
 @import 'elements/creative-commons';
 @import 'elements/tooltip';
+@import 'elements/drawer';
 
 // +Base - Specific Views
 // ====================

--- a/cms/static/sass/elements/_drawer.scss
+++ b/cms/static/sass/elements/_drawer.scss
@@ -1,0 +1,30 @@
+// studio - elements - side drawers
+// ====================
+
+.drawer-cover {
+  @extend %ui-depth3;
+
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.drawer {
+  @extend %ui-depth4;
+
+  display: none;
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 33.33vw;
+  height: 100vh;
+  background-color: $gray-l4;
+}
+
+body.drawer-open {
+  overflow: hidden;
+}

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -281,7 +281,7 @@ from django.urls import reverse
                 assets_url = reverse('assets_handler', kwargs={'course_key_string': str(course_locator.course_key)})
                 %>
                 <h2 class="sr">${_("Course Outline")}</h2>
-                <article class="outline outline-complex outline-course" data-locator="${course_locator}" data-course-key="${course_locator.course_key}" data-course-assets="${assets_url}">
+                <article class="outline outline-complex outline-course" data-locator="${course_locator}" data-course-key="${course_locator.course_key}" data-course-assets="${assets_url}" data-taxonomy-tags-widget-url="${taxonomy_tags_widget_url}">
                 </article>
             </div>
             <div class="ui-loading">
@@ -321,4 +321,7 @@ from django.urls import reverse
         </aside>
     </section>
 </div>
+
+<div id="manage-tags-drawer" class="drawer"></div>
+<div class="drawer-cover"></div>
 </%block>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -169,6 +169,17 @@ if (is_proctored_exam) {
                         </a>
                     </li>
                 <% } %>
+
+                <% if (xblockInfo.isVertical() && typeof useTaggingTaxonomyListPage !== "undefined" && useTaggingTaxonomyListPage) { %>
+                    <li class="action-item">
+                        <a href="#" data-tooltip="<%- gettext('Manage Tags') %>" class="manage-tags-button action-button">
+                            <span class="icon fa fa-tag" aria-hidden="true"></span>
+                            <span>?</span>
+                            <span class="sr action-button-text"><%- gettext('Manage Tags') %></span>
+                        </a>
+                    </li>
+                <% } %>
+
                 <% if (typeof enableCopyPasteUnits !== "undefined" && enableCopyPasteUnits) { %>
                     <!--
                         If the ENABLE_COPY_PASTE_UNITS feature flag is enabled, all these actions (besides "Publish")
@@ -192,9 +203,11 @@ if (is_proctored_exam) {
                                         <li class="nav-item">
                                             <a class="copy-button" href="#" role="button"><%- gettext('Copy to Clipboard') %></a>
                                         </li>
-                                        <li class="nav-item">
-                                            <a class="manage-tags-button" href="#" role="button"><%- gettext('Manage Tags') %></a>
-                                        </li>
+                                        <% if (typeof useTaggingTaxonomyListPage !== "undefined" && useTaggingTaxonomyListPage) { %>
+                                            <li class="nav-item">
+                                                <a class="manage-tags-button" href="#" role="button"><%- gettext('Manage Tags') %></a>
+                                            </li>
+                                        <% } %>
                                     <% } %>
                                     <% if (xblockInfo.isDuplicable()) { %>
                                         <li class="nav-item">

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -192,6 +192,9 @@ if (is_proctored_exam) {
                                         <li class="nav-item">
                                             <a class="copy-button" href="#" role="button"><%- gettext('Copy to Clipboard') %></a>
                                         </li>
+                                        <li class="nav-item">
+                                            <a class="manage-tags-button" href="#" role="button"><%- gettext('Manage Tags') %></a>
+                                        </li>
                                     <% } %>
                                     <% if (xblockInfo.isDuplicable()) { %>
                                         <li class="nav-item">


### PR DESCRIPTION
## Description

This adds "Manage Tags" action in the units' dropdown that opens up a side drawer containing an iframe to the course authoring mfe that will handle the taxonomy tags UI for the unit.

Clicking outside the side drawer or on the x in the iframe closes the side drawer.

## Supporting information

Related Tickets:
- https://github.com/openedx/modular-learning/issues/118

Related PRs:
- https://github.com/openedx/frontend-app-course-authoring/pull/654

## Testing instructions

1. Make sure you have the [frontend-app-course-authoring](https://github.com/openedx/frontend-app-course-authoring/) repo cloned and checkout the branch of this PR https://github.com/openedx/frontend-app-course-authoring/pull/654
2. Start the frontend-app-course-authoring with `npm start`
3. Checkout this PRs branch and run it in your devstack
4. If you don't already have sample taxonomy/tags data, follow the instructions in this repo to generate sample data: https://github.com/open-craft/taxonomy-sample-data
5. Navigate to studio to one of the sample course created in from the previous step: http://localhost:18010/course/course-v1:SampleTaxonomyOrg1+STC1+2023_1 
6. Locate a unit in the course outline page, and confirm that the there is no tags button showing in either the actions dropdown or next to it
7. Next, navigate to http://localhost:18010/admin/waffle/flag/ and create a new flag: `new_studio_mfe.use_tagging_taxonomy_list_page` make sure it is active for everyone
8. Navigate back to the course outline page, refresh it, you should see the tags button with a question mark (the count will be implemented in a later PR), along with the "Manage Tags" option in the actions dropdown.

![Screen Shot 2023-11-08 at 3 53 53 PM](https://github.com/openedx/edx-platform/assets/6829768/3e1d3925-1fa6-454f-98a7-b867c9f5bf01)

9. Confirm that both methods open the side drawer with no issues
10. Testing the drawer functionality is part of the testing instructions in the PR https://github.com/openedx/frontend-app-course-authoring/pull/654 

---
Private-ref: [FAL-3523](https://tasks.opencraft.com/browse/FAL-3523)