### PR TITLE
fix: course mode added to the metadata

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/serializers.py
@@ -29,6 +29,14 @@ class CourseTabSerializer(serializers.Serializer):
         return request.build_absolute_uri(tab.link_func(self.context.get('course'), reverse))
 
 
+class CourseModeSerrializer(serializers.Serializer):
+    """
+    Serializer for the Course Mode
+    """
+    slug = serializers.CharField()
+    name = serializers.CharField()
+
+
 class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     """
     Serializer for the Course Home Course Metadata
@@ -48,3 +56,4 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     username = serializers.CharField()
     user_timezone = serializers.CharField()
     can_view_certificate = serializers.BooleanField()
+    course_modes = CourseModeSerrializer(many=True)

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -14,6 +14,7 @@ from lms.djangoapps.certificates.api import certificates_viewable_for_course
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.djangoapps.courseware_api.utils import get_celebrations_dict
 
+from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.course_goals.models import UserActivity
@@ -117,6 +118,8 @@ class CourseHomeMetadataView(RetrieveAPIView):
         # Record course goals user activity for (web) learning mfe course tabs
         UserActivity.record_user_activity(request.user, course_key)
 
+        course_modes = CourseMode.modes_for_course(course_key, include_expired=True, only_selectable=False)
+
         data = {
             'course_id': course.id,
             'username': username,
@@ -133,6 +136,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'celebrations': celebrations,
             'user_timezone': user_timezone,
             'can_view_certificate': certificates_viewable_for_course(course),
+            'course_modes': course_modes,
         }
         context = self.get_serializer_context()
         context['course'] = course


### PR DESCRIPTION
## Description

This is a [backport](https://github.com/openedx/edx-platform/pull/33690) MR to the master branch.

According to the chapter [Sending Email Messages to Learners in Different Enrollment Tracks](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/manage_live_course/bulk_email.html#sending-email-messages-to-learners-in-different-enrollment-tracks) course can may more than one mode and instructor must have the ability to send the email for users in this modes.
Communication MFE had a hardcoded 2 modes for every course. Sometimes it lead to the error.
<img width="1585" alt="изображение" src="https://github.com/openedx/frontend-app-communications/assets/69678257/28184523-0769-41f0-bcad-9b2deb12b759">

`courseModes` was added to `courseMetadata` to display real course email recipient options.

Related MR: 

- [frontend-app-communications/open-release/quince.master](https://github.com/openedx/frontend-app-communications/pull/172)
- [frontend-app-communications/master](https://github.com/openedx/frontend-app-communications/pull/171)

## Deadline

None


