### PR TITLE
chore: bump ORA version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -793,7 +793,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==5.5.5
+ora2==6.0.0
     # via -r requirements/edx/bundled.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1328,7 +1328,7 @@ optimizely-sdk==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==5.5.5
+ora2==6.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -933,7 +933,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.5.5
+ora2==6.0.0
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -997,7 +997,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.5.5
+ora2==6.0.0
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via


### PR DESCRIPTION
## Description

Add new UI config for ORA:
- Legacy UI (no change, default experience)
- MFE UI (supports new focus pop-out view, enabled with `openresponseassessment.mfe_view` config flag)

## Supporting information

See https://github.com/openedx/edx-ora2/releases/tag/v6.0.0 for full changelog.

## Testing instructions

No change for legacy view.
MFE view currently mid-testing.

## Deadline

ASAP
