### PR TITLE
fix: Social link parsing approach changed

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -43,7 +43,7 @@ class UserAccountSettingsTest(TestCase):
         ('twitter', 'https://www.twiter.com/edX/', None, False),
         ('twitter', 'https://www.twitter.com/edX/123s', None, False),
         ('twitter', 'twitter.com/edX', 'https://www.twitter.com/edX', True),
-        ('twitter', 'twitter.com/edX?foo=bar', 'https://www.twitter.com/edX', True),
+        ('twitter', 'twitter.com/edX?foo=bar', 'https://www.twitter.com/edX?foo=bar', True),
         ('twitter', 'twitter.com/test.user', 'https://www.twitter.com/test.user', True),
         ('linkedin', 'www.linkedin.com/harryrein', None, False),
         ('linkedin', 'www.linkedin.com/in/harryrein-1234', 'https://www.linkedin.com/in/harryrein-1234', True),

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -37,8 +37,8 @@ class UserAccountSettingsTest(TestCase):
 
     @ddt.data(
         ('facebook', 'www.facebook.com/edX', 'https://www.facebook.com/edX', True),
-        ('facebook', 'facebook.com/edX', 'https://www.facebook.com/edX', True),
-        ('facebook', 'HTTP://facebook.com/edX', 'https://www.facebook.com/edX', True),
+        ('facebook', 'facebook.com/edX/', 'https://www.facebook.com/edX', True),
+        ('facebook', 'HTTP://facebook.com/edX/', 'https://www.facebook.com/edX', True),
         ('facebook', 'www.evilwebsite.com/123', None, False),
         ('twitter', 'https://www.twiter.com/edX/', None, False),
         ('twitter', 'https://www.twitter.com/edX/123s', None, False),

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -37,8 +37,8 @@ class UserAccountSettingsTest(TestCase):
 
     @ddt.data(
         ('facebook', 'www.facebook.com/edX', 'https://www.facebook.com/edX', True),
-        ('facebook', 'facebook.com/edX/', 'https://www.facebook.com/edX', True),
-        ('facebook', 'HTTP://facebook.com/edX/', 'https://www.facebook.com/edX', True),
+        ('facebook', 'facebook.com/edX', 'https://www.facebook.com/edX', True),
+        ('facebook', 'HTTP://facebook.com/edX', 'https://www.facebook.com/edX', True),
         ('facebook', 'www.evilwebsite.com/123', None, False),
         ('twitter', 'https://www.twiter.com/edX/', None, False),
         ('twitter', 'https://www.twitter.com/edX/123s', None, False),

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -85,7 +85,7 @@ def _get_username_from_social_link(platform_name, new_social_link):
         return new_social_link
 
     url_stub = re.escape(settings.SOCIAL_PLATFORMS[platform_name]['url_stub'])
-    username_match = re.search(r'(www\.)?' + url_stub + r'(?P<username>.+)(\?.*)?$', new_social_link, re.IGNORECASE)
+    username_match = re.search(r'(www\.)?' + url_stub + r'(?P<username>.+?)(?:/)?$', new_social_link, re.IGNORECASE)
     if username_match:
         username = username_match.group('username')
     else:

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -6,7 +6,6 @@ import logging
 import random
 import re
 import string
-from urllib.parse import urlparse  # pylint: disable=import-error
 
 import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from completion.models import BlockCompletion
@@ -85,11 +84,8 @@ def _get_username_from_social_link(platform_name, new_social_link):
     if not new_social_link:
         return new_social_link
 
-    # Parse the social link as if it were a URL.
-    parse_result = urlparse(new_social_link)
-    url_domain_and_path = parse_result[1] + parse_result[2]
     url_stub = re.escape(settings.SOCIAL_PLATFORMS[platform_name]['url_stub'])
-    username_match = re.search(r'(www\.)?' + url_stub + r'(?P<username>.*?)[/]?$', url_domain_and_path, re.IGNORECASE)
+    username_match = re.search(r'(www\.)?' + url_stub + r'(?P<username>.+)(\?.*)?$', new_social_link, re.IGNORECASE)
     if username_match:
         username = username_match.group('username')
     else:


### PR DESCRIPTION
## Description

Since social URLs can be not only as a {social_media}/{username} we need to allow the use of any profile links

Related: [master](https://github.com/openedx/edx-platform/pull/33565)