### PR TITLE
feat: return navigation disabled as sequence metadata

### DIFF
--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -376,7 +376,18 @@ class SequenceBlock(
         meta['display_name'] = self.display_name_with_default
         meta['format'] = getattr(self, 'format', '')
         meta['is_hidden_after_due'] = is_hidden_after_due
+        meta['navigation_disabled'] = self.is_sequence_navigation_disabled()
         return meta
+
+    def is_sequence_navigation_disabled(self):
+        """
+        Returns whether the navigation to other sequences is disabled.
+
+        As of today, this is used to disable the navigation to other sequences when the
+        current sequence is configured as Hide from Table of Contents. But it can be
+        extended to other use cases in the future.
+        """
+        return getattr(self, "hide_from_toc", False)
 
     @classmethod
     def verify_current_content_visibility(cls, date, hide_after_date):

--- a/xmodule/tests/test_sequence.py
+++ b/xmodule/tests/test_sequence.py
@@ -443,6 +443,15 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         assert metadata['tag'] == 'sequential'
         assert metadata['display_name'] == self.sequence_3_1.display_name_with_default
 
+    def test_get_metadata_navigation_disabled(self):
+        """Test that the sequence metadata is returned correctly when navigation is disabled"""
+        self.sequence_3_1.hide_from_toc = True
+        metadata = self.sequence_3_1.get_metadata()
+        assert len(metadata['items']) == 3
+        assert metadata['tag'] == 'sequential'
+        assert metadata['display_name'] == self.sequence_3_1.display_name_with_default
+        assert metadata['navigation_disabled'] is True
+
     @override_settings(FIELD_OVERRIDE_PROVIDERS=(
         'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
     ))


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR returns a `navigation_desabled` field as sequence metadata to disable navigation in the Learning MFE within sequences when Hide From TOC is enabled for the current sequence. These changes are part of a series of PR(s) that implement the [Feature Enhancement Proposal: Hide Sections from course outline](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3853975595/Feature+Enhancement+Proposal+Hide+Sections+from+course+outline): https://github.com/openedx/edx-platform/pulls?q=is%3Apr+is%3Aopen+hide+from+toc

## Supporting information

https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3853975595/Feature+Enhancement+Proposal+Hide+Sections+from+course+outline

## Testing instructions

For the Learning MFE changes, please follow the instructions listed [here](https://github.com/openedx/frontend-app-learning/pull/1273). Then, go to the LMS using the link to your hidden subsection, it should look something like this:

![image](https://github.com/openedx/edx-platform/assets/64440265/ccabe320-3d7d-4857-82fe-6c89da188249)

Without prev, next and sequence breadcrumbs. You can also test the metadata API call individually by loading a course subsection in the LMS, and search for this call in the dev console:
GET http://local.edly.io:8000/api/courseware/sequence/<SEQUENCE ID>
You'll find: 
![image](https://github.com/openedx/edx-platform/assets/64440265/d0645c05-eb1c-43ce-beff-c369900ba51d)
When hide from TOC enabled for the subsection, and otherwise:
![image](https://github.com/openedx/edx-platform/assets/64440265/0a050a22-bf60-4b02-aa37-864858e7886d)

## Deadline

After PR #33952

## Other information

As I mentioned, this PR is part of a series of PRs implementing the feature enhancement of Hide From TOC. This initiative is an open-source contribution to the Open edX platform funded by a Unidigital project from the Spanish Government - 2023.
