### PR TITLE
Revert "feat: Upgrade Python dependency edx-drf-extensions"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -470,7 +470,7 @@ edx-django-utils==5.7.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-completion

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -739,7 +739,7 @@ edx-django-utils==5.7.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -546,7 +546,7 @@ edx-django-utils==5.7.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -571,7 +571,7 @@ edx-django-utils==5.7.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion


### PR DESCRIPTION
Reverts openedx/edx-platform#33660

This was causing the following error in `handle_xblock_callback`:
```
File /edx/app/edxapp/edx-platform/lms/djangoapps/courseware/block_render.py, line 767, in handle_xblock_callback
                               File /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_rest_framework_extensions/auth/jwt/authentication.py, line 152, in authenticate
                               File /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_rest_framework_extensions/auth/jwt/authentication.py, line 284, in _is_failed_jwt_cookie_and_session_user_mismatch
                               File /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_rest_framework_extensions/auth/jwt/authentication.py, line 335, in _is_jwt_cookie_and_session_user_mismatch
```