### PR TITLE
[FC-0036] feat: Add ability to get unassigned taxonomies

### DIFF
--- a/openedx/core/djangoapps/content_tagging/api.py
+++ b/openedx/core/djangoapps/content_tagging/api.py
@@ -109,6 +109,24 @@ def get_taxonomies_for_org(
     )
 
 
+def get_unassigned_taxonomies(enabled=True) -> QuerySet:
+    """
+    Generate a list of the enabled orphaned Taxomonies, i.e. that do not belong to any
+    organization. We don't use `TaxonomyOrg.get_relationships` as that returns
+    Taxonomies which are available for all Organizations when no `org` is provided
+    """
+    return oel_tagging.get_taxonomies(enabled=enabled).filter(
+        ~(
+            Exists(
+                TaxonomyOrg.objects.filter(
+                    taxonomy=OuterRef("pk"),
+                    rel_type=TaxonomyOrg.RelType.OWNER,
+                )
+            )
+        )
+    )
+
+
 def get_content_tags(
     object_key: ContentKey,
     taxonomy_id: int | None = None,

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/serializers.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/serializers.py
@@ -46,6 +46,7 @@ class TaxonomyOrgListQueryParamsSerializer(TaxonomyListQueryParamsSerializer):
         queryset=Organization.objects.all(),
         required=False,
     )
+    unassigned: fields.Field = serializers.BooleanField(required=False)
 
 
 class TaxonomyUpdateOrgBodySerializer(serializers.Serializer):

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -282,7 +282,8 @@ class TestTaxonomyListCreateViewSet(TestTaxonomyObjectsMixin, APITestCase):
             user_attr: str,
             expected_taxonomies: list[str],
             enabled_parameter: bool | None = None,
-            org_parameter: str | None = None
+            org_parameter: str | None = None,
+            unassigned_parameter: bool | None = None
     ) -> None:
         """
         Helper function to call the list endpoint and check the response
@@ -293,7 +294,11 @@ class TestTaxonomyListCreateViewSet(TestTaxonomyObjectsMixin, APITestCase):
         self.client.force_authenticate(user=user)
 
         # Set parameters cleaning empty values
-        query_params = {k: v for k, v in {"enabled": enabled_parameter, "org": org_parameter}.items() if v is not None}
+        query_params = {k: v for k, v in {
+            "enabled": enabled_parameter,
+            "org": org_parameter,
+            "unassigned": unassigned_parameter,
+        }.items() if v is not None}
 
         response = self.client.get(url, query_params, format="json")
 
@@ -362,6 +367,31 @@ class TestTaxonomyListCreateViewSet(TestTaxonomyObjectsMixin, APITestCase):
             org_parameter=org_parameter,
             expected_taxonomies=expected_taxonomies,
         )
+
+    def test_list_unassigned_taxonomies(self):
+        """
+        Test that passing in "unassigned" query param returns Taxonomies that
+        are unassigned. i.e. does not belong to any org
+        """
+        self._test_list_taxonomy(
+            user_attr="staff",
+            expected_taxonomies=["ot1", "ot2"],
+            unassigned_parameter=True,
+        )
+
+    def test_list_unassigned_and_org_filter_invalid(self) -> None:
+        """
+        Test that passing "org" and "unassigned" query params should throw an error
+        """
+        url = TAXONOMY_ORG_LIST_URL
+
+        self.client.force_authenticate(user=self.user)
+
+        query_params = {"org": "orgA", "unassigned": "true"}
+
+        response = self.client.get(url, query_params, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @ddt.data(
         ("user", (), None),

--- a/openedx/core/djangoapps/content_tagging/tests/test_api.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_api.py
@@ -156,6 +156,13 @@ class TestAPITaxonomy(TestTaxonomyMixin, TestCase):
             getattr(self, taxonomy_attr) for taxonomy_attr in expected
         ]
 
+    def test_get_unassigned_taxonomies(self):
+        expected = ["taxonomy_no_orgs"]
+        taxonomies = list(api.get_unassigned_taxonomies())
+        assert taxonomies == [
+            getattr(self, taxonomy_attr) for taxonomy_attr in expected
+        ]
+
     @ddt.data(
         ("taxonomy_all_orgs", "all_orgs_course_tag"),
         ("taxonomy_all_orgs", "all_orgs_block_tag"),


### PR DESCRIPTION
## Description

This adds a query param to fetch unassigned taxonomies, i.e. taxonomies that do not belong to any org.

## Supporting information

Related Tickets:
- https://github.com/openedx/modular-learning/issues/108
- https://github.com/open-craft/frontend-app-course-authoring/pull/21

## Testing instructions

Make sure the provided tests cover the intended case and pass

---
Private-ref: [FAL-3544](https://tasks.opencraft.com/browse/FAL-3544)