### PR TITLE
fix: duplicate library_content children asynchronously

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -48,7 +48,7 @@ remote platform instances as well as local modulestore APIs.  Additionally,
 there are Celery-based interfaces suitable for background processing controlled
 through RESTful APIs (see :mod:`.views`).
 """
-
+from __future__ import annotations
 
 import abc
 import collections
@@ -76,6 +76,7 @@ from opaque_keys.edx.locator import (
     LibraryUsageLocatorV2,
     LibraryLocator as LibraryLocatorV1
 )
+from opaque_keys import InvalidKeyError
 from openedx_events.content_authoring.data import ContentLibraryData, LibraryBlockData
 from openedx_events.content_authoring.signals import (
     CONTENT_LIBRARY_CREATED,
@@ -124,7 +125,9 @@ from openedx.core.lib.blockstore_api import (
 )
 from openedx.core.djangolib import blockstore_cache
 from openedx.core.djangolib.blockstore_cache import BundleCache
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.library_root_xblock import LibraryRoot as LibraryRootV1
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from . import tasks
 
@@ -639,7 +642,7 @@ def delete_library(library_key):
         raise
 
 
-def get_library_blocks(library_key, text_search=None, block_types=None):
+def get_library_blocks(library_key, text_search=None, block_types=None) -> list[LibraryXBlockMetadata]:
     """
     Get the list of top-level XBlocks in the specified library.
 
@@ -668,7 +671,7 @@ def get_library_blocks(library_key, text_search=None, block_types=None):
     # If indexing is disabled, or connection to elastic failed
     if metadata is None:
         metadata = []
-        ref = ContentLibrary.objects.get_by_key(library_key)
+        ref = ContentLibrary.objects.get_by_key(library_key)  # type: ignore[attr-defined]
         lib_bundle = LibraryBundle(library_key, ref.bundle_uuid, draft_name=DRAFT_NAME)
         usages = lib_bundle.get_top_level_usages()
 
@@ -701,7 +704,7 @@ def get_library_blocks(library_key, text_search=None, block_types=None):
     ]
 
 
-def _lookup_usage_key(usage_key):
+def _lookup_usage_key(usage_key) -> tuple[BundleDefinitionLocator, LibraryBundle]:
     """
     Given a LibraryUsageLocatorV2 (usage key for an XBlock in a content library)
     return the definition key and LibraryBundle
@@ -716,7 +719,7 @@ def _lookup_usage_key(usage_key):
     return def_key, lib_bundle
 
 
-def get_library_block(usage_key):
+def get_library_block(usage_key) -> LibraryXBlockMetadata:
     """
     Get metadata (LibraryXBlockMetadata) about one specific XBlock in a library
 
@@ -888,7 +891,7 @@ def delete_library_block(usage_key, remove_from_parent=True):
     )
 
 
-def create_library_block_child(parent_usage_key, block_type, definition_id):
+def create_library_block_child(parent_usage_key, block_type, definition_id) -> LibraryXBlockMetadata:
     """
     Create a new XBlock definition in this library of the specified type (e.g.
     "html"), and add it as a child of the specified existing block.
@@ -908,7 +911,7 @@ def create_library_block_child(parent_usage_key, block_type, definition_id):
     include_data = XBlockInclude(link_id=None, block_type=block_type, definition_id=definition_id, usage_hint=None)
     parent_block.runtime.add_child_include(parent_block, include_data)
     parent_block.save()
-    ref = ContentLibrary.objects.get_by_key(parent_usage_key.context_key)
+    ref = ContentLibrary.objects.get_by_key(parent_usage_key.context_key)  # type: ignore[attr-defined]
     LIBRARY_BLOCK_UPDATED.send_event(
         library_block=LibraryBlockData(
             library_key=ref.library_key,
@@ -1163,6 +1166,48 @@ def revert_changes(library_key):
             update_blocks=True
         )
     )
+
+
+# V1/V2 Compatibility Helpers
+# (Should be removed as part of
+#  https://github.com/openedx/edx-platform/issues/32457)
+# ======================================================
+
+def get_v1_or_v2_library(
+    library_id: str | LibraryLocatorV1 | LibraryLocatorV2,
+) -> LibraryRootV1 | ContentLibraryMetadata | None:
+    """
+    Fetch either a V1 or V2 content library from a V1/V2 key (or key string).
+
+    Returns None if not found.
+    If key is invalid, raises InvalidKeyError.
+
+    Examples:
+    * get_v1_or_v2_library("library-v1:ProblemX+PR0B") -> <LibraryRootV1>
+    * get_v1_or_v2_library("lib:RG:rg-1")              -> <ContentLibraryMetadata>
+    * get_v1_or_v2_library("fail")                     -> <InvalidKeyError>
+
+    If you just want to get a V2 library, use `get_library` instead.
+    """
+    library_key: LibraryLocatorV1 | LibraryLocatorV2
+    if isinstance(library_id, str):
+        try:
+            library_key = LibraryLocatorV1.from_string(library_id)
+        except InvalidKeyError:
+            library_key = LibraryLocatorV2.from_string(library_id)
+    else:
+        library_key = library_id
+    if isinstance(library_key, LibraryLocatorV2):
+        try:
+            return get_library(library_key)
+        except ContentLibrary.DoesNotExist:
+            return None
+    elif isinstance(library_key, LibraryLocatorV1):
+        store = modulestore()
+        try:
+            return store.get_library(library_key, remove_version=False, remove_branch=False, head_validation=False)
+        except ItemNotFoundError:
+            return None
 
 
 # Import from Courseware

--- a/xmodule/modulestore/xml_importer.py
+++ b/xmodule/modulestore/xml_importer.py
@@ -900,10 +900,7 @@ def _update_and_import_block(
             try:
                 # Update library content block's children on draft branch
                 with store.branch_setting(branch_setting=ModuleStoreEnum.Branch.draft_preferred):
-                    LibraryToolsService(store, user_id).trigger_update_children_task(
-                        block,
-                        version=block.source_library_version,
-                    )
+                    LibraryToolsService(store, user_id).trigger_refresh_children(block)
             except ValueError as err:
                 # The specified library version does not exist.
                 log.error(err)

--- a/xmodule/tests/test_library_content.py
+++ b/xmodule/tests/test_library_content.py
@@ -493,19 +493,10 @@ class LibraryContentBlockTestMixin:
             assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-@patch('xmodule.library_tools.SearchEngine.get_search_engine', Mock(return_value=None, autospec=True))
-class TestLibraryContentBlockNoSearchIndex(LibraryContentBlockTestMixin, LibraryContentTest):
-    """
-    Tests for library container when no search index is available.
-    Tests fallback low-level CAPA problem introspection
-    """
-    pass  # pylint:disable=unnecessary-pass
-
-
 search_index_mock = Mock(spec=SearchEngine)  # pylint: disable=invalid-name
 
 
-@patch('xmodule.library_tools.SearchEngine.get_search_engine', Mock(return_value=search_index_mock, autospec=True))
+@patch.object(SearchEngine, 'get_search_engine', Mock(return_value=None, autospec=True))
 class TestLibraryContentBlockWithSearchIndex(LibraryContentBlockTestMixin, LibraryContentTest):
     """
     Tests for library container with mocked search engine response.

