### PR TITLE
feat: Course roles perm_name property in permissions enum

### DIFF
--- a/openedx/core/djangoapps/course_roles/data.py
+++ b/openedx/core/djangoapps/course_roles/data.py
@@ -162,3 +162,7 @@ class CourseRolesPermission(Enum):
         _("Specific Masquerading"),
         _("Can view the course as an Audit, Verified, Beta Tester, Master's track, username/email."),
     )
+
+    @property
+    def code(self):
+        return f'course_roles.{self.value.name}'

--- a/openedx/core/djangoapps/course_roles/data.py
+++ b/openedx/core/djangoapps/course_roles/data.py
@@ -164,5 +164,9 @@ class CourseRolesPermission(Enum):
     )
 
     @property
-    def code(self):
+    def perm_name(self):
+        """
+        The permission name with the course_roles prefix.
+        Example: course_roles.manage_content
+        """
         return f'course_roles.{self.value.name}'


### PR DESCRIPTION
Add the `perm_name` property to the permissions enum to make it easier to use them with the `has_perm` method of the `User` class.

example:
`user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name)`

instead of:
`user.has_perm(f'course_roles.{CourseRolesPermission.MANAGE_CONTENT.value.name}')`