### PR TITLE
feat: update `initialize` endpoint and create `assessments/feedback` endpoint in ORA Staff Grader

### DIFF
--- a/lms/djangoapps/ora_staff_grader/constants.py
+++ b/lms/djangoapps/ora_staff_grader/constants.py
@@ -3,6 +3,7 @@
 # Query params
 PARAM_ORA_LOCATION = "oraLocation"
 PARAM_SUBMISSION_ID = "submissionUUID"
+PARAM_ASSESSMENT_TYPE = "assessmentType"
 
 # Error codes
 ERR_UNKNOWN = "ERR_UNKNOWN"

--- a/lms/djangoapps/ora_staff_grader/constants.py
+++ b/lms/djangoapps/ora_staff_grader/constants.py
@@ -3,7 +3,6 @@
 # Query params
 PARAM_ORA_LOCATION = "oraLocation"
 PARAM_SUBMISSION_ID = "submissionUUID"
-PARAM_ASSESSMENT_TYPE = "assessmentType"
 
 # Error codes
 ERR_UNKNOWN = "ERR_UNKNOWN"

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -12,6 +12,7 @@ Other handlers return status OK even for an error, but contain error info in the
 These are checked (usually by checking for a {"success":false} response) and raise errors, possibly with extra context.
 """
 import json
+from http import HTTPStatus
 from lms.djangoapps.ora_staff_grader.errors import (
     LockContestedError,
     XBlockInternalError,
@@ -28,6 +29,21 @@ def get_submissions(request, usage_id):
     response = call_xblock_json_handler(request, usage_id, handler_name, {})
 
     if response.status_code != 200:
+        raise XBlockInternalError(context={"handler": handler_name})
+
+    return json.loads(response.content)
+
+
+def get_assessments(request, usage_id, submission_uuid, assessment_type):
+    """
+    Get a list of assessments from the ORA's 'list_assessments_grades' XBlock.json_handler
+    """
+    handler_name = "list_assessments"
+    body = {"item_id": usage_id, "submission_uuid": submission_uuid, "assessment_type": assessment_type}
+
+    response = call_xblock_json_handler(request, usage_id, handler_name, body)
+
+    if response.status_code != HTTPStatus.OK:
         raise XBlockInternalError(context={"handler": handler_name})
 
     return json.loads(response.content)
@@ -168,5 +184,5 @@ def batch_delete_submission_locks(request, usage_id, submission_uuids):
     response = call_xblock_json_handler(request, usage_id, handler_name, body)
 
     # Errors should raise a blanket exception. Otherwise body is empty, 200 is implicit success
-    if response.status_code != 200:
+    if response.status_code != HTTPStatus.OK:
         raise XBlockInternalError(context={"handler": handler_name})

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -13,6 +13,9 @@ These are checked (usually by checking for a {"success":false} response) and rai
 """
 import json
 from http import HTTPStatus
