### PR TITLE
fix: Incorrect ORA assignment link in Dates tab

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -699,7 +699,7 @@ def _ora_assessment_to_assignment(
     date_config_type = block_data.get_xblock_field(ora_block, 'date_config_type', 'manual')
     assignment_type = block_data.get_xblock_field(ora_block, 'format', None)
     block_title = block_data.get_xblock_field(ora_block, 'title', _('Open Response Assessment'))
-    course_key = block_data.root_block_usage_key
+    block_key = block_data.root_block_usage_key
 
     # Steps with no "due" date, like staff or training, should not show up here
     assessment_step_due = assessment.get('start')
@@ -712,7 +712,7 @@ def _ora_assessment_to_assignment(
         extra_info = None
     elif date_config_type == 'course_end':
         assessment_start = None
-        assessment_due = block_data.get_xblock_field(course_key, 'end')
+        assessment_due = block_data.get_xblock_field(block_key, 'end')
         extra_info = None
     else:
         assessment_start, assessment_due = None, None
@@ -746,7 +746,7 @@ def _ora_assessment_to_assignment(
     now = datetime.now(pytz.UTC)
     assignment_released = not assessment_start or assessment_start < now
     if assignment_released:
-        url = reverse('jump_to', args=[course_key, ora_block])
+        url = reverse('jump_to', args=[block_key.course_key, ora_block])
 
     past_due = not complete and assessment_due and assessment_due < now
     first_component_block_id = str(ora_block)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Fixes the generated URL for ORA assignments in the Dates tab in Learning MFE. In the current behavior, the ORA assignment links are broken and throw a 404 because we are passing the block key instead of the course key in the `jump_to` URL.

More Details can be seen at https://github.com/openedx/edx-platform/pull/33118#discussion_r1423846632
Associated Ticket: https://github.com/mitodl/hq/issues/3093


Useful information to include:
- This bug affects every role

**Generated example Link:**

(Before): 
```
http://localhost:18000/courses/block-v1:Arbisoft+ARB_ORA_1+1+type@course+block@course/jump_to/block-v1:Arbisoft+ARB_ORA_1+1+type@openassessment+block@7c58ff39466744afa9646e2ac4f72ecb
```
(After): 
```
http://localhost:18000/courses/course-v1:Arbisoft+ARB_ORA_1+1/jump_to/block-v1:Arbisoft+ARB_ORA_1+1+type@openassessment+block@7c58ff39466744afa9646e2ac4f72ecb
```

Screenshot of where this is happening:

<img width="716" alt="Pasted Graphic copy1" src="https://github.com/openedx/edx-platform/assets/34372316/dc22b336-e311-4d3d-9ea0-ee0d16192dcc">


## Supporting information

Please read through https://github.com/openedx/edx-platform/pull/33118#discussion_r1423846632

## Testing instructions
- Create some Open Responses in a course through the studio
- Open the `Dates` tab in the Learning MFE
- You will see the ORA assessment links 
- Clicking the links should take the user to the correct unit and not to a 404 page

NOTE: I would recommend reproducing this first on the master branch

Please provide detailed step-by-step instructions for testing this change.

## Deadline

This is a user-facing bug, We should merge this soon.


## NOTE:

Once this is merged, I will also create a folloup backport PR to quince and other releases if needed.