### PR TITLE
feat: Language auto tagging library blocks

### DIFF
--- a/openedx/core/djangoapps/content_tagging/handlers.py
+++ b/openedx/core/djangoapps/content_tagging/handlers.py
@@ -2,17 +2,32 @@
 Automatic tagging of content
 """
 
+import crum
 import logging
 
 from django.dispatch import receiver
-from openedx_events.content_authoring.data import CourseData, XBlockData
-from openedx_events.content_authoring.signals import COURSE_CREATED, XBLOCK_CREATED, XBLOCK_DELETED, XBLOCK_UPDATED
+from openedx_events.content_authoring.data import (
+    CourseData,
+    XBlockData,
+    LibraryBlockData,
+)
+from openedx_events.content_authoring.signals import (
+    COURSE_CREATED,
+    XBLOCK_CREATED,
+    XBLOCK_DELETED,
+    XBLOCK_UPDATED,
+    LIBRARY_BLOCK_CREATED,
+    LIBRARY_BLOCK_UPDATED,
+    LIBRARY_BLOCK_DELETED,
+)
 
 from .tasks import delete_course_tags
 from .tasks import (
     delete_xblock_tags,
     update_course_tags,
-    update_xblock_tags
+    update_xblock_tags,
+    update_library_block_tags,
+    delete_library_block_tags,
 )
 from .toggles import CONTENT_TAGGING_AUTO
 
@@ -74,3 +89,39 @@ def delete_tag_xblock(**kwargs):
         delete_course_tags.delay(str(xblock_info.usage_key.course_key))
 
     delete_xblock_tags.delay(str(xblock_info.usage_key))
+
+
+@receiver(LIBRARY_BLOCK_CREATED)
+@receiver(LIBRARY_BLOCK_UPDATED)
+def auto_tag_library_block(**kwargs):
+    """
+    Automatically tag Library Blocks based on metadata
+    """
+    if not CONTENT_TAGGING_AUTO.is_enabled():
+        return
+
+    library_block_data = kwargs.get("library_block", None)
+    if not library_block_data or not isinstance(library_block_data, LibraryBlockData):
+        log.error("Received null or incorrect data for event")
+        return
+
+    current_request = crum.get_current_request()
+    update_library_block_tags.delay(
+        str(library_block_data.usage_key), current_request.LANGUAGE_CODE
+    )
+
+
+@receiver(LIBRARY_BLOCK_DELETED)
+def delete_tag_library_block(**kwargs):
+    """
+    Delete tags associated with a Library XBlock whenever the block is deleted.
+    """
+    library_block_data = kwargs.get("library_block", None)
+    if not library_block_data or not isinstance(library_block_data, LibraryBlockData):
+        log.error("Received null or incorrect data for event")
+        return
+
+    try:
+        delete_library_block_tags(str(library_block_data.usage_key))
+    except Exception as err:  # pylint: disable=broad-except
+        log.error(f"Failed to delete library block tags: {err}")

--- a/openedx/core/djangoapps/content_tagging/tests/test_tasks.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_tasks.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from django.test import override_settings
+from django.test import override_settings, LiveServerTestCase
+from django.http import HttpRequest
 from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx_tagging.core.tagging.models import Tag, Taxonomy
 from organizations.models import Organization
@@ -13,6 +14,9 @@ from organizations.models import Organization
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangolib.testing.utils import skip_unless_cms
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
+from openedx.core.lib.blockstore_api import create_collection
+from openedx.core.djangoapps.content_libraries.api import create_library, create_library_block, delete_library_block
+from openedx.core.lib.blockstore_api.tests.base import BlockstoreAppTestMixin
 
 from .. import api
 from ..models.base import TaxonomyOrg
@@ -51,7 +55,12 @@ class LanguageTaxonomyTestMixin:
 
 @skip_unless_cms  # Auto-tagging is only available in the CMS
 @override_waffle_flag(CONTENT_TAGGING_AUTO, active=True)
-class TestAutoTagging(LanguageTaxonomyTestMixin, ModuleStoreTestCase):  # type: ignore[misc]
+class TestAutoTagging(  # type: ignore[misc]
+    LanguageTaxonomyTestMixin,
+    ModuleStoreTestCase,
+    BlockstoreAppTestMixin,
+    LiveServerTestCase
+):
     """
     Test if the Course and XBlock tags are automatically created
     """
@@ -234,6 +243,63 @@ class TestAutoTagging(LanguageTaxonomyTestMixin, ModuleStoreTestCase):  # type: 
 
         # Delete the XBlock
         self.store.delete_item(vertical.location, self.user_id)
+
+        # Still no tags
+        assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, None)
+
+    def test_create_delete_library_block(self):
+        # Create collection and library
+        collection = create_collection("Test library collection")
+        library = create_library(
+            collection_uuid=collection.uuid,
+            org=self.orgA,
+            slug="lib_a",
+            title="Library Org A",
+            description="This is a library from Org A",
+        )
+
+        fake_request = HttpRequest()
+        fake_request.LANGUAGE_CODE = "pt-br"
+        with patch('crum.get_current_request', return_value=fake_request):
+            # Create Library Block
+            library_block = create_library_block(library.key, "problem", "Problem1")
+
+        usage_key_str = str(library_block.usage_key)
+
+        # Check if the tags are created in the Library Block with the user's preferred language
+        assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, 'Português (Brasil)')
+
+        # Delete the XBlock
+        delete_library_block(library_block.usage_key)
+
+        # Check if the tags are deleted
+        assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, None)
+
+    @override_waffle_flag(CONTENT_TAGGING_AUTO, active=False)
+    def test_waffle_disabled_create_delete_library_block(self):
+        # Create collection and library
+        collection = create_collection("Test library collection 2")
+        library = create_library(
+            collection_uuid=collection.uuid,
+            org=self.orgA,
+            slug="lib_a2",
+            title="Library Org A 2",
+            description="This is a library from Org A 2",
+        )
+
+        fake_request = HttpRequest()
+        fake_request.LANGUAGE_CODE = "pt-br"
+        with patch('crum.get_current_request', return_value=fake_request):
+            # Create Library Block
+            library_block = create_library_block(library.key, "problem", "Problem2")
+
+        usage_key_str = str(library_block.usage_key)
+
+        # No tags created
+        assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, None)
+
+        # Delete the XBlock
+        delete_library_block(library_block.usage_key)
 
         # Still no tags
         assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, None)


### PR DESCRIPTION
## Description

This PR adds functionality of automatically tagging library blocks with a language tag when they created/update and automatically deletes them when they are deleted.

## Supporting information

Related Tickets:
- Closes https://github.com/openedx/modular-learning/issues/97

## Testing instructions

1. Run your devstack on this PR
1. Set the `content_tagging.auto` waffle flag
1. Make sure you have the [library authoring mfe](https://github.com/openedx/frontend-app-library-authoring) setup and running locally, so you can create library and add blocks to them
1. Navigate to studio then click on the Libraries tab, the library mfe should open
1. From there create a new library if you don't already have, and click on it
1. Before creating new blocks, check the existing object tags in the cms shell (`make cms-shell`):
```sh
>>> from openedx_tagging.core.tagging.models import ObjectTag
>>> ObjectTag.objects.all().count()
```
1. Back in the library authoring mfe, create a new block, then go back to the shell and check that a new ObjectTag was created, the count should increase and you can also inspect the `.last()` to see the newly created one
1. Navigate back to the library authoring mfe, and delete the newly created block and confirm in the cms shell that the count when down and the `.last()` is now longer what it was in the previous step.

---
Private-ref: [FAL-3497](https://tasks.opencraft.com/browse/FAL-3497)