### PR TITLE
feat: add notification for course update

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -53,3 +53,16 @@ REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(
 # .. toggle_warning: Flag course_experience.relative_dates should also be active for relative dates functionalities to work.
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-844
 CUSTOM_RELATIVE_DATES = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.custom_relative_dates', __name__)
+
+
+# .. toggle_name: studio.enable_course_update_notifications
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable course update notifications.
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 14-Feb-2024
+# .. toggle_target_removal_date: 14-Mar-2024
+ENABLE_COURSE_UPDATE_NOTIFICATIONS = CourseWaffleFlag(
+    f'{WAFFLE_NAMESPACE}.enable_course_update_notifications',
+    __name__
+)

--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -19,7 +19,8 @@ import re
 from django.http import HttpResponseBadRequest
 from django.utils.translation import gettext as _
 
-from cms.djangoapps.contentstore.utils import track_course_update_event
+from cms.djangoapps.contentstore.config.waffle import ENABLE_COURSE_UPDATE_NOTIFICATIONS
+from cms.djangoapps.contentstore.utils import track_course_update_event, send_course_update_notification
 from openedx.core.lib.xblock_utils import get_course_update_items
 from xmodule.html_block import CourseInfoBlock  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -43,7 +44,7 @@ def get_course_updates(location, provided_id, user_id):
     return _get_visible_update(course_update_items)
 
 
-def update_course_updates(location, update, passed_id=None, user=None):
+def update_course_updates(location, update, passed_id=None, user=None, request_method=None):
     """
     Either add or update the given course update.
     Add:
@@ -86,8 +87,17 @@ def update_course_updates(location, update, passed_id=None, user=None):
 
     # update db record
     save_course_update_items(location, course_updates, course_update_items, user)
-    # track course update event
-    track_course_update_event(location.course_key, user, course_update_dict)
+
+    if request_method == "POST":
+        # track course update event
+        track_course_update_event(location.course_key, user, course_update_dict)
+
+        # send course update notification
+        if ENABLE_COURSE_UPDATE_NOTIFICATIONS.is_enabled(location.course_key):
+            send_course_update_notification(
+                location.course_key, course_update_dict["content"], user,
+            )
+
     # remove status key
     if "status" in course_update_dict:
         del course_update_dict["status"]

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1016,7 +1016,9 @@ def course_info_update_handler(request, course_key_string, provided_id=None):
     # can be either and sometimes django is rewriting one to the other:
     elif request.method in ('POST', 'PUT'):
         try:
-            return JsonResponse(update_course_updates(usage_key, request.json, provided_id, request.user))
+            return JsonResponse(update_course_updates(
+                usage_key, request.json, provided_id, request.user, request.method
+            ))
         except:  # lint-amnesty, pylint: disable=bare-except
             return HttpResponseBadRequest(
                 "Failed to save",

--- a/openedx/core/djangoapps/notifications/audience_filters.py
+++ b/openedx/core/djangoapps/notifications/audience_filters.py
@@ -104,6 +104,7 @@ class EnrollmentAudienceFilter(NotificationAudienceFilterBase):
         return CourseEnrollment.objects.filter(
             course_id=self.course_key,
             mode__in=enrollment_modes,
+            is_active=True,
         ).values_list('user_id', flat=True)
 
 

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -161,7 +161,24 @@ COURSE_NOTIFICATION_TYPES = {
         },
         'email_template': '',
         'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE]
-    }
+    },
+    'course_update': {
+        'notification_app': 'updates',
+        'name': 'course_update',
+        'is_core': False,
+        'info': '',
+        'web': True,
+        'email': True,
+        'push': True,
+        'non_editable': [],
+        'content_template': _('<{p}>You have a new course update: '
+                              '<{strong}>{course_update_content}</{strong}></{p}>'),
+        'content_context': {
+            'course_update_content': 'Course update',
+        },
+        'email_template': '',
+        'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE]
+    },
 }
 
 COURSE_NOTIFICATION_APPS = {
@@ -173,7 +190,15 @@ COURSE_NOTIFICATION_APPS = {
         'core_email': True,
         'core_push': True,
         'non_editable': ['web']
-    }
+    },
+    'updates': {
+        'enabled': True,
+        'core_info': _('Notifications for new announcements and updates from the course team.'),
+        'core_web': True,
+        'core_email': True,
+        'core_push': True,
+        'non_editable': []
+    },
 }
 
 

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 NOTIFICATION_CHANNELS = ['web', 'push', 'email']
 
 # Update this version when there is a change to any course specific notification type or app.
-COURSE_NOTIFICATION_CONFIG_VERSION = 6
+COURSE_NOTIFICATION_CONFIG_VERSION = 7
 
 
 def get_course_notification_preference_config():

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -249,13 +249,47 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'info': 'Notifications for responses and comments on your posts, and the ones you’re '
                                     'following, including endorsements to your responses and on your posts.'
                         },
-                        'new_discussion_post': {'web': False, 'email': False, 'push': False, 'info': ''},
-                        'new_question_post': {'web': False, 'email': False, 'push': False, 'info': ''},
-                        'content_reported': {'web': True, 'email': True, 'push': True, 'info': ''},
+                        'new_discussion_post': {
+                            'web': False,
+                            'email': False,
+                            'push': False,
+                            'info': ''
+                        },
+                        'new_question_post': {
+                            'web': False,
+                            'email': False,
+                            'push': False,
+                            'info': ''
+                        },
+                        'content_reported': {
+                            'web': True,
+                            'email': True,
+                            'push': True,
+                            'info': ''
+                        },
                     },
                     'non_editable': {
                         'core': ['web']
                     }
+                },
+                'updates': {
+                    'enabled': True,
+                    'core_notification_types': [],
+                    'notification_types': {
+                        'course_update': {
+                            'web': True,
+                            'email': True,
+                            'push': True,
+                            'info': ''
+                        },
+                        'core': {
+                            'web': True,
+                            'email': True,
+                            'push': True,
+                            'info': 'Notifications for new announcements and updates from the course team.'
+                        }
+                    },
+                    'non_editable': {}
                 }
             }
         }
@@ -293,8 +327,8 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
     @mock.patch.dict(COURSE_NOTIFICATION_TYPES, {
         **COURSE_NOTIFICATION_TYPES,
         **{
-            'new_question_post': {
-                'name': 'new_question_post',
+            'content_reported': {
+                'name': 'content_reported',
                 'visible_to': [FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_ADMINISTRATOR]
             }
         }
@@ -318,7 +352,9 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
 
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
         expected_response = self._expected_api_response()
+
         if not role:
             expected_response = remove_notifications_with_visibility_settings(expected_response)
 
@@ -474,6 +510,27 @@ class UserNotificationChannelPreferenceAPITest(ModuleStoreTestCase):
                     'non_editable': {
                         'core': ['web']
                     }
+                },
+                'updates': {
+                    'enabled': True,
+                    'core_notification_types': [
+
+                    ],
+                    'notification_types': {
+                        'course_update': {
+                            'web': True,
+                            'email': True,
+                            'push': True,
+                            'info': ''
+                        },
+                        'core': {
+                            'web': True,
+                            'email': True,
+                            'push': True,
+                            'info': 'Notifications for new announcements and updates from the course team.'
+                        }
+                    },
+                    'non_editable': {}
                 }
             }
         }
@@ -742,7 +799,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data['count'], 4)
             self.assertEqual(response.data['count_by_app_name'], {
-                'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1, 'discussion': 0})
+                'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1, 'discussion': 0, 'updates': 0})
             self.assertEqual(response.data['show_notifications_tray'], show_notifications_tray_enabled)
 
     def test_get_unseen_notifications_count_for_unauthenticated_user(self):
@@ -763,7 +820,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['count'], 0)
-        self.assertEqual(response.data['count_by_app_name'], {'discussion': 0})
+        self.assertEqual(response.data['count_by_app_name'], {'discussion': 0, 'updates': 0})
 
     def test_get_expiry_days_in_count_view(self):
         """

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -121,19 +121,19 @@ def filter_out_visible_notifications(
     :param user_forum_roles: List of forum roles for the user
     :return: Updated user preferences dictionary
     """
-    for key in user_preferences:
-        if 'notification_types' in user_preferences[key]:
-            # Iterate over the types to remove and pop them from the dictionary
-            for notification_type, is_visible_to in notifications_with_visibility.items():
-                is_visible = False
-                for role in is_visible_to:
-                    if role in user_forum_roles:
-                        is_visible = True
-                        break
-                if is_visible:
-                    continue
+    discussion_user_preferences = user_preferences.get('discussion', {})
+    if 'notification_types' in discussion_user_preferences:
+        # Iterate over the types to remove and pop them from the dictionary
+        for notification_type, is_visible_to in notifications_with_visibility.items():
+            is_visible = False
+            for role in is_visible_to:
+                if role in user_forum_roles:
+                    is_visible = True
+                    break
+            if is_visible:
+                continue
 
-                user_preferences[key]['notification_types'].pop(notification_type)
+            discussion_user_preferences['notification_types'].pop(notification_type)
     return user_preferences
 
 


### PR DESCRIPTION
### [INF-1244](https://2u-internal.atlassian.net/browse/INF-1244)

### Description

Add notification when a course update is created. The audience of this notification would be all active enrollments within the course.

The notification is created with the help of the `COURSE_NOTIFICATION_REQUESTED` course-wide event, that specifies all active enrollments as the audience for this notification. 
The notification is only created when a "new" course update is created, and NOT when an existing course update is updated.


The notification will look like this in the header (for those MFEs that currently have the notification tray in header)

<img width="558" alt="Screenshot 2024-02-06 at 2 05 10 PM" src="https://github.com/openedx/edx-platform/assets/30112155/8704b981-55fc-49bf-a9e8-783bdfc01586">

