### PR TITLE
Update all edx-platform REST endpoints to support JWT Auth

### DIFF
--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -3,7 +3,6 @@
 
 from django.conf import settings
 from django.http import Http404
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import parsers, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
@@ -21,7 +20,6 @@ from ..serializers.course_runs import (
 
 
 class CourseRunViewSet(viewsets.GenericViewSet):  # lint-amnesty, pylint: disable=missing-class-docstring
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     lookup_value_regex = settings.COURSE_KEY_REGEX
     permission_classes = (permissions.IsAdminUser,)
     serializer_class = CourseRunSerializer

--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.http import Http404
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import parsers, permissions, status, viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.response import Response
 

--- a/common/djangoapps/entitlements/rest_api/v1/views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/views.py
@@ -14,7 +14,6 @@ from edx_rest_framework_extensions.paginators import DefaultPagination
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions, status, viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 

--- a/common/djangoapps/entitlements/rest_api/v1/views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/views.py
@@ -328,7 +328,6 @@ class EntitlementEnrollmentViewSet(viewsets.GenericViewSet):
         - Unenroll
         - Switch Enrollment
     """
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     # TODO: ARCH-91
     # This view is excluded from Swagger doc generation because it
     # does not specify a serializer class.

--- a/common/djangoapps/third_party_auth/api/tests/test_permissions.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_permissions.py
@@ -4,7 +4,6 @@ Tests for the Third Party Auth permissions
 
 import ddt
 from django.test import RequestFactory, TestCase
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.jwt.tests.utils import generate_jwt
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
@@ -25,7 +24,6 @@ class ThirdPartyAuthPermissionTest(TestCase):
 
     class SomeTpaClassView(APIView):
         """view used to test TPA_permissions"""
-        authentication_classes = (JwtAuthentication, SessionAuthentication)
         permission_classes = (TPA_PERMISSIONS,)
         required_scopes = ['tpa:read']
 

--- a/common/djangoapps/third_party_auth/api/tests/test_permissions.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_permissions.py
@@ -5,7 +5,6 @@ Tests for the Third Party Auth permissions
 import ddt
 from django.test import RequestFactory, TestCase
 from edx_rest_framework_extensions.auth.jwt.tests.utils import generate_jwt
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 

--- a/common/djangoapps/third_party_auth/saml_configuration/views.py
+++ b/common/djangoapps/third_party_auth/saml_configuration/views.py
@@ -3,7 +3,6 @@ Viewset for auth/saml/v0/saml_configuration
 """
 
 from rest_framework import permissions, viewsets
-from rest_framework.authentication import SessionAuthentication
 
 from ..models import SAMLConfiguration
 from .serializers import SAMLConfigurationSerializer

--- a/common/djangoapps/third_party_auth/saml_configuration/views.py
+++ b/common/djangoapps/third_party_auth/saml_configuration/views.py
@@ -2,7 +2,6 @@
 Viewset for auth/saml/v0/saml_configuration
 """
 
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import permissions, viewsets
 from rest_framework.authentication import SessionAuthentication
 
@@ -11,7 +10,6 @@ from .serializers import SAMLConfigurationSerializer
 
 
 class SAMLConfigurationMixin:
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = SAMLConfigurationSerializer
 

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -7,7 +7,6 @@ from django.db.utils import IntegrityError
 from edx_rbac.mixins import PermissionRequiredMixin
 from rest_framework import permissions, viewsets, status
 from rest_framework.response import Response
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ParseError, ValidationError
 
 from enterprise.models import EnterpriseCustomerIdentityProvider, EnterpriseCustomer

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -5,7 +5,6 @@ Viewset for auth/saml/v0/samlproviderconfig
 from django.shortcuts import get_list_or_404
 from django.db.utils import IntegrityError
 from edx_rbac.mixins import PermissionRequiredMixin
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import permissions, viewsets, status
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication
@@ -20,7 +19,6 @@ from ..utils import convert_saml_slug_provider_id
 
 
 class SAMLProviderMixin:
-    authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = SAMLProviderConfigSerializer
 

--- a/common/djangoapps/third_party_auth/samlproviderdata/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderdata/views.py
@@ -10,7 +10,6 @@ from django.shortcuts import get_object_or_404
 from edx_rbac.mixins import PermissionRequiredMixin
 from enterprise.models import EnterpriseCustomerIdentityProvider
 from rest_framework import permissions, status, viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response

--- a/common/djangoapps/third_party_auth/samlproviderdata/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderdata/views.py
@@ -8,7 +8,6 @@ from requests.exceptions import SSLError, MissingSchema, HTTPError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from edx_rbac.mixins import PermissionRequiredMixin
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from enterprise.models import EnterpriseCustomerIdentityProvider
 from rest_framework import permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
@@ -31,7 +30,6 @@ log = logging.getLogger(__name__)
 
 
 class SAMLProviderDataMixin:
-    authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = SAMLProviderDataSerializer
 

--- a/lms/djangoapps/bulk_user_retirement/views.py
+++ b/lms/djangoapps/bulk_user_retirement/views.py
@@ -3,7 +3,6 @@ An API for retiring user accounts.
 """
 import logging
 
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from rest_framework import permissions, status
@@ -34,7 +33,6 @@ class BulkUsersRetirementView(APIView):
 
           * usernames: Comma separated strings of usernames that should be retired.
     """
-    authentication_classes = (JwtAuthentication, )
     permission_classes = (permissions.IsAuthenticated, CanRetireUser)
 
     def post(self, request, **kwargs):  # pylint: disable=unused-argument

--- a/lms/djangoapps/commerce/api/v1/views.py
+++ b/lms/djangoapps/commerce/api/v1/views.py
@@ -72,7 +72,6 @@ class CourseRetrieveUpdateView(PutAsCreateMixin, RetrieveUpdateAPIView):
 class OrderView(APIView):
     """ Retrieve order details. """
 
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     permission_classes = (IsAuthenticatedOrActivationOverridden,)
 
     def get(self, request, number):

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -376,7 +376,6 @@ class OutlineTabView(RetrieveAPIView):
 
 
 @api_view(['POST'])
-@authentication_classes((JwtAuthentication,))
 @permission_classes((IsAuthenticated,))
 def dismiss_welcome_message(request):  # pylint: disable=missing-function-docstring
     course_id = request.data.get('course_id', None)

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -675,7 +675,7 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 
         # Test unauthenticated
         response = self.client.post(self.url, data)
-        assert response.status_code == 401
+        assert response.status_code == 403
 
         # Test non-service worker
         random_user = UserFactory()

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1146,7 +1146,6 @@ class ReplaceUsernamesView(APIView):
 
     """
 
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
 
     def post(self, request):

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1099,7 +1099,6 @@ class RetireUserView(APIView):
         Empty string
     """
 
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanRetireUser)
 
     def post(self, request):

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1146,6 +1146,7 @@ class ReplaceUsernamesView(APIView):
 
     """
 
+    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
 
     def post(self, request):

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -244,7 +244,6 @@ class RetireUserView(APIView):
           - EdxNotesServiceUnavailable is thrown: the edx-notes-api IDA is not available.
     """
 
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanRetireUser)
 
     def post(self, request):

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -11,7 +11,6 @@ from django.contrib.auth.decorators import login_required
 from django.http import Http404, HttpResponse
 from django.urls import reverse
 from django.views.decorators.http import require_GET
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions, status
 from rest_framework.response import Response

--- a/lms/djangoapps/instructor_task/rest_api/v1/views.py
+++ b/lms/djangoapps/instructor_task/rest_api/v1/views.py
@@ -9,7 +9,6 @@ import pytz
 import dateutil
 from celery.states import REVOKED
 from django.db import transaction
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework import generics, status
@@ -35,10 +34,6 @@ class ListScheduledBulkEmailInstructorTasks(generics.ListAPIView):
                data also includes information about the and course email instance associated with each task.
         * 403: User does not have the required role to view this data.
     """
-    authentication_classes = (
-        JwtAuthentication,
-        SessionAuthentication,
-    )
     permission_classes = (
         CanViewOrModifyScheduledBulkCourseEmailTasks,
     )
@@ -74,10 +69,6 @@ class ModifyScheduledBulkEmailInstructorTask(generics.DestroyAPIView, generics.U
         * 403: User does not have permission to modify the object specified.
         * 404: Requested schedule object could not be found and thus could not be modified or removed.
     """
-    authentication_classes = (
-        JwtAuthentication,
-        SessionAuthentication,
-    )
     permission_classes = (
         CanViewOrModifyScheduledBulkCourseEmailTasks,
     )

--- a/lms/djangoapps/instructor_task/rest_api/v1/views.py
+++ b/lms/djangoapps/instructor_task/rest_api/v1/views.py
@@ -9,7 +9,6 @@ import pytz
 import dateutil
 from celery.states import REVOKED
 from django.db import transaction
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework import generics, status
 

--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -1,7 +1,6 @@
 """ API v0 views. """
 import logging
 
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from enterprise.models import EnterpriseCourseEnrollment
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -80,8 +79,6 @@ class Programs(APIView):
             }
         ]
     """
-
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
 
     permission_classes = (IsAuthenticated,)
 
@@ -298,12 +295,7 @@ class ProgramProgressDetailView(APIView):
             }
     """
 
-    authentication_classes = (
-        JwtAuthentication,
-        SessionAuthentication,
-    )
-
-    permission_classes = (IsAuthenticated,)
+     permission_classes = (IsAuthenticated,)
 
     def get(self, request, program_uuid):
         """

--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -295,7 +295,7 @@ class ProgramProgressDetailView(APIView):
             }
     """
 
-     permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated,)
 
     def get(self, request, program_uuid):
         """

