### PR TITLE
feat: Bump openedx-learning to 0.3.6

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -108,7 +108,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.3.5
+openedx-learning==0.3.6
 
 # lti-consumer-xblock 9.6.2 contains a breaking change that makes
 # existing custom parameter configurations unusable.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -783,7 +783,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.3.5
+openedx-learning==0.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1314,7 +1314,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.5
+openedx-learning==0.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -926,7 +926,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.5
+openedx-learning==0.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -985,7 +985,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.3.5
+openedx-learning==0.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Bumps openedx-learning package to version 0.3.6.

## Supporting information

Related Tickets:
- https://github.com/openedx/modular-learning/issues/122
- https://github.com/openedx/frontend-app-course-authoring/pull/704

## Testing instructions

1. Run local devstack on this branch
2. Run `make requirements` inside `cms-shell` and `lms-shell`
3. Check that openedx-learning version 0.3.6 is installed: `pip freeze | grep "openedx-learning"`

--
Private-ref: [FAL-3530](https://tasks.opencraft.com/browse/FAL-3530)