### PR TITLE
Revert "temp: add temporary logs for course wide notifications"

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -1,8 +1,6 @@
 """
 Discussion notifications sender util.
 """
-import logging
-
 from django.conf import settings
 from lms.djangoapps.discussion.django_comment_client.permissions import get_team
 from openedx_events.learning.data import UserNotificationData, CourseNotificationData
@@ -20,9 +18,6 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_MODERATOR,
     CourseDiscussionSettings,
 )
-
-
-log = logging.getLogger(__name__)
 
 
 class DiscussionNotificationSender:
@@ -262,8 +257,6 @@ class DiscussionNotificationSender:
             'username': self.creator.username,
             'post_title': self.thread.title
         }
-
-        log.info(f"Temp: Audience filter for course-wide notification is {audience_filters}")
         self._send_course_wide_notification(notification_type, audience_filters, context)
 
 

--- a/openedx/core/djangoapps/notifications/audience_filters.py
+++ b/openedx/core/djangoapps/notifications/audience_filters.py
@@ -1,7 +1,6 @@
 """
 Audience based filters for notifications
 """
-import logging
 
 from abc import abstractmethod
 
@@ -20,9 +19,6 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_COMMUNITY_TA,
     FORUM_ROLE_STUDENT,
 )
-
-
-log = logging.getLogger(__name__)
 
 
 class NotificationAudienceFilterBase:
@@ -84,12 +80,10 @@ class CourseRoleAudienceFilter(NotificationAudienceFilterBase):
 
         if 'staff' in course_roles:
             staff_users = CourseStaffRole(course_key).users_with_role().values_list('id', flat=True)
-            log.info(f'Temp: Course wide notification, staff users calculated are {staff_users}')
             user_ids.extend(staff_users)
 
         if 'instructor' in course_roles:
             instructor_users = CourseInstructorRole(course_key).users_with_role().values_list('id', flat=True)
-            log.info(f'Temp: Course wide notification, instructor users calculated are {instructor_users}')
             user_ids.extend(instructor_users)
 
         return user_ids

--- a/openedx/core/djangoapps/notifications/handlers.py
+++ b/openedx/core/djangoapps/notifications/handlers.py
@@ -96,13 +96,10 @@ def calculate_course_wide_notification_audience(course_key, audience_filters):
             if filter_class:
                 filter_instance = filter_class(course_key)
                 filtered_users = filter_instance.filter(filter_values)
-                log.info(f'Temp: Course-wide notification filtered users are '
-                         f'{filtered_users} for filter type {filter_type}')
                 audience_user_ids.extend(filtered_users)
         else:
             raise ValueError(f"Invalid audience filter type: {filter_type}")
 
-    log.info(f'Temp: Course-wide notification after audience filter is applied, users: {list(set(audience_user_ids))}')
     return list(set(audience_user_ids))
 
 
@@ -131,5 +128,4 @@ def generate_course_notifications(signal, sender, course_notification_data, meta
         'content_url': course_notification_data.get('content_url'),
     }
 
-    log.info(f"Temp: Course-wide notification, user_ids to sent notifications to {notification_data.get('user_ids')}")
     send_notifications.delay(**notification_data)


### PR DESCRIPTION
Reverts openedx/edx-platform#33978

These logs were added for testing course-wide notifications.
This PR removes these logs, after testing has been completed.