### PR TITLE
docs: edx-enterprise-4.7.0 for enterprise api-docs

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,7 +26,7 @@ django-storages==1.14
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
 
 # edx-drf-extensions 8.13.0 was causing errors, as mentioned in this revert PR:
 # https://github.com/openedx/edx-platform/pull/33682.

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -22,9 +22,9 @@ cryptography==38.0.4
     #   -r requirements/edx-sandbox/py38.in
 cycler==0.12.1
     # via matplotlib
-fonttools==4.43.1
+fonttools==4.44.0
     # via matplotlib
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via matplotlib
 joblib==1.3.2
     # via nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -9,21 +9,25 @@
 acid-xblock==0.2.1
     # via -r requirements/edx/kernel.in
 aiohttp==3.8.6
-    # via
-    #   geoip2
-    #   openai
+    # via geoip2
 aiosignal==1.3.1
     # via aiohttp
 algoliasearch==2.6.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
 analytics-python==1.4.post1
     # via -r requirements/edx/kernel.in
 aniso8601==9.0.1
     # via edx-tincan-py35
+annotated-types==0.6.0
+    # via pydantic
+anyio==3.7.1
+    # via
+    #   httpx
+    #   openai
 appdirs==1.4.4
     # via fs
 asgiref==3.7.2
@@ -31,9 +35,7 @@ asgiref==3.7.2
     #   django
     #   django-countries
 asn1crypto==1.5.1
-    # via
-    #   oscrypto
-    #   snowflake-connector-python
+    # via snowflake-connector-python
 async-timeout==4.0.3
     # via
     #   aiohttp
@@ -64,7 +66,7 @@ backports-zoneinfo[tzdata]==0.2.1
     #   kombu
 beautifulsoup4==4.12.2
     # via pynliner
-billiard==4.1.0
+billiard==4.2.0
     # via celery
 bleach[css]==6.1.0
     # via
@@ -79,13 +81,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
-boto3==1.28.62
+boto3==1.28.82
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.82
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -106,6 +108,8 @@ certifi==2023.7.22
     # via
     #   -r requirements/edx/paver.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   py2neo
     #   requests
     #   snowflake-connector-python
@@ -169,7 +173,7 @@ cryptography==38.0.4
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.7.1
+cssutils==2.9.0
     # via pynliner
 defusedxml==0.7.1
     # via
@@ -180,7 +184,9 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.14
     # via jwcrypto
-django==3.2.22
+distro==1.8.0
+    # via openai
+django==3.2.23
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/kernel.in
@@ -265,7 +271,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via -r requirements/edx/kernel.in
 django-countries==7.5.1
     # via
@@ -290,7 +296,7 @@ django-filter==23.3
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==5.0.1
+django-ipware==5.0.2
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -323,7 +329,7 @@ django-mptt==0.14.0
     #   openedx-django-wiki
 django-multi-email-field==0.7.0
     # via edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via -r requirements/edx/kernel.in
 django-oauth-toolkit==1.7.1
     # via
@@ -402,7 +408,7 @@ djangorestframework==3.14.0
     #   super-csv
 djangorestframework-xml==2.0.0
     # via edx-enterprise
-done-xblock==2.1.0
+done-xblock==2.2.0
     # via -r requirements/edx/bundled.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
@@ -445,16 +451,16 @@ edx-celeryutils==1.2.3
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/kernel.in
-edx-completion==4.3.0
+edx-completion==4.4.0
     # via -r requirements/edx/kernel.in
 edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/kernel.in
-edx-django-utils==5.7.0
+edx-django-utils==5.8.0
     # via
     #   -r requirements/edx/kernel.in
     #   django-config-models
@@ -472,6 +478,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-completion
     #   edx-enterprise
@@ -482,7 +489,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -520,7 +527,7 @@ edx-proctoring==4.16.1
     #   edx-proctoring-proctortrack
 edx-rbac==1.8.0
     # via edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -565,11 +572,14 @@ enmerkar-underscore==2.2.0
 event-tracking==2.2.0
     # via
     #   -r requirements/edx/kernel.in
+    #   edx-completion
     #   edx-proctoring
     #   edx-search
-fastavro==1.8.4
+exceptiongroup==1.1.3
+    # via anyio
+fastavro==1.9.0
     # via openedx-events
-filelock==3.12.4
+filelock==3.13.1
     # via snowflake-connector-python
 frozenlist==1.4.0
     # via
@@ -593,24 +603,32 @@ glob2==0.7
     # via -r requirements/edx/kernel.in
 gunicorn==21.2.0
     # via -r requirements/edx/kernel.in
+h11==0.14.0
+    # via httpcore
 help-tokens==2.3.0
     # via -r requirements/edx/kernel.in
 html5lib==1.1
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
-icalendar==5.0.10
+httpcore==1.0.1
+    # via httpx
+httpx==0.25.1
+    # via openai
+icalendar==5.0.11
     # via -r requirements/edx/kernel.in
 idna==3.4
     # via
     #   -r requirements/edx/paver.txt
+    #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
     #   snowflake-connector-python
     #   yarl
 importlib-metadata==6.8.0
     # via markdown
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -647,7 +665,7 @@ jsonfield==3.1.0
     #   edx-submissions
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.19.1
+jsonschema==4.19.2
     # via
     #   drf-spectacular
     #   optimizely-sdk
@@ -657,7 +675,7 @@ jwcrypto==1.5.0
     # via
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.2
+kombu==5.3.3
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/kernel.in
@@ -692,7 +710,7 @@ lxml==4.9.3
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/bundled.in
-mako==1.2.4
+mako==1.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock
@@ -717,7 +735,7 @@ markupsafe==2.1.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.4.0
+maxminddb==2.5.1
     # via geoip2
 mock==5.1.0
     # via -r requirements/edx/paver.txt
