### PR TITLE
fix: name length validation

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -405,6 +405,10 @@ def get_name_validation_error(name):
 
     """
     if name:
+        # Validation for the name length
+        if len(name) > 255:
+            return _("Full name can`t be longer than 255 symbols")
+        
         regex = re.findall(r'https|http?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+', name)
         return _('Enter a valid name') if bool(regex) else ''
     else:

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -407,7 +407,7 @@ def get_name_validation_error(name):
     if name:
         # Validation for the name length
         if len(name) > 255:
-            return _("Full name can`t be longer than 255 symbols")
+            return _("Full name can't be longer than 255 symbols")
 
         regex = re.findall(r'https|http?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+', name)
         return _('Enter a valid name') if bool(regex) else ''

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -408,7 +408,7 @@ def get_name_validation_error(name):
         # Validation for the name length
         if len(name) > 255:
             return _("Full name can`t be longer than 255 symbols")
-        
+
         regex = re.findall(r'https|http?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+', name)
         return _('Enter a valid name') if bool(regex) else ''
     else:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -34,7 +34,8 @@ from openedx.core.djangoapps.ace_common.tests.mixins import EmailTemplateTagMixi
 from openedx.core.djangoapps.user_api.accounts import PRIVATE_VISIBILITY
 from openedx.core.djangoapps.user_api.accounts.api import (
     get_account_settings,
-    update_account_settings
+    update_account_settings,
+    get_name_validation_error
 )
 from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (  # pylint: disable=unused-import
     RetirementTestCase,
@@ -569,6 +570,13 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         account_settings = get_account_settings(self.default_request)[0]
         assert account_settings['country'] is None
         assert account_settings['state'] is None
+
+    def test_get_name_validation_error_too_long():
+        """
+        Test validation error when the name is too long.
+        """
+        result = get_name_validation_error("A" * 256)
+        assert result == 'Full name can`t be longer than 255 symbols'
 
 
 @patch('openedx.core.djangoapps.user_api.accounts.image_helpers._PROFILE_IMAGE_SIZES', [50, 10])

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -571,12 +571,12 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         assert account_settings['country'] is None
         assert account_settings['state'] is None
 
-    def test_get_name_validation_error_too_long():
+    def test_get_name_validation_error_too_long(self):
         """
         Test validation error when the name is too long.
         """
         result = get_name_validation_error("A" * 256)
-        assert result == 'Full name can`t be longer than 255 symbols'
+        assert result == "Full name can't be longer than 255 symbols"
 
 
 @patch('openedx.core.djangoapps.user_api.accounts.image_helpers._PROFILE_IMAGE_SIZES', [50, 10])


### PR DESCRIPTION
According to the UserProfile limitation for the name field:
name = models.CharField(blank=True, max_length=255, db_index=True)
we need to add the validation for the name length.
A better solution would be to use the separate constant which we could use for both the model field and validation criteria, but considering that the field has been unchanged since Feb 2012 - it was rejected to simplify the fix.

Related: [master](https://github.com/openedx/edx-platform/pull/33501)