### PR TITLE
fix: remove duplicates

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -10,7 +10,6 @@ Along with it, we moved the business logic of the other views in that file, sinc
 """
 import logging
 from datetime import datetime
-from uuid import uuid4
 
 from attrs import asdict
 from django.conf import settings
@@ -18,11 +17,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.utils.timezone import timezone
 from django.utils.translation import gettext as _
 from edx_django_utils.plugins import pluggable_override
-from openedx_events.content_authoring.data import DuplicatedXBlockData
-from openedx_events.content_authoring.signals import XBLOCK_DUPLICATED
 from openedx_tagging.core.tagging import api as tagging_api
 from edx_proctoring.api import (
     does_backend_support_onboarding,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -53,7 +53,6 @@ from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.cache_utils import request_cached
 from openedx.core.toggles import ENTRANCE_EXAMS
-<<<<<<< HEAD
 from xmodule.course_block import DEFAULT_START_DATE
 from xmodule.modulestore import EdxJSONEncoder, ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -61,31 +60,6 @@ from xmodule.modulestore.draft_and_published import DIRECT_ONLY_CATEGORIES
 from xmodule.modulestore.exceptions import InvalidLocationError, ItemNotFoundError
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.tabs import CourseTabList
-=======
-from xmodule.course_block import (
-    DEFAULT_START_DATE,
-)  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore import (
-    EdxJSONEncoder,
-    ModuleStoreEnum,
-)  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import (
-    modulestore,
-)  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.draft_and_published import (
-    DIRECT_ONLY_CATEGORIES,
-)  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.exceptions import (
-    InvalidLocationError,
-    ItemNotFoundError,
-)  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.inheritance import (
-    own_metadata,
-)  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.tabs import (
-    CourseTabList,
-)  # lint-amnesty, pylint: disable=wrong-import-order
->>>>>>> c67608e558 (fix: lint)
 
 from ..utils import (
     ancestor_has_staff_lock,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -53,6 +53,7 @@ from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.cache_utils import request_cached
 from openedx.core.toggles import ENTRANCE_EXAMS
+<<<<<<< HEAD
 from xmodule.course_block import DEFAULT_START_DATE
 from xmodule.modulestore import EdxJSONEncoder, ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -60,6 +61,31 @@ from xmodule.modulestore.draft_and_published import DIRECT_ONLY_CATEGORIES
 from xmodule.modulestore.exceptions import InvalidLocationError, ItemNotFoundError
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.tabs import CourseTabList
+=======
+from xmodule.course_block import (
+    DEFAULT_START_DATE,
+)  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore import (
+    EdxJSONEncoder,
+    ModuleStoreEnum,
+)  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import (
+    modulestore,
+)  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.draft_and_published import (
+    DIRECT_ONLY_CATEGORIES,
+)  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.exceptions import (
+    InvalidLocationError,
+    ItemNotFoundError,
+)  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.inheritance import (
+    own_metadata,
+)  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.tabs import (
+    CourseTabList,
+)  # lint-amnesty, pylint: disable=wrong-import-order
+>>>>>>> c67608e558 (fix: lint)
 
 from ..utils import (
     ancestor_has_staff_lock,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -225,7 +225,7 @@ def handle_xblock(request, usage_key_string=None):
                 parent_usage_key,
                 duplicate_source_usage_key,
                 request.user,
-                request.json.get("display_name"),
+                display_name=request.json.get('display_name'),
             )
 
             return JsonResponse(


### PR DESCRIPTION
Removes some duplicate methods.

Testing:
- go to `localhost:18010/cms-api/ui`, go to GET xblock section, put in course id and block id from a local test course, and see that you get a successful response
- go to studio and open any xblock

Automatic tests already cover that permissions are correct and still work.