@@ -737,7 +755,7 @@ mysqlclient==2.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-blockstore
-newrelic==9.1.0
+newrelic==9.1.1
     # via
     #   -r requirements/edx/bundled.in
     #   edx-django-utils
@@ -760,7 +778,7 @@ oauthlib==3.2.2
     #   social-auth-core
 olxcleaner==0.2.1
     # via -r requirements/edx/kernel.in
-openai==0.28.1
+openai==1.2.1
     # via edx-enterprise
 openedx-atlas==0.5.0
     # via -r requirements/edx/kernel.in
@@ -795,8 +813,6 @@ optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
 ora2==6.0.0
     # via -r requirements/edx/bundled.in
-oscrypto==1.3.0
-    # via snowflake-connector-python
 packaging==23.2
     # via
     #   drf-yasg
@@ -818,7 +834,7 @@ path-py==12.5.0
     #   staff-graded-xblock
 paver==1.3.4
     # via -r requirements/edx/paver.txt
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/edx/paver.txt
     #   stevedore
@@ -841,7 +857,7 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.39
     # via click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
@@ -861,7 +877,10 @@ pycryptodomex==3.19.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-    #   snowflake-connector-python
+pydantic==2.4.2
+    # via openai
+pydantic-core==2.10.1
+    # via pydantic
 pygments==2.16.1
     # via
     #   -r requirements/edx/bundled.in
@@ -910,7 +929,7 @@ pyparsing==3.1.1
     # via
     #   chem
     #   openedx-calc
-pyrsistent==0.19.3
+pyrsistent==0.20.0
     # via optimizely-sdk
 pysrt==1.1.2
     # via
@@ -1001,7 +1020,6 @@ requests==2.31.0
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
-    #   openai
     #   optimizely-sdk
     #   pyjwkest
     #   pylti1p3
@@ -1015,11 +1033,11 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/kernel.in
     #   social-auth-core
-rpds-py==0.10.4
+rpds-py==0.12.0
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.17.35
+ruamel-yaml==0.18.5
     # via drf-yasg
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
@@ -1040,7 +1058,7 @@ scipy==1.7.3
     #   openedx-calc
 semantic-version==2.10.0
     # via edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via -r requirements/edx/kernel.in
 simplejson==3.19.2
     # via
@@ -1084,7 +1102,11 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==3.2.1
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   httpx
+snowflake-connector-python==3.4.0
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via
@@ -1112,7 +1134,7 @@ sqlparse==0.4.4
     #   -r requirements/edx/kernel.in
     #   django
     #   openedx-blockstore
-staff-graded-xblock==2.1.1
+staff-graded-xblock==2.2.0
     # via -r requirements/edx/bundled.in
 stevedore==5.1.0
     # via
@@ -1127,13 +1149,13 @@ super-csv==3.1.0
     # via edx-bulk-grades
 sympy==1.12
     # via openedx-calc
-testfixtures==7.2.0
+testfixtures==7.2.2
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify
 tinycss2==1.2.1
     # via bleach
-tomlkit==0.12.1
+tomlkit==0.12.2
     # via snowflake-connector-python
 tqdm==4.66.1
     # via
@@ -1142,10 +1164,14 @@ tqdm==4.66.1
 typing-extensions==4.8.0
     # via
     #   -r requirements/edx/paver.txt
+    #   annotated-types
     #   asgiref
     #   django-countries
     #   edx-opaque-keys
     #   kombu
+    #   openai
+    #   pydantic
+    #   pydantic-core
     #   pylti1p3
     #   snowflake-connector-python
 tzdata==2023.3
@@ -1161,7 +1187,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.txt
@@ -1172,7 +1198,7 @@ urllib3==1.26.17
     #   snowflake-connector-python
 user-util==1.0.0
     # via -r requirements/edx/kernel.in
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
@@ -1183,7 +1209,7 @@ walrus==0.9.3
     # via edx-event-bus-redis
 watchdog==3.0.0
     # via -r requirements/edx/paver.txt
-wcwidth==0.2.8
+wcwidth==0.2.9
     # via prompt-toolkit
 web-fragments==2.1.0
     # via
@@ -1202,7 +1228,7 @@ webob==1.8.7
     # via
     #   -r requirements/edx/kernel.in
     #   xblock
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -r requirements/edx/paver.txt
     #   deprecated
@@ -1218,22 +1244,20 @@ xblock[django]==1.8.1
     #   lti-consumer-xblock
     #   ora2
     #   staff-graded-xblock
+    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.3.0
     # via -r requirements/edx/bundled.in
-xblock-google-drive==0.4.0
+xblock-google-drive==0.5.0
     # via -r requirements/edx/bundled.in
 xblock-poll==1.13.0
     # via -r requirements/edx/bundled.in
 xblock-utils==4.0.0
     # via
-    #   done-xblock
     #   edx-sga
     #   lti-consumer-xblock
-    #   staff-graded-xblock
-    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
 xmlsec==1.3.13
     # via python3-saml

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -8,7 +8,7 @@ chardet==5.2.0
     # via diff-cover
 coverage==7.3.2
     # via -r requirements/edx/coverage.in
-diff-cover==7.7.0
+diff-cover==8.0.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.2
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -21,7 +21,6 @@ aiohttp==3.8.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   geoip2
-    #   openai
 aiosignal==1.3.1
     # via
     #   -r requirements/edx/doc.txt
