### PR TITLE
feat: added new thread notifications behind new course wide waffle flag

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tasks.py
@@ -7,7 +7,7 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.locator import CourseKey
 from lms.djangoapps.courseware.courses import get_course_with_access
 from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS, ENABLE_COURSEWIDE_NOTIFICATIONS
 from lms.djangoapps.discussion.rest_api.discussions_notifications import DiscussionNotificationSender
 
 
@@ -21,7 +21,7 @@ def send_thread_created_notification(thread_id, course_key_str, user_id):
     Send notification when a new thread is created
     """
     course_key = CourseKey.from_string(course_key_str)
-    if not ENABLE_NOTIFICATIONS.is_enabled(course_key):
+    if not (ENABLE_NOTIFICATIONS.is_enabled(course_key) and ENABLE_COURSEWIDE_NOTIFICATIONS.is_enabled(course_key)):
         return
     thread = Thread(id=thread_id).retrieve()
     user = User.objects.get(id=user_id)

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -25,7 +25,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_STUDENT,
     CourseDiscussionSettings
 )
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_COURSEWIDE_NOTIFICATIONS, ENABLE_NOTIFICATIONS
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -44,6 +44,7 @@ def _get_mfe_url(course_id, post_id):
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 @override_waffle_flag(ENABLE_NOTIFICATIONS, active=True)
+@override_waffle_flag(ENABLE_COURSEWIDE_NOTIFICATIONS, active=True)
 class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """
     Test cases related to new_discussion_post and new_question_post notification types

--- a/openedx/core/djangoapps/notifications/config/waffle.py
+++ b/openedx/core/djangoapps/notifications/config/waffle.py
@@ -37,3 +37,13 @@ SHOW_NOTIFICATIONS_TRAY = CourseWaffleFlag(f"{WAFFLE_NAMESPACE}.show_notificatio
 # .. toggle_target_removal_date: 2024-06-01
 # .. toggle_tickets: INF-902
 ENABLE_NOTIFICATIONS_FILTERS = CourseWaffleFlag(f"{WAFFLE_NAMESPACE}.enable_notifications_filters", __name__)
+
+# .. toggle_name: notifications.enable_coursewide_notifications
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable coursewide notifications
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2023-10-25
+# .. toggle_target_removal_date: 2024-06-01
+# .. toggle_tickets: INF-1145
+ENABLE_COURSEWIDE_NOTIFICATIONS = CourseWaffleFlag(f"{WAFFLE_NAMESPACE}.enable_coursewide_notifications", __name__)

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -18,7 +18,11 @@ from rest_framework.test import APIClient, APITestCase
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS, SHOW_NOTIFICATIONS_TRAY
+from openedx.core.djangoapps.notifications.config.waffle import (
+    ENABLE_COURSEWIDE_NOTIFICATIONS,
+    ENABLE_NOTIFICATIONS,
+    SHOW_NOTIFICATIONS_TRAY
+)
 from openedx.core.djangoapps.notifications.models import CourseNotificationPreference, Notification
 from openedx.core.djangoapps.notifications.serializers import NotificationCourseEnrollmentSerializer
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -255,7 +259,8 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
         Test get user notification preference.
         """
         self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
-        response = self.client.get(self.path)
+        with override_waffle_flag(ENABLE_COURSEWIDE_NOTIFICATIONS, active=True):
+            response = self.client.get(self.path)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, self._expected_api_response())
         event_name, event_data = mock_emit.call_args[0]

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -36,7 +36,7 @@ from .serializers import (
     UserCourseNotificationPreferenceSerializer,
     UserNotificationPreferenceUpdateSerializer
 )
-from .utils import get_show_notifications_tray
+from .utils import filter_course_wide_preferences, get_show_notifications_tray
 
 
 @allow_any_authenticated_user()
@@ -183,7 +183,8 @@ class UserNotificationPreferenceView(APIView):
         user_preference = CourseNotificationPreference.get_updated_user_course_preferences(request.user, course_id)
         serializer = UserCourseNotificationPreferenceSerializer(user_preference)
         notification_preferences_viewed_event(request, course_id)
-        return Response(serializer.data)
+        preferences = filter_course_wide_preferences(course_id, serializer.data)
+        return Response(preferences)
 
     def patch(self, request, course_key_string):
         """


### PR DESCRIPTION
Following changes are in this PR

- Created new waffle flag `notifications.enable_coursewide_notifications`
- `new_discussion_post` and `new_question_post` will only be visible in preference if waffle flag is enabled
- Moved code of `new_discussion_post` and `new_question_post` behind waffle flag `notifications.enable_coursewide_notifications`.

Ticket Link: [INF-1145](https://2u-internal.atlassian.net/browse/INF-1145)