+
+from rest_framework.request import Request
+
 from lms.djangoapps.ora_staff_grader.errors import (
     LockContestedError,
     XBlockInternalError,
@@ -34,12 +37,23 @@ def get_submissions(request, usage_id):
     return json.loads(response.content)
 
 
-def get_assessments_given(request, usage_id, submission_uuid):
+def get_assessments_to(request: Request, usage_id: str, submission_uuid: str):
     """
-    Get a list of assessments given from the ORA's 'list_assessments_given' XBlock.json_handler
+    Get a list of assessments given from ORA `list_assessments_to` XBlock.json_handler.
+
+    Lists all assessments given by a user (according to their submissionUUID)
+    in an ORA assignment. Assessments can be Self, Peer and Staff.
+
+    Args:
+        request (Request): The request object
+        usage_id (str): Usage ID of the XBlock for running the handler
+        submission_uuid (str): The ORA submission UUID
     """
-    handler_name = "list_assessments_given"
-    data = {"item_id": usage_id, "submission_uuid": submission_uuid}
+    handler_name = "list_assessments_to"
+    data = {
+        "item_id": usage_id,
+        "submission_uuid": submission_uuid,
+    }
 
     response = call_xblock_json_handler(request, usage_id, handler_name, data)
 
@@ -49,12 +63,22 @@ def get_assessments_given(request, usage_id, submission_uuid):
     return json.loads(response.content)
 
 
-def get_assessments_received(request, usage_id, submission_uuid):
+def get_assessments_from(request: Request, usage_id: str, submission_uuid: str):
     """
-    Get a list of assessments received from the ORA's 'list_assessments_received' XBlock.json_handler
+    Get a list of assessments received from ORA `list_assessments_from` XBlock.json_handler
+
+    Lists all assessments received by a user (according to their submissionUUID)
+    in an ORA assignment. Assessments can be Self, Peer and Staff.
+
+    Args:
+        request (Request): The request object
+        usage_id (str): Usage ID of the XBlock for running the handler
+        submission_uuid (str): The ORA submission UUID
     """
-    handler_name = "list_assessments_received"
-    data = {"submission_uuid": submission_uuid}
+    handler_name = "list_assessments_from"
+    data = {
+        "submission_uuid": submission_uuid,
+    }
 
     response = call_xblock_json_handler(request, usage_id, handler_name, data)
 

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -37,46 +37,26 @@ def get_submissions(request, usage_id):
     return json.loads(response.content)
 
 
-def get_assessments_to(request: Request, usage_id: str, submission_uuid: str):
+def get_assessments(request: Request, usage_id: str, handler_name: str, submission_uuid: str):
     """
-    Get a list of assessments given from ORA `list_assessments_to` XBlock.json_handler.
+    Get a list of assessments according to the handler name from ORA XBlock.json_handler
 
-    Lists all assessments given by a user (according to their submissionUUID)
-    in an ORA assignment. Assessments can be Self, Peer and Staff.
+    * `list_assessments_to` handler
+        Lists all assessments given by a user (according to their submissionUUID)
+        in an ORA assignment. Assessments can be Self, Peer and Staff.
+
+    * `list_assessments_from` handler
+        Lists all assessments received by a user (according to their submissionUUID)
+        in an ORA assignment. Assessments can be Self, Peer and Staff.
 
     Args:
-        request (Request): The request object
+        request (Request): The request object.
         usage_id (str): Usage ID of the XBlock for running the handler
+        handler_name (str): The name of the handler to call
         submission_uuid (str): The ORA submission UUID
     """
-    handler_name = "list_assessments_to"
     data = {
         "item_id": usage_id,
-        "submission_uuid": submission_uuid,
-    }
-
-    response = call_xblock_json_handler(request, usage_id, handler_name, data)
-
-    if response.status_code != HTTPStatus.OK:
-        raise XBlockInternalError(context={"handler": handler_name})
-
-    return json.loads(response.content)
-
-
-def get_assessments_from(request: Request, usage_id: str, submission_uuid: str):
-    """
-    Get a list of assessments received from ORA `list_assessments_from` XBlock.json_handler
-
-    Lists all assessments received by a user (according to their submissionUUID)
-    in an ORA assignment. Assessments can be Self, Peer and Staff.
-
-    Args:
-        request (Request): The request object
-        usage_id (str): Usage ID of the XBlock for running the handler
-        submission_uuid (str): The ORA submission UUID
-    """
-    handler_name = "list_assessments_from"
-    data = {
         "submission_uuid": submission_uuid,
     }
 

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -65,7 +65,12 @@ def get_assessments(request: Request, usage_id: str, handler_name: str, submissi
     if response.status_code != HTTPStatus.OK:
         raise XBlockInternalError(context={"handler": handler_name})
 
-    return json.loads(response.content)
+    try:
+        return json.loads(response.content)
+    except json.JSONDecodeError as exc:
+        raise XBlockInternalError(
+            context={"handler": handler_name, "details": response.content}
+        ) from exc
 
 
 def get_submission_info(request, usage_id, submission_uuid):

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -34,11 +34,11 @@ def get_submissions(request, usage_id):
     return json.loads(response.content)
 
 
-def get_given_assessments(request, usage_id, submission_uuid):
+def get_assessments_given(request, usage_id, submission_uuid):
     """
-    Get a list of given assessments from the ORA's 'list_given_assessments' XBlock.json_handler
+    Get a list of assessments given from the ORA's 'list_assessments_given' XBlock.json_handler
     """
-    handler_name = "list_given_assessments"
+    handler_name = "list_assessments_given"
     data = {"item_id": usage_id, "submission_uuid": submission_uuid}
 
     response = call_xblock_json_handler(request, usage_id, handler_name, data)
@@ -49,11 +49,11 @@ def get_given_assessments(request, usage_id, submission_uuid):
     return json.loads(response.content)
 
 
-def get_received_assessments(request, usage_id, submission_uuid):
+def get_assessments_received(request, usage_id, submission_uuid):
     """
-    Get a list of received assessments from the ORA's 'list_received_assessments' XBlock.json_handler
+    Get a list of assessments received from the ORA's 'list_assessments_received' XBlock.json_handler
     """
-    handler_name = "list_received_assessments"
+    handler_name = "list_assessments_received"
     data = {"submission_uuid": submission_uuid}
 
     response = call_xblock_json_handler(request, usage_id, handler_name, data)

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -34,14 +34,29 @@ def get_submissions(request, usage_id):
     return json.loads(response.content)
 
 
-def get_assessments(request, usage_id, submission_uuid, assessment_type):
+def get_given_assessments(request, usage_id, submission_uuid):
     """
-    Get a list of assessments from the ORA's 'list_assessments_grades' XBlock.json_handler
+    Get a list of given assessments from the ORA's 'list_given_assessments' XBlock.json_handler
     """
-    handler_name = "list_assessments"
-    body = {"item_id": usage_id, "submission_uuid": submission_uuid, "assessment_type": assessment_type}
+    handler_name = "list_given_assessments"
+    data = {"item_id": usage_id, "submission_uuid": submission_uuid}
 
-    response = call_xblock_json_handler(request, usage_id, handler_name, body)
+    response = call_xblock_json_handler(request, usage_id, handler_name, data)
+
+    if response.status_code != HTTPStatus.OK:
+        raise XBlockInternalError(context={"handler": handler_name})
+
+    return json.loads(response.content)
+
+
+def get_received_assessments(request, usage_id, submission_uuid):
+    """
+    Get a list of received assessments from the ORA's 'list_received_assessments' XBlock.json_handler
+    """
+    handler_name = "list_received_assessments"
+    data = {"submission_uuid": submission_uuid}
+
+    response = call_xblock_json_handler(request, usage_id, handler_name, data)
 
     if response.status_code != HTTPStatus.OK:
         raise XBlockInternalError(context={"handler": handler_name})
@@ -184,5 +199,5 @@ def batch_delete_submission_locks(request, usage_id, submission_uuids):
     response = call_xblock_json_handler(request, usage_id, handler_name, body)
 
     # Errors should raise a blanket exception. Otherwise body is empty, 200 is implicit success
-    if response.status_code != HTTPStatus.OK:
+    if response.status_code != 200:
         raise XBlockInternalError(context={"handler": handler_name})

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -135,11 +135,13 @@ class ScoreSerializer(serializers.Serializer):
 
 class SubmissionMetadataSerializer(serializers.Serializer):
     """
-    Submission metadata for displaying submissions table in ESG
+    Submission metadata for displaying submissions table in Enhanced Staff Grader (ESG)
     """
 
     submissionUUID = serializers.CharField(source="submissionUuid")
     username = serializers.CharField(allow_null=True)
+    email = serializers.CharField(allow_null=True)
+    fullname = serializers.CharField(allow_null=True)
     teamName = serializers.CharField(allow_null=True)
     dateSubmitted = serializers.DateTimeField()
     dateGraded = serializers.DateTimeField(allow_null=True)
@@ -159,6 +161,56 @@ class SubmissionMetadataSerializer(serializers.Serializer):
             "gradeStatus",
             "lockStatus",
             "score",
+            "email",
+            "fullname",
+        ]
+        read_only_fields = fields
+
+
+class AssessmentScoresSerializer(serializers.Serializer):
+    """
+    Score information associated with a specific assessment.
+
+    This serializer was intended for displaying assessment information in the Enhanced Staff Grader (ESG).
+    """
+    criterion_name = serializers.CharField()
+    score_earned = serializers.IntegerField()
+    score_type = serializers.CharField()
+
+    class Meta:
+        fields = [
+            "criterion_name",
+            "score_earned",
+            "score_type",
+        ]
+        read_only_fields = fields
+
+
+class AssessmentSerializer(serializers.Serializer):
+    """
+    Data for displaying Assessment objects for the response from the assessment
+    feedback endpoint in Enhanced Staff Grader (ESG)
+    This serializer is included in the AssessmentFeedbackSerializer as a ListField
+    """
+    assessment_id = serializers.CharField()
+    scorer_name = serializers.CharField(allow_null=True)
+    scorer_username = serializers.CharField(allow_null=True)
+    scorer_email = serializers.CharField(allow_null=True)
+    assesment_date = serializers.DateTimeField()
+    assesment_scores = serializers.ListField(child=AssessmentScoresSerializer())
+    problem_step = serializers.CharField(allow_null=True)
+    feedback = serializers.CharField(allow_null=True)
+
+    class Meta:
+        fields = [
+            "assessment_id",
+            "scorer_name",
+            "scorer_username",
+            "scorer_email",
+            "assesment_date",
+            "assesment_scores",
+            "problem_step",
+            "feedback",
         ]
         read_only_fields = fields
 
@@ -188,6 +240,19 @@ class InitializeSerializer(serializers.Serializer):
         Revert back to BooleanField in AU-617 when ESG officially supports team ORAs
         """
         return obj['isEnabled'] and not obj['oraMetadata'].teams_enabled
+
+
+class AssessmentFeedbackSerializer(serializers.Serializer):
+    """
+    Serialize info for every assessment for the response from the assessment
+    feedback endpoint in Enhanced Staff Grader (ESG)
+    """
+
+    assessments = serializers.ListField(child=AssessmentSerializer())
+
+    class Meta:
+        fields = ["assessments", ]
+        read_only_fields = fields
 
 
 class UploadedFileSerializer(serializers.Serializer):

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -169,9 +169,9 @@ class SubmissionMetadataSerializer(serializers.Serializer):
 
 class AssessmentScoresSerializer(serializers.Serializer):
     """
-    Score information associated with a specific assessment.
+    Serializer for score information associated with a specific assessment.
 
-    This serializer was intended for displaying assessment information in the Enhanced Staff Grader (ESG).
+    This serializer is included in the `AssessmentSerializer` as a `ListField`
     """
     criterion_name = serializers.CharField()
     score_earned = serializers.IntegerField()
@@ -188,16 +188,17 @@ class AssessmentScoresSerializer(serializers.Serializer):
 
 class AssessmentSerializer(serializers.Serializer):
     """
-    Data for displaying Assessment objects for the response from the assessment
-    feedback endpoint in Enhanced Staff Grader (ESG)
-    This serializer is included in the AssessmentFeedbackSerializer as a ListField
+    Serializer for the each assessment metadata in the response from the assessments
+    feedback endpoints (from/to) in Enhanced Staff Grader (ESG)
+
+    This serializer is included in the `AssessmentFeedbackSerializer` as a `ListField`
     """
     assessment_id = serializers.CharField()
     scorer_name = serializers.CharField(allow_null=True)
     scorer_username = serializers.CharField(allow_null=True)
     scorer_email = serializers.CharField(allow_null=True)
-    assesment_date = serializers.DateTimeField()
-    assesment_scores = serializers.ListField(child=AssessmentScoresSerializer())
+    assessment_date = serializers.DateTimeField()
+    assessment_scores = serializers.ListField(child=AssessmentScoresSerializer())
     problem_step = serializers.CharField(allow_null=True)
     feedback = serializers.CharField(allow_null=True)
 
@@ -207,8 +208,8 @@ class AssessmentSerializer(serializers.Serializer):
             "scorer_name",
             "scorer_username",
             "scorer_email",
-            "assesment_date",
-            "assesment_scores",
+            "assessment_date",
+            "assessment_scores",
             "problem_step",
             "feedback",
         ]
@@ -244,14 +245,14 @@ class InitializeSerializer(serializers.Serializer):
 
 class AssessmentFeedbackSerializer(serializers.Serializer):
     """
-    Serialize info for every assessment for the response from the assessment
-    feedback endpoint in Enhanced Staff Grader (ESG)
+    Serializer for a list of assessments for the response from the assessments
+    feedback endpoints (from/to) in Enhanced Staff Grader (ESG)
     """
 
     assessments = serializers.ListField(child=AssessmentSerializer())
 
     class Meta:
-        fields = ["assessments", ]
+        fields = ["assessments"]
         read_only_fields = fields
 
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -241,6 +241,8 @@ class TestSubmissionMetadataSerializer(TestCase):
             "submissionUuid": "a",
             "username": "foo",
             "teamName": "",
+            'email': "jondoes@example.com",
+            'fullname': "",
             "dateSubmitted": "1969-07-16 13:32:00",
             "dateGraded": "None",
             "gradedBy": "",
@@ -251,6 +253,8 @@ class TestSubmissionMetadataSerializer(TestCase):
         "b": {
             "submissionUuid": "b",
             "username": "",
+            'email': "jondoes@example.com",
+            'fullname': "Jhon Does",
             "teamName": "bar",
             "dateSubmitted": "1969-07-20 20:17:40",
             "dateGraded": "None",
@@ -262,6 +266,8 @@ class TestSubmissionMetadataSerializer(TestCase):
         "c": {
             "submissionUuid": "c",
             "username": "baz",
+            'email': "jondoes@example.com",
+            'fullname': "Jhon Does",
             "teamName": "",
             "dateSubmitted": "1969-07-21 21:35:00",
             "dateGraded": "1969-07-24 16:44:00",
@@ -293,6 +299,8 @@ class TestSubmissionMetadataSerializer(TestCase):
         submission = {
             "submissionUuid": "empty-score",
             "username": "WOPR",
+            'email': "jhondoes@example.com",
+            'fullname': "",
             "dateSubmitted": "1983-06-03 00:00:00",
             "dateGraded": None,
             "gradedBy": None,
@@ -304,6 +312,8 @@ class TestSubmissionMetadataSerializer(TestCase):
         expected_output = {
             "submissionUUID": "empty-score",
             "username": "WOPR",
+            'email': "jhondoes@example.com",
+            'fullname': "",
             "teamName": None,
             "dateSubmitted": "1983-06-03 00:00:00",
             "dateGraded": None,

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -13,6 +13,7 @@ from lms.djangoapps.ora_staff_grader.views import (
     SubmissionLockView,
     SubmissionStatusFetchView,
     UpdateGradeView,
+    AssessmentFeedbackView,
 )
 
 
@@ -22,6 +23,7 @@ app_name = "ora-staff-grader"
 urlpatterns += [
     path("mock/", include("lms.djangoapps.ora_staff_grader.mock.urls")),
     path("initialize", InitializeView.as_view(), name="initialize"),
+    path("assessments/feedback", AssessmentFeedbackView.as_view(), name="assessment-feedback"),
     path("submission/batch/unlock", SubmissionBatchUnlockView.as_view(), name="batch-unlock"),
     path("submission/files", SubmissionFilesFetchView.as_view(), name="fetch-files"),
     path(

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -13,8 +13,8 @@ from lms.djangoapps.ora_staff_grader.views import (
     SubmissionLockView,
     SubmissionStatusFetchView,
     UpdateGradeView,
-    AssessmentGivenFeedbackView,
-    AssessmentReceivedFeedbackView,
+    AssessmentFeedbackToView,
+    AssessmentFeedbackFromView,
 )
 
 
@@ -24,8 +24,8 @@ app_name = "ora-staff-grader"
 urlpatterns += [
     path("mock/", include("lms.djangoapps.ora_staff_grader.mock.urls")),
     path("initialize", InitializeView.as_view(), name="initialize"),
-    path("assessments/feedback/from", AssessmentReceivedFeedbackView.as_view(), name="assessment-received-feedback"),
-    path("assessments/feedback/to", AssessmentGivenFeedbackView.as_view(), name="assessment-given-feedback"),
+    path("assessments/feedback/from", AssessmentFeedbackFromView.as_view(), name="assessment-feedback-from"),
+    path("assessments/feedback/to", AssessmentFeedbackToView.as_view(), name="assessment-feedback-to"),
     path("submission/batch/unlock", SubmissionBatchUnlockView.as_view(), name="batch-unlock"),
     path("submission/files", SubmissionFilesFetchView.as_view(), name="fetch-files"),
     path(

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -3,7 +3,7 @@ URLs for Enhanced Staff Grader (ESG) backend-for-frontend (BFF)
 """
 from django.urls import include
 from django.urls import path
-
+from rest_framework.routers import DefaultRouter
 
 from lms.djangoapps.ora_staff_grader.views import (
     InitializeView,
@@ -13,19 +13,18 @@ from lms.djangoapps.ora_staff_grader.views import (
     SubmissionLockView,
     SubmissionStatusFetchView,
     UpdateGradeView,
-    AssessmentFeedbackToView,
-    AssessmentFeedbackFromView,
+    AssessmentFeedbackView,
 )
-
 
 urlpatterns = []
 app_name = "ora-staff-grader"
 
+router = DefaultRouter()
+router.register("assessments/feedback", AssessmentFeedbackView, basename="assessment-feedback")
+
 urlpatterns += [
     path("mock/", include("lms.djangoapps.ora_staff_grader.mock.urls")),
     path("initialize", InitializeView.as_view(), name="initialize"),
-    path("assessments/feedback/from", AssessmentFeedbackFromView.as_view(), name="assessment-feedback-from"),
-    path("assessments/feedback/to", AssessmentFeedbackToView.as_view(), name="assessment-feedback-to"),
     path("submission/batch/unlock", SubmissionBatchUnlockView.as_view(), name="batch-unlock"),
     path("submission/files", SubmissionFilesFetchView.as_view(), name="fetch-files"),
     path(
@@ -37,3 +36,5 @@ urlpatterns += [
     path("submission/grade", UpdateGradeView.as_view(), name="update-grade"),
     path("submission", SubmissionFetchView.as_view(), name="fetch-submission"),
 ]
+
+urlpatterns += router.urls

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -13,7 +13,8 @@ from lms.djangoapps.ora_staff_grader.views import (
     SubmissionLockView,
     SubmissionStatusFetchView,
     UpdateGradeView,
-    AssessmentFeedbackView,
+    AssessmentGivenFeedbackView,
+    AssessmentReceivedFeedbackView,
 )
 
 
@@ -23,7 +24,8 @@ app_name = "ora-staff-grader"
 urlpatterns += [
     path("mock/", include("lms.djangoapps.ora_staff_grader.mock.urls")),
     path("initialize", InitializeView.as_view(), name="initialize"),
-    path("assessments/feedback", AssessmentFeedbackView.as_view(), name="assessment-feedback"),
+    path("assessments/feedback/from", AssessmentReceivedFeedbackView.as_view(), name="assessment-received-feedback"),
+    path("assessments/feedback/to", AssessmentGivenFeedbackView.as_view(), name="assessment-given-feedback"),
     path("submission/batch/unlock", SubmissionBatchUnlockView.as_view(), name="batch-unlock"),
     path("submission/files", SubmissionFilesFetchView.as_view(), name="fetch-files"),
     path(

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -43,8 +43,8 @@ from lms.djangoapps.ora_staff_grader.ora_api import (
     get_assessment_info,
     get_submission_info,
     get_submissions,
-    get_assessments_given,
-    get_assessments_received,
+    get_assessments_to,
+    get_assessments_from,
     submit_grade,
 )
 from lms.djangoapps.ora_staff_grader.serializers import (
@@ -150,31 +150,32 @@ class InitializeView(StaffGraderBaseView):
             return UnknownErrorResponse()
 
 
-class AssessmentGivenFeedbackView(StaffGraderBaseView):
+class AssessmentFeedbackToView(StaffGraderBaseView):
     """
-    GET data about assessments given by a user in a submission
+    (GET) List all assessments given by a user (according to
+    their submissionUUID) in an ORA assignment.
 
-    * Query Params:
+    **Query Params**:
         - oraLocation (str): ORA location for XBlock handling
-        - submissionUUID (str): A submission to get assessments for
+        - submissionUUID (str): The ORA submission UUID
 
     Response: {
         assessments (List[dict]): [
             {
-                "assessment_id: (str) assessment id
-                "scorer_name: (str) scorer name
-                "scorer_username: (str) scorer username
-                "scorer_email: (str) scorer email
-                "assessment_date: (str) assessment date
+                "assessment_id: (str) Assessment id
+                "scorer_name: (str) Scorer name
+                "scorer_username: (str) Scorer username
+                "scorer_email: (str) Scorer email
+                "assessment_date: (str) Assessment date
                 "assessment_scores (List[dict]) [
                     {
-                        "criterion_name: (str) criterion name
-                        "score_earned: (int) score earned
-                        "score_type: (str) score type
+                        "criterion_name: (str) Criterion name
+                        "score_earned: (int) Score earned
+                        "score_type: (str) Score type
                     }
                 ]
-                "problem_step (str) problem step (Self, Peer, or Staff)
-                "feedback: (str) feedback
+                "problem_step (str) Problem step (Self, Peer, or Staff)
+                "feedback: (str) Feedback of the assessment
             }
         ]
     }
@@ -187,9 +188,9 @@ class AssessmentGivenFeedbackView(StaffGraderBaseView):
     """
     @require_params([PARAM_ORA_LOCATION, PARAM_SUBMISSION_ID])
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
-        """ Get data about assessments given by a user"""
+        """Get assessments given by a user in an ORA assignment"""
         try:
-            assessments_data = {"assessments": get_assessments_given(request, ora_location, submission_uuid)}
+            assessments_data = {"assessments": get_assessments_to(request, ora_location, submission_uuid)}
             response_data = AssessmentFeedbackSerializer(assessments_data).data
             return Response(response_data)
 
@@ -206,31 +207,32 @@ class AssessmentGivenFeedbackView(StaffGraderBaseView):
             return UnknownErrorResponse()
 
 
-class AssessmentReceivedFeedbackView(StaffGraderBaseView):
+class AssessmentFeedbackFromView(StaffGraderBaseView):
     """
-    GET data about assessments received by a user in a submission
+    (GET) List all assessments received by a user (according to
+    their submissionUUID) in an ORA assignment.
 
-    * Query Params:
+    **Query Params**:
         - oraLocation (str): ORA location for XBlock handling
-        - submissionUUID (str): A submission to get assessments for
+        - submissionUUID (str): The ORA submission UUID
 
     Response: {
         assessments (List[dict]): [
             {
-                "assessment_id: (str) assessment id
-                "scorer_name: (str) scorer name
-                "scorer_username: (str) scorer username
-                "scorer_email: (str) scorer email
-                "assessment_date: (str) assessment date
+                "assessment_id: (str) Assessment id
+                "scorer_name: (str) Scorer name
+                "scorer_username: (str) Scorer username
+                "scorer_email: (str) Scorer email
+                "assessment_date: (str) Assessment date
                 "assessment_scores (List[dict]) [
                     {
-                        "criterion_name: (str) criterion name
-                        "score_earned: (int) score earned
-                        "score_type: (str) score type
+                        "criterion_name: (str) Criterion name
+                        "score_earned: (int) Score earned
+                        "score_type: (str) Score type
                     }
                 ]
-                "problem_step (str) problem step (Self, Peer, or Staff)
-                "feedback: (str) feedback
+                "problem_step (str) Problem step (Self, Peer, or Staff)
+                "feedback: (str) Feedback of the assessment
             }
         ]
     }
@@ -244,9 +246,9 @@ class AssessmentReceivedFeedbackView(StaffGraderBaseView):
 
     @require_params([PARAM_ORA_LOCATION, PARAM_SUBMISSION_ID])
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
-        """Get data about assessments received by a user"""
+        """Get assessments received by a user in an ORA assignment"""
         try:
-            assessments_data = {"assessments": get_assessments_received(request, ora_location, submission_uuid)}
+            assessments_data = {"assessments": get_assessments_from(request, ora_location, submission_uuid)}
             response_data = AssessmentFeedbackSerializer(assessments_data).data
             return Response(response_data)
 

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -43,8 +43,8 @@ from lms.djangoapps.ora_staff_grader.ora_api import (
     get_assessment_info,
     get_submission_info,
     get_submissions,
-    get_given_assessments,
-    get_received_assessments,
+    get_assessments_given,
+    get_assessments_received,
     submit_grade,
 )
 from lms.djangoapps.ora_staff_grader.serializers import (
@@ -152,7 +152,11 @@ class InitializeView(StaffGraderBaseView):
 
 class AssessmentGivenFeedbackView(StaffGraderBaseView):
     """
-    GET data about assessments given by a user.
+    GET data about assessments given by a user in a submission
+
+    * Query Params:
+        - oraLocation (str): ORA location for XBlock handling
+        - submissionUUID (str): A submission to get assessments for
 
     Response: {
         assessments (List[dict]): [
@@ -185,7 +189,7 @@ class AssessmentGivenFeedbackView(StaffGraderBaseView):
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
         """ Get data about assessments given by a user"""
         try:
-            assessments_data = {"assessments": get_given_assessments(request, ora_location, submission_uuid)}
+            assessments_data = {"assessments": get_assessments_given(request, ora_location, submission_uuid)}
             response_data = AssessmentFeedbackSerializer(assessments_data).data
             return Response(response_data)
 
@@ -204,7 +208,11 @@ class AssessmentGivenFeedbackView(StaffGraderBaseView):
 
 class AssessmentReceivedFeedbackView(StaffGraderBaseView):
     """
-    GET data about assessments received by a user.
+    GET data about assessments received by a user in a submission
+
+    * Query Params:
+        - oraLocation (str): ORA location for XBlock handling
+        - submissionUUID (str): A submission to get assessments for
 
     Response: {
         assessments (List[dict]): [
@@ -238,7 +246,7 @@ class AssessmentReceivedFeedbackView(StaffGraderBaseView):
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
         """Get data about assessments received by a user"""
         try:
-            assessments_data = {"assessments": get_received_assessments(request, ora_location, submission_uuid)}
+            assessments_data = {"assessments": get_assessments_received(request, ora_location, submission_uuid)}
             response_data = AssessmentFeedbackSerializer(assessments_data).data
             return Response(response_data)
 


### PR DESCRIPTION
## Description
> This cover letter was based on [this PR](https://github.com/openedx/edx-platform/pull/33600)

For this PR we have the following goals:

1. Create two new endpoints:
    - The `/api/ora_staff_grader/assessments/feedback/from` endpoint to list the assessment received for a specific submission of a learner.
    - The `/api/ora_staff_grader/assessments/feedback/to` endpoint to list the assessment given by a learner based on their submission ID.
2. Update the `/api/ora_staff_grader/initialize` endpoint to add the `fullname` and `email` fields.

> [!NOTE]  
> [This PR](https://github.com/openedx/frontend-app-ora-grading/pull/263) in the ORA Grading MFE will use these endpoints to display a more detailed table to the instructor.

## Dependencies

> [!IMPORTANT]  
> This upgrade will consist of two PRs: one for ORA and the other for edx-platform. This is because the main serializer of the service resides in the platform. To test it, you must fetch and set up the ORA version with the new handlers.
> - **ORA PR link**: https://github.com/openedx/edx-ora2/pull/2101

## What changed?

### 1. New endpoints

#### `/api/ora_staff_grader/assessments/feedback/from`

This endpoint fetches assessment details for a given:
- Submission UUID
- ORA Location

#### `/api/ora_staff_grader/assessments/feedback/to`

This endpoint fetches assessment details for a given:
- Submission UUID
- ORA Location

Both endpoints return the scorer information and scoring details to fill the following Staff Grade MFE table:

![image](https://github.com/openedx/edx-ora2/assets/64033729/f6792f0a-c902-48c1-9003-3e79685dc79d)

The following is an example of the response from either of the two endpoints:

```json
{
   "assessments": [
      {
         "assessment_id" : "8",
         "scorer_name" : "Nikola Tesla",
         "scorer_username" : "nikola",
         "scorer_email" : "nikola@tesla.com",
         "assesment_date" : "2024-02-15 15:29:55.374959+00:00",
         "assesment_scores" : [
            {
               "criterion_name" : "Ideas",
               "score_earned" : 3,
               "score_type" :" Fair"
            },
            {
               "criterion_name" :" Content",
               "score_earned" : 1,
               "score_type" :" Fair"
            }
         ],
         "problem_step" : "Peer",
         "feedback" : "Good Job"
      }
   ]
}
``` 

### 2. Updated endpoint

#### `/api/ora_staff_grader/initialize`

This is a pre-existing endpoint to which two extra fields are added (`fullname`, `email`) to fill the following table:

![image](https://github.com/openedx/edx-ora2/assets/64033729/61e419a1-ab54-476f-94a1-46282316465d)

The following is an example of the response from this endpoint:

```json
...
    "submissions" : {
        "619b8fb2-ebc0-49ed-9b35-4700efb28f66" : {
            "submissionUUID" : "619b8fb2-ebc0-49ed-9b35-4700efb28f66",
            "username" : "admin",
            "email" : "admin@admin.com",
            "fullname" : "Fernando Gonzalez",
            "teamName" : null,
            "dateSubmitted" : "2023-10-13 15:36:13.781179+00:00",
            "dateGraded" : "2023-10-17 20:26:07.146547+00:00",
            "gradedBy" : "admin",
            "gradeStatus" : "graded",
            "lockStatus" : "unlocked",
            "score" : {
                "pointsEarned" : 10,
                "pointsPossible" : 10
            }
        }
    },
``` 

## Testing Instructions

To test this, you can use Postman:

1. Get an auth token from `/oauth2/access_token/` with the following **x-www-form-urlencoded** content type body:

    ```
    client_id: login-service-client-id
    client_secret: <your-client-secret>
    grant_type: password
    username: <your-username>
    password: <your-password>
    ```
    From the response, copy the `access_token`, which must be sent in the headers of the endpoints.

3. Test the endpoints:
- `/api/ora_staff_grader/initialize`
    - **Query Params**: oraLocation
- `/api/ora_staff_grader/assessments/feedback/from`
    - **Query Params**: oraLocation, submissionUUID
- `/api/ora_staff_grader/assessments/feedback/to`
    - **Query Params**: oraLocation, submissionUUID
 
**NOTE**: From the MFE ora-grading you can get the `oraLocation` from here:

![image](https://github.com/openedx/edx-ora2/assets/64033729/fcd10b8c-cbbd-427e-93de-334f8c0ed7e1)

And the `submissionUUID` from the response of the `initialize` endpoint here:

![image](https://github.com/openedx/edx-ora2/assets/64033729/340943e3-f735-4009-9e24-b52e84ac625c)

Make sure that the `oraLocation` value is encoded.

![image](https://github.com/openedx/edx-ora2/assets/64033729/9a2f01f7-96bc-4856-b08c-8d353eb88bb0)