### PR TITLE
chore: upgrade xblock-utils to 3.2.0 to support TinyMCE v5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1192,7 +1192,7 @@ xblock-google-drive==0.3.0
     # via -r requirements/edx/base.in
 xblock-poll==1.13.0
     # via -r requirements/edx/base.in
-xblock-utils==3.0.0
+xblock-utils==3.2.0
     # via
     #   -r requirements/edx/base.in
     #   edx-sga

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1721,7 +1721,7 @@ xblock-google-drive==0.3.0
     # via -r requirements/edx/testing.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/testing.txt
-xblock-utils==3.0.0
+xblock-utils==3.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-sga

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1589,7 +1589,7 @@ xblock-google-drive==0.3.0
     # via -r requirements/edx/base.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
-xblock-utils==3.0.0
+xblock-utils==3.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-sga


### PR DESCRIPTION
## Description

This PR upgrades xblock-utils to version 3.2.0 to support TinyMCE v5 in the Palm release. The current version of xblock-utils is 3.0.0, configured for TinyMCE v4. This configuration causes an error after the upgrading of TinyMCE from v4.0.20 to v5.5.1 in this PR: https://github.com/openedx/edx-platform/pull/30335

Useful information to include:
- Which edX user roles will this change impact? Learner and Course Author using TinyMCE WYSIWYG editor in palm. 
- Screenshots:
      Before: 
<img width="894" alt="Screenshot 2024-01-31 at 3 22 45 PM" src="https://github.com/openedx/edx-platform/assets/88967643/3af8848d-82cb-4e00-8f3d-eb765b9ac287">
      After: 
<img width="894" alt="Screenshot 2024-01-31 at 3 04 30 PM" src="https://github.com/openedx/edx-platform/assets/88967643/c17134c8-1217-4496-b122-81b06b530b68">

## Supporting information
Issue: https://github.com/mitodl/edx-sga/issues/346
Discussion: https://discuss.openedx.org/t/tinymce-problem-in-edx-sga-problems-modern-theme-not-found/11148
xblock-util v3.2.0 TinyMCE changes PR: https://github.com/openedx-unsupported/xblock-utils/pull/207

## Testing instructions
- Configure [edx-sga](https://github.com/mitodl/edx-sga) (if not already) in your edx-platform palm release.
- Create an edx-sga xblock using the instructions in the [edx-sga repo](https://github.com/mitodl/edx-sga).
- Click `Edit` and scroll down to the `Solution` setting.
- Ensure that the `WYSIWYG` editor is functioning properly.

## Deadline

None