@@ -36,7 +35,7 @@ algoliasearch==2.6.3
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -52,13 +51,16 @@ aniso8601==9.0.1
     #   edx-tincan-py35
 annotated-types==0.6.0
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pydantic
 anyio==3.7.1
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   fastapi
-    #   httpcore
+    #   httpx
+    #   openai
     #   starlette
 appdirs==1.4.4
     # via
@@ -75,7 +77,6 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   oscrypto
     #   snowflake-connector-python
 astroid==2.13.5
     # via
@@ -118,6 +119,7 @@ backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   backports-zoneinfo
     #   celery
     #   icalendar
     #   kombu
@@ -127,7 +129,7 @@ beautifulsoup4==4.12.2
     #   -r requirements/edx/testing.txt
     #   pydata-sphinx-theme
     #   pynliner
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -136,6 +138,7 @@ bleach[css]==6.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   bleach
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-django-wiki
@@ -147,14 +150,14 @@ boto==2.39.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.28.62
+boto3==1.28.82
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.82
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -280,6 +283,7 @@ coreschema==0.0.4
 coverage[toml]==7.3.2
     # via
     #   -r requirements/edx/testing.txt
+    #   coverage
     #   pytest-cov
 crowdsourcehinter-xblock==0.6
     # via
@@ -303,12 +307,12 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
-cssutils==2.7.1
+cssutils==2.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pynliner
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/edx/testing.txt
 deepmerge==1.1.0
     # via
@@ -327,7 +331,7 @@ deprecated==1.2.14
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jwcrypto
-diff-cover==7.7.0
+diff-cover==8.0.0
     # via -r requirements/edx/testing.txt
 dill==0.3.7
     # via
@@ -337,7 +341,12 @@ distlib==0.3.7
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==3.2.22
+distro==1.8.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   openai
+django==3.2.23
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/doc.txt
@@ -438,7 +447,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -476,7 +485,7 @@ django-filter==23.3
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==5.0.1
+django-ipware==5.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -520,7 +529,7 @@ django-multi-email-field==0.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -582,7 +591,7 @@ django-stubs==1.16.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
     #   djangorestframework-stubs
-django-stubs-ext==4.2.2
+django-stubs-ext==4.2.5
     # via django-stubs
 django-user-tasks==3.1.0
     # via
@@ -643,7 +652,7 @@ docutils==0.19
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-done-xblock==2.1.0
+done-xblock==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -708,7 +717,7 @@ edx-codejail==3.3.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-completion==4.3.0
+edx-completion==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -718,11 +727,11 @@ edx-django-release-util==1.3.0
     #   -r requirements/edx/testing.txt
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-utils==5.7.0
+edx-django-utils==5.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -741,6 +750,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-completion
@@ -752,7 +762,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
@@ -770,7 +780,7 @@ edx-i18n-tools==1.3.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/edx/testing.txt
 edx-milestones==0.5.0
     # via
@@ -790,6 +800,7 @@ edx-opaque-keys[django]==2.5.1
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-milestones
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-when
@@ -810,7 +821,7 @@ edx-rbac==1.8.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -878,10 +889,12 @@ event-tracking==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   edx-completion
     #   edx-proctoring
     #   edx-search
 exceptiongroup==1.1.3
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   anyio
     #   pytest
@@ -891,20 +904,20 @@ execnet==2.0.2
     #   pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.txt
-faker==19.9.0
+faker==19.13.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.103.2
+fastapi==0.104.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-fastavro==1.8.4
+fastavro==1.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.12.4
+filelock==3.13.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -940,17 +953,17 @@ geoip2==4.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-gitdb==4.0.10
+gitdb==4.0.11
     # via
     #   -r requirements/edx/doc.txt
     #   gitpython
-gitpython==3.1.37
+gitpython==3.1.40
     # via -r requirements/edx/doc.txt
 glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-grimp==3.0
+grimp==3.1
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
@@ -960,6 +973,7 @@ gunicorn==21.2.0
     #   -r requirements/edx/testing.txt
 h11==0.14.0
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpcore
     #   uvicorn
@@ -972,17 +986,19 @@ html5lib==1.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-httpcore==0.16.3
+httpcore==1.0.1
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpx
 httpretty==1.1.4
     # via -r requirements/edx/testing.txt
-httpx==0.23.3
+httpx==0.25.1
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   pact-python
-icalendar==5.0.10
+    #   openai
+icalendar==5.0.11
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -991,16 +1007,16 @@ idna==3.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
-    #   rfc3986
     #   snowflake-connector-python
     #   yarl
 imagesize==1.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-import-linter==1.12.0
+import-linter==1.12.1
     # via -r requirements/edx/testing.txt
 importlib-metadata==6.8.0
     # via
@@ -1011,7 +1027,7 @@ importlib-metadata==6.8.0
     #   markdown
     #   pytest-randomly
     #   sphinx
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1084,7 +1100,7 @@ jsonfield==3.1.0
     #   edx-submissions
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.19.1
+jsonschema==4.19.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1102,7 +1118,7 @@ jwcrypto==1.5.0
     #   -r requirements/edx/testing.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.2
+kombu==5.3.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1157,7 +1173,7 @@ mailsnake==1.6.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-mako==1.2.4
+mako==1.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1188,7 +1204,7 @@ markupsafe==2.1.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.4.0
+maxminddb==2.5.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1226,7 +1242,7 @@ multidict==6.0.4
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.6.0
+mypy==1.6.1
     # via
     #   -r requirements/edx/development.in
     #   django-stubs
@@ -1238,7 +1254,7 @@ mysqlclient==2.2.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-blockstore
-newrelic==9.1.0
+newrelic==9.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1273,7 +1289,7 @@ olxcleaner==0.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openai==0.28.1
+openai==1.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1332,11 +1348,6 @@ ora2==6.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-oscrypto==1.3.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   snowflake-connector-python
 packaging==23.2
     # via
     #   -r requirements/edx/../pip-tools.txt
