### PR TITLE
fix: Added check while syncing discussion settings in import

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -715,6 +715,7 @@ def import_olx(self, user_id, course_key_string, archive_path, archive_name, lan
                 from .views.entrance_exam import add_entrance_exam_milestone
                 add_entrance_exam_milestone(course.id, entrance_exam_chapter)
                 LOGGER.info(f'Course import {course.id}: Entrance exam imported')
+    if is_course:
         sync_discussion_settings(courselike_key, user)
 
 


### PR DESCRIPTION
### Description
Added condition to check if import is course, before syncing discussion settings.

### Ticket
https://2u-internal.atlassian.net/browse/INF-1173
### Error

```
[2023-11-26 16:20:17,741: ERROR/ForkPoolWorker-15] Task cms.djangoapps.contentstore.tasks.import_olx[306cf4df-b6e9-4475-ba92-6fbb65a3af7c] raised unexpected: AttributeError("'NoneType' object has no attribute 'id'")
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/tasks.py", line 453, in sync_discussion_settings
    discussion_config = DiscussionsConfiguration.objects.get(context_key=course_key)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 435, in get
    raise self.model.DoesNotExist(
openedx.core.djangoapps.discussions.models.DiscussionsConfiguration.DoesNotExist: DiscussionsConfiguration matching query does not exist.
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/application_celery.py", line 99, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/tasks.py", line 718, in import_olx
    sync_discussion_settings(courselike_key, user)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/tasks.py", line 473, in sync_discussion_settings
    LOGGER.info(f'Course import {course.id}: DiscussionsConfiguration sync failed: {exc}')
AttributeError: 'NoneType' object has no attribute 'id'
```