### PR TITLE
chore: Update actions/upload-artifact from v2 to v3

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: save pytest warnings json file
       if: success()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-warnings-json
         path: |


### PR DESCRIPTION
v2 is giving warnings:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

v3 is updated to Node 16:
https://github.com/actions/upload-artifact/releases/tag/v3.0.0