@@ -1351,7 +1362,7 @@ packaging==23.2
     #   snowflake-connector-python
     #   sphinx
     #   tox
-pact-python==2.0.1
+pact-python==2.1.1
     # via -r requirements/edx/testing.txt
 pansi==2020.7.3
     # via
@@ -1375,7 +1386,7 @@ paver==1.3.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1431,7 +1442,7 @@ prompt-toolkit==3.0.39
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1472,16 +1483,18 @@ pycryptodomex==3.19.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-    #   snowflake-connector-python
 pydantic==2.4.2
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   fastapi
+    #   openai
 pydantic-core==2.10.1
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pydantic
-pydata-sphinx-theme==0.14.1
+pydata-sphinx-theme==0.14.3
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx-book-theme
@@ -1510,6 +1523,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
+    #   pyjwt
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core
@@ -1531,7 +1545,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1587,7 +1601,7 @@ pyproject-hooks==1.0.0
     #   build
 pyquery==2.0.0
     # via -r requirements/edx/testing.txt
-pyrsistent==0.19.3
+pyrsistent==0.20.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1597,7 +1611,7 @@ pysrt==1.1.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/edx/testing.txt
     #   pylint-pytest
@@ -1612,7 +1626,7 @@ pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
 pytest-cov==4.1.0
     # via -r requirements/edx/testing.txt
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements/edx/testing.txt
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.txt
@@ -1623,7 +1637,9 @@ pytest-metadata==1.8.0
 pytest-randomly==3.15.0
     # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==3.3.1
-    # via -r requirements/edx/testing.txt
+    # via
+    #   -r requirements/edx/testing.txt
+    #   pytest-xdist
 python-dateutil==2.8.2
     # via
     #   -r requirements/edx/doc.txt
@@ -1742,7 +1758,6 @@ requests==2.31.0
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
-    #   openai
     #   optimizely-sdk
     #   pact-python
     #   pyjwkest
@@ -1759,17 +1774,13 @@ requests-oauthlib==1.3.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   social-auth-core
-rfc3986[idna2008]==1.5.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   httpx
-rpds-py==0.10.4
+rpds-py==0.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jsonschema
     #   referencing
-ruamel-yaml==0.17.35
+ruamel-yaml==0.18.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1808,7 +1819,7 @@ semantic-version==2.10.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1870,15 +1881,15 @@ smmap==5.0.1
     #   gitdb
 sniffio==1.3.0
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   anyio
-    #   httpcore
     #   httpx
 snowballstemmer==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==3.2.1
+snowflake-connector-python==3.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1929,7 +1940,7 @@ sphinx-mdinclude==0.5.3
     # via
     #   -r requirements/edx/doc.txt
     #   sphinxcontrib-openapi
-sphinx-reredirects==0.1.2
+sphinx-reredirects==0.1.3
     # via -r requirements/edx/doc.txt
 sphinxcontrib-applehelp==1.0.4
     # via
@@ -1951,8 +1962,10 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-sphinxcontrib-openapi[markdown]==0.8.1
-    # via -r requirements/edx/doc.txt
+sphinxcontrib-openapi[markdown]==0.8.3
+    # via
+    #   -r requirements/edx/doc.txt
+    #   sphinxcontrib-openapi
 sphinxcontrib-qthelp==1.0.3
     # via
     #   -r requirements/edx/doc.txt
@@ -1970,7 +1983,7 @@ sqlparse==0.4.4
     #   django
     #   django-debug-toolbar
     #   openedx-blockstore
-staff-graded-xblock==2.1.1
+staff-graded-xblock==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1997,7 +2010,7 @@ sympy==1.12
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-calc
-testfixtures==7.2.0
+testfixtures==7.2.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2028,7 +2041,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.12.1
+tomlkit==0.12.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2075,6 +2088,7 @@ typing-extensions==4.8.0
     #   import-linter
     #   kombu
     #   mypy
+    #   openai
     #   pydantic
     #   pydantic-core
     #   pydata-sphinx-theme
@@ -2103,14 +2117,13 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   elasticsearch
-    #   pact-python
     #   py2neo
     #   requests
     #   snowflake-connector-python
@@ -2118,18 +2131,18 @@ user-util==1.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-uvicorn==0.23.2
+uvicorn==0.24.0.post1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -2150,7 +2163,7 @@ watchdog==3.0.0
     #   -r requirements/edx/development.in
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-wcwidth==0.2.8
+wcwidth==0.2.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2176,11 +2189,11 @@ webob==1.8.7
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblock
-wheel==0.41.2
+wheel==0.41.3
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   pip-tools
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2199,14 +2212,16 @@ xblock[django]==1.8.1
     #   lti-consumer-xblock
     #   ora2
     #   staff-graded-xblock
+    #   xblock
+    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock-google-drive==0.4.0
+xblock-google-drive==0.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2218,11 +2233,8 @@ xblock-utils==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   done-xblock
     #   edx-sga
     #   lti-consumer-xblock
-    #   staff-graded-xblock
-    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
 xmlsec==1.3.13
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -14,7 +14,6 @@ aiohttp==3.8.6
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
-    #   openai
 aiosignal==1.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -25,7 +24,7 @@ algoliasearch==2.6.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/edx/base.txt
     #   kombu
@@ -35,6 +34,15 @@ aniso8601==9.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-tincan-py35
+annotated-types==0.6.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   pydantic
+anyio==3.7.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpx
+    #   openai
 appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
@@ -47,7 +55,6 @@ asgiref==3.7.2
 asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
