### PR TITLE
Fix ORA uploaded response (for Palm)

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -4,6 +4,8 @@ Serializers for Enhanced Staff Grader (ESG)
 # pylint: disable=abstract-method
 # pylint: disable=missing-function-docstring
 
+from urllib.parse import urljoin
+from django.conf import settings
 from rest_framework import serializers
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -191,10 +193,16 @@ class InitializeSerializer(serializers.Serializer):
 class UploadedFileSerializer(serializers.Serializer):
     """Serializer for a file uploaded as a part of a response"""
 
-    downloadUrl = serializers.URLField(source="download_url")
+    downloadUrl = serializers.SerializerMethodField(method_name="get_download_url")
     description = serializers.CharField()
     name = serializers.CharField()
     size = serializers.IntegerField()
+
+    def get_download_url(self, obj):
+        """
+        Get the representation for SerializerMethodField `downloadUrl`
+        """
+        return urljoin(settings.LMS_ROOT_URL, obj.get("download_url"))
 
 
 class ResponseSerializer(serializers.Serializer):


### PR DESCRIPTION
This is a [backport](https://github.com/openedx/edx-platform/pull/33677) pull request to the master branch.

## Description

The details are described in [this discussion](https://discuss.openedx.org/t/ora-grading-returns-error/11482).

**Now everything works correctly:**

<img width="1671" alt="Знімок екрана 2023-11-08 о 14 10 40" src="https://github.com/openedx/edx-platform/assets/98233552/abc8b3a7-0eb9-4991-847a-6f19b9b69a4f">

Do not pay attention to the fact that the screenshot was taken from a local instance. It has been tested on the production server, and everything works just as correctly.