### PR TITLE
fix: add import statement for handlers

### DIFF
--- a/lms/djangoapps/certificates/apps.py
+++ b/lms/djangoapps/certificates/apps.py
@@ -23,6 +23,7 @@ class CertificatesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from lms.djangoapps.certificates import signals  # pylint: disable=unused-import
+        from lms.djangoapps.certificates import handlers  # pylint: disable=unused-import
         if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
             from lms.djangoapps.certificates.services import CertificateService
             set_runtime_service('certificates', CertificateService())


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds an import statement to the certificates apps that enables the handler which revokes a certificate based on a rejected exam attempt.

Which edX user roles will this change impact? Learners and Instructors

## Testing instructions

- Make sure special exams is enabled and Proctorio is proctoring provider
- Go to instructor dashboard and reject exam attempt
- There should be no certificate generated / certificate should be revoked if one was already generated.
- Certificate should be revoked regardless of passing grade.

## Deadline

Should be completed before beta launch of LTI for Proctoring.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
