### PR TITLE
Add permission checks to role checks - courseware, learner home, teams, content

### DIFF
--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -222,12 +222,12 @@ class TestGetBlocksQueryCounts(TestGetBlocksQueryCountsBase):
             self._get_blocks(
                 course,
                 expected_mongo_queries=0,
-                expected_sql_queries=22 if with_storage_backing else 21,
+                expected_sql_queries=21 if with_storage_backing else 20,
             )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, True, 31),
-        (ModuleStoreEnum.Type.split, 2, False, 21),
+        (ModuleStoreEnum.Type.split, 2, True, 30),
+        (ModuleStoreEnum.Type.split, 2, False, 20),
     )
     @ddt.unpack
     def test_query_counts_uncached(self, store_type, expected_mongo_queries, with_storage_backing, num_sql_queries):

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -166,7 +166,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
         self.course.enable_subsection_gating = True
         self.setup_gated_section(self.blocks[gated_block_ref], self.blocks[gating_block_ref])
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             self.get_blocks_and_check_against_expected(self.user, expected_blocks_before_completion)
 
         # clear the request cache to simulate a new request
@@ -179,7 +179,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
             self.user,
         )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             self.get_blocks_and_check_against_expected(self.user, self.ALL_BLOCKS_EXCEPT_SPECIAL)
 
     def test_staff_access(self):

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -42,6 +42,7 @@ from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.mobile_api.models import IgnoreMobileAvailableFlagConfig
 from lms.djangoapps.courseware.toggles import course_is_invitation_only
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.features.course_duration_limits.access import check_course_expired
 from common.djangoapps.student import auth
 from common.djangoapps.student.models import CourseEnrollmentAllowed
@@ -83,7 +84,8 @@ def has_ccx_coach_role(user, course_key):
         ccx_id = course_key.ccx
         role = CourseCcxCoachRole(course_key)
 
