### PR TITLE
Update openedx-learning, new format for the "get object tags" REST API (unstable) [FC-0036]

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1136,13 +1136,19 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
 
         assert response.status_code == expected_status
         if status.is_success(expected_status):
-            assert len(response.data) == len(tag_values)
-            assert set(t["value"] for t in response.data) == set(tag_values)
+            tags_by_taxonomy = response.data[str(self.courseA)]["taxonomies"]
+            if tag_values:
+                response_taxonomy = tags_by_taxonomy[0]
+                assert response_taxonomy["name"] == taxonomy.name
+                response_tags = response_taxonomy["tags"]
+                assert [t["value"] for t in response_tags] == tag_values
+            else:
+                assert tags_by_taxonomy == []  # No tags are set from any taxonomy
 
             # Check that re-fetching the tags returns what we set
-            response = self.client.get(url, format="json")
-            assert status.is_success(response.status_code)
-            assert set(t["value"] for t in response.data) == set(tag_values)
+            new_response = self.client.get(url, format="json")
+            assert status.is_success(new_response.status_code)
+            assert new_response.data == response.data
 
     @ddt.data(
         "staffA",
@@ -1214,13 +1220,19 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
 
         assert response.status_code == expected_status
         if status.is_success(expected_status):
-            assert len(response.data) == len(tag_values)
-            assert set(t["value"] for t in response.data) == set(tag_values)
+            tags_by_taxonomy = response.data[str(self.xblockA)]["taxonomies"]
+            if tag_values:
+                response_taxonomy = tags_by_taxonomy[0]
+                assert response_taxonomy["name"] == taxonomy.name
+                response_tags = response_taxonomy["tags"]
+                assert [t["value"] for t in response_tags] == tag_values
+            else:
+                assert tags_by_taxonomy == []  # No tags are set from any taxonomy
 
             # Check that re-fetching the tags returns what we set
-            response = self.client.get(url, format="json")
-            assert status.is_success(response.status_code)
-            assert set(t["value"] for t in response.data) == set(tag_values)
+            new_response = self.client.get(url, format="json")
+            assert status.is_success(new_response.status_code)
+            assert new_response.data == response.data
 
     @ddt.data(
         "staffA",

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -121,7 +121,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.3.0
+openedx-learning==0.3.2
 
 # lti-consumer-xblock 9.6.2 contains a breaking change that makes
 # existing custom parameter configurations unusable.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -785,7 +785,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.3.0
+openedx-learning==0.3.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1318,7 +1318,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.0
+openedx-learning==0.3.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -925,7 +925,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.0
+openedx-learning==0.3.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -992,7 +992,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.0
+openedx-learning==0.3.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This updates our `openedx-learning` repo to the latest version, which includes some improvements to the REST API for "get object tags". (An unstable API that isn't yet used in prod by anyone.)

## Supporting information

See https://github.com/openedx/openedx-learning/pull/111 and https://github.com/openedx/modular-learning/issues/133

## Testing instructions

For now, it's sufficient to run the test suite.

## Deadline

None

## Other information

This will simplify https://github.com/openedx/edx-platform/pull/33563

Private ref: FAL-3547