### PR TITLE
feat: [FC-0031] Add optional field 'is_enrolled' to course detail view

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -5,6 +5,8 @@ Course API Serializers.  Representing course catalog data
 
 import urllib
 
+from common.djangoapps.student.models import CourseEnrollment
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from edx_django_utils import monitoring as monitoring_utils
 from rest_framework import serializers
@@ -164,10 +166,19 @@ class CourseDetailSerializer(CourseSerializer):  # pylint: disable=abstract-meth
         """
         Get the `certificate_available_date` in response
         if the `certificates.auto_certificate_generation` waffle switch is enabled
+
+        Get the 'is_enrolled' in response
+        if user is authenticated and 'username' is in query params.
         """
         response = super().to_representation(instance)
         if can_show_certificate_available_date_field(instance):
             response['certificate_available_date'] = instance.certificate_available_date
+
+        requested_user = self.context['request'].query_params.get('username', None)
+        if self.context['request'].user.is_authenticated and requested_user:
+            User = get_user_model()
+            requested_user = User.objects.get(username=requested_user)
+            response['is_enrolled'] = CourseEnrollment.is_enrolled(requested_user, instance.id)
         return response
 
 


### PR DESCRIPTION
## Description

In this PR, the `is_enrolled` parameter is included in the `CourseDetailView` endpoint's response when the optional `username` query parameter is provided.



## Supporting information

This contribution is a part of the [FC-0031](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3844505604/FC-0031+-+Mobile+API+Migration)


## Testing instructions

GET /api/mobile/v3/course_info/{course_key}/info

See that "is_enrolled" is present in the response

## Other information

The rejected implementation for the mobile endpoint can be found in https://github.com/openedx/edx-platform/pull/33297

