### PR TITLE
fix: Open Responses Styling and Layout

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1858,6 +1858,17 @@
 .instructor-dashboard-wrapper-2 section.idash-section#open_response_assessment {
   .open-response-assessment {
     padding-top: 20px;
+
+    
+    .open-response-assessment-content {
+      .open-response-assessment-summary, .open-response-assessment-main-table {
+        line-height: 1;
+
+        table tr td {
+          padding-right: 20px;
+        }
+      }
+    }
   }
 }
 

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1859,7 +1859,6 @@
   .open-response-assessment {
     padding-top: 20px;
 
-    
     .open-response-assessment-content {
       .open-response-assessment-summary, .open-response-assessment-main-table {
         line-height: 1;


### PR DESCRIPTION
## Description

The Open Responses tab on instructor dashboard on LMS has a few issues with table styling; there isn't enough spacing between some columns which makes the text difficult to read, and the bottom of some numbers in the summary table are cutoff.
This change adds padding to the right of each column to ensure longer text is still legible and changes the line height from 1em to 1 (unitless), which maintains the same style but doesn't cut off the bottom.

## Supporting information

Fix for this ticket: https://github.com/openedx/wg-build-test-release/issues/223

## Testing instructions

LMS > View Course > Instructor tab > Open Responses

## Other information

Old:
![old](https://github.com/openedx/edx-platform/assets/76498195/6cb4a0c7-b008-4453-a798-1a69c0713b38)

New:
![new](https://github.com/openedx/edx-platform/assets/76498195/42c80b66-8eec-4c10-b997-a72eaf68c6c1)
