### PR TITLE
feat: update video and asset api to include usage loactions

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -435,7 +435,7 @@ def _get_assets_in_json_format(assets, course_key, assets_usage_locations_map):
     for asset in assets:
         asset_key = asset['asset_key']
         asset_key_string = str(asset_key)
-        usage_locations = assets_usage_locations_map[asset_key_string]
+        usage_locations = getattr(assets_usage_locations_map, 'asset_key_string', [])
         thumbnail_asset_key = _get_thumbnail_asset_key(asset, course_key)
         asset_is_locked = asset.get('locked', False)
         asset_file_size = asset.get('length', None)

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -91,7 +91,7 @@ def handle_assets(request, course_key_string=None, asset_key_string=None):
     return HttpResponseNotFound()
 
 
-def get_asset_usage_path(request, course_key, asset_key_string):
+def get_asset_usage_path_json(request, course_key, asset_key_string):
     """
     Get a list of units with ancestors that use given asset.
     """
@@ -99,9 +99,16 @@ def get_asset_usage_path(request, course_key, asset_key_string):
     if not has_course_author_access(request.user, course_key):
         raise PermissionDenied()
     asset_location = AssetKey.from_string(asset_key_string) if asset_key_string else None
+    usage_locations = _get_asset_usage_path(course_key, [{ 'asset_key': asset_location }])
+    return JsonResponse({ 'usage_locations': usage_locations })
+
+
+def _get_asset_usage_path(course_key, assets):
+    """
+    Get a list of units with ancestors that use given asset.
+    """
     store = modulestore()
-    usage_locations = []
-    static_path = StaticContent.get_static_path_from_location(asset_location)
+    usage_locations = {str(asset['asset_key']):[] for asset in assets}
     verticals = store.get_items(
         course_key,
         qualifiers={
@@ -114,26 +121,34 @@ def get_asset_usage_path(request, course_key, asset_key_string):
         blocks.extend(vertical.get_children())
 
     for block in blocks:
-        is_video_block = getattr(block, 'category', '') == 'video'
-        if is_video_block:
-            handout = getattr(block, 'handout', '')
-            if handout and str(asset_location) in handout:
-                unit = block.get_parent()
-                subsection = unit.get_parent()
-                subsection_display_name = getattr(subsection, 'display_name', '')
-                unit_display_name = getattr(unit, 'display_name', '')
-                xblock_display_name = getattr(block, 'display_name', '')
-                usage_locations.append(f'{subsection_display_name} - {unit_display_name} / {xblock_display_name}')
-        else:
-            data = getattr(block, 'data', '')
-            if static_path in data or str(asset_location) in data:
-                unit = block.get_parent()
-                subsection = unit.get_parent()
-                subsection_display_name = getattr(subsection, 'display_name', '')
-                unit_display_name = getattr(unit, 'display_name', '')
-                xblock_display_name = getattr(block, 'display_name', '')
-                usage_locations.append(f'{subsection_display_name} - {unit_display_name} / {xblock_display_name}')
-    return JsonResponse({'usage_locations': usage_locations})
+        for asset in assets:
+            asset_key = asset['asset_key']
+            asset_key_string = str(asset_key)
+            static_path = StaticContent.get_static_path_from_location(asset_key)
+            is_video_block = getattr(block, 'category', '') == 'video'
+            if is_video_block:
+                handout = getattr(block, 'handout', '')
+                if handout and asset_key_string in handout:
+                    unit = block.get_parent()
+                    subsection = unit.get_parent()
+                    subsection_display_name = getattr(subsection, 'display_name', '')
+                    unit_display_name = getattr(unit, 'display_name', '')
+                    xblock_display_name = getattr(block, 'display_name', '')
+                    current_locations = usage_locations[asset_key_string]
+                    new_location = f'{subsection_display_name} - {unit_display_name} / {xblock_display_name}'
+                    usage_locations[asset_key_string] = [*current_locations, new_location]
+            else:
+                data = getattr(block, 'data', '')
+                if static_path in data or asset_key_string in data:
+                    unit = block.get_parent()
+                    subsection = unit.get_parent()
+                    subsection_display_name = getattr(subsection, 'display_name', '')
+                    unit_display_name = getattr(unit, 'display_name', '')
+                    xblock_display_name = getattr(block, 'display_name', '')
+                    current_locations = usage_locations[asset_key_string]
+                    new_location = f'{subsection_display_name} - {unit_display_name} / {xblock_display_name}'
+                    usage_locations[asset_key_string] = [*current_locations, new_location]
+    return  usage_locations
 
 
 def _asset_index(request, course_key):
@@ -196,6 +211,8 @@ def _assets_json(request, course_key):
 
     assets, total_count = _get_assets_for_page(course_key, query_options)
 
+    assets_usage_locations_map = _get_asset_usage_path(course_key, assets)
+
     if request_options['requested_page'] > 0 and first_asset_to_display_index >= total_count and total_count > 0:  # lint-amnesty, pylint: disable=chained-comparison
         _update_options_to_requery_final_page(query_options, total_count)
         current_page = query_options['current_page']
@@ -203,7 +220,7 @@ def _assets_json(request, course_key):
         assets, total_count = _get_assets_for_page(course_key, query_options)
 
     last_asset_to_display_index = first_asset_to_display_index + len(assets)
-    assets_in_json_format = _get_assets_in_json_format(assets, course_key)
+    assets_in_json_format = _get_assets_in_json_format(assets, course_key, assets_usage_locations_map)
 
     response_payload = {
         'start': first_asset_to_display_index,
@@ -412,10 +429,13 @@ def _update_options_to_requery_final_page(query_options, total_asset_count):
     query_options['current_page'] = int(math.floor((total_asset_count - 1) / query_options['page_size']))
 
 
-def _get_assets_in_json_format(assets, course_key):
+def _get_assets_in_json_format(assets, course_key, assets_usage_locations_map):
     """returns assets information in JSON Format"""
     assets_in_json_format = []
     for asset in assets:
+        asset_key = asset['asset_key']
+        asset_key_string = str(asset_key)
+        usage_locations = assets_usage_locations_map[asset_key_string]
         thumbnail_asset_key = _get_thumbnail_asset_key(asset, course_key)
         asset_is_locked = asset.get('locked', False)
         asset_file_size = asset.get('length', None)
@@ -424,11 +444,12 @@ def _get_assets_in_json_format(assets, course_key):
             asset['displayname'],
             asset['contentType'],
             asset['uploadDate'],
-            asset['asset_key'],
+            asset_key,
             thumbnail_asset_key,
             asset_is_locked,
             course_key,
             asset_file_size,
+            usage_locations,
         )
 
         assets_in_json_format.append(asset_in_json)
@@ -670,7 +691,7 @@ def _delete_thumbnail(thumbnail_location, course_key, asset_key):  # lint-amnest
             logging.warning('Could not delete thumbnail: %s', thumbnail_location)
 
 
-def get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key, file_size=None):
+def get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key, file_size=None, usage_locations=[]):
     '''
     Helper method for formatting the asset information to send to client.
     '''