-        if role.has_user(user):
+        # TODO: remove role check once course_roles is fully impelented and data is migrated
+        if role.has_user(user) or user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name):
             list_ccx = CustomCourseForEdX.objects.filter(
                 course_id=course_key.to_course_locator(),
                 coach=user
@@ -174,7 +176,12 @@ def has_staff_access_to_preview_mode(user, course_key):
     """
     has_admin_access_to_course = any(administrative_accesses_to_course_for_user(user, course_key))
 
-    return has_admin_access_to_course or is_masquerading_as_student(user, course_key)
+    # TODO: remove role check once course_roles is fully impelented and data is migrated
+    return (
+        has_admin_access_to_course or
+        is_masquerading_as_student(user, course_key) or
+        user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name)
+    )
 
 
 def _can_view_courseware_with_prerequisites(user, course):
@@ -721,12 +728,12 @@ def _has_access_to_course(user, access_level, course_key):
         return ACCESS_DENIED
 
     global_staff, staff_access, instructor_access = administrative_accesses_to_course_for_user(user, course_key)
-
+    permissions_access = user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name)
     if global_staff:
         debug("Allow: user.is_staff")
         return ACCESS_GRANTED
 
-    if access_level not in ('staff', 'instructor'):
+    if access_level not in ('staff', 'instructor') and not permissions_access:
         log.debug("Error in access._has_access_to_course access_level=%s unknown", access_level)
         debug("Deny: unknown access level")
         return ACCESS_DENIED
@@ -737,6 +744,10 @@ def _has_access_to_course(user, access_level, course_key):
 
     if instructor_access and access_level in ('staff', 'instructor'):
         debug("Allow: user has course instructor access")
+        return ACCESS_GRANTED
+    
+    if permissions_access:
+        debug("Allow: user has view all content permission")
         return ACCESS_GRANTED
 
     debug("Deny: user did not have correct access")
@@ -875,11 +886,19 @@ def is_mobile_available_for_user(user, block):
     Checks:
         mobile_available flag on the course
         Beta User and staff access overrides the mobile_available flag
+        Permission to view_all_published_content or
+        view_only_published_content overrides mobile_available flag
     Arguments:
         block (CourseBlock|CourseOverview): course or overview of course in question
     """
+    permissions_access = (
+        user.has_perm(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name) and
+        user.has_perm(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name)
+    )
+    # TODO: remove role check once course_roles is fully impelented and data is migrated
     return (
         auth.user_has_role(user, CourseBetaTesterRole(block.id))
+        or permissions_access
         or _has_staff_access_to_block(user, block, block.id)
         or _is_block_mobile_available(block)
     )

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -61,7 +61,7 @@ def adjust_start_date(user, days_early_for_beta, start, course_key):
     # TODO: remove role check once course_roles is fully impelented and data is migrated
     if (
         CourseBetaTesterRole(course_key).has_user(user) or
-        user.has_perm(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name)
+        user.has_perm(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name, course_key)
     ):
         debug("Adjust start time: user in beta role for %s", course_key)
         delta = timedelta(days_early_for_beta)

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -25,6 +25,7 @@ from lms.djangoapps.courseware.access_response import (
     StartDateError
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, COURSE_PRE_START_ACCESS_FLAG
 from xmodule.course_block import COURSE_VISIBILITY_PUBLIC  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.util.xmodule_django import get_current_request_hostname  # lint-amnesty, pylint: disable=wrong-import-order
@@ -57,7 +58,11 @@ def adjust_start_date(user, days_early_for_beta, start, course_key):
         # bail early if no beta testing is set up
         return start
 
-    if CourseBetaTesterRole(course_key).has_user(user):
+    # TODO: remove role check once course_roles is fully impelented and data is migrated
+    if (
+        CourseBetaTesterRole(course_key).has_user(user) or
+        user.has_perm(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name)
+    ):
         debug("Adjust start time: user in beta role for %s", course_key)
         delta = timedelta(days_early_for_beta)
         effective = start - delta

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -68,6 +68,7 @@ from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from lms.djangoapps.lms_xblock.runtime import UserTagsService, lms_wrappers_aside, lms_applicable_aside_types
 from lms.djangoapps.verify_student.services import XBlockVerificationService
 from openedx.core.djangoapps.bookmarks.api import BookmarksService
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.services import CreditService
 from openedx.core.djangoapps.util.user_utils import SystemUser
@@ -572,7 +573,15 @@ def prepare_runtime_for_user(
     block_wrappers.append(partial(course_expiration_wrapper, user))
     block_wrappers.append(partial(offer_banner_wrapper, user))
 
-    user_is_staff = bool(has_access(user, 'staff', course_id))
+    has_permission = (
+        user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name) and
+        user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name)
+    )
+    # TODO: remove role check once course_roles is fully impelented and data is migrated
+    user_is_staff = (
+        bool(has_access(user, 'staff', course_id)) or
+        has_permission
+    )
 
     if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):
         if user_is_staff or is_masquerading_as_specific_student(user, course_id):
