### PR TITLE
feat: bump edx-search to 3.8.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -517,7 +517,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.1
+edx-search==3.8.2
     # via -r requirements/edx/kernel.in
 edx-sga==0.23.0
     # via -r requirements/edx/bundled.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -820,7 +820,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.1
+edx-search==3.8.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -599,7 +599,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.1
+edx-search==3.8.2
     # via -r requirements/edx/base.txt
 edx-sga==0.23.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -630,7 +630,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.1
+edx-search==3.8.2
     # via -r requirements/edx/base.txt
 edx-sga==0.23.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
Bump edx-search to 3.8.2, add hotfix to correct wrong timings events being emitted

https://github.com/openedx/edx-search/releases/tag/v3.8.2