### PR TITLE
Add permission checks to role checks - discussion and course_live

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -134,9 +134,9 @@ def has_discussion_privileges(user, course_id):
         if user.id in user_ids:
             return True
     if user.has_perm(
-        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
     ) and user.has_perm(
-        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
     ):
         return True
     return False

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -134,9 +134,9 @@ def has_discussion_privileges(user, course_id):
         if user.id in user_ids:
             return True
     if user.has_perm(
-        "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
     ) and user.has_perm(
-        "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'"
+        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
     ):
         return True
     return False

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -29,6 +29,7 @@ from lms.djangoapps.discussion.django_comment_client.permissions import (
 )
 from lms.djangoapps.discussion.django_comment_client.settings import MAX_COMMENT_DEPTH
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.djangoapps.discussions.utils import (
     get_accessible_discussion_xblocks,
     get_accessible_discussion_xblocks_by_course_id,
@@ -126,11 +127,18 @@ def has_discussion_privileges(user, course_id):
     Returns:
       bool
     """
+    # TODO: remove user_ids check once course_roles is fully impelented and data is migrated
     roles = get_role_ids(course_id)
 
     for user_ids in roles.values():
         if user.id in user_ids:
             return True
+    if user.has_perm(
+        "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+    ) and user.has_perm(
+        "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'"
+    ):
+        return True
     return False
 
 

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -134,9 +134,9 @@ def has_discussion_privileges(user, course_id):
         if user.id in user_ids:
             return True
     if user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_id
     ) and user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name, course_id
     ):
         return True
     return False

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -365,11 +365,11 @@ def get_course(request, course_key):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         "is_course_staff": CourseStaffRole(course_key).has_user(request.user) or
         request.user.has_perm(
-            f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+            CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
         ),
         "is_course_admin": CourseInstructorRole(course_key).has_user(request.user) or
         request.user.has_perm(
-            f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+            CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
         ),
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
@@ -991,10 +991,10 @@ def get_thread_list(
         if (
             Role.user_has_role_for_course(request.user, course_key, allowed_roles) or
             request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
             ) or
             request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
             )
         ):
             try:

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -365,11 +365,11 @@ def get_course(request, course_key):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         "is_course_staff": CourseStaffRole(course_key).has_user(request.user) or
         request.user.has_perm(
-            CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
+            CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key
         ),
         "is_course_admin": CourseInstructorRole(course_key).has_user(request.user) or
         request.user.has_perm(
-            CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
+            CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key
         ),
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
@@ -991,10 +991,10 @@ def get_thread_list(
         if (
             Role.user_has_role_for_course(request.user, course_key, allowed_roles) or
             request.user.has_perm(
-                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key
             ) or
             request.user.has_perm(
-                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name, course_key
             )
         ):
             try:

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -40,6 +40,7 @@ from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE, ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE
 from lms.djangoapps.discussion.toggles_utils import reported_content_email_notification_enabled
 from lms.djangoapps.discussion.views import is_privileged_user
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
     DiscussionTopicLink,
@@ -361,8 +362,15 @@ def get_course(request, course_key):
         }),
         "is_group_ta": bool(user_roles & {FORUM_ROLE_GROUP_MODERATOR}),
         "is_user_admin": request.user.is_staff,
-        "is_course_staff": CourseStaffRole(course_key).has_user(request.user),
-        "is_course_admin": CourseInstructorRole(course_key).has_user(request.user),
+        # TODO: remove role checks once course_roles is fully impelented and data is migrated
+        "is_course_staff": CourseStaffRole(course_key).has_user(request.user) or
+            request.user.has_perm(
+                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+            ),
+        "is_course_admin": CourseInstructorRole(course_key).has_user(request.user) or
+            request.user.has_perm(
+                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+            ),
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
         "group_at_subsection": course_config.plugin_configuration.get("group_at_subsection", False),
@@ -979,7 +987,14 @@ def get_thread_list(
     ]
 
     if request.GET.get("group_id", None):
-        if Role.user_has_role_for_course(request.user, course_key, allowed_roles):
+        # TODO: remove role check once course_roles is fully impelented and data is migrated
+        if (Role.user_has_role_for_course(request.user, course_key, allowed_roles) or
+            request.user.has_perm(
+                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+            ) or
+            request.user.has_perm(
+                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'"
+            )):
             try:
                 group_id = int(request.GET.get("group_id", None))
             except ValueError:

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -364,13 +364,13 @@ def get_course(request, course_key):
         "is_user_admin": request.user.is_staff,
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         "is_course_staff": CourseStaffRole(course_key).has_user(request.user) or
-            request.user.has_perm(
-                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
-            ),
+        request.user.has_perm(
+            f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+        ),
         "is_course_admin": CourseInstructorRole(course_key).has_user(request.user) or
-            request.user.has_perm(
-                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
-            ),
+        request.user.has_perm(
+            f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+        ),
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
         "group_at_subsection": course_config.plugin_configuration.get("group_at_subsection", False),
@@ -988,13 +988,15 @@ def get_thread_list(
 
     if request.GET.get("group_id", None):
         # TODO: remove role check once course_roles is fully impelented and data is migrated
-        if (Role.user_has_role_for_course(request.user, course_key, allowed_roles) or
+        if (
+            Role.user_has_role_for_course(request.user, course_key, allowed_roles) or
             request.user.has_perm(
-                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
             ) or
             request.user.has_perm(
-                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'"
-            )):
+                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
+            )
+        ):
             try:
                 group_id = int(request.GET.get("group_id", None))
             except ValueError:

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -12,11 +12,11 @@ from common.djangoapps.student.roles import (
     CourseStaffRole,
     GlobalStaff,
 )
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from lms.djangoapps.discussion.django_comment_client.utils import (
     get_user_role_names,
     has_discussion_privileges,
 )
-from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
 from openedx.core.djangoapps.django_comment_common.models import (
@@ -162,9 +162,9 @@ class IsStaffOrCourseTeamOrEnrolled(permissions.BasePermission):
             CourseStaffRole(course_key).has_user(request.user) or
             CourseInstructorRole(course_key).has_user(request.user) or
             (request.user.has_perm(
-                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
             ) and request.user.has_perm(
-                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'"
+                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
             )) or
             CourseEnrollment.is_enrolled(request.user, course_key) or
             has_discussion_privileges(request.user, course_key)

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -162,9 +162,9 @@ class IsStaffOrCourseTeamOrEnrolled(permissions.BasePermission):
             CourseStaffRole(course_key).has_user(request.user) or
             CourseInstructorRole(course_key).has_user(request.user) or
             (request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
             ) and request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
             )) or
             CourseEnrollment.is_enrolled(request.user, course_key) or
             has_discussion_privileges(request.user, course_key)

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -161,10 +161,10 @@ class IsStaffOrCourseTeamOrEnrolled(permissions.BasePermission):
             GlobalStaff().has_user(request.user) or
             CourseStaffRole(course_key).has_user(request.user) or
             CourseInstructorRole(course_key).has_user(request.user) or
-            (request.user.has_perm(
-                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
-            ) and request.user.has_perm(
+            (request.user.has_perms([
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name,
                 CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
+            ], course_key
             )) or
             CourseEnrollment.is_enrolled(request.user, course_key) or
             has_discussion_privileges(request.user, course_key)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -758,8 +758,11 @@ def is_course_staff(course_key: CourseKey, user: User):
     Check if user has course instructor or course staff role.
     """
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    return (CourseInstructorRole(course_key).has_user(user) or CourseStaffRole(course_key).has_user(user) or
-        user.has_perm("f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"))
+    return (
+        CourseInstructorRole(course_key).has_user(user) or
+        CourseStaffRole(course_key).has_user(user) or
+        user.has_perm(f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}')
+    )
 
 
 def is_privileged_user(course_key: CourseKey, user: User):
@@ -777,9 +780,9 @@ def is_privileged_user(course_key: CourseKey, user: User):
     has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
     has_moderate_discussion_permissions = user.has_perm(
-        "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
     ) or user.has_perm(
-        "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'"
+        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
     )
     return GlobalStaff().has_user(user) or has_course_role or has_moderate_discussion_permissions
 
@@ -816,7 +819,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         is_educator_or_staff = (
             is_course_staff(course_key, request.user) or GlobalStaff().has_user(request.user) or
-            request.user.has_perm("f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_MODERATORS.value.name}'")
+            request.user.has_perm(f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_MODERATORS.value.name}')
         )
         try:
             base_context = _create_base_discussion_view_context(request, course_key)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -819,7 +819,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         is_educator_or_staff = (
             is_course_staff(course_key, request.user) or GlobalStaff().has_user(request.user) or
-            request.user.has_perm(CourseRolesPermission.MODERATE_DISCUSSION_MODERATORS.perm_name)
+            request.user.has_perm(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.perm_name)
         )
         try:
             base_context = _create_base_discussion_view_context(request, course_key)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -761,7 +761,7 @@ def is_course_staff(course_key: CourseKey, user: User):
     return (
         CourseInstructorRole(course_key).has_user(user) or
         CourseStaffRole(course_key).has_user(user) or
-        user.has_perm(f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}')
+        user.has_perm(CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name)
     )
 
 
@@ -780,9 +780,9 @@ def is_privileged_user(course_key: CourseKey, user: User):
     has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
     has_moderate_discussion_permissions = user.has_perm(
-        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
     ) or user.has_perm(
-        f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value.name}'
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
     )
     return GlobalStaff().has_user(user) or has_course_role or has_moderate_discussion_permissions
 
