### PR TITLE
chore: revert change to Mathjax

### DIFF
--- a/cms/djangoapps/pipeline_js/js/xmodule.js
+++ b/cms/djangoapps/pipeline_js/js/xmodule.js
@@ -23,11 +23,6 @@ define(
             'mathjax',
             function() {
                 window.MathJax.Hub.Config({
-                    styles: {
-                        '.MathJax_SVG>svg': {'max-width': '100%'},
-                        // This is to resolve for people who use center mathjax with tables
-                        'table>tbody>tr>td>.MathJax_SVG>svg': {'max-width': 'inherit'},
-                    },
                     tex2jax: {
                         inlineMath: [
                             ['\\(', '\\)'],
@@ -65,14 +60,7 @@ define(
                     if (oldWidth !== document.documentElement.scrollWidth) {
                         t = window.setTimeout(function() {
                             oldWidth = document.documentElement.scrollWidth;
-                            MathJax.Hub.Queue(
-                                ['Rerender', MathJax.Hub],
-                                [() => $('.MathJax_SVG>svg').toArray().forEach(el => {
-                                    if ($(el).width() === 0) {
-                                        $(el).css('max-width', 'inherit');
-                                    }
-                                })]
-                            );
+                            MathJax.Hub.Queue(['Rerender', MathJax.Hub]);
                             t = -1;
                         }, delay);
                     }

--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -81,11 +81,6 @@
   <!-- Configure and load MathJax -->
   <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
-      styles: {
-        '.MathJax_SVG>svg': { 'max-width': '100%' },
-        // This is to resolve for people who use center mathjax with tables
-        'table>tbody>tr>td>.MathJax_SVG>svg': { 'max-width': 'inherit'},
-      },
       CommonHTML: { linebreaks: { automatic: true } },
       SVG: { linebreaks: { automatic: true } },
       "HTML-CSS": { linebreaks: { automatic: true } },
@@ -115,11 +110,6 @@
           oldWidth = document.documentElement.scrollWidth;
           MathJax.Hub.Queue(
             ["Rerender", MathJax.Hub],
-            [() => $('.MathJax_SVG>svg').toArray().forEach(el => {
-              if ($(el).width() === 0) {
-                $(el).css('max-width', 'inherit');
-              }
-            })]
           );
           t = -1;
         }, delay);

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -29,11 +29,6 @@
 %if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
-    styles: {
-      '.MathJax_SVG>svg': { 'max-width': '100%', },
-      // This is to resolve for people who use center mathjax with tables
-      'table>tbody>tr>td>.MathJax_SVG>svg': { 'max-width': 'inherit'},
-    },
     CommonHTML: { linebreaks: { automatic: true } },
     SVG: { linebreaks: { automatic: true } },
     "HTML-CSS": { linebreaks: { automatic: true } },
@@ -44,11 +39,6 @@
 %else:
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
-    styles: {
-      '.MathJax_SVG>svg': { 'max-width': '100%', },
-      // This is to resolve for people who use center mathjax with tables
-      'table>tbody>tr>td>.MathJax_SVG>svg': { 'max-width': 'inherit'},
-    },
     messageStyle: "none",
     CommonHTML: { linebreaks: { automatic: true } },
     SVG: { linebreaks: { automatic: true } },
@@ -116,11 +106,6 @@
           oldWidth = document.documentElement.scrollWidth;
           MathJax.Hub.Queue(
             ["Rerender", MathJax.Hub],
-            [() => $('.MathJax_SVG>svg').toArray().forEach(el => {
-              if ($(el).width() === 0) {
-                $(el).css('max-width', 'inherit');
-              }
-            })]
           );
           t = -1;
         }, delay);


### PR DESCRIPTION
## Description

https://2u-internal.atlassian.net/browse/CR-6332

- remove custom css to support line break. It broke more thing than what we bargain for.

Useful information to include:
- revert the custom from:
  - https://github.com/openedx/edx-platform/pull/32606
  - https://github.com/openedx/edx-platform/pull/32824
  - but keep redraw on resize
 
## Supporting information



## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
