### PR TITLE
fix: respect ENABLE_NEW_STRUCTURE_DISCUSSIONS flag in course import

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -464,7 +464,8 @@ def sync_discussion_settings(course_key, user):
             course.discussions_settings['provider_type'] = Provider.OPEN_EDX
             modulestore().update_item(course, user.id)
 
-        discussion_config.provider_type = Provider.OPEN_EDX
+            discussion_config.provider_type = Provider.OPEN_EDX
+
         discussion_config.enable_graded_units = discussion_settings['enable_graded_units']
         discussion_config.unit_level_visibility = discussion_settings['unit_level_visibility']
         discussion_config.save()


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR fixes an issue with the course import.

When a course is imported and `ENABLE_NEW_STRUCTURE_DISCUSSIONS` is disabled, it still sets `DiscussionsConfiguration.provider_type = openedx`

## Supporting information

https://github.com/mitodl/hq/issues/3076

## Testing instructions

- Checkout master branch
- Disable ENABLE_NEW_STRUCTURE_DISCUSSIONS at `/admin/waffle/flag/`
- Create a new course in studio.
- Verify that the provider_type is set to `legacy` at `/admin/discussions/discussionsconfiguration/`
- Add a new unit to the course content and verify that the discussions xBlock is available.
- Now, import a compressed file in this new course at `<studio_url>/import/<course_key>`
- Verify that the provider_type is **changed** to `openedx` at `/admin/discussions/discussionsconfiguration/` and it did not respect `ENABLE_NEW_STRUCTURE_DISCUSSIONS`.
- Discussion xBlock is also hidden while creating a unit.
- Now, checkout this branch and verify that the course import respected `ENABLE_NEW_STRUCTURE_DISCUSSIONS` and discussions xBlock is available before and after course import.