### PR TITLE
fix: handle 500 exception for JwtUserEmailMismatchError

### DIFF
--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -10,6 +10,7 @@ from django.core.exceptions import SuspiciousOperation
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from edx_django_utils.cache import RequestCache
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtUserEmailMismatchError
 
 from openedx.core.lib.request_utils import (
     IgnoredErrorMiddleware,
@@ -429,3 +430,11 @@ class TestIgnoredErrorExceptionHandler(unittest.TestCase):
             ],
             any_order=True
         )
+
+    def test_handler_returns_401_for_jwt_user_email_mismatch_error(self):
+        mock_context = {'request': self.mock_request}
+        exception = JwtUserEmailMismatchError('test error')
+        response = ignored_error_exception_handler(exception, mock_context)
+
+        assert response.status_code == 401
+        assert response.data['error'] == 'test error'


### PR DESCRIPTION
When `edx-drf-extension`'s `JwtAuthentication` class [raises](https://github.com/openedx/edx-drf-extensions/blob/master/edx_rest_framework_extensions/auth/jwt/authentication.py#L113-L119) `JwtUserEmailMismatchError`, its not identified by `ignored_error_exception_handler` [which returns](https://github.com/openedx/edx-platform/blob/master/openedx/core/lib/request_utils.py#L99) `response = None` and hence we [get](https://www.django-rest-framework.org/api-guide/exceptions/#custom-exception-handling) `500 Server not found`. This PR handles this issue by adding check for `JwtUserEmailMismatchError` explicitly and return 401 unauthorized. 