### PR TITLE
Revert "refactor: changed survey report message location and added a new info…"

### DIFF
--- a/lms/templates/admin/base_site.html
+++ b/lms/templates/admin/base_site.html
@@ -21,6 +21,6 @@
 
 {% endblock %}
 
-{% block messages %}{{ block.super }}
+{% block header %}{{ block.super }}
     {% include "survey_report/admin_banner.html" %}
 {% endblock %}

--- a/openedx/features/survey_report/admin.py
+++ b/openedx/features/survey_report/admin.py
@@ -21,7 +21,7 @@ class SurveyReportAdmin(admin.ModelAdmin):
     )
 
     list_display = (
-        'id', 'summary', 'created_at', 'report_state'
+        'id', 'summary', 'created_at', 'state'
     )
 
     actions = ['send_report']
@@ -79,17 +79,5 @@ class SurveyReportAdmin(admin.ModelAdmin):
         if 'delete_selected' in actions:
             del actions['delete_selected']
         return actions
-
-    def report_state(self, obj):
-        """
-        Method to define the custom State column with the new "send" state,
-        to avoid modifying the current models.
-        """
-        try:
-            if obj.surveyreportupload_set.last().is_uploaded():
-                return "Sent"
-        except AttributeError:
-            return obj.state.capitalize()
-    report_state.short_description = 'State'
 
 admin.site.register(SurveyReport, SurveyReportAdmin)

--- a/openedx/features/survey_report/templates/survey_report/admin_banner.html
+++ b/openedx/features/survey_report/templates/survey_report/admin_banner.html
@@ -1,6 +1,5 @@
 {% block survey_report_banner %}
 {% if show_survey_report_banner %}
-{% load static %}
 <div id="originalContent" style="border: 3px solid #06405d; margin-bottom: 50px; rgb(0 0 0 / 18%) 0px 3px 5px;">
   <div  style="background-color: #06405d;padding: 17px 37px;">
     <h1 style="margin: 0; color: #FFFF; font-weight: 600;">Join the Open edX Data Sharing Initiative and shape the future of learning</h1>
@@ -32,7 +31,6 @@
 {% endif %}
 
     <!-- The original content of the block -->
-    <script type="text/javascript" src="{% static 'common/js/vendor/jquery.js' %}"></script>
     <script>
    $(document).ready(function(){
     $('#dismissButton').click(function() {

--- a/openedx/features/survey_report/templates/survey_report/change_list.html
+++ b/openedx/features/survey_report/templates/survey_report/change_list.html
@@ -5,7 +5,7 @@
     <li>
         <form method="POST" action="{% url 'openedx.generate_survey_report' %}" class="inline">
             {% csrf_token %}
-            <input type="submit" value="Generate and Send Report" class="default" name="_sendreport">
+            <input type="submit" value="Generate Report" class="default" name="_generatereport">
         </form>
     </li>
 </ul>


### PR DESCRIPTION
Reverts openedx/edx-platform#34033

This PR is currently preventing enterprise from managing learners within enterprises as jquery is now loaded twice on django admin pages. 

This is the offending line from the PR:
```
<script type="text/javascript" src="{% static 'common/js/vendor/jquery.js' %}"></script>
```

Jira: https://2u-internal.atlassian.net/browse/ENT-8310

@ormsbee @Asespinel 