### PR TITLE
feat: added thread_flagged and comment_flagged signals in legacy discussion

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -177,8 +177,10 @@ class ThreadActionGroupIdTestCase(
         self._assert_json_response_contains_group_info(response)
 
     def test_flag(self, mock_request):
-        response = self.call_view("flag_abuse_for_thread", mock_request)
-        self._assert_json_response_contains_group_info(response)
+        with mock.patch('openedx.core.djangoapps.django_comment_common.signals.thread_flagged.send') as signal_mock:
+            response = self.call_view("flag_abuse_for_thread", mock_request)
+            self._assert_json_response_contains_group_info(response)
+            self.assertEqual(signal_mock.call_count, 1)
         response = self.call_view("un_flag_abuse_for_thread", mock_request)
         self._assert_json_response_contains_group_info(response)
 
@@ -1347,6 +1349,48 @@ class UpdateCommentUnicodeTestCase(
         assert response.status_code == 200
         assert mock_request.called
         assert mock_request.call_args[1]['data']['body'] == text
+
+
+@patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
+class CommentActionTestCase(
+        MockRequestSetupMixin,
+        CohortedTestCase,
+        GroupIdAssertionMixin
+):
+    def call_view(
+            self,
+            view_name,
+            mock_request,
+            user=None,
+            post_params=None,
+            view_args=None
+    ):
+        self._set_mock_request_data(
+            mock_request,
+            {
+                "user_id": str(self.student.id),
+                "group_id": self.student_cohort.id,
+                "closed": False,
+                "type": "thread",
+                "commentable_id": "non_team_dummy_id",
+                "body": "test body",
+            }
+        )
+        request = RequestFactory().post("dummy_url", post_params or {})
+        request.user = user or self.student
+        request.view_name = view_name
+
+        return getattr(views, view_name)(
+            request,
+            course_id=str(self.course.id),
+            comment_id="dummy",
+            **(view_args or {})
+        )
+
+    def test_flag(self, mock_request):
+        with mock.patch('openedx.core.djangoapps.django_comment_common.signals.comment_flagged.send') as signal_mock:
+            self.call_view("flag_abuse_for_comment", mock_request)
+            self.assertEqual(signal_mock.call_count, 1)
 
 
 @disable_signal(views, 'comment_created')

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -55,10 +55,12 @@ from openedx.core.djangoapps.django_comment_common.signals import (
     comment_deleted,
     comment_edited,
     comment_endorsed,
+    comment_flagged,
     comment_voted,
     thread_created,
     thread_deleted,
     thread_edited,
+    thread_flagged,
     thread_followed,
     thread_unfollowed,
     thread_voted
@@ -900,6 +902,7 @@ def flag_abuse_for_thread(request, course_id, thread_id):
     thread = cc.Thread.find(thread_id)
     thread.flagAbuse(user, thread)
     track_discussion_reported_event(request, course, thread)
+    thread_flagged.send(sender='flag_abuse_for_thread', user=request.user, post=thread)
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
 
@@ -938,6 +941,7 @@ def flag_abuse_for_comment(request, course_id, comment_id):
     comment = cc.Comment.find(comment_id)
     comment.flagAbuse(user, comment)
     track_discussion_reported_event(request, course, comment)
+    comment_flagged.send(sender='flag_abuse_for_comment', user=request.user, post=comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
 
 


### PR DESCRIPTION
Added the following new signals in legacy discussion experience

- thread_flagged
- comment_flagged

Ticket: [INF-1151](https://2u-internal.atlassian.net/browse/INF-1151)