### PR TITLE
fix: remove sender id from audience

### DIFF
--- a/openedx/core/djangoapps/notifications/handlers.py
+++ b/openedx/core/djangoapps/notifications/handlers.py
@@ -114,13 +114,17 @@ def generate_course_notifications(signal, sender, course_notification_data, meta
 
     from openedx.core.djangoapps.notifications.tasks import send_notifications
     course_notification_data = course_notification_data.__dict__
+    user_ids = calculate_course_wide_notification_audience(
+        str(course_notification_data['course_key']),
+        course_notification_data['audience_filters']
+    )
+    sender_id = course_notification_data.get('content_context', {}).get('sender_id')
+    if sender_id in user_ids:
+        user_ids.remove(sender_id)
 
     notification_data = {
         'course_key': str(course_notification_data['course_key']),
-        'user_ids': calculate_course_wide_notification_audience(
-            str(course_notification_data['course_key']),
-            course_notification_data['audience_filters'],
-        ),
+        'user_ids': user_ids,
         'context': course_notification_data.get('content_context'),
         'app_name': course_notification_data.get('app_name'),
         'notification_type': course_notification_data.get('notification_type'),

--- a/openedx/core/djangoapps/notifications/tests/test_handlers.py
+++ b/openedx/core/djangoapps/notifications/tests/test_handlers.py
@@ -1,0 +1,38 @@
+"""
+Tests for the notifications handlers.
+"""
+from django.test import TestCase
+from unittest.mock import patch
+from openedx_events.learning.signals import COURSE_NOTIFICATION_REQUESTED
+from openedx_events.learning.data import CourseNotificationData
+
+
+class CourseNotificationsTest(TestCase):
+    """
+    Tests for the course notifications.
+    """
+
+    @patch('openedx.core.djangoapps.notifications.handlers.calculate_course_wide_notification_audience')
+    @patch('openedx.core.djangoapps.notifications.tasks.send_notifications')
+    def test_generate_course_notifications(self, mock_send_notifications, mock_calculate_audience):
+        # Set up mock objects
+        mock_calculate_audience.return_value = [1, 2, 3, 4]  # Example user IDs
+        notification_data = CourseNotificationData(
+            course_key='abc/123',
+            content_context={
+                "replier_name": 'name',
+                "post_title": 'title',
+                "course_name": 'course',
+                "sender_id": 3,
+            },
+            notification_type='new_discussion_post',
+            content_url="https://example.com",
+            app_name="discussion",
+            audience_filters={},
+        )
+        COURSE_NOTIFICATION_REQUESTED.send_event(course_notification_data=notification_data)
+
+        # Check if the sender_id was removed from the user_ids
+        expected_user_ids = [1, 2, 4]  # 3 should be removed
+        notification_data = mock_send_notifications.delay.call_args[1]
+        self.assertEqual(notification_data['user_ids'], expected_user_ids)


### PR DESCRIPTION
## Description

Remove Author ID from event data if course-wide notification, because we don't want to send a notification to the creator of the content.
i.e if the User has created a new thread he should not get a notification for it

## Ticket
https://2u-internal.atlassian.net/browse/INF-1209