### PR TITLE
temp: add constraint to edx-drf-extensions 8.12.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -28,6 +28,10 @@ django-storages==1.14
 # for them.
 edx-enterprise==4.6.12
 
+# edx-drf-extensions 8.13.0 was causing errors, as mentioned in this revert PR:
+# https://github.com/openedx/edx-platform/pull/33682.
+edx-drf-extensions==8.12.0
+
 # django-oauth-toolkit version >=2.0.0 has breaking changes. More details
 # mentioned on this issue https://github.com/openedx/edx-platform/issues/32884
 django-oauth-toolkit==1.7.1


### PR DESCRIPTION
## Description

edx-drf-extensions 8.13.0 was causing errors, as mentioned in this revert PR to 8.12.0: https://github.com/openedx/edx-platform/pull/33682

This adds a temporary constraint to keep it at 8.12.0.

Note: I didn't want this to hold up getting the revert to Production, so this was implemented separately.