### PR TITLE
fix: manage tags menu string case

### DIFF
--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -137,7 +137,7 @@ block_is_unit = is_unit(xblock)
                                         % endif
                                         % if use_tagging:
                                             <li class="nav-item">
-                                                <a class="manage-tags-button" href="#" role="button">${_("Manage tags")}</a>
+                                                <a class="manage-tags-button" href="#" role="button">${_("Manage Tags")}</a>
                                             </li>
                                         % endif
                                         % if is_course:


### PR DESCRIPTION
## Description
This PR fixes the case in the unit edit menu.

![image](https://github.com/openedx/edx-platform/assets/849463/66b6de3a-5e14-4217-9132-12704b816580)

## Suporting Information
- Part of https://github.com/openedx/modular-learning/issues/176

## Testing instructions
Edit the course in Studio, edit a unit and, check the menu if the case is correct (like the image)
___
Private-ref: [FAL-3615](https://tasks.opencraft.com/browse/FAL-3615)