@@ -582,6 +591,9 @@ def prepare_runtime_for_user(
             block_wrappers.append(partial(add_staff_markup, user, disable_staff_debug_info))
 
     store = modulestore()
+    # The user_is_staff, user_is_beta_test, and user_role cannot be removed until
+    # all x-blocks have been updated to use permissions, once they have been updated
+    # remove role check in favor of permissions checks
 
     services = {
         'fs': FSService(),
@@ -596,6 +608,10 @@ def prepare_runtime_for_user(
             # See the docstring of `DjangoXBlockUserService`.
             deprecated_anonymous_user_id=anonymous_id_for_user(user, None),
             request_country_code=user_location,
+            user_has_manage_content=user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name),
+            user_has_manage_grades=user.has_perm(CourseRolesPermission.MANAGE_GRADES.perm_name),
+            user_has_access_data_downloads=user.has_perm(CourseRolesPermission.ACCESS_DATA_DOWNLOADS.perm_name),
+            user_has_view_all_content=user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name)
         ),
         'verification': XBlockVerificationService(),
         'proctoring': ProctoringService(),

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -574,8 +574,10 @@ def prepare_runtime_for_user(
     block_wrappers.append(partial(offer_banner_wrapper, user))
 
     has_permission = (
-        user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name) and
-        user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name)
+        user.has_perms([
+            CourseRolesPermission.VIEW_ALL_CONTENT.perm_name,
+            CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name
+        ], course_id)
     )
     # TODO: remove role check once course_roles is fully impelented and data is migrated
     user_is_staff = (
@@ -608,10 +610,16 @@ def prepare_runtime_for_user(
             # See the docstring of `DjangoXBlockUserService`.
             deprecated_anonymous_user_id=anonymous_id_for_user(user, None),
             request_country_code=user_location,
-            user_has_manage_content=user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name),
-            user_has_manage_grades=user.has_perm(CourseRolesPermission.MANAGE_GRADES.perm_name),
-            user_has_access_data_downloads=user.has_perm(CourseRolesPermission.ACCESS_DATA_DOWNLOADS.perm_name),
-            user_has_view_all_content=user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name)
+            user_has_manage_content=user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name, course_id),
+            user_has_manage_grades=user.has_perm(CourseRolesPermission.MANAGE_GRADES.perm_name, course_id),
+            user_has_access_data_downloads=user.has_perm(
+                CourseRolesPermission.ACCESS_DATA_DOWNLOADS.perm_name,
+                course_id
+            ),
+            user_has_view_all_content=user.has_perm(
+                CourseRolesPermission.VIEW_ALL_CONTENT.perm_name,
+                course_id
+            )
         ),
         'verification': XBlockVerificationService(),
         'proctoring': ProctoringService(),

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -102,8 +102,8 @@ class MasqueradeView(View):
         # TODO: remove role check once course_roles is fully impelented and data is migrated
         is_staff = has_staff_roles(request.user, course_key)
         has_permissions = (
-            request.user.has_perm(CourseRolesPermission.GENERAL_MASQUERADING.perm_name) or
-            request.user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name)
+            request.user.has_perm(CourseRolesPermission.GENERAL_MASQUERADING.perm_name, course_key) or
+            request.user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name, course_key)
         )
         if not is_staff and not has_permissions:
             return JsonResponse({
@@ -174,8 +174,8 @@ class MasqueradeView(View):
         # TODO: remove role check once course_roles is fully impelented and data is migrated
         is_staff = has_staff_roles(request.user, course_key)
         has_permissions = (
-            request.user.has_perm(CourseRolesPermission.GENERAL_MASQUERADING.perm_name) or
-            request.user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name)
+            request.user.has_perm(CourseRolesPermission.GENERAL_MASQUERADING.perm_name, course_key) or
+            request.user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name, course_key)
         )
         if not is_staff and not has_permissions:
             return JsonResponse({
@@ -409,12 +409,12 @@ def check_content_start_date_for_masquerade_user(course_key, user, request, cour
         # TODO: remove role check once course_roles is fully impelented and data is migrated
         is_staff = has_staff_roles(user, course_key)
         has_permissions = (
-            user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name) and
+            user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name, course_key) and
             (
-                user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name) or
-                user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name) or
-                user.has_perm(CourseRolesPermission.VIEW_LIVE_AND_PUBLISHED_CONTENT.perm_name) or
-                user.has_perm(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name)
+                user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name, course_key) or
+                user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name, course_key) or
+                user.has_perm(CourseRolesPermission.VIEW_LIVE_AND_PUBLISHED_CONTENT.perm_name, course_key) or
+                user.has_perm(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name, course_key)
             )
         )
         if group_masquerade or (

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -20,6 +20,7 @@ from web_fragments.fragment import Fragment
 from xblock.runtime import KeyValueStore
 
 from common.djangoapps.course_modes.models import CourseMode
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from openedx.core.djangolib.markup import HTML
 from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITION_ID
@@ -98,8 +99,13 @@ class MasqueradeView(View):
         Retrieve data on the active and available masquerade options
         """
         course_key = CourseKey.from_string(course_key_string)
+        # TODO: remove role check once course_roles is fully impelented and data is migrated
         is_staff = has_staff_roles(request.user, course_key)
-        if not is_staff:
+        has_permissions = (
+            request.user.has_perm(CourseRolesPermission.GENERAL_MASQUERADING.perm_name) or
+            request.user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name)
+        )
+        if not is_staff and not has_permissions:
             return JsonResponse({
                 'success': False,
             })
@@ -165,8 +171,13 @@ class MasqueradeView(View):
         to CourseMasquerade objects.
         """
         course_key = CourseKey.from_string(course_key_string)
+        # TODO: remove role check once course_roles is fully impelented and data is migrated
         is_staff = has_staff_roles(request.user, course_key)
-        if not is_staff:
+        has_permissions = (
+            request.user.has_perm(CourseRolesPermission.GENERAL_MASQUERADING.perm_name) or
+            request.user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name)
+        )
+        if not is_staff and not has_permissions:
             return JsonResponse({
                 'success': False,
             })
