### PR TITLE
feat: split full name into first name and last name

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -313,7 +313,7 @@ class RegistrationFormFactory:
     Construct Registration forms and associated fields.
     """
 
-    DEFAULT_FIELDS = ["email", "name", "username", "password"]
+    DEFAULT_FIELDS = ["email", "first_name", "last_name", "username", "password"]
 
     def _is_field_visible(self, field_name):
         """Check whether a field is visible based on Django settings. """
@@ -331,8 +331,6 @@ class RegistrationFormFactory:
 
         self.EXTRA_FIELDS = [
             "confirm_email",
-            "first_name",
-            "last_name",
             "city",
             "state",
             "country",
@@ -915,9 +913,15 @@ class RegistrationFormFactory:
         # which allows the user to input the First Name
         first_name_label = _("First Name")
 
+        first_name_instructions = _("This name will be used on any certificates that you earn.")
+
         form_desc.add_field(
             "first_name",
             label=first_name_label,
+            instructions=first_name_instructions,
+            restrictions={
+                "max_length": accounts.NAME_MAX_LENGTH,
+            },
             required=required
         )
 
@@ -932,9 +936,15 @@ class RegistrationFormFactory:
         # which allows the user to input the First Name
         last_name_label = _("Last Name")
 
+        last_name_instructions = _("This name will be used on any certificates that you earn.")
+
         form_desc.add_field(
             "last_name",
             label=last_name_label,
+            instructions=last_name_instructions,
+            restrictions={
+                "max_length": accounts.NAME_MAX_LENGTH,
+            },
             required=required
         )
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -589,13 +589,27 @@ class RegistrationViewTestV1(
         self._assert_reg_field(
             no_extra_fields_setting,
             {
-                "name": "name",
+                "name": "first_name",
                 "type": "text",
                 "required": True,
-                "label": "Full Name",
+                "label": "First Name",
                 "instructions": "This name will be used on any certificates that you earn.",
                 "restrictions": {
-                    "max_length": 255
+                    "max_length": NAME_MAX_LENGTH
+                },
+            }
+        )
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                "name": "last_name",
+                "type": "text",
+                "required": True,
+                "label": "Last Name",
+                "instructions": "This name will be used on any certificates that you earn.",
+                "restrictions": {
+                    "max_length": NAME_MAX_LENGTH
                 },
             }
         )
@@ -1311,10 +1325,12 @@ class RegistrationViewTestV1(
 
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
+
         field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
             "email",
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "password",
             "city",
@@ -1343,13 +1359,12 @@ class RegistrationViewTestV1(
             "confirm_email": "required",
         },
         REGISTRATION_FIELD_ORDER=[
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "email",
             "confirm_email",
             "password",
-            "first_name",
-            "last_name",
             "city",
             "state",
             "country",
@@ -1374,8 +1389,9 @@ class RegistrationViewTestV1(
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['name', 'username', 'email', 'password', 'city', 'state', 'country', 'gender',
-                               'year_of_birth', 'level_of_education', 'mailing_address', 'goals', 'honor_code']
+        assert field_names == ['first_name', 'last_name', 'username', 'email', 'password',
+                               'city', 'state', 'country', 'gender', 'year_of_birth',
+                               'level_of_education', 'mailing_address', 'goals', 'honor_code']
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1392,11 +1408,10 @@ class RegistrationViewTestV1(
         },
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
         REGISTRATION_FIELD_ORDER=[
-            "name",
-            "confirm_email",
-            "password",
             "first_name",
             "last_name",
+            "confirm_email",
+            "password",
             "gender",
             "year_of_birth",
             "level_of_education",
@@ -1414,10 +1429,11 @@ class RegistrationViewTestV1(
 
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
-        field_names = [field["name"] for field in form_desc["fields"]]
 
+        field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
-            "name",
+            "first_name",
+            "last_name",
             "password",
             "gender",
             "year_of_birth",
@@ -1999,11 +2015,10 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         },
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
         REGISTRATION_FIELD_ORDER=[
-            "name",
-            "confirm_email",
-            "password",
             "first_name",
             "last_name",
+            "confirm_email",
+            "password",
             "gender",
             "year_of_birth",
             "level_of_education",
@@ -2024,7 +2039,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         field_names = [field["name"] for field in form_desc["fields"]]
 
         assert field_names == [
-            "name",
+            "first_name",
+            "last_name",
             "confirm_email",
             "password",
             "gender",
@@ -2055,13 +2071,12 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             "confirm_email": "required",
         },
         REGISTRATION_FIELD_ORDER=[
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "email",
             "confirm_email",
             "password",
-            "first_name",
-            "last_name",
             "city",
             "state",
             "country",
@@ -2086,8 +2101,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['name', 'username', 'email', 'confirm_email',
-                               'password', 'city', 'state', 'country',
+        assert field_names == ['first_name', 'last_name', 'username', 'email',
+                               'confirm_email', 'password', 'city', 'state', 'country',
                                'gender', 'year_of_birth', 'level_of_education',
                                'mailing_address', 'goals', 'honor_code']
 
@@ -2116,7 +2131,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
             "email",
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "password",
             "confirm_email",
@@ -2162,7 +2178,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
             "email",
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "password",
             "confirm_email",


### PR DESCRIPTION
### Description

Split full name to first name and last name and add to the registration form, both fields(first name and last name) are required.

#### JIRA

[VAN-1807](https://2u-internal.atlassian.net/browse/VAN-1807)

#### How Has This Been Tested?

Tested Locally

###Screenshots:
Before|After|
|-------|-----|
|![Screenshot 2024-01-26 at 4 07 16 PM](https://github.com/openedx/edx-platform/assets/7627421/ee78e8f6-3430-4b1a-ad38-d93ec03b4359)|![Screenshot 2024-01-26 at 4 06 44 PM](https://github.com/openedx/edx-platform/assets/7627421/425b5dab-7e51-4b59-9fb1-aab9662dbb51)|
|![Screenshot 2024-01-26 at 4 07 22 PM](https://github.com/openedx/edx-platform/assets/7627421/0edbc108-beb1-4243-ad58-b61c7226fada)|![Screenshot 2024-01-26 at 4 06 51 PM](https://github.com/openedx/edx-platform/assets/7627421/4c16e31c-fc0b-4edf-b263-4edcd338d174)


