### PR TITLE
feat: add brand_color variable for the email templates

### DIFF
--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -406,10 +406,9 @@ class EmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, CacheIsolat
             subject='Request to change édX account e-mail',
             body_fragments=[
                 'We received a request to change the e-mail associated with',
-                'your édX account from {old_email} to {new_email}.'.format(
-                    old_email=old_email,
-                    new_email=new_email,
-                ),
+                'your édX account from',
+                old_email,
+                new_email,
                 'If this is correct, please confirm your new e-mail address by visiting:',
                 f'http://edx.org/email_confirm/{registration_key}',
                 'Please do not reply to this e-mail; if you require assistance,',
@@ -467,13 +466,11 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
 
         # Text fragments we expect in the body of the confirmation email
         self.email_fragments = [
-            "This is to confirm that you changed the e-mail associated with {platform_name}"
-            " from {old_email} to {new_email}. If you did not make this request, please contact us immediately."
-            " Contact information is listed at:".format(
-                platform_name=settings.PLATFORM_NAME,
-                old_email=self.user.email,
-                new_email=PendingEmailChange.objects.get(activation_key=self.key).new_email
-            ),
+            "This is to confirm that you changed the e-mail associated with ",
+            str(settings.PLATFORM_NAME),
+            "If you did not make this request, please contact us immediately. Contact information is listed at:",
+            self.user.email,
+            PendingEmailChange.objects.get(activation_key=self.key).new_email,
             "We keep a log of old e-mails, so if this request was unintentional, we can investigate."
         ]
 

--- a/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -50,7 +50,7 @@
                 {% blocktrans trimmed asvar assist_msg %}
                 If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor} or email {start_anchor_email}{{ support_email }}{end_anchor}.
                 {% endblocktrans %}
-                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe start_anchor_email='<a href="mailto:'|add:support_email|add:'">'|safe end_anchor='</a>'|safe %}
+                {% interpolate_html assist_msg start_anchor_web='<a style="color: '|add:brand_color|add:';" href="'|add:support_url|add:'">'|safe start_anchor_email='<a style="color: '|add:brand_color|add:';" href="mailto:'|add:support_email|add:'">'|safe end_anchor='</a>'|safe %}
                 <br />
             </p>
         </td>

--- a/common/templates/student/edx_ace/emailchange/email/body.html
+++ b/common/templates/student/edx_ace/emailchange/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with old_email='<a href="mailto:'|add:old_email|add:'" style="color: '|add:brand_color|add:';">'|add:old_email|add:'</a>'|safe new_email='<a href="mailto:'|add:new_email|add:'" style="color: '|add:brand_color|add:';">'|add:new_email|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -31,4 +32,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/common/templates/student/edx_ace/emailchangeconfirmation/email/body.html
+++ b/common/templates/student/edx_ace/emailchangeconfirmation/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with old_email='<a href="mailto:'|add:old_email|add:'" style="color: '|add:brand_color|add:';">'|add:old_email|add:'</a>'|safe new_email='<a href="mailto:'|add:new_email|add:'" style="color: '|add:brand_color|add:';">'|add:new_email|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -30,4 +31,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1228,14 +1228,17 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert text_body.startswith('Dear NotEnrolled Student\n\n')
 
         for body in [text_body, html_body]:
-            assert f'You have been enrolled in {self.course.display_name} at edx.org by a member of the course staff.'\
-                   in body
-
-            assert 'This course will now appear on your edx.org dashboard.' in body
+            assert f'You have been enrolled in {self.course.display_name} at ' in body
+            assert self.site_name in body
+            assert ' by a member of the course staff.' in body
+            assert 'This course will now appear on your ' in body
             assert f'{protocol}://{self.site_name}{self.course_path}' in body
 
         assert 'To start accessing course materials, please visit' in text_body
