### PR TITLE
feat: enable Toggle State API in CMS

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -69,7 +69,6 @@ urlpatterns = oauth2_urlpatterns + [
     path('organizations', OrganizationListView.as_view(), name='organizations'),
     path('api/toggles/', include('openedx.core.djangoapps.waffle_utils.urls')),
 
-
     # noop to squelch ajax errors
     path('event', contentstore_views.event, name='event'),
     path('heartbeat', include('openedx.core.djangoapps.heartbeat.urls')),

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -67,6 +67,8 @@ urlpatterns = oauth2_urlpatterns + [
     path('not_found', contentstore_views.not_found, name='not_found'),
     path('server_error', contentstore_views.server_error, name='server_error'),
     path('organizations', OrganizationListView.as_view(), name='organizations'),
+    path('api/toggles/', include('openedx.core.djangoapps.waffle_utils.urls')),
+
 
     # noop to squelch ajax errors
     path('event', contentstore_views.event, name='event'),


### PR DESCRIPTION
The Toggle State API lets global staff users inspect the computed state of all toggles, which can be a helpful short-circuit to reasoning about the various layers of configuration that feed into edx-platform.

Currently the API is only enabled in LMS. This would enable it in CMS as well. Although LMS and CMS share many of the same base settings, they each have their own overrides and extensions to configuration, so exposing a separate CMS Toggle State API will be beneficial.

## How I tested

On master, start LMS and CMS, log in as a superuser.
* Confirm: `<LMS_BASE>/api/toggles/v0/state` shows toggles, `<CMS_BASE>/api/toggles/v0/state` shows 404.

Switch to this branch. Restart LMS and CMS.
* Confirm: `<LMS_BASE>/api/toggles/v0/state`  and `<CMS_BASE>/api/toggles/v0/state` both show toggles.
* Confirm: At least one CMS-specific setting (`FEATURES['DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO']`) isn't visible using LMS_BASE.
* Confirm: At least one LMS-specific setting (`ENABLE_REQUIRE_THIRD_PARTY_AUTH`) isn't visible using CMS_BASE.
* Note: All Waffle flags (LMS, CMS, and shared) will be visible from both endpoints because they are registered on code import, not via settings files.
* Note: Many LMS-specific and CMS-specific settings will still be visible from both toggle endpoints, because we do a poor job keeping our settings files decoupled.

Log out, log back in as a regular user.
* Confirm that `<CMS_BASE>/api/toggles/v0/state` does not return toggle state.