--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -2,7 +2,6 @@
 import logging
 
 from enterprise.models import EnterpriseCourseEnrollment
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/lms/djangoapps/support/views/feature_based_enrollments.py
+++ b/lms/djangoapps/support/views/feature_based_enrollments.py
@@ -4,7 +4,6 @@ Support tool for viewing course duration information
 
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.generics import GenericAPIView
 

--- a/lms/djangoapps/support/views/feature_based_enrollments.py
+++ b/lms/djangoapps/support/views/feature_based_enrollments.py
@@ -2,7 +2,6 @@
 Support tool for viewing course duration information
 """
 
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 from rest_framework.authentication import SessionAuthentication
@@ -43,9 +42,6 @@ class FeatureBasedEnrollmentSupportAPIView(GenericAPIView):
     Support-only API View for getting feature based enrollment configuration details
     for a course.
     """
-    authentication_classes = (
-        JwtAuthentication, SessionAuthentication
-    )
     permission_classes = (IsAuthenticated,)
 
     @method_decorator(require_support_permission)

--- a/lms/djangoapps/support/views/program_enrollments.py
+++ b/lms/djangoapps/support/views/program_enrollments.py
@@ -6,7 +6,6 @@ from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imp
 from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
@@ -77,9 +76,6 @@ class LinkProgramEnrollmentSupportAPIView(APIView):
     """
     Support-only API View for linking learner enrollments by support staff.
     """