@@ -395,8 +406,22 @@ def check_content_start_date_for_masquerade_user(course_key, user, request, cour
     if now < most_future_date and _is_masquerading:
         group_masquerade = is_masquerading_as_student(user, course_key)
         specific_student_masquerade = is_masquerading_as_specific_student(user, course_key)
+        # TODO: remove role check once course_roles is fully impelented and data is migrated
         is_staff = has_staff_roles(user, course_key)
-        if group_masquerade or (specific_student_masquerade and not is_staff):
+        has_permissions = (
+            user.has_perm(CourseRolesPermission.SPECIFIC_MASQUERADING.perm_name) and
+            (
+                user.has_perm(CourseRolesPermission.MANAGE_CONTENT.perm_name) or
+                user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name) or
+                user.has_perm(CourseRolesPermission.VIEW_LIVE_AND_PUBLISHED_CONTENT.perm_name) or
+                user.has_perm(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name)
+            )
+        )
+        if group_masquerade or (
+            specific_student_masquerade and (
+                not is_staff and not has_permissions
+            )
+        ):
             PageLevelMessages.register_warning_message(
                 request,
                 HTML(_('This user does not have access to this content because \

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -446,7 +446,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
         # * django_comment_client_role
         # * DiscussionsConfiguration
 
-        num_queries = 6
+        num_queries = 9
 
         for discussion in discussions:
             discussion_xblock = get_block_for_descriptor(
@@ -466,7 +466,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
 
             # query to check for provider_type
             # query to check waffle flag discussions.enable_new_structure_discussions
-            num_queries = 2
+            num_queries = 5
 
             html = fragment.content
             assert 'data-user-create-comment="false"' in html

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -153,8 +153,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert mock_block_structure_create.call_count == 1
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, 49, True),
-        (ModuleStoreEnum.Type.split, 2, 49, False),
+        (ModuleStoreEnum.Type.split, 2, 48, True),
+        (ModuleStoreEnum.Type.split, 2, 48, False),
     )
     @ddt.unpack
     def test_query_counts(self, default_store, num_mongo_calls, num_sql_calls, create_multiple_subsections):
@@ -165,7 +165,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                     self._apply_recalculate_subsection_grade()
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, 49),
+        (ModuleStoreEnum.Type.split, 2, 48),
     )
     @ddt.unpack
     def test_query_counts_dont_change_with_more_content(self, default_store, num_mongo_calls, num_sql_calls):
@@ -210,7 +210,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, 49),
+        (ModuleStoreEnum.Type.split, 2, 48),
     )
     @ddt.unpack
     def test_persistent_grades_on_course(self, default_store, num_mongo_queries, num_sql_queries):

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -333,7 +333,7 @@ def check_course_access(user, course_enrollments):
                 administrative_accesses_to_course_for_user(
                     user, course_enrollment.course_id
                 ) or
