### PR TITLE
docs: edx-enterprise-4.7.0 for enterprise api-docs

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,7 +26,7 @@ django-storages==1.14
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
 
 # edx-drf-extensions 8.13.0 was causing errors, as mentioned in this revert PR:
 # https://github.com/openedx/edx-platform/pull/33682.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -472,6 +472,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-completion
     #   edx-enterprise
@@ -482,7 +483,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -741,6 +741,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-completion
@@ -752,7 +753,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -548,6 +548,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
@@ -558,7 +559,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -573,6 +573,7 @@ edx-django-utils==5.7.0
     #   super-csv
 edx-drf-extensions==8.12.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
@@ -583,7 +584,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.12
+edx-enterprise==4.7.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
https://github.com/openedx/edx-enterprise/releases/tag/4.7.0

We somehow haven't had api-docs available for edx-enterprise for a while. This adds them such that they exist at http://localhost:18000/enterprise/api-docs/