### PR TITLE
feat: Show notification types with respect to user forum roles

### DIFF
--- a/openedx/core/djangoapps/notifications/serializers.py
+++ b/openedx/core/djangoapps/notifications/serializers.py
@@ -12,6 +12,24 @@ from openedx.core.djangoapps.notifications.models import (
     get_notification_channels
 )
 from .base_notification import COURSE_NOTIFICATION_APPS, COURSE_NOTIFICATION_TYPES
+from .utils import filter_course_wide_preferences, remove_preferences_with_no_access
+
+
+def add_info_to_notification_config(config_obj):
+    """
+    Add info of all notification types
+    """
+
+    config = config_obj['notification_preference_config']
+    for notification_app, app_prefs in config.items():
+        notification_types = app_prefs.get('notification_types', {})
+        for notification_type, type_prefs in notification_types.items():
+            if notification_type == "core":
+                type_info = COURSE_NOTIFICATION_APPS.get(notification_app, {}).get('core_info', '')
+            else:
+                type_info = COURSE_NOTIFICATION_TYPES.get(notification_type, {}).get('info', '')
+            type_prefs['info'] = type_info
+    return config_obj
 
 
 class CourseOverviewSerializer(serializers.ModelSerializer):
@@ -51,17 +69,13 @@ class UserCourseNotificationPreferenceSerializer(serializers.ModelSerializer):
         """
         Override to_representation to add info of all notification types
         """
-        value = super().to_representation(instance)
-        config = value['notification_preference_config']
-        for notification_app, app_prefs in config.items():
-            notification_types = app_prefs.get('notification_types', {})
-            for notification_type, type_prefs in notification_types.items():
-                if notification_type == "core":
-                    type_info = COURSE_NOTIFICATION_APPS.get(notification_app, {}).get('core_info', '')
-                else:
-                    type_info = COURSE_NOTIFICATION_TYPES.get(notification_type, {}).get('info', '')
-                type_prefs['info'] = type_info
-        return value
+        preferences = super().to_representation(instance)
+        course_id = self.context['course_id']
+        user = self.context['user']
+        preferences = add_info_to_notification_config(preferences)
+        preferences = filter_course_wide_preferences(course_id, preferences)
+        preferences = remove_preferences_with_no_access(preferences, user)
+        return preferences
 
     def get_course_name(self, obj):
         """


### PR DESCRIPTION
Check forum roles in case attribute named `visible_to` is set on notification preference object . This type of notification preference would be visible one to user that have role that is set in configurations.

Example 
```python

from openedx.core.djangoapps.django_comment_common.models import (
    FORUM_ROLE_ADMINISTRATOR,
    FORUM_ROLE_COMMUNITY_TA,
    FORUM_ROLE_GROUP_MODERATOR,
    FORUM_ROLE_MODERATOR,
)
COURSE_NOTIFICATION_TYPES = {
...
    'new_question_post': {
        'notification_app': 'discussion',
        'name': 'new_question_post',
        'is_core': False,
        'info': '',
        'web': False,
        'email': False,
        'push': False,
        'non_editable': [],
        'content_template': _('<{p}><{strong}>{username}</{strong}> asked <{strong}>{post_title}</{strong}></{p}>'),
        'content_context': {
            'post_title': 'Post title',
            'username': 'Post author name',
        },
        'email_template': '',
        'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE],
        'visible_to': [FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_ADMINISTRATOR]

    }
...
}

```
