### PR TITLE
Update the BulkEmailFlag __str__ function to avoid infinite recursion

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -523,8 +523,7 @@ class BulkEmailFlag(ConfigurationModel):
         app_label = "bulk_email"
 
     def __str__(self):
-        current_model = BulkEmailFlag.current()
         return "BulkEmailFlag: enabled {}, require_course_email_auth: {}".format(
-            current_model.is_enabled(),
-            current_model.require_course_email_auth
+            self.enabled,
+            self.require_course_email_auth
         )


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR changes the __str__ method of BulkEmailFlag to avoid the infinite recursion to occur due to a Network Request via `BulkEmailFlag.current()` method. For more information see the relevant Github Issue in the Supporting Information.

## Supporting information

Github Issue: #32300 

## Testing instructions

- Create an LMS shell and write the following code:
` >>> from lms.djangoapps.bulk_email.models import BulkEmailFlag `
` >>> b = BulkEmailFlag.objects.create() `
` >>> str(b) `
- You will get this output without any errors
` 'BulkEmailFlag: enabled False, require_course_email_auth: True' `

