### PR TITLE
feat: remove old proctoring settings url

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -46,7 +46,6 @@ from common.djangoapps.util.milestones_helpers import (
 )
 from common.djangoapps.xblock_django.user_service import DjangoXBlockUserService
 from openedx.core import toggles as core_toggles
-from openedx.core.djangoapps.course_apps.toggles import proctoring_settings_modal_view_enabled
 from openedx.core.djangoapps.credit.api import get_credit_requirements, is_credit_course
 from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
@@ -246,10 +245,7 @@ def get_proctored_exam_settings_url(course_locator) -> str:
         mfe_base_url = get_course_authoring_url(course_locator)
         course_mfe_url = f'{mfe_base_url}/course/{course_locator}'
         if mfe_base_url:
-            if proctoring_settings_modal_view_enabled(course_locator):
-                proctored_exam_settings_url = f'{course_mfe_url}/pages-and-resources/proctoring/settings'
-            else:
-                proctored_exam_settings_url = f'{course_mfe_url}/proctored-exam-settings'
+            proctored_exam_settings_url = f'{course_mfe_url}/pages-and-resources/proctoring/settings'
     return proctored_exam_settings_url
 
 

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -9,10 +9,8 @@ from opaque_keys.edx.keys import CourseKey
 
 from xmodule.modulestore.django import modulestore
 
-from cms.djangoapps.contentstore.utils import get_proctored_exam_settings_url
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_apps.plugins import CourseApp
-from openedx.core.djangoapps.course_apps.toggles import proctoring_settings_modal_view_enabled
 from openedx.core.lib.courses import get_course_by_id
 
 User = get_user_model()
@@ -210,11 +208,6 @@ class ProctoringCourseApp(CourseApp):
             "enable": False,
             "configure": True,
         }
-
-    @staticmethod
-    def legacy_link(course_key: CourseKey):
-        if not proctoring_settings_modal_view_enabled(course_key):
-            return get_proctored_exam_settings_url(course_key)
 
 
 class CustomPagesCourseApp(CourseApp):

--- a/openedx/core/djangoapps/course_apps/toggles.py
+++ b/openedx/core/djangoapps/course_apps/toggles.py
@@ -6,19 +6,6 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 #: Namespace for use by course apps for creating availability toggles
 COURSE_APPS_WAFFLE_NAMESPACE = 'course_apps'
 
-# .. toggle_name: course_apps.proctoring_settings_modal_view
-# .. toggle_use_cases: temporary
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: When enabled, users will be directed to a new proctoring settings
-#    modal on the Pages and Resources view when accessing proctored exam settings.
-# .. toggle_warning: None
-# .. toggle_creation_date: 2021-08-17
-# .. toggle_target_removal_date: None
-PROCTORING_SETTINGS_MODAL_VIEW = CourseWaffleFlag(
-    f'{COURSE_APPS_WAFFLE_NAMESPACE}.proctoring_settings_modal_view', __name__
-)
-
 # .. toggle_name: course_apps.exams_ida
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
@@ -30,13 +17,6 @@ PROCTORING_SETTINGS_MODAL_VIEW = CourseWaffleFlag(
 EXAMS_IDA = CourseWaffleFlag(
     f'{COURSE_APPS_WAFFLE_NAMESPACE}.exams_ida', __name__
 )
-
-
-def proctoring_settings_modal_view_enabled(course_key):
-    """
-    Returns a boolean if proctoring settings modal view is enabled for a course.
-    """
-    return PROCTORING_SETTINGS_MODAL_VIEW.is_enabled(course_key)
 
 
 def exams_ida_enabled(course_key):

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,6 @@ ignore_imports =
     ############################################################################
     # lms side imports that we are ignoring for now
     lms.djangoapps.course_home_api.outline.tests.test_view -> cms.djangoapps.contentstore.outlines
-    lms.djangoapps.courseware.plugins -> cms.djangoapps.contentstore.utils
     lms.djangoapps.course_home_api.tests.utils -> cms.djangoapps.contentstore.outlines
     # lms.djangoapps.instructor.tests.test_api & lms.djangoapps.instructor.tests.test_tools
     #   -> openedx.core.djangoapps.course_date_signals.handlers


### PR DESCRIPTION
This flag was introduced to gate the rollout of moving the UI component for proctoring settings into the pages and resources view and was never cleaned up. At this point we should always be linking the the new page for this, the old UI component in course authoring will be removed.

### 2U JIRA: [COSMO-59](https://2u-internal.atlassian.net/browse/COSMO-59)