### PR TITLE
fix: hide feedback widget by default

### DIFF
--- a/xmodule/assets/video/_display.scss
+++ b/xmodule/assets/video/_display.scss
@@ -162,6 +162,7 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
 
   .wrapper-transcript-feedback {
     display: none;
+    
     .transcript-feedback-buttons {
       display: flex;
     }

--- a/xmodule/assets/video/_display.scss
+++ b/xmodule/assets/video/_display.scss
@@ -161,6 +161,7 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
   }
 
   .wrapper-transcript-feedback {
+    display: none;
     .transcript-feedback-buttons {
       display: flex;
     }


### PR DESCRIPTION
## Description

When landing on a video unit in Studio, if the Waffle Flag for the feedback widget is enabled but the current caption for the video is not AI generated: while the video is loading the feedback widget is not shown. Once the request to ai-translations service finishes and gets as a response that the captions were AI generated we display the feedback widget. If not, the widget remains not shown.

## Supporting information

## Testing instructions

## Deadline

## Other information