### PR TITLE
feat: show message in visibility tab in subsections when hide from toc is enabled from ui

### DIFF
--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -131,7 +131,7 @@ describe('CourseOutlinePage', function() {
             group_access: {},
             user_partition_info: {},
             hide_from_toc: false,
-            enable_hide_from_toc_ui: true
+            enable_hide_from_toc_ui: true,
         }, options, {child_info: {children: children}});
     };
 

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -1192,7 +1192,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 AbstractVisibilityEditor.prototype.getContext.call(this),
                 {
                     hide_after_due: this.modelVisibility() === 'hide_after_due',
-                    self_paced: course.get('self_paced') === true
+                    self_paced: course.get('self_paced') === true,
+                    enable_hide_from_toc_ui: this.model.get('enable_hide_from_toc_ui'),
                 }
             );
         }

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -202,6 +202,33 @@
         min-height: 95px;
       }
 
+      .enable-hide-from-toc-container {
+        background: #E5F1F8;
+        padding: 20px 32px;
+        margin: 16px 0px;
+        border-radius: 10px;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+
+        .icon-message {
+          color: white;
+          background: #0075B4;
+          padding: 8px;
+          border-radius: 50%;
+          transform: rotate(90deg);
+          font-size: 16px;
+          height: 18px;
+          width: 20px;
+        }
+
+        .text-message {
+          padding: 0px 10px;
+          word-wrap: break-word;
+          font-weight: 500;
+        }
+      }
+
       .list-fields,
       .list-actions {
         display: inline-block;

--- a/cms/templates/js/content-visibility-editor.underscore
+++ b/cms/templates/js/content-visibility-editor.underscore
@@ -1,6 +1,12 @@
 <form>
 <h3 class="modal-section-title" id="content_visibility_label"><%- gettext('Subsection Visibility') %></h3>
 <div class="modal-section-content staff-lock">
+    <% if (enable_hide_from_toc_ui) { %>
+        <div class="enable-hide-from-toc-container">
+            <span class="icon fa fa-solid fa-link icon-message"></span>
+            <p class="text-message"><%- gettext('To hide the subsections and keep them accesible through links, you must adjust it from the section that contains them.') %></p>
+        </div>
+    <% } %>
     <div class="list-fields list-input content-visibility" role="group" aria-labelledby="content_visibility_label">
         <label class="label">
             <input class="input input-radio" name="content-visibility" type="radio" value="visible" aria-describedby="visible_description">


### PR DESCRIPTION
## Description
This PR shows a message in the visibility tab of the subsections when the Hide From TOC in UI is enabled. This is enabled with a Django setting flag used in [this PR](https://github.com/openedx/edx-platform/pull/33952)

## Supporting information

These changes are part of the effort made to implement [Feature Enhancement Proposal: Hide Sections from Course Outline](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3853975595/Feature+Enhancement+Proposal+Hide+Sections+from+course+outline)

## Screenshots
![image](https://github.com/openedx/edx-platform/assets/64033729/41f01743-51b8-4005-a7ac-a96c7b82c423)

## Dependencies
> [!IMPORTANT]
> This PR needs the changes made from [this PR](https://github.com/openedx/edx-platform/pull/33952), which includes the new section visibility option from Studio UI.

## Testing instructions

1. In your environment add a mount of `edx-platform` with `tutor mounts add <path/to/edx-platform>` 
2. Move into this branch with `git checkout bav/show-hft-message-in-visibility-tab-subsection`
3. Get the changes from [this PR](https://github.com/openedx/edx-platform/pull/33952) with `git rebase MJG/configurable-hide-from-toc`
4. Run `tutor dev exec lms openedx-assets build --env=dev` for regenerate the assets.
5. Create your course with sections and subsections.
6. In the subsection settings (⚙️) go to the **Visibility** tab, you should not see any change.
7. Now, add this setting in your environment: `FEATURES["ENABLE_HIDE_FROM_TOC_UI"] = True`
8. Run `tutor dev restart`
9. Go back to the subsection settings and see the new message.

## Deadline
This effort is part of the Spanish consortium project, so it'd be ideal to merge this before the end of the project.