@@ -690,4 +711,5 @@ def get_asset_json(display_name, content_type, date, location, thumbnail_locatio
         # needed for Backbone delete/update.
         'id': str(location),
         'file_size': file_size,
+        'usage_locations': usage_locations,
     }

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -99,8 +99,8 @@ def get_asset_usage_path_json(request, course_key, asset_key_string):
     if not has_course_author_access(request.user, course_key):
         raise PermissionDenied()
     asset_location = AssetKey.from_string(asset_key_string) if asset_key_string else None
-    usage_locations = _get_asset_usage_path(course_key, [{ 'asset_key': asset_location }])
-    return JsonResponse({ 'usage_locations': usage_locations })
+    usage_locations = _get_asset_usage_path(course_key, [{'asset_key': asset_location}])
+    return JsonResponse({'usage_locations': usage_locations})
 
 
 def _get_asset_usage_path(course_key, assets):
@@ -108,7 +108,7 @@ def _get_asset_usage_path(course_key, assets):
     Get a list of units with ancestors that use given asset.
     """
     store = modulestore()
-    usage_locations = {str(asset['asset_key']):[] for asset in assets}
+    usage_locations = {str(asset['asset_key']): [] for asset in assets}
     verticals = store.get_items(
         course_key,
         qualifiers={
@@ -148,7 +148,7 @@ def _get_asset_usage_path(course_key, assets):
                     current_locations = usage_locations[asset_key_string]
                     new_location = f'{subsection_display_name} - {unit_display_name} / {xblock_display_name}'
                     usage_locations[asset_key_string] = [*current_locations, new_location]
-    return  usage_locations
+    return usage_locations
 
 
 def _asset_index(request, course_key):

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -691,13 +691,15 @@ def _delete_thumbnail(thumbnail_location, course_key, asset_key):  # lint-amnest
             logging.warning('Could not delete thumbnail: %s', thumbnail_location)
 
 
-def get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key, file_size=None, usage_locations=[]):
+def get_asset_json(display_name, content_type, date, location, thumbnail_location,
+                   locked, course_key, file_size=None, usage=None):
     '''
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
     external_url = urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), asset_url)
     portable_url = StaticContent.get_static_path_from_location(location)
+    usage_locations = [] if usage is None else usage
     return {
         'display_name': display_name,
         'content_type': content_type,

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
@@ -56,6 +56,9 @@ class VideoModelSerializer(serializers.Serializer):
     transcripts = serializers.ListField(
         child=serializers.CharField()
     )
+    usage_locations = serializers.ListField(
+        child=serializers.CharField()
+    )
 
 
 class VideoActiveTranscriptPreferencesSerializer(serializers.Serializer):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -177,6 +177,6 @@ class VideoUsageView(DeveloperErrorViewMixin, APIView):
         if not has_studio_read_access(request.user, course_key):
             self.permission_denied(request)
 
-        usage_locations = get_video_usage_path(request, course_key, edx_video_id)
+        usage_locations = get_video_usage_path(course_key, edx_video_id)
         serializer = VideoUsageSerializer(usage_locations)
         return Response(serializer.data)

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -15,7 +15,6 @@ from boto.s3.connection import S3Connection
 from boto import s3
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.exceptions import PermissionDenied
 from django.http import FileResponse, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
@@ -42,7 +41,6 @@ from rest_framework import status as rest_status
 from rest_framework.response import Response
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
-from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import ensure_csrf_cookie
 from cms.djangoapps.contentstore.asset_storage_handlers import (
     handle_assets,
-    get_asset_usage_path,
+    get_asset_usage_path_json,
     update_course_run_asset as update_course_run_asset_source_function,
     get_file_size as get_file_size_source_function,
     delete_asset as delete_asset_source_function,
@@ -57,7 +57,7 @@ def assets_handler(request, course_key_string=None, asset_key_string=None):
 @login_required
 @ensure_csrf_cookie
 def asset_usage_path_handler(request, course_key_string, asset_key_string):
-    return get_asset_usage_path(request, course_key_string, asset_key_string)
+    return get_asset_usage_path_json(request, course_key_string, asset_key_string)
 
 
 def update_course_run_asset(course_key, upload_file):

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -244,7 +244,7 @@ class PaginationTestCase(AssetsTestCase):
                     "thumbnail_location": thumbnail_location,
                     "locked": None,
                     "static_full_url": "/assets/courseware/v1/asset-v1:org+class+run+type@asset+block@my_file_name.jpg",
-                    "usage_locations": { str(asset_key): [] }
+                    "usage_locations": {str(asset_key): []}
                 }
             ],
             1

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -56,6 +56,7 @@ class AssetsTestCase(CourseTestCase):
         Post to the asset upload url
         """
         asset = self.get_sample_asset(name, asset_type)
