### PR TITLE
fix: Update the date to the max year possible in a test.

### DIFF
--- a/openedx/features/survey_report/tests/test_query_methods.py
+++ b/openedx/features/survey_report/tests/test_query_methods.py
@@ -45,7 +45,7 @@ class TestSurveyReportCommands(ModuleStoreTestCase):
         """
         Test that get_unique_courses_offered returns the correct number of courses.
         """
-        course_overview = CourseOverviewFactory.create(id=self.first_course.id, start="2019-01-01", end="2024-01-01")
+        course_overview = CourseOverviewFactory.create(id=self.first_course.id, start="2019-01-01", end="9999-01-01")
         CourseEnrollmentFactory.create(user=self.user, course_id=course_overview.id)
         CourseEnrollmentFactory.create(user=self.user1, course_id=course_overview.id)
         CourseEnrollmentFactory.create(user=self.user2, course_id=course_overview.id)


### PR DESCRIPTION
This test broke on January 1, 2024. This is Python's MAXYEAR for datetimes. Seems safer.