### PR TITLE
feat: include children info in xblock api

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -178,6 +178,16 @@ def handle_xblock(request, usage_key_string=None):
                         xblock, is_concise=True
                     )
                     return JsonResponse(ancestor_info)
+                elif "childrenInfo" in fields:
+                    xblock = get_xblock(usage_key, request.user)
+                    children_info = _create_xblock_child_info(
+                        xblock,
+                        course_outline=None,
+                        graders=None,
+                        include_children_predicate=ALWAYS,
+                        is_concise=True
+                    )
+                    return JsonResponse(children_info)
                 # TODO: pass fields to get_block_info and only return those
                 with modulestore().bulk_operations(usage_key.course_key):
                     response = get_block_info(get_xblock(usage_key, request.user))
@@ -845,25 +855,14 @@ def get_block_info(
                 modulestore().get_course(xblock.location.course_key, depth=None)
             )
 
-        # Note that children are returned for library_content blocks.
-        if category == "library_content":
-            xblock_info = create_xblock_info(
-                xblock,
-                data=data,
-                metadata=own_metadata(xblock),
-                include_ancestor_info=include_ancestor_info,
-                include_child_info=True,
-                include_children_predicate=ALWAYS
-            )
-        else:
-            xblock_info = create_xblock_info(
-                xblock,
-                data=data,
-                metadata=own_metadata(xblock),
-                include_ancestor_info=include_ancestor_info,
-                include_child_info=include_child_info,
-                include_children_predicate=include_children_predicate
-            )
+        # Note that children aren't being returned until we have a use case.
+        xblock_info = create_xblock_info(
+            xblock,
+            data=data,
+            metadata=own_metadata(xblock),
+            include_ancestor_info=include_ancestor_info,
+            include_children_predicate=include_children_predicate
+        )
         if include_publishing_info:
             add_container_page_publishing_info(xblock, xblock_info)
 

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -180,7 +180,11 @@ def handle_xblock(request, usage_key_string=None):
                     return JsonResponse(ancestor_info)
                 # TODO: pass fields to get_block_info and only return those
                 with modulestore().bulk_operations(usage_key.course_key):
-                    response = get_block_info(get_xblock(usage_key, request.user))
+                    response = get_block_info(
+                        get_xblock(usage_key, request.user),
+                        include_child_info=True,
+                        include_children_predicate=ALWAYS
+                    )
                     if "customReadToken" in fields:
                         parent_children = _get_block_parent_children(get_xblock(usage_key, request.user))
                         response.update(parent_children)
@@ -824,8 +828,9 @@ def get_block_info(
     xblock,
     rewrite_static_links=True,
     include_ancestor_info=False,
+    include_child_info=False,
     include_publishing_info=False,
-    include_children_predicate=False,
+    include_children_predicate=NEVER,
 ):
     """
     metadata, data, id representation of a leaf block fetcher.
@@ -849,6 +854,7 @@ def get_block_info(
             data=data,
             metadata=own_metadata(xblock),
             include_ancestor_info=include_ancestor_info,
+            include_child_info=include_child_info,
             include_children_predicate=include_children_predicate
         )
         if include_publishing_info:

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -834,7 +834,6 @@ def get_block_info(
     xblock,
     rewrite_static_links=True,
     include_ancestor_info=False,
-    include_child_info=False,
     include_publishing_info=False,
     include_children_predicate=NEVER,
 ):
@@ -843,7 +842,6 @@ def get_block_info(
     :param usage_key: A UsageKey
     """
     with modulestore().bulk_operations(xblock.location.course_key):
-        category = getattr(xblock, "category", "")
         data = getattr(xblock, "data", "")
         if rewrite_static_links:
             data = replace_static_urls(data, None, course_id=xblock.location.course_key)


### PR DESCRIPTION
This change will send children info for when the xblock api is called with `/xblock/{blockId}?fields=childrenInfo`. This was created to allow the Library Content Editor Block to access the blocks of its selected library. The frontend PR can be found here: https://github.com/openedx/frontend-lib-content-components/pull/411

Example:
GET `http://localhost:18010/xblock/block-v1:edX+DemoX+Demo_Course+type@library_content+block@10391c53c21b4f439c1f3aed3525be89?fields=childrenInfo`

returns:
```
{
  "children": [
    {
      "id": "block-v1:edX+DemoX+Demo_Course+type@html+block@ff2da4992821e87349f9",
      "display_name": "Text",
      "category": "html",
      "has_children": false
    }
  ]
}
```