@@ -819,7 +819,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         is_educator_or_staff = (
             is_course_staff(course_key, request.user) or GlobalStaff().has_user(request.user) or
-            request.user.has_perm(f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_MODERATORS.value.name}')
+            request.user.has_perm(CourseRolesPermission.MODERATE_DISCUSSION_MODERATORS.perm_name)
         )
         try:
             base_context = _create_base_discussion_view_context(request, course_key)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -761,7 +761,7 @@ def is_course_staff(course_key: CourseKey, user: User):
     return (
         CourseInstructorRole(course_key).has_user(user) or
         CourseStaffRole(course_key).has_user(user) or
-        user.has_perm(CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name)
+        user.has_perm(CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key)
     )
 
 
@@ -780,9 +780,9 @@ def is_privileged_user(course_key: CourseKey, user: User):
     has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
     has_moderate_discussion_permissions = user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key
     ) or user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name
+        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name, course_key
     )
     return GlobalStaff().has_user(user) or has_course_role or has_moderate_discussion_permissions
 
@@ -819,7 +819,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         is_educator_or_staff = (
             is_course_staff(course_key, request.user) or GlobalStaff().has_user(request.user) or
-            request.user.has_perm(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.perm_name)
+            request.user.has_perm(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.perm_name, course_key)
         )
         try:
             base_context = _create_base_discussion_view_context(request, course_key)

