### PR TITLE
fix: fix failing test due to 2024

### DIFF
--- a/openedx/features/survey_report/tests/test_query_methods.py
+++ b/openedx/features/survey_report/tests/test_query_methods.py
@@ -45,7 +45,11 @@ class TestSurveyReportCommands(ModuleStoreTestCase):
         """
         Test that get_unique_courses_offered returns the correct number of courses.
         """
-        course_overview = CourseOverviewFactory.create(id=self.first_course.id, start="2019-01-01", end="2024-01-01")
+        course_overview = CourseOverviewFactory.create(
+            id=self.first_course.id,
+            start=datetime.now() - timedelta(weeks=1),
+            end=datetime.now() + timedelta(weeks=1)
+        )
         CourseEnrollmentFactory.create(user=self.user, course_id=course_overview.id)
         CourseEnrollmentFactory.create(user=self.user1, course_id=course_overview.id)
         CourseEnrollmentFactory.create(user=self.user2, course_id=course_overview.id)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Fixes a test failing due to hard coded date/year.

## Supporting information

Fixes a test and uses datetime.now in place of hard-coded year.

## Testing instructions

All checks should pass.

## Deadline

Should be an urgent one as tests are failing for all the PRs.
