### PR TITLE
feat: Add tags count for v2 library components

### DIFF
--- a/openedx/core/djangoapps/content_libraries/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/serializers.py
@@ -117,6 +117,7 @@ class LibraryXBlockMetadataSerializer(serializers.Serializer):
     # When creating a new XBlock in a library, the slug becomes the ID part of
     # the definition key and usage key:
     slug = serializers.CharField(write_only=True)
+    tags_count = serializers.IntegerField(read_only=True)
 
 
 class LibraryXBlockTypeSerializer(serializers.Serializer):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -103,7 +103,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.4.1
+openedx-learning==0.4.2
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -779,7 +779,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.4.1
+openedx-learning==0.4.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1311,7 +1311,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.4.1
+openedx-learning==0.4.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -921,7 +921,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.4.1
+openedx-learning==0.4.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -981,7 +981,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.4.1
+openedx-learning==0.4.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Includes content tags counts (including implicit) for Library V2 components in their metadata response.

## Supporting information

Related Tickets:
- Needed for https://github.com/openedx/frontend-app-library-authoring/pull/400

## Testing instructions

Follow the testing instructions on https://github.com/openedx/frontend-app-library-authoring/pull/400, specifically make sure the tags counts appear correctly.

---
Private-ref: [FAL-3599](https://tasks.opencraft.com/browse/FAL-3599)