### PR TITLE
Upgrade click

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -504,7 +504,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
             url = reverse('course_modes_choose', args=[str(self.course.id)])
             response = self.client.get(url)
             # URL-encoded version of 1/1/15, 12:00 AM
-            redirect_url = reverse('dashboard') + '?course_closed=1%2F1%2F15%2C+12%3A00+AM'
+            redirect_url = reverse('dashboard') + '?course_closed=1%2F1%2F15%2C+12%3A00%E2%80%AFAM'
             self.assertRedirects(response, redirect_url)
 
     @ddt.data(

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -109,9 +109,6 @@ djangorestframework-stubs==3.14.0  # Pinned to match django-stubs. Remove this w
 # https://github.com/openedx/edx-platform/issues/31616
 libsass==0.10.0
 
-# greater version breaking upgrade builds
-click==8.1.6
-
 # pinning this version to avoid updates while the library is being developed
 openedx-learning==0.3.4
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -85,9 +85,6 @@ algoliasearch==2.6.3
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/32222
 urllib3<2.0.0
 
-# Sphinx==5.3.0 requires docutils<0.20
-# Issue to unpin Sphinx to resolve this constraint: https://github.com/openedx/edx-lint/issues/338
-docutils<0.20
 
 # greater version has dropped few dependencies. Fix this in other ticket.
 drf-yasg<1.21.6


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
