### PR TITLE
feat: Added correct image for FB sharing (palm.master)

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -17,9 +17,20 @@ from six import string_types
 
 <%inherit file="../main.html" />
 <%block name="headextra">
-  ## OG (Open Graph) title and description added below to give social media info to display
+  <%
+    site_domain = static.get_value('site_domain', settings.SITE_NAME)
+    site_protocol = 'https' if settings.HTTPS == 'on' else 'http'
+
+    og_img_url = "{protocol}://{domain}{path}".format(
+        protocol=site_protocol,
+        domain=site_domain,
+        path=course_image_urls['large']
+    )
+  %>
+  ## OG (Open Graph) title, image and description added below to give social media info to display
   ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
   <meta property="og:title" content="${course.display_name_with_default}" />
+  <meta property="og:image" content="${og_img_url}" />
   <meta property="og:description" content="${get_course_about_section(request, course, 'short_description')}" />
 </%block>
 


### PR DESCRIPTION
#### Issue
This pull request addresses the issue related to missing Open Graph (OG) image metadata in the HTML.

#### Context
The absence of the `<meta property="og:image" />` tag was causing issues with social media sharing and previewing content. This addition ensures that the correct OG image is associated with the page for improved sharing capabilities.

#### Related Pull Requests
- master - https://github.com/openedx/edx-platform/pull/33784
- palm.master - https://github.com/openedx/edx-platform/pull/33783
- quince.master - https://github.com/openedx/edx-platform/pull/33785