-    #   oscrypto
     #   snowflake-connector-python
 async-timeout==4.0.3
     # via
@@ -80,6 +87,7 @@ backoff==1.10.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/base.txt
+    #   backports-zoneinfo
     #   celery
     #   icalendar
     #   kombu
@@ -88,13 +96,14 @@ beautifulsoup4==4.12.2
     #   -r requirements/edx/base.txt
     #   pydata-sphinx-theme
     #   pynliner
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
 bleach[css]==6.1.0
     # via
     #   -r requirements/edx/base.txt
+    #   bleach
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-django-wiki
@@ -105,13 +114,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.62
+boto3==1.28.82
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.82
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -132,6 +141,8 @@ certifi==2023.7.22
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   py2neo
     #   requests
     #   snowflake-connector-python
@@ -210,7 +221,7 @@ cryptography==38.0.4
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.7.1
+cssutils==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
@@ -227,7 +238,11 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/base.txt
     #   jwcrypto
-django==3.2.22
+distro==1.8.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   openai
+django==3.2.23
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
@@ -318,7 +333,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via -r requirements/edx/base.txt
 django-countries==7.5.1
     # via
@@ -347,7 +362,7 @@ django-filter==23.3
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==5.0.1
+django-ipware==5.0.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -384,7 +399,7 @@ django-multi-email-field==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
@@ -473,7 +488,7 @@ docutils==0.19
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-done-xblock==2.1.0
+done-xblock==2.2.0
     # via -r requirements/edx/base.txt
 drf-jwt==1.19.2
     # via
@@ -521,16 +536,16 @@ edx-celeryutils==1.2.3
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
-edx-completion==4.3.0
+edx-completion==4.4.0
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/base.txt
-edx-django-utils==5.7.0
+edx-django-utils==5.8.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -548,6 +563,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
@@ -558,7 +574,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -583,6 +599,7 @@ edx-opaque-keys[django]==2.5.1
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-milestones
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-when
@@ -599,7 +616,7 @@ edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -649,13 +666,18 @@ enmerkar-underscore==2.2.0
 event-tracking==2.2.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-completion
     #   edx-proctoring
     #   edx-search
-fastavro==1.8.4
+exceptiongroup==1.1.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   anyio
+fastavro==1.9.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.12.4
+filelock==3.13.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -680,25 +702,39 @@ future==0.18.3
     #   pyjwkest
 geoip2==4.7.0
     # via -r requirements/edx/base.txt
-gitdb==4.0.10
+gitdb==4.0.11
     # via gitpython
-gitpython==3.1.37
+gitpython==3.1.40
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
 gunicorn==21.2.0
     # via -r requirements/edx/base.txt
+h11==0.14.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpcore
 help-tokens==2.3.0
     # via -r requirements/edx/base.txt
 html5lib==1.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-icalendar==5.0.10
+httpcore==1.0.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpx
+httpx==0.25.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   openai
+icalendar==5.0.11
     # via -r requirements/edx/base.txt
 idna==3.4
     # via
     #   -r requirements/edx/base.txt
+    #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
     #   snowflake-connector-python
@@ -710,7 +746,7 @@ importlib-metadata==6.8.0
     #   -r requirements/edx/base.txt
     #   markdown
     #   sphinx
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -762,7 +798,7 @@ jsonfield==3.1.0
     #   edx-submissions
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.19.1
+jsonschema==4.19.2
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
@@ -777,7 +813,7 @@ jwcrypto==1.5.0
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.2
+kombu==5.3.3
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -816,7 +852,7 @@ lxml==4.9.3
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.2.4
+mako==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -843,7 +879,7 @@ markupsafe==2.1.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.4.0
+maxminddb==2.5.1
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -871,7 +907,7 @@ mysqlclient==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-newrelic==9.1.0
+newrelic==9.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -897,7 +933,7 @@ oauthlib==3.2.2
     #   social-auth-core
 olxcleaner==0.2.1
     # via -r requirements/edx/base.txt
-openai==0.28.1
+openai==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -935,10 +971,6 @@ optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
 ora2==6.0.0
     # via -r requirements/edx/base.txt
-oscrypto==1.3.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   snowflake-connector-python
 packaging==23.2
     # via
     #   -r requirements/edx/base.txt
@@ -965,7 +997,7 @@ path-py==12.5.0
     #   staff-graded-xblock
 paver==1.3.4
     # via -r requirements/edx/base.txt
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/edx/base.txt
     #   stevedore
@@ -1000,7 +1032,7 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1024,8 +1056,15 @@ pycryptodomex==3.19.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-    #   snowflake-connector-python
-pydata-sphinx-theme==0.14.1
+pydantic==2.4.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   openai
+pydantic-core==2.10.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   pydantic
+pydata-sphinx-theme==0.14.3
     # via sphinx-book-theme
 pygments==2.16.1
     # via
@@ -1048,6 +1087,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
+    #   pyjwt
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core
@@ -1084,7 +1124,7 @@ pyparsing==3.1.1
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc
-pyrsistent==0.19.3
+pyrsistent==0.20.0
     # via
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
@@ -1185,7 +1225,6 @@ requests==2.31.0
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
-    #   openai
     #   optimizely-sdk
     #   pyjwkest
     #   pylti1p3
@@ -1200,12 +1239,12 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-rpds-py==0.10.4
+rpds-py==0.12.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   referencing
-ruamel-yaml==0.17.35
+ruamel-yaml==0.18.5
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1237,7 +1276,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via -r requirements/edx/base.txt
 simplejson==3.19.2
     # via
@@ -1284,9 +1323,14 @@ slumber==0.7.1
     #   edx-rest-api-client
 smmap==5.0.1
     # via gitdb
