### PR TITLE
feat: expose `hide_from_toc` field in course blocks

### DIFF
--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -57,6 +57,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('has_scheduled_content'),
     SupportedFieldType('weight'),
     SupportedFieldType('show_correctness'),
+    SupportedFieldType('hide_from_toc'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),
     # 'student_view_multi_device'

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -54,6 +54,7 @@ class CourseBlockSerializer(serializers.Serializer):
                 'resume_block': block.get('resume_block', False),
                 'type': block_type,
                 'has_scheduled_content': block.get('has_scheduled_content'),
+                'hide_from_toc': block.get('hide_from_toc'),
             },
         }
         for child in children:

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -404,6 +404,16 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert response.status_code == 200
         assert response.data['user_has_passing_grade'] is True
 
+    def test_hide_from_toc_field(self):
+        """
+        Test that the hide_from_toc field is returned in the response.
+        """
+        CourseEnrollment.enroll(self.user, self.course.id)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        for block in response.data["course_blocks"]["blocks"].values():
+            assert "hide_from_toc" in block
+
     def assert_can_enroll(self, can_enroll):
         response = self.client.get(self.url)
         assert response.status_code == 200

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -115,6 +115,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
             'completion',
             'complete',
             'resume_block',
+            'hide_from_toc',
         ],
         allow_start_dates_in_future=allow_start_dates_in_future,
     )


### PR DESCRIPTION
## Description
This PR exposes the `hide_from_toc` field for course blocks (sections, sequences...) so it's visible as part of the course metadata.

This change is made to show instructors a message in the course outline for the hidden sections and their children. However, it can be used by any other client to obtain content visibility information.

## Supporting information

These changes are part of the effort made to implement [Feature Enhancement Proposal: Hide Sections from Course Outline](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3853975595/Feature+Enhancement+Proposal+Hide+Sections+from+course+outline)

## What Changed?

### /api/course_home/outline/{course-id}

This endpoint was updated to return the `hide_from_toc` field in the blocks of the course. The following is an example of the response:

```json
{
   ...
   "course_blocks": {
      "blocks": {
         "block-v1:eduNEXT+HFT+Demo+type@course+block@course": {
            "children": [
               "block-v1:eduNEXT+HFT+Demo+type@chapter+block@1d110f659c154377b6f764189cc7fa35"
            ],
            "complete": true,
            "description": null,
            "display_name": "Hide From TOC Course",
            "due": null,
            "effort_activities": 0,
            "effort_time": 1,
            "icon": null,
            "id": "block-v1:eduNEXT+HFT+Demo+type@course+block@course",
            "lms_web_url": "http://local.overhang.io:8000/courses/course-v1:eduNEXT+HFT+Demo/jump_to/block-v1:eduNEXT+HFT+Demo+type@course+block@course",
            "resume_block": true,
            "type": "course",
            "has_scheduled_content": null,
            "hide_from_toc": false
         },
         "block-v1:eduNEXT+HFT+Demo+type@chapter+block@1d110f659c154377b6f764189cc7fa35": {
            "children": [
               "block-v1:eduNEXT+HFT+Demo+type@sequential+block@4fbfd9bb42284431af028c812cc6bbd5"
            ],
            "complete": true,
            "description": null,
            "display_name": "Section",
            "due": null,
            "effort_activities": 0,
            "effort_time": 1,
            "icon": null,
            "id": "block-v1:eduNEXT+HFT+Demo+type@chapter+block@1d110f659c154377b6f764189cc7fa35",
            "lms_web_url": "http://local.overhang.io:8000/courses/course-v1:eduNEXT+HFT+Demo/jump_to/block-v1:eduNEXT+HFT+Demo+type@chapter+block@1d110f659c154377b6f764189cc7fa35",
            "resume_block": true,
            "type":" chapter",
            "has_scheduled_content": null,
            "hide_from_toc": false
         },
         "block-v1:eduNEXT+HFT+Demo+type@sequential+block@4fbfd9bb42284431af028c812cc6bbd5": {
            "children": [
               
            ],
            "complete": true,
            "description": null,
            "display_name": "Subsection",
            "due": null,
            "effort_activities": 0,
            "effort_time": 1,
            "icon": null,
            "id": "block-v1:eduNEXT+HFT+Demo+type@sequential+block@4fbfd9bb42284431af028c812cc6bbd5",
            "lms_web_url": "http://local.overhang.io:8000/courses/course-v1:eduNEXT+HFT+Demo/jump_to/block-v1:eduNEXT+HFT+Demo+type@sequential+block@4fbfd9bb42284431af028c812cc6bbd5",
            "resume_block": true,
            "type": "sequential",
            "has_scheduled_content": null,
            "hide_from_toc": false
         }
      }
   }
   ...
}
``` 

## Testing instructions

1. Move into this branch
2. Create your course with sections and subsections.
3. Using CURL you can test the endpoint. Replace the value of the variables with your values as appropriate:

    ```bash
    curl --location '{lms-domain}/api/course_home/outline/{course-id}' \
    --header 'Authorization: Bearer {access-token}'
    ```
   Another option is to go to the course outline in the URL: `{mfe-domain}/learning/course/{course-id}/home`. **Right-click** > **Inspect** > **Network**. Select the endpoint request and review the response.

    ![image](https://github.com/openedx/edx-platform/assets/64033729/77cc3e12-4ae3-44a6-b2fa-cc049c410623)
4. In all course blocks the `hide_from_toc` field should be set to `false`

## Deadline

This effort is part of the Spanish consortium project, so it'd be ideal to merge this before the end of the project.

