### PR TITLE
feat: make hide from TOC a visibility section setting

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/xblock.py
@@ -77,3 +77,4 @@ class XblockSerializer(StrictSerializer):
     target_index = serializers.IntegerField(required=False, allow_null=True)
     boilerplate = serializers.JSONField(required=False, allow_null=True)
     staged_content = serializers.CharField(required=False, allow_null=True)
+    hide_from_toc = serializers.BooleanField(required=False, allow_null=True)

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1445,6 +1445,23 @@ class ContentStoreTest(ContentStoreTestCase):
         ).replace('REPLACE', r'([0-9]|[a-f]){3,}')
         self.assertRegex(data['locator'], retarget)
 
+    @ddt.data(True, False)
+    def test_hide_xblock_from_toc_via_handler(self, hide_from_toc):
+        """Test that the hide_from_toc field can be set via the xblock_handler."""
+        course = CourseFactory.create()
+        sequential = BlockFactory.create(parent_location=course.location)
+        data = {
+            "metadata": {
+                "hide_from_toc": hide_from_toc
+            }
+        }
+
+        response = self.client.ajax_post(get_url("xblock_handler", sequential.location), data)
+        sequential = self.store.get_item(sequential.location)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(hide_from_toc, sequential.hide_from_toc)
+
     def test_capa_block(self):
         """Test that a problem treats markdown specially."""
         course = CourseFactory.create()

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -177,6 +177,14 @@ define(
                 * List of tags of the unit. This list is managed by the content_tagging module.
                 */
                tags: null,
+               /**
+                * True if the xblock is not visible to students only via links.
+                */
+               hide_from_toc: null,
+               /**
+                * True iff this xblock should display a "Contains staff only content" message.
+                */
+               hide_from_toc_message: null,
             },
 
             initialize: function() {

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -42,8 +42,6 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights_enabled: true,
             highlights_enabled_for_messaging: false,
-            hide_from_toc: false,
-            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -71,8 +69,6 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights_enabled: true,
             highlights_enabled_for_messaging: false,
-            hide_from_toc: false,
-            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -98,8 +94,6 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights: [],
             highlights_enabled: true,
-            hide_from_toc: false,
-            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -150,8 +144,6 @@ describe('CourseOutlinePage', function() {
             user_partitions: [],
             group_access: {},
             user_partition_info: {},
-            hide_from_toc: false,
-            enable_hide_from_toc_ui: true
         }, options);
     };
 

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -42,6 +42,8 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights_enabled: true,
             highlights_enabled_for_messaging: false,
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -68,7 +70,9 @@ describe('CourseOutlinePage', function() {
             show_review_rules: true,
             user_partition_info: {},
             highlights_enabled: true,
-            highlights_enabled_for_messaging: false
+            highlights_enabled_for_messaging: false,
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -93,7 +97,9 @@ describe('CourseOutlinePage', function() {
             group_access: {},
             user_partition_info: {},
             highlights: [],
-            highlights_enabled: true
+            highlights_enabled: true,
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -123,7 +129,9 @@ describe('CourseOutlinePage', function() {
             },
             user_partitions: [],
             group_access: {},
-            user_partition_info: {}
+            user_partition_info: {},
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -141,7 +149,9 @@ describe('CourseOutlinePage', function() {
             edited_by: 'MockUser',
             user_partitions: [],
             group_access: {},
-            user_partition_info: {}
+            user_partition_info: {},
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options);
     };
 
@@ -1214,7 +1224,9 @@ describe('CourseOutlinePage', function() {
                 is_practice_exam: false,
                 is_proctored_exam: false,
                 default_time_limit_minutes: 150,
-                hide_after_due: true
+                hide_after_due: true,
+                hide_from_toc: false,
+                enable_hide_from_toc_ui: true,
             }, [
                 createMockVerticalJSON({
                     has_changes: true,
@@ -1397,6 +1409,7 @@ describe('CourseOutlinePage', function() {
                     default_time_limit_minutes: 150,
                     hide_after_due: true,
                     is_onboarding_exam: false,
+                    hide_from_toc: null,
                 }
             });
             expect(requests[0].requestHeaders['X-HTTP-Method-Override']).toBe('PATCH');
@@ -2240,6 +2253,8 @@ describe('CourseOutlinePage', function() {
                     is_practice_exam: false,
                     is_proctored_exam: false,
                     default_time_limit_minutes: null,
+                    hide_from_toc: false,
+                    enable_hide_from_toc_ui: true,
                 }, [
                     createMockVerticalJSON({
                         has_changes: true,
@@ -2521,6 +2536,7 @@ describe('CourseOutlinePage', function() {
                     publish: 'republish',
                     metadata: {
                         visible_to_staff_only: null,
+                        hide_from_toc: null
                     }
                 });
             })

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -42,6 +42,8 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights_enabled: true,
             highlights_enabled_for_messaging: false,
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -69,6 +71,8 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights_enabled: true,
             highlights_enabled_for_messaging: false,
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -94,6 +98,8 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights: [],
             highlights_enabled: true,
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options, {child_info: {children: children}});
     };
 
@@ -144,6 +150,8 @@ describe('CourseOutlinePage', function() {
             user_partitions: [],
             group_access: {},
             user_partition_info: {},
+            hide_from_toc: false,
+            enable_hide_from_toc_ui: true
         }, options);
     };
 

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -314,6 +314,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             var isProctoredExam = xblockInfo.get('is_proctored_exam');
             var isPracticeExam = xblockInfo.get('is_practice_exam');
             var isOnboardingExam = xblockInfo.get('is_onboarding_exam');
+            var enableHideFromTOCUI = xblockInfo.get('enable_hide_from_toc_ui');
             var html = this.template($.extend({}, {
                 xblockInfo: xblockInfo,
                 xblockType: this.options.xblockType,
@@ -323,6 +324,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 isProctoredExam: isProctoredExam,
                 isPracticeExam: isPracticeExam,
                 isOnboardingExam: isOnboardingExam,
+                enableHideFromTOCUI: enableHideFromTOCUI,
                 isTimedExam: isTimeLimited && !(
                     isProctoredExam || isPracticeExam || isOnboardingExam
                 ),
@@ -798,6 +800,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             return this.model.get('ancestor_has_staff_lock');
         },
 
+        isModelHiddenFromTOC: function() {
+            return this.model.get('hide_from_toc');
+        },
+
         getContext: function() {
             return {
                 hasExplicitStaffLock: this.isModelLocked(),
@@ -812,6 +818,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         afterRender: function() {
             AbstractVisibilityEditor.prototype.afterRender.call(this);
             this.setLock(this.isModelLocked());
+            this.setHideFromTOC(this.isModelHiddenFromTOC());
+            this.setVisibleToLearners(this.isVisibleToLearners());
         },
 
         setLock: function(value) {
@@ -822,8 +830,24 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             return this.$('#staff_lock').is(':checked');
         },
 
+        setHideFromTOC: function(value) {
+            this.$('#hide_from_toc').prop('checked', value);
+        },
+
+        setVisibleToLearners: function(value) {
+            this.$('#visible_to_learners').prop('checked', value);
+        },
+
+        isVisibleToLearners: function() {
+            return this.$('#staff_lock').is(':not(:checked)') && this.$('#hide_from_toc').is(':not(:checked)');
+        },
+
+        isHiddenFromTOC: function() {
+            return this.$('#hide_from_toc').is(':checked');
+        },
+
         hasChanges: function() {
-            return this.isModelLocked() !== this.isLocked();
+            return this.isModelLocked() !== this.isLocked() || this.isModelHiddenFromTOC() !== this.isHiddenFromTOC();
         },
 
         getRequestData: function() {
@@ -831,7 +855,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 return {
                     publish: 'republish',
                     metadata: {
-                        visible_to_staff_only: this.isLocked() ? true : null
+                        visible_to_staff_only: this.isLocked() ? true : null,
+                        hide_from_toc: this.isHiddenFromTOC() ? true : null
                     }
                 };
             } else {
@@ -1055,12 +1080,20 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 if (this.currentVisibility() === 'staff_only') {
                     metadata.visible_to_staff_only = true;
                     metadata.hide_after_due = null;
+                    metadata.hide_from_toc = null;
                 } else if (this.currentVisibility() === 'hide_after_due') {
                     metadata.visible_to_staff_only = null;
                     metadata.hide_after_due = true;
-                } else {
+                    metadata.hide_from_toc = null;
+                } else if (this.currentVisibility() === 'hide_from_toc'){
                     metadata.visible_to_staff_only = null;
                     metadata.hide_after_due = null;
+                    metadata.hide_from_toc = true;
+                }
+                else {
+                    metadata.visible_to_staff_only = null;
+                    metadata.hide_after_due = null;
+                    metadata.hide_from_toc = null;
                 }
 
                 return {

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -315,6 +315,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             var isPracticeExam = xblockInfo.get('is_practice_exam');
             var isOnboardingExam = xblockInfo.get('is_onboarding_exam');
             var enableHideFromTOCUI = xblockInfo.get('enable_hide_from_toc_ui');
+            var hideFromTOC = xblockInfo.get('hide_from_toc');
             var html = this.template($.extend({}, {
                 xblockInfo: xblockInfo,
                 xblockType: this.options.xblockType,
@@ -325,6 +326,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 isPracticeExam: isPracticeExam,
                 isOnboardingExam: isOnboardingExam,
                 enableHideFromTOCUI: enableHideFromTOCUI,
+                hideFromTOC: hideFromTOC,
                 isTimedExam: isTimeLimited && !(
                     isProctoredExam || isPracticeExam || isOnboardingExam
                 ),
@@ -855,8 +857,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 return {
                     publish: 'republish',
                     metadata: {
-                        visible_to_staff_only: this.isLocked() ? true : null,
-                        hide_from_toc: this.isHiddenFromTOC() ? true : null
+                        visible_to_staff_only: this.isLocked() || null,
+                        hide_from_toc: this.isHiddenFromTOC() || null
                     }
                 };
             } else {

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -149,6 +149,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
                         releaseDate: this.model.get('release_date'),
                         releaseDateFrom: this.model.get('release_date_from'),
                         hasExplicitStaffLock: this.model.get('has_explicit_staff_lock'),
+                        hideFromTOC: this.model.get('hide_from_toc'),
                         staffLockFrom: this.model.get('staff_lock_from'),
                         enableCopyUnit: this.model.get('enable_copy_paste_units'),
                         course: window.course,

--- a/cms/static/js/views/utils/xblock_utils.js
+++ b/cms/static/js/views/utils/xblock_utils.js
@@ -29,6 +29,8 @@ function($, _, gettext, ViewUtils, ModuleUtils, XBlockInfo, StringUtils) {
          *
          *   staffOnly - all of the block's content is to be shown to staff only
          *     Note: staff only items do not affect their parent's state.
+         *
+         *   hideFromTOC - all of the block's content is to be hidden from the table of contents.
          */
     VisibilityState = {
         live: 'live',
@@ -36,7 +38,8 @@ function($, _, gettext, ViewUtils, ModuleUtils, XBlockInfo, StringUtils) {
         unscheduled: 'unscheduled',
         needsAttention: 'needs_attention',
         staffOnly: 'staff_only',
-        gated: 'gated'
+        gated: 'gated',
+        hideFromTOC: 'hide_from_toc'
     };
 
     /**
@@ -309,6 +312,9 @@ function($, _, gettext, ViewUtils, ModuleUtils, XBlockInfo, StringUtils) {
     getXBlockVisibilityClass = function(visibilityState) {
         if (visibilityState === VisibilityState.staffOnly) {
             return 'is-staff-only';
+        }
+        if (visibilityState === VisibilityState.hideFromTOC) {
+            return 'is-hidden-from-toc';
         }
         if (visibilityState === VisibilityState.gated) {
             return 'is-gated';

--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -112,6 +112,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, XBlockStringFieldE
                 includesChildren: this.shouldRenderChildren(),
                 hasExplicitStaffLock: this.model.get('has_explicit_staff_lock'),
                 staffOnlyMessage: this.model.get('staff_only_message'),
+                hideFromTOCMessage: this.model.get('hide_from_toc_message'),
                 course: course,
                 enableCopyPasteUnits: this.model.get("enable_copy_paste_units"), // ENABLE_COPY_PASTE_UNITS waffle flag
                 useTaggingTaxonomyListPage: this.model.get("use_tagging_taxonomy_list_page"), // ENABLE_TAGGING_TAXONOMY_LIST_PAGE waffle flag

--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -507,6 +507,18 @@ $outline-indent-width: $baseline;
     }
   }
 
+  // CASE: is hidden from TOC
+  &.is-hidden-from-toc {
+    // needed to make sure direct children only
+    > .section-status,
+    > .subsection-status,
+    > .unit-status {
+      .status-message .icon {
+        color: $color-hide-from-toc;
+      }
+    }
+  }
+
   // CASE: has gated content
   &.is-gated {
 
@@ -603,6 +615,11 @@ $outline-indent-width: $baseline;
         border-left-color: $color-staff-only;
       }
 
+      // CASE: is hidden from TOC
+      &.is-hidden-from-toc {
+        border-left-color: $color-hide-from-toc;
+      }
+
       // CASE: has gated content
       &.is-gated {
         border-left-color: $color-gated;
@@ -696,6 +713,11 @@ $outline-indent-width: $baseline;
     // CASE: is presented for staff only
     &.is-staff-only {
       border-left-color: $color-staff-only;
+    }
+
+    // CASE: is hidden from TOC
+    &.is-hidden-from-toc {
+      border-left-color: $color-hide-from-toc;
     }
 
     // CASE: is presented for gated

--- a/cms/static/sass/partials/cms/theme/_variables-v1.scss
+++ b/cms/static/sass/partials/cms/theme/_variables-v1.scss
@@ -218,6 +218,7 @@ $color-ready: $green !default;
 $color-warning: $orange-l2 !default;
 $color-error: $red-l2 !default;
 $color-staff-only: $black !default;
+$color-hide-from-toc: $black !default;
 $color-gated: $black !default;
 
 $color-heading-base: $gray-d2 !default;

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -155,6 +155,15 @@
         }
       }
 
+      // CASE: is hidden from TOC
+      &.is-hidden-from-toc{
+        @extend %bar-module-black;
+
+        &.is-scheduled .wrapper-release .copy {
+          text-decoration: line-through;
+        }
+      }
+
       // CASE: content is gated
       &.is-gated {
         @extend %bar-module-black;

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -22,7 +22,13 @@ var addStatusMessage = function (statusType, message) {
         statusIconClass = 'fa-warning';
     } else if (statusType === 'staff-only' || statusType === 'gated') {
         statusIconClass = 'fa-lock';
-    } else if (statusType === 'partition-groups') {
+    } else if(statusType === 'hide-from-toc-chapter') {
+        statusIconClass = 'fa-eye-slash';
+    }
+    else if(statusType === 'hide-from-toc-sequence') {
+        statusIconClass = 'fa-ban';
+    }
+    else if (statusType === 'partition-groups') {
         statusIconClass = 'fa-eye';
     }
 
@@ -48,6 +54,15 @@ if (prereq) {
 if (staffOnlyMessage) {
     messageType = 'staff-only';
     messageText = gettext('Contains staff only content');
+    addStatusMessage(messageType, messageText);
+} else if (hideFromTOCMessage && !xblockInfo.isVertical()){
+    if (xblockInfo.isChapter()) {
+        messageText = gettext('Hidden in the course outline, but sections are accessible for your learners through their separate link.');
+        messageType = 'hide-from-toc-chapter';
+    } else {
+        messageText = gettext('Subsections are not navigable between each other, they can only be accessed through their link.');
+        messageType = 'hide-from-toc-sequence';
+    }
     addStatusMessage(messageType, messageText);
 } else {
     if (visibilityState === 'needs_attention' && xblockInfo.isVertical()) {

--- a/cms/templates/js/staff-lock-editor.underscore
+++ b/cms/templates/js/staff-lock-editor.underscore
@@ -39,6 +39,11 @@
         <span> <%- gettext('Hide in Course Outline, accessible via Link') %> </span>
     </label>
     <p class='field-message' id='hide-from-toc-description'> <%- gettext('It is intentionally hidden from standard navigation, ensuring that only individuals with the link can view its contents.') %> </p>
+    <% if (hideFromTOC) { %>
+      <p class="tip tip-warning">
+        <%- gettext('If you make this section visible in the table of content, learners will be able to see its content.') %>
+      </p>
+    <% } %>
   <% } %>
   </div>
 </div>

--- a/cms/templates/js/staff-lock-editor.underscore
+++ b/cms/templates/js/staff-lock-editor.underscore
@@ -7,6 +7,29 @@
     <% } %>
 </h3>
 <div class="list-fields list-input content-visibility" role="group" aria-labelledby="content_visibility_label">
+<% if (enableHideFromTOCUI) { %>
+  <div class="modal-section-content no-visibility-option">
+      <label class="label">
+          <input type="radio" id="visible_to_learners" name="content-visibility" class="input input-radio" />
+          <span> <%- gettext('Visible to learners') %> </span>
+      </label>
+      <p class='field-message' id='visible-to-learners-description'> <%- gettext('It is visible to learners, ensuring that all learners can view its contents.') %> </p>
+  </div>
+  <div class="modal-section-content hide-from-toc">
+    <% if (!xblockInfo.isVertical()) { %>
+      <label class="label">
+        <input type="radio" id="hide_from_toc" name="content-visibility" class="input input-radio" />
+        <span> <%- gettext('Hide in Course Outline, accessible via Link') %> </span>
+      </label>
+      <p class='field-message' id='hide-from-toc-description'> <%- gettext('It is intentionally hidden from standard navigation, ensuring that only individuals with the link can view its contents.') %> </p>
+      <% if (hideFromTOC) { %>
+          <p class="tip tip-warning">
+            <%- gettext('If you make this section visible in the table of content, learners will be able to see its content.') %>
+          </p>
+      <% } %>
+    <% } %>
+  </div>
+<% } %>
 <div class="modal-section-content staff-lock">
     <label class="label">
       <% var inputType = enableHideFromTOCUI ? 'radio' : 'checkbox'; %>
@@ -27,28 +50,5 @@
         </p>
   <% } %>
 </div>
-<% if (enableHideFromTOCUI) { %>
-  <div class="modal-section-content hide-from-toc">
-    <% if (!xblockInfo.isVertical()) { %>
-      <label class="label">
-        <input type="radio" id="hide_from_toc" name="content-visibility" class="input input-radio" />
-        <span> <%- gettext('Hide in Course Outline, accessible via Link') %> </span>
-      </label>
-      <p class='field-message' id='hide-from-toc-description'> <%- gettext('It is intentionally hidden from standard navigation, ensuring that only individuals with the link can view its contents.') %> </p>
-      <% if (hideFromTOC) { %>
-          <p class="tip tip-warning">
-            <%- gettext('If you make this section visible in the table of content, learners will be able to see its content.') %>
-          </p>
-      <% } %>
-    <% } %>
-  </div>
-  <div class="modal-section-content no-visibility-option">
-      <label class="label">
-          <input type="radio" id="visible_to_learners" name="content-visibility" class="input input-radio" />
-          <span> <%- gettext('Visible to learners') %> </span>
-      </label>
-      <p class='field-message' id='visible-to-learners-description'> <%- gettext('It is visible to learners, ensuring that all learners can view its contents.') %> </p>
-  </div>
 </div>
-<% } %>
 </form>

--- a/cms/templates/js/staff-lock-editor.underscore
+++ b/cms/templates/js/staff-lock-editor.underscore
@@ -6,6 +6,7 @@
         <%- gettext('Section Visibility') %>
     <% } %>
 </h3>
+<div class="list-fields list-input content-visibility" role="group" aria-labelledby="content_visibility_label">
 <div class="modal-section-content staff-lock">
     <label class="label">
       <% var inputType = enableHideFromTOCUI ? 'radio' : 'checkbox'; %>
@@ -27,7 +28,6 @@
   <% } %>
 </div>
 <% if (enableHideFromTOCUI) { %>
-<div class="list-fields list-input content-visibility" role="group" aria-labelledby="content_visibility_label">
   <div class="modal-section-content hide-from-toc">
     <% if (!xblockInfo.isVertical()) { %>
       <label class="label">
@@ -47,7 +47,7 @@
           <input type="radio" id="visible_to_learners" name="content-visibility" class="input input-radio" />
           <span> <%- gettext('Visible to learners') %> </span>
       </label>
-      <p class='field-message' id='staff-lock-description'> <%- gettext('It is visible to learners, ensuring that all learners can view its contents.') %> </p>
+      <p class='field-message' id='visible-to-learners-description'> <%- gettext('It is visible to learners, ensuring that all learners can view its contents.') %> </p>
   </div>
 </div>
 <% } %>

--- a/cms/templates/js/staff-lock-editor.underscore
+++ b/cms/templates/js/staff-lock-editor.underscore
@@ -6,7 +6,44 @@
         <%- gettext('Section Visibility') %>
     <% } %>
 </h3>
-<div class="modal-section-content staff-lock">
+<% if (enableHideFromTOCUI) { %>
+<div class="list-fields list-input content-visibility" role="group" aria-labelledby="content_visibility_label">
+  <div class="modal-section-content no-visibility-option">
+      <label class="label">
+          <input type="radio" id="visible_to_learners" name="content-visibility" class="input input-radio" />
+          <span> <%- gettext('Visible to learners') %> </span>
+      </label>
+      <p class='field-message' id='staff-lock-description'> <%- gettext('It is visible to learners, ensuring that all learners can view its contents.') %> </p>
+  </div>
+    <div class="modal-section-content staff-lock">
+      <label class="label">
+          <input type="radio" id="staff_lock" name="content-visibility" class="input input-radio" />
+          <span> <%- gettext('Hide from learners') %> </span>
+      </label>
+      <p class='field-message' id='staff-lock-description'> <%- gettext('It is intentionally hidden from learners, ensuring that only the course staff can view its contents.') %> </p>
+      <% if (hasExplicitStaffLock && !ancestorLocked) { %>
+          <p class="tip tip-warning">
+            <% if (xblockInfo.isVertical()) { %>
+              <p> <%- gettext('If the unit was previously published and released to learners, any changes you made to the unit when it was hidden will now be visible to learners.') %> </p>
+            <% } else { %>
+              <% var message = gettext('If you make this %(xblockType)s visible to learners, learners will be able to see its content after the release date has passed and you have published the unit. Only units that are explicitly hidden from learners will remain hidden after you clear this option for the %(xblockType)s.') %>
+              <%- interpolate(message, { xblockType: xblockType }, true) %>
+            <% } %>
+          </p>
+      <% } %>
+  </div>
+  <div class="modal-section-content hide-from-toc">
+  <% if (!xblockInfo.isVertical()) { %>
+    <label class="label">
+        <input type="radio" id="hide_from_toc" name="content-visibility" class="input input-radio" />
+        <span> <%- gettext('Hide in Course Outline, accessible via Link') %> </span>
+    </label>
+    <p class='field-message' id='hide-from-toc-description'> <%- gettext('It is intentionally hidden from standard navigation, ensuring that only individuals with the link can view its contents.') %> </p>
+  <% } %>
+  </div>
+</div>
+<% } else { %>
+  <div class="modal-section-content staff-lock">
     <label class="label">
         <input type="checkbox" id="staff_lock" name="staff_lock" class="input input-checkbox" />
         <%- gettext('Hide from learners') %>
@@ -22,4 +59,5 @@
         </p>
     <% } %>
 </div>
+<% } %>
 </form>

--- a/cms/templates/js/staff-lock-editor.underscore
+++ b/cms/templates/js/staff-lock-editor.underscore
@@ -6,48 +6,49 @@
         <%- gettext('Section Visibility') %>
     <% } %>
 </h3>
+<div class="modal-section-content staff-lock">
+    <label class="label">
+      <% var inputType = enableHideFromTOCUI ? 'radio' : 'checkbox'; %>
+        <input type="<%- inputType %>" id="staff_lock" name="content-visibility" class="<%- inputType === 'radio' ? 'input input-radio' : 'input input-checkbox' %>" />
+        <%- gettext('Hide from learners') %>
+      </label>
+    <% if (enableHideFromTOCUI) { %>
+      <p class='field-message' id='staff-lock-description'> <%- gettext('It is intentionally hidden from learners, ensuring that only the course staff can view its contents.') %> </p>
+    <% } %>
+    <% if (hasExplicitStaffLock && !ancestorLocked) { %>
+        <p class="tip tip-warning">
+          <% if (xblockInfo.isVertical()) { %>
+            <%- gettext('If the unit was previously published and released to learners, any changes you made to the unit when it was hidden will now be visible to learners.') %>
+          <% } else { %>
+            <% var message = gettext('If you make this %(xblockType)s visible to learners, learners will be able to see its content after the release date has passed and you have published the unit. Only units that are explicitly hidden from learners will remain hidden after you clear this option for the %(xblockType)s.') %>
+            <%- interpolate(message, { xblockType: xblockType }, true) %>
+          <% } %>
+        </p>
+  <% } %>
+</div>
 <% if (enableHideFromTOCUI) { %>
 <div class="list-fields list-input content-visibility" role="group" aria-labelledby="content_visibility_label">
+  <div class="modal-section-content hide-from-toc">
+    <% if (!xblockInfo.isVertical()) { %>
+      <label class="label">
+        <input type="radio" id="hide_from_toc" name="content-visibility" class="input input-radio" />
+        <span> <%- gettext('Hide in Course Outline, accessible via Link') %> </span>
+      </label>
+      <p class='field-message' id='hide-from-toc-description'> <%- gettext('It is intentionally hidden from standard navigation, ensuring that only individuals with the link can view its contents.') %> </p>
+      <% if (hideFromTOC) { %>
+          <p class="tip tip-warning">
+            <%- gettext('If you make this section visible in the table of content, learners will be able to see its content.') %>
+          </p>
+      <% } %>
+    <% } %>
+  </div>
   <div class="modal-section-content no-visibility-option">
       <label class="label">
           <input type="radio" id="visible_to_learners" name="content-visibility" class="input input-radio" />
           <span> <%- gettext('Visible to learners') %> </span>
       </label>
       <p class='field-message' id='staff-lock-description'> <%- gettext('It is visible to learners, ensuring that all learners can view its contents.') %> </p>
-  <div class="modal-section-content hide-from-toc">
-  <% if (!xblockInfo.isVertical()) { %>
-    <label class="label">
-        <input type="radio" id="hide_from_toc" name="content-visibility" class="input input-radio" />
-        <span> <%- gettext('Hide in Course Outline, accessible via Link') %> </span>
-    </label>
-    <p class='field-message' id='hide-from-toc-description'> <%- gettext('It is intentionally hidden from standard navigation, ensuring that only individuals with the link can view its contents.') %> </p>
-    <% if (hideFromTOC) { %>
-      <p class="tip tip-warning">
-        <%- gettext('If you make this section visible in the table of content, learners will be able to see its content.') %>
-      </p>
-    <% } %>
-  <% } %>
   </div>
 </div>
 <% } %>
-<div class="modal-section-content staff-lock">
-  <label class="label">
-    <% var inputType = enableHideFromTOCUI ? 'radio' : 'checkbox'; %>
-      <input type="<%- inputType %>" id="staff_lock" name="content-visibility" class="<%- inputType === 'radio' ? 'input input-radio' : 'input input-checkbox' %>" />
-      <%- gettext('Hide from learners') %>
-    </label>
-  <% if (enableHideFromTOCUI) { %>
-    <p class='field-message' id='staff-lock-description'> <%- gettext('It is intentionally hidden from learners, ensuring that only the course staff can view its contents.') %> </p>
-  <% } %>
-  <% if (hasExplicitStaffLock && !ancestorLocked) { %>
-      <p class="tip tip-warning">
-        <% if (xblockInfo.isVertical()) { %>
-          <%- gettext('If the unit was previously published and released to learners, any changes you made to the unit when it was hidden will now be visible to learners.') %>
-        <% } else { %>
-          <% var message = gettext('If you make this %(xblockType)s visible to learners, learners will be able to see its content after the release date has passed and you have published the unit. Only units that are explicitly hidden from learners will remain hidden after you clear this option for the %(xblockType)s.') %>
-          <%- interpolate(message, { xblockType: xblockType }, true) %>
-        <% } %>
-      </p>
-  <% } %>
-</div>
 </form>

--- a/cms/templates/js/staff-lock-editor.underscore
+++ b/cms/templates/js/staff-lock-editor.underscore
@@ -14,24 +14,6 @@
           <span> <%- gettext('Visible to learners') %> </span>
       </label>
       <p class='field-message' id='staff-lock-description'> <%- gettext('It is visible to learners, ensuring that all learners can view its contents.') %> </p>
-  </div>
-    <div class="modal-section-content staff-lock">
-      <label class="label">
-          <input type="radio" id="staff_lock" name="content-visibility" class="input input-radio" />
-          <span> <%- gettext('Hide from learners') %> </span>
-      </label>
-      <p class='field-message' id='staff-lock-description'> <%- gettext('It is intentionally hidden from learners, ensuring that only the course staff can view its contents.') %> </p>
-      <% if (hasExplicitStaffLock && !ancestorLocked) { %>
-          <p class="tip tip-warning">
-            <% if (xblockInfo.isVertical()) { %>
-              <p> <%- gettext('If the unit was previously published and released to learners, any changes you made to the unit when it was hidden will now be visible to learners.') %> </p>
-            <% } else { %>
-              <% var message = gettext('If you make this %(xblockType)s visible to learners, learners will be able to see its content after the release date has passed and you have published the unit. Only units that are explicitly hidden from learners will remain hidden after you clear this option for the %(xblockType)s.') %>
-              <%- interpolate(message, { xblockType: xblockType }, true) %>
-            <% } %>
-          </p>
-      <% } %>
-  </div>
   <div class="modal-section-content hide-from-toc">
   <% if (!xblockInfo.isVertical()) { %>
     <label class="label">
@@ -47,22 +29,25 @@
   <% } %>
   </div>
 </div>
-<% } else { %>
-  <div class="modal-section-content staff-lock">
-    <label class="label">
-        <input type="checkbox" id="staff_lock" name="staff_lock" class="input input-checkbox" />
-        <%- gettext('Hide from learners') %>
-     </label>
-    <% if (hasExplicitStaffLock && !ancestorLocked) { %>
-        <p class="tip tip-warning">
-          <% if (xblockInfo.isVertical()) { %>
-            <%- gettext('If the unit was previously published and released to learners, any changes you made to the unit when it was hidden will now be visible to learners.') %>
-          <% } else { %>
-            <% var message = gettext('If you make this %(xblockType)s visible to learners, learners will be able to see its content after the release date has passed and you have published the unit. Only units that are explicitly hidden from learners will remain hidden after you clear this option for the %(xblockType)s.') %>
-            <%- interpolate(message, { xblockType: xblockType }, true) %>
-          <% } %>
-        </p>
-    <% } %>
-</div>
 <% } %>
+<div class="modal-section-content staff-lock">
+  <label class="label">
+    <% var inputType = enableHideFromTOCUI ? 'radio' : 'checkbox'; %>
+      <input type="<%- inputType %>" id="staff_lock" name="content-visibility" class="<%- inputType === 'radio' ? 'input input-radio' : 'input input-checkbox' %>" />
+      <%- gettext('Hide from learners') %>
+    </label>
+  <% if (enableHideFromTOCUI) { %>
+    <p class='field-message' id='staff-lock-description'> <%- gettext('It is intentionally hidden from learners, ensuring that only the course staff can view its contents.') %> </p>
+  <% } %>
+  <% if (hasExplicitStaffLock && !ancestorLocked) { %>
+      <p class="tip tip-warning">
+        <% if (xblockInfo.isVertical()) { %>
+          <%- gettext('If the unit was previously published and released to learners, any changes you made to the unit when it was hidden will now be visible to learners.') %>
+        <% } else { %>
+          <% var message = gettext('If you make this %(xblockType)s visible to learners, learners will be able to see its content after the release date has passed and you have published the unit. Only units that are explicitly hidden from learners will remain hidden after you clear this option for the %(xblockType)s.') %>
+          <%- interpolate(message, { xblockType: xblockType }, true) %>
+        <% } %>
+      </p>
+  <% } %>
+</div>
 </form>

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -240,6 +240,13 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
 
+    hide_from_toc = Boolean(
+        display_name=_("Hide from Table of Contents"),
+        help=_("Enter true or false. If true, this block will be hidden from the Table of Contents."),
+        default=False,
+        scope=Scope.settings
+    )
+
     @property
     def close_date(self):
         """


### PR DESCRIPTION
## Description

This PR exposes the `hide_from_toc` xblock attribute so course authors can configure it as a section visibility option in Studio. Before this change, the Hide from TOC functionality was mainly used by OLX components. Hence, it wasn't available for configuration through the Studio UI. Still, its implementation existed in the platform and could be used by setting the attribute: `hide_from_toc=true` as part of the OLX definition. 

So we could use the `hide_from_toc` attribute in the Studio UI making it configurable for sections and their children, we did the following:

- Add `hide_from_toc` to the CMS Xblock handlers, serializers, and data classes so it can be recognized when setting the new visibility state option
-  Add it to the inheritance mixin so the sections' children recognize the configuration option
- Make it available in the backbone frontend for course authors to configure as in `visible_to_staff_only`

## Supporting information

These changes are part of the effort made to implement [feature enhancement proposal: Hide sections from course outline](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3853975595/Feature+Enhancement+Proposal+Hide+Sections+from+course+outline)

## Testing instructions

1. Move into this branch
2. Collect statics by running: `tutor dev exec lms openedx-assets build --env=dev`
3. Enable TOC UI by setting: `FEATURES["ENABLE_HIDE_FROM_TOC_UI"] = True` in your CMS environment, this will allow course staff to configure the hide from toc option from the Studio UI.
4. Given the error explained in the **Other information** section, please use: `CELERY_ALWAYS_EAGER = True` in both of your environments (LMS/CMS).
5. Go to a sections' course, click the configuration gear > Visibility > Hide in course outline
6. As an instructor, you should be able to see the hidden section with its children
7. As a student, you should be able to see the hidden subsections/units with the URL from the blocks' `View Live` option

https://github.com/openedx/edx-platform/assets/64440265/659c2bee-adbc-468a-a2ed-bf6c4ce0cbd8

## Deadline

This effort is part of the Spanish consortium project, so it'd be ideal to merge this before the end of the project.

## Other information

After deploying these changes to a tutor nightly remote installation, we found that the changes weren't reflected on the Course Outline after saving the new visibility changes for the 1st time. Now, the second time we save the changes are triggered. We don't have an explanation for it yet, but we're actively working on it. Here's a video of the behavior:

https://github.com/openedx/edx-platform/assets/64440265/3785ec67-50f6-4281-a2da-82b7c6dcf906

Update: This was solved by https://github.com/openedx/edx-platform/pull/34020, which is already under review.