--- a/openedx/core/djangoapps/course_live/permissions.py
+++ b/openedx/core/djangoapps/course_live/permissions.py
@@ -27,7 +27,7 @@ class IsStaffOrInstructor(BasePermission):
         return (
             CourseInstructorRole(course_key).has_user(request.user) or
             CourseStaffRole(course_key).has_user(request.user) or
-            request.user.has_perm(f'course_roles.{CourseRolesPermission.MANAGE_CONTENT.value.name}')
+            request.user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name)
         )
 
 
@@ -45,13 +45,13 @@ class IsEnrolledOrStaff(BasePermission):
 
         user_has_permissions = (
             request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.VIEW_ALL_CONTENT.value.name}'
+                CourseRolesPermission.VIEW_ALL_CONTENT.perm_name
             ) or
             request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.value.name}'
+                CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name
             ) or
             request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.value.name}'
+                CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name
             )
         )
         # TODO: remove role checks once course_roles is fully impelented and data is migrated

--- a/openedx/core/djangoapps/course_live/permissions.py
+++ b/openedx/core/djangoapps/course_live/permissions.py
@@ -27,7 +27,7 @@ class IsStaffOrInstructor(BasePermission):
         return (
             CourseInstructorRole(course_key).has_user(request.user) or
             CourseStaffRole(course_key).has_user(request.user) or
-            request.user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name)
+            request.user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name, course_key)
         )
 
 
@@ -45,13 +45,13 @@ class IsEnrolledOrStaff(BasePermission):
 
         user_has_permissions = (
             request.user.has_perm(
-                CourseRolesPermission.VIEW_ALL_CONTENT.perm_name
+                CourseRolesPermission.VIEW_ALL_CONTENT.perm_name, course_key
             ) or
             request.user.has_perm(
-                CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name
+                CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name, course_key
             ) or
             request.user.has_perm(
-                CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name
+                CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name, course_key
             )
         )
         # TODO: remove role checks once course_roles is fully impelented and data is migrated

