### PR TITLE
chore: update lti-consumer-xblock version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -111,10 +111,5 @@ click==8.1.6
 # pinning this version to avoid updates while the library is being developed
 openedx-learning==0.3.6
 
-# lti-consumer-xblock 9.6.2 contains a breaking change that makes
-# existing custom parameter configurations unusable.
-# https://github.com/openedx/xblock-lti-consumer/issues/410 has been opened to track a fix
-lti-consumer-xblock==9.6.1
-
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -669,10 +669,8 @@ libsass==0.10.0
     #   -r requirements/edx/paver.txt
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.6.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/kernel.in
+lti-consumer-xblock==9.8.1
+    # via -r requirements/edx/kernel.in
 lxml==4.9.3
     # via
     #   -r requirements/edx/kernel.in
@@ -1227,7 +1225,6 @@ xblock-poll==1.13.0
 xblock-utils==4.0.0
     # via
     #   edx-sga
-    #   lti-consumer-xblock
     #   xblock-google-drive
 xmlsec==1.3.13
     # via python3-saml

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1130,9 +1130,8 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.6.1
+lti-consumer-xblock==9.8.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 lxml==4.9.3
@@ -2213,7 +2212,6 @@ xblock-utils==4.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-sga
-    #   lti-consumer-xblock
     #   xblock-google-drive
 xmlsec==1.3.13
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -796,10 +796,8 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.6.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+lti-consumer-xblock==9.8.1
+    # via -r requirements/edx/base.txt
 lxml==4.9.3
     # via
     #   -r requirements/edx/base.txt
@@ -1496,7 +1494,6 @@ xblock-utils==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-sga
-    #   lti-consumer-xblock
     #   xblock-google-drive
 xmlsec==1.3.13
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -854,10 +854,8 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.6.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+lti-consumer-xblock==9.8.1
+    # via -r requirements/edx/base.txt
 lxml==4.9.3
     # via
     #   -r requirements/edx/base.txt
@@ -1621,7 +1619,6 @@ xblock-utils==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-sga
-    #   lti-consumer-xblock
     #   xblock-google-drive
 xmlsec==1.3.13
     # via


### PR DESCRIPTION
## Description

v9.6.2 of the lti-consumer-xblock library contained a breaking change that made existing custom parameter fields in an LTI 1.3 configuration invalid. The latest version of this library, 9.8.1, ensures that custom parameter field validation is backwards compatible.

## Supporting information

PR in xblock-lti-consumer that contains fix: https://github.com/openedx/xblock-lti-consumer/pull/412