### PR TITLE
chore: bump ORA to 6.0.10

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -790,7 +790,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==6.0.9
+ora2==6.0.10
     # via -r requirements/edx/bundled.in
 packaging==23.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1325,7 +1325,7 @@ optimizely-sdk==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.0.9
+ora2==6.0.10
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -932,7 +932,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==6.0.9
+ora2==6.0.10
     # via -r requirements/edx/base.txt
 packaging==23.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -992,7 +992,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==6.0.9
+ora2==6.0.10
     # via -r requirements/edx/base.txt
 packaging==23.2
     # via


### PR DESCRIPTION
## Description

Bump ORA to 6.0.10 to fix file issue in peer assessments for new ORA experience

## Supporting information

JIRA: [AU-1579](https://2u-internal.atlassian.net/browse/AU-1579)

## Deadline

ASAP
