### PR TITLE
 feat: add CourseHomeCoursesV2 with filtering & ordering capabilities 

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/urls.py
@@ -7,10 +7,12 @@ from django.urls import include
 
 from .v0 import urls as v0_urls
 from .v1 import urls as v1_urls
+from .v2 import urls as v2_urls
 
 app_name = 'cms.djangoapps.contentstore'
 
 urlpatterns = [
     path('v0/', include(v0_urls)),
     path('v1/', include(v1_urls)),
+    path('v2/', include(v2_urls))
 ]

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
@@ -1,0 +1,1 @@
+from .home import CourseHomeSerializer, CourseHomeTabSerializer, LibraryTabSerializer

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
@@ -1,1 +1,1 @@
-from .home import CourseHomeSerializer, CourseHomeTabSerializer, LibraryTabSerializer
+from .home import CourseHomeTabSerializer

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/home.py
@@ -1,0 +1,74 @@
+"""
+API Serializers for course home
+"""
+
+from rest_framework import serializers
+
+from openedx.core.lib.api.serializers import CourseKeyField
+
+from cms.djangoapps.contentstore.rest_api.serializers.common import CourseCommonSerializer
+
+
+class UnsucceededCourseSerializer(serializers.Serializer):
+    """Serializer for unsucceeded course"""
+    display_name = serializers.CharField()
+    course_key = CourseKeyField()
+    org = serializers.CharField()
+    number = serializers.CharField()
+    run = serializers.CharField()
+    is_failed = serializers.BooleanField()
+    is_in_progress = serializers.BooleanField()
+    dismiss_link = serializers.CharField()
+
+
+class LibraryViewSerializer(serializers.Serializer):
+    """Serializer for library view"""
+    display_name = serializers.CharField()
+    library_key = serializers.CharField()
+    url = serializers.CharField()
+    org = serializers.CharField()
+    number = serializers.CharField()
+    can_edit = serializers.BooleanField()
+
+
+class CourseHomeTabSerializer(serializers.Serializer):
+    archived_courses = CourseCommonSerializer(required=False, many=True)
+    courses = CourseCommonSerializer(required=False, many=True)
+    in_process_course_actions = UnsucceededCourseSerializer(many=True, required=False, allow_null=True)
+
+
+class LibraryTabSerializer(serializers.Serializer):
+    libraries = LibraryViewSerializer(many=True, required=False, allow_null=True)
+
+
+class CourseHomeSerializer(serializers.Serializer):
+    """Serializer for course home"""
+    allow_course_reruns = serializers.BooleanField()
+    allow_to_create_new_org = serializers.BooleanField()
+    allow_unicode_course_id = serializers.BooleanField()
+    allowed_organizations = serializers.ListSerializer(
+        child=serializers.CharField(),
+        allow_empty=True
+    )
+    archived_courses = CourseCommonSerializer(required=False, many=True)
+    can_create_organizations = serializers.BooleanField()
+    course_creator_status = serializers.CharField()
+    courses = CourseCommonSerializer(required=False, many=True)
+    in_process_course_actions = UnsucceededCourseSerializer(many=True, required=False, allow_null=True)
+    libraries = LibraryViewSerializer(many=True, required=False, allow_null=True)
+    libraries_enabled = serializers.BooleanField()
+    taxonomies_enabled = serializers.BooleanField()
+    library_authoring_mfe_url = serializers.CharField()
+    taxonomy_list_mfe_url = serializers.CharField()
+    optimization_enabled = serializers.BooleanField()
+    redirect_to_library_authoring_mfe = serializers.BooleanField()
+    request_course_creator_url = serializers.CharField()
+    rerun_creator_status = serializers.BooleanField()
+    show_new_library_button = serializers.BooleanField()
+    split_studio_home = serializers.BooleanField()
+    studio_name = serializers.CharField()
+    studio_short_name = serializers.CharField()
+    studio_request_email = serializers.CharField()
+    tech_support_email = serializers.CharField()
+    platform_name = serializers.CharField()
+    user_is_active = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/home.py
@@ -21,54 +21,7 @@ class UnsucceededCourseSerializer(serializers.Serializer):
     dismiss_link = serializers.CharField()
 
 
