### PR TITLE
feat: Added XblockMixin for skill tagging

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -68,6 +68,10 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
 from openedx.core.lib.derived import derived, derived_collection_entry
 from openedx.core.release import doc_version
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
+try:
+    from skill_tagging.skill_tagging_mixin import SkillTaggingMixin
+except ImportError:
+    SkillTaggingMixin = None
 
 ################################### FEATURES ###################################
 # .. setting_name: PLATFORM_NAME
@@ -1633,6 +1637,8 @@ from xmodule.x_module import XModuleMixin  # lint-amnesty, pylint: disable=wrong
 # This should be moved into an XBlock Runtime/Application object
 # once the responsibility of XBlock creation is moved out of modulestore - cpennington
 XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin, XModuleMixin, EditInfoMixin)
+if SkillTaggingMixin:
+    XBLOCK_MIXINS += (SkillTaggingMixin,)
 XBLOCK_EXTRA_MIXINS = ()
 
 # .. setting_name: XBLOCK_FIELD_DATA_WRAPPERS


### PR DESCRIPTION
## Description

This PR adds a Xblock Mixin for verifying the skill tags associated with Xblocks. The Mixin class resides [here](https://github.com/openedx/xblock-skill-tagging/blob/43228d90abf157c96caa8165214e058b8b6295ef/skill_tagging/skill_tagging_mixin.py#L30).

## Other information

The setting was previously [reverted](https://github.com/openedx/edx-platform/pull/33102/files) due to high number of LMS -> Discovery service calls. A [probabilistic throttle](https://github.com/openedx/xblock-skill-tagging/blob/43228d90abf157c96caa8165214e058b8b6295ef/skill_tagging/pipeline.py#L39) has been added to reduce the calls frequency. A django [Waffle switch](https://github.com/openedx/edx-platform/blob/5c58eb47bd06c0928b5890705be021754422ef51/xmodule/vertical_block.py#L45) has been added to quickly respond to any anomalous events.
