### PR TITLE
fix: legacy reported content will send email based on discussion settings

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -38,7 +38,6 @@ from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE, ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE
-from lms.djangoapps.discussion.toggles_utils import reported_content_email_notification_enabled
 from lms.djangoapps.discussion.views import is_privileged_user
 from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
@@ -1367,8 +1366,7 @@ def _handle_abuse_flagged_field(form_value, user, cc_content, request):
     if form_value:
         cc_content.flagAbuse(user, cc_content)
         track_discussion_reported_event(request, course, cc_content)
-        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key) and reported_content_email_notification_enabled(
-                course_key):
+        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key):
             if cc_content.type == 'thread':
                 thread_flagged.send(sender='flag_abuse_for_thread', user=user, post=cc_content)
             else:

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -20,6 +20,7 @@ from opaque_keys.edx.keys import CourseKey
 from six.moves.urllib.parse import urljoin
 
 from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
+from lms.djangoapps.discussion.toggles_utils import reported_content_email_notification_enabled
 from openedx.core.djangoapps.discussions.url_helpers import get_discussions_mfe_url
 from xmodule.modulestore.django import modulestore
 
@@ -98,6 +99,8 @@ def send_ace_message(context):  # lint-amnesty, pylint: disable=missing-function
 def send_ace_message_for_reported_content(context):  # lint-amnesty, pylint: disable=missing-function-docstring
     context['course_id'] = CourseKey.from_string(context['course_id'])
     context['course_name'] = modulestore().get_course(context['course_id']).display_name
+    if not reported_content_email_notification_enabled(context['course_id']):
+        return
 
     moderators = get_users_with_moderator_roles(context)
     context['site'] = Site.objects.get(id=context['site_id'])


### PR DESCRIPTION
When a thread was reported in legacy discussions, email was being sent regardless of course discussion settings. Updated check that will work in both legacy forum and MFE

Ticket Link: [INF-1214](https://2u-internal.atlassian.net/browse/INF-1214)