### PR TITLE
feat: course about page markup and styles improvements

### DIFF
--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -156,7 +156,10 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         assert resp.status_code == 200
         pre_requisite_courses = get_prerequisite_courses_display(course)
         pre_requisite_course_about_url = reverse('about_course', args=[str(pre_requisite_courses[0]['key'])])
-        assert '<span class="important-dates-item-text pre-requisite"><a href="{}">{}</a></span>'.format(pre_requisite_course_about_url, pre_requisite_courses[0]['display']) in resp.content.decode(resp.charset).strip('\n')  # pylint: disable=line-too-long
+        assert (
+            f'You must successfully complete <a href="{pre_requisite_course_about_url}">'
+            f'{pre_requisite_courses[0]["display"]}</a> before you begin this course.'
+        ) in resp.content.decode(resp.charset).strip('\n')
 
     @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
     def test_about_page_unfulfilled_prereqs(self):
@@ -190,7 +193,10 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         assert resp.status_code == 200
         pre_requisite_courses = get_prerequisite_courses_display(course)
         pre_requisite_course_about_url = reverse('about_course', args=[str(pre_requisite_courses[0]['key'])])
-        assert '<span class="important-dates-item-text pre-requisite"><a href="{}">{}</a></span>'.format(pre_requisite_course_about_url, pre_requisite_courses[0]['display']) in resp.content.decode(resp.charset).strip('\n')  # pylint: disable=line-too-long
+        assert (
+            f'You must successfully complete <a href="{pre_requisite_course_about_url}">'
+            f'{pre_requisite_courses[0]["display"]}</a> before you begin this course.'
+        ) in resp.content.decode(resp.charset).strip('\n')
 
         url = reverse('about_course', args=[str(pre_requisite_course.id)])
         resp = self.client.get(url)

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -44,12 +44,22 @@
       > div.table {
         display: table;
         width: 100%;
+
+        @include media-breakpoint-down(sm) {
+          display: flex;
+          flex-direction: column;
+        }
       }
 
       .intro {
         box-sizing: border-box;
 
         @include clearfix();
+
+        @include media-breakpoint-down(sm) {
+            width: auto;
+            order: 2;
+        }
 
         display: table-cell;
         vertical-align: middle;
@@ -127,6 +137,10 @@
           a.add-to-cart {
             @include button(shiny, $button-color);
 
+            @include media-breakpoint-down(md) {
+              width: 100%;
+            }
+
             box-sizing: border-box;
             border-radius: 3px;
             display: block;
@@ -189,6 +203,11 @@
             @include float(left);
             @include margin(1px, flex-gutter(8), 0, 0);
             @include transition(none);
+            @include media-breakpoint-down(md) {
+              width: 100%;
+              margin-right: 0;
+              margin-bottom: 10px;
+            }
 
             width: flex-grid(5, 8);
           }
@@ -212,6 +231,11 @@
         position: relative;
         width: flex-grid(4);
         z-index: 2;
+
+        @include media-breakpoint-down(sm) {
+          width: auto;
+          order: 1;
+        }
 
         .hero {
           border: 1px solid $border-color-3;

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -65,11 +65,10 @@ from six import string_types
       <div class="table">
       <section class="intro">
         <div class="heading-group">
-          <h1>
-            ${course.display_name_with_default}
-          </h1>
-          <br />
+          <h1>${course.display_name_with_default}</h1>
           <span>${course.display_org_with_default}</span>
+          <br />
+          <p>${get_course_about_section(request, course, 'short_description')}</p>
         </div>
 
         <div class="main-cta">
@@ -222,7 +221,6 @@ from six import string_types
             <span class="icon fa fa-list-ul" aria-hidden="true"></span>
             <p class="important-dates-item-title">${_("Prerequisites")}</p>
             ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
-            <span class="important-dates-item-text pre-requisite"><a href="${prc_target}">${pre_requisite_courses[0]['display']}</a></span>
             <p class="tip">
             ${Text(_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.")).format(
               link_start=HTML('<a href="{}">').format(prc_target),
@@ -234,7 +232,11 @@ from six import string_types
           % endif
 
           % if get_course_about_section(request, course, "prerequisites"):
-            <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
+            <li class="important-dates-item">
+              <span class="icon fa fa-book" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Requirements")}</p>
+              <span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span>
+            </li>
           % endif
         </ol>
         </%block>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -220,7 +220,6 @@ from six import string_types
           <li class="prerequisite-course important-dates-item">
             <span class="icon fa fa-list-ul" aria-hidden="true"></span>
             <p class="important-dates-item-title">${_("Prerequisites")}</p>
-            ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
             <p class="tip">
             ${Text(_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.")).format(
               link_start=HTML('<a href="{}">').format(prc_target),


### PR DESCRIPTION
Similar PR is opened to the master branch:
https://github.com/openedx/edx-platform/pull/33712

There is some fixes for the course about page:

- display a course short description in course about heading-group (if necessary)
- removing duplicated pre-requisite info in right sidebar
- code formatting for the block `% if get_course_about_section(request, course, "prerequisites"):`

Fixes were also made to the `_course_about.scss` styles, to fix responsive layout of the course about header element.

Before fixes:
<img width="383" alt="1_before" src="https://github.com/openedx/edx-platform/assets/25877054/84ded004-0d79-4b2d-8dc5-f527a740af72">

After fixes:
<img width="384" alt="2_after" src="https://github.com/openedx/edx-platform/assets/25877054/a1eadc72-1d77-4c59-96e0-5eb4efa5212a">

