### PR TITLE
feat: move new_question_post and new_discussion_post notifications to use course wide notification event

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -8,7 +8,7 @@ import ddt
 import httpretty
 from django.conf import settings
 from edx_toggles.toggles.testutils import override_waffle_flag
-from openedx_events.learning.signals import USER_NOTIFICATION_REQUESTED
+from openedx_events.learning.signals import USER_NOTIFICATION_REQUESTED, COURSE_NOTIFICATION_REQUESTED
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import StaffFactory, UserFactory
@@ -158,14 +158,6 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
         self.register_get_thread_response(thread)
         return thread
 
-    def assert_users_id_list(self, user_ids_1, user_ids_2):
-        """
-        Assert whether the user ids in two lists are same
-        """
-        assert len(user_ids_1) == len(user_ids_2)
-        for user_id in user_ids_1:
-            assert user_id in user_ids_2
-
     def test_basic(self):
         """
         Left empty intentionally. This test case is inherited from DiscussionAPIViewTestMixin
@@ -176,15 +168,6 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
         Left empty intentionally. This test case is inherited from DiscussionAPIViewTestMixin
         """
 
-    def test_no_notification_if_course_has_no_enrollments(self):
-        """
-        Tests no notification is send if course has no enrollments
-        """
-        handler = mock.Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
-        send_thread_created_notification(self.thread['id'], str(self.course.id), self.author.id)
-        self.assertEqual(handler.call_count, 0)
-
     @ddt.data(
         ('new_question_post',),
         ('new_discussion_post',),
@@ -192,7 +175,7 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
     @ddt.unpack
     def test_notification_is_send_to_all_enrollments(self, notification_type):
         """
-        Tests notification is send to all users if course is not cohorted
+        Tests notification is sent to all users if course is not cohorted
         """
         self._assign_enrollments()
         thread_type = (
@@ -202,12 +185,13 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
         )
         thread = self._create_thread(thread_type=thread_type)
         handler = mock.Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
+        COURSE_NOTIFICATION_REQUESTED.connect(handler)
         send_thread_created_notification(thread['id'], str(self.course.id), self.author.id)
         self.assertEqual(handler.call_count, 1)
-        assert notification_type == handler.call_args[1]['notification_data'].notification_type
-        user_ids_list = [user.id for user in self.notification_to_all_users]
-        self.assert_users_id_list(user_ids_list, handler.call_args[1]['notification_data'].user_ids)
+        course_notification_data = handler.call_args[1]['course_notification_data']
+        assert notification_type == course_notification_data.notification_type
+        notification_audience_filters = {}
+        assert notification_audience_filters == course_notification_data.audience_filters
 
     @ddt.data(
         ('cohort_1', 'new_question_post'),
@@ -218,7 +202,7 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
     @ddt.unpack
     def test_notification_is_send_to_cohort_ids(self, cohort_text, notification_type):
         """
-        Tests if notification is send only to privileged users and cohort members if the
+        Tests if notification is sent only to privileged users and cohort members if the
         course is cohorted
         """
         self._assign_enrollments()
@@ -238,12 +222,17 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
         cohort_id = cohort.id
         thread = self._create_thread(group_id=cohort_id, thread_type=thread_type)
         handler = mock.Mock()
-        USER_NOTIFICATION_REQUESTED.connect(handler)
+        COURSE_NOTIFICATION_REQUESTED.connect(handler)
         send_thread_created_notification(thread['id'], str(self.course.id), self.author.id)
-        assert notification_type == handler.call_args[1]['notification_data'].notification_type
+        course_notification_data = handler.call_args[1]['course_notification_data']
+        assert notification_type == course_notification_data.notification_type
+        notification_audience_filters = {
+            'cohorts': [cohort_id],
+            'course_roles': ['staff', 'instructor'],
+            'discussion_roles': ['Administrator', 'Moderator', 'Community TA'],
+        }
+        assert notification_audience_filters == handler.call_args[1]['course_notification_data'].audience_filters
         self.assertEqual(handler.call_count, 1)
-        user_ids_list = [user.id for user in audience]
-        self.assert_users_id_list(user_ids_list, handler.call_args[1]['notification_data'].user_ids)
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/notifications/audience_filters.py
+++ b/openedx/core/djangoapps/notifications/audience_filters.py
@@ -4,9 +4,14 @@ Audience based filters for notifications
 
 from abc import abstractmethod
 
+from opaque_keys.edx.keys import CourseKey
+
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.roles import CourseStaffRole, CourseInstructorRole
 from lms.djangoapps.discussion.django_comment_client.utils import get_users_with_roles
+from lms.djangoapps.teams.models import CourseTeam
+from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
     FORUM_ROLE_MODERATOR,
@@ -33,11 +38,10 @@ class NotificationAudienceFilterBase:
         pass
 
 
-class RoleAudienceFilter(NotificationAudienceFilterBase):
+class ForumRoleAudienceFilter(NotificationAudienceFilterBase):
     """
     Filter class for roles
     """
-    # TODO: Add course roles to this. We currently support only forum roles
     allowed_filters = [
         FORUM_ROLE_ADMINISTRATOR,
         FORUM_ROLE_MODERATOR,
@@ -53,6 +57,36 @@ class RoleAudienceFilter(NotificationAudienceFilterBase):
         if not self.is_valid_filter(roles):
             raise ValueError(f'Invalid roles {roles} passed to RoleAudienceFilter')
         return [user.id for user in get_users_with_roles(roles, self.course_key)]
+
+
+class CourseRoleAudienceFilter(NotificationAudienceFilterBase):
+    """
+    Filter class for course roles
+    """
+    allowed_filters = ['staff', 'instructor']
+
+    def filter(self, course_roles):
+        """
+        Filter users based on their course roles
+        """
+        if not self.is_valid_filter(course_roles):
+            raise ValueError(f'Invalid roles {course_roles} passed to CourseRoleAudienceFilter')
+
+        user_ids = []
+
+        course_key = self.course_key
+        if not isinstance(course_key, CourseKey):
+            course_key = CourseKey.from_string(course_key)
+
+        if 'staff' in course_roles:
+            staff_users = CourseStaffRole(course_key).users_with_role().values_list('id', flat=True)
+            user_ids.extend(staff_users)
+
+        if 'instructor' in course_roles:
+            instructor_users = CourseInstructorRole(course_key).users_with_role().values_list('id', flat=True)
+            user_ids.extend(instructor_users)
+
+        return user_ids
 
 
 class EnrollmentAudienceFilter(NotificationAudienceFilterBase):
@@ -71,3 +105,39 @@ class EnrollmentAudienceFilter(NotificationAudienceFilterBase):
             course_id=self.course_key,
             mode__in=enrollment_modes,
         ).values_list('user_id', flat=True)
+
+
+class TeamAudienceFilter(NotificationAudienceFilterBase):
+    """
+    Filter class for team roles
+    """
+
+    def filter(self, team_ids):
+        """
+        Filter users based on team id
+        """
+        teams = CourseTeam.objects.filter(team_id__in=team_ids, course_id=self.course_key)
+
+        if not teams:   # invalid team ids passed
+            raise ValueError(f'Invalid Team ids {team_ids} passed to TeamAudienceFilter for course {self.course_key}')
+
+        user_ids = []
+        for team in teams:
+            user_ids.extend(team.users.all().values_list('id', flat=True))
+
+        return user_ids
+
+
+class CohortAudienceFilter(NotificationAudienceFilterBase):
+    """
+    Filter class for cohort roles
+    """
+
+    def filter(self, group_ids):
+        """
+        Filter users based on their cohort ids
+        """
+        users_in_cohort = CourseUserGroup.objects.filter(
+            course_id=self.course_key, id__in=group_ids
+        ).values_list('users__id', flat=True)
+        return users_in_cohort

--- a/openedx/core/djangoapps/notifications/handlers.py
+++ b/openedx/core/djangoapps/notifications/handlers.py
@@ -14,17 +14,24 @@ from openedx_events.learning.signals import (
 )
 
 from common.djangoapps.student.models import CourseEnrollment
-from openedx.core.djangoapps.notifications.audience_filters import RoleAudienceFilter, EnrollmentAudienceFilter
+from openedx.core.djangoapps.notifications.audience_filters import (
+    ForumRoleAudienceFilter,
+    EnrollmentAudienceFilter,
+    TeamAudienceFilter,
+    CohortAudienceFilter,
+    CourseRoleAudienceFilter,
+)
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
 from openedx.core.djangoapps.notifications.models import CourseNotificationPreference
 
 log = logging.getLogger(__name__)
 
-AUDIENCE_FILTER_TYPES = ['role', 'enrollment']
-
 AUDIENCE_FILTER_CLASSES = {
-    'role': RoleAudienceFilter,
-    'enrollment': EnrollmentAudienceFilter,
+    'discussion_roles': ForumRoleAudienceFilter,
+    'course_roles': CourseRoleAudienceFilter,
+    'enrollments': EnrollmentAudienceFilter,
+    'teams': TeamAudienceFilter,
+    'cohorts': CohortAudienceFilter,
 }
 
 
@@ -76,11 +83,15 @@ def calculate_course_wide_notification_audience(course_key, audience_filters):
     Calculate the audience for a course-wide notification based on the audience filters
     """
     if not audience_filters:
-        return CourseEnrollment.objects.filter(course_id=course_key, is_active=True).values_list('user_id', flat=True)
+        active_enrollments = CourseEnrollment.objects.filter(
+            course_id=course_key,
+            is_active=True
+        ).values_list('user_id', flat=True)
+        return list(active_enrollments)
 
     audience_user_ids = []
     for filter_type, filter_values in audience_filters.items():
-        if filter_type in AUDIENCE_FILTER_TYPES:
+        if filter_type in AUDIENCE_FILTER_CLASSES.keys():  # lint-amnesty, pylint: disable=consider-iterating-dictionary
             filter_class = AUDIENCE_FILTER_CLASSES.get(filter_type)
             if filter_class:
                 filter_instance = filter_class(course_key)
@@ -93,20 +104,24 @@ def calculate_course_wide_notification_audience(course_key, audience_filters):
 
 
 @receiver(COURSE_NOTIFICATION_REQUESTED)
-def generate_course_notifications(signal, sender, notification_data, metadata, **kwargs):
+def generate_course_notifications(signal, sender, course_notification_data, metadata, **kwargs):
     """
     Watches for COURSE_NOTIFICATION_REQUESTED signal and calls send_notifications task
     """
-    from openedx.core.djangoapps.notifications.tasks import send_notifications
-    notification_data = notification_data.__dict__
-    notification_data['course_key'] = str(notification_data['course_key'])
 
-    audience_filters = notification_data.pop('audience_filters')
-    user_ids = calculate_course_wide_notification_audience(
-        notification_data['course_key'],
-        audience_filters,
-    )
-    notification_data['user_ids'] = user_ids
-    notification_data['context'] = notification_data.pop('content_context')
+    from openedx.core.djangoapps.notifications.tasks import send_notifications
+    course_notification_data = course_notification_data.__dict__
+
+    notification_data = {
+        'course_key': str(course_notification_data['course_key']),
+        'user_ids': calculate_course_wide_notification_audience(
+            str(course_notification_data['course_key']),
+            course_notification_data['audience_filters'],
+        ),
+        'context': course_notification_data.get('content_context'),
+        'app_name': course_notification_data.get('app_name'),
+        'notification_type': course_notification_data.get('notification_type'),
+        'content_url': course_notification_data.get('content_url'),
+    }
 
     send_notifications.delay(**notification_data)


### PR DESCRIPTION
### [INF-1135](https://2u-internal.atlassian.net/browse/INF-1135)


### Description

This PR moves the `new_discussion_post` and `new_question_post` forum notification to use the new course wide notification event.

New audience filter classes are added as well, to cater for more audience filter options. The changes to filters include:
- breaking down roles into discussions and course roles
- adding cohort filter
- adding team filter

The mapping to use these is provided in code (the key is used to specify the filter class, and should match when adding filter to `audience_filter` attribute in event):

```python
AUDIENCE_FILTER_CLASSES = {
    'discussion_roles': ForumRoleAudienceFilter,
    'course_roles': CourseRoleAudienceFilter,
    'enrollments': EnrollmentAudienceFilter,
    'teams': TeamAudienceFilter,
    'cohorts': CohortAudienceFilter,
}
```

For the `new_discussion_post` and `new_question_post`, the notification audience would have 3 scenarios:

- Content is part of team
```python
{
  'teams': ['content_team_id'],
  'course_roles': ['staff', 'instructor'],
  'discussion_roles': ['admin', 'moderator', 'community_ta'],
}
```

- Content is part of cohort
```python
{
  'cohorts': ['cohort'],
  'course_roles': ['staff', 'instructor'],
  'discussion_roles': ['admin', 'moderator', 'community_ta'],
}
```

- Content is for everyone - (No filter specified, the notification is sent out to all active enrollments)
```python
{}
```

_NOTE: We are including course roles and discussion roles for both these type in the audience filters (when audience filter applies)_