-    authentication_classes = (
-        JwtAuthentication, SessionAuthentication
-    )
     permission_classes = (
         IsAuthenticated,
     )
@@ -312,9 +308,6 @@ class ProgramEnrollmentsInspectorAPIView(ProgramEnrollmentInspector, APIView):
     information of a learner.
     """
 
-    authentication_classes = (
-        JwtAuthentication, SessionAuthentication
-    )
     permission_classes = (
         IsAuthenticated,
     )

--- a/lms/djangoapps/support/views/program_enrollments.py
+++ b/lms/djangoapps/support/views/program_enrollments.py
@@ -7,7 +7,6 @@ from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from social_django.models import UserSocialAuth

--- a/lms/djangoapps/user_tours/v1/views.py
+++ b/lms/djangoapps/user_tours/v1/views.py
@@ -2,7 +2,6 @@
 from django.conf import settings
 from django.db import transaction, IntegrityError
 from django.shortcuts import get_object_or_404
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -24,7 +23,6 @@ class UserTourView(RetrieveUpdateAPIView):
         GET /api/user_tours/v1/{username}
         PATCH /api/user_tours/v1/{username}
     """
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (IsAuthenticated,)
     serializer_class = UserTourSerializer
 
@@ -104,7 +102,6 @@ class UserDiscussionsToursView(APIView):
     ]
     """
 
-    authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, tour_id=None):

--- a/lms/djangoapps/user_tours/v1/views.py
+++ b/lms/djangoapps/user_tours/v1/views.py
@@ -2,7 +2,6 @@
 from django.conf import settings
 from django.db import transaction, IntegrityError
 from django.shortcuts import get_object_or_404
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -7,7 +7,6 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from opaque_keys.edx.keys import CourseKey
 
@@ -34,7 +33,6 @@ class AuthenticatedAPIView(APIView):
     """
     Authenticated API View.
     """
-    authentication_classes = (SessionAuthentication, JwtAuthentication)
     permission_classes = (IsAuthenticated,)
 
 

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -3,7 +3,6 @@ Views served by the Agreements app
 """
 
 from django.conf import settings
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response