-class LibraryViewSerializer(serializers.Serializer):
-    """Serializer for library view"""
-    display_name = serializers.CharField()
-    library_key = serializers.CharField()
-    url = serializers.CharField()
-    org = serializers.CharField()
-    number = serializers.CharField()
-    can_edit = serializers.BooleanField()
-
-
 class CourseHomeTabSerializer(serializers.Serializer):
     archived_courses = CourseCommonSerializer(required=False, many=True)
     courses = CourseCommonSerializer(required=False, many=True)
     in_process_course_actions = UnsucceededCourseSerializer(many=True, required=False, allow_null=True)
-
-
-class LibraryTabSerializer(serializers.Serializer):
-    libraries = LibraryViewSerializer(many=True, required=False, allow_null=True)
-
-
-class CourseHomeSerializer(serializers.Serializer):
-    """Serializer for course home"""
-    allow_course_reruns = serializers.BooleanField()
-    allow_to_create_new_org = serializers.BooleanField()
-    allow_unicode_course_id = serializers.BooleanField()
-    allowed_organizations = serializers.ListSerializer(
-        child=serializers.CharField(),
-        allow_empty=True
-    )
-    archived_courses = CourseCommonSerializer(required=False, many=True)
-    can_create_organizations = serializers.BooleanField()
-    course_creator_status = serializers.CharField()
-    courses = CourseCommonSerializer(required=False, many=True)
-    in_process_course_actions = UnsucceededCourseSerializer(many=True, required=False, allow_null=True)
-    libraries = LibraryViewSerializer(many=True, required=False, allow_null=True)
-    libraries_enabled = serializers.BooleanField()
-    taxonomies_enabled = serializers.BooleanField()
-    library_authoring_mfe_url = serializers.CharField()
-    taxonomy_list_mfe_url = serializers.CharField()
-    optimization_enabled = serializers.BooleanField()
-    redirect_to_library_authoring_mfe = serializers.BooleanField()
-    request_course_creator_url = serializers.CharField()
-    rerun_creator_status = serializers.BooleanField()
-    show_new_library_button = serializers.BooleanField()
-    split_studio_home = serializers.BooleanField()
-    studio_name = serializers.CharField()
-    studio_short_name = serializers.CharField()
-    studio_request_email = serializers.CharField()
-    tech_support_email = serializers.CharField()
-    platform_name = serializers.CharField()
-    user_is_active = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v2/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path(
         'home/courses',
         HomePageCoursesView.as_view(),
-        name="courses"),
+        name="courses",
+    ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v2/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/urls.py
@@ -1,0 +1,15 @@
+""" Contenstore API v2 URLs. """
+
+from django.conf import settings
+from django.urls import re_path, path
+
+from .views import HomePageCoursesView
+
+app_name = 'v2'
+
+urlpatterns = [
+    path(
+        'home/courses',
+        HomePageCoursesView.as_view(),
+        name="courses"),
+]

--- a/cms/djangoapps/contentstore/rest_api/v2/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/__init__.py
@@ -1,0 +1,1 @@
+from .home import HomePageCoursesView

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -24,7 +24,13 @@ class HomePageCoursesView(APIView):
                 "query",
                 apidocs.ParameterLocation.QUERY,
                 description="Query param to filter by course name, org, or number",
