### PR TITLE
feat: filter courses by user language by default

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -126,6 +126,19 @@ ENABLE_OPTIMIZELY_IN_COURSEWARE = WaffleSwitch(  # lint-amnesty, pylint: disable
     'RET.enable_optimizely_in_courseware', __name__
 )
 
+# .. toggle_name: courseware.discovery_default_language_filter
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Enable courses to be filtered by user language by default.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-11-02
+# .. toggle_target_removal_date: None
+# .. toggle_warning: The ENABLE_COURSE_DISCOVERY feature flag should be enabled.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33647
+ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER = WaffleSwitch(
+    f'{WAFFLE_FLAG_NAMESPACE}.discovery_default_language_filter', __name__
+)
+
 
 def courseware_mfe_is_active() -> bool:
     """

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -137,7 +137,10 @@ from openedx.features.enterprise_support.api import data_sharing_consent_require
 
 from ..block_render import get_block, get_block_by_usage_id, get_block_for_descriptor
 from ..tabs import _get_dynamic_tabs
-from ..toggles import COURSEWARE_OPTIMIZED_RENDER_XBLOCK
+from ..toggles import (
+    COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
+    ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER,
+)
 
 log = logging.getLogger("edx.courseware")
 
@@ -275,6 +278,7 @@ def courses(request):
     """
     courses_list = []
     course_discovery_meanings = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
+    set_default_filter = ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER.is_enabled()
     if not settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
         courses_list = get_courses(request.user)
 
@@ -292,6 +296,7 @@ def courses(request):
         {
             'courses': courses_list,
             'course_discovery_meanings': course_discovery_meanings,
+            'set_default_filter': set_default_filter,
             'programs_list': programs_list,
         }
     )

--- a/lms/static/js/discovery/discovery_factory.js
+++ b/lms/static/js/discovery/discovery_factory.js
@@ -5,7 +5,7 @@
         'js/discovery/views/search_form', 'js/discovery/views/courses_listing',
         'js/discovery/views/filter_bar', 'js/discovery/views/refine_sidebar'],
     function(Backbone, SearchState, Filters, SearchForm, CoursesListing, FilterBar, RefineSidebar) {
-        return function(meanings, searchQuery, userLanguage, userTimezone) {
+        return function(meanings, searchQuery, userLanguage, userTimezone, setDefaultFilter) {
             var dispatcher = _.extend({}, Backbone.Events);
             var search = new SearchState();
             var filters = new Filters();
@@ -21,10 +21,16 @@
                 userLanguage: userLanguage,
                 userTimezone: userTimezone
             };
+            if (setDefaultFilter && userLanguage) {
+                filters.add({
+                    type: 'language',
+                    query: userLanguage,
+                    name: refineSidebar.termName('language', userLanguage)
+                });
+            }
             listing = new CoursesListing({model: courseListingModel});
 
             dispatcher.listenTo(form, 'search', function(query) {
-                filters.reset();
                 form.showLoadingIndicator();
                 search.performSearch(query, filters.getTerms());
             });
@@ -42,6 +48,7 @@
             dispatcher.listenTo(filterBar, 'clearFilter', removeFilter);
 
             dispatcher.listenTo(filterBar, 'clearAll', function() {
+                filters.reset();
                 form.doSearch('');
             });
 

--- a/lms/static/js/discovery/views/search_form.js
+++ b/lms/static/js/discovery/views/search_form.js
@@ -52,11 +52,13 @@
             },
 
             showNotFoundMessage: function(term) {
-                var msg = interpolate(
-                    gettext('We couldn\'t find any results for "%s".'),
-                    [_.escape(term)]
-                );
-                this.$message.html(msg);
+                if (term) {
+                    var msg = interpolate(
+                        gettext('We couldn\'t find any results for "%s".'),
+                        [_.escape(term)]
+                    );
+                    this.$message.html(msg);
+                }
                 this.clearSearch();
             },
 

--- a/lms/static/js/spec/discovery/discovery_factory_spec.js
+++ b/lms/static/js/spec/discovery/discovery_factory_spec.js
@@ -45,7 +45,8 @@ define([
                     start: '1970-01-01T05:00:00+00:00',
                     image_url: '/c4x/edX/DemoX/asset/images_course_image.jpg',
                     org: 'edX',
-                    id: 'edX/DemoX/Demo_Course'
+                    id: 'edX/DemoX/Demo_Course',
+                    language: 'en'
                 }
             }
         ],