--- a/openedx/core/djangoapps/course_live/tab.py
+++ b/openedx/core/djangoapps/course_live/tab.py
@@ -11,6 +11,7 @@ from lms.djangoapps.courseware.tabs import EnrolledTab
 from openedx.core.djangoapps.course_live.config.waffle import ENABLE_COURSE_LIVE
 from openedx.core.djangoapps.course_live.models import CourseLiveConfiguration
 from openedx.core.djangoapps.course_live.providers import HasGlobalCredentials, ProviderManager
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.lib.cache_utils import request_cached
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
 from openedx.features.lti_course_tab.tab import LtiCourseLaunchMixin
@@ -34,7 +35,23 @@ def user_is_staff_or_instructor(user: AbstractBaseUser, course: CourseBlock) -> 
     """
     Check if the user is a staff or instructor for the course.
     """
-    return CourseStaffRole(course.id).has_user(user) or CourseInstructorRole(course.id).has_user(user)
+    user_has_permissions = (
+        user.has_perm(
+            f'course_roles.{CourseRolesPermission.VIEW_ALL_CONTENT.value.name}'
+        ) or
+        user.has_perm(
+            f'course_roles.{CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.value.name}'
+        ) or
+        user.has_perm(
+            f'course_roles.{CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.value.name}'
+        )
+    )
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
+    return (
+        CourseStaffRole(course.id).has_user(user) or
+        CourseInstructorRole(course.id).has_user(user) or
+        user_has_permissions
+    )
 
 
 class CourseLiveTab(LtiCourseLaunchMixin, TabFragmentViewMixin, EnrolledTab):

--- a/openedx/core/djangoapps/course_live/tab.py
+++ b/openedx/core/djangoapps/course_live/tab.py
@@ -37,13 +37,13 @@ def user_is_staff_or_instructor(user: AbstractBaseUser, course: CourseBlock) -> 
     """
     user_has_permissions = (
         user.has_perm(
-            f'course_roles.{CourseRolesPermission.VIEW_ALL_CONTENT.value.name}'
+            CourseRolesPermission.VIEW_ALL_CONTENT.perm_name
         ) or
         user.has_perm(
-            f'course_roles.{CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.value.name}'
+            CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name
         ) or
         user.has_perm(
-            f'course_roles.{CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.value.name}'
+            CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name
         )
     )
     # TODO: remove role checks once course_roles is fully impelented and data is migrated

--- a/openedx/core/djangoapps/course_live/tab.py
+++ b/openedx/core/djangoapps/course_live/tab.py
@@ -37,13 +37,13 @@ def user_is_staff_or_instructor(user: AbstractBaseUser, course: CourseBlock) -> 
     """
     user_has_permissions = (
         user.has_perm(
-            CourseRolesPermission.VIEW_ALL_CONTENT.perm_name
+            CourseRolesPermission.VIEW_ALL_CONTENT.perm_name, course.id
         ) or
         user.has_perm(
-            CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name
+            CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name, course.id
         ) or
         user.has_perm(
-            CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name
+            CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name, course.id
         )
     )
     # TODO: remove role checks once course_roles is fully impelented and data is migrated

--- a/openedx/core/djangoapps/course_roles/permissions.py
+++ b/openedx/core/djangoapps/course_roles/permissions.py
@@ -5,9 +5,8 @@ Bridgekeeper permissions for course roles
 from bridgekeeper import perms
 from bridgekeeper.rules import is_staff
 
-from lms.djangoapps.courseware.rules import HasRolesRule
 from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
-from openedx.core.djangoapps.course_roles.rules import HasPermissionRule, HasForumsRolesRule
+from openedx.core.djangoapps.course_roles.rules import HasPermissionRule
 
 
 # DO NOT USE FOR AUTHORIZATION
@@ -17,89 +16,50 @@ from openedx.core.djangoapps.course_roles.rules import HasPermissionRule, HasFor
 perms['course_roles.is_staff'] = (
     is_staff
 )
