### PR TITLE
fix: add missing function import in certificate template

### DIFF
--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -165,3 +165,19 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
             response,
             'This should not survive being overwritten by static content',
         )
+
+    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, GOOGLE_ANALYTICS_4_ID='GA-abc')
+    @with_site_configuration(configuration={'platform_name': 'My Platform Site'})
+    def test_html_view_with_g4(self):
+        test_url = get_certificate_url(
+            user_id=self.user.id,
+            course_id=str(self.course.id),
+            uuid=self.cert.verify_uuid
+        )
+        self._add_course_certificates(count=1, signatory_count=2)
+        response = self.client.get(test_url)
+        self.assertContains(
+            response,
+            'awarded this My Platform Site Honor Code Certificate of Completion',
+        )
+        self.assertContains(response, 'googletagmanager')

--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -1,7 +1,9 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
-<%! from django.utils.translation import gettext as _%>
-
+<%!
+from django.utils.translation import gettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
+%>
 <%
 # set doc language direction
 from django.utils.translation import get_language_bidi


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Currently the default certificate template breaks during rendering if `GOOGLE_ANALYTICS_4_ID` is defined, because of a missing import.

This PR fixes this issue.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Login to [this sandbox](https://pr-33904-139931.staging.do.opencraft.hosting) using the default credentials `openedx`/`openedx`.
2. Go to the instructor tab of the demo course and open the network tab in developer tools of your browser to check calls to `googletagmanager.com` with the dummy id `GTM-ABCD123`. This verifies that `GOOGLE_ANALYTICS_4_ID` is configured correctly for this sandbox.
3. Go to the [certificates page](https://studio.pr-33904-139931.staging.do.opencraft.hosting/certificates/course-v1:edX+DemoX+Demo_Course) in Studio for the demo course and click on `Preview Certificate`.
4. Verify certificate with the default template is rendered correctly.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Private Ref: OpenCraft Internal Ticket - [BB-8212](https://tasks.opencraft.com/browse/BB-8212)

## Sandbox configuration

**Settings**

```yaml
TUTOR_GROVE_LMS_ENV: |
  GOOGLE_ANALYTICS_4_ID: "GTM-ABCD123"
```