-    )],
+            ),
+            apidocs.string_parameter(
+                "order",
+                apidocs.ParameterLocation.QUERY,
+                description="Query param to order by course name, org, or number",
+            ),
+    ],
         responses={
             200: CourseHomeTabSerializer,
             401: "The requester is not authenticated.",
@@ -36,7 +42,7 @@ class HomePageCoursesView(APIView):
 
         **Example Request**
 
-            GET /api/contentstore/v1/home/courses
+            GET /api/contentstore/v2/home/courses
 
         **Response Values**
 

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -1,0 +1,88 @@
+import edx_api_doc_tools as apidocs
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from openedx.core.lib.api.view_utils import view_auth_classes
+
+from ....utils import get_course_context_v2
+from ..serializers import CourseHomeTabSerializer
+
+
+@view_auth_classes(is_authenticated=True)
+class HomePageCoursesView(APIView):
+    """
+    View for getting all courses and libraries available to the logged in user.
+    """
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                "org",
+                apidocs.ParameterLocation.QUERY,
+                description="Query param to filter by course org",
+            ),
+            apidocs.string_parameter(
+                "query",
+                apidocs.ParameterLocation.QUERY,
+                description="Query param to filter by course name, org, or number",
+    )],
+        responses={
+            200: CourseHomeTabSerializer,
+            401: "The requester is not authenticated.",
+        },
+    )
+    def get(self, request: Request):
+        """
+        Get an object containing all courses.
+
+        **Example Request**
+
+            GET /api/contentstore/v1/home/courses
+
+        **Response Values**
+
+        If the request is successful, an HTTP 200 "OK" response is returned.
+
+        The HTTP 200 response contains a single dict that contains keys that
+        are the course's home.
+
+        **Example Response**
+
+        ```json
+        {
+            "archived_courses": [
+                {
+                    "course_key": "course-v1:edX+P315+2T2023",
+                    "display_name": "Quantum Entanglement",
+                    "lms_link": "//localhost:18000/courses/course-v1:edX+P315+2T2023",
+                    "number": "P315",
+                    "org": "edX",
+                    "rerun_link": "/course_rerun/course-v1:edX+P315+2T2023",
+                    "run": "2T2023"
+                    "url": "/course/course-v1:edX+P315+2T2023"
+                },
+            ],
+            "courses": [
+                 {
+                    "course_key": "course-v1:edX+E2E-101+course",
+                    "display_name": "E2E Test Course",
+                    "lms_link": "//localhost:18000/courses/course-v1:edX+E2E-101+course",
+                    "number": "E2E-101",
+                    "org": "edX",
+                    "rerun_link": "/course_rerun/course-v1:edX+E2E-101+course",
+                    "run": "course",
+                    "url": "/course/course-v1:edX+E2E-101+course"
+                },
+            ],
+            "in_process_course_actions": [],
+        }
+        ```
+        """
+
+        active_courses, archived_courses, in_process_course_actions = get_course_context_v2(request)
+        courses_context = {
+            "courses": active_courses,
+            "archived_courses": archived_courses,
+            "in_process_course_actions": in_process_course_actions,
+        }
+        serializer = CourseHomeTabSerializer(courses_context)
+        return Response(serializer.data)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1566,47 +1566,6 @@ def get_course_context_v2(request):
     return active_courses, archived_courses, in_process_course_actions
 
 
-def get_courses_filtered_by_query(request, active_courses, archived_courses):
-    """Return tuple of Course Overviews filtered by a query parameter sent in the request.
-
-    The query parameter is used to filter the Course Overviews by:
-    - Course display name
-    - Course number
-    - Course Key
-    - Course run
-    - Organization
-
-    Args:
-        request (HttpRequest): The request object.
-        active_courses (list): List of active Course Overviews.
-        archived_courses (list): List of archived Course Overviews.
-
-    Returns:
-        tuple: Tuple of filtered Course Overviews.
-    """
-    query = request.GET.get('query', '')
-    if not query:
-        return active_courses, archived_courses
-
-    def filter_course_overviews(course_overviews):
-        """Filter course overviews by the query parameter."""
-        courses = []
-        for course_overview in course_overviews:
-            if query.lower() in course_overview.get('display_name').lower():
-                courses.append(course_overview)
-            elif query.lower() in course_overview.get('number').lower():
-                courses.append(course_overview)
-            elif query.lower() in course_overview.get('course_key').lower():
-                courses.append(course_overview)
-            elif query.lower() in course_overview.get('run').lower():
-                courses.append(course_overview)
-            elif query.lower() in course_overview.get('org').lower():
-                courses.append(course_overview)
-        return courses
-
-    return filter_course_overviews(active_courses), filter_course_overviews(archived_courses)
-
-
 def get_home_context(request, no_course=False):
     """
     Utils is used to get context of course home.

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -15,7 +15,7 @@ from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import PermissionDenied, ValidationError as DjangoValidationError
+from django.core.exceptions import FieldError, PermissionDenied, ValidationError as DjangoValidationError
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.urls import reverse

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -607,7 +607,11 @@ def get_courses_order_by(order_query, base_queryset):
     """
     if not order_query:
         return base_queryset
