### PR TITLE
feat: make course -> lib import synchronous

### DIFF
--- a/xmodule/library_tools.py
+++ b/xmodule/library_tools.py
@@ -129,9 +129,9 @@ class LibraryToolsService:
                 raise ObjectDoesNotExist(f"Version {library_version} of library {library_key} not found.")
             raise ObjectDoesNotExist(f"Library {library_key} not found.")
 
-        # TODO: This task is synchronous until we can figure out race conditions with import
+        # TODO: This task is synchronous until we can figure out race conditions with import.
         # These race conditions lead to failed imports of library content from course import.
-        # See: TNL-TNL-11339, https://github.com/openedx/edx-platform/issues/34029 for more info.
+        # See: TNL-11339, https://github.com/openedx/edx-platform/issues/34029 for more info.
         library_tasks.sync_from_library.apply(
             user_id=self.user_id,
             dest_block_id=str(dest_block.scope_ids.usage_id),

--- a/xmodule/library_tools.py
+++ b/xmodule/library_tools.py
@@ -128,12 +128,15 @@ class LibraryToolsService:
             if library_version:
                 raise ObjectDoesNotExist(f"Version {library_version} of library {library_key} not found.")
             raise ObjectDoesNotExist(f"Library {library_key} not found.")
-        library_tasks.sync_from_library.delay(
+
+        # TODO: This task is synchronous until we can figure out race conditions with import
+        # These race conditions lead to failed imports of library content from course import.
+        # See: TNL-TNL-11339, https://github.com/openedx/edx-platform/issues/34029 for more info.
+        library_tasks.sync_from_library.apply(
             user_id=self.user_id,
             dest_block_id=str(dest_block.scope_ids.usage_id),
             library_version=library_version,
         )
-
     def trigger_duplication(self, source_block: LibraryContentBlock, dest_block: LibraryContentBlock) -> None:
         """
         Queue a task to duplicate the children of `source_block` to `dest_block`.

--- a/xmodule/library_tools.py
+++ b/xmodule/library_tools.py
@@ -133,9 +133,11 @@ class LibraryToolsService:
         # These race conditions lead to failed imports of library content from course import.
         # See: TNL-11339, https://github.com/openedx/edx-platform/issues/34029 for more info.
         library_tasks.sync_from_library.apply(
-            user_id=self.user_id,
-            dest_block_id=str(dest_block.scope_ids.usage_id),
-            library_version=library_version,
+            kwargs=dict(
+                user_id=self.user_id,
+                dest_block_id=str(dest_block.scope_ids.usage_id),
+                library_version=library_version,
+            ),
         )
     def trigger_duplication(self, source_block: LibraryContentBlock, dest_block: LibraryContentBlock) -> None:
         """

--- a/xmodule/library_tools.py
+++ b/xmodule/library_tools.py
@@ -139,6 +139,7 @@ class LibraryToolsService:
                 library_version=library_version,
             ),
         )
+
     def trigger_duplication(self, source_block: LibraryContentBlock, dest_block: LibraryContentBlock) -> None:
         """
         Queue a task to duplicate the children of `source_block` to `dest_block`.


### PR DESCRIPTION
## Description
On an openedx platform with async workers enabled,

If a course author uploads a course which references some library that exists already on the platform, they run into errors.

This is because [xml_importer makes an async call to spawn the import of the content from the library](https://github.com/openedx/edx-platform/blob/efaef4510ed333d5a1c12359c466162a2e780920/xmodule/modulestore/xml_importer.py#L904)

And then it proceeds to attempt to copy & publish the library content block's children, which leads to the likely state where the celery task has not copied in the LCB's new children, and this means that the publish cannot see the children, and fails.

In order to fix this, I am making the call to sync_from_library an `apply` call, not a `delay` call, so that it operates synchronously until we figure out a long-term solution.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11339
https://github.com/openedx/edx-platform/issues/34029