-                user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name)
+                user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name, course_enrollment.course_id)
             ),
         }
 

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -53,6 +53,7 @@ from lms.djangoapps.learner_home.utils import (
     get_masquerade_user,
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -327,10 +328,12 @@ def check_course_access(user, course_enrollments):
             "is_too_early_to_view": not check_course_open_for_learner(
                 user, course_enrollment.course
             ),
+            # TODO: remove role checks once course_roles is fully impelented and data is migrated
             "user_has_staff_access": any(
                 administrative_accesses_to_course_for_user(
                     user, course_enrollment.course_id
-                )
+                ) or
+                user.has_perm(CourseRolesPermission.VIEW_ALL_CONTENT.perm_name)
             ),
         }
 

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -16,6 +16,7 @@ from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRol
 from lms.djangoapps.courseware.courses import has_access
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.lib.teams_config import TeamsetType
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -144,6 +145,9 @@ def has_course_staff_privileges(user, course_key):
         return True
     if CourseInstructorRole(course_key).has_user(user):
         return True
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
+    if user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name):
+        return True
     return False
 
 
@@ -160,6 +164,7 @@ def has_team_api_access(user, course_key, access_username=None):
     Returns:
       bool: True if the user has access, False otherwise.
     """
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
     if has_course_staff_privileges(user, course_key):
         return True
     if has_discussion_privileges(user, course_key):

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -165,7 +165,10 @@ def has_team_api_access(user, course_key, access_username=None):
       bool: True if the user has access, False otherwise.
     """
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    if has_course_staff_privileges(user, course_key):
+    if (
+        has_course_staff_privileges(user, course_key) or
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+    ):
         return True
     if has_discussion_privileges(user, course_key):
         return True
@@ -181,7 +184,11 @@ def user_organization_protection_status(user, course_key):
     If the user is a staff of the course, we return the protection_exempt status
     else, we return the unprotected status
     """
-    if has_course_staff_privileges(user, course_key):
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
+    if (
+        has_course_staff_privileges(user, course_key) or
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+    ):
         return OrganizationProtectionStatus.protection_exempt
     enrollment = CourseEnrollment.get_enrollment(user, course_key)
     if enrollment and enrollment.is_active:
@@ -205,8 +212,13 @@ def has_specific_team_access(user, team):
         - be in the correct bubble
         - be in the team if it is private
     """