+        print(asset)
         response = self.client.post(self.url, {"name": name, "file": asset})
         return response
 
@@ -242,7 +243,8 @@ class PaginationTestCase(AssetsTestCase):
                     "thumbnail": None,
                     "thumbnail_location": thumbnail_location,
                     "locked": None,
-                    "static_full_url": "/assets/courseware/v1/asset-v1:org+class+run+type@asset+block@my_file_name.jpg"
+                    "static_full_url": "/assets/courseware/v1/asset-v1:org+class+run+type@asset+block@my_file_name.jpg",
+                    "usage_locations": { str(asset_key): [] }
                 }
             ],
             1

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -373,7 +373,8 @@ class VideosHandlerTestCase(
                     'transcripts',
                     'transcription_status',
                     'transcript_urls',
-                    'error_description'
+                    'error_description',
+                    'usage_locations'
                 }
             )
             dateutil.parser.parse(response_video['created'])
@@ -389,7 +390,8 @@ class VideosHandlerTestCase(
             [
                 'edx_video_id', 'client_video_id', 'created', 'duration',
                 'status', 'course_video_image_url', 'file_size', 'download_link',
-                'transcripts', 'transcription_status', 'transcript_urls', 'error_description'
+                'transcripts', 'transcription_status', 'transcript_urls',
+                'error_description', 'usage_locations'
             ],
             [
                 {
@@ -406,7 +408,8 @@ class VideosHandlerTestCase(
             [
                 'edx_video_id', 'client_video_id', 'created', 'duration',
                 'status', 'course_video_image_url', 'file_size', 'download_link',
-                'transcripts', 'transcription_status', 'transcript_urls', 'error_description'
+                'transcripts', 'transcription_status', 'transcript_urls',
+                'error_description', 'usage_locations'
             ],
             [
                 {


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR updates API endpoints for the video and file fetch to includes the usage locations for each of the files/videos. The table view in the MFE has an active column that requires this data on the initial load of the page to load as users expect. Previous, the check mark in the active column on the table view would only appear after a user loaded the corresponding info modal. The table is supposed to provide a quick view to the user for whether or not a video/file is in use. Now the column loads as expected and the rows/cards can properly be filtered on the active value. This change impacts Authors.

## Supporting information

JIRA Ticket: [TNL-11215](https://2u-internal.atlassian.net/browse/TNL-11215)
> “Active” checkmark does not show up in table view until after the Info modal has been loaded

## Testing instructions

Note: Use the `course-authoring` MFE the files and videos pages for testing

1. Change the table view to the list view
2. Filter the page to show the active files
3. Should show the files that actively used in an xblock
4. Click the more menu (...) and open the info modal
5. Usage section should load the expected locations where the file is used

## Deadline

None

## Other information
`course-authoring` PR #[701](https://github.com/openedx/frontend-app-course-authoring/pull/701) is dependent on this change.