+sniffio==1.3.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   anyio
+    #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.2.1
+snowflake-connector-python==3.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1329,7 +1373,7 @@ sphinx-design==0.5.0
     # via -r requirements/edx/doc.in
 sphinx-mdinclude==0.5.3
     # via sphinxcontrib-openapi
-sphinx-reredirects==0.1.2
+sphinx-reredirects==0.1.3
     # via -r requirements/edx/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -1341,7 +1385,7 @@ sphinxcontrib-httpdomain==1.8.1
     # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-openapi[markdown]==0.8.1
+sphinxcontrib-openapi[markdown]==0.8.3
     # via -r requirements/edx/doc.in
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
@@ -1354,7 +1398,7 @@ sqlparse==0.4.4
     #   -r requirements/edx/base.txt
     #   django
     #   openedx-blockstore
-staff-graded-xblock==2.1.1
+staff-graded-xblock==2.2.0
     # via -r requirements/edx/base.txt
 stevedore==5.1.0
     # via
@@ -1372,7 +1416,7 @@ sympy==1.12
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==7.2.0
+testfixtures==7.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1384,7 +1428,7 @@ tinycss2==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   bleach
-tomlkit==0.12.1
+tomlkit==0.12.2
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -1396,10 +1440,14 @@ tqdm==4.66.1
 typing-extensions==4.8.0
     # via
     #   -r requirements/edx/base.txt
+    #   annotated-types
     #   asgiref
     #   django-countries
     #   edx-opaque-keys
     #   kombu
+    #   openai
+    #   pydantic
+    #   pydantic-core
     #   pydata-sphinx-theme
     #   pylti1p3
     #   snowflake-connector-python
@@ -1418,7 +1466,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -1429,7 +1477,7 @@ urllib3==1.26.17
     #   snowflake-connector-python
 user-util==1.0.0
     # via -r requirements/edx/base.txt
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   amqp
@@ -1445,7 +1493,7 @@ walrus==0.9.3
     #   edx-event-bus-redis
 watchdog==3.0.0
     # via -r requirements/edx/base.txt
-wcwidth==0.2.8
+wcwidth==0.2.9
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
@@ -1467,7 +1515,7 @@ webob==1.8.7
     # via
     #   -r requirements/edx/base.txt
     #   xblock
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   deprecated
@@ -1483,23 +1531,22 @@ xblock[django]==1.8.1
     #   lti-consumer-xblock
     #   ora2
     #   staff-graded-xblock
+    #   xblock
+    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.3.0
     # via -r requirements/edx/base.txt
-xblock-google-drive==0.4.0
+xblock-google-drive==0.5.0
     # via -r requirements/edx/base.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
 xblock-utils==4.0.0
     # via
     #   -r requirements/edx/base.txt
-    #   done-xblock
     #   edx-sga
     #   lti-consumer-xblock
-    #   staff-graded-xblock
-    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
 xmlsec==1.3.13
     # via

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -28,9 +28,9 @@ path==16.7.1
     # via -r requirements/edx/paver.in
 paver==1.3.4
     # via -r requirements/edx/paver.in
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-psutil==5.9.5
+psutil==5.9.6
     # via -r requirements/edx/paver.in
 pymemcache==4.0.0
     # via -r requirements/edx/paver.in
@@ -54,11 +54,11 @@ stevedore==5.1.0
     #   edx-opaque-keys
 typing-extensions==4.8.0
     # via edx-opaque-keys
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests
 watchdog==3.0.0
     # via -r requirements/edx/paver.in
-wrapt==1.15.0
+wrapt==1.16.0
     # via -r requirements/edx/paver.in

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -40,11 +40,11 @@ glom==22.1.0
     # via semgrep
 idna==3.4
     # via requests
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-jsonschema==4.19.1
+jsonschema==4.19.2
     # via semgrep
 jsonschema-specifications==2023.7.1
     # via jsonschema
@@ -54,14 +54,12 @@ mdurl==0.1.2
     # via markdown-it-py
 packaging==23.2
     # via semgrep
-peewee==3.16.3
+peewee==3.17.0
     # via semgrep
 pkgutil-resolve-name==1.3.10
     # via jsonschema
 pygments==2.16.1
     # via rich
-python-lsp-jsonrpc==1.0.0
-    # via semgrep
 referencing==0.30.2
     # via
     #   jsonschema
@@ -70,15 +68,15 @@ requests==2.31.0
     # via semgrep
 rich==13.6.0
     # via semgrep
-rpds-py==0.10.4
+rpds-py==0.12.0
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.17.35
+ruamel-yaml==0.17.40
     # via semgrep
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-semgrep==1.43.0
+semgrep==1.48.0
     # via -r requirements/edx/semgrep.in
 tomli==2.0.1
     # via semgrep
@@ -86,9 +84,7 @@ typing-extensions==4.8.0
     # via
     #   rich
     #   semgrep
-ujson==5.8.0
-    # via python-lsp-jsonrpc
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -12,7 +12,6 @@ aiohttp==3.8.6
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
-    #   openai
 aiosignal==1.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -21,7 +20,7 @@ algoliasearch==2.6.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/edx/base.txt
     #   kombu
@@ -32,11 +31,15 @@ aniso8601==9.0.1
     #   -r requirements/edx/base.txt
     #   edx-tincan-py35
 annotated-types==0.6.0
-    # via pydantic
+    # via
+    #   -r requirements/edx/base.txt
+    #   pydantic
 anyio==3.7.1
     # via
+    #   -r requirements/edx/base.txt
     #   fastapi
