### PR TITLE
feat: support rendering XBlocks in the Learning MFE [FC-0035]

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -143,7 +143,7 @@ ${block_content | n, decode.utf8}
 <script type="text/javascript">
 // assumes courseware.html's loaded this method.
 $(function () {
-    setup_debug('${element_id | n, js_escaped_string}',
+    (typeof setup_debug !== 'undefined') && setup_debug('${element_id | n, js_escaped_string}',
         %if edit_link:
         '${edit_link | n, js_escaped_string}',
         %else:


### PR DESCRIPTION
Rendering blocks directly in the MFE was developed for the Library Authoring MFE. The solution was then ported to the Learning MFE. This commit includes backend changes required to retrieve data of non-blockstore XBlocks from LMS.

Please see https://github.com/openedx/frontend-app-learning/pull/1281 for the details and testing instructions.

## Other information

* https://github.com/aximcollaborative/funded-contributions/issues/15
* _Private-ref: [BB-7872](https://tasks.opencraft.com/browse/BB-7872)_