### PR TITLE
feat: add api for multiple video downloads

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
@@ -17,5 +17,6 @@ from .videos import (
     CourseVideosSerializer,
     VideoUploadSerializer,
     VideoImageSerializer,
-    VideoUsageSerializer
+    VideoUsageSerializer,
+    VideoDownloadSerializer
 )

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
@@ -114,6 +114,15 @@ class VideoUsageSerializer(serializers.Serializer):
     )
 
 
+class VideoDownloadSerializer(serializers.Serializer):
+    """Serializer for video downloads"""
+    files = serializers.listField(
+        child=serializers.DictField(
+            child=serializers.CharField()
+        )
+    )
+
+
 class VideoUploadSerializer(StrictSerializer):
     """
     Strict Serializer for video upload urls.

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/videos.py
@@ -116,7 +116,7 @@ class VideoUsageSerializer(serializers.Serializer):
 
 class VideoDownloadSerializer(serializers.Serializer):
     """Serializer for video downloads"""
-    files = serializers.listField(
+    files = serializers.ListField(
         child=serializers.DictField(
             child=serializers.CharField()
         )

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -15,7 +15,8 @@ from .views import (
     ProctoredExamSettingsView,
     ProctoringErrorsView,
     HelpUrlsView,
-    VideoUsageView
+    VideoUsageView,
+    VideoDownloadView
 )
 
 app_name = 'v1'
@@ -36,6 +37,11 @@ urlpatterns = [
     re_path(
         fr'^videos/{COURSE_ID_PATTERN}/{VIDEO_ID_PATTERN}/usage$',
         VideoUsageView.as_view(),
+        name="video_usage"
+    ),
+    re_path(
+        fr'^videos/{COURSE_ID_PATTERN}/download$',
+        VideoDownloadView.as_view(),
         name="video_usage"
     ),
     re_path(

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -11,5 +11,6 @@ from .settings import CourseSettingsView
 from .videos import (
     CourseVideosView,
     VideoUsageView,
+    VideoDownloadView
 )
 from .help_urls import HelpUrlsView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -20,6 +20,7 @@ from cms.djangoapps.contentstore.video_storage_handlers import (
 from cms.djangoapps.contentstore.rest_api.v1.serializers import (
     CourseVideosSerializer,
     VideoUsageSerializer,
+    VideoDownloadSerializer
 )
 import cms.djangoapps.contentstore.toggles as contentstore_toggles
 
@@ -189,6 +190,7 @@ class VideoDownloadView(DeveloperErrorViewMixin, APIView):
     View for course video downloads.
     """
     @apidocs.schema(
+        body=VideoDownloadSerializer,
         parameters=[
             apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
         ],
@@ -204,7 +206,11 @@ class VideoDownloadView(DeveloperErrorViewMixin, APIView):
         """
         Get an object containing course videos.
         **Example Request**
-            PUT /api/contentstore/v1/videos/download
+            PUT /api/contentstore/v1/videos/download, {
+                "files": [
+                    {"url": 'someUrl.com', "name": 'test.mp4'}
+                ]
+            }
         **Response Values**
         If the request is successful, an HTTP 200 "OK" response is returned.
         The HTTP 200 response contains a zip file attachment containing all the

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -3,9 +3,7 @@ Public rest API endpoints for contentstore API video assets (outside authoring A
 """
 import edx_api_doc_tools as apidocs
 import logging
-import os
 from opaque_keys.edx.keys import CourseKey
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -218,4 +216,3 @@ class VideoDownloadView(DeveloperErrorViewMixin, APIView):
             self.permission_denied(request)
         files = request.data['files']
         return create_video_zip(course_id, files)
-    

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -206,7 +206,7 @@ class VideoDownloadView(DeveloperErrorViewMixin, APIView):
         """
         Get an object containing course videos.
         **Example Request**
-            PUT /api/contentstore/v1/videos/download, {
+            PUT /api/contentstore/v1/videos/{course_id}/download, {
                 "files": [
                     {"url": 'someUrl.com', "name": 'test.mp4'}
                 ]
@@ -214,7 +214,7 @@ class VideoDownloadView(DeveloperErrorViewMixin, APIView):
         **Response Values**
         If the request is successful, an HTTP 200 "OK" response is returned.
         The HTTP 200 response contains a zip file attachment containing all the
-        requested videos.
+        requested videos. The returned file's name will be {course_id}_videos_{random_id}.zip.
         """
         course_key = CourseKey.from_string(course_id)
 

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -8,6 +8,12 @@ import csv
 import io
 import json
 import logging
+import os
+import requests
+import shutil
+import pathlib
+import zipfile
+
 from contextlib import closing
 from datetime import datetime, timedelta
 from uuid import uuid4
@@ -15,7 +21,7 @@ from boto.s3.connection import S3Connection
 from boto import s3
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.http import FileResponse, HttpResponseNotFound
+from django.http import FileResponse, HttpResponseNotFound, StreamingHttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_noop
@@ -35,10 +41,14 @@ from edxval.api import (
     update_video_image,
     update_video_status
 )
+from fs.osfs import OSFS
 from opaque_keys.edx.keys import CourseKey
+from path import Path as path
 from pytz import UTC
 from rest_framework import status as rest_status
 from rest_framework.response import Response
+from tempfile import NamedTemporaryFile, mkdtemp
+from wsgiref.util import FileWrapper
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.util.json_request import JsonResponse
@@ -219,6 +229,53 @@ def handle_videos(request, course_key_string, edx_video_id=None):
 
         data, status = videos_post(course, request)
         return JsonResponse(data, status=status)
+
+
+def send_zip(zip, size=None):
+    """
+    Generates a streaming http response for the zip file
+    """
+    wrapper = FileWrapper(zip, settings.COURSE_EXPORT_DOWNLOAD_CHUNK_SIZE)
+    response = StreamingHttpResponse(wrapper, content_type='application/zip')
+    response['Content-Dispositon'] = 'attachment; filename=%s' % os.path.basename(zip.name)
+    response['Content-Length'] = size
+    return response
+
+
+def create_video_zip(course_key_string, files):
+    """
+    Generates the video zip, or returns None if there was an error.
+
+    Updates the context with any error information if applicable.
+    """
+    name = course_key_string + '_videos'
+    video_folder_zip = NamedTemporaryFile(prefix=name + '_',
+                                     suffix=".zip")  # lint-amnesty, pylint: disable=consider-using-with
+    root_dir = path(mkdtemp())
+    video_dir = root_dir + '/' + name
+    zip_folder = None
+    try:
+        for file in files:
+            url = file['url']
+            file_name = file['name']
+            response = requests.get(url, allow_redirects=True)   
+            file_type = '.' + response.headers['Content-Type'][6:]
+            if not file_type in file_name:
+                file_name = file['name'] + file_type
+            if not os.path.isdir(video_dir):
+                os.makedirs(video_dir)
+            with OSFS(video_dir).open(file_name, mode="wb") as f:
+                f.write(response.content)
+        directory = pathlib.Path(video_dir)
+        with zipfile.ZipFile(video_folder_zip, mode="w") as archive:
+            for file_path in directory.iterdir():
+                archive.write(file_path, arcname=file_path.name)
+        zip_folder = open(video_folder_zip.name, '+rb')
+        
+        return send_zip(zip_folder, video_folder_zip.tell())
+    finally:
+        if os.path.exists(root_dir / name):
+            shutil.rmtree(root_dir / name)
 
 
 def get_video_usage_path(course_key, edx_video_id):


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR introduces a new api for zipping video files. Previously the javascript in `course-authoring` handled the download behavior for multiple videos. However, the links to fetch the files from their s3 buckets did not have the proper CORS configurations so the videos could not properly be zipped into a file. Now the api fetches the files and creates a zip file that is returned to the frontend to download in user's browser. This change impacts Authors.

## Supporting information

JIRA Tickets: [TNL-11228](https://2u-internal.atlassian.net/browse/TNL-11228)
> Multi-select download only downloads the first video selected

## Testing instructions

1. Load the `course-authoring` videos page
2. Select at least two videos to download
3. Click Actions
4. Click Download
5. Downloading toast should appear
6. Zip file should download
7. Extract files from zip
8. Should contain selected videos
9. Open each video file to confirm that video can play

## Deadline

None

## Other information

This PR blocks the merging of `course-authoring` PR #[782](https://github.com/openedx/frontend-app-course-authoring/pull/728)
