### PR TITLE
feat: add new course access error_code for enterprise learners in future courses

### DIFF
--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -144,6 +144,33 @@ class StartDateError(AccessError):
         )
 
 
+class StartDateEnterpriseLearnerError(AccessError):
+    """
+    Access denied because the course has not started yet and the user is not staff.  Use this error when this user is
+    also an enterprise learner and enrolled in the requested course.
+    """
+    def __init__(self, start_date, display_error_to_user=True):
+        """
+        Arguments:
+            display_error_to_user: If True, display this error to users in the UI.
+        """
+        error_code = "course_not_started_enterprise_learner"
+        if start_date == DEFAULT_START_DATE:
+            developer_message = "Course has not started, and the learner is enrolled via an enterprise subsidy."
+            user_message = _("Course has not started")
+        else:
+            developer_message = (
+                f"Course does not start until {start_date}, and the learner is enrolled via an enterprise subsidy."
+            )
+            user_message = _("Course does not start until {}"  # lint-amnesty, pylint: disable=translation-of-non-string
+                             .format(f"{start_date:%B %d, %Y}"))
+        super().__init__(
+            error_code,
+            developer_message,
+            user_message if display_error_to_user else None
+        )
+
+
 class MilestoneAccessError(AccessError):
     """
     Access denied because the user has unfulfilled milestones

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -57,6 +57,14 @@ from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: di
 )
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.features.enterprise_support.api import add_enterprise_customer_to_session
+from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
+from openedx.features.enterprise_support.tests.factories import (
+    EnterpriseCourseEnrollmentFactory,
+    EnterpriseCustomerUserFactory,
+    EnterpriseCustomerFactory
+)
+from crum import set_current_request
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
 
@@ -847,7 +855,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
     )
     @ddt.unpack
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    def test_course_catalog_access_num_queries(self, user_attr_name, action, course_attr_name):
+    def test_course_catalog_access_num_queries_no_enterprise(self, user_attr_name, action, course_attr_name):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
 
         course = getattr(self, course_attr_name)
@@ -886,3 +894,71 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
         course_overview = CourseOverview.get_from_id(course.id)
         with self.assertNumQueries(num_queries, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             bool(access.has_access(user, action, course_overview, course_key=course.id))
+
+    @ddt.data(
+        *itertools.product(
+            ['user_normal', 'user_staff', 'user_anonymous'],
+            ['course_started', 'course_not_started'],
+        )
+    )
+    @ddt.unpack
+    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
+    def test_course_catalog_access_num_queries_enterprise(self, user_attr_name, course_attr_name):
+        """
+        Similar to test_course_catalog_access_num_queries_no_enterprise, except enable enterprise features and make the
+        basic enrollment look like an enterprise-subsidized enrollment, setting up one of each:
+
+        * EnterpriseCustomer
+        * EnterpriseCustomerUser
+        * EnterpriseCourseEnrollment
+        * A mock request session to pre-cache the enterprise customer data.
+        """
+        ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
+
+        course = getattr(self, course_attr_name)
+
+        request = RequestFactory().get('/')
+        request.session = {}
+
+        # get a fresh user object that won't have any cached role information
+        if user_attr_name == 'user_anonymous':
+            user = AnonymousUserFactory()
+            request.user = user
+        else:
+            user = getattr(self, user_attr_name)
+            user = User.objects.get(id=user.id)
+            request.user = user
+            course_enrollment = CourseEnrollmentFactory(user=user, course_id=course.id)
+            enterprise_customer = EnterpriseCustomerFactory(enable_learner_portal=True)
+            add_enterprise_customer_to_session(request, EnterpriseCustomerSerializer(enterprise_customer).data)
+            enterprise_customer_user = EnterpriseCustomerUserFactory(
+                user_id=user.id,
+                enterprise_customer=enterprise_customer,
+            )
+            EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
+        set_current_request(request)
+
+        if user_attr_name == 'user_staff':
+            if course_attr_name == 'course_started':
+                # read: CourseAccessRole + django_comment_client.Role
+                num_queries = 2
+            else:
+                # read: CourseAccessRole + EnterpriseCourseEnrollment
+                num_queries = 2
+        elif user_attr_name == 'user_normal':
+            if course_attr_name == 'course_started':
+                # read: CourseAccessRole + django_comment_client.Role + FBEEnrollmentExclusion + CourseMode
+                num_queries = 4
+            else:
+                # read: CourseAccessRole + CourseEnrollmentAllowed + EnterpriseCourseEnrollment
+                num_queries = 3
+        elif user_attr_name == 'user_anonymous':
+            if course_attr_name == 'course_started':
+                # read: CourseMode
+                num_queries = 1
+            else:
+                num_queries = 0
+
+        course_overview = CourseOverview.get_from_id(course.id)
+        with self.assertNumQueries(num_queries, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
+            bool(access.has_access(user, 'see_exists', course_overview, course_key=course.id))


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Normally, the course API would return an access error_code of `course_not_started` if the course has not started yet.  This change breaks that up into two codes:

* if the course has not started:
  * return `course_not_started_enterprise_learner` if the learner is enrolled as a subsidized enterprise learner.
  * else, return `course_not_started`.

This supports a change to the frontend which will interpret `course_not_started_enterprise_learner` differently and trigger a redirect to the enterprise (B2B) learner dashboard instead of the B2C dashboard.

ENT-8078

## Supporting information

Companion PR: https://github.com/openedx/frontend-app-learning/pull/1251
