### PR TITLE
[FC-0049] feat: Serialize tag data in OLX for blocks

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -129,6 +129,7 @@ from django.urls import reverse_lazy
 
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 from cms.lib.xblock.authoring_mixin import AuthoringMixin
+from cms.lib.xblock.tagging.tagged_block_mixin import TaggedBlockMixin
 from xmodule.modulestore.edit_info import EditInfoMixin
 from openedx.core.djangoapps.theming.helpers_dirs import (
     get_themes_unchecked,
@@ -975,6 +976,7 @@ XBLOCK_MIXINS = (
     XModuleMixin,
     EditInfoMixin,
     AuthoringMixin,
+    TaggedBlockMixin,
 )
 XBLOCK_EXTRA_MIXINS = ()
 

--- a/cms/lib/xblock/tagging/tagged_block_mixin.py
+++ b/cms/lib/xblock/tagging/tagged_block_mixin.py
@@ -1,0 +1,57 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
+from urllib.parse import quote
+
+
+class TaggedBlockMixin:
+    """
+    Mixin containing XML serializing and parsing functionality for tagged blocks
+    """
+
+    def serialize_tag_data(self):
+        """
+        Serialize block's tag data to include in the xml, escaping special characters
+
+        Example tags:
+            LightCast Skills Taxonomy: ["Typing", "Microsoft Office"]
+            Open Canada Skills Taxonomy: ["MS Office", "<some:;,skill/|=>"]
+
+        Example serialized tags:
+            lightcast-skills:Typing,Microsoft Office;open-canada-skills:MS Office,%3Csome%3A%3B%2Cskill%2F%7C%3D%3E
+        """
+        # This import is done here since we import and use TaggedBlockMixin in the cms settings, but the
+        # content_tagging app wouldn't have loaded yet, so importing it outside causes an error
+        from openedx.core.djangoapps.content_tagging.api import get_object_tags
+        content_tags = get_object_tags(self.scope_ids.usage_id)
+
+        serialized_tags = []
+        taxonomies_and_tags = {}
+        for tag in content_tags:
+            taxonomy_export_id = tag.taxonomy.export_id
+
+            if not taxonomies_and_tags.get(taxonomy_export_id):
+                taxonomies_and_tags[taxonomy_export_id] = []
+
+            # Escape special characters in tag values, except spaces (%20) for better readability
+            escaped_tag = quote(tag.value).replace("%20", " ")
+            taxonomies_and_tags[taxonomy_export_id].append(escaped_tag)
+
+        for taxonomy in taxonomies_and_tags:
+            merged_tags = ','.join(taxonomies_and_tags.get(taxonomy))
+            serialized_tags.append(f"{taxonomy}:{merged_tags}")
+
+        return ";".join(serialized_tags)
+
+    def add_tags_to_node(self, node):
+        """
+        Serialize and add tag data (if any) to node
+        """
+        tag_data = self.serialize_tag_data()
+        if tag_data:
+            node.set('tags-v1', tag_data)
+
+    def add_xml_to_node(self, node):
+        """
+        Include the serialized tag data in XML when adding to node
+        """
+        super().add_xml_to_node(node)
+        self.add_tags_to_node(node)

--- a/openedx/core/lib/xblock_serializer/block_serializer.py
+++ b/openedx/core/lib/xblock_serializer/block_serializer.py
@@ -7,6 +7,8 @@ import os
 
 from lxml import etree
 
+from cms.lib.xblock.tagging.tagged_block_mixin import TaggedBlockMixin
+
 from .data import StaticFile
 from . import utils
 
@@ -112,6 +114,10 @@ class XBlockSerializer:
             olx_node.attrib["editor"] = block.editor
         if block.use_latex_compiler:
             olx_node.attrib["use_latex_compiler"] = "true"
+
+        # Serialize and add tag data if any
+        if isinstance(block, TaggedBlockMixin):
+            block.add_tags_to_node(olx_node)
 
         # Escape any CDATA special chars
         escaped_block_data = block.data.replace("]]>", "]]&gt;")

--- a/openedx/core/lib/xblock_serializer/test_api.py
+++ b/openedx/core/lib/xblock_serializer/test_api.py
@@ -6,8 +6,11 @@ from xml.etree import ElementTree
 from openedx.core.djangolib.testing.utils import skip_unless_cms
 from xmodule.modulestore.django import contentstore, modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, upload_file_to_course
-from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory, ToyCourseFactory
+from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory, ToyCourseFactory, LibraryFactory
 from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
+from openedx_tagging.core.tagging.models import Tag
+from openedx.core.djangoapps.content_tagging.models import TaxonomyOrg
+from openedx.core.djangoapps.content_tagging import api as tagging_api
 
 from . import api
 
@@ -65,6 +68,112 @@ And it shouldn't matter if we use entities or numeric codes &mdash; &Omega; &ne;
 """
 
 
+EXPECTED_OPENASSESSMENT_OLX = """
+<openassessment
+    submission_start="2001-01-01T00:00"
+    submission_due="2029-01-01T00:00"
+    text_response="required"
+    text_response_editor="text"
+    allow_multiple_files="True"
+    allow_latex="False"
+    prompts_type="text"
+    teams_enabled="False"
+    selected_teamset_id=""
+    show_rubric_during_response="False"
+    tags-v1="t1-export-id:%3Cspecial %22%27-%3D%2C. %7C%3D chars %3E tag,anotherTag,normal tag"
+>
+  <title>Open Response Assessment</title>
+  <assessments>
+    <assessment name="student-training">
+      <example>
+        <answer>
+          <part>Replace this text with your own sample response for this assignment. Then, under Response Score to the right, select an option for each criterion. Learners practice performing peer assessments by assessing this response and comparing the options that they select in the rubric with the options that you specified.</part>
+        </answer>
+        <select criterion="Ideas" option="Fair"/>
+        <select criterion="Content" option="Good"/>
+      </example>
+      <example>
+        <answer>
+          <part>Replace this text with another sample response, and then specify the options that you would select for this response.</part>
+        </answer>
+        <select criterion="Ideas" option="Poor"/>
+        <select criterion="Content" option="Good"/>
+      </example>
+    </assessment>
+    <assessment name="peer-assessment" must_grade="5" must_be_graded_by="3" enable_flexible_grading="False" start="2001-01-01T00:00" due="2029-01-01T00:00"/>
+    <assessment name="self-assessment" start="2001-01-01T00:00" due="2029-01-01T00:00"/>
+    <assessment name="staff-assessment" start="2001-01-01T00:00" due="2029-01-01T00:00" required="False"/>
+  </assessments>
+  <prompts>
+    <prompt>
+      <description>
+    Censorship in the Libraries
+
+    'All of us can think of a book that we hope none of our children or any other children have taken off the shelf. But if I have the right to remove that book from the shelf -- that work I abhor -- then you also have exactly the same right and so does everyone else. And then we have no books left on the shelf for any of us.' --Katherine Paterson, Author
+
+    Write a persuasive essay to a newspaper reflecting your views on censorship in libraries. Do you believe that certain materials, such as books, music, movies, magazines, etc., should be removed from the shelves if they are found offensive? Support your position with convincing arguments from your own experience, observations, and/or reading.
+
+    Read for conciseness, clarity of thought, and form.
+</description>
+    </prompt>
+  </prompts>
+  <rubric>
+    <criterion feedback="optional">
+      <name>Ideas</name>
+      <label>Ideas</label>
+      <prompt>Determine if there is a unifying theme or main idea.</prompt>
+      <option points="0">
+        <name>Poor</name>
+        <label>Poor</label>
+        <explanation>Difficult for the reader to discern the main idea.  Too brief or too repetitive to establish or maintain a focus.</explanation>
+      </option>
+      <option points="3">
+        <name>Fair</name>
+        <label>Fair</label>
+        <explanation>Presents a unifying theme or main idea, but may include minor tangents.  Stays somewhat focused on topic and task.</explanation>
+      </option>
+      <option points="5">
+        <name>Good</name>
+        <label>Good</label>
+        <explanation>Presents a unifying theme or main idea without going off on tangents.  Stays completely focused on topic and task.</explanation>
+      </option>
+    </criterion>
+    <criterion>
+      <name>Content</name>
+      <label>Content</label>
+      <prompt>Assess the content of the submission</prompt>
+      <option points="0">
+        <name>Poor</name>
+        <label>Poor</label>
+        <explanation>Includes little information with few or no details or unrelated details.  Unsuccessful in attempts to explore any facets of the topic.</explanation>
+      </option>
+      <option points="1">
+        <name>Fair</name>
+        <label>Fair</label>
+        <explanation>Includes little information and few or no details.  Explores only one or two facets of the topic.</explanation>
+      </option>
+      <option points="3">
+        <name>Good</name>
+        <label>Good</label>
+        <explanation>Includes sufficient information and supporting details. (Details may not be fully developed; ideas may be listed.)  Explores some facets of the topic.</explanation>
+      </option>
+      <option points="5">
+        <name>Excellent</name>
+        <label>Excellent</label>
+        <explanation>Includes in-depth information and exceptional supporting details that are fully developed.  Explores all facets of the topic.</explanation>
+      </option>
+    </criterion>
+    <feedbackprompt>
+(Optional) What aspects of this response stood out to you? What did it do well? How could it be improved?
+</feedbackprompt>
+    <feedback_default_text>
+I think that this response...
+</feedback_default_text>
+  </rubric>
+</openassessment>
+"""
+
+
 @skip_unless_cms
 class XBlockSerializationTestCase(SharedModuleStoreTestCase):
     """
@@ -78,6 +187,25 @@ class XBlockSerializationTestCase(SharedModuleStoreTestCase):
         """
         super().setUpClass()
         cls.course = ToyCourseFactory.create()
+
+        # Create taxonomies and tags for testing
+        cls.taxonomy1 = tagging_api.create_taxonomy(name="t1", enabled=True, export_id="t1-export-id")
+        TaxonomyOrg.objects.create(
+            taxonomy=cls.taxonomy1,
+            rel_type=TaxonomyOrg.RelType.OWNER,
+        )
+        cls.taxonomy2 = tagging_api.create_taxonomy(name="t2", enabled=True, export_id="t2-export-id")
+        TaxonomyOrg.objects.create(
+            taxonomy=cls.taxonomy2,
+            rel_type=TaxonomyOrg.RelType.OWNER,
+        )
+        root1 = Tag.objects.create(taxonomy=cls.taxonomy1, value="ROOT1")
+        root2 = Tag.objects.create(taxonomy=cls.taxonomy2, value="ROOT2")
+        Tag.objects.create(taxonomy=cls.taxonomy1, value="normal tag", parent=root1)
+        Tag.objects.create(taxonomy=cls.taxonomy1, value="<special \"'-=,. |= chars > tag", parent=root1)
+        Tag.objects.create(taxonomy=cls.taxonomy1, value="anotherTag", parent=root1)
+        Tag.objects.create(taxonomy=cls.taxonomy2, value="tag", parent=root2)
+        Tag.objects.create(taxonomy=cls.taxonomy2, value="other tag", parent=root2)
 
     def assertXmlEqual(self, xml_str_a: str, xml_str_b: str) -> bool:
         """ Assert that the given XML strings are equal, ignoring attribute order and some whitespace variations. """
@@ -286,4 +414,274 @@ class XBlockSerializationTestCase(SharedModuleStoreTestCase):
                 <jsinput html_file='/static/simple-question.html' />
             </problem>
             """
+        )
+
+    def test_tagged_units(self):
+        """
+        Test units (vertical blocks) that have applied tags
+        """
+        course = CourseFactory.create(display_name='Tagged Unit Course', run="TUC")
+        unit = BlockFactory(
+            parent_location=course.location,
+            category="vertical",
+            display_name="Tagged Unit",
+        )
+
+        # Add a bunch of tags
+        tagging_api.tag_object(
+            object_id=unit.location,
+            taxonomy=self.taxonomy1,
+            tags=["normal tag", "<special \"'-=,. |= chars > tag", "anotherTag"]
+        )
+        tagging_api.tag_object(
+            object_id=unit.location,
+            taxonomy=self.taxonomy2,
+            tags=["tag", "other tag"]
+        )
+
+        # Check that the tags data in included in the OLX and properly escaped
+        serialized = api.serialize_xblock_to_olx(unit)
+        expected_serialized_tags = (
+            "t1-export-id:%3Cspecial %22%27-%3D%2C. %7C%3D chars %3E tag,anotherTag,normal tag;"
+            "t2-export-id:other tag,tag"
+        )
+        self.assertXmlEqual(
+            serialized.olx_str,
+            f"""
+            <vertical
+                display_name="Tagged Unit"
+                url_name="Tagged_Unit"
+                tags-v1="{expected_serialized_tags}"
+            />
+            """
+        )
+
+    def test_tagged_html_block(self):
+        """
+        Test html blocks that have applied tags
+        """
+        course = CourseFactory.create(display_name='Tagged HTML Block Test Course', run="THBTC")
+
+        # Create html block
+        html_block = BlockFactory.create(
+            parent_location=course.location,
+            category="html",
+            display_name="Tagged Non-default HTML Block",
+            editor="raw",
+            use_latex_compiler=True,
+            data="🍔",
+        )
+
+        # Add a bunch of tags
+        tagging_api.tag_object(
+            object_id=html_block.location,
+            taxonomy=self.taxonomy1,
+            tags=["normal tag", "<special \"'-=,. |= chars > tag", "anotherTag"]
+        )
+        tagging_api.tag_object(
+            object_id=html_block.location,
+            taxonomy=self.taxonomy2,
+            tags=["tag", "other tag"]
+        )
+
+        # Check that the tags data in included in the OLX and properly escaped
+        serialized = api.serialize_xblock_to_olx(html_block)
+        expected_serialized_tags = (
+            "t1-export-id:%3Cspecial %22%27-%3D%2C. %7C%3D chars %3E tag,anotherTag,normal tag;"
+            "t2-export-id:other tag,tag"
+        )
+        self.assertXmlEqual(
+            serialized.olx_str,
+            f"""
+            <html
+                url_name="Tagged_Non-default_HTML_Block"
+                display_name="Tagged Non-default HTML Block"
+                editor="raw"
+                use_latex_compiler="true"
+                tags-v1="{expected_serialized_tags}"
+            ><![CDATA[
+                🍔
+            ]]></html>
+            """
+        )
+
+    def test_tagged_problem_blocks(self):
+        """
+        Test regular problem block + problem block with dependancy that
+        have applied tags
+        """
+        course = CourseFactory.create(display_name='Tagged Python Testing course', run="TPY")
+        upload_file_to_course(
+            course_key=course.id,
+            contentstore=contentstore(),
+            source_file='./common/test/data/uploads/python_lib.zip',
+            target_filename=DEFAULT_PYTHON_LIB_FILENAME,
+        )
+
+        regular_problem = BlockFactory.create(
+            parent_location=course.location,
+            category="problem",
+            display_name="Tagged Problem No Python",
+            max_attempts=3,
+            data="<problem><optionresponse></optionresponse></problem>",
+        )
+
+        python_problem = BlockFactory.create(
+            parent_location=course.location,
+            category="problem",
+            display_name="Tagged Python Problem",
+            data='<problem>This uses python: <script type="text/python">...</script>...</problem>',
+        )
+
+        # Add a bunch of tags to the problem blocks
+        tagging_api.tag_object(
+            object_id=regular_problem.location,
+            taxonomy=self.taxonomy1,
+            tags=["normal tag", "<special \"'-=,. |= chars > tag", "anotherTag"]
+        )
+        tagging_api.tag_object(
+            object_id=regular_problem.location,
+            taxonomy=self.taxonomy2,
+            tags=["tag", "other tag"]
+        )
+        tagging_api.tag_object(
+            object_id=python_problem.location,
+            taxonomy=self.taxonomy1,
+            tags=["normal tag", "<special \"'-=,. |= chars > tag", "anotherTag"]
+        )
+        tagging_api.tag_object(
+            object_id=python_problem.location,
+            taxonomy=self.taxonomy2,
+            tags=["tag", "other tag"]
+        )
+
+        # Check that the tags data in included in the OLX and properly escaped
+        serialized = api.serialize_xblock_to_olx(regular_problem)
+        expected_serialized_tags = (
+            "t1-export-id:%3Cspecial %22%27-%3D%2C. %7C%3D chars %3E tag,anotherTag,normal tag;"
+            "t2-export-id:other tag,tag"
+        )
+        self.assertXmlEqual(
+            serialized.olx_str,
+            f"""
+            <problem
+                display_name="Tagged Problem No Python"
+                url_name="Tagged_Problem_No_Python"
+                max_attempts="3"
+                tags-v1="{expected_serialized_tags}"
+            >
+                <optionresponse></optionresponse>
+            </problem>
+            """
+        )
+
+        serialized = api.serialize_xblock_to_olx(python_problem)
+        expected_serialized_tags = (
+            "t1-export-id:%3Cspecial %22%27-%3D%2C. %7C%3D chars %3E tag,anotherTag,normal tag;"
+            "t2-export-id:other tag,tag"
+        )
+        self.assertXmlEqual(
+            serialized.olx_str,
+            f"""
+            <problem
+                display_name="Tagged Python Problem"
+                url_name="Tagged_Python_Problem"
+                tags-v1="{expected_serialized_tags}"
+            >
+                This uses python: <script type="text/python">...</script>...
+            </problem>
+            """
+        )
+
+    def test_tagged_library_content_blocks(self):
+        """
+        Test library content blocks that have applied tags
+        """
+        course = CourseFactory.create(display_name='Tagged Library Content course', run="TLCC")
+        lib = LibraryFactory()
+        lc_block = BlockFactory(
+            parent_location=course.location,
+            category="library_content",
+            source_library_id=str(lib.location.library_key),
+            display_name="Tagged LC Block",
+            max_count=1,
+        )
+
+        # Add a bunch of tags to the library content block
+        tagging_api.tag_object(
+            object_id=lc_block.location,
+            taxonomy=self.taxonomy1,
+            tags=["normal tag", "<special \"'-=,. |= chars > tag", "anotherTag"]
+        )
+
+        # Check that the tags data in included in the OLX and properly escaped
+        serialized = api.serialize_xblock_to_olx(lc_block)
+        self.assertXmlEqual(
+            serialized.olx_str,
+            f"""
+            <library_content
+                display_name="Tagged LC Block"
+                max_count="1"
+                source_library_id="{str(lib.location.library_key)}"
+                url_name="Tagged_LC_Block"
+                tags-v1="t1-export-id:%3Cspecial %22%27-%3D%2C. %7C%3D chars %3E tag,anotherTag,normal tag"
+            />
+            """
+        )
+
+    def test_tagged_video_block(self):
+        """
+        Test video blocks that have applied tags
+        """
+        course = CourseFactory.create(display_name='Tagged Video Test course', run="TVTC")
+        video_block = BlockFactory.create(
+            parent_location=course.location,
+            category="video",
+            display_name="Tagged Video Block",
+        )
+
+        # Add tags to video block
+        tagging_api.tag_object(
+            object_id=video_block.location,
+            taxonomy=self.taxonomy1,
+            tags=["normal tag", "<special \"'-=,. |= chars > tag", "anotherTag"]
+        )
+
+        # Check that the tags data in included in the OLX and properly escaped
+        serialized = api.serialize_xblock_to_olx(video_block)
+        self.assertXmlEqual(
+            serialized.olx_str,
+            """
+            <video
+                youtube="1.00:3_yD_cEKoCk"
+                url_name="Tagged_Video_Block"
+                display_name="Tagged Video Block"
+                tags-v1="t1-export-id:%3Cspecial %22%27-%3D%2C. %7C%3D chars %3E tag,anotherTag,normal tag"
+            />
+            """
+        )
+
+    def test_tagged_openassessment_block(self):
+        """
+        Test openassessment blocks that have applied tags
+        """
+        course = CourseFactory.create(display_name='Tagged OpenAssessment Test course', run="TOTC")
+        openassessment_block = BlockFactory.create(
+            parent_location=course.location,
+            category="openassessment",
+            display_name="Tagged OpenAssessment Block",
+        )
+
+        # Add a tags to openassessment block
+        tagging_api.tag_object(
+            object_id=openassessment_block.location,
+            taxonomy=self.taxonomy1,
+            tags=["normal tag", "<special \"'-=,. |= chars > tag", "anotherTag"]
+        )
+
+        # Check that the tags data in included in the OLX and properly escaped
+        serialized = api.serialize_xblock_to_olx(openassessment_block)
+        self.assertXmlEqual(
+            serialized.olx_str,
+            EXPECTED_OPENASSESSMENT_OLX
         )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -791,7 +791,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
