### PR TITLE
chore: ignore default_app_config warning

### DIFF
--- a/cms/pytest.ini
+++ b/cms/pytest.ini
@@ -12,6 +12,8 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore:.*You can remove default_app_config.*:PendingDeprecationWarning
+    ignore:.*You can remove default_app_config.*:DeprecationWarning
 norecursedirs = envs
 python_classes =
 python_files = test.py tests.py test_*.py *_tests.py

--- a/common/test/pytest.ini
+++ b/common/test/pytest.ini
@@ -11,4 +11,6 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore:.*You can remove default_app_config.*:PendingDeprecationWarning
+    ignore:.*You can remove default_app_config.*:DeprecationWarning
 norecursedirs = .cache

--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -126,6 +126,7 @@ def log_python_warnings():
     warnings.filterwarnings('ignore', 'Setting _field_data is deprecated')
     warnings.filterwarnings('ignore', 'Setting _field_data via the constructor is deprecated')
     warnings.filterwarnings('ignore', '.*unclosed.*', category=ResourceWarning)
+    warnings.filterwarnings('ignore', '.*You can remove default_app_config.*')
     # try:
     #     # There are far too many of these deprecation warnings in startup to output for every management command;
     #     # suppress them until we've fixed at least the most common ones as reported by the test suite

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,9 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore:.*You can remove default_app_config.*:PendingDeprecationWarning
+    ignore:.*You can remove default_app_config.*:DeprecationWarning
+
 junit_family = xunit2
 norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/envs
 python_classes =


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: Palm is in support. Fixes you make on master may still be needed on Palm.
    🌴🌴🌴🌴     If so, make another pull request against the open-release/palm.master branch,
🌴🌴🌴🌴         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌴🌴

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

```
RemovedInDjango41Warning: 'webpack_loader' defines default_app_config = 'webpack_loader.apps.WebpackLoaderConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```

This warning is appearing 29 times during provisioning. It clutters logs and hinders dev experience (https://github.com/openedx/edx-platform/issues/32888). It's coming from multiple dependencies, and it won't cause any mayor issue besides cluttering. Only one of those dependencies are openedx related, and I made a PR to fix the warning there: https://github.com/openedx/completion/pull/259

## Supporting information

Related Issues:
- https://github.com/openedx/edx-platform/issues/33572
- https://github.com/openedx/edx-platform/issues/32888

## Testing instructions

- on devstack run `make dev.up.lms` and `make lms-shell`
- inside the shell run `./manage.py lms shell` or `./manage.py cms shell`
- make sure there are no warnings containing `You can remove default_app_config.`
## Deadline

None
