### PR TITLE
fix: "Copy Unit" button should be behind enable_copy_paste_units flag

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1387,9 +1387,6 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
             else:
                 xblock_info["staff_only_message"] = False
 
-            # If the ENABLE_COPY_PASTE_UNITS feature flag is enabled, we show the newer menu that allows copying/pasting
-            xblock_info["enable_copy_paste_units"] = ENABLE_COPY_PASTE_UNITS.is_enabled()
-
             # If the ENABLE_TAGGING_TAXONOMY_LIST_PAGE feature flag is enabled, we show the "Manage Tags" options
             if use_tagging_taxonomy_list_page():
                 xblock_info["use_tagging_taxonomy_list_page"] = True
@@ -1401,6 +1398,10 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
         xblock_info["user_partition_info"] = get_visibility_partition_info(
             xblock, course=course
         )
+
+        if course_outline or is_xblock_unit:
+            # If the ENABLE_COPY_PASTE_UNITS feature flag is enabled, we show the newer menu that allows copying/pasting
+            xblock_info["enable_copy_paste_units"] = ENABLE_COPY_PASTE_UNITS.is_enabled()
 
         if is_xblock_unit and summary_configuration.is_enabled():
             xblock_info["summary_configuration_enabled"] = summary_configuration.is_summary_enabled(xblock_info['id'])

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -150,6 +150,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
                         releaseDateFrom: this.model.get('release_date_from'),
                         hasExplicitStaffLock: this.model.get('has_explicit_staff_lock'),
                         staffLockFrom: this.model.get('staff_lock_from'),
+                        enableCopyUnit: this.model.get('enable_copy_paste_units'),
                         course: window.course,
                         HtmlUtils: HtmlUtils
                     })

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -128,14 +128,16 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
             </li>
         </ul>
     </div>
-    <div class="wrapper-pub-actions bar-mod-actions">
-        <ul>
-            <li>
-                <button class="btn btn-outline-primary btn-default action-copy">
-                    <span class="icon fa fa-copy" aria-hidden="true"></span>
-                    <span class="button-label"><%- gettext("Copy Unit") %></span>
-                </button>
-            </li>
-        </ul>
-    </div>
+    <% if (enableCopyUnit) { %>
+        <div class="wrapper-pub-actions bar-mod-actions">
+            <ul>
+                <li>
+                    <button class="btn btn-outline-primary btn-default action-copy">
+                        <span class="icon fa fa-copy" aria-hidden="true"></span>
+                        <span class="button-label"><%- gettext("Copy Unit") %></span>
+                    </button>
+                </li>
+            </ul>
+        </div>
+    <% } %>
 </div>


### PR DESCRIPTION
## Description

This is a quick follow-up and fix for https://github.com/openedx/edx-platform/pull/33724 . The new Copy Unit button was appearing regardless of the `contentstore.enable_copy_paste_units` waffle flag. And once a unit was copied, the other new functionality could become visible.

This fixes the button so that it only appears when the `contentstore.enable_copy_paste_units` feature flag is explicitly enabled.

![Screenshot 2023-12-01 at 12 45 38 PM](https://github.com/openedx/edx-platform/assets/945577/4b4d044a-cf2b-4391-b1ac-578d612ee857)
