### PR TITLE
chore: update PR template for Quince release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,6 @@
 🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
 🌳🌳
 
-🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
-                Please consider whether your change should be applied to Palm as well.
 
 Please give your pull request a short but descriptive title.
 Use conventional commits to separate and summarize commits logically:


### PR DESCRIPTION
Quince is now the latest release and Palm is no longer supported. This updates the PR template accordingly.

See: https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#4d.-Inform-edx-platform-developers-via-the-PR-template