### PR TITLE
fix: upgrade to edx-drf-extensions 8.13.1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -28,10 +28,6 @@ django-storages==1.14
 # for them.
 edx-enterprise==4.7.0
 
-# edx-drf-extensions 8.13.0 was causing errors, as mentioned in this revert PR:
-# https://github.com/openedx/edx-platform/pull/33682.
-edx-drf-extensions==8.12.0
-
 # django-oauth-toolkit version >=2.0.0 has breaking changes. More details
 # mentioned on this issue https://github.com/openedx/edx-platform/issues/32884
 django-oauth-toolkit==1.7.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -476,9 +476,8 @@ edx-django-utils==5.8.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.12.0
+edx-drf-extensions==8.13.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-completion
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -748,9 +748,8 @@ edx-django-utils==5.8.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.12.0
+edx-drf-extensions==8.13.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-completion

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -561,9 +561,8 @@ edx-django-utils==5.8.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.12.0
+edx-drf-extensions==8.13.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -579,9 +579,8 @@ edx-django-utils==5.8.0
     #   openedx-blockstore
     #   ora2
     #   super-csv
-edx-drf-extensions==8.12.0
+edx-drf-extensions==8.13.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise


### PR DESCRIPTION
## Description

Upgrade to edx-drf-extensions 8.13.1 that includes a fix for JWT vs Session monitoring that caused
errors in edx-platform in 8.13.0.

## Supporting information

See https://github.com/openedx/edx-drf-extensions/releases/tag/v8.13.1