### PR TITLE
CourseRoles: instructor dashboard manage_students permissions checks

### DIFF
--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -113,7 +113,7 @@ perms[MANAGE_DISCUSSIONS] = (
     HasPermissionRule(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS) |
     HasForumsRolesRule(FORUM_ROLE_ADMINISTRATOR)
 )
-# # TODO: remove role checks once course_roles is fully implemented and data is migrated
+# TODO: remove role checks once course_roles is fully implemented and data is migrated
 perms[MANAGE_STUDENTS] = (
     HasAccessRule('instructor') |
     HasAccessRule('staff') |

--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -40,6 +40,7 @@ MANAGE_STUDENTS = 'instructor.manage_students'
 MANAGE_MEMBERSHIP_LIMITED = 'instructor.manage_membership_limited'
 MANAGE_MEMBERSHIP_FULL = 'instructor.manage_membership_full'
 MANAGE_COHORTS = 'instructor.manage_cohorts'
+MANAGE_COURSE_INFO = 'instructor.manage_course_info'
 
 perms[ALLOW_STUDENT_TO_BYPASS_ENTRANCE_EXAM] = HasAccessRule('staff')
 perms[ASSIGN_TO_COHORTS] = HasAccessRule('staff')
@@ -112,7 +113,7 @@ perms[MANAGE_DISCUSSIONS] = (
     HasPermissionRule(CourseRolesPermission.MANAGE_DISCUSSION_MODERATORS) |
     HasForumsRolesRule(FORUM_ROLE_ADMINISTRATOR)
 )
-# TODO: remove role checks once course_roles is fully implemented and data is migrated
+# # TODO: remove role checks once course_roles is fully implemented and data is migrated
 perms[MANAGE_STUDENTS] = (
     HasAccessRule('instructor') |
     HasAccessRule('staff') |
@@ -132,5 +133,13 @@ perms[MANAGE_MEMBERSHIP_FULL] = (
 perms[MANAGE_COHORTS] = (
     HasAccessRule('instructor') |
     HasAccessRule('staff') |
-    HasPermissionRule(CourseRolesPermission.MANAGE_COHORTS)
+    HasPermissionRule(CourseRolesPermission.MANAGE_COHORTS) |
+    HasPermissionRule(CourseRolesPermission.MANAGE_STUDENTS)
+)
+# TODO: remove role checks once course_roles is fully implemented
+perms[MANAGE_COURSE_INFO] = (
+    HasAccessRule('instructor') |
+    HasAccessRule('staff') |
+    HasPermissionRule(CourseRolesPermission.MANAGE_ALL_USERS) |
+    HasPermissionRule(CourseRolesPermission.MANAGE_USERS_EXCEPT_ADMIN_AND_STAFF)
 )

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -25,6 +25,7 @@ from common.djangoapps.student.tests.factories import AdminFactory, CourseAccess
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import XssTestMixin
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseAuthorization
 from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.tabs import get_course_tab_list
@@ -595,6 +596,30 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
     @override_settings(ANALYTICS_DASHBOARD_URL='http://example.com')
     @override_settings(ANALYTICS_DASHBOARD_NAME='Example')
+    @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
+    def test_dashboard_analytics_access_based_on_permissions(self):
+        """
+        Test analytics dashboard message is shown based on user permissions
+        """
+        user = UserFactory.create()
+        role = Role.objects.create(name='test_role_1')
+        role.permissions.create(name=CourseRolesPermission.MANAGE_STUDENTS.value.name)
+        role.permissions.create(
+            name=CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD.value.name
+        )
+        UserRole.objects.get_or_create(
+            user=user,
+            role=role,
+            course=self.course_overview,
+        )
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
+        response = self.client.get(self.url)
+        analytics_section = '<li class="nav-item"><button type="button" class="btn-link instructor_analytics"' \
+                            ' data-section="instructor_analytics">Analytics</button></li>'
+        self.assertContains(response, analytics_section)
+
+    @override_settings(ANALYTICS_DASHBOARD_URL='http://example.com')
+    @override_settings(ANALYTICS_DASHBOARD_NAME='Example')
     def test_dashboard_analytics_points_at_insights(self):
         """
         Test analytics dashboard message is shown
@@ -681,8 +706,12 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         self.assertContains(response, ora_section)
 
+    @ddt.data(
+        (CourseRolesPermission.MANAGE_GRADES.value.name),
+        (CourseRolesPermission.MANAGE_STUDENTS.value.name)
+    )
     @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
-    def test_open_response_assessment_page_access_based_on_permissions(self):
+    def test_open_response_assessment_page_access_based_on_permissions(self, permission):
         """
         Test that Open Responses is available only if course contains at least one ORA block
         and user has correct permissions
@@ -696,7 +725,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
         user = UserFactory.create()
         role = Role.objects.create(name='test_role_1')
-        role.permissions.create(name=CourseRolesPermission.MANAGE_GRADES.value.name)
+        role.permissions.create(name=permission)
         role.permissions.create(
             name=CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD.value.name
         )
@@ -749,6 +778,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
     @ddt.data(
         (CourseRolesPermission.MANAGE_ALL_USERS.value.name, True),
         (CourseRolesPermission.MANAGE_USERS_EXCEPT_ADMIN_AND_STAFF.value.name, False),
+        (CourseRolesPermission.MANAGE_STUDENTS.value.name, False)
     )
     @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
     @ddt.unpack
@@ -777,8 +807,12 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         self.assertContains(response, membership_section)
         self.assertEqual(access, admin_role in str(response.content))
 
+    @ddt.data(
+        (CourseRolesPermission.MANAGE_COHORTS.value.name),
+        (CourseRolesPermission.MANAGE_STUDENTS.value.name)
+    )
     @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
-    def test_cohort_page_access_based_on_permissions(self):
+    def test_cohort_page_access_based_on_permissions(self, permission):
         """
         Test that Cohorts tab is available only if user has correct permissions
         """
@@ -788,7 +822,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
         user = UserFactory.create()
         role = Role.objects.create(name='test_role_1')
-        role.permissions.create(name=CourseRolesPermission.MANAGE_COHORTS.value.name)
+        role.permissions.create(name=permission)
         role.permissions.create(
             name=CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD.value.name
         )
@@ -804,6 +838,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
     @ddt.data(
         (CourseRolesPermission.MANAGE_ALL_USERS.value.name),
         (CourseRolesPermission.MANAGE_USERS_EXCEPT_ADMIN_AND_STAFF.value.name),
+        (CourseRolesPermission.MANAGE_STUDENTS.value.name)
     )
     @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
     def test_student_admin_page_access_based_on_permissions(self, permission_name):
@@ -829,9 +864,13 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url).content.decode('utf-8')
         self.assertEqual(True, admin_section in response)
 
+    @ddt.data(
+        (CourseRolesPermission.MANAGE_ALL_USERS.value.name),
+        (CourseRolesPermission.MANAGE_STUDENTS.value.name)
+    )
     @patch('lms.djangoapps.instructor.views.instructor_dashboard.is_enabled_for_course')
     @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
-    def test_extensions_page_access_based_on_permissions(self, mock):
+    def test_extensions_page_access_based_on_permissions(self, permission, mock):
         """
         Test that Extensions is available only if user has correct permissions
         """
@@ -842,7 +881,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
         user = UserFactory.create()
         role = Role.objects.create(name='test_role_1')
-        role.permissions.create(name=CourseRolesPermission.MANAGE_ALL_USERS.value.name)
+        role.permissions.create(name=permission)
         role.permissions.create(
             name=CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD.value.name
         )
@@ -855,6 +894,67 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url).content.decode('utf-8')
         self.assertEqual(True, extension_section in response)
 
+    @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
+    def test_send_email_page_access_based_on_permissions(self):
+        """
+        Test that Email tab is available only if user has correct permissions
+        """
+        send_email_section = (
+            '<li class="nav-item"><button type="button" class="btn-link send_email" '
+            'data-section="send_email">Email</button></li>'
+        )
+        BulkEmailFlag.objects.create(enabled=True, require_course_email_auth=True)
+        cauth = CourseAuthorization(course_id=self.course.id, email_enabled=True)
+        cauth.save()
+        user = UserFactory.create()
+        role = Role.objects.create(name='test_role_1')
+        role.permissions.create(name=CourseRolesPermission.MANAGE_STUDENTS.value.name)
+        role.permissions.create(
+            name=CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD.value.name
+        )
+        UserRole.objects.get_or_create(
+            user=user,
+            role=role,
+            course=self.course_overview,
+        )
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
+        response = self.client.get(self.url)
+        self.assertContains(response, send_email_section)
+
+    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_waffle_flag(USE_PERMISSION_CHECKS_FLAG, active=True)
+    def test_special_exams_proctored_page_access_based_on_permissions(self):
+        """
+        Test that Email tab is available only if user has correct permissions
+        """
+        special_exams_section = (
+            '<li class="nav-item"><button type="button" class="btn-link special_exams" '
+            'data-section="special_exams">Special Exams</button></li>'
+        )
+        course = CourseFactory.create(
+            enable_proctored_exams=True,
+            enable_timed_exams=True,
+            grading_policy={"GRADE_CUTOFFS": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5}},
+            display_name='<script>alert("XSS")</script>',
+            default_store=ModuleStoreEnum.Type.split
+        )
+        course_overview = CourseOverview.get_from_id(course.id)
+        course_overview.save()
+        user = UserFactory.create()
+        role = Role.objects.create(name='test_role_1')
+        role.permissions.create(name=CourseRolesPermission.MANAGE_STUDENTS.value.name)
+        role.permissions.create(
+            name=CourseRolesPermission.ACCESS_INSTRUCTOR_DASHBOARD.value.name
+        )
+        UserRole.objects.get_or_create(
+            user=user,
+            role=role,
+            course=course_overview,
+        )
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
+        url = reverse('instructor_dashboard', kwargs={'course_id': str(course.id)})
+        response = self.client.get(url)
+        self.assertContains(response, special_exams_section)
 
 @ddt.ddt
 class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTestCase, XssTestMixin):

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -956,6 +956,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(url)
         self.assertContains(response, special_exams_section)
 