-    #   httpcore
+    #   httpx
+    #   openai
     #   starlette
 appdirs==1.4.4
     # via
@@ -50,7 +53,6 @@ asgiref==3.7.2
 asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
-    #   oscrypto
     #   snowflake-connector-python
 astroid==2.13.5
     # via
@@ -85,6 +87,7 @@ backoff==1.10.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/edx/base.txt
+    #   backports-zoneinfo
     #   celery
     #   icalendar
     #   kombu
@@ -93,13 +96,14 @@ beautifulsoup4==4.12.2
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   pynliner
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
 bleach[css]==6.1.0
     # via
     #   -r requirements/edx/base.txt
+    #   bleach
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-django-wiki
@@ -110,13 +114,13 @@ boto==2.39.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-boto3==1.28.62
+boto3==1.28.82
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.31.62
+botocore==1.31.82
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -235,11 +239,11 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
-cssutils==2.7.1
+cssutils==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/edx/testing.in
 defusedxml==0.7.1
     # via
@@ -252,13 +256,17 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/base.txt
     #   jwcrypto
-diff-cover==7.7.0
+diff-cover==8.0.0
     # via -r requirements/edx/coverage.txt
 dill==0.3.7
     # via pylint
 distlib==0.3.7
     # via virtualenv
-django==3.2.22
+distro==1.8.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   openai
+django==3.2.23
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
@@ -349,7 +357,7 @@ django-config-models==2.5.1
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==4.2.0
+django-cors-headers==4.3.0
     # via -r requirements/edx/base.txt
 django-countries==7.5.1
     # via
@@ -378,7 +386,7 @@ django-filter==23.3
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==5.0.1
+django-ipware==5.0.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -415,7 +423,7 @@ django-multi-email-field==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==4.11.0
+django-mysql==4.12.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
@@ -498,7 +506,7 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-done-xblock==2.1.0
+done-xblock==2.2.0
     # via -r requirements/edx/base.txt
 drf-jwt==1.19.2
     # via
@@ -546,16 +554,16 @@ edx-celeryutils==1.2.3
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
-edx-completion==4.3.0
+edx-completion==4.4.0
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
     #   openedx-blockstore
-edx-django-sites-extensions==4.0.1
+edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/base.txt
-edx-django-utils==5.7.0
+edx-django-utils==5.8.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -573,6 +581,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
@@ -583,7 +592,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -596,7 +605,7 @@ edx-i18n-tools==1.3.0
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   ora2
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/edx/testing.in
 edx-milestones==0.5.0
     # via -r requirements/edx/base.txt
@@ -611,6 +620,7 @@ edx-opaque-keys[django]==2.5.1
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-milestones
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-when
@@ -627,7 +637,7 @@ edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.0
+edx-rest-api-client==5.6.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -677,25 +687,27 @@ enmerkar-underscore==2.2.0
 event-tracking==2.2.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-completion
     #   edx-proctoring
     #   edx-search
 exceptiongroup==1.1.3
     # via
+    #   -r requirements/edx/base.txt
     #   anyio
     #   pytest
 execnet==2.0.2
     # via pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.in
-faker==19.9.0
+faker==19.13.0
     # via factory-boy
-fastapi==0.103.2
+fastapi==0.104.1
     # via pact-python
-fastavro==1.8.4
+fastavro==1.9.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.12.4
+filelock==3.13.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -726,12 +738,13 @@ geoip2==4.7.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-grimp==3.0
+grimp==3.1
     # via import-linter
 gunicorn==21.2.0
     # via -r requirements/edx/base.txt
 h11==0.14.0
     # via
+    #   -r requirements/edx/base.txt
     #   httpcore
     #   uvicorn
 help-tokens==2.3.0
@@ -740,31 +753,35 @@ html5lib==1.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-httpcore==0.16.3
-    # via httpx
+httpcore==1.0.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpx
 httpretty==1.1.4
     # via -r requirements/edx/testing.in
-httpx==0.23.3
-    # via pact-python
-icalendar==5.0.10
+httpx==0.25.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   openai
+icalendar==5.0.11
     # via -r requirements/edx/base.txt
 idna==3.4
     # via
     #   -r requirements/edx/base.txt
     #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
-    #   rfc3986
     #   snowflake-connector-python
     #   yarl
-import-linter==1.12.0
+import-linter==1.12.1
     # via -r requirements/edx/testing.in
 importlib-metadata==6.8.0
     # via
     #   -r requirements/edx/base.txt
     #   markdown
     #   pytest-randomly
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -823,7 +840,7 @@ jsonfield==3.1.0
     #   edx-submissions
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.19.1
+jsonschema==4.19.2
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
@@ -837,7 +854,7 @@ jwcrypto==1.5.0
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.2
+kombu==5.3.3
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -879,7 +896,7 @@ lxml==4.9.3
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.2.4
+mako==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -907,7 +924,7 @@ markupsafe==2.1.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.4.0
+maxminddb==2.5.1
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -935,7 +952,7 @@ mysqlclient==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-newrelic==9.1.0
+newrelic==9.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -961,7 +978,7 @@ oauthlib==3.2.2
     #   social-auth-core
 olxcleaner==0.2.1
     # via -r requirements/edx/base.txt
-openai==0.28.1
+openai==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -999,10 +1016,6 @@ optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
 ora2==6.0.0
     # via -r requirements/edx/base.txt
-oscrypto==1.3.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   snowflake-connector-python
 packaging==23.2
     # via
     #   -r requirements/edx/base.txt
@@ -1012,7 +1025,7 @@ packaging==23.2
     #   pytest
     #   snowflake-connector-python
     #   tox
-pact-python==2.0.1
+pact-python==2.1.1
     # via -r requirements/edx/testing.in
 pansi==2020.7.3
     # via
