### PR TITLE
fix: youtube race condition when GTM loads

### DIFF
--- a/xmodule/js/src/video/01_initialize.js
+++ b/xmodule/js/src/video/01_initialize.js
@@ -169,10 +169,9 @@
                             _oldOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady || undefined;
 
                             window.onYouTubeIframeAPIReady = function() {
-                                window.onYouTubeIframeAPIReady.resolve();
+                                _youtubeApiDeferred.resolve();
                             };
 
-                            window.onYouTubeIframeAPIReady.resolve = _youtubeApiDeferred.resolve;
                             window.onYouTubeIframeAPIReady.done = _youtubeApiDeferred.done;
 
                             if (_oldOnYouTubeIframeAPIReady) {


### PR DESCRIPTION
## Description

The changes fix an issue with YouTube videos when Google Analytics is used. It prevents the video XBlock from properly loading YouTube videos.

It's caused by a race condition, in which both Open edX and GTM implement [onYouTubeIframeAPIReady](https://developers.google.com/youtube/iframe_api_reference#Requirements) and run already existing implementations of this callback.

The issue arises when GTM overwrites it, as the callback implemented by Open edX expects a `resolve()` attribute that isn't implemented by GTM. This change ensures the original global is used by Open edX so it's never overwritten.

## Testing instructions

## Testing

1. Set up a devstack/instance with this branch and Google Analytics.
2. Navigate to a Unit containing a YouTube video and open your browser Development Tools.
3. Add the following breakpoint:
![image](https://github.com/open-craft/edx-platform/assets/5691347/105c3992-6f93-495a-b6a3-b663fdd2ed98)
4. Reload the page and wait a couple of seconds before pressing F8 to continue running. This ensures that `onYouTubeIframeAPIReady` is overwritten by GTM.
5. Make sure the YouTube video loads correctly.
6. Disable the breakpoint and reload, again making sure the Youtube video loads when the callback set by Open edX is used.

## Deadline

"None"

## Other information

- https://developers.google.com/youtube/iframe_api_reference#Requirements
