### PR TITLE
refactor: changed survey report banner location and added the sent state

### DIFF
--- a/lms/templates/admin/base_site.html
+++ b/lms/templates/admin/base_site.html
@@ -21,6 +21,6 @@
 
 {% endblock %}
 
-{% block header %}{{ block.super }}
+{% block messages %}{{ block.super }}
     {% include "survey_report/admin_banner.html" %}
 {% endblock %}

--- a/openedx/features/survey_report/api.py
+++ b/openedx/features/survey_report/api.py
@@ -11,7 +11,8 @@ from openedx.features.survey_report.models import (
     SurveyReportUpload,
     SurveyReportAnonymousSiteID,
     SURVEY_REPORT_ERROR,
-    SURVEY_REPORT_GENERATED
+    SURVEY_REPORT_GENERATED,
+    SURVEY_REPORT_SENT
 )
 from openedx.features.survey_report.queries import (
     get_course_enrollments,
@@ -108,6 +109,10 @@ def send_report_to_external_api(report_id: int) -> None:
         status_code=request.status_code,
         request_details=request.content
     )
+
+    # Update the state attribute to "sent"
+    report.state = SURVEY_REPORT_SENT
+    report.save()
 
 
 def update_report(survey_report_id: int, data: dict) -> None:

--- a/openedx/features/survey_report/models.py
+++ b/openedx/features/survey_report/models.py
@@ -9,11 +9,13 @@ from jsonfield import JSONField
 
 SURVEY_REPORT_PROCESSING = 'processing'
 SURVEY_REPORT_GENERATED = 'generated'
+SURVEY_REPORT_SENT= 'sent'
 SURVEY_REPORT_ERROR = 'error'
 
 SURVEY_REPORT_STATES = [
     (SURVEY_REPORT_PROCESSING, 'Processing'),
     (SURVEY_REPORT_GENERATED, 'Generated'),
+    (SURVEY_REPORT_SENT, 'Sent'),
     (SURVEY_REPORT_ERROR, 'Error'),
 ]
 

--- a/openedx/features/survey_report/templates/survey_report/admin_banner.html
+++ b/openedx/features/survey_report/templates/survey_report/admin_banner.html
@@ -31,6 +31,7 @@
 {% endif %}
 
     <!-- The original content of the block -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
    $(document).ready(function(){
     $('#dismissButton').click(function() {

--- a/openedx/features/survey_report/templates/survey_report/change_list.html
+++ b/openedx/features/survey_report/templates/survey_report/change_list.html
@@ -5,7 +5,7 @@
     <li>
         <form method="POST" action="{% url 'openedx.generate_survey_report' %}" class="inline">
             {% csrf_token %}
-            <input type="submit" value="Generate Report" class="default" name="_generatereport">
+            <input type="submit" value="Send Report" class="default" name="_sendreport">
         </form>
     </li>
 </ul>


### PR DESCRIPTION
**Description**

This pull request introduces a refactor of the Survey Report management in the Django admin site. The changes include two key modifications aimed at enhancing the clarity and functionality of the admin interface.

1. Moving Survey Report Banner to the "Messages" Section

- The Survey Report Banner, previously located in the header section, has now been moved to the "Messages" side of the admin site.
- This change aims to make the banner  more intuitive and user-friendly.

2. Adding a New State "Sent" to Reports

- A new state, "Sent," has been added to the reports.
- This state is applied to reports that have been successfully sent to Axim.
- Previously, only the state "generated" was implemented which could be confusing and didn't confirm if the report was sent or not.

Testing

1. You can click on the "send report" button to send the report and a confirmation message should appear
2. You can also click on the "Dismiss" button to close the banner message
3. You should see the recently sent message under {{domain}}/admin/survey_report/ with the state "sent"

Example:
![survey_report](https://github.com/openedx/edx-platform/assets/79876430/b4795af4-60c2-4524-8de9-48f271caceb4)
