### PR TITLE
fix: usage_locations always returning empty

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -438,11 +438,12 @@ def _get_assets_in_json_format(assets, course_key, assets_usage_locations_map):
         thumbnail_asset_key = _get_thumbnail_asset_key(asset, course_key)
         asset_is_locked = asset.get('locked', False)
         asset_file_size = asset.get('length', None)
+
         try:
             usage_locations = assets_usage_locations_map[asset_key_string]
         except KeyError:
             usage_locations = []
-        print(asset['displayname'], usage_locations)
+
         asset_in_json = get_asset_json(
             asset['displayname'],
             asset['contentType'],

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -435,11 +435,14 @@ def _get_assets_in_json_format(assets, course_key, assets_usage_locations_map):
     for asset in assets:
         asset_key = asset['asset_key']
         asset_key_string = str(asset_key)
-        usage_locations = assets_usage_locations_map[asset_key_string]
         thumbnail_asset_key = _get_thumbnail_asset_key(asset, course_key)
         asset_is_locked = asset.get('locked', False)
         asset_file_size = asset.get('length', None)
-
+        try:
+            usage_locations = assets_usage_locations_map[asset_key_string]
+        except:
+            usage_locations = []
+        print(asset['displayname'], usage_locations)
         asset_in_json = get_asset_json(
             asset['displayname'],
             asset['contentType'],

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -440,7 +440,7 @@ def _get_assets_in_json_format(assets, course_key, assets_usage_locations_map):
         asset_file_size = asset.get('length', None)
         try:
             usage_locations = assets_usage_locations_map[asset_key_string]
-        except:
+        except KeyError:
             usage_locations = []
         print(asset['displayname'], usage_locations)
         asset_in_json = get_asset_json(

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -435,7 +435,7 @@ def _get_assets_in_json_format(assets, course_key, assets_usage_locations_map):
     for asset in assets:
         asset_key = asset['asset_key']
         asset_key_string = str(asset_key)
-        usage_locations = getattr(assets_usage_locations_map, 'asset_key_string', [])
+        usage_locations = assets_usage_locations_map[asset_key_string]
         thumbnail_asset_key = _get_thumbnail_asset_key(asset, course_key)
         asset_is_locked = asset.get('locked', False)
         asset_file_size = asset.get('length', None)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR fixes the `usage_locations` for all assets returned and empty list. Now the asset has the correct usage locations associated list. This change impacts Authors.

## Testing instructions

1. Open a course
2. Add a new text block
3. Edit the text block to use an image from your assets
4. Navigate to the Files page
5. Switch to the list view
6. Search for the image that you added to the new text block
7. Active column should have a checkmark

## Deadline

None
