### PR TITLE
 fix: overwrite previous tags on import [FC-0036]

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1824,10 +1824,9 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
         response = self.client.get(url)
         tags = response.data["results"]
-        all_tags = [{"value": tag.value} for tag in self.old_tags] + new_tags
-        assert len(tags) == len(all_tags)
+        assert len(tags) == len(new_tags)
         for i, tag in enumerate(tags):
-            assert tag["value"] == all_tags[i]["value"]
+            assert tag["value"] == new_tags[i]["value"]
 
     def test_import_no_file(self) -> None:
         """

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -121,7 +121,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.3.4
+openedx-learning==0.3.5
 
 # lti-consumer-xblock 9.6.2 contains a breaking change that makes
 # existing custom parameter configurations unusable.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -803,7 +803,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.3.4
+openedx-learning==0.3.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1340,7 +1340,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.4
+openedx-learning==0.3.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -961,7 +961,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.4
+openedx-learning==0.3.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1011,7 +1011,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.4
+openedx-learning==0.3.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description
Updates the openedx-learning library to change the import endpoint to overwrite previous tags from the target taxonomy.

## Supporting Information
* Part of https://github.com/openedx/modular-learning/issues/140
* Depends on:
  * https://github.com/openedx/openedx-learning/pull/121 

## Testing instructions
* Please ensure that the tests cover the expected behavior of the view

## Before merge
* [x] ToDo: update dependencies after https://github.com/openedx/openedx-learning/pull/121 merge (0d9b82e86d56c219d599be2aa6e076d0a108f2a6)
____
Private-ref: [FAL-3536](https://tasks.opencraft.com/browse/FAL-3536)