### PR TITLE
feat: include custom relative dates flag info in outline api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_index.py
@@ -29,3 +29,4 @@ class CourseIndexSerializer(serializers.Serializer):
     proctoring_errors = ProctoringErrorListSerializer(many=True)
     reindex_link = serializers.CharField()
     rerun_notification_id = serializers.IntegerField()
+    is_custom_relative_dates_active = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_index.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
 from cms.djangoapps.contentstore.rest_api.v1.serializers import CourseIndexSerializer
 from cms.djangoapps.contentstore.utils import get_course_index_context
 from common.djangoapps.student.auth import has_studio_read_access
@@ -92,6 +93,7 @@ class CourseIndexView(DeveloperErrorViewMixin, APIView):
         course_index_context.update({
             "discussions_incontext_learnmore_url": settings.DISCUSSIONS_INCONTEXT_LEARNMORE_URL,
             "discussions_incontext_feedback_url": settings.DISCUSSIONS_INCONTEXT_FEEDBACK_URL,
+            "is_custom_relative_dates_active": CUSTOM_RELATIVE_DATES.is_enabled(course_key),
         })
 
         serializer = CourseIndexSerializer(course_index_context)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
@@ -5,6 +5,9 @@ from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
 
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
 from cms.djangoapps.contentstore.rest_api.v1.mixins import PermissionAccessMixin
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import get_lms_link_for_item
@@ -46,6 +49,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
             kwargs={"course_id": self.course.id},
         )
 
+    @override_waffle_flag(CUSTOM_RELATIVE_DATES, active=True)
     def test_course_index_response(self):
         """Check successful response content"""
         response = self.client.get(self.url)
@@ -59,6 +63,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
             },
             "discussions_incontext_feedback_url": "",
             "discussions_incontext_learnmore_url": "",
+            "is_custom_relative_dates_active": True,
             "initial_state": None,
             "initial_user_clipboard": {
                 "content": None,
@@ -78,6 +83,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(expected_response, response.data)
 
+    @override_waffle_flag(CUSTOM_RELATIVE_DATES, active=False)
     def test_course_index_response_with_show_locators(self):
         """Check successful response content with show query param"""
         response = self.client.get(self.url, {"show": str(self.unit.location)})
@@ -91,6 +97,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
             },
             "discussions_incontext_feedback_url": "",
             "discussions_incontext_learnmore_url": "",
+            "is_custom_relative_dates_active": False,
             "initial_state": {
                 "expanded_locators": [
                     str(self.unit.location),


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Adds custom_relative_dates waffle flag info to course outline rest API. This is required for displaying custom due dates in course outline MFE.

Useful information to include:
- Which edX user roles will this change impact? `Developer`.

## Supporting information

`Private-ref`: [BB-8485](https://tasks.opencraft.com/browse/BB-8485)

## Testing instructions

* Get master devstack up and running.
* Start lms and cms using `make {lms,cms}-up`.
* Go to http://localhost:18010/api-docs/
* Scroll down till you find documentation for `/contentstore/v1/course_index/{course_id}` api.
* Use `Try it out` and check `is_custom_relative_dates_active` field is included in API.


## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.