-perms[CourseRolesPermission.MANAGE_CONTENT.perm_name] = (
-    HasRolesRule('staff', 'instructor')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_CONTENT)
-)
+perms[CourseRolesPermission.MANAGE_CONTENT.perm_name] = HasPermissionRule(CourseRolesPermission.MANAGE_CONTENT)
 perms[CourseRolesPermission.MANAGE_COURSE_SETTINGS.perm_name] = (
-    HasRolesRule('staff', 'instructor')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_COURSE_SETTINGS)
+    HasPermissionRule(CourseRolesPermission.MANAGE_COURSE_SETTINGS)
 )
 perms[CourseRolesPermission.MANAGE_ADVANCED_SETTINGS.perm_name] = (
-    HasRolesRule('staff', 'instructor')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_ADVANCED_SETTINGS)
+    HasPermissionRule(CourseRolesPermission.MANAGE_ADVANCED_SETTINGS)
 )
-perms[CourseRolesPermission.VIEW_ALL_CONTENT.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.VIEW_ALL_CONTENT)
-)
+perms[CourseRolesPermission.VIEW_ALL_CONTENT.perm_name] = HasPermissionRule(CourseRolesPermission.VIEW_ALL_CONTENT)
 perms[CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name] = (
-    HasRolesRule('beta_testers', 'ccx_coach')
-    | HasForumsRolesRule('administrator')
-    | HasPermissionRule(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT)
+    HasPermissionRule(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT)
 )
 perms[CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name] = (
     HasPermissionRule(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT)
 )
 perms[CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'ccx_coach', 'data_researcher', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD)
+    HasPermissionRule(CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD)
 )
 perms[CourseRolesPermission.ACCESS_DATA_DOWNLOADS.perm_name] = (
-    HasRolesRule('data_researcher')
-    | HasPermissionRule(CourseRolesPermission.ACCESS_DATA_DOWNLOADS)
+    HasPermissionRule(CourseRolesPermission.ACCESS_DATA_DOWNLOADS)
 )
-perms[CourseRolesPermission.MANAGE_GRADES.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'ccx_coach', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_GRADES)
-)
-perms[CourseRolesPermission.VIEW_GRADEBOOK.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.VIEW_GRADEBOOK)
-)
-perms[CourseRolesPermission.MANAGE_ALL_USERS.perm_name] = (
-    HasRolesRule('instructor')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_ALL_USERS)
-)
+perms[CourseRolesPermission.MANAGE_GRADES.perm_name] = HasPermissionRule(CourseRolesPermission.MANAGE_GRADES)
+perms[CourseRolesPermission.VIEW_GRADEBOOK.perm_name] = HasPermissionRule(CourseRolesPermission.VIEW_GRADEBOOK)
+perms[CourseRolesPermission.MANAGE_ALL_USERS.perm_name] = HasPermissionRule(CourseRolesPermission.MANAGE_ALL_USERS)
 perms[CourseRolesPermission.MANAGE_USERS_EXCEPT_ADMIN_AND_STAFF.perm_name] = (
-    HasRolesRule('staff', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_USERS_EXCEPT_ADMIN_AND_STAFF)
+    HasPermissionRule(CourseRolesPermission.MANAGE_USERS_EXCEPT_ADMIN_AND_STAFF)
 )
 perms[CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasForumsRolesRule('administrator')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS)
+    HasPermissionRule(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS)
 )
-perms[CourseRolesPermission.MANAGE_COHORTS.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_COHORTS)
-)
-perms[CourseRolesPermission.MANAGE_STUDENTS.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'ccx_coach', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_STUDENTS)
-)
+perms[CourseRolesPermission.MANAGE_COHORTS.perm_name] = HasPermissionRule(CourseRolesPermission.MANAGE_COHORTS)
+perms[CourseRolesPermission.MANAGE_STUDENTS.perm_name] = HasPermissionRule(CourseRolesPermission.MANAGE_STUDENTS)
 perms[CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasForumsRolesRule('administrator', 'moderator', 'community_ta')
-    | HasPermissionRule(CourseRolesPermission.MODERATE_DISCUSSION_FORUMS)
+    HasPermissionRule(CourseRolesPermission.MODERATE_DISCUSSION_FORUMS)
 )
 perms[CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasForumsRolesRule('administrator', 'moderator', 'group_moderator', 'community_ta')
-    | HasPermissionRule(CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT)
+    HasPermissionRule(CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT)
 )
 perms[CourseRolesPermission.MANAGE_CERTIFICATES.perm_name] = (
     HasPermissionRule(CourseRolesPermission.MANAGE_CERTIFICATES)
 )
