### PR TITLE
chore: add ora mfe to devstack env

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -301,6 +301,9 @@ CLOSEST_CLIENT_IP_FROM_HEADERS = []
 CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:18150'
 CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:18150'
 
+########################## ORA MFE APP ##############################
+ORA_MICROFRONTEND_URL = 'http://localhost:1992'
+
 ############################ AI_TRANSLATIONS ##################################
 AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 


### PR DESCRIPTION
## Description

add `ORA_MICROFRONTEND_URL` to cms devstack environment because there isn't a common devstack environment setup.
