### PR TITLE
fix: videos title in content dropdown for mfe page

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -145,7 +145,7 @@
                   % endif
                   % if context_course.video_pipeline_configured and video_upload_mfe_enabled:
                   <li class="nav-item nav-course-courseware-videos">
-                    <a href="${get_video_uploads_url(course_key)}">${_("Video Uploads")}</a>
+                    <a href="${get_video_uploads_url(course_key)}">${_("Videos")}</a>
                   </li>
                   % endif
                 </ul>


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

The Video Uploads page was renamed to just "Videos" in the MFE version of the page. The dropdown should reflect the name change when the MFE version is enabled. This change impacts Authors.

Before

<img width="199" alt="Screenshot 2024-01-10 at 9 48 56 AM" src="https://github.com/openedx/edx-platform/assets/42981026/beb6e335-72b1-4b8b-8c55-ddf0469d7efb">

After

<img width="199" alt="Screenshot 2024-01-10 at 9 50 14 AM" src="https://github.com/openedx/edx-platform/assets/42981026/b8f7ab5a-5703-47a4-96ea-16f3e0fc9af6">

## Testing instructions

1. Confirm that `contentstore.new_studio_mfe.use_new_video_uploads_page` is not enabled
2. Open a course in Studio
3. Open the Content dropdown
4. The last item should be "Video Uploads"
5. Enable `contentstore.new_studio_mfe.use_new_video_uploads_page`
6. Reload a course in Studio
3. Open the Content dropdown
4. The last item should be "Videos"

## Deadline

None
