### PR TITLE
feat: Support sending OAuth token to codejail service

### DIFF
--- a/xmodule/capa/safe_exec/remote_exec.py
+++ b/xmodule/capa/safe_exec/remote_exec.py
@@ -49,25 +49,6 @@ def get_remote_exec(*args, **kwargs):
     return remote_exec_function(*args, **kwargs)
 
 
-# .. setting_name: CODE_JAIL_REST_SERVICE_OAUTH_URL
-# .. setting_default: None
-# .. setting_description: The OAuth server to get access tokens from when making calls to
-#   the codejail service. Requires setting CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID and
-#   CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET. If not specified, no authorization header will
-#   be sent.
-CODE_JAIL_REST_SERVICE_OAUTH_URL = getattr(settings, 'CODE_JAIL_REST_SERVICE_OAUTH_URL', None)
-# .. setting_name: CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID
-# .. setting_default: None
-# .. setting_description: The OAuth client credential ID to use when making calls to
-#   the codejail service. If not specified, no authorization header will be sent.
-CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID = getattr(settings, 'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID', None)
-# .. setting_name: CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET
-# .. setting_default: None
-# .. setting_description: The OAuth client credential secret to use when making calls to
-#   the codejail service. If not specified, no authorization header will be sent.
-CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET = getattr(settings, 'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET', None)
-
-
 def _get_codejail_client():
     """
     Return a ``requests`` compatible HTTP client that has .get(...) and .post(...) methods.
@@ -75,6 +56,24 @@ def _get_codejail_client():
     The client will send an OAuth token if the appropriate CODE_JAIL_REST_SERVICE_* settings
     are configured.
     """
+    # .. setting_name: CODE_JAIL_REST_SERVICE_OAUTH_URL
+    # .. setting_default: None
+    # .. setting_description: The OAuth server to get access tokens from when making calls to
+    #   the codejail service. Requires setting CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID and
+    #   CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET. If not specified, no authorization header will
+    #   be sent.
+    CODE_JAIL_REST_SERVICE_OAUTH_URL = getattr(settings, 'CODE_JAIL_REST_SERVICE_OAUTH_URL', None)
+    # .. setting_name: CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID
+    # .. setting_default: None
+    # .. setting_description: The OAuth client credential ID to use when making calls to
+    #   the codejail service. If not specified, no authorization header will be sent.
+    CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID = getattr(settings, 'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID', None)
+    # .. setting_name: CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET
+    # .. setting_default: None
+    # .. setting_description: The OAuth client credential secret to use when making calls to
+    #   the codejail service. If not specified, no authorization header will be sent.
+    CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET = getattr(settings, 'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET', None)
+
     oauth_configured = (
         CODE_JAIL_REST_SERVICE_OAUTH_URL and
         CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID and CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET

--- a/xmodule/capa/safe_exec/tests/test_remote_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_remote_exec.py
@@ -1,0 +1,50 @@
+"""Tests for remote_exec.py"""
+
+import unittest
+
+import ddt
+import requests
+from django.test import override_settings
+from edx_rest_api_client.client import OAuthAPIClient
+
+from xmodule.capa.safe_exec import remote_exec
+
+
+@ddt.ddt
+class RemoteExecTest(unittest.TestCase):
+    """Tests for remote execution."""
+
+    # pylint: disable=protected-access
+    @ddt.unpack
+    @ddt.data(
+        ({}, False),
+        # If just one or two settings present, skip auth
+        ({'CODE_JAIL_REST_SERVICE_OAUTH_URL': 'https://oauth.localhost'}, False),
+        (
+            {
+                'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID': 'some-id',
+                'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET': 'some-key'
+            },
+            False,
+        ),
+        # Configure auth if all present
+        (
+            {
+                'CODE_JAIL_REST_SERVICE_OAUTH_URL': 'https://oauth.localhost',
+                'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_ID': 'some-id',
+                'CODE_JAIL_REST_SERVICE_OAUTH_CLIENT_SECRET': 'some-key',
+            },
+            True,
+        ),
+    )
+    def test_auth_config(self, settings, expect_auth):
+        """
+        Check if the correct client is selected based on configuration.
+        """
+        with override_settings(**settings):
+            if expect_auth:
+                assert isinstance(remote_exec._get_codejail_client(), OAuthAPIClient)
+            else:
+                # Don't actually care that it's the requests module specifically,
+                # just that it's something generic and unconfigured for auth.
+                assert remote_exec._get_codejail_client() is requests


### PR DESCRIPTION
This supports having an authenticated codejail service in general, but in particular is to support the temporary use of the LMS as a codejail service for the CMS: https://github.com/openedx/edx-platform/issues/33538

The new settings are all optional, and if not provided, the current behavior does not change.