--- a/xmodule/tests/test_library_tools.py
+++ b/xmodule/tests/test_library_tools.py
@@ -124,7 +124,7 @@ class ContentLibraryToolsTest(MixedSplitTestCase, ContentLibrariesRestApiTest):
         assert len(content_block.children) == 0
 
         # Populate children from library
-        self.tools.trigger_update_children_task(content_block)
+        self.tools.trigger_refresh_children(content_block)
 
         # The updates happen in a Celery task, so this particular content_block instance is no updated.
         # We must re-instantiate it from modulstore in order to see the updated children list.
@@ -161,7 +161,7 @@ class ContentLibraryToolsTest(MixedSplitTestCase, ContentLibrariesRestApiTest):
         )
 
         # Import the unit block from the library to the course
-        self.tools.trigger_update_children_task(lc_block)
+        self.tools.trigger_refresh_children(lc_block)
         lc_block = self.store.get_item(lc_block.location)
 
         # Verify imported block with its children
@@ -182,7 +182,7 @@ class ContentLibraryToolsTest(MixedSplitTestCase, ContentLibrariesRestApiTest):
 
         # Check that reimporting updates the target block
         self._set_library_block_olx(html_block_id, '<html><a href="/static/test.txt">Foo bar</a></html>')
-        self.tools.trigger_update_children_task(lc_block)
+        self.tools.trigger_refresh_children(lc_block)
         lc_block = self.store.get_item(lc_block.location)
 
         assert len(lc_block.children) == 1
@@ -209,6 +209,6 @@ class ContentLibraryToolsTest(MixedSplitTestCase, ContentLibrariesRestApiTest):
         )
 
         assert len(content_block.children) == 0
-        self.tools.trigger_update_children_task(content_block)
+        self.tools.trigger_refresh_children(content_block)
         content_block = self.store.get_item(content_block.location)
         assert len(content_block.children) == 1


### PR DESCRIPTION
This is an intermediate PR against https://github.com/openedx/edx-platform/pull/33263. 

We move the implementation of LibraryContentBlock.studio_post_duplicate into a new Celery task: duplicate_children. This is necessary because the first half of studio_post_duplicate (that is: refresh_children) has been moved into a Celery task, so the second half (that is: _copy_overrides) must also move into a Celery task so that it can occur after refresh_children. [More context](https://github.com/openedx/edx-platform/pull/33263#discussion_r1377689356).

This involved some renaming and refactoring. The layers now look like this, from top to bottom:
* **LibraryContentBlock** has methods `.refresh_children` and `.studio_post_duplicate`, which use...
* **LibraryToolsService**, via methods `.trigger_refresh_children` and `.trigger_duplicate_children`, which use...
* **content_libraries.tasks** via tasks `refresh_children` and `duplicate_children`, which share the `_update_children` helper function, and the `LibraryUpdateChildrenTask` base class.

Ride-along changes:
* Removed `version` parameter from the above methods/tasks. For V1 libraries, it was always set to `block.source_library_version`. For V2 libraries, it was completely ignored.
* Removed duplicate filtering code
* Merged duplicate `_get_library` implements into `content_libraries.api:get_v1_or_v2_library`
* Added various type annotations.