-    return base_queryset.order_by(order_query)
+    try:
+        return base_queryset.order_by(order_query)
+    except FieldError as e:
+        log.exception(f"Error ordering courses by {order_query}: {e}")
+        return base_queryset
 
 
 @function_trace('_accessible_libraries_iter')

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -594,8 +594,8 @@ def get_courses_by_search_query(search_query, course_overviews):
         course_overviews (Course Overview objects): course overview queryset to be filtered.
     """
     if not search_query:
-        return base_queryset
-    return CourseOverview.get_courses_matching_query(search_query, base_queryset=base_queryset)
+        return course_overviews
+    return CourseOverview.get_courses_matching_query(search_query, course_overviews=course_overviews)
 
 
 def get_courses_order_by(order_query, course_overviews):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -586,12 +586,12 @@ def _accessible_courses_list_from_groups_v2(request):
     return courses_list, []
 
 
-def get_courses_by_search_query(search_query, base_queryset):
+def get_courses_by_search_query(search_query, course_overviews):
     """Return course overviews based on a base queryset filtered by a search query.
 
     Args:
-        search_query (str): any string used to filter Course Overviews.
-        base_queryset (Course Overview objects): queryset to be filtered.
+        search_query (str): any string used to filter Course Overviews based on visible fields.
+        course_overviews (Course Overview objects): course overview queryset to be filtered.
     """
     if not search_query:
         return base_queryset

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -598,7 +598,7 @@ def get_courses_by_search_query(search_query, base_queryset):
     return CourseOverview.get_courses_matching_query(search_query, base_queryset=base_queryset)
 
 
-def get_courses_order_by(order_query, base_queryset):
+def get_courses_order_by(order_query, course_overviews):
     """Return course overviews based on a base queryset ordered by a query.
 
     Args:
@@ -606,12 +606,12 @@ def get_courses_order_by(order_query, base_queryset):
         base_queryset (Course Overview objects): queryset to be ordered.
     """
     if not order_query:
-        return base_queryset
+        return course_overviews
     try:
-        return base_queryset.order_by(order_query)
+        return course_overviews.order_by(order_query)
     except FieldError as e:
         log.exception(f"Error ordering courses by {order_query}: {e}")
-        return base_queryset
+        return course_overviews
 
 
 @function_trace('_accessible_libraries_iter')

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -449,6 +449,8 @@ def _accessible_courses_summary_iter_v2(request, org=None):
     courses_summary = get_courses_by_search_query(search_query, order, courses_summary)
     courses_summary = filter(course_filter, courses_summary)
     in_process_course_actions = get_in_process_course_actions(request)
+    courses_summary = get_courses_by_search_query(search_query, courses_summary)
+    courses_summary = get_courses_order_by(order, courses_summary)
     return courses_summary, in_process_course_actions
 
 
@@ -582,10 +584,12 @@ def _accessible_courses_list_from_groups_v2(request):
     order = request.GET.get('order')
     courses_list = get_courses_by_search_query(search_query, order, courses_list)
 
+    courses_list = get_courses_by_search_query(search_query, courses_list)
+    courses_list = get_courses_order_by(order, courses_list)
     return courses_list, []
 
 
-def get_courses_by_search_query(search_query, order_query, base_queryset):
+def get_courses_by_search_query(search_query, base_queryset):
     """Return course overviews based on a base queryset filtered by a search query.
 
     Args:
