### PR TITLE
CourseRoles: instructor dashboard permissions checks

### DIFF
--- a/common/djangoapps/student/role_helpers.py
+++ b/common/djangoapps/student/role_helpers.py
@@ -10,7 +10,6 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_MODERATOR,
     Role
 )
-from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.lib.cache_utils import request_cached
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
@@ -28,24 +27,19 @@ def has_staff_roles(user, course_key):
     Return true if a user has any of the following roles
     Staff, Instructor, Beta Tester, Forum Community TA, Forum Group Moderator, Forum Moderator, Forum Administrator
     """
-    # TODO: remove role checks once course_roles is fully implemented and data is migrated
     forum_roles = [FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_GROUP_MODERATOR,
                    FORUM_ROLE_MODERATOR, FORUM_ROLE_ADMINISTRATOR]
-    permissions = [
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.value,
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.value,
-    ]
     is_staff = CourseStaffRole(course_key).has_user(user)
     is_instructor = CourseInstructorRole(course_key).has_user(user)
     is_beta_tester = CourseBetaTesterRole(course_key).has_user(user)
     is_org_staff = OrgStaffRole(course_key.org).has_user(user)
     is_org_instructor = OrgInstructorRole(course_key.org).has_user(user)
     is_global_staff = GlobalStaff().has_user(user)
+    # TODO: consider switching to check discussion permissions instead of discussion roles
     has_forum_role = Role.user_has_role_for_course(user, course_key, forum_roles)
-    has_discussion_perms = any(user.has_perm(permission, course_key) for permission in permissions)
     if (
         any([is_staff, is_instructor, is_beta_tester, is_org_staff,
-            is_org_instructor, is_global_staff, has_forum_role, has_discussion_perms])
+            is_org_instructor, is_global_staff, has_forum_role])
     ):
         return True
     return False

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -127,18 +127,12 @@ def has_discussion_privileges(user, course_id):
     Returns:
       bool
     """
-    # TODO: remove user_ids check once course_roles is fully impelented and data is migrated
+    # TODO: consider switching this to check for a specific discussion permission, instead of the role
     roles = get_role_ids(course_id)
 
     for user_ids in roles.values():
         if user.id in user_ids:
             return True
-    if user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_id
-    ) and user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name, course_id
-    ):
-        return True
     return False
 
 

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -984,16 +984,8 @@ def get_thread_list(
     ]
 
     if request.GET.get("group_id", None):
-        # TODO: remove role check once course_roles is fully impelented and data is migrated
-        if (
-            Role.user_has_role_for_course(request.user, course_key, allowed_roles) or
-            request.user.has_perm(
-                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key
-            ) or
-            request.user.has_perm(
-                CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name, course_key
-            )
-        ):
+        # TODO: consider switching this to check for a specific discussion permission
+        if Role.user_has_role_for_course(request.user, course_key, allowed_roles):
             try:
                 group_id = int(request.GET.get("group_id", None))
             except ValueError:

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -777,14 +777,9 @@ def is_privileged_user(course_key: CourseKey, user: User):
         FORUM_ROLE_MODERATOR,
         FORUM_ROLE_ADMINISTRATOR,
     ]
+    # TODO: consider switching this to check for a specific discussion permission instead of the role
     has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
-    # TODO: remove role checks once course_roles is fully impelented and data is migrated
-    has_moderate_discussion_permissions = user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS.perm_name, course_key
-    ) or user.has_perm(
-        CourseRolesPermission.MODERATE_DISCUSSION_FORUMS_FOR_A_COHORT.perm_name, course_key
-    )
-    return GlobalStaff().has_user(user) or has_course_role or has_moderate_discussion_permissions
+    return GlobalStaff().has_user(user) or has_course_role
 
 
 class DiscussionBoardFragmentView(EdxFragmentView):
@@ -816,10 +811,8 @@ class DiscussionBoardFragmentView(EdxFragmentView):
         course_key = CourseKey.from_string(course_id)
         # Force using the legacy view if a user profile is requested or the URL contains a specific topic or thread
         force_legacy_view = (profile_page_context or thread_id or discussion_id)
-        # TODO: remove role checks once course_roles is fully impelented and data is migrated
         is_educator_or_staff = (
-            is_course_staff(course_key, request.user) or GlobalStaff().has_user(request.user) or
-            request.user.has_perm(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.perm_name, course_key)
+            is_course_staff(course_key, request.user) or GlobalStaff().has_user(request.user)
         )
         try:
             base_context = _create_base_discussion_view_context(request, course_key)

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -201,7 +201,11 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         (CourseRolesPermission.MANAGE_ALL_USERS.value.name, False, False, True),
         (CourseRolesPermission.MANAGE_ALL_USERS.value.name, True, False, False),
         (CourseRolesPermission.MANAGE_ALL_USERS.value.name, True, True, True),
-        (CourseRolesPermission.MANAGE_ALL_USERS.value.name, False, True, True)
+        (CourseRolesPermission.MANAGE_ALL_USERS.value.name, False, True, True),
+        (CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.value.name, False, False, True),
+        (CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.value.name, True, False, False),
+        (CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.value.name, True, True, True),
+        (CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS.value.name, False, True, True),
     )
     @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
     @ddt.unpack

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -136,6 +136,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
     sections = []
     if access['manage_membership_full'] or access['manage_membership_limited']:
         sections.append(_section_course_info(course, access))
+    if access['manage_membership_full'] or access['manage_membership_limited'] or access['manage_discussions']:
         sections.append(_section_membership(course, access))
     if access['manage_cohorts']:
         sections.append(_section_cohort_management(course, access))


### PR DESCRIPTION
### Description
This PR adds permissions checks for course level permissions in the instructor_dashboard. The permissions checks are in places where access was not previously granted/limited by role. These permissions are designed to be assigned to course level roles that will be assigned to a user. The PR also removes permissions checks from places on the feature branch where only comment_client roles were previously checked. comment_client roles are based on permissions and a different solution should be considered for these roles.

This PR should have no immediate impact on any users. Later PRs will create new course_roles and migrate existing student_courseaccessrole user roles to the new course_roles user roles. Only after that time will these permissions grant or block access to instructor_dashboard.

### Supporting information
[course_roles tech spec](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3824648277/RBAC+Tech+Spec)

### Testing instructions
Testing will be completed on the feature branch once additional services have been updated to add permissions checks. Testing will involve creating a course_roles role and assigning it to a user. This user will then be used to confirm the correct access is granted to the user.

### Other information
This is a PR to a [feature branch](https://github.com/openedx/edx-platform/tree/CourseRoles).