-    return has_course_staff_privileges(user, team.course_id) or (
-        user_protection_status_matches_team(user, team) and user_on_team_or_team_is_public(user, team)
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
+    user_has_manage_student_permission = user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+    return (
+        has_course_staff_privileges(user, team.course_id) or
+        user_has_manage_student_permission or (
+            user_protection_status_matches_team(user, team) and user_on_team_or_team_is_public(user, team)
+        )
     )
 
 
@@ -216,8 +228,13 @@ def has_specific_teamset_access(user, course_block, teamset_id):
     All non-staff users have access to open and public_managed teamsets.
     Non-staff users only have access to a private_managed teamset if they are in a team in that teamset
     """
-    return has_course_staff_privileges(user, course_block.id) or \
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
+    user_has_manage_student_permission = user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+    return (
+        has_course_staff_privileges(user, course_block.id) or
+        user_has_manage_student_permission or \
         teamset_is_public_or_user_is_on_team_in_teamset(user, course_block, teamset_id)
+    )
 
 
 def teamset_is_public_or_user_is_on_team_in_teamset(user, course_block, teamset_id):
@@ -327,9 +344,11 @@ def can_user_modify_team(user, team):
 
     Assumes that user is enrolled in course run.
     """
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
     return (
         (not is_instructor_managed_team(team)) or
-        has_course_staff_privileges(user, team.course_id)
+        has_course_staff_privileges(user, team.course_id) or
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
     )
 
 
@@ -339,9 +358,11 @@ def can_user_create_team_in_topic(user, course_id, topic_id):
 
     Assumes that user is enrolled in course run.
     """
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
     return (
         (not is_instructor_managed_topic(course_id, topic_id)) or
-        has_course_staff_privileges(user, course_id)
+        has_course_staff_privileges(user, course_id) or
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
     )
 
 
@@ -406,7 +427,11 @@ def anonymous_user_ids_for_team(user, team):
     if not user or not team:
         raise Exception("User and team must be provided for ID lookup")
 
-    if not has_course_staff_privileges(user, team.course_id) and not user_is_a_team_member(user, team):
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
+    if (
+        not has_course_staff_privileges(user, team.course_id) and not
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+    ) and not user_is_a_team_member(user, team):
         raise Exception("User {user} is not permitted to access team info for {team}".format(
             user=user.username,
             team=team.team_id

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -146,7 +146,7 @@ def has_course_staff_privileges(user, course_key):
     if CourseInstructorRole(course_key).has_user(user):
         return True
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    if user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name):
+    if user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, course_key):
         return True
     return False
 
@@ -167,7 +167,7 @@ def has_team_api_access(user, course_key, access_username=None):
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
     if (
         has_course_staff_privileges(user, course_key) or
-        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, course_key)
     ):
         return True
     if has_discussion_privileges(user, course_key):
@@ -187,7 +187,7 @@ def user_organization_protection_status(user, course_key):
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
     if (
         has_course_staff_privileges(user, course_key) or
-        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, course_key)
     ):
         return OrganizationProtectionStatus.protection_exempt
     enrollment = CourseEnrollment.get_enrollment(user, course_key)
@@ -213,7 +213,7 @@ def has_specific_team_access(user, team):
         - be in the team if it is private
     """
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    user_has_manage_student_permission = user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+    user_has_manage_student_permission = user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, team.course_id)
     return (
         has_course_staff_privileges(user, team.course_id) or
         user_has_manage_student_permission or (
@@ -229,10 +229,10 @@ def has_specific_teamset_access(user, course_block, teamset_id):
     Non-staff users only have access to a private_managed teamset if they are in a team in that teamset
     """
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    user_has_manage_student_permission = user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+    user_has_manage_student_permission = user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, course_block.id)
     return (
         has_course_staff_privileges(user, course_block.id) or
-        user_has_manage_student_permission or \
+        user_has_manage_student_permission or
         teamset_is_public_or_user_is_on_team_in_teamset(user, course_block, teamset_id)
     )
 
@@ -348,7 +348,7 @@ def can_user_modify_team(user, team):
     return (
         (not is_instructor_managed_team(team)) or
         has_course_staff_privileges(user, team.course_id) or
-        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, team.course_id)
     )
 
 
@@ -362,7 +362,7 @@ def can_user_create_team_in_topic(user, course_id, topic_id):
     return (
         (not is_instructor_managed_topic(course_id, topic_id)) or
         has_course_staff_privileges(user, course_id) or
-        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, course_id)
     )
 
 
@@ -430,7 +430,7 @@ def anonymous_user_ids_for_team(user, team):
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
     if (
         not has_course_staff_privileges(user, team.course_id) and not
-        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, team.course_id)
     ) and not user_is_a_team_member(user, team):
         raise Exception("User {user} is not permitted to access team info for {team}".format(
             user=user.username,

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -164,11 +164,7 @@ def has_team_api_access(user, course_key, access_username=None):
     Returns:
       bool: True if the user has access, False otherwise.
     """
-    # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    if (
-        has_course_staff_privileges(user, course_key) or
-        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, course_key)
-    ):
+    if has_course_staff_privileges(user, course_key):
         return True
     if has_discussion_privileges(user, course_key):
         return True

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -251,7 +251,8 @@ class BulkTeamCountTopicSerializerTestCase(BaseTopicSerializerTestCase):
         request = RequestFactory().get('/api/team/v0/topics')
         request.user = self.user
 
