### PR TITLE
fix: decoration of see all children link in wiki pages

### DIFF
--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -262,9 +262,9 @@
       a {
         display: block;
         padding: 2px 4px 2px 10px;
-        border-radius: 3px;
         font-size: 0.9em;
         line-height: 25px;
+        border-left: 1px solid $m-blue;
 
         &:hover,
         &:focus {

--- a/lms/templates/wiki/article.html
+++ b/lms/templates/wiki/article.html
@@ -33,7 +33,7 @@
 
       {% if urlpath %}
       <div class="see-children">
-        <a href="{% url 'wiki:dir' path=urlpath.path %}">{% trans "See all children" as tmsg %} | {{ tmsg | force_escape}}</a>
+        <a href="{% url 'wiki:dir' path=urlpath.path %}">{% trans "See all children" as tmsg %} {{ tmsg | force_escape}}</a>
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
### Description
This pull request contains small recommendations for fixing the styling of the "See all children" link and replacing the decorative separator from the HTML markup with a style one.

#### Related Pull Requests
PR to the open-release/quince.master branch: https://github.com/openedx/edx-platform/pull/33669
PR to the master branch: https://github.com/openedx/edx-platform/pull/33670

#### Screenshots/sandbox (optional):
|Before|After|
|-------|-----|
|    <img width="1693" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/74462f05-73ec-4bc9-92f0-bc1718a8c141">  |   <img width="1692" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/dcf92d07-af7f-4703-b734-8fc0c9df00a9">   |
