### PR TITLE
feat: add duplicate_children logging

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -301,10 +301,10 @@ def duplicate_children(
     source_block = store.get_item(BlockUsageLocator.from_string(source_block_id))
     with store.bulk_operations(source_block.scope_ids.usage_id.context_key):
         try:
-            TASK_LOGGER.info('Copying Overrides for %s', dest_block.scope_ids.usage_id)
+            TASK_LOGGER.info('Copying Overrides from %s to %s', source_block_id, dest_block_id)
             _copy_overrides(store=store, user_id=user_id, source_block=source_block, dest_block=dest_block)
         except Exception as exception:  # pylint: disable=broad-except
-            TASK_LOGGER.exception('Error importing children for %s', dest_block.scope_ids.usage_id, exc_info=True)
+            TASK_LOGGER.exception('Error Copying Overrides from %s to %s', source_block_id, dest_block_id)
             if self.status.state != UserTaskStatus.FAILED:
                 self.status.fail({'raw_error_msg': str(exception)})
 

--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -300,7 +300,13 @@ def duplicate_children(
     # Then, copy over any overridden settings the course author may have applied to the blocks.
     source_block = store.get_item(BlockUsageLocator.from_string(source_block_id))
     with store.bulk_operations(source_block.scope_ids.usage_id.context_key):
-        _copy_overrides(store=store, user_id=user_id, source_block=source_block, dest_block=dest_block)
+        try:
+            TASK_LOGGER.info('Copying Overrides for %s', dest_block.scope_ids.usage_id)
+            _copy_overrides(store=store, user_id=user_id, source_block=source_block, dest_block=dest_block)
+        except Exception as exception:  # pylint: disable=broad-except
+            TASK_LOGGER.exception('Error importing children for %s', dest_block.scope_ids.usage_id, exc_info=True)
+            if task.status.state != UserTaskStatus.FAILED:
+                task.status.fail({'raw_error_msg': str(exception)})
 
 
 def _sync_children(

--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -305,8 +305,8 @@ def duplicate_children(
             _copy_overrides(store=store, user_id=user_id, source_block=source_block, dest_block=dest_block)
         except Exception as exception:  # pylint: disable=broad-except
             TASK_LOGGER.exception('Error importing children for %s', dest_block.scope_ids.usage_id, exc_info=True)
-            if task.status.state != UserTaskStatus.FAILED:
-                task.status.fail({'raw_error_msg': str(exception)})
+            if self.status.state != UserTaskStatus.FAILED:
+                self.status.fail({'raw_error_msg': str(exception)})
 
 
 def _sync_children(


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Add some logging to better capture the failures we've seen in duplication of library blocks.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