--- a/openedx/core/djangoapps/demographics/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/demographics/rest_api/v1/views.py
@@ -1,5 +1,4 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import permissions, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
@@ -18,7 +17,6 @@ class DemographicsStatusView(APIView):
     The API will return whether or not to display the Demographics UI based on
     the User's status in the Platform
     """
-    authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated, )
 
     def _response_context(self, user, user_demographics=None):

--- a/openedx/core/djangoapps/demographics/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/demographics/rest_api/v1/views.py
@@ -1,6 +1,5 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
 from rest_framework import permissions, status
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -421,7 +421,6 @@ class UnenrollmentView(APIView):
             If the request is successful, an HTTP 200 "OK" response is
             returned along with a list of all courses from which the user was unenrolled.
         """
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanRetireUser,)
 
     def post(self, request):
@@ -1023,9 +1022,6 @@ class EnrollmentAllowedView(APIView):
     """
     A view that allows the retrieval and creation of enrollment allowed for a given user email and course id.
     """
-    authentication_classes = (
-        JwtAuthentication,
-    )
     permission_classes = (permissions.IsAdminUser,)
     throttle_classes = (EnrollmentUserThrottle,)
     serializer_class = CourseEnrollmentAllowedSerializer

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -456,7 +456,6 @@ class NameChangeView(ViewSet):
     """
     Viewset to manage profile name change requests.
     """
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     permission_classes = (permissions.IsAuthenticated,)
 
     def create(self, request):
@@ -514,7 +513,6 @@ class AccountDeactivationView(APIView):
     Account deactivation viewset. Currently only supports POST requests.
     Only admins can deactivate accounts.
     """
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanDeactivateUser)
 
     def post(self, request, username):
@@ -693,7 +691,6 @@ class AccountRetirementPartnerReportView(ViewSet):
     ORIGINAL_NAME_KEY = 'original_name'
     STUDENT_ID_KEY = 'student_id'
 
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanRetireUser,)
     parser_classes = (JSONParser,)
     serializer_class = UserRetirementStatusSerializer
@@ -831,7 +828,6 @@ class CancelAccountRetirementStatusView(ViewSet):
     """
     Provides API endpoints for canceling retirement process for a user's account.
     """
-    authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated, CanCancelUserRetirement,)
 
     def cancel_retirement(self, request):
@@ -873,7 +869,6 @@ class AccountRetirementStatusView(ViewSet):
     """
     Provides API endpoints for managing the user retirement process.
     """
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanRetireUser,)
     parser_classes = (JSONParser,)
     serializer_class = UserRetirementStatusSerializer
@@ -1080,7 +1075,6 @@ class LMSAccountRetirementView(ViewSet):
     """
     Provides an API endpoint for retiring a user in the LMS.
     """
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanRetireUser,)
     parser_classes = (JSONParser,)
 
@@ -1136,7 +1130,6 @@ class AccountRetirementView(ViewSet):
     """
     Provides API endpoint for retiring a user.
     """
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanRetireUser,)
     parser_classes = (JSONParser,)
 
@@ -1276,7 +1269,6 @@ class UsernameReplacementView(APIView):
     This API will be called first, before calling the APIs in other services as this
     one handles the checks on the usernames provided.
     """
-    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
 
     def post(self, request):

--- a/openedx/core/djangoapps/waffle_utils/views.py
+++ b/openedx/core/djangoapps/waffle_utils/views.py
@@ -4,7 +4,6 @@ Views that we will use to view toggle state in edx-platform.
 from collections import OrderedDict
 from enum import Enum
 
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.permissions import IsStaff
 from edx_toggles.toggles.state import ToggleStateReport, get_or_create_toggle_response
 from rest_framework import views
@@ -59,10 +58,6 @@ class ToggleStateView(views.APIView):
     An endpoint for displaying the state of toggles in edx-platform.
     """
 
-    authentication_classes = (
-        JwtAuthentication,
-        SessionAuthentication,
-    )
     permission_classes = (IsStaff,)
 
     def get(self, request):

--- a/openedx/core/djangoapps/waffle_utils/views.py
+++ b/openedx/core/djangoapps/waffle_utils/views.py
@@ -7,7 +7,6 @@ from enum import Enum
 from edx_rest_framework_extensions.permissions import IsStaff
 from edx_toggles.toggles.state import ToggleStateReport, get_or_create_toggle_response
 from rest_framework import views
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 from .models import WaffleFlagCourseOverrideModel, WaffleFlagOrgOverrideModel


### PR DESCRIPTION
**Description**:  The default [DRF Auth classes](https://www.django-rest-framework.org/api-guide/authentication) were recently updated to allow for both JWT and Session auth by default. Any endpoint that overrides the AUTHENTICATION_CLASSES but has just session, just JWT or just both of those should be updated to remove the override.


Ticket: https://github.com/orgs/openedx/projects/55/views/1?pane=issue&itemId=39035029