### PR TITLE
feat: add ip_chain.safest_client_ip to emitted XForwardedForMiddleware metrics

### DIFF
--- a/openedx/core/lib/x_forwarded_for/middleware.py
+++ b/openedx/core/lib/x_forwarded_for/middleware.py
@@ -48,6 +48,8 @@ class XForwardedForMiddleware(MiddlewareMixin):
         # Only used to support ip.legacy switch.
         request.META['ORIGINAL_REMOTE_ADDR'] = request.META['REMOTE_ADDR']
 
+        safest_client_ip = ip.get_safest_client_ip(request)
+
         try:
             # Give some observability into IP chain length and composition. Useful
             # for monitoring in case of unexpected network config changes, etc.
@@ -66,6 +68,8 @@ class XForwardedForMiddleware(MiddlewareMixin):
             external_chain = ip.get_all_client_ips(request)
             set_custom_attribute('ip_chain.external.count', len(external_chain))
             set_custom_attribute('ip_chain.external.types', '-'.join(_ip_type(s) for s in external_chain))
+
+            set_custom_attribute('ip_chain.safest_client_ip', safest_client_ip)
         except BaseException:
             warnings.warn('Error while computing IP chain metrics')
 
@@ -107,4 +111,4 @@ class XForwardedForMiddleware(MiddlewareMixin):
         if legacy_ip.USE_LEGACY_IP.is_enabled():
             request.META['REMOTE_ADDR'] = legacy_ip.get_legacy_ip(request)
         else:
-            request.META['REMOTE_ADDR'] = ip.get_safest_client_ip(request)
+            request.META['REMOTE_ADDR'] = safest_client_ip

--- a/openedx/core/lib/x_forwarded_for/tests/test_middleware.py
+++ b/openedx/core/lib/x_forwarded_for/tests/test_middleware.py
@@ -65,7 +65,15 @@ class TestXForwardedForMiddleware(TestCase):
         ('XXXXXXXX, 1.2.3.4, 5.5.5.5', 'XXXXXXXX, 1.2.3.4, 5.5.5.5, 127.0.0.1', 4, 'unknown-pub-pub-priv', '5.5.5.5'),
     )
     @patch("openedx.core.lib.x_forwarded_for.middleware.set_custom_attribute")
-    def test_xff_metrics(self, xff, expected_raw, expected_count, expected_types, expected_safest_client_ip, mock_set_custom_attribute):
+    def test_xff_metrics(
+        self,
+        xff,
+        expected_raw,
+        expected_count,
+        expected_types,
+        expected_safest_client_ip,
+        mock_set_custom_attribute,
+    ):
         request = RequestFactory().get('/somewhere')
         if xff is not None:
             request.META['HTTP_X_FORWARDED_FOR'] = xff

--- a/openedx/core/lib/x_forwarded_for/tests/test_middleware.py
+++ b/openedx/core/lib/x_forwarded_for/tests/test_middleware.py
@@ -60,12 +60,12 @@ class TestXForwardedForMiddleware(TestCase):
 
     @ddt.unpack
     @ddt.data(
-        (None, '127.0.0.1', 1, 'priv'),
-        ('1.2.3.4', '1.2.3.4, 127.0.0.1', 2, 'pub-priv'),
-        ('XXXXXXXX, 1.2.3.4, 5.5.5.5', 'XXXXXXXX, 1.2.3.4, 5.5.5.5, 127.0.0.1', 4, 'unknown-pub-pub-priv'),
+        (None, '127.0.0.1', 1, 'priv', '127.0.0.1'),
+        ('1.2.3.4', '1.2.3.4, 127.0.0.1', 2, 'pub-priv', '1.2.3.4'),
+        ('XXXXXXXX, 1.2.3.4, 5.5.5.5', 'XXXXXXXX, 1.2.3.4, 5.5.5.5, 127.0.0.1', 4, 'unknown-pub-pub-priv', '5.5.5.5'),
     )
     @patch("openedx.core.lib.x_forwarded_for.middleware.set_custom_attribute")
-    def test_xff_metrics(self, xff, expected_raw, expected_count, expected_types, mock_set_custom_attribute):
+    def test_xff_metrics(self, xff, expected_raw, expected_count, expected_types, expected_safest_client_ip, mock_set_custom_attribute):
         request = RequestFactory().get('/somewhere')
         if xff is not None:
             request.META['HTTP_X_FORWARDED_FOR'] = xff
@@ -76,4 +76,5 @@ class TestXForwardedForMiddleware(TestCase):
             call('ip_chain.raw', expected_raw),
             call('ip_chain.count', expected_count),
             call('ip_chain.types', expected_types),
-        ])
+            call('ip_chain.safest_client_ip', expected_safest_client_ip),
+        ], any_order=True)


### PR DESCRIPTION
## Description

This PR adds the result of get_safest_client_ip() to the emitted metrics of XForwardedForMiddleware.

For more information on `get_safest_client_ip()`, please see [these docs](https://github.com/openedx/edx-django-utils/blob/3523c7eb6ef19833ad764b470d1aa1c0e46d2a19/edx_django_utils/ip/__init__.py#L2) in edx-django-utils.

## Additional Information

Idea was @timmc-edx's!

## Testing instructions

* On stage:
  * [ ] Spot check ip_chain metrics are still being emitted in New Relic post-deploy.
  * [ ] Check ip_chain.safest_client_ip matches value of a request.
* On prod:
  * [ ] Spot check ip_chain metrics are still being emitted in New Relic post-deploy.
  * [ ] Check ip_chain.safest_client_ip matches value of a request.

## Deadline

None.

## Other information

Context: Found it useful to have the safest_client_ip when tracing user journeys in our monitoring system.