### PR TITLE
docs: ADR for course data independence from libraries

### DIFF
--- a/openedx/core/djangoapps/content_libraries/docs/decisions/0001-index-libraries-in-elasticsearch.rst
+++ b/openedx/core/djangoapps/content_libraries/docs/decisions/0001-index-libraries-in-elasticsearch.rst
@@ -1,8 +1,8 @@
 1. Index libraries in elasticsearch
------------------------------------
+###################################
 
 Status
-------
+******
 
 **Revoked**
 
@@ -30,7 +30,7 @@ code.
 
 
 Context
--------
+*******
 
 The new content libraries reside in blockstore instead of edx-platform's models,
 which means that we are no longer able to query databases to get complete
@@ -46,7 +46,7 @@ This is a very inefficient way to fetch metadata for a list of
 libraries/xblocks, and makes it even harder to filter/query them.
 
 Decision
---------
+********
 
 Index the libraries and xblocks in elasticsearch to make them queryable. These
 indexes are updated whenever a library or XBlock is updated through the studio.
@@ -58,7 +58,7 @@ fallbacks have been implemented in case elastic is down or hasn't been enabled
 yet.
 
 Consequences
-------------
+************
 
 List APIs are significantly faster and are able to support filtering and
 searching now that the metadata can be queried using elasticsearch. This also

--- a/openedx/core/djangoapps/content_libraries/docs/decisions/0002-libraries-lti-provider.rst
+++ b/openedx/core/djangoapps/content_libraries/docs/decisions/0002-libraries-lti-provider.rst
@@ -1,18 +1,18 @@
 Allow content libraries to be used by LTI consumers
----------------------------------------------------
+###################################################
 
 Status
-------
+******
 
 Pending
 
 Context
--------
+*******
 
 Currently, there's no way for xblocks in blockstore-based content libraries to be served to other LTI consumers. This ADR explores ways in which this can be achieved, without overly complicating the codebase. The platform currently does have an :code:`lms.lti_provider` app which implements the LTI 1.1 spec, but it only works for modulestore-based courses, and the LTI 1.1 spec itself is also deprecated and deemed insecure.
 
 Decision
---------
+********
 
 We will use the latest LTI spec (`LTI 1.3`_) to serve the xblocks. This would be independent of the existing LTI 1.1 implementation, and will not require any changes in that app.
 
@@ -33,7 +33,7 @@ The rest of the functionality would be similar to how the current LTI 1.1 provid
 
 
 Consequences
-------------
+************
 
 Once implemented, content from blockstore-based libraries can be easily embedded into other LMS platforms. This is made easier by the fact that these libraries are designed to be embeddable, and can be easily rendered inside iframes. The library content can be used independently of courseware, are independent from course enrollments, and supports grading outside courses.  Including the ability to forward learner scoring via LTI.
 

--- a/openedx/core/djangoapps/content_libraries/docs/decisions/0003-course-content-independence.rst
+++ b/openedx/core/djangoapps/content_libraries/docs/decisions/0003-course-content-independence.rst
@@ -1,0 +1,48 @@
+3. Course Content should not depend on Library Content
+######################################################
+
+Status
+******
+
+Accepted
+
+
+Context
+*******
+
+When a course uses content from a library via a ``LibraryContentBlock``, it creates a course-local copy of the library's blocks. For each library block, it will also store certain metadata in the ModuleStore that connects the course copy with the original in the library, such as the usage key and version of the original, as well as the library-suggested values for various fields (e.g. ``num_attempts=10``).
+
+This metadata is not currently a part of the course export, and must be reconstructed by querying the library during the course import process. This causes a number of issues:
+
+#. The course might be imported into a site where the library does not exist, meaning that there's no way for us to figure out what the library-suggested values should be. This becomes a problem for any block which does not override its library-suggested value: the block will fall back to the block-type-suggested value, which is often not appropriate.
+#. The course might be imported into a site where a copy of the library exists, but the versions do not match. In this case, we currently just grab the latest library version metadata because we don't have anything else to go on.
+#. Studio Clipboard Copy & Paste functionality depends on serialization to OLX, so this metadata information is lost when an author tries to make copies of the content in other places.
+
+We have experienced a number of `serious bugs <https://openedx.atlassian.net/wiki/spaces/COMM/pages/3858661405/Bugs+from+Content+Libraries+V1#Issues-with-update_children>`_ because of this auto-sync behavior.
+
+Decision
+********
+
+Content that is stored in a Course should only have to query content in a Library in the following unavoidable circumstances:
+
+#. Initially picking the content that will be used (copied into) the Course.
+#. Checking to see if an updated version of the content is available.
+#. Updating the content copied into the Course with a more recent version stored in the Library (only done when a course author explicitly triggers it).
+
+In all other cases, the course copy of the content should be self-sufficient and should not require "syncing" to a library to fill in missing metadata. In particular, the following operations should be possible to do without querying the library:
+
+* Import and Export of courses within and across sites.
+* Copy/Paste/Duplicate of content within and across courses.
+
+Consequences
+************
+
+Technical:
+
+* We will need to serialize more metadata into the course export, probably by adding new fields to OLX. We will need to make this metadata available for library content operations in the XBlock runtime (ADRs to follow).
+* We will need to update Import/Copy-Paste/Duplicate to use this metadata rather triggering a library sync.
+
+User-facing:
+
+* This should remove a major source of bugs and confusion during the import process.
+* We should be able to begin preserving edits to library content during the Duplicate and Copy-Paste operations, which has been impossible as long as those operations have involved a library sync.


### PR DESCRIPTION
This is an ADR around the idea that course content should not need to sync metadata from libraries during the import process or when copy and pasting.