-        with self.assertNumQueries(num_queries + 2):  # num_queries on teams tables, plus 2 split modulestore queries
+        with self.assertNumQueries(num_queries + 3):
+            # num_queries on teams tables, plus 2 split modulestore queries, plus a perms query
             serializer = self.serializer(
                 topics,
                 context={

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -33,6 +33,7 @@ from common.djangoapps.util.model_utils import truncate_fields
 from lms.djangoapps.courseware.courses import get_course_with_access, has_access
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser, BearerAuthentication
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.permissions import IsCourseStaffInstructor, IsStaffOrReadOnly
@@ -1070,7 +1071,9 @@ def _filter_hidden_private_teamsets(user, teamsets, course_block):
     Return a filtered list of teamsets, removing any private teamsets that a user doesn't have access to.
     Follows the same logic as `has_specific_teamset_access` but in bulk rather than for one teamset at a time
     """
-    if has_course_staff_privileges(user, course_block.id):
+    # TODO: remove role checks once course_roles is fully impelented and data is migrated
+    if (has_course_staff_privileges(user, course_block.id) or
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)):
         return teamsets
     private_teamset_ids = [teamset.teamset_id for teamset in course_block.teamsets if teamset.is_private_managed]
     teamset_ids_user_has_access_to = set(
@@ -1384,7 +1387,11 @@ class MembershipListView(ExpandableFieldViewMixin, GenericAPIView):
                     status=status.HTTP_404_NOT_FOUND
                 )
             teamset_teams = CourseTeam.objects.filter(course_id=requested_course_key, topic_id=teamset_id)
-            if has_course_staff_privileges(request.user, requested_course_key):
+            # TODO: remove role checks once course_roles is fully impelented and data is migrated
+            if (
+                has_course_staff_privileges(request.user, requested_course_key) or
+                request.user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+            ):
                 teams_with_access = list(teamset_teams)
             else:
                 teams_with_access = [
@@ -1689,7 +1696,11 @@ class MembershipBulkManagementView(GenericAPIView):
         """
         Raises 403 if user does not have access to this endpoint.
         """
-        if not has_course_staff_privileges(self.request.user, self.course.id):
+        # TODO: remove role checks once course_roles is fully impelented and data is migrated
+        if not (
+            has_course_staff_privileges(self.request.user, self.course.id) or
+            self.request.user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+        ):
             raise PermissionDenied(
                 "To manage team membership of {}, you must be course staff.".format(
                     self.course.id

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -1072,8 +1072,10 @@ def _filter_hidden_private_teamsets(user, teamsets, course_block):
     Follows the same logic as `has_specific_teamset_access` but in bulk rather than for one teamset at a time
     """
     # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    if (has_course_staff_privileges(user, course_block.id) or
-        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)):
+    if (
+        has_course_staff_privileges(user, course_block.id) or
+        user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, course_block.id)
+    ):
         return teamsets
     private_teamset_ids = [teamset.teamset_id for teamset in course_block.teamsets if teamset.is_private_managed]
     teamset_ids_user_has_access_to = set(
@@ -1390,7 +1392,7 @@ class MembershipListView(ExpandableFieldViewMixin, GenericAPIView):
             # TODO: remove role checks once course_roles is fully impelented and data is migrated
             if (
                 has_course_staff_privileges(request.user, requested_course_key) or
-                request.user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+                request.user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, requested_course_key)
             ):
                 teams_with_access = list(teamset_teams)
             else:
