### PR TITLE
[FC-0009] [FAL-3496] Copy/paste unit from within a unit 

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -75,6 +75,7 @@ function(
         $body.click(function() {
             $('.nav-dd .nav-item .wrapper-nav-sub').removeClass('is-shown');
             $('.nav-dd .nav-item .title').removeClass('is-selected');
+            $('.custom-dropdown .dropdown-options').hide();
         });
 
         $('.nav-dd .nav-item, .filterable-column .nav-item').click(function(e) {

--- a/cms/static/js/spec/views/pages/container_subviews_spec.js
+++ b/cms/static/js/spec/views/pages/container_subviews_spec.js
@@ -581,33 +581,6 @@ describe('Container Subviews', function() {
         });
     });
 
-    describe('PublishHistory', function() {
-        var lastPublishCss = '.wrapper-last-publish';
-
-        it('renders never published when the block is unpublished', function() {
-            renderContainerPage(this, mockContainerXBlockHtml, {
-                published: false, published_on: null, published_by: null
-            });
-            expect(containerPage.$(lastPublishCss).text()).toContain('Never published');
-        });
-
-        it('renders the last published date and user when the block is published', function() {
-            renderContainerPage(this, mockContainerXBlockHtml);
-            fetch({
-                published: true, published_on: 'Jul 01, 2014 at 12:45 UTC', published_by: 'amako'
-            });
-            expect(containerPage.$(lastPublishCss).text())
-                .toContain('Last published Jul 01, 2014 at 12:45 UTC by amako');
-        });
-
-        it('renders correctly when the block is published without publish info', function() {
-            renderContainerPage(this, mockContainerXBlockHtml);
-            fetch({
-                published: true, published_on: null, published_by: null
-            });
-            expect(containerPage.$(lastPublishCss).text()).toContain('Previously published');
-        });
-    });
 
     describe('Message Area', function() {
         var messageSelector = '.container-message .warning',

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -77,6 +77,7 @@ function($, _, Backbone, gettext, BasePage,
                 model: this.model
             });
             this.messageView.render();
+            this.clipboardBroadcastChannel = new BroadcastChannel("studio_clipboard_channel");
             // Display access message on units and split test components
             if (!this.isLibraryPage) {
                 this.containerAccessView = new ContainerSubviews.ContainerAccess({
@@ -89,7 +90,8 @@ function($, _, Backbone, gettext, BasePage,
                     el: this.$('#publish-unit'),
                     model: this.model,
                     // When "Discard Changes" is clicked, the whole page must be re-rendered.
-                    renderPage: this.render
+                    renderPage: this.render,
+                    clipboardBroadcastChannel: this.clipboardBroadcastChannel,
                 });
                 this.xblockPublisher.render();
 
@@ -120,7 +122,6 @@ function($, _, Backbone, gettext, BasePage,
             }
 
             this.listenTo(Backbone, 'move:onXBlockMoved', this.onXBlockMoved);
-            this.clipboardBroadcastChannel = new BroadcastChannel("studio_clipboard_channel");
         },
 
         getViewParameters: function() {
@@ -144,6 +145,7 @@ function($, _, Backbone, gettext, BasePage,
                 hiddenCss = 'is-hidden';
 
             loadingElement.removeClass(hiddenCss);
+            self.initializePasteActionButton();
 
             // Hide both blocks until we know which one to show
             xblockView.$el.addClass(hiddenCss);
@@ -175,9 +177,14 @@ function($, _, Backbone, gettext, BasePage,
                     if (!self.isLibraryPage && !self.isLibraryContentPage) {
                         self.initializePasteButton();
                     }
+
                 },
                 block_added: options && options.block_added
             });
+        },
+
+        initializePasteActionButton() {
+            // logic to hide/show paste button
         },
 
         findXBlockElement: function(target) {

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -145,7 +145,6 @@ function($, _, Backbone, gettext, BasePage,
                 hiddenCss = 'is-hidden';
 
             loadingElement.removeClass(hiddenCss);
-            self.initializePasteActionButton();
 
             // Hide both blocks until we know which one to show
             xblockView.$el.addClass(hiddenCss);
@@ -181,10 +180,6 @@ function($, _, Backbone, gettext, BasePage,
                 },
                 block_added: options && options.block_added
             });
-        },
-
-        initializePasteActionButton() {
-            // logic to hide/show paste button
         },
 
         findXBlockElement: function(target) {

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -178,6 +178,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
 
         copyToClipboard: function(e) {
             e.preventDefault();
+            e.stopPropagation();
             const clipboardEndpoint = "/api/content-staging/v1/clipboard/";
             const usageKeyToCopy = this.model.get('id');
             // Start showing a "Copying" notification:

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -107,7 +107,8 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
         events: {
             'click .action-publish': 'publish',
             'click .action-discard': 'discardChanges',
-            'click .action-staff-lock': 'toggleStaffLock'
+            'click .action-staff-lock': 'toggleStaffLock',
+            'click .action-copy': 'copyToClipboard'
         },
 
         // takes XBlockInfo as a model
@@ -117,6 +118,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
             this.template = this.loadTemplate('publish-xblock');
             this.model.on('sync', this.onSync, this);
             this.renderPage = this.options.renderPage;
+            this.clipboardBroadcastChannel = this.options.clipboardBroadcastChannel;
         },
 
         onSync: function(model) {
@@ -171,6 +173,49 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
                 MoveXBlockUtils.hideMovedNotification();
             }).done(function() {
                 xblockInfo.fetch();
+            });
+        },
+
+        copyToClipboard: function(e) {
+            e.preventDefault();
+            const clipboardEndpoint = "/api/content-staging/v1/clipboard/";
+            const usageKeyToCopy = this.model.get('id');
+            // Start showing a "Copying" notification:
+            ViewUtils.runOperationShowingMessage(gettext('Copying'), () => {
+                return $.postJSON(
+                    clipboardEndpoint,
+                    { usage_key: usageKeyToCopy },
+                ).then((data) => {
+                    const status = data.content?.status;
+                    if (status === "ready") {
+                        // something that enables the paste button in the actions dropdown
+                        this.clipboardBroadcastChannel.postMessage(data);
+                        return data;
+                    } else if (status === "loading") {
+                        // The clipboard is being loaded asynchonously.
+                        // Poll the endpoint until the copying process is complete:
+                        const deferred = $.Deferred();
+                        const checkStatus = () => {
+                            $.getJSON(clipboardEndpoint, (pollData) => {
+                                const newStatus = pollData.content?.status;
+                                if (newStatus === "ready") {
+                                    // something that enables the paste button in actions dropdown
+                                    this.clipboardBroadcastChannel.postMessage(pollData);
+                                    deferred.resolve(pollData);
+                                } else if (newStatus === "loading") {
+                                    setTimeout(checkStatus, 1_000);
+                                } else {
+                                    deferred.reject();
+                                    throw new Error(`Unexpected clipboard status "${newStatus}" in successful API response.`);
+                                }
+                            })
+                        }
+                        setTimeout(checkStatus, 1_000);
+                        return deferred;
+                    } else {
+                        throw new Error(`Unexpected clipboard status "${status}" in successful API response.`);
+                    }
+                });
             });
         },
 