-ora2==6.0.32
+ora2==6.0.33
     # via -r requirements/edx/bundled.in
 packaging==23.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1323,7 +1323,7 @@ optimizely-sdk==4.1.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.0.32
+ora2==6.0.33
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -931,7 +931,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-ora2==6.0.32
+ora2==6.0.33
     # via -r requirements/edx/base.txt
 packaging==23.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -989,7 +989,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-ora2==6.0.32
+ora2==6.0.33
     # via -r requirements/edx/base.txt
 packaging==23.2
     # via

--- a/xmodule/tests/test_export.py
+++ b/xmodule/tests/test_export.py
@@ -56,6 +56,7 @@ class PureXBlock(XBlock):
 
 
 @ddt.ddt
+@pytest.mark.django_db
 class RoundTripTestCase(unittest.TestCase):
     """
     Check that our test courses roundtrip properly.

--- a/xmodule/xml_block.py
+++ b/xmodule/xml_block.py
@@ -428,6 +428,8 @@ class XmlMixin:
         """
         For exporting, set data on `node` from ourselves.
         """
+        # Importing here to avoid circular import
+        from cms.lib.xblock.tagging.tagged_block_mixin import TaggedBlockMixin
         # Get the definition
         xml_object = self.definition_to_xml(self.runtime.export_fs)
 
@@ -497,6 +499,10 @@ class XmlMixin:
             # add org and course attributes on the pointer tag
             node.set('org', self.location.org)
             node.set('course', self.location.course)
+
+        # Serialize and add tag data if any
+        if isinstance(self, TaggedBlockMixin):
+            self.add_tags_to_node(node)
 
     def definition_to_xml(self, resource_fs):
         """


