### PR TITLE
fix: long-skipped test

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_export_olx.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export_olx.py
@@ -93,7 +93,7 @@ class TestCourseExportOlx(ModuleStoreTestCase):
 
         test_course_key = self.create_dummy_course(ModuleStoreEnum.Type.split)
         output_wrapper = BytesIOBufferWrapper(BytesIO())
-        call_command('export_olx', str(test_course_key))
+        call_command('export_olx', str(test_course_key), stdout=output_wrapper)
         output_wrapper.bytes_io.seek(0)
         output = output_wrapper.bytes_io.read()
         with tarfile.open(fileobj=BytesIO(output), mode="r:gz") as tar_file:


### PR DESCRIPTION
Referenced issue: [A long-skipped test should be unskipped or deleted #31694](https://github.com/openedx/edx-platform/issues/31694)

Removed skip from the test and implemented a BytesIO wrapper.
It works in Python 3.8 and Django 3.2 using BytesIO, but the command writes to the stdout buffer, so a wrapper was necessary to allow it to happen in the test.