### PR TITLE
feat: Publish mobile SKUs to LMS

### DIFF
--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -100,6 +100,8 @@ class Course:
             merged_mode.currency = posted_mode.currency
             merged_mode.sku = posted_mode.sku
             merged_mode.bulk_sku = posted_mode.bulk_sku
+            merged_mode.android_sku = posted_mode.android_sku
+            merged_mode.ios_sku = posted_mode.ios_sku
             merged_mode.expiration_datetime = posted_mode.expiration_datetime
             merged_mode.save()
 

--- a/lms/djangoapps/commerce/api/v1/serializers.py
+++ b/lms/djangoapps/commerce/api/v1/serializers.py
@@ -34,7 +34,7 @@ class CourseModeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CourseMode
-        fields = ('name', 'currency', 'price', 'sku', 'bulk_sku', 'expires')
+        fields = ('name', 'currency', 'price', 'sku', 'bulk_sku', 'expires', 'android_sku', 'ios_sku')
         # For disambiguating within the drf-yasg swagger schema
         ref_name = 'commerce.CourseMode'
 

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -65,6 +65,8 @@ class CourseApiViewTestMixin:
             'sku': course_mode.sku,
             'bulk_sku': course_mode.bulk_sku,
             'expires': cls._serialize_datetime(course_mode.expiration_datetime),
+            'android_sku': course_mode.android_sku,
+            'ios_sku': course_mode.ios_sku
         }
 
     @classmethod


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Support mobile SKUs in Course mode serializer. This is to be used by the Ecommerce when publishing seats as course modes into the LMS.

## Supporting information

Jira ticket: https://2u-internal.atlassian.net/browse/LEARNER-9682
Related PR: https://github.com/openedx/ecommerce/pull/4057

## Testing instructions

None.

## Deadline

27th November 2023

