### PR TITLE
fix: video drf 500 error

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
@@ -67,7 +67,7 @@ class VideoActiveTranscriptPreferencesSerializer(serializers.Serializer):
     three_play_turnaround = serializers.CharField()
     preferred_languages = serializers.ListField(
         child=serializers.CharField()
-    ),
+    )
     video_source_language = serializers.CharField()
     modified = serializers.CharField()
 

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
@@ -58,6 +58,20 @@ class VideoModelSerializer(serializers.Serializer):
     )
 
 
+class VideoActiveTranscriptPreferencesSerializer(serializers.Serializer):
+    """Serializer for a videos active transcript preferences"""
+    course_id = serializers.CharField(),
+    provider = serializers.CharField(),
+    cielo24_fidelity = serializers.CharField(),
+    cielo24_turnaround = serializers.CharField(),
+    three_play_turnaround = serializers.CharField(),
+    preferred_languages = serializers.ListField(
+        child=serializers.CharField(),
+    ),
+    video_source_language = serializers.CharField(),
+    modified = serializers.CharField(),
+
+
 class CourseVideosSerializer(serializers.Serializer):
     """Serializer for course videos"""
     image_upload_url = serializers.CharField()
@@ -72,15 +86,16 @@ class CourseVideosSerializer(serializers.Serializer):
     video_upload_max_file_size = serializers.CharField()
     video_image_settings = VideoImageSettingsSerializer(required=True, allow_null=False)
     is_video_transcript_enabled = serializers.BooleanField()
-    active_transcript_preferences = serializers.BooleanField(required=False, allow_null=True)
+    active_transcript_preferences = VideoActiveTranscriptPreferencesSerializer(required=False, allow_null=True)
     transcript_credentials = serializers.DictField(
-        child=serializers.CharField()
+        child=serializers.BooleanField()
     )
     transcript_available_languages = serializers.ListField(
         child=serializers.DictField(
             child=serializers.CharField()
         )
     )
+    # transcript_available_languages = serializers.BooleanField(required=False, allow_null=True)
     video_transcript_settings = VideoTranscriptSettingsSerializer()
     pagination_context = serializers.DictField(
         child=serializers.CharField(),

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
@@ -60,16 +60,16 @@ class VideoModelSerializer(serializers.Serializer):
 
 class VideoActiveTranscriptPreferencesSerializer(serializers.Serializer):
     """Serializer for a videos active transcript preferences"""
-    course_id = serializers.CharField(),
-    provider = serializers.CharField(),
-    cielo24_fidelity = serializers.CharField(),
-    cielo24_turnaround = serializers.CharField(),
-    three_play_turnaround = serializers.CharField(),
+    course_id = serializers.CharField()
+    provider = serializers.CharField()
+    cielo24_fidelity = serializers.CharField()
+    cielo24_turnaround = serializers.CharField()
+    three_play_turnaround = serializers.CharField()
     preferred_languages = serializers.ListField(
-        child=serializers.CharField(),
+        child=serializers.CharField()
     ),
-    video_source_language = serializers.CharField(),
-    modified = serializers.CharField(),
+    video_source_language = serializers.CharField()
+    modified = serializers.CharField()
 
 
 class CourseVideosSerializer(serializers.Serializer):


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR resolves the issues 500 error when a course's `active_transcript_preferences` is not `null`. Previously, a course would load successfully in the course authoring MFE if a course did not have any transcript preferences. But when that setting was updated, the API would return a 500 error. Now the serializer type has been updated and the page renders as expected when `active_transcript_preferences` is not `null`. This change impacts "Course Authors".

## Testing instructions

1. Navigate to the course authoring video page
    a. make sure `ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN = true` is set in course authoring
2. The page should load as expected

## Deadline

None

## Other information

This change only impacts the Course Authoring's video page.
