### PR TITLE
fix: practice exams assigned to wrong type

### DIFF
--- a/cms/djangoapps/contentstore/exams.py
+++ b/cms/djangoapps/contentstore/exams.py
@@ -109,7 +109,7 @@ def get_exam_type(is_proctored, is_practice, is_onboarding):
         if is_onboarding:
             exam_type = 'onboarding'
         elif is_practice:
-            exam_type = 'practice_proctored'
+            exam_type = 'practice'
         else:
             exam_type = 'proctored'
     else:

--- a/cms/djangoapps/contentstore/tests/test_exams.py
+++ b/cms/djangoapps/contentstore/tests/test_exams.py
@@ -60,7 +60,7 @@ class TestExamService(ModuleStoreTestCase):
     @ddt.data(
         (False, False, False, 'timed'),
         (True, False, False, 'proctored'),
-        (True, True, False, 'practice_proctored'),
+        (True, True, False, 'practice'),
         (True, True, True, 'onboarding'),
     )
     @ddt.unpack


### PR DESCRIPTION
Publishing a 'practice proctored' exam was resulting in a blank screen in the section for the learners. Turns out this exam type should have just been 'practice'. 'practice_proctored' isn't a valid value in our UI, there is no practice without proctoring. This only impacted courses are those with LTI exams enabled. (so nothing in production)

### 2U ticket: [COSMO-54](https://2u-internal.atlassian.net/browse/COSMO-54?atlOrigin=eyJpIjoiMzNmOWNhZGNkMGFjNDFiYmE1OGE4MzRhM2U1M2U2ZTgiLCJwIjoiaiJ9)