### PR TITLE
chore: Remove old datadog related settings.

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -411,14 +411,6 @@ BLOCKSTORE_API_URL = ENV_TOKENS.get('BLOCKSTORE_API_URL', None)  # e.g. "https:/
 # Configure an API auth token at (blockstore URL)/admin/authtoken/token/
 BLOCKSTORE_API_AUTH_TOKEN = AUTH_TOKENS.get('BLOCKSTORE_API_AUTH_TOKEN', None)
 
-# Datadog for events!
-DATADOG = AUTH_TOKENS.get("DATADOG", {})
-DATADOG.update(ENV_TOKENS.get("DATADOG", {}))
-
-# TODO: deprecated (compatibility with previous settings)
-if 'DATADOG_API' in AUTH_TOKENS:
-    DATADOG['api_key'] = AUTH_TOKENS['DATADOG_API']
-
 # Celery Broker
 CELERY_ALWAYS_EAGER = ENV_TOKENS.get("CELERY_ALWAYS_EAGER", False)
 CELERY_BROKER_TRANSPORT = ENV_TOKENS.get("CELERY_BROKER_TRANSPORT", "")

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -240,9 +240,6 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         even though the actual stored state in the database will be ``"{}"``).
     """
 
-    # Use this sample rate for DataDog events.
-    API_DATADOG_SAMPLE_RATE = 0.1
-
     class ServiceUnavailable(XBlockUserStateClient.ServiceUnavailable):
         """
         This error is raised if the service backing this client is currently unavailable.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -525,14 +525,6 @@ BLOCKSTORE_API_URL = ENV_TOKENS.get('BLOCKSTORE_API_URL', None)  # e.g. "https:/
 # Configure an API auth token at (blockstore URL)/admin/authtoken/token/
 BLOCKSTORE_API_AUTH_TOKEN = AUTH_TOKENS.get('BLOCKSTORE_API_AUTH_TOKEN', None)
 
-# Datadog for events!
-DATADOG = AUTH_TOKENS.get("DATADOG", {})
-DATADOG.update(ENV_TOKENS.get("DATADOG", {}))
-
-# TODO: deprecated (compatibility with previous settings)
-if 'DATADOG_API' in AUTH_TOKENS:
-    DATADOG['api_key'] = AUTH_TOKENS['DATADOG_API']
-
 # Analytics API
 ANALYTICS_API_KEY = AUTH_TOKENS.get("ANALYTICS_API_KEY", ANALYTICS_API_KEY)
 ANALYTICS_API_URL = ENV_TOKENS.get("ANALYTICS_API_URL", ANALYTICS_API_URL)

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -30,12 +30,6 @@ class Thread(models.Model):
         'close_reason_code', 'edit_reason_code', 'closing_user_id', 'editing_user_id',
     ]
 
-    # metric_tag_fields are used by Datadog to record metrics about the model
-    metric_tag_fields = [
-        'course_id', 'group_id', 'pinned', 'closed', 'anonymous', 'anonymous_to_peers',
-        'endorsed', 'read',
-    ]
-
     # initializable_fields are sent in POST requests
     initializable_fields = updatable_fields + ['thread_type', 'context']
 

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -56,9 +56,6 @@ XMODULE_METRIC_NAME = 'edxapp.xmodule'
 XMODULE_DURATION_METRIC_NAME = XMODULE_METRIC_NAME + '.duration'
 XMODULE_METRIC_SAMPLE_RATE = 0.1
 
-# Stats event sent to DataDog in order to determine if old XML parsing can be deprecated.
-DEPRECATION_VSCOMPAT_EVENT = 'deprecation.vscompat'
-
 # xblock view names
 
 # This is the view that will be rendered to display the XBlock in the LMS.


### PR DESCRIPTION
Datadog was removed 6+ years ago but some settings and related keys got
left behind.  Get rid of them since we don't need them and also to
prevent people from assuming it's okay to hardcode datadog settings into
our codebase.
