### PR TITLE
feat: add work experience field.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -268,7 +268,8 @@ def _get_extended_profile_fields():
             platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME)
         ),
         "profession": _("Profession"),
-        "specialty": _("Specialty")
+        "specialty": _("Specialty"),
+        "work_experience": _("Work experience")
     }
 
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -20,6 +20,7 @@ from openedx.core.djangoapps.lang_pref.tests.test_api import EN, LT_LT
 from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.user_api.accounts.settings_views import account_settings_context, get_user_orders
 from openedx.core.djangoapps.user_api.accounts.toggles import REDIRECT_TO_ACCOUNT_MICROFRONTEND
 from openedx.core.djangoapps.user_api.tests.factories import UserPreferenceFactory
@@ -107,6 +108,21 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
 
             expected_beta_language = {'code': 'lt-lt', 'name': settings.LANGUAGE_DICT.get('lt-lt')}
             assert context['beta_language'] == expected_beta_language
+
+    @with_site_configuration(
+        configuration={
+            'extended_profile_fields': ['work_experience']
+        }
+    )
+    def test_context_extended_profile(self):
+        """
+        Test that if the field is available in extended_profile configuration then the field
+        will be sent in response.
+        """
+        context = account_settings_context(self.request)
+        extended_pofile_field = context['extended_profile_fields'][0]
+        assert extended_pofile_field['field_name'] == 'work_experience'
+        assert extended_pofile_field['field_label'] == 'Work experience'
 
     @mock.patch('openedx.core.djangoapps.user_api.accounts.settings_views.enterprise_customer_for_request')
     @mock.patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')

--- a/openedx/core/djangoapps/user_authn/api/form_fields.py
+++ b/openedx/core/djangoapps/user_authn/api/form_fields.py
@@ -364,3 +364,15 @@ def add_confirm_email_field(is_field_required=False):
         'label': email_label,
         'error_message': accounts.REQUIRED_FIELD_CONFIRM_EMAIL_TEXT_MSG if is_field_required else '',
     }
+
+
+def add_work_experience_field(is_field_required=False):
+    """
+    Returns the user work experience field description
+    """
+    # Translators: This label appears above a dropdown menu to select
+    # the user's work experience
+    work_experience_label = _("Work experience")
+    return _add_field_with_configurable_select_options(
+        'work_experience', work_experience_label, is_field_required,
+    )


### PR DESCRIPTION
### Description
I have added a work experience field that will be shown on the front-end authn welcome page and also on the legacy account setting page.  

### Ticket 
https://2u-internal.atlassian.net/browse/VAN-1788

###
How Has This Been Tested?
you can add settings in django admin site configuration like this 
```
"extended_profile_fields": [
        "work_experience"
    ],
    "EXTRA_FIELD_OPTIONS": {
        "work_experience": [
            "0",
            "1",
            "2",
            "3",
            "4",
            "5",
            "6",
            "7",
            "8",
            "9",
            "10+"
        ]
    }

```
and the filed will be shown in welcome page of auth mfe and account settings.