### PR TITLE
chore: bump edx-enterprise to 4.9.0 to get "Setup auth org id" button

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ click>=8.0,<9.0
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==4.8.18
+edx-enterprise==4.9.0
 
 # django-oauth-toolkit version >=2.0.0 has breaking changes. More details
 # mentioned on this issue https://github.com/openedx/edx-platform/issues/32884

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -474,7 +474,7 @@ edx-drf-extensions==9.0.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.8.18
+edx-enterprise==4.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -755,7 +755,7 @@ edx-drf-extensions==9.0.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.8.18
+edx-enterprise==4.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -552,7 +552,7 @@ edx-drf-extensions==9.0.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.8.18
+edx-enterprise==4.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -580,7 +580,7 @@ edx-drf-extensions==9.0.1
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.8.18
+edx-enterprise==4.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Together with a config change, this version bump will add a "Setup auth org id" button to the Change Enterprise Customer django admin screen.

ENT-8169