### PR TITLE
docs: add pytest django setting specification to docs

### DIFF
--- a/docs/concepts/testing/testing.rst
+++ b/docs/concepts/testing/testing.rst
@@ -114,9 +114,15 @@ For example, this command runs a single python unit test file::
     pytest xmodule/tests/test_stringify.py
 
 Note -
-edx-platorm has multiple services (lms, cms) in it. The environment for each service is different enough that we run some tests in both environments in jenkins. To make sure tests will pass in each of these environments (especially for tests in "common" directory), you will need to test in each seperately. Add --rootdir flag at end of your pytest call and specify the env you are testing in::
+edx-platorm has multiple services (lms, cms) in it. The environment for each service is different enough that we run some tests in both environments in Github Actions. 
+To test in each of these environments (especially for tests in "common" and "xmodule" directories), you will need to test in each seperately.
+To specify that the tests are run with the relevant service as root, Add --rootdir flag at end of your pytest call and specify the env to test in::
 
     pytest test --rootdir <lms or cms>
+
+Or, if you need django settings from a particular enviroment, add --ds flag to the end of your pytest call and specify the django settings object::
+
+    pytest test --ds=<lms.envs.test or cms.envs.test>
 
 Various tools like ddt create tests with very complex names, rather than figuring out the name yourself, you can:
 


### PR DESCRIPTION
Sometimes, especially in the `common` and `xmodule` and `openedx` folders, understanding what django settings are run with pytest can be a bit tricky. This PR adds to the testing overview doc a hint to use the `ds` flag on pytest to specify a django settings object. This is particularly important when you are trying to have tests that only run in one environment (between cms and lms) run correctly.
