### PR TITLE
chore: update Django to 4.2.8 for Quince - Security Patch

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -24,7 +24,3 @@
 elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -181,7 +181,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.14
     # via jwcrypto
-django==4.2.6
+django==4.2.8
     # via
     #   -r requirements/edx/kernel.in
     #   django-appconf

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -343,7 +343,7 @@ distlib==0.3.7
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.6
+django==4.2.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2053,7 +2053,6 @@ tomlkit==0.12.1
     #   snowflake-connector-python
 tox==3.28.0
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   tox-battery
 tox-battery==0.6.2

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -230,7 +230,7 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/base.txt
     #   jwcrypto
-django==4.2.6
+django==4.2.8
     # via
     #   -r requirements/edx/base.txt
     #   django-appconf

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -263,7 +263,7 @@ dill==0.3.7
     # via pylint
 distlib==0.3.7
     # via virtualenv
-django==4.2.6
+django==4.2.8
     # via
     #   -r requirements/edx/base.txt
     #   django-appconf

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1514,7 +1514,6 @@ tomlkit==0.12.1
     #   snowflake-connector-python
 tox==3.28.0
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/testing.in
     #   tox-battery
 tox-battery==0.6.2


### PR DESCRIPTION
### Description
This PR updates Django to version 4.2.8 in the Quince release branch. The update includes the latest security patch (4.2.7), as part of the BTR working group's ongoing efforts to ensure the security of Open edX's supported named releases.

For more information, see: [https://github.com/openedx/wg-build-test-release/issues/324](https://github.com/openedx/wg-build-test-release/issues/324)