### PR TITLE
fix: disable video status translation for JSON endpoint

### DIFF
--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -173,9 +173,8 @@ class StatusDisplayStrings:
 
     @staticmethod
     def get(val_status):
-        """Map a VAL status string to a localized display string"""
-        # pylint: disable=translation-of-non-string
-        return _(StatusDisplayStrings._STATUS_MAP.get(val_status, StatusDisplayStrings._UNKNOWN))
+        """Map a VAL status string to a display string"""
+        return StatusDisplayStrings._STATUS_MAP.get(val_status, StatusDisplayStrings._UNKNOWN)
 
 
 def handle_videos(request, course_key_string, edx_video_id=None):
@@ -657,7 +656,10 @@ def _get_videos(course, pagination_conf=None):
                 language_code=language_code,
             )
         # Convert the video status.
-        video['status'] = convert_video_status(video, is_video_encodes_ready)
+        # Legacy frontend expects the status to be translated unlike MFEs which handle translation themselves.
+        video['status_nontranslated'] = convert_video_status(video, is_video_encodes_ready)
+        # pylint: disable=translation-of-non-string
+        video['status'] = _(video['status_nontranslated'])
 
     return videos, pagination_context
 
@@ -675,7 +677,7 @@ def _get_index_videos(course, pagination_conf=None):
     """
     course_id = str(course.id)
     attrs = [
-        'edx_video_id', 'client_video_id', 'created', 'duration',
+        'edx_video_id', 'client_video_id', 'created', 'duration', 'status_nontranslated',
         'status', 'courses', 'encoded_videos', 'transcripts', 'transcription_status',
         'transcript_urls', 'error_description'
     ]

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -367,6 +367,7 @@ class VideosHandlerTestCase(
                     'created',
                     'duration',
                     'status',
+                    'status_nontranslated',
                     'course_video_image_url',
                     'file_size',
                     'download_link',
@@ -388,8 +389,8 @@ class VideosHandlerTestCase(
         (
             [
                 'edx_video_id', 'client_video_id', 'created', 'duration',
-                'status', 'course_video_image_url', 'file_size', 'download_link',
-                'transcripts', 'transcription_status', 'transcript_urls',
+                'status', 'status_nontranslated', 'course_video_image_url', 'file_size',
+                'download_link', 'transcripts', 'transcription_status', 'transcript_urls',
                 'error_description'
             ],
             [
@@ -406,8 +407,8 @@ class VideosHandlerTestCase(
         (
             [
                 'edx_video_id', 'client_video_id', 'created', 'duration',
-                'status', 'course_video_image_url', 'file_size', 'download_link',
-                'transcripts', 'transcription_status', 'transcript_urls',
+                'status', 'status_nontranslated', 'course_video_image_url', 'file_size',
+                'download_link', 'transcripts', 'transcription_status', 'transcript_urls',
                 'error_description'
             ],
             [


### PR DESCRIPTION
## Description

This PR is related to  GET [/videos](https://github.com/openedx/edx-platform/blob/5009d052e50ab651275750ae3404af43bcccdb7b/cms/djangoapps/contentstore/video_storage_handlers.py#L177) endpoint in JSON format. It disables server-side translation for this format. This endpoint is consumed by [frontend-lib-content-components](https://github.com/openedx/frontend-lib-content-components/blob/287cc23ee7ed8c72f31f853accb89d9481b3f37d/src/editors/data/services/cms/urls.js#L99) which is used by  `frontend-app-course-authoring`. 
The usecase is a Video Gallery that lists videos and enables the user to filter by video status. The issue arises from the fact that the statuses returned by this endpoint are already translated which makes [comparing their values](https://github.com/openedx/frontend-lib-content-components/blob/287cc23ee7ed8c72f31f853accb89d9481b3f37d/src/editors/containers/VideoGallery/hooks.js#L57) to the filter's predefined values  problematic.

The changes introduced here only disable translation but still send the English human-friendly string instead of the canonical [status values ](https://github.com/openedx/edx-platform/blob/f74d48341bd4ec3444080b9f6af66a90b516430a/cms/djangoapps/contentstore/video_storage_handlers.py#L150-L171) because there is a one-to-many relationship between the status formats. For instance `Failed` maps to multiple canonical statues: `file_corrupt`, `pipeline_error`, etc. So sending the canonical statues would require duplicating those mapping which is far form ideal. Thus, considering that the English human-friendly status as a reference to be filtered against (and manipulated in other different ways) seemed like a reasonable trade-off.  

## Supporting information

Private ref: BB-8076

## Testing instructions

1. Run `make dev.up.cms` 
2. Enable mock video uploads (create [waffle flag](http://localhost:18010/admin/waffle/flag/) contentstore.mock_video_uploads enabled for everyone)
3. Modify [def _get_and_validate_course](https://github.com/openedx/edx-platform/blob/565b34e4e0904d1a55e56db403893a207c62e4c3/cms/djangoapps/contentstore/video_storage_handlers.py#L479) as follows. This a quick and dirty way to circumvent the video pipeline checks. 
```python
def _get_and_validate_course(course_key_string, user):
    """
    Given a course key, return the course if it exists, the given user has
    access to it, and it is properly configured for video uploads
    """
    course_key = CourseKey.from_string(course_key_string)

    # For now, assume all studio users that have access to the course can upload videos.
    # In the future, we plan to add a new org-level role for video uploaders.
    return get_course_and_check_access(course_key, user)
```
4.Modify [def handle_videos](https://github.com/openedx/edx-platform/blob/565b34e4e0904d1a55e56db403893a207c62e4c3/cms/djangoapps/contentstore/video_storage_handlers.py#L209) to always return json to facilitate testing from the browser. 
```python
def handle_videos(request, course_key_string, edx_video_id=None):
    .
    .
    if request.method == "GET":
        return videos_index_json(course)
    .
    .
```
5.  Head to [Course Videos](http://localhost:18010/admin/edxval/coursevideo/) in Django Admin and create some course videos for the Demo course. Use the Devstack provisionned videos.
![Screenshot from 2023-12-16 12-59-12](https://github.com/openedx/edx-platform/assets/28169169/8dabd8dc-0e75-4387-9a74-0e891bb1fd6b)

6. Head to http://localhost:18010/videos/course-v1:edX+DemoX+Demo_Course. You should see a json of the Course Videos you created.
7. Head back to  [Course Videos](http://localhost:18010/admin/edxval/coursevideo/) in the admin panel and edit the status of the Video that your Course Video links to. You must use canonical values. Set status to `ingest` or `upload_failed` which will map to `In Progress` and `Failed` respectively.
8. Head to your [account](http://localhost:18000/account/settings) and change your language setting. (For some reason, only English was showing in my case. I simply changed the value of the Option HTML tag to `fr` instead of `en` and it worked.)

Before applying the changes in this MR, the video status would be translated. After applying it, it is not.

Apologies for the convoluted instructions.

