### PR TITLE
fix: open new editors from non-unit Studio container page

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -367,7 +367,7 @@ function($, _, Backbone, gettext, BasePage,
             event.preventDefault();
 
             if (!options || options.view !== 'visibility_view') {
-                const primaryHeader = $(event.target).closest('.xblock-header-primary');
+                const primaryHeader = $(event.target).closest('.xblock-header-primary, .nav-actions');
 
                 var useNewTextEditor = primaryHeader.attr('use-new-editor-text'),
                     useNewVideoEditor = primaryHeader.attr('use-new-editor-video'),

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -13,6 +13,8 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from cms.djangoapps.contentstore.helpers import xblock_studio_url, xblock_type_display_name
+from cms.djangoapps.contentstore.toggles import use_new_text_editor, use_new_problem_editor, use_new_video_editor, use_video_gallery_flow
+from cms.djangoapps.contentstore.utils import get_editor_page_base_url
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
@@ -111,6 +113,13 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <%block name="content">
 
+<%
+use_new_editor_text = use_new_text_editor()
+use_new_editor_video = use_new_video_editor()
+use_new_editor_problem = use_new_problem_editor()
+use_new_video_gallery_flow = use_video_gallery_flow()
+%>
+
 <script type="text/javascript">
     window.STUDIO_FRONTEND_IN_CONTEXT_IMAGE_SELECTION = true;
 </script>
@@ -161,7 +170,15 @@ from openedx.core.djangolib.markup import HTML, Text
             </div>
         </div>
 
-        <nav class="nav-actions" aria-label="${_('Page Actions')}">
+        <nav class="nav-actions" aria-label="${_('Page Actions')}"
+        use-new-editor-text = ${use_new_editor_text}
+        use-new-editor-video = ${use_new_editor_video}
+        use-new-editor-problem = ${use_new_editor_problem}
+        use-video-gallery-flow = ${use_new_video_gallery_flow}
+        authoring_MFE_base_url = ${get_editor_page_base_url(xblock_locator.course_key)}
+        data-block-type = ${xblock.scope_ids.block_type}
+        data-usage-id = ${xblock.scope_ids.usage_id}
+        >
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
                 ## Hide the sequence navigation when we've browsed into a child of the unit, e.g. showing the child blocks of a problem-builder xblock


### PR DESCRIPTION
Make the edit button on a container page for a non-unit block (i.e. an individual text, problem or video block) open the new editor when the relevant flag is enabled.

<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

The Studio Course Container page "Edit" button goes to legacy editors. This pull request fixes that so it goes to the new editors.

Impacts Course Author users.

## Testing instructions

1. Enable the new editors (create waffle flags new_core_editors.use_new_text_editor, new_core_editors.use_new_problem_editor, new_core_editors.use_new_video_editor enabled for everyone).

2. Find the block id.

   1. Click "Edit" on a block.

   2. See that you are redirected to the new editor.

   3. Find the block id from the last path component of the URL.

      - e.g. `block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4`.

3. Go to `http://localhost:18010/container/[block id]`.

   - e.g. `http://localhost:18010/container/block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4`.

4. Click the "Edit" button on the top right of the page.

5. See that you are redirected to the new editor.

Repeat for the 3 block types: text, problem, video.

## Deadline

None

## Other information

Private-Ref: [BB-7941](https://tasks.opencraft.com/browse/BB-7941)