### PR TITLE
fix: improve regex for contains_url

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -93,7 +93,7 @@ def contains_url(value):
     """
     Validator method to check whether full name contains url
     """
-    regex = re.findall(r'https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))*', value)
+    regex = re.findall(r'://', value)
     return bool(regex)
 
 


### PR DESCRIPTION
## Description

This regex is used for checking if a field contains a URL. We did this because we didn't want URLs in a user's "full name".

The capturing groups on the current regex are not needed to capture a URL. This commit simplifies and makes the regex stricter by banning the character combination "://".

## Supporting information

* Jira: [VAN-332](https://2u-internal.atlassian.net/browse/VAN-332)

## Testing instructions

```
% python
>>> import re
>>> re.findall(r'://', "https://test.com")
['://']
>>> re.findall(r'://', "http://test.com")
['://']
>>> re.findall(r'://', "User Name")
[]
>>> re.findall(r'://', "User")
[]
>>> re.findall(r'://', "://")
```