### PR TITLE
chore: update connect_timeout for memcache server

### DIFF
--- a/cms/envs/bok_choy.env.json
+++ b/cms/envs/bok_choy.env.json
@@ -7,7 +7,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_celery",
@@ -20,7 +21,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_default",
@@ -33,7 +35,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_general",
@@ -46,7 +49,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_mongo_metadata_inheritance",
@@ -59,7 +63,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_static_files",

--- a/cms/envs/bok_choy.yml
+++ b/cms/envs/bok_choy.yml
@@ -11,6 +11,7 @@ CACHES:
       ignore_exc: true
       no_delay: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_celery
     LOCATION: ['localhost:11211']
@@ -20,6 +21,7 @@ CACHES:
       ignore_exc: true
       no_delay: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_default
     LOCATION: ['localhost:11211']
@@ -29,6 +31,7 @@ CACHES:
       ignore_exc: true
       no_delay: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_general
     LOCATION: ['localhost:11211']
@@ -38,6 +41,7 @@ CACHES:
       ignore_exc: true
       no_delay: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_mongo_metadata_inheritance
     LOCATION: ['localhost:11211']
@@ -47,6 +51,7 @@ CACHES:
       ignore_exc: true
       no_delay: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_static_files
     LOCATION: ['localhost:11211']

--- a/cms/envs/bok_choy_docker.env.json
+++ b/cms/envs/bok_choy_docker.env.json
@@ -7,7 +7,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_celery",
@@ -20,7 +21,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_default",
@@ -33,7 +35,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "sandbox_general",
@@ -46,7 +49,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_mongo_metadata_inheritance",
@@ -59,7 +63,8 @@
             "OPTIONS": {
                 "no_delay": true,
                 "ignore_exc": true,
-                "use_pooling": true
+                "use_pooling": true,
+                "connect_timeout": 0.5
             },
             "KEY_FUNCTION": "common.djangoapps.util.memcache.safe_key",
             "KEY_PREFIX": "integration_static_files",

--- a/cms/envs/bok_choy_docker.yml
+++ b/cms/envs/bok_choy_docker.yml
@@ -11,6 +11,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_celery
     LOCATION: ['edx.devstack.memcached:11211']
@@ -20,6 +21,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_default
     LOCATION: ['edx.devstack.memcached:11211']
@@ -29,6 +31,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_general
     LOCATION: ['edx.devstack.memcached:11211']
@@ -38,6 +41,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_mongo_metadata_inheritance
     LOCATION: ['edx.devstack.memcached:11211']
@@ -47,6 +51,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_static_files
     LOCATION: ['edx.devstack.memcached:11211']

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2182,6 +2182,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'course_structure_cache': {
@@ -2194,6 +2195,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'celery': {
@@ -2206,6 +2208,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'mongo_metadata_inheritance': {
@@ -2218,6 +2221,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'staticfiles': {
@@ -2229,6 +2233,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'default': {
@@ -2241,6 +2246,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'configuration': {
@@ -2252,6 +2258,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'general': {
@@ -2263,6 +2270,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
 }

--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -57,6 +57,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: celery
         LOCATION:
@@ -68,6 +69,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce
         LOCATION:
@@ -78,6 +80,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: course_structure
         LOCATION:
@@ -89,6 +92,7 @@ CACHES:
             ignore_exc: true
             no_delay: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: default
         LOCATION:
@@ -100,6 +104,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: general
         LOCATION:
@@ -110,6 +115,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: mongo_metadata_inheritance
         LOCATION:
@@ -121,6 +127,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce_general
         LOCATION:

--- a/lms/envs/bok_choy.yml
+++ b/lms/envs/bok_choy.yml
@@ -23,6 +23,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_celery
     LOCATION: ['localhost:11211']
@@ -32,6 +33,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_default
     LOCATION: ['localhost:11211']
@@ -41,6 +43,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: sandbox_general
     LOCATION: ['localhost:11211']
@@ -50,6 +53,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_mongo_metadata_inheritance
     LOCATION: ['localhost:11211']
@@ -59,6 +63,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
     KEY_PREFIX: integration_static_files
     LOCATION: ['localhost:11211']

--- a/lms/envs/bok_choy_docker.yml
+++ b/lms/envs/bok_choy_docker.yml
@@ -16,6 +16,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
   default:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
@@ -25,6 +26,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
   general:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
@@ -34,6 +36,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
   mongo_metadata_inheritance:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
@@ -43,6 +46,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
   staticfiles:
     BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
     KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
@@ -52,6 +56,7 @@ CACHES:
       no_delay: true
       ignore_exc: true
       use_pooling: true
+      connect_timeout: 0.5
 CELERY_BROKER_HOSTNAME: localhost
 CELERY_BROKER_PASSWORD: celery
 CELERY_BROKER_TRANSPORT: amqp

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1127,6 +1127,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'course_structure_cache': {
@@ -1139,6 +1140,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'celery': {
@@ -1151,6 +1153,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'mongo_metadata_inheritance': {
@@ -1163,6 +1166,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'staticfiles': {
@@ -1174,6 +1178,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'default': {
@@ -1186,6 +1191,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'configuration': {
@@ -1197,6 +1203,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
     'general': {
@@ -1208,6 +1215,7 @@ CACHES = {
             'no_delay': True,
             'ignore_exc': True,
             'use_pooling': True,
+            'connect_timeout': 0.5
         }
     },
 }

--- a/lms/envs/devstack-experimental.yml
+++ b/lms/envs/devstack-experimental.yml
@@ -76,6 +76,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: celery
         LOCATION:
@@ -87,6 +88,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce
         LOCATION:
@@ -97,6 +99,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: course_structure
         LOCATION:
@@ -108,6 +111,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: default
         LOCATION:
@@ -119,6 +123,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: general
         LOCATION:
@@ -129,6 +134,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: mongo_metadata_inheritance
         LOCATION:
@@ -140,6 +146,7 @@ CACHES:
             no_delay: true
             ignore_exc: true
             use_pooling: true
+            connect_timeout: 0.5
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 78f87108afce_general
         LOCATION:


### PR DESCRIPTION
Update `connect_timeout` for `memcache` server

**Best practices**
- https://github.com/pinterest/pymemcache/blob/8cd0d8740e80ad29dab6decb8e81cb0c6ec5d374/docs/getting_started.rst#best-practices

**Description**
- https://github.com/pinterest/pymemcache/blob/8cd0d8740e80ad29dab6decb8e81cb0c6ec5d374/pymemcache/client/base.py#L300
![image](https://github.com/edx/edx-internal/assets/42294172/546cc525-8b25-4225-b814-7a1f615a56b3)