-        assert 'This email was automatically sent from edx.org to NotEnrolled Student\n\n' in text_body
+        assert (
+            f'This email was automatically sent from {self.site_name} to {self.notenrolled_student.first_name} '
+            f'{self.notenrolled_student.last_name}\n\n'
+        ) in text_body
 
     @ddt.data('http', 'https')
     def test_enroll_with_email_not_registered(self, protocol):
@@ -1264,22 +1267,21 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert register_url in html_body
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to join {course} at edx.org by a member of the course staff.'.format(
+            assert 'You have been invited to join {course} at '.format(
                 course=self.course.display_name
             ) in body
-
-            assert ('fill out the registration form making sure to use '
-                    'robot-not-an-email-yet@robot.org in the Email field') in body
-
+            assert self.site_name in body
+            assert ' by a member of the course staff.' in body
+            assert 'fill out the registration form making sure to use ' in body
+            assert self.notregistered_email in body
+            assert ' in the Email field' in body
             assert 'Once you have registered and activated your account,' in body
-
             assert '{proto}://{site}{about_path}'.format(
                 proto=protocol,
                 site=self.site_name,
                 about_path=self.about_path
             ) in body
-
-            assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
+            assert 'This email was automatically sent from ' in body
 
     @ddt.data('http', 'https')
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
@@ -1302,23 +1304,22 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert 'Please finish your registration and fill' in html_body
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to join {display_name} at edx.org by a member of the course staff.'.format(
+            assert 'You have been invited to join {display_name} at '.format(
                 display_name=self.course.display_name
             ) in body
-
+            assert self.site_name in body
+            assert 'by a member of the course staff.' in body
             assert '{proto}://{site}/register'.format(
                 proto=protocol,
                 site=self.site_name
             ) in body
-
-            assert ('fill out the registration form making sure to use '
-                    'robot-not-an-email-yet@robot.org in the Email field') in body
-
+            assert 'fill out the registration form making sure to use ' in body
+            assert self.notregistered_email in body
+            assert ' in the Email field' in body
             assert 'You can then enroll in {display_name}.'.format(
                 display_name=self.course.display_name
             ) in body
-
-            assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
+            assert 'This email was automatically sent from ' in body
 
     @ddt.data('http', 'https')
     def test_enroll_with_email_not_registered_autoenroll(self, protocol):
@@ -1353,20 +1354,19 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert register_url in html_body
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to join {display_name} at edx.org by a member of the course staff.'.format(
+            assert 'You have been invited to join {display_name} at '.format(
                 display_name=self.course.display_name
             ) in body
-
-            assert (' and fill '
-                    'out the registration form making sure to use robot-not-an-email-yet@robot.org '
-                    'in the Email field') in body
-
+            assert self.site_name in body
+            assert 'by a member of the course staff.' in body
+            assert ' and fill out the registration form making sure to use ' in body
+            assert self.notregistered_email in body
+            assert 'in the Email field' in body
             assert ('Once you have registered and activated your account, '
                     'you will see {display_name} listed on your dashboard.').format(
                 display_name=self.course.display_name
             ) in body
-
-            assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
+            assert 'This email was automatically sent from ' in body
 
     def test_unenroll_without_email(self):
         url = reverse('students_update_enrollment', kwargs={'course_id': str(self.course.id)})
@@ -1461,13 +1461,15 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert text_body.startswith('Dear Enrolled Student')
 
         for body in [text_body, html_body]:
-            assert 'You have been unenrolled from {display_name} at edx.org by a member of the course staff.'.format(
+            assert 'You have been unenrolled from {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
-            assert 'This course will no longer appear on your edx.org dashboard.' in body
+            assert self.site_name in body
+            assert ' by a member of the course staff.' in body
+            assert 'This course will no longer appear on your ' in body
             assert 'Your other courses have not been affected.' in body
-            assert 'This email was automatically sent from edx.org to Enrolled Student' in body
+            assert 'This email was automatically sent from ' in body
+            assert f'to {self.enrolled_student.first_name} {self.enrolled_student.last_name}' in body
 
     def test_unenroll_with_email_allowed_student(self):
         url = reverse('students_update_enrollment', kwargs={'course_id': str(self.course.id)})
@@ -1519,7 +1521,9 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
             ) in body
 
             assert 'Please disregard the invitation previously sent.' in body
