### PR TITLE
feat: expose course_roles.use_permission_checks waffle flag for mfe use

### DIFF
--- a/openedx/core/djangoapps/course_roles/urls.py
+++ b/openedx/core/djangoapps/course_roles/urls.py
@@ -3,10 +3,11 @@ URL configuration for course roles api.
 """
 from django.urls import path
 
-from .views import UserPermissionsView
+from .views import UserPermissionsView, UserPermissionsFlagView
 
 app_name = 'course_roles_api'
 
 urlpatterns = [
     path('v1/user_permissions/', UserPermissionsView.as_view(), name='user_permissions'),
+    path('v1/user_permissions/enabled/', UserPermissionsFlagView.as_view(), name='permission_check_flag')
 ]

--- a/openedx/core/djangoapps/course_roles/views.py
+++ b/openedx/core/djangoapps/course_roles/views.py
@@ -8,7 +8,10 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.lib.api.view_utils import view_auth_classes
-from openedx.core.djangoapps.course_roles.helpers import get_all_user_permissions_for_a_course
+from openedx.core.djangoapps.course_roles.helpers import (
+    get_all_user_permissions_for_a_course,
+    use_permission_checks
+)
 
 
 @view_auth_classes()
@@ -48,3 +51,24 @@ class UserPermissionsView(APIView):
         except ValueError as exc:
             raise NotFound(str(exc)) from exc
         return Response(permissions)
+
+
+@view_auth_classes()
+class UserPermissionsFlagView(APIView):
+    """
+    View for getting the permission_checks waffle flag value
+    """
+
+    def get(self, request):
+        """
+        Get endpoint to explose whether the permission_check_flag is enabled
+        **Permissions**: User must be authenticated.
+        **Response Format**:
+        ```json
+        {
+            "enabled": bool
+        }
+        ```
+        """
+        payload = {'enabled': use_permission_checks()}
+        return Response(payload)


### PR DESCRIPTION
## Description

This PR adds a course_roles endpoint to expose the value of the course_roles.use_permission_checks waffle flag for use by the authoring MFE.

## Other information

This is a PR to a feature branch. The feature branch PR will include a link to the PR for the authoring MFE.