@@ -1031,7 +1044,7 @@ path-py==12.5.0
     #   staff-graded-xblock
 paver==1.3.4
     # via -r requirements/edx/base.txt
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/edx/base.txt
     #   stevedore
@@ -1073,7 +1086,7 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1105,11 +1118,15 @@ pycryptodomex==3.19.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-    #   snowflake-connector-python
 pydantic==2.4.2
-    # via fastapi
+    # via
+    #   -r requirements/edx/base.txt
+    #   fastapi
+    #   openai
 pydantic-core==2.10.1
-    # via pydantic
+    # via
+    #   -r requirements/edx/base.txt
+    #   pydantic
 pygments==2.16.1
     # via
     #   -r requirements/edx/base.txt
@@ -1129,6 +1146,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
+    #   pyjwt
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core
@@ -1146,7 +1164,7 @@ pylint==2.15.10
     #   pylint-pytest
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via edx-lint
 pylint-plugin-utils==0.8.2
     # via
@@ -1185,7 +1203,7 @@ pyparsing==3.1.1
     #   openedx-calc
 pyquery==2.0.0
     # via -r requirements/edx/testing.in
-pyrsistent==0.19.3
+pyrsistent==0.20.0
     # via
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
@@ -1193,7 +1211,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/edx/testing.in
     #   pylint-pytest
@@ -1208,7 +1226,7 @@ pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
 pytest-cov==4.1.0
     # via -r requirements/edx/testing.in
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements/edx/testing.in
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.in
@@ -1314,7 +1332,6 @@ requests==2.31.0
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
-    #   openai
     #   optimizely-sdk
     #   pact-python
     #   pyjwkest
@@ -1329,14 +1346,12 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-rfc3986[idna2008]==1.5.0
-    # via httpx
-rpds-py==0.10.4
+rpds-py==0.12.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   referencing
-ruamel-yaml==0.17.35
+ruamel-yaml==0.18.5
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1368,7 +1383,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==2.0.1
+shapely==2.0.2
     # via -r requirements/edx/base.txt
 simplejson==3.19.2
     # via
@@ -1419,10 +1434,10 @@ slumber==0.7.1
     #   edx-rest-api-client
 sniffio==1.3.0
     # via
+    #   -r requirements/edx/base.txt
     #   anyio
-    #   httpcore
     #   httpx
-snowflake-connector-python==3.2.1
+snowflake-connector-python==3.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1454,7 +1469,7 @@ sqlparse==0.4.4
     #   -r requirements/edx/base.txt
     #   django
     #   openedx-blockstore
-staff-graded-xblock==2.1.1
+staff-graded-xblock==2.2.0
     # via -r requirements/edx/base.txt
 starlette==0.27.0
     # via fastapi
@@ -1474,7 +1489,7 @@ sympy==1.12
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==7.2.0
+testfixtures==7.2.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1494,7 +1509,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.12.1
+tomlkit==0.12.2
     # via
     #   -r requirements/edx/base.txt
     #   pylint
@@ -1524,6 +1539,7 @@ typing-extensions==4.8.0
     #   grimp
     #   import-linter
     #   kombu
+    #   openai
     #   pydantic
     #   pydantic-core
     #   pylint
@@ -1548,27 +1564,26 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
     #   elasticsearch
-    #   pact-python
     #   py2neo
     #   requests
     #   snowflake-connector-python
 user-util==1.0.0
     # via -r requirements/edx/base.txt
-uvicorn==0.23.2
+uvicorn==0.24.0.post1
     # via pact-python
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via tox
 voluptuous==0.13.1
     # via
@@ -1580,7 +1595,7 @@ walrus==0.9.3
     #   edx-event-bus-redis
 watchdog==3.0.0
     # via -r requirements/edx/base.txt
-wcwidth==0.2.8
+wcwidth==0.2.9
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
@@ -1602,7 +1617,7 @@ webob==1.8.7
     # via
     #   -r requirements/edx/base.txt
     #   xblock
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   astroid
@@ -1619,23 +1634,22 @@ xblock[django]==1.8.1
     #   lti-consumer-xblock
     #   ora2
     #   staff-graded-xblock
+    #   xblock
+    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==3.2.0
+xblock-drag-and-drop-v2==3.3.0
     # via -r requirements/edx/base.txt
-xblock-google-drive==0.4.0
+xblock-google-drive==0.5.0
     # via -r requirements/edx/base.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
 xblock-utils==4.0.0
     # via
     #   -r requirements/edx/base.txt
-    #   done-xblock
     #   edx-sga
     #   lti-consumer-xblock
-    #   staff-graded-xblock
-    #   xblock-drag-and-drop-v2
     #   xblock-google-drive
 xmlsec==1.3.13
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -23,7 +23,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.2
+wheel==0.41.3
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.41.2
+wheel==0.41.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.2.1
+pip==23.3.1
     # via -r requirements/pip.in
 setuptools==68.2.2
     # via -r requirements/pip.in

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -6,11 +6,11 @@
 #
 certifi==2023.7.22
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 idna==3.4
     # via requests
 requests==2.31.0
     # via -r scripts/xblock/requirements.in
-urllib3==2.0.6
+urllib3==2.0.7
     # via requests


### PR DESCRIPTION
https://github.com/openedx/edx-enterprise/releases/tag/4.7.0

We somehow haven't had api-docs available for edx-enterprise for a while. This adds them such that they exist at http://localhost:18000/enterprise/api-docs/

I couldn't upgrade *only* edx-enterprise: https://github.com/openedx/edx-platform/actions/runs/6815851396/job/18535862869?pr=33687