+
 @ddt.ddt
 class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTestCase, XssTestMixin):
     """

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -27,10 +27,6 @@ from openedx_filters.learning.filters import InstructorDashboardRenderStarted
 from common.djangoapps.course_modes.models import CourseMode, CourseModesArchive
 from common.djangoapps.edxmako.shortcuts import render_to_response, render_to_string
 from common.djangoapps.student.models import CourseEnrollment
-from common.djangoapps.student.roles import (
-    CourseInstructorRole,
-    CourseStaffRole
-)
 from common.djangoapps.util.json_request import JsonResponse
 from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
 from lms.djangoapps.bulk_email.models_api import is_bulk_email_disabled_for_course
@@ -48,7 +44,6 @@ from lms.djangoapps.courseware.masquerade import get_masquerade_role
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from lms.djangoapps.instructor.constants import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
-from openedx.core.djangoapps.course_roles.data import CourseRolesPermission
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.djangoapps.discussions.utils import available_division_schemes
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings


### PR DESCRIPTION
### Description
This PR adds permissions checks for course level permissions in the instructor_dashboard. The permissions checks are in places where access was not previously granted/limited by role. These permissions are designed to be assigned to course level roles that will be assigned to a user. 

This PR should have no immediate impact on any users. Later PRs will create new course_roles and migrate existing student_courseaccessrole user roles to the new course_roles user roles. Only after that time will these permissions grant or block access to instructor_dashboard.

### Supporting information
[course_roles tech spec](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3824648277/RBAC+Tech+Spec)

### Testing instructions
Testing will be completed on the feature branch once additional services have been updated to add permissions checks. Testing will involve creating a course_roles role and assigning it to a user. This user will then be used to confirm the correct access is granted to the user.

### Other information
This is a PR to a [feature branch](https://github.com/openedx/edx-platform/tree/CourseRoles).