### PR TITLE
Pin optimizely sdk

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -107,3 +107,9 @@ openedx-learning==0.4.4
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1
+
+# optimizely-sdk 5.0.0 is breaking following test with segmentation fault
+# common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest::test_secure_key_configuration
+# needs to be fixed in the follow up issue 
+# https://github.com/openedx/edx-platform/issues/34103
+optimizely-sdk==4.1.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -112,4 +112,4 @@ openai<=0.28.1
 # common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest::test_secure_key_configuration
 # needs to be fixed in the follow up issue 
 # https://github.com/openedx/edx-platform/issues/34103
-optimizely-sdk==4.1.1
+optimizely-sdk<5.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -786,7 +786,9 @@ openedx-learning==0.4.4
 openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
-    # via -r requirements/edx/bundled.in
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/bundled.in
 ora2==6.0.29
     # via -r requirements/edx/bundled.in
 packaging==23.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1322,6 +1322,7 @@ openedx-mongodbproxy==0.2.0
     #   -r requirements/edx/testing.txt
 optimizely-sdk==4.1.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 ora2==6.0.29

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -928,7 +928,9 @@ openedx-learning==0.4.4
 openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 ora2==6.0.29
     # via -r requirements/edx/base.txt
 packaging==23.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -988,7 +988,9 @@ openedx-learning==0.4.4
 openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 ora2==6.0.29
     # via -r requirements/edx/base.txt
 packaging==23.2


### PR DESCRIPTION
## Description
- Pinned optimizely-sdk version because `optimizely-sdk>5.0` started failing unit tests.
- Created follow up issue # https://github.com/openedx/edx-platform/issues/34103 to remove this constraint later on.