### PR TITLE
feat: allow staff and admin to pin posts

### DIFF
--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -93,6 +93,7 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
     is_thread = cc_content["type"] == "thread"
     is_comment = cc_content["type"] == "comment"
     has_moderation_privilege = context["has_moderation_privilege"]
+    is_staff_or_admin = context["is_staff_or_admin"]
 
     if is_thread:
         is_thread_closed = cc_content["closed"]
@@ -107,7 +108,7 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
         "abuse_flagged": True,
         "closed": is_thread and has_moderation_privilege,
         "close_reason_code": is_thread and has_moderation_privilege,
-        "pinned": is_thread and has_moderation_privilege,
+        "pinned": is_thread and (has_moderation_privilege or is_staff_or_admin),
         "read": is_thread,
     }
     if is_thread:

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -85,6 +85,7 @@ def get_context(course, request, thread=None):
         "cc_requester": cc_requester,
         "has_moderation_privilege": has_moderation_privilege,
         "is_global_staff": is_global_staff,
+        "is_staff_or_admin": requester.id in course_staff_user_ids,
     }
 
 


### PR DESCRIPTION
Staff and Admin roles can pin posts in new experience

Ticket: [INF-779](https://2u-internal.atlassian.net/browse/INF-779)