### PR TITLE
fix: session_language url renamed to update_language

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -324,7 +324,7 @@
               % if user.is_authenticated:
               <input title="preference api" type="hidden" id="preference-api-url" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
               % else:
-              <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+              <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
               % endif
               <label><span class="sr">${_("Choose Language")}</span>
               <select class="input select language-selector" id="settings-language-value" name="language">

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -90,7 +90,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             % if user.is_authenticated:
                 <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
             % else:
-                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
             % endif
             <label><span class="sr">${_("Choose Language")}</span>
             <select class="input select language-selector" id="settings-language-value" name="language">

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -58,7 +58,7 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
                 % if user.is_authenticated:
                   <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
                 % else:
-                  <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                  <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
                 % endif
                 <label><span class="sr">${_("Choose Language")}</span>
                   <select class="input select language-selector" id="settings-language-value" name="language">


### PR DESCRIPTION
## Description

The url was renamed from session_language to update_language but it was still referred to in some html templates. Without this change, any instance with multiple languages configured via Darklang will raise error in the dashboard.


Useful information to include:
- Which edX user roles will this change impact: "Learner", "Course Author", "Developer", and "Operator".

## Testing instructions

- In master branch
- Enable multiple languages via darklang. [Tutorial link](https://discuss.overhang.io/t/howto-enable-multiple-languages-for-your-open-edx-platform/140)
- Logout and try to visit home url: http://localhost:18000/dashboard in case of devstack.
- It will raise 500 error.
- Checkout this PR and it should be fixed.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
