### PR TITLE
[FC-0036] fix: allows taxonomy list to "filter by org" even if org does not exist

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -343,6 +343,8 @@ class TestTaxonomyListCreateViewSet(TestTaxonomyObjectsMixin, APITestCase):
         ("orgA", ["st1", "st2", "t1", "t2", "tA1", "tA2", "tBA1", "tBA2"]),
         ("orgB", ["st1", "st2", "t1", "t2", "tB1", "tB2", "tBA1", "tBA2"]),
         ("orgX", ["st1", "st2", "t1", "t2"]),
+        # Non-existent orgs are ignored
+        ("invalidOrg", ["st1", "st2", "t1", "t2"]),
     )
     @ddt.unpack
     def test_list_taxonomy_org_filter(self, org_parameter: str, expected_taxonomies: list[str]) -> None:
@@ -354,20 +356,6 @@ class TestTaxonomyListCreateViewSet(TestTaxonomyObjectsMixin, APITestCase):
             org_parameter=org_parameter,
             expected_taxonomies=expected_taxonomies,
         )
-
-    def test_list_taxonomy_invalid_org(self) -> None:
-        """
-        Tests that using an invalid org in the filter will raise BAD_REQUEST
-        """
-        url = TAXONOMY_ORG_LIST_URL
-
-        self.client.force_authenticate(user=self.staff)
-
-        query_params = {"org": "invalidOrg"}
-
-        response = self.client.get(url, query_params, format="json")
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @ddt.data(
         ("user", (), None),

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
@@ -52,8 +52,10 @@ class TaxonomyOrgView(TaxonomyView):
         query_params = TaxonomyOrgListQueryParamsSerializer(data=self.request.query_params.dict())
         query_params.is_valid(raise_exception=True)
         enabled = query_params.validated_data.get("enabled", None)
+
+        # If org filtering was requested, then use it, even if the org is invalid/None
         org = query_params.validated_data.get("org", None)
-        if org:
+        if "org" in query_params.validated_data:
             queryset = get_taxonomies_for_org(enabled, org)
         else:
             queryset = get_taxonomies(enabled)


### PR DESCRIPTION
If the user requests the taxonomies linked to a non-existent org, then we want to see the non-org taxonomies.

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Allows the "taxonomy list" endpoint to filter by `org` even if the requested `org` is not found in the `Organizations` list.
Previously, attempting to filter taxonomies by a non-existent org would throw an error (400 Bad Request).
With this change, filtering by an non-existent org will return only the (global) instance-level taxonomies.

This case comes up in devstack (the `edX` Organization for the DemoX is not automatically created), and may also affect other small deployments which don't use Organizations.

## Supporting information

Came across this while testing PRs for https://github.com/openedx/modular-learning/issues/118

## Testing instructions

1. If you don't already have sample taxonomy/tags data, follow the instructions in this repo to generate sample data: https://github.com/open-craft/taxonomy-sample-data
2. Visit the "taxonomy list" endpoint, with no filters: http://localhost:18010/api/content_tagging/v1/taxonomies/

    All taxonomies should be returned.
1. Visit the "taxonomy list" endpoint and filter by a non-existent org, e.g. http://localhost:18010/api/content_tagging/v1/taxonomies/?org=edX

   Only those taxonomies with `all_orgs=True` should be listed.

## Deadline

None

## Other information

Private-ref: [FAL-3523](https://tasks.opencraft.com/browse/FAL-3523)