@@ -594,8 +598,6 @@ def get_courses_by_search_query(search_query, order_query, base_queryset):
     """
     if not search_query:
         return base_queryset
-    if order_query:
-        base_queryset = base_queryset.order_by(order_query)
     return CourseOverview.get_courses_matching_any_filter(
         filters={
             'org__icontains': search_query,
@@ -603,6 +605,18 @@ def get_courses_by_search_query(search_query, order_query, base_queryset):
         },
         base_queryset=base_queryset,
     )
+
+
+def get_courses_order_by(order_query, base_queryset):
+    """Return course overviews based on a base queryset ordered by a query.
+
+    Args:
+        order_query (str): any string used to order Course Overviews.
+        base_queryset (Course Overview objects): queryset to be ordered.
+    """
+    if not order_query:
+        return base_queryset
+    return base_queryset.order_by(order_query)
 
 
 @function_trace('_accessible_libraries_iter')

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -594,8 +594,15 @@ def get_courses_by_search_query(search_query, course_overviews):
         course_overviews (Course Overview objects): course overview queryset to be filtered.
     """
     if not search_query:
-        return base_queryset
-    return CourseOverview.get_courses_matching_query(search_query, base_queryset=base_queryset)
+        return course_overviews
+    filters = {
+        'id__icontains': search_query,
+        'display_name__icontains': search_query,
+        'org__icontains': search_query,
+    }
+    for lookup, value in filters.items():
+        course_overviews |= CourseOverview.get_all_courses(filter_={lookup: value})
+    return course_overviews
 
 
 def get_courses_order_by(order_query, course_overviews):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -595,13 +595,7 @@ def get_courses_by_search_query(search_query, base_queryset):
     """
     if not search_query:
         return base_queryset
-    return CourseOverview.get_courses_matching_any_filter(
-        filters={
-            'org__icontains': search_query,
-            'display_name__icontains': search_query,
-        },
-        base_queryset=base_queryset,
-    )
+    return CourseOverview.get_courses_matching_query(search_query, base_queryset=base_queryset)
 
 
 def get_courses_order_by(order_query, base_queryset):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -446,11 +446,10 @@ def _accessible_courses_summary_iter_v2(request, org=None):
 
     search_query = request.GET.get('query')
     order = request.GET.get('order')
-    courses_summary = get_courses_by_search_query(search_query, order, courses_summary)
-    courses_summary = filter(course_filter, courses_summary)
-    in_process_course_actions = get_in_process_course_actions(request)
     courses_summary = get_courses_by_search_query(search_query, courses_summary)
     courses_summary = get_courses_order_by(order, courses_summary)
+    courses_summary = filter(course_filter, courses_summary)
+    in_process_course_actions = get_in_process_course_actions(request)
     return courses_summary, in_process_course_actions
 
 
@@ -582,8 +581,6 @@ def _accessible_courses_list_from_groups_v2(request):
 
     search_query = request.GET.get('query')
     order = request.GET.get('order')
-    courses_list = get_courses_by_search_query(search_query, order, courses_list)
-
     courses_list = get_courses_by_search_query(search_query, courses_list)
     courses_list = get_courses_order_by(order, courses_list)
     return courses_list, []

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -594,15 +594,8 @@ def get_courses_by_search_query(search_query, course_overviews):
         course_overviews (Course Overview objects): course overview queryset to be filtered.
     """
     if not search_query:
-        return course_overviews
-    filters = {
-        'id__icontains': search_query,
-        'display_name__icontains': search_query,
-        'org__icontains': search_query,
-    }
-    for lookup, value in filters.items():
-        course_overviews |= CourseOverview.get_all_courses(filter_={lookup: value})
-    return course_overviews
+        return base_queryset
+    return CourseOverview.get_courses_matching_query(search_query, base_queryset=base_queryset)
 
 
 def get_courses_order_by(order_query, course_overviews):

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -701,7 +701,7 @@ class CourseOverview(TimeStampedModel):
         return course_overviews
 
     @classmethod
-    def get_courses_matching_any_filter(cls, filters, base_queryset=None):
+    def get_courses_matching_query(cls, query, base_queryset=None):
         """
         Return a queryset of CourseOverview objects based on the given filter(s).
 
@@ -709,12 +709,13 @@ class CourseOverview(TimeStampedModel):
             filters (dict): required parameter that allows filtering based on the CourseOverview
             parameters and the available Django field lookups.
         """
-        course_overviews = CourseOverview.objects.none()
         if not base_queryset:
             base_queryset = CourseOverview.objects.all()
