### PR TITLE
fix: add missing function import in certificate template (#33904)

### DIFF
--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -165,3 +165,19 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
             response,
             'This should not survive being overwritten by static content',
         )
+
+    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, GOOGLE_ANALYTICS_4_ID='GA-abc')
+    @with_site_configuration(configuration={'platform_name': 'My Platform Site'})
+    def test_html_view_with_g4(self):
+        test_url = get_certificate_url(
+            user_id=self.user.id,
+            course_id=str(self.course.id),
+            uuid=self.cert.verify_uuid
+        )
+        self._add_course_certificates(count=1, signatory_count=2)
+        response = self.client.get(test_url)
+        self.assertContains(
+            response,
+            'awarded this My Platform Site Honor Code Certificate of Completion',
+        )
+        self.assertContains(response, 'googletagmanager')

--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -1,7 +1,9 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
-<%! from django.utils.translation import gettext as _%>
-
+<%!
+from django.utils.translation import gettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
+%>
 <%
 # set doc language direction
 from django.utils.translation import get_language_bidi


### PR DESCRIPTION
## Description

* fix: add missing function import in certificate template
* test: add test case to check certificates generated when GA4 is enabled

(cherry picked from commit d0a49d1a01bda06722139513919b1aafcf739fa9)

Cherry picked from PR #33904

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Private Ref : [BB-8212](https://tasks.opencraft.com/browse/BB-8212)