-perms[CourseRolesPermission.MANAGE_LIBRARIES.perm_name] = (
-    HasRolesRule('library_user')
-    | HasPermissionRule(CourseRolesPermission.MANAGE_LIBRARIES)
-)
+perms[CourseRolesPermission.MANAGE_LIBRARIES.perm_name] = HasPermissionRule(CourseRolesPermission.MANAGE_LIBRARIES)
 perms[CourseRolesPermission.GENERAL_MASQUERADING.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.GENERAL_MASQUERADING)
+    HasPermissionRule(CourseRolesPermission.GENERAL_MASQUERADING)
 )
 perms[CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name] = (
-    HasRolesRule('staff', 'instructor', 'limited_staff')
-    | HasPermissionRule(CourseRolesPermission.SPECIFIC_MASQUERADING)
+    HasPermissionRule(CourseRolesPermission.SPECIFIC_MASQUERADING)
 )

--- a/openedx/core/djangoapps/discussions/permissions.py
+++ b/openedx/core/djangoapps/discussions/permissions.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import BasePermission
 
 from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff, CourseInstructorRole
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.lib.api.view_utils import validate_course_key
 
 DEFAULT_MESSAGE = "You're not authorized to perform this operation."
@@ -29,10 +30,13 @@ class IsStaffOrCourseTeam(BasePermission):
 
         if GlobalStaff().has_user(request.user):
             return True
-
+        # TODO: remove role checks once course_roles is fully impelented and data is migrated
         return (
             CourseInstructorRole(course_key).has_user(request.user) or
             CourseStaffRole(course_key).has_user(request.user) or
+            request.user.has_perm(
+                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+            ) or
             has_discussion_privileges(request.user, course_key)
         )
 

--- a/openedx/core/djangoapps/discussions/permissions.py
+++ b/openedx/core/djangoapps/discussions/permissions.py
@@ -35,7 +35,7 @@ class IsStaffOrCourseTeam(BasePermission):
             CourseInstructorRole(course_key).has_user(request.user) or
             CourseStaffRole(course_key).has_user(request.user) or
             request.user.has_perm(
-                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
             ) or
             has_discussion_privileges(request.user, course_key)
         )

--- a/openedx/core/djangoapps/discussions/permissions.py
+++ b/openedx/core/djangoapps/discussions/permissions.py
@@ -35,7 +35,7 @@ class IsStaffOrCourseTeam(BasePermission):
             CourseInstructorRole(course_key).has_user(request.user) or
             CourseStaffRole(course_key).has_user(request.user) or
             request.user.has_perm(
-                "f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'"
+                f'course_roles.{CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value.name}'
             ) or
             has_discussion_privileges(request.user, course_key)
         )

--- a/openedx/core/djangoapps/discussions/permissions.py
+++ b/openedx/core/djangoapps/discussions/permissions.py
@@ -35,7 +35,7 @@ class IsStaffOrCourseTeam(BasePermission):
             CourseInstructorRole(course_key).has_user(request.user) or
             CourseStaffRole(course_key).has_user(request.user) or
             request.user.has_perm(
-                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name
+                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key
             ) or
             has_discussion_privileges(request.user, course_key)
         )


### PR DESCRIPTION
## Description

This PR adds permissions checks alongside the existing roles checks for course level permissions in discussions and course_live. These permissions are designed to be assigned to course level roles that will be assigned to a user. 

This PR should have no immediate impact on any users. Later PRs will create new course_roles and migrate existing student_courseaccessrole user roles to the new course_roles user roles. Only after that time will these permissions grant access to discussions and course_live. 

## Supporting information

[course_roles tech spec](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3824648277/RBAC+Tech+Spec)


## Testing instructions

Testing will be completed on the feature branch once additional services have been updated to add permissions checks. Testing will involve creating a course_roles role and assigning it to a user. This user will then be used to confirm the correct access is granted to the user.

## Other information

This is a PR to a [feature branch](https://github.com/openedx/edx-platform/tree/CourseRoles). 