--- a/cms/static/js/views/utils/xblock_utils.js
+++ b/cms/static/js/views/utils/xblock_utils.js
@@ -8,7 +8,7 @@ function($, _, gettext, ViewUtils, ModuleUtils, XBlockInfo, StringUtils) {
 
     var addXBlock, duplicateXBlock, deleteXBlock, createUpdateRequestData, updateXBlockField, VisibilityState,
         getXBlockVisibilityClass, getXBlockListTypeClass, updateXBlockFields, getXBlockType, findXBlockInfo,
-        moveXBlock;
+        moveXBlock, pasteXBlock;
 
     /**
          * Represents the possible visibility states for an xblock:
@@ -67,6 +67,85 @@ function($, _, gettext, ViewUtils, ModuleUtils, XBlockInfo, StringUtils) {
                     });
                 return addOperation.promise();
             });
+    };
+
+    pasteXBlock = function(target) {
+        var parentLocator = target.data('parent'),
+            displayName = target.data('default-name');
+
+        return ViewUtils.runOperationShowingMessage(gettext('Pasting'), () => {
+            return $.postJSON(ModuleUtils.getUpdateUrl(), {
+                parent_locator: parentLocator,
+                staged_content: "clipboard",
+            }).then((data) => {
+                return data;
+            });
+        }).done((data) => {
+            const {
+                conflicting_files: conflictingFiles,
+                error_files: errorFiles,
+                new_files: newFiles,
+            } = data.static_file_notices;
+
+            const notices = [];
+            if (errorFiles.length) {
+                notices.push((next) => new PromptView.Error({
+                    title: gettext("Some errors occurred"),
+                    message: (
+                        gettext("The following required files could not be added to the course:") +
+                        " " + errorFiles.join(", ")
+                    ),
+                    actions: {primary: {text: gettext("OK"), click: (x) => { x.hide(); next(); }}},
+                }));
+            }
+            if (conflictingFiles.length) {
+                notices.push((next) => new PromptView.Warning({
+                    title: gettext("You may need to update a file(s) manually"),
+                    message: (
+                        gettext(
+                            "The following files already exist in this course but don't match the " +
+                            "version used by the component you pasted:"
+                        ) + " " + conflictingFiles.join(", ")
+                    ),
+                    actions: {primary: {text: gettext("OK"), click: (x) => { x.hide(); next(); }}},
+                }));
+            }
+            if (newFiles.length) {
+                notices.push(() => new NotificationView.Info({
+                    title: gettext("New file(s) added to Files & Uploads."),
+                    message: (
+                        gettext("The following required files were imported to this course:") +
+                        " "  + newFiles.join(", ")
+                    ),
+                    actions: {
+                        primary: {
+                            text: gettext('View files'),
+                            click: function(notification) {
+                                const article = document.querySelector('[data-course-assets]');
+                                const assetsUrl = $(article).attr('data-course-assets');
+                                window.location.href = assetsUrl;
+                                return;
+                            }
+                        },
+                        secondary: {
+                            text: gettext('Dismiss'),
+                            click: function(notification) {
+                                return notification.hide();
+                            }
+                        }
+                    }
+                }));
+            }
+            if (notices.length) {
+                // Show the notices, one at a time:
+                const showNext = () => {
+                    const view = notices.shift()(showNext);
+                    view.show();
+                }
+                // Delay to avoid conflict with the "Pasting..." notification.
+                setTimeout(showNext, 1250);
+            }
+        });
     };
 
     /**
@@ -308,6 +387,7 @@ function($, _, gettext, ViewUtils, ModuleUtils, XBlockInfo, StringUtils) {
         getXBlockListTypeClass: getXBlockListTypeClass,
         updateXBlockFields: updateXBlockFields,
         getXBlockType: getXBlockType,
-        findXBlockInfo: findXBlockInfo
+        findXBlockInfo: findXBlockInfo,
+        pasteXBlock: pasteXBlock
     };
 });

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -14,6 +14,10 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
             'click .notification-action-button': 'fireNotificationActionEvent'
         },
 
+        options: {
+            clipboardData: { content: null },
+        },
+
         initialize: function() {
             BaseView.prototype.initialize.call(this);
             this.view = this.options.view;

--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -300,6 +300,40 @@ $seq-nav-height: 40px;
         @include border-right-style(solid);
       }
 
+      .custom-dropdown {
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdown-options {
+        position: absolute;
+        top: 100%;
+        z-index: 1000;
+        background-color: #ffffff;
+        min-width: 265px;
+        right: 0;
+
+        li {
+          padding: 0.5em 1em;
+          cursor: pointer;
+
+          a {
+            display: block;
+            width: 100%;
+            color: black;
+          }
+
+          .checkmark {
+            float: right;
+            margin-left: 10px;
+          }
+        }
+      }
+
+      .dropdown-options li:hover {
+        background-color: #f1f1f1;
+      }
+
       button {
         @extend %ui-fake-link;
         @extend %ui-clear-button;

--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -288,6 +288,11 @@ $seq-nav-height: 40px;
   ol {
     display: flex;
 
+    .custom-dropdown {
+      position: relative;
+      display: inline-flex;
+    }
+
     li {
       box-sizing: border-box;
       min-width: 40px;
@@ -300,9 +305,16 @@ $seq-nav-height: 40px;
         @include border-right-style(solid);
       }
 
-      .custom-dropdown {
-        position: relative;
-        display: inline-block;
+      .dropdown-main-button {
+        border-right: 1px solid #e7e7e7 !important;
+      }
+
+      .dropdown-toggle-button {
+        width: 15% !important;
+
+        &:hover {
+          border-bottom: 1px solid #e7e7e7 !important;
+        }
       }
 
       .dropdown-options {

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -243,6 +243,8 @@
         .action-copy {
           width: 100%;
           border-color: #0075b4;
+          padding-top: 12px;
+          padding-bottom: 12px;
 
           &:hover {
             @extend %btn-primary-blue;

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -243,8 +243,10 @@
         .action-copy {
           width: 100%;
           border-color: #0075b4;
-          padding-top: 12px;
-          padding-bottom: 12px;
+          padding-top: 10px;
+          padding-bottom: 10px;
+          line-height: 24px;
+          border-radius: 4px;
 
           &:hover {
             @extend %btn-primary-blue;

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -239,6 +239,15 @@
             color: $gray-l1;
           }
         }
+
+        .action-copy {
+          width: 100%;
+          border-color: #0075b4;
+
+          &:hover {
+            @extend %btn-primary-blue;
+          }
+        }
       }
     }
 

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -53,6 +53,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 clipboardData: ${user_clipboard | n, dump_js_escaped_json},
             }
         );
+
         require(["js/models/xblock_info", "js/views/xblock", "js/views/utils/xblock_utils", "common/js/components/utils/view_utils"], function (XBlockInfo, XBlockView, XBlockUtils, ViewUtils) {
             var model = new XBlockInfo({
                 id: '${subsection.location|n, decode.utf8}'
@@ -60,19 +61,63 @@ from openedx.core.djangolib.markup import HTML, Text
             var xblockView = new XBlockView({
                 model: model,
                 el: $('#sequence-nav'),
-                view: 'author_view?position=${position|n, decode.utf8}&next_url=${next_url|n, decode.utf8}&prev_url=${prev_url|n, decode.utf8}'
+                view: 'author_view?position=${position|n, decode.utf8}&next_url=${next_url|n, decode.utf8}&prev_url=${prev_url|n, decode.utf8}',
+                clipboardData: ${user_clipboard | n, dump_js_escaped_json},
             });
+
             xblockView.xblockReady = function() {
-                $('.seq_new_button').click(function(evt) {
-                    evt.preventDefault();
-                    XBlockUtils.addXBlock($(evt.target)).done(function(locator) {
-                        ViewUtils.redirect('/container/' + locator + '?action=new');
-                        return false;
-                    });
-                    return false;
+                const optionIcons = {
+                    'New Unit': 'fa-plus',
+                    'Paste as new unit': 'fa-clipboard'
+                };
+
+                if (!this.options.clipboardData && !this.options.clipboardData.source_usage_key.includes("vertical")) {
+                    $('.seq_paste_unit').hide();
+                }
+                $('.custom-dropdown .dropdown-toggle-button').on('click', function(event) {
+                    event.stopPropagation(); // Prevent the event from closing immediately when we open it
+                    $(this).next('.dropdown-options').slideToggle('fast'); // This toggles the dropdown visibility
+                    updateCheckmarks($(this).text().trim());
                 });
 
+                updateCheckmarks = function(activeOptionText) {
+                    $('.dropdown-options .checkmark').remove();
+                    $('.dropdown-options a').each(function() {
+                        if ($(this).text().trim() === activeOptionText) {
+                            $(this).append('<span class="checkmark fa fa-check"></span>'); // Checkmark icon
+                        }
+                    });
+                }
+
+                $('.dropdown-options').click(function(event) {
+                    event.preventDefault();
+                    var $target = $(event.target),
+                        newLabel = $target.text().trim(),
+                        newIconClass = optionIcons[newLabel];
+
+                    if ($target.hasClass('seq_new_unit') || $target.hasClass('seq_paste_unit')) {
+                        // Change the text of the main button
+                        $('.dropdown-toggle-button').text(newLabel);
+                        // Change the icon of the main button
+                        $('.dropdown-toggle-button').prepend('<span class="icon fa ' + newIconClass + '" aria-hidden="true"></span>');
+
+                        updateCheckmarks(newLabel);
+
+                        if ($target.hasClass('seq_new_unit')) {
+                            XBlockUtils.addXBlock($(event.target)).done(function(locator) {
+                                ViewUtils.redirect('/container/' + locator + '?action=new');
+                            });
+                        }
+
+                        if ($target.hasClass('seq_paste_unit')) {
+                            XBlockUtils.pasteXBlock($(event.target)).done(function(data) {
+                                ViewUtils.redirect('/container/' + data.locator + '?action=new');
+                            });
+                        }
+                    }
+                });
             };
+
             xblockView.render();
         });
     </%static:webpack>

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -54,7 +54,7 @@ from openedx.core.djangolib.markup import HTML, Text
             }
         );
 
-        require(["js/models/xblock_info", "js/views/xblock", "js/views/utils/xblock_utils", "common/js/components/utils/view_utils"], function (XBlockInfo, XBlockView, XBlockUtils, ViewUtils) {
+        require(["js/models/xblock_info", "js/views/xblock", "js/views/utils/xblock_utils", "common/js/components/utils/view_utils", "gettext"], function (XBlockInfo, XBlockView, XBlockUtils, ViewUtils, gettext) {
             var model = new XBlockInfo({
                 id: '${subsection.location|n, decode.utf8}'
             });
@@ -66,27 +66,15 @@ from openedx.core.djangolib.markup import HTML, Text
             });
 
             xblockView.xblockReady = function() {
-                this.clipboardBroadcastChannel = new BroadcastChannel("studio_clipboard_channel");
-                this.clipboardBroadcastChannel.onmessage = (event) => {
-                    if (!event.data.source_usage_key?.includes("vertical")) {
-                        $('.seq_paste_unit').closest('li').hide();
-                    } else {
-                        $('.seq_paste_unit').closest('li').show();
-                    }
-                };
                 var currentAction = "new_unit";
                 var actionIcons = {
                     'new_unit': 'fa fa-plus',
                     'paste_unit': 'fa fa-clipboard'
                 };
                 var actionLabels = {
-                    'new_unit': 'New Unit',
-                    'paste_unit': 'Paste Unit'
+                    'new_unit': gettext('New Unit'),
+                    'paste_unit': gettext('Paste Unit')
                 };
-
-                if (!this.options.clipboardData.content || !this.options.clipboardData.source_usage_key?.includes("vertical")) {
-                    $('.seq_paste_unit').closest('li').hide();
-                }
 
                 var updateButtonAndCheckmarks = function(selectedAction) {
                     var iconName = actionIcons[selectedAction];
@@ -102,6 +90,36 @@ from openedx.core.djangolib.markup import HTML, Text
                         }
                     });
                 };
+
+                var resetToDefaultAction = function() {
+                    // Set the current action to "new unit"
+                    currentAction = 'new_unit';
+
+                    // Update the button label and icon to "new unit"
+                    var defaultLabel = actionLabels[currentAction];
+                    var defaultIconName = actionIcons[currentAction];
+                    $('.dropdown-main-button .button-label').text(defaultLabel);
+                    $('.dropdown-main-button .icon').removeClass('fa-plus fa-clipboard').addClass(defaultIconName);
+
+                    // Ensure that the checkmarks are updated to reflect the default state
+                    updateButtonAndCheckmarks(currentAction);
+
+                    // Hide the "Paste as new unit" option
+                    $('.seq_paste_unit').closest('li').hide();
+                };
+
+                this.clipboardBroadcastChannel = new BroadcastChannel("studio_clipboard_channel");
+                this.clipboardBroadcastChannel.onmessage = (event) => {
+                    if (!event.data.source_usage_key?.includes("vertical")) {
+                        resetToDefaultAction();
+                    } else {
+                        $('.seq_paste_unit').closest('li').show();
+                    }
+                };
+
+                if (!this.options.clipboardData.content || !this.options.clipboardData.source_usage_key?.includes("vertical")) {
+                    resetToDefaultAction();
+                }
 
                 $('.custom-dropdown .dropdown-toggle-button').on('click', function(event) {
                     event.stopPropagation(); // Prevent the event from closing immediately when we open it

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -66,56 +66,88 @@ from openedx.core.djangolib.markup import HTML, Text
             });
 
             xblockView.xblockReady = function() {
-                const optionIcons = {
-                    'New Unit': 'fa-plus',
-                    'Paste as new unit': 'fa-clipboard'
+                this.clipboardBroadcastChannel = new BroadcastChannel("studio_clipboard_channel");
+                this.clipboardBroadcastChannel.onmessage = (event) => {
+                    if (!event.data.source_usage_key?.includes("vertical")) {
+                        $('.seq_paste_unit').closest('li').hide();
+                    } else {
+                        $('.seq_paste_unit').closest('li').show();
+                    }
+                };
+                var currentAction = "new_unit";
+                var actionIcons = {
+                    'new_unit': 'fa fa-plus',
+                    'paste_unit': 'fa fa-clipboard'
+                };
+                var actionLabels = {
+                    'new_unit': 'New Unit',
+                    'paste_unit': 'Paste Unit'
                 };
 
-                if (!this.options.clipboardData && !this.options.clipboardData.source_usage_key.includes("vertical")) {
-                    $('.seq_paste_unit').hide();
+                if (!this.options.clipboardData.content || !this.options.clipboardData.source_usage_key?.includes("vertical")) {
+                    $('.seq_paste_unit').closest('li').hide();
                 }
+
+                var updateButtonAndCheckmarks = function(selectedAction) {
+                    var iconName = actionIcons[selectedAction];
+                    var buttonIconSpan = $('.dropdown-main-button .icon');
+
+                    // Update the button icon
+                    buttonIconSpan.removeClass('fa-plus fa-clipboard').addClass(iconName);
+
+                    $('.dropdown-options a').each(function() {
+                        $(this).find('.checkmark').remove();
+                        if ($(this).data('action') === selectedAction) {
+                            $(this).append('<span class="checkmark fa fa-check"></span>');
+                        }
+                    });
+                };
+
                 $('.custom-dropdown .dropdown-toggle-button').on('click', function(event) {
                     event.stopPropagation(); // Prevent the event from closing immediately when we open it
                     $(this).next('.dropdown-options').slideToggle('fast'); // This toggles the dropdown visibility
-                    updateCheckmarks($(this).text().trim());
+                    var isExpanded = $(this).attr('aria-expanded') === 'true';
+                    $(this).attr('aria-expanded', !isExpanded);
                 });
 
-                updateCheckmarks = function(activeOptionText) {
-                    $('.dropdown-options .checkmark').remove();
-                    $('.dropdown-options a').each(function() {
-                        if ($(this).text().trim() === activeOptionText) {
-                            $(this).append('<span class="checkmark fa fa-check"></span>'); // Checkmark icon
-                        }
-                    });
-                }
-
-                $('.dropdown-options').click(function(event) {
+                $('.dropdown-options a').click(function(event) {
                     event.preventDefault();
-                    var $target = $(event.target),
-                        newLabel = $target.text().trim(),
-                        newIconClass = optionIcons[newLabel];
+                    var $option = $(this);
+                    var newAction = $option.data('action')
 
-                    if ($target.hasClass('seq_new_unit') || $target.hasClass('seq_paste_unit')) {
-                        // Change the text of the main button
-                        $('.dropdown-toggle-button').text(newLabel);
-                        // Change the icon of the main button
-                        $('.dropdown-toggle-button').prepend('<span class="icon fa ' + newIconClass + '" aria-hidden="true"></span>');
+                    var newLabel = actionLabels[newAction];
+                    $('.custom-dropdown .dropdown-main-button .button-label').text(newLabel);
+                    currentAction = newAction;
 
-                        updateCheckmarks(newLabel);
+                    updateButtonAndCheckmarks(currentAction);
+                    $('.custom-dropdown .dropdown-options').slideUp('fast');
+                });
 
-                        if ($target.hasClass('seq_new_unit')) {
-                            XBlockUtils.addXBlock($(event.target)).done(function(locator) {
+                $('#execute-action-button').on('click', function(event) {
+                    event.preventDefault();
+                    var $button = $(this);
+                    switch (currentAction) {
+                        case 'new_unit':
+                            XBlockUtils.addXBlock($button).done(function(locator) {
                                 ViewUtils.redirect('/container/' + locator + '?action=new');
                             });
-                        }
-
-                        if ($target.hasClass('seq_paste_unit')) {
-                            XBlockUtils.pasteXBlock($(event.target)).done(function(data) {
+                            break;
+                        case 'paste_unit':
+                            XBlockUtils.pasteXBlock($button).done(function(data) {
                                 ViewUtils.redirect('/container/' + data.locator + '?action=new');
                             });
-                        }
+                            break;
+                        default:
+                            console.error('Unknown action');
+                            break;
                     }
                 });
+
+                if ($('.seq_paste_unit').is(':visible')) {
+                    updateButtonAndCheckmarks(currentAction);
+                } else {
+                    updateButtonAndCheckmarks('new_unit');
+                }
             };
 
             xblockView.render();

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -66,60 +66,27 @@ from openedx.core.djangolib.markup import HTML, Text
             });
 
             xblockView.xblockReady = function() {
-                var currentAction = "new_unit";
-                var actionIcons = {
-                    'new_unit': 'fa fa-plus',
-                    'paste_unit': 'fa fa-clipboard'
-                };
-                var actionLabels = {
-                    'new_unit': gettext('New Unit'),
-                    'paste_unit': gettext('Paste Unit')
-                };
 
-                var updateButtonAndCheckmarks = function(selectedAction) {
-                    var iconName = actionIcons[selectedAction];
-                    var buttonIconSpan = $('.dropdown-main-button .icon');
-
-                    // Update the button icon
-                    buttonIconSpan.removeClass('fa-plus fa-clipboard').addClass(iconName);
-
-                    $('.dropdown-options a').each(function() {
-                        $(this).find('.checkmark').remove();
-                        if ($(this).data('action') === selectedAction) {
-                            $(this).append('<span class="checkmark fa fa-check"></span>');
-                        }
-                    });
-                };
-
-                var resetToDefaultAction = function() {
-                    // Set the current action to "new unit"
-                    currentAction = 'new_unit';
-
-                    // Update the button label and icon to "new unit"
-                    var defaultLabel = actionLabels[currentAction];
-                    var defaultIconName = actionIcons[currentAction];
-                    $('.dropdown-main-button .button-label').text(defaultLabel);
-                    $('.dropdown-main-button .icon').removeClass('fa-plus fa-clipboard').addClass(defaultIconName);
-
-                    // Ensure that the checkmarks are updated to reflect the default state
-                    updateButtonAndCheckmarks(currentAction);
-
-                    // Hide the "Paste as new unit" option
-                    $('.seq_paste_unit').closest('li').hide();
-                };
-
-                this.clipboardBroadcastChannel = new BroadcastChannel("studio_clipboard_channel");
-                this.clipboardBroadcastChannel.onmessage = (event) => {
-                    if (!event.data.source_usage_key?.includes("vertical")) {
-                        resetToDefaultAction();
+                var toggleCaretButton = function(clipboardData) {
+                    if (clipboardData && clipboardData.content && clipboardData.source_usage_key.includes("vertical")) {
+                        $('.dropdown-toggle-button').show();
                     } else {
-                        $('.seq_paste_unit').closest('li').show();
+                        $('.dropdown-toggle-button').hide();
+                        $('.dropdown-options').hide();
                     }
                 };
+                this.clipboardBroadcastChannel = new BroadcastChannel("studio_clipboard_channel");
+                this.clipboardBroadcastChannel.onmessage = (event) => {
+                    toggleCaretButton(event.data);
+                };
+                toggleCaretButton(this.options.clipboardData);
 
-                if (!this.options.clipboardData.content || !this.options.clipboardData.source_usage_key?.includes("vertical")) {
-                    resetToDefaultAction();
-                }
+                $('#new-unit-button').on('click', function(event) {
+                    event.preventDefault();
+                    XBlockUtils.addXBlock($(this)).done(function(locator) {
+                        ViewUtils.redirect('/container/' + locator + '?action=new');
+                    });
+                });
 
                 $('.custom-dropdown .dropdown-toggle-button').on('click', function(event) {
                     event.stopPropagation(); // Prevent the event from closing immediately when we open it
@@ -128,44 +95,13 @@ from openedx.core.djangolib.markup import HTML, Text
                     $(this).attr('aria-expanded', !isExpanded);
                 });
 
-                $('.dropdown-options a').click(function(event) {
+                $('.seq_paste_unit').on('click', function(event) {
                     event.preventDefault();
-                    var $option = $(this);
-                    var newAction = $option.data('action')
-
-                    var newLabel = actionLabels[newAction];
-                    $('.custom-dropdown .dropdown-main-button .button-label').text(newLabel);
-                    currentAction = newAction;
-
-                    updateButtonAndCheckmarks(currentAction);
-                    $('.custom-dropdown .dropdown-options').slideUp('fast');
+                    $('.dropdown-options').hide();
+                    XBlockUtils.pasteXBlock($(this)).done(function(data) {
+                        ViewUtils.redirect('/container/' + data.locator + '?action=new');
+                    });
                 });
-
-                $('#execute-action-button').on('click', function(event) {
-                    event.preventDefault();
-                    var $button = $(this);
-                    switch (currentAction) {
-                        case 'new_unit':
-                            XBlockUtils.addXBlock($button).done(function(locator) {
-                                ViewUtils.redirect('/container/' + locator + '?action=new');
-                            });
-                            break;
-                        case 'paste_unit':
-                            XBlockUtils.pasteXBlock($button).done(function(data) {
-                                ViewUtils.redirect('/container/' + data.locator + '?action=new');
-                            });
-                            break;
-                        default:
-                            console.error('Unknown action');
-                            break;
-                    }
-                });
-
-                if ($('.seq_paste_unit').is(':visible')) {
-                    updateButtonAndCheckmarks(currentAction);
-                } else {
-                    updateButtonAndCheckmarks('new_unit');
-                }
             };
 
             xblockView.render();

--- a/cms/templates/js/publish-history.underscore
+++ b/cms/templates/js/publish-history.underscore
@@ -10,8 +10,3 @@ if (published_on && published_by) {
     copy = gettext("Previously published");
 }
 %>
-
-<div class="wrapper-last-publish">
-    <% // xss-lint: disable=underscore-not-escaped %>
-    <p class="copy"><%= copy %></p>
-</div>

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -128,4 +128,13 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
             </li>
         </ul>
     </div>
+    <div class="wrapper-pub-actions bar-mod-actions">
+        <ul>
+            <li>
+                <a class="action-copy"
+                   href="#" ><%- gettext("Copy Unit") %>
+                </a>
+            </li>
+        </ul>
+    </div>
 </div>

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -131,9 +131,10 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
     <div class="wrapper-pub-actions bar-mod-actions">
         <ul>
             <li>
-                <a class="action-copy"
-                   href="#" ><%- gettext("Copy Unit") %>
-                </a>
+                <button class="btn btn-outline-primary btn-default action-copy">
+                    <span class="icon fa fa-copy" aria-hidden="true"></span>
+                    <span class="button-label"><%- gettext("Copy Unit") %></span>
+                </button>
             </li>
         </ul>
     </div>

--- a/lms/templates/seq_block.html
+++ b/lms/templates/seq_block.html
@@ -85,22 +85,15 @@
         % endfor
         % endif
         % if exclude_units:
-        <li role="presentation">
-          <button class="seq_new_button inactive xnav-item tab"
-            role="tab"
-            tabindex="-1"
-            aria-selected="false"
-            aria-expanded="false"
-            aria-controls="seq_content"
-            data-parent="${item_id}"
-            data-category="vertical"
-            data-default-name="${_('Unit')}"
-          >
-          <span
-                class="fa fa-plus"
-                aria-hidden="true"
-          ></span> New Unit
-        </button>
+        <li role="presentation" class="custom-dropdown">
+          <button class="dropdown-toggle-button">
+            <span class="icon fa fa-plus" aria-hidden="true"></span>
+            New Unit
+          </button>
+          <ul class="dropdown-options" style="display: none;">
+            <li><a href="#" class="seq_new_unit" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">New Unit</a></li>
+            <li><a href="#" class="seq_paste_unit" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">Paste as new unit</a></li>
+          </ul>
         </li>
         % endif
       </ol>

--- a/lms/templates/seq_block.html
+++ b/lms/templates/seq_block.html
@@ -88,14 +88,14 @@
         <li role="presentation" class="custom-dropdown">
           <button id="execute-action-button" class="dropdown-main-button" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">
             <span class="icon fa fa-plus" aria-hidden="true"></span>
-            <span class="button-label">New Unit</span>
+            <span class="button-label">${_("New Unit")}</span>
           </button>
           <button class="dropdown-toggle-button" aria-haspopup="true" aria-expanded="false">
             <span class="icon fa fa-caret-down" aria-hidden="true"></span>
           </button>
           <ul class="dropdown-options" style="display: none;">
-            <li><a href="#" class="seq_new_unit" data-action="new_unit">New Unit</a></li>
-            <li><a href="#" class="seq_paste_unit" data-action="paste_unit">Paste as new unit</a></li>
+            <li><a href="#" class="seq_new_unit" data-action="new_unit">${_("New Unit")}</a></li>
+            <li><a href="#" class="seq_paste_unit" data-action="paste_unit">${_("Paste as new unit")}</a></li>
           </ul>
         </li>
         % endif

--- a/lms/templates/seq_block.html
+++ b/lms/templates/seq_block.html
@@ -86,13 +86,16 @@
         % endif
         % if exclude_units:
         <li role="presentation" class="custom-dropdown">
-          <button class="dropdown-toggle-button">
+          <button id="execute-action-button" class="dropdown-main-button" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">
             <span class="icon fa fa-plus" aria-hidden="true"></span>
-            New Unit
+            <span class="button-label">New Unit</span>
+          </button>
+          <button class="dropdown-toggle-button" aria-haspopup="true" aria-expanded="false">
+            <span class="icon fa fa-caret-down" aria-hidden="true"></span>
           </button>
           <ul class="dropdown-options" style="display: none;">
-            <li><a href="#" class="seq_new_unit" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">New Unit</a></li>
-            <li><a href="#" class="seq_paste_unit" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">Paste as new unit</a></li>
+            <li><a href="#" class="seq_new_unit" data-action="new_unit">New Unit</a></li>
+            <li><a href="#" class="seq_paste_unit" data-action="paste_unit">Paste as new unit</a></li>
           </ul>
         </li>
         % endif

--- a/lms/templates/seq_block.html
+++ b/lms/templates/seq_block.html
@@ -86,16 +86,15 @@
         % endif
         % if exclude_units:
         <li role="presentation" class="custom-dropdown">
-          <button id="execute-action-button" class="dropdown-main-button" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">
+          <button id="new-unit-button" class="dropdown-main-button" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">
             <span class="icon fa fa-plus" aria-hidden="true"></span>
-            <span class="button-label">${_("New Unit")}</span>
+            ${_("New Unit")}
           </button>
-          <button class="dropdown-toggle-button" aria-haspopup="true" aria-expanded="false">
+          <button class="dropdown-toggle-button" aria-haspopup="true" aria-expanded="false" style="display: none;">
             <span class="icon fa fa-caret-down" aria-hidden="true"></span>
           </button>
           <ul class="dropdown-options" style="display: none;">
-            <li><a href="#" class="seq_new_unit" data-action="new_unit">${_("New Unit")}</a></li>
-            <li><a href="#" class="seq_paste_unit" data-action="paste_unit">${_("Paste as new unit")}</a></li>
+            <li><a href="#" class="seq_paste_unit" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">${_("Paste as new unit")}</a></li>
           </ul>
         </li>
         % endif

--- a/scripts/xsslint_thresholds.json
+++ b/scripts/xsslint_thresholds.json
@@ -11,7 +11,7 @@
         "django-trans-missing-escape": 0,
         "javascript-concat-html": 2,
         "javascript-escape": 1,
-        "javascript-jquery-append": 1,
+        "javascript-jquery-append": 2,
         "javascript-jquery-html": 5,
         "javascript-jquery-insert-into-target": 2,
         "javascript-jquery-insertion": 0,
@@ -36,5 +36,5 @@
         "python-wrap-html": 0,
         "underscore-not-escaped": 2
     },
-    "total": 63
+    "total": 64
 }


### PR DESCRIPTION
## Description

This PR adds the option to copy/paste a unit from within a unit in CMS as per the designs in [this wireframe](https://www.figma.com/file/y2qfzidTxxfYK8ONgyT7KP/Copy-Paste-Wireframes?type=design&node-id=3104-6457&mode=design&t=zE4OMczgdKsB1573-0). It also removes the `last published` section.

## Supporting Information
https://github.com/openedx/modular-learning/issues/96


OpenCraft Internal Jira task - [FAL-3496](https://tasks.opencraft.com/browse/FAL-3496)

## Screenshots

1. Copy button section:

![copy-unit-button](https://github.com/openedx/edx-platform/assets/13742492/b743726e-9d1c-4ee6-b31f-c62b509b9217)


2. Copy button hover/select:

![copy-unit-button-selected](https://github.com/openedx/edx-platform/assets/13742492/4022aebc-ad7c-49b1-b29c-4e6eead45184)



3. Dropdown menu options when unit is copied:

![Screenshot from 2023-11-30 16-53-43](https://github.com/openedx/edx-platform/assets/13742492/2f8ba999-de57-4c59-97ab-203905809ed8)


## Testing Instructions
1. Checkout the PR branch on the devstack.
2. Enable the `contentstore.enable_copy_paste_units` waffle flag in cms admin panel.
3. In Studio, open a unit and verify that the dropdown that shows up when `New Unit` button is clicked, only contains one option i.e. `New Unit`
4. Click on `Copy to Clipboard` button.
5. Verify that the dropdown now contains another option `Paste as new unit`.
6. Select `Paste as new unit` option and verify that the copies unit is pasted as a new unit.
7. Copy only a component from the unit to clipboard and verify that the paste option doesn't show up.
