### PR TITLE
fix: discussion tab should be None if discussion tab is disabled

### DIFF
--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -74,7 +74,7 @@ class CourseOverviewField(serializers.RelatedField):  # lint-amnesty, pylint: di
                 'discussion_course',
                 kwargs={'course_id': course_id},
                 request=request,
-            ) if course_overview.is_discussion_tab_enabled() else None,
+            ) if course_overview.is_discussion_tab_enabled(request.user) else None,
 
             # This is an old API that was removed as part of DEPR-4. We keep the
             # field present in case API parsers expect it, but this API is now

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -23,7 +23,6 @@ class CourseOverviewField(serializers.RelatedField):  # lint-amnesty, pylint: di
         request = self.context.get('request')
         api_version = self.context.get('api_version')
         enrollment = CourseEnrollment.get_enrollment(user=self.context.get('request').user, course_key=course_id)
-
         return {
             # identifiers
             'id': course_id,

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -36,6 +36,7 @@ from lms.djangoapps.mobile_api.testutils import (
 )
 from lms.djangoapps.mobile_api.utils import API_V1, API_V05, API_V2, API_V3
 from openedx.core.lib.courses import course_image_url
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from xmodule.course_block import DEFAULT_START_DATE  # lint-amnesty, pylint: disable=wrong-import-order
@@ -713,3 +714,50 @@ class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin)
         assert serialized['course']['number'] == self.course.display_coursenumber
         assert serialized['course']['org'] == self.course.display_organization
         self._expiration_in_response(serialized, api_version)
+
+
+@ddt.ddt
+@patch.dict(settings.FEATURES, {'ENABLE_DISCUSSION_SERVICE': True})
+class TestDiscussionCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin):
+    """
+    Tests discussion data in course enrollment serializer
+    """
+
+    def setUp(self):
+        """
+        Setup data for test
+        """
+        super().setUp()
+        self.login_and_enroll()
+        self.request = RequestFactory().get('/')
+        self.request.user = self.user
+
+    def get_serialized_data(self, api_version):
+        """
+        Return data from CourseEnrollmentSerializer
+        """
+        if api_version == API_V05:
+            serializer = CourseEnrollmentSerializerv05
+        else:
+            serializer = CourseEnrollmentSerializer
+
+        return serializer(
+            CourseEnrollment.enrollments_for_user(self.user)[0],
+            context={'request': self.request, 'api_version': api_version},
+        ).data
+
+    @ddt.data(True, False)
+    def test_discussion_tab_url(self, discussion_tab_enabled):
+        """
+        Tests discussion tab url is None if tab is disabled
+        """
+        config, _ = DiscussionsConfiguration.objects.get_or_create(context_key=self.course.id)
+        config.enabled = discussion_tab_enabled
+        config.save()
+        serialized = self.get_serialized_data(API_V2)
+        discussion_url = serialized["course"]["discussion_url"]
+        if discussion_tab_enabled:
+            assert discussion_url is not None
+            assert isinstance(discussion_url, str)
+        else:
+            assert discussion_url is None

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -717,7 +717,7 @@ class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin)
 
 
 @ddt.ddt
-class TestDiscussionCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin):
+class TestDiscussionCourseEnrollmentSerializer(UrlResetMixin, MobileAPITestCase, MilestonesTestCaseMixin):
     """
     Tests discussion data in course enrollment serializer
     """

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -717,7 +717,6 @@ class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin)
 
 
 @ddt.ddt
-@patch.dict(settings.FEATURES, {'ENABLE_DISCUSSION_SERVICE': True})
 class TestDiscussionCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin):
     """
     Tests discussion data in course enrollment serializer
@@ -727,7 +726,8 @@ class TestDiscussionCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTest
         """
         Setup data for test
         """
-        super().setUp()
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_DISCUSSION_SERVICE': True}):
+            super().setUp()
         self.login_and_enroll()
         self.request = RequestFactory().get('/')
         self.request.user = self.user
@@ -754,7 +754,8 @@ class TestDiscussionCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTest
         config, _ = DiscussionsConfiguration.objects.get_or_create(context_key=self.course.id)
         config.enabled = discussion_tab_enabled
         config.save()
-        serialized = self.get_serialized_data(API_V2)
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_DISCUSSION_SERVICE': True}):
+            serialized = self.get_serialized_data(API_V2)
         discussion_url = serialized["course"]["discussion_url"]
         if discussion_tab_enabled:
             assert discussion_url is not None


### PR DESCRIPTION
`discussion_url` will be None if discussion tab is disabled for API `/api/mobile/v2/users/{username}/course_enrollments/`

Ticket Link: [INF-1101](https://2u-internal.atlassian.net/browse/INF-1101)