### PR TITLE
feat: add is_ai_translations_enabled to get_course_videos_context util

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
@@ -89,6 +89,7 @@ class CourseVideosSerializer(serializers.Serializer):
     video_upload_max_file_size = serializers.CharField()
     video_image_settings = VideoImageSettingsSerializer(required=True, allow_null=False)
     is_video_transcript_enabled = serializers.BooleanField()
+    is_ai_translations_enabled = serializers.BooleanField()
     active_transcript_preferences = VideoActiveTranscriptPreferencesSerializer(required=False, allow_null=True)
     transcript_credentials = serializers.DictField(
         child=serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_videos.py
@@ -127,8 +127,9 @@ class CourseVideosViewTest(CourseTestCase, PermissionAccessMixin):
             )
             self.assertIn("transcript_credentials_handler_url", transcript_settings)
             self.assertEqual(expected_credentials_handler, transcript_settings["transcript_credentials_handler_url"])
-            from openedx.core.djangoapps.video_config.toggles import XPERT_TRANSLATIONS_UI
-        with patch('openedx.core.djangoapps.video_config.toggles.XPERT_TRANSLATIONS_UI.is_enabled') as xpertTranslationfeature:
+        with patch(
+            'openedx.core.djangoapps.video_config.toggles.XPERT_TRANSLATIONS_UI.is_enabled'
+        ) as xpertTranslationfeature:
             xpertTranslationfeature.return_value = True
             response = self.client.get(self.url)
             self.assertIn("is_ai_translations_enabled", response.data)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_videos.py
@@ -56,6 +56,7 @@ class CourseVideosViewTest(CourseTestCase, PermissionAccessMixin):
                 "supported_file_formats": settings.VIDEO_IMAGE_SUPPORTED_FILE_FORMATS
             },
             "is_video_transcript_enabled": False,
+            "is_ai_translations_enabled": False,
             "active_transcript_preferences": None,
             "transcript_credentials": None,
             "transcript_available_languages": get_all_transcript_languages(),
@@ -126,3 +127,9 @@ class CourseVideosViewTest(CourseTestCase, PermissionAccessMixin):
             )
             self.assertIn("transcript_credentials_handler_url", transcript_settings)
             self.assertEqual(expected_credentials_handler, transcript_settings["transcript_credentials_handler_url"])
+            from openedx.core.djangoapps.video_config.toggles import XPERT_TRANSLATIONS_UI
+        with patch('openedx.core.djangoapps.video_config.toggles.XPERT_TRANSLATIONS_UI.is_enabled') as xpertTranslationfeature:
+            xpertTranslationfeature.return_value = True
+            response = self.client.get(self.url)
+            self.assertIn("is_ai_translations_enabled", response.data)
+            self.assertTrue(response.data["is_ai_translations_enabled"])

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -77,6 +77,7 @@ from cms.djangoapps.contentstore.toggles import (
     use_new_video_uploads_page,
     use_new_custom_pages,
     use_tagging_taxonomy_list_page,
+    # use_xpert_translations_component,
 )
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from xmodule.library_tools import LibraryToolsService
@@ -1595,7 +1596,7 @@ def get_course_videos_context(course_block, pagination_conf, course_key=None):
         get_transcript_preferences,
     )
     from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
-    from openedx.core.djangoapps.video_config.toggles import XPERT_TRANSLATIONS_UI
+    from openedx.core.djangoapps.video_config.toggles import use_xpert_translations_component
     from xmodule.video_block.transcripts_utils import Transcript  # lint-amnesty, pylint: disable=wrong-import-order
 
     from .video_storage_handlers import (
@@ -1620,7 +1621,7 @@ def get_course_videos_context(course_block, pagination_conf, course_key=None):
             course = modulestore().get_course(course_key)
 
     is_video_transcript_enabled = VideoTranscriptEnabledFlag.feature_enabled(course.id)
-    is_ai_translations_enabled = XPERT_TRANSLATIONS_UI.is_enabled(course.id)
+    is_ai_translations_enabled = use_xpert_translations_component(course.id)
     previous_uploads, pagination_context = _get_index_videos(course, pagination_conf)
     course_video_context = {
         'context_course': course,

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1595,6 +1595,7 @@ def get_course_videos_context(course_block, pagination_conf, course_key=None):
         get_transcript_preferences,
     )
     from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
+    from openedx.core.djangoapps.video_config.toggles import XPERT_TRANSLATIONS_UI
     from xmodule.video_block.transcripts_utils import Transcript  # lint-amnesty, pylint: disable=wrong-import-order
 
     from .video_storage_handlers import (
@@ -1619,6 +1620,7 @@ def get_course_videos_context(course_block, pagination_conf, course_key=None):
             course = modulestore().get_course(course_key)
 
     is_video_transcript_enabled = VideoTranscriptEnabledFlag.feature_enabled(course.id)
+    is_ai_translations_enabled = XPERT_TRANSLATIONS_UI.is_enabled(course.id)
     previous_uploads, pagination_context = _get_index_videos(course, pagination_conf)
     course_video_context = {
         'context_course': course,
@@ -1639,6 +1641,7 @@ def get_course_videos_context(course_block, pagination_conf, course_key=None):
             'supported_file_formats': settings.VIDEO_IMAGE_SUPPORTED_FILE_FORMATS
         },
         'is_video_transcript_enabled': is_video_transcript_enabled,
+        'is_ai_translations_enabled': is_ai_translations_enabled,
         'active_transcript_preferences': None,
         'transcript_credentials': None,
         'transcript_available_languages': get_all_transcript_languages(),

--- a/openedx/core/djangoapps/video_config/toggles.py
+++ b/openedx/core/djangoapps/video_config/toggles.py
@@ -37,3 +37,10 @@ TRANSCRIPT_FEEDBACK = CourseWaffleFlag(
 XPERT_TRANSLATIONS_UI = CourseWaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.xpert_translations_ui', __name__
 )
+
+
+def use_xpert_translations_component(course_key):
+    """
+    Returns a boolean if xpert translations ui component is enabled
+    """
+    return XPERT_TRANSLATIONS_UI.is_enabled(course_key)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
This pull request uses XPERT_TRANSLATIONS_UI in the get_course_videos_context utils function which is to be consumed by the MFE frontend-app course authoring in other to enable or disable xpert translations UI.

## Supporting information

## Testing instructions

## Deadline

## Other information
