### PR TITLE
fix: course wide preferences are visible when patch call is sent

### DIFF
--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -219,7 +219,8 @@ class UserNotificationPreferenceView(APIView):
         updated_notification_preferences = preference_update.save()
         notification_preference_update_event(request.user, course_id, preference_update.validated_data)
         serializer = UserCourseNotificationPreferenceSerializer(updated_notification_preferences)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        preferences = filter_course_wide_preferences(course_id, serializer.data)
+        return Response(preferences, status=status.HTTP_200_OK)
 
 
 @allow_any_authenticated_user()


### PR DESCRIPTION
Course wide notification preferences were visible when app level notification is switched off then switched on again

Ticket: [INF-1162](https://2u-internal.atlassian.net/browse/INF-1162)