-            assert 'This email was automatically sent from edx.org to robot-allowed@robot.org' in body
+            assert 'This email was automatically sent from ' in body
+            assert self.site_name in body
+            assert self.allowed_email in body
 
     @ddt.data('http', 'https')
     @patch('lms.djangoapps.instructor.enrollment.uses_shib')
@@ -1551,11 +1555,13 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert course_url in html_body
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to join {display_name} at edx.org by a member of the course staff.'.format(
+            assert 'You have been invited to join {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
-            assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
+            assert self.site_name in body
+            assert ' by a member of the course staff.' in body
+            assert 'This email was automatically sent from ' in body
+            assert self.notregistered_email in body
 
     @patch('lms.djangoapps.instructor.enrollment.uses_shib')
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
@@ -1576,11 +1582,13 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert text_body.startswith('Dear student,')
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to join {display_name} at edx.org by a member of the course staff.'.format(
+            assert 'You have been invited to join {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
-            assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
+            assert self.site_name in body
+            assert ' by a member of the course staff.' in body
+            assert 'This email was automatically sent from ' in body
+            assert self.notregistered_email in body
 
     @ddt.data('http', 'https')
     @patch('lms.djangoapps.instructor.enrollment.uses_shib')
@@ -1611,11 +1619,13 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         assert 'To access this course click on the button below and login:' in html_body
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to join {display_name} at edx.org by a member of the course staff.'.format(
+            assert 'You have been invited to join {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
-            assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
+            assert ' by a member of the course staff.' in body
+            assert 'This email was automatically sent from ' in body
+            assert self.site_name in body
+            assert self.notregistered_email in body
 
     def test_enroll_already_enrolled_student(self):
         """
@@ -1998,22 +2008,19 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         assert f'Visit {self.course.display_name}' in html_body
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to be a beta tester for {display_name} at edx.org'.format(
+            assert 'You have been invited to be a beta tester for {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
+            assert self.site_name in body
             assert 'by a member of the course staff.' in body
             assert 'enroll in this course and begin the beta test' in body
-
             assert '{proto}://{site}{about_path}'.format(
                 proto=protocol,
                 site=self.site_name,
                 about_path=self.about_path,
             ) in body
-
-            assert 'This email was automatically sent from edx.org to {student_email}'.format(
-                student_email=self.notenrolled_student.email,
-            ) in body
+            assert 'This email was automatically sent from ' in body
+            assert self.notenrolled_student.email in body
 
     @ddt.data('http', 'https')
     def test_add_notenrolled_with_email_autoenroll(self, protocol):
@@ -2050,22 +2057,19 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         assert text_body.startswith(f'Dear {student_name}')
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to be a beta tester for {display_name} at edx.org'.format(
+            assert 'You have been invited to be a beta tester for {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
+            assert self.site_name in body
             assert 'by a member of the course staff' in body
-
             assert 'To start accessing course materials, please visit' in body
             assert '{proto}://{site}{course_path}'.format(
                 proto=protocol,
                 site=self.site_name,
                 course_path=self.course_path
             )
-
-            assert 'This email was automatically sent from edx.org to {student_email}'.format(
-                student_email=self.notenrolled_student.email,
-            ) in body
+            assert 'This email was automatically sent from ' in body
+            assert self.notenrolled_student.email in body
 
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_add_notenrolled_email_mktgsite(self):
@@ -2081,16 +2085,14 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         assert text_body.startswith(f'Dear {student_name}')
 
         for body in [text_body, html_body]:
-            assert 'You have been invited to be a beta tester for {display_name} at edx.org'.format(
+            assert 'You have been invited to be a beta tester for {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
+            assert self.site_name in body
             assert 'by a member of the course staff.' in body
-            assert 'Visit edx.org' in body
             assert 'enroll in this course and begin the beta test' in body
-            assert 'This email was automatically sent from edx.org to {student_email}'.format(
-                student_email=self.notenrolled_student.email,
-            ) in body
+            assert 'This email was automatically sent from ' in body
+            assert self.notenrolled_student.email in body
 
     def test_enroll_with_email_not_registered(self):
         # User doesn't exist
@@ -2184,18 +2186,15 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         assert text_body.startswith(f'Dear {self.beta_tester.profile.name}')
 
         for body in [text_body, html_body]:
-            assert 'You have been removed as a beta tester for {display_name} at edx.org'.format(
+            assert 'You have been removed as a beta tester for {display_name} at '.format(
                 display_name=self.course.display_name,
             ) in body
-
+            assert self.site_name in body
             assert ('This course will remain on your dashboard, but you will no longer be '
                     'part of the beta testing group.') in body
-
             assert 'Your other courses have not been affected.' in body
-
-            assert 'This email was automatically sent from edx.org to {email_address}'.format(
-                email_address=self.beta_tester.email,
-            ) in body
+            assert 'This email was automatically sent from ' in body
+            assert self.beta_tester.email in body
 
 
 class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTestCase):

--- a/lms/templates/instructor/edx_ace/addbetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/addbetatester/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with site_name='<a href="'|add:site_name|add:'" style="color: '|add:brand_color|add:';">'|safe|add:site_name|add:'</a>'|safe email_address='<a href="mailto:'|add:email_address|add:'" style="color: '|add:brand_color|add:';">'|safe|add:email_address|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -67,4 +68,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with site_name='<a href="'|add:site_name|add:'" style="color: '|add:brand_color|add:';">'|safe|add:site_name|add:'</a>'|safe email_address='<a href="mailto:'|add:email_address|add:'" style="color: '|add:brand_color|add:';">'|safe|add:email_address|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -81,4 +82,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with site_name='<a href="'|add:site_name|add:'" style="color: '|add:brand_color|add:';">'|safe|add:site_name|add:'</a>'|safe email_address='<a href="mailto:'|add:email_address|add:'" style="color: '|add:brand_color|add:';">'|safe|add:email_address|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -30,4 +31,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with site_name='<a href="'|add:site_name|add:'" style="color: '|add:brand_color|add:';">'|safe|add:site_name|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -39,4 +40,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with site_name='<a href="'|add:site_name|add:'" style="color: '|add:brand_color|add:';">'|safe|add:site_name|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -37,4 +38,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/lms/templates/instructor/edx_ace/removebetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/removebetatester/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with site_name='<a href="'|add:site_name|add:'" style="color: '|add:brand_color|add:';">'|safe|add:site_name|add:'</a>'|safe email_address='<a href="mailto:'|add:email_address|add:'" style="color: '|add:brand_color|add:';">'|safe|add:email_address|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -44,4 +45,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html
+++ b/lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+{% with dashboard_link='<a href="'|add:dashboard_link|add:'" style="color: '|add:brand_color|add:';">'|add:dashboard_link|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
   <tr>
     <td>
@@ -39,4 +40,5 @@
     </td>
   </tr>
 </table>
+{% endwith %}
 {% endblock %}

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -29,6 +29,7 @@
 
 {% google_analytics_tracking_pixel %}
 
+{% with brand_color="#005686" logo_max_height="65px" %}
 <div bgcolor="#f5f5f5" lang="{{ LANGUAGE_CODE|default:"en" }}" dir="{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}" style="
   margin: 0;
   padding: 0;
@@ -79,7 +80,7 @@
                                   <tr>
                                     <td align="left" valign="top">
                                       <a href="{% with_link_tracking homepage_url %}">
-                                        <img src="{{ logo_url }}" style="max-height: 65px;" height="auto" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                                        <img src="{{ logo_url }}" style="max-height: {{ logo_max_height }};" height="auto" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                                     </td>
                                   </tr>
                                 </table>
@@ -218,8 +219,8 @@
           {% get_action_links channel omit_unsubscribe_link=omit_unsubscribe_link as action_links %}
           {% for action_link_url, action_link_text in action_links %}
             <p>
-              <a href="{{ action_link_url }}" style="color: #005686">
-                <font color="#005686"><b>{{ action_link_text }}</b></font>
+              <a href="{{ action_link_url }}" style="color: {{ brand_color }};">
+                <font color="{{ brand_color }}"><b>{{ action_link_text }}</b></font>
               </a>
             </p>
           {% endfor %}
@@ -253,6 +254,7 @@
   <![endif]-->
 
 </div>
+{% endwith %}
 
 {# Debug info that is not user-visible #}
 <span id="ace-message-id" style="display:none;">{{ message.log_id }}</span>

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/return_to_course_cta.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/return_to_course_cta.html
@@ -21,11 +21,11 @@
         border-radius: 4px;
         -webkit-border-radius: 4px;
         -moz-border-radius: 4px;
-        background-color: #005686;
-        border-top: 12px solid #005686;
-        border-bottom: 12px solid #005686;
-        border-right: 50px solid #005686;
-        border-left: 50px solid #005686;
+        background-color: {{ brand_color }};
+        border-top: 12px solid {{ brand_color }};
+        border-bottom: 12px solid {{ brand_color }};
+        border-right: 50px solid {{ brand_color }};
+        border-left: 50px solid {{ brand_color }};
         display: inline-block;
     ">
         {# old email clients require the use of the font tag :( #}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
@@ -101,11 +101,11 @@
                         border-radius: 4px;
                         -webkit-border-radius: 4px;
                         -moz-border-radius: 4px;
-                        background-color: #005686;
-                        border-top: 10px solid #005686;
-                        border-bottom: 10px solid #005686;
-                        border-right: 16px solid #005686;
-                        border-left: 16px solid #005686;
+                        background-color: {{ brand_color }};
+                        border-top: 10px solid {{ brand_color }};
+                        border-bottom: 10px solid {{ brand_color }};
+                        border-right: 16px solid {{ brand_color }};
+                        border-left: 16px solid {{ brand_color }};
                         display: inline-block;
                 ">
                     {# old email clients require the use of the font tag :( #}

--- a/openedx/core/djangoapps/user_api/templates/user_api/edx_ace/deletionnotificationmessage/email/body.html
+++ b/openedx/core/djangoapps/user_api/templates/user_api/edx_ace/deletionnotificationmessage/email/body.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 {% block content %}
+{% with contact_email='<a href="'|add:contact_email|add:'" style="color: '|add:brand_color|add:';">'|safe|add:contact_email|add:'</a>'|safe %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
@@ -44,4 +45,5 @@
         </td>
     </tr>
 </table>
+{% endwith %}
 {% endblock %}


### PR DESCRIPTION
Added a color variable to simplify branding of email templates used on different platforms. Also added a variable for the maximum height of the email logo image.

The main purpose of adding these variables is to be able to control the color used on buttons, links, etc. in emails. To avoid making these changes in many files, it can now be done by changing the value of one variable in the `base_body` template.

For example, as in the screenshot below, the size of the logo, the color of the button and links affected by brand_color variable which is setted here with the logo height.
`{% with brand_color="#1b511a" logo_max_height="65px" %}`

Similar PR is opened to the master branch:
https://github.com/openedx/edx-platform/pull/33421

<img width="617" alt="Screenshot 2023-10-05 at 17 45 15" src="https://github.com/openedx/edx-platform/assets/25877054/a26dc6f6-3c6f-47cb-8a34-3d42e4537ed6">
