### PR TITLE
Fix ObjectTag taxonomy rule [FC-0036] 

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -239,7 +239,9 @@ def can_view_object_tag_taxonomy(user: UserType, taxonomy: oel_tagging.Taxonomy)
 
     This rule is different from can_view_taxonomy because it checks if the taxonomy is enabled.
     """
-    return taxonomy.cast().enabled and can_view_taxonomy(user, taxonomy)
+    # Note: in the REST API, where we're dealing with multiple taxonomies at once, permissions
+    # are also enforced by ObjectTagTaxonomyOrgFilterBackend.
+    return not taxonomy or (taxonomy.cast().enabled and can_view_taxonomy(user, taxonomy))
 
 
 @rules.predicate


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

There is a bug in the ObjectTag rules which appears when the REST API tries to fetch all ObjectTags for a given object_id (without limiting to a specific taxonomy). This PR illustrates the issue by adding a test which fails, and then fixes it by fixing the rule.

## Supporting information

Relates to https://github.com/openedx/modular-learning/issues/118

## Testing instructions

This change is covered by tests, but to test manually:

1. Run this branch in your devstack
2. Enable waffle flag `new_studio_mfe.use_tagging_taxonomy_list_page`
3. Load sample taxonomy and tag data as [described here](https://github.com/open-craft/taxonomy-sample-data/#getting-started).
4. Login using the `staff` account (can't use a superuser; superusers bypass permissions rule checks).
5. Visit the created [Sample Taxonomy Course (1)](http://localhost:18010/course/course-v1:SampleTaxonomyOrg1+STC1+2023_1)
6. Expand out the first section/subsection to show the Tag icons for those units ![tag_icon](https://github.com/openedx/edx-platform/assets/7556571/03651e35-0f2b-4e4f-b657-c3008126404c)
7. Click a Tag icon. The tagging drawer should load without error.

## Deadline

None

## Other information

Private-ref: [FAL-3530](https://tasks.opencraft.com/browse/FAL-3530)