### PR TITLE
fix: prevent transcript feedback widget from appearing when there is no video_id

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -82,7 +82,7 @@ from openedx.core.djangolib.js_utils import (
                                 <div class="btn-link close-btn float-right">
                                     <span style="color: black" class="icon fa fa-close" />
                                 </div>
-    
+
                                 <br />
                                 % for sharing_site_info in sharing_sites_info:
                                 <a
@@ -153,7 +153,7 @@ from openedx.core.djangolib.js_utils import (
             % endif
         </div>
         % endif
-        % if transcript_feedback_enabled:
+        % if transcript_feedback_enabled and video_id:
         <div class="wrapper-transcript-feedback" data-video-id='${video_id}' data-user-id='${user_id}'>
             <h4 class="hd hd-5">${_('How is the transcript quality ?')}</h4>
             <div class="transcript-feedback-buttons">


### PR DESCRIPTION
It was noted by a team member that there had been a spike in XBlockSaveErrors for the past few days. Upon further inspection, they happened due to a missing parameter on the requests to the Transcript feedback API when attempting to render the feedback widget. 

This scenario was caused by some YouTube videos not having `video_id`. To quiet the noise, we're preventing the rendering of the feedback widget entirely when the `video_id` parameter is not available on the video block.

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
