### PR TITLE
fix: removed enable_discussion_mfe from email content

### DIFF
--- a/lms/djangoapps/discussion/toggles_utils.py
+++ b/lms/djangoapps/discussion/toggles_utils.py
@@ -1,7 +1,6 @@
 """
 Utils for Discussions feature toggles
 """
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings
 
 
@@ -10,5 +9,4 @@ def reported_content_email_notification_enabled(course_key):
     Checks for relevant flag and setting and returns boolean for reported
     content email notification for course
     """
-    return bool(ENABLE_DISCUSSIONS_MFE.is_enabled(course_key) and
-                CourseDiscussionSettings.get(course_key).reported_content_email_notifications)
+    return CourseDiscussionSettings.get(course_key).reported_content_email_notifications


### PR DESCRIPTION
Reported email content was checking if enable_discussions_mfe flag is enabled or not. Removed this requirement while sending reported content email. It will only check if toggle is enabled in course authoring mfe.