### PR TITLE
fix: manual scope typo

### DIFF
--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -180,7 +180,7 @@ class LibraryContentBlock(
         # True -> Draw selections from `candidates`.
         # False -> Draw selections from `children`.
         default=False,
-        cope=Scope.settings,
+        scope=Scope.settings,
     )
     # This cannot be called `show_reset_button`, because children blocks inherit this as a default value.
     allow_resetting_children = Boolean(


### PR DESCRIPTION
Fix for typo with library_content_block.py's manual field.