### PR DESCRIPTION
## Description

This PR serializes applied tags on various blocks and includes them in the OLX when they are copied. The format of the serialized tags are based on https://github.com/openedx/modular-learning/issues/174

## Supporting information

Related Ticket:
- https://github.com/openedx/modular-learning/issues/179
- Currently implemented without the use of Export ID, but should it should utilize it once the following PRs are merged:
    - https://github.com/openedx/openedx-learning/pull/145
    - https://github.com/openedx/edx-platform/pull/34143
- For the tags to serialize and appear for OpenAssessmentBlocks, we need:
    - https://github.com/openedx/edx-ora2/pull/2171

## Testing instructions

1. Start you localdev stack on this branch
1. Make sure you have Taxonomy/Tags data setup locally: https://github.com/open-craft/taxonomy-sample-data/
1. Once you have a course with a bunch of units and blocks with tags applied, trying copying units and various types of blocks
1. For each copy, double check that [staged content](http://localhost:18010/admin/content_staging/stagedcontent/) contains the tags data and there are no issues with pasting
1. Also confirm that when copying a unit/block that contains no tag, the `tags-v1` is not included in the OLX
1. Finally, make sure the tests cover the various cases.
1. For the OpenAssessmentBlock to work, you should setup https://github.com/openedx/edx-ora2/pull/2171 locally


---
Private-ref: [FAL-3605](https://tasks.opencraft.com/browse/FAL-3605)