### PR TITLE
feat: Use built-in retry features of Celery when retrying Credentials grading tasks

### DIFF
--- a/openedx/core/djangoapps/credentials/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tasks.py
@@ -82,14 +82,14 @@ class TestSendGradeToCredentialTask(TestCase):
 
     def test_retry(self, mock_get_api_client):
         """
-        Test that we retry when an exception occurs.
+        Test that we retry the appropriate number of times when an exception occurs.
         """
         mock_get_api_client.side_effect = boom
 
         task = tasks.send_grade_to_credentials.delay('user', 'course-v1:org+course+run', True, 'A', 1.0, None)
 
         pytest.raises(Exception, task.get)
-        assert mock_get_api_client.call_count == (tasks.MAX_RETRIES + 1)
+        assert mock_get_api_client.call_count == 11
 
 
 @ddt.ddt


### PR DESCRIPTION
## Description

This PR updates the `send_grade_to_credentials` task to use built-in features of Celery to handle task retries. We believe the current exponential backoff and retry mechanism is too aggressive and can cause issues overloading Credentials when many grade updates occur at once (because of a big `notify_credentials` run or a regrade kicked off by a change to a grading policy in a course). 