@@ -193,6 +194,35 @@ define([
             expect($('.active-filter [data-value="edX1"]').length).toBe(1);
             $('.search-facets li [data-value="edX1"]').trigger('click');
             expect($('.active-filter [data-value="edX1"]').length).toBe(0);
+        });
+    });
+
+    describe('discovery.DiscoveryFactory default filters', function() {
+        beforeEach(function() {
+            loadFixtures('js/fixtures/discovery.html');
+            TemplateHelpers.installTemplates([
+                'templates/discovery/course_card',
+                'templates/discovery/facet',
+                'templates/discovery/facet_option',
+                'templates/discovery/filter',
+                'templates/discovery/filter_bar'
+            ]);
+            // setDefaultFilter to true
+            DiscoveryFactory(MEANINGS, '', 'en', 'Asia/Kolkata', true);
+
+            jasmine.clock().install();
+        });
+
+        afterEach(function() {
+            jasmine.clock().uninstall();
+        });
+
+        it('filters by default language', function() {
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            var request = AjaxHelpers.currentRequest(requests);
+            // make sure language filter is set
+            expect(request.requestBody).toMatch(/language=en/);
         });
     });
 });

--- a/lms/static/js/spec/discovery/views/search_form_spec.js
+++ b/lms/static/js/spec/discovery/views/search_form_spec.js
@@ -41,10 +41,17 @@ define(['jquery', 'js/discovery/views/search_form'], function($, SearchForm) {
         it('shows messages', function() {
             this.form.showFoundMessage(123);
             expect($('#discovery-message')).toContainHtml(123);
-            this.form.showNotFoundMessage();
-            expect($('#discovery-message')).not.toBeEmpty();
             this.form.showErrorMessage();
             expect($('#discovery-message')).not.toBeEmpty();
+        });
+
+        it('shows not found messages', function() {
+            // message should not be displayed if search term is empty
+            this.form.showNotFoundMessage();
+            expect($('#discovery-message')).toBeEmpty();
+            this.form.showNotFoundMessage('xyz');
+            expect($('#discovery-message')).not.toBeEmpty();
+            expect($('#discovery-message')).toContainHtml('xyz');
         });
 
         it('shows default error message', function() {

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -23,7 +23,8 @@
       ${course_discovery_meanings | n, dump_js_escaped_json},
       getParameterByName('search_query'),
       "${user_language | n, js_escaped_string}",
-      "${user_timezone | n, js_escaped_string}"
+      "${user_timezone | n, js_escaped_string}",
+      ${set_default_filter | n, dump_js_escaped_json}
     );
   </%static:require_module>
 </%block>


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Adds a waffle switch to filter courses by selected site language by default

Useful information to include:
- Which edX user roles will this change impact? **Learner**

`Private-ref`: [BB-8091](https://tasks.opencraft.com/browse/BB-8091)

## Testing instructions

* Setup master devstack and checkout this PR
* Add below snippet to `lms/envs/private.py`
```python
FEATURES['ENABLE_COURSE_DISCOVERY'] = True
```
* Start lms and cms using `make {lms,cms}-up`
* Add `courseware.discovery_default_language_filter` waffle switch in [django admin](http://localhost:18000/admin/waffle/switch/).
* Add a new course or update language of any existing course to some other language.
* Go to http://localhost:18000/courses
* If you have never set your language via account settings, you should see all the courses without any filters applied.
* Now change your language by going to Account page.
![image](https://github.com/openedx/edx-platform/assets/10894099/d8d36a7a-cd05-42c3-bcd6-cfcc47c5d146)

  * Only `English` option is available in the `Language` field.
  * You can add multiple languages by adding a new Darklang config in http://localhost:18000/admin/dark_lang/darklangconfig/
   
![image](https://github.com/openedx/edx-platform/assets/10894099/210f8366-cdf4-43c8-a3ac-dae3de02a090)

* Open http://localhost:18000/courses, a default language filter should be applied.