### PR TITLE
feat: bring in new client id configuration from ebk

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -478,7 +478,7 @@ edx-enterprise==4.10.9
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.3.2
     # via -r requirements/edx/kernel.in
@@ -770,7 +770,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==2.0.3
     # via -r requirements/edx/kernel.in
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-event-bus-kafka

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -760,7 +760,7 @@ edx-enterprise==4.10.9
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1300,7 +1300,7 @@ openedx-django-wiki==2.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -556,7 +556,7 @@ edx-enterprise==4.10.9
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.3.2
     # via -r requirements/edx/base.txt
@@ -912,7 +912,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.3
     # via -r requirements/edx/base.txt
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -73,8 +73,8 @@ edx-codejail
 edx-django-utils>=5.4.0             # Utilities for cache, monitoring, and plugins
 edx-drf-extensions
 edx-enterprise
-# edx-event-bus-kafka 4.0.0 adds support for configurable consumer API
-edx-event-bus-kafka>=4.0.1          # Kafka implementation of event bus
+# edx-event-bus-kafka 5.6.0 adds support for putting client ids on event producers/consumers
+edx-event-bus-kafka>=5.6.0          # Kafka implementation of event bus
 edx-event-bus-redis
 edx-milestones
 edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -584,7 +584,7 @@ edx-enterprise==4.10.9
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.3.2
     # via -r requirements/edx/base.txt
@@ -972,7 +972,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.3
     # via -r requirements/edx/base.txt
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka


### PR DESCRIPTION

## Description
Upgrade edx-event-bus-kafka to allow adding client ids to event producers and consumers. Will be set to 'cms' and 'lms' respectively (based on SERVICE_VARIANT).
