### PR TITLE
Tagging: serialize object permissions to REST API [FC-0036]

### DIFF
--- a/openedx/core/djangoapps/content_tagging/api.py
+++ b/openedx/core/djangoapps/content_tagging/api.py
@@ -3,8 +3,6 @@ Content Tagging APIs
 """
 from __future__ import annotations
 
-from typing import Iterator
-
 import openedx_tagging.core.tagging.api as oel_tagging
 from django.db.models import Q, QuerySet, Exists, OuterRef
 from openedx_tagging.core.tagging.models import Taxonomy
@@ -101,7 +99,7 @@ def get_taxonomies_for_org(
     return oel_tagging.get_taxonomies(enabled=enabled).filter(
         Exists(
             TaxonomyOrg.get_relationships(
-                taxonomy=OuterRef("pk"),
+                taxonomy=OuterRef("pk"),  # type: ignore
                 rel_type=TaxonomyOrg.RelType.OWNER,
                 org_short_name=org_short_name,
             )
@@ -130,7 +128,7 @@ def get_unassigned_taxonomies(enabled=True) -> QuerySet:
 def get_content_tags(
     object_key: ContentKey,
     taxonomy_id: int | None = None,
-) -> Iterator[ContentObjectTag]:
+) -> QuerySet:
     """
     Generates a list of content tags for a given object.
 
@@ -147,7 +145,7 @@ def tag_content_object(
     object_key: ContentKey,
     taxonomy: Taxonomy,
     tags: list,
-) -> Iterator[ContentObjectTag]:
+) -> QuerySet:
     """
     This is the main API to use when you want to add/update/delete tags from a content object (e.g. an XBlock or
     course).

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
@@ -81,11 +81,11 @@ class TaxonomyOrgView(TaxonomyView):
         serializer.instance = create_taxonomy(**serializer.validated_data, orgs=user_admin_orgs)
 
     @action(detail=False, url_path="import", methods=["post"])
-    def create_import(self, request: Request, **kwargs) -> Response:
+    def create_import(self, request: Request, **kwargs) -> Response:  # type: ignore
         """
         Creates a new taxonomy with the given orgs and imports the tags from the uploaded file.
         """
-        response = super().create_import(request, **kwargs)
+        response = super().create_import(request=request, **kwargs)  # type: ignore
 
         # If creation was successful, set the orgs for the new taxonomy
         if status.is_success(response.status_code):

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -219,7 +219,7 @@ def can_change_object_tag_objectid(user: UserType, object_id: str) -> bool:
     Everyone that has permission to edit the object should be able to tag it.
     """
     if not object_id:
-        raise ValueError("object_id must be provided")
+        return True
     try:
         usage_key = UsageKey.from_string(object_id)
         if not usage_key.course_key.is_course:
@@ -274,7 +274,7 @@ def can_change_taxonomy_tag(user: UserType, tag: oel_tagging.Tag | None = None) 
     return oel_tagging.is_taxonomy_admin(user) and (
         not tag
         or not taxonomy
-        or (taxonomy and not taxonomy.allow_free_text and not taxonomy.system_defined)
+        or (bool(taxonomy) and not taxonomy.allow_free_text and not taxonomy.system_defined)
     )
 
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -103,7 +103,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.4.2
+git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions#egg=openedx-learning==0.4.3
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -103,7 +103,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions#egg=openedx-learning==0.4.3
+git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions#egg=openedx-learning==0.4.4
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -103,7 +103,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions#egg=openedx-learning==0.4.4
+openedx-learning==0.4.4
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -779,7 +779,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.4.2
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -779,7 +779,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
+openedx-learning==0.4.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1311,7 +1311,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.4.2
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1311,7 +1311,7 @@ openedx-filters==1.6.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
+openedx-learning==0.4.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -921,7 +921,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
+openedx-learning==0.4.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -921,7 +921,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.4.2
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -981,7 +981,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
+openedx-learning==0.4.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -981,7 +981,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.4.2
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/serialize-permissions
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Updates the installed version of openedx-learning and relevant tests to use the updated REST API serializers in https://github.com/openedx/openedx-learning/pull/138.

The Tagging feature is disabled in edX/2U production, so this change should not impact anyone.

## Supporting information

Part of https://github.com/openedx/modular-learning/issues/160

## Testing instructions

See https://github.com/openedx/frontend-app-course-authoring/pull/787 for manual testing instructions.

## Deadline

None

## Other information

Depends on:

* https://github.com/openedx/openedx-learning/pull/138

Private ref: FAL-3577