-        for lookup, value in filters.items():
-            course_overviews |= base_queryset.filter(**{lookup: value})
-        return course_overviews
+        return base_queryset.filter(
+            Q(display_name__icontains=query) |
+            Q(org__icontains=query) |
+            Q(id__icontains=query)
+        )
 
     @classmethod
     def get_all_course_keys(cls):

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -701,7 +701,7 @@ class CourseOverview(TimeStampedModel):
         return course_overviews
 
     @classmethod
-    def get_courses_matching_query(cls, query, base_queryset=None):
+    def get_courses_matching_query(cls, query, course_overviews=None):
         """
         Return a queryset of CourseOverview objects based on the given query.
 
@@ -709,9 +709,9 @@ class CourseOverview(TimeStampedModel):
             filters (dict): required parameter that allows filtering based on the CourseOverview
             parameters and the available Django field lookups.
         """
-        if not base_queryset:
-            base_queryset = CourseOverview.objects.all()
-        return base_queryset.filter(
+        if not course_overviews:
+            course_overviews = CourseOverview.objects.all()
+        return course_overviews.filter(
             Q(display_name__icontains=query) |
             Q(org__icontains=query) |
             Q(id__icontains=query)

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -701,6 +701,22 @@ class CourseOverview(TimeStampedModel):
         return course_overviews
 
     @classmethod
+    def get_courses_matching_any_filter(cls, filters, base_queryset=None):
+        """
+        Return a queryset of CourseOverview objects based on the given filter(s).
+
+        Arguments:
+            filters (dict): required parameter that allows filtering based on the CourseOverview
+            parameters and the available Django field lookups.
+        """
+        course_overviews = CourseOverview.objects.none()
+        if not base_queryset:
+            base_queryset = CourseOverview.objects.all()
+        for lookup, value in filters.items():
+            course_overviews |= base_queryset.filter(**{lookup: value})
+        return course_overviews
+
+    @classmethod
     def get_all_course_keys(cls):
         """
         Returns all course keys from course overviews.

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -703,7 +703,7 @@ class CourseOverview(TimeStampedModel):
     @classmethod
     def get_courses_matching_query(cls, query, base_queryset=None):
         """
-        Return a queryset of CourseOverview objects based on the given filter(s).
+        Return a queryset of CourseOverview objects based on the given query.
 
         Arguments:
             filters (dict): required parameter that allows filtering based on the CourseOverview

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -701,23 +701,6 @@ class CourseOverview(TimeStampedModel):
         return course_overviews
 
     @classmethod
-    def get_courses_matching_query(cls, query, base_queryset=None):
-        """
-        Return a queryset of CourseOverview objects based on the given query.
-
-        Arguments:
-            filters (dict): required parameter that allows filtering based on the CourseOverview
-            parameters and the available Django field lookups.
-        """
-        if not base_queryset:
-            base_queryset = CourseOverview.objects.all()
-        return base_queryset.filter(
-            Q(display_name__icontains=query) |
-            Q(org__icontains=query) |
-            Q(id__icontains=query)
-        )
-
-    @classmethod
     def get_all_course_keys(cls):
         """
         Returns all course keys from course overviews.

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -701,6 +701,23 @@ class CourseOverview(TimeStampedModel):
         return course_overviews
 
     @classmethod
+    def get_courses_matching_query(cls, query, base_queryset=None):
+        """
+        Return a queryset of CourseOverview objects based on the given query.
+
+        Arguments:
+            filters (dict): required parameter that allows filtering based on the CourseOverview
+            parameters and the available Django field lookups.
+        """
+        if not base_queryset:
+            base_queryset = CourseOverview.objects.all()
+        return base_queryset.filter(
+            Q(display_name__icontains=query) |
+            Q(org__icontains=query) |
+            Q(id__icontains=query)
+        )
+
+    @classmethod
     def get_all_course_keys(cls):
         """
         Returns all course keys from course overviews.


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds a new version of the CourseHomeCourses API with filtering & ordering, intending to be used by the new Course Home MFE. The new API is based on CourseHomeCourses with tweaks, so it gets courses with Course Overview helpers that allow filtering and ordering with query set API methods.

## Supporting information

For more information on this enhancement, please check:


## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
