### PR TITLE
fix: do not show legacy in case openedx discussion provider is selected

### DIFF
--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -314,14 +314,14 @@ class ProviderDataTest(CourseInstructorAuthorizedTest, DataTestMixin):
         # If the legacy provider is selected always show the legacy provider,
         # and only show the new one if the toggle is enabled
         (Provider.LEGACY, [Provider.LEGACY], Provider.OPEN_EDX, False),
-        (Provider.LEGACY, [Provider.LEGACY, Provider.OPEN_EDX], 'dummy', True),
+        (Provider.LEGACY, [Provider.LEGACY], 'dummy', True),
         # If the new provider is selected show the legacy provider only
         # if the new discussions toggle is disabled
-        (Provider.OPEN_EDX, [Provider.OPEN_EDX, Provider.LEGACY], 'dummy', False),
+        (Provider.OPEN_EDX, [Provider.OPEN_EDX], 'dummy', False),
         (Provider.OPEN_EDX, [Provider.OPEN_EDX], Provider.LEGACY, True),
         # If some other provider is selected show only legacy provider if the toggle is false
         # and only the new provider if the toggle is enabled
-        (Provider.PIAZZA, [Provider.LEGACY], Provider.OPEN_EDX, False),
+        (Provider.PIAZZA, [], Provider.OPEN_EDX, False),
         (Provider.PIAZZA, [Provider.OPEN_EDX], Provider.LEGACY, True),
     )
     @ddt.unpack
@@ -424,9 +424,11 @@ class DataTest(AuthorizedApiTest, DataTestMixin):
         with override_waffle_flag(ENABLE_NEW_STRUCTURE_DISCUSSIONS, new_structure_enabled):
             response = self._get()
             data = response.json()
-            visible_providers = [Provider.OPEN_EDX, Provider.LEGACY]
-            if not new_structure_enabled:
+            visible_providers = []
+            if current_provider == Provider.LEGACY:
                 visible_providers = [Provider.LEGACY]
+            if current_provider != Provider.LEGACY and new_structure_enabled:
+                visible_providers = [Provider.OPEN_EDX]
             for visible_provider in visible_providers:
                 assert visible_provider in data['providers']['available'].keys()
 

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -194,7 +194,6 @@ class DiscussionsProvidersView(APIView):
         else:
             hidden_providers.append(Provider.OPEN_EDX)
 
-
         serializer = DiscussionsProvidersSerializer(
             {
                 'features': [
@@ -210,6 +209,7 @@ class DiscussionsProvidersView(APIView):
             }
         )
         return serializer.data
+
 
 class CombinedDiscussionsConfigurationView(DiscussionsConfigurationSettingsView):
     """

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -156,7 +156,7 @@ class DiscussionsProvidersView(APIView):
         Handle HTTP/GET requests
         """
         # Return all providers always, if the user is staff
-        data = self.get_provider_data(course_key_string, show_all=request.user.is_staff)
+        data = self.get_provider_data(course_key_string, show_all=False)
         return Response(data)
 
     @staticmethod
@@ -189,6 +189,12 @@ class DiscussionsProvidersView(APIView):
                 if configuration.provider_type != Provider.OPEN_EDX:
                     hidden_providers.append(Provider.OPEN_EDX)
 
+        if configuration.provider_type != Provider.LEGACY:
+            hidden_providers.append(Provider.LEGACY)
+        else:
+            hidden_providers.append(Provider.OPEN_EDX)
+
+
         serializer = DiscussionsProvidersSerializer(
             {
                 'features': [
@@ -204,7 +210,6 @@ class DiscussionsProvidersView(APIView):
             }
         )
         return serializer.data
-
 
 class CombinedDiscussionsConfigurationView(DiscussionsConfigurationSettingsView):
     """


### PR DESCRIPTION
## Description

Show ONLY legacy provider to all roles, if the course is using legacy provider
Show ONLY openedx provider to all roles, if the course is using openedx provider
Show ONLY openedx provider to all roles, if the course is using LTI provider

## Ticket : 
https://2u-internal.atlassian.net/browse/INF-1089