### PR TITLE
chore: bump ORA to 6.0.19

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -787,7 +787,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==6.0.17
+ora2==6.0.19
     # via -r requirements/edx/bundled.in
 packaging==23.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1324,7 +1324,7 @@ optimizely-sdk==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.0.17
+ora2==6.0.19
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -929,7 +929,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==6.0.17
+ora2==6.0.19
     # via -r requirements/edx/base.txt
 packaging==23.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -989,7 +989,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==6.0.17
+ora2==6.0.19
     # via -r requirements/edx/base.txt
 packaging==23.2
     # via


### PR DESCRIPTION
## Description

Bump ORA from [6.0.17 to 6.0.19](https://github.com/openedx/edx-ora2/compare/v6.0.17...v6.0.19)

## Deadline

ASAP