@@ -1699,7 +1701,7 @@ class MembershipBulkManagementView(GenericAPIView):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         if not (
             has_course_staff_privileges(self.request.user, self.course.id) or
-            self.request.user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name)
+            self.request.user.has_perm(CourseRolesPermission.MANAGE_STUDENTS.perm_name, self.course.id)
         ):
             raise PermissionDenied(
                 "To manage team membership of {}, you must be course staff.".format(

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
@@ -12,6 +12,8 @@ from openedx.core import types
 from common.djangoapps.student.auth import user_has_role
 from common.djangoapps.student.roles import CourseBetaTesterRole
 
+from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
+
 from ...data import ScheduleData, ScheduleItemData, UserCourseOutlineData
 from .base import OutlineProcessor
 
@@ -60,7 +62,13 @@ class ScheduleOutlineProcessor(OutlineProcessor):
         course_usage_key = self.course_key.make_usage_key('course', 'course')
         self._course_start = self.keys_to_schedule_fields[course_usage_key].get('start')
         self._course_end = self.keys_to_schedule_fields[course_usage_key].get('end')
-        self._is_beta_tester = user_has_role(self.user, CourseBetaTesterRole(self.course_key))
+        # TODO: remove role checks once course_roles is fully impelented and data is migrated
+        self._is_beta_tester = (
+            user_has_role(self.user, CourseBetaTesterRole(self.course_key)) or
+            self.user.has_perm(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name) or
+            self.user.has_perm(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name)
+        )
+
 
     def inaccessible_sequences(self, full_course_outline):
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
@@ -65,10 +65,9 @@ class ScheduleOutlineProcessor(OutlineProcessor):
         # TODO: remove role checks once course_roles is fully impelented and data is migrated
         self._is_beta_tester = (
             user_has_role(self.user, CourseBetaTesterRole(self.course_key)) or
-            self.user.has_perm(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name) or
-            self.user.has_perm(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name)
+            self.user.has_perm(CourseRolesPermission.VIEW_ALL_PUBLISHED_CONTENT.perm_name, self.course_key) or
+            self.user.has_perm(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name, self.course_key)
         )
-
 
     def inaccessible_sequences(self, full_course_outline):
         """

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -274,7 +274,7 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
     def test_schedule_context(self):
         resolver = self.create_resolver()
         # using this to make sure the select_related stays intact
-        with self.assertNumQueries(38):
+        with self.assertNumQueries(50):
             sc = resolver.get_schedules()
             schedules = list(sc)
         apple_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/store_apple_229x78.jpg'

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -1190,9 +1190,10 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
             self.user, blocks_dict['not_graded_1'], course['course'].id
         ) is None
 
-    @patch.object(ContentTypeGatingService, '_get_user', return_value=UserFactory.build())
+    @patch.object(ContentTypeGatingService, '_get_user')
     def test_check_children_for_content_type_gating_paywall(self, mocked_user):  # pylint: disable=unused-argument
         ''' Verify that the method returns a content type gate when appropriate '''
+        mocked_user.return_value = self.user
         course = self._create_course()
         blocks_dict = course['blocks']
         CourseEnrollmentFactory.create(

--- a/openedx/features/content_type_gating/tests/test_models.py
+++ b/openedx/features/content_type_gating/tests/test_models.py
@@ -75,7 +75,7 @@ class TestContentTypeGatingConfig(CacheIsolationTestCase):  # pylint: disable=mi
         user = self.user
         course_key = self.course_overview.id
 
-        query_count = 15
+        query_count = 12
 
         with self.assertNumQueries(query_count):
             enabled = ContentTypeGatingConfig.enabled_for_enrollment(

--- a/openedx/features/course_duration_limits/tests/test_models.py
+++ b/openedx/features/course_duration_limits/tests/test_models.py
@@ -78,7 +78,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         user = self.user
         course_key = self.course_overview.id  # lint-amnesty, pylint: disable=unused-variable
 
-        query_count = 15
+        query_count = 12
 
         with self.assertNumQueries(query_count):
             enabled = CourseDurationLimitConfig.enabled_for_enrollment(user, self.course_overview)


### PR DESCRIPTION
### Description
This PR adds permissions checks alongside the existing roles checks for course level permissions in courseware, learner_home, teams, and content. These permissions are designed to be assigned to course level roles that will be assigned to a user.

This PR should have no immediate impact on any users. Later PRs will create new course_roles and migrate existing student_courseaccessrole user roles to the new course_roles user roles. Only after that time will these permissions grant access to courseware, learner_home, teams, and content.

### Supporting information
[course_roles tech spec](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3824648277/RBAC+Tech+Spec)

### Testing instructions
Testing will be completed on the feature branch once additional services have been updated to add permissions checks. Testing will involve creating a course_roles role and assigning it to a user. This user will then be used to confirm the correct access is granted to the user.

### Other information
This is a PR to a [feature branch](https://github.com/openedx/edx-platform/tree/CourseRoles).