### PR TITLE
feat: add discussion settings to course index api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_index.py
@@ -20,6 +20,7 @@ class CourseIndexSerializer(serializers.Serializer):
     deprecated_blocks_info = serializers.DictField()
     discussions_incontext_feedback_url = serializers.CharField()
     discussions_incontext_learnmore_url = serializers.CharField()
+    discussions_settings = serializers.DictField()
     initial_state = InitialIndexStateSerializer()
     initial_user_clipboard = serializers.DictField()
     language_code = serializers.CharField()
@@ -29,4 +30,5 @@ class CourseIndexSerializer(serializers.Serializer):
     proctoring_errors = ProctoringErrorListSerializer(many=True)
     reindex_link = serializers.CharField()
     rerun_notification_id = serializers.IntegerField()
+    advance_settings_url = serializers.CharField()
     is_custom_relative_dates_active = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
@@ -77,7 +77,13 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
             "notification_dismiss_url": None,
             "proctoring_errors": [],
             "reindex_link": f"/course/{self.course.id}/search_reindex",
-            "rerun_notification_id": None
+            "rerun_notification_id": None,
+            "discussions_settings": {
+                "enable_in_context": True,
+                "enable_graded_units": False,
+                "unit_level_visibility": True,
+            },
+            "advance_settings_url": f"/settings/advanced/{self.course.id}",
         }
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -117,7 +123,13 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
             "notification_dismiss_url": None,
             "proctoring_errors": [],
             "reindex_link": f"/course/{self.course.id}/search_reindex",
-            "rerun_notification_id": None
+            "rerun_notification_id": None,
+            "discussions_settings": {
+                "enable_in_context": True,
+                "enable_graded_units": False,
+                "unit_level_visibility": True,
+            },
+            "advance_settings_url": f"/settings/advanced/{self.course.id}",
         }
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1760,6 +1760,7 @@ def _get_course_index_context(request, course_key, course_block):
     course_index_context = {
         'language_code': request.LANGUAGE_CODE,
         'context_course': course_block,
+        'discussions_settings': course_block.discussions_settings,
         'lms_link': lms_link,
         'sections': sections,
         'course_structure': course_structure,


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Adds discussion settings info to course outline rest API. This is required for displaying alerts related to discussion settings in course outline MFE.

Useful information to include:
- Which edX user roles will this change impact? `Developer`.

## Supporting information

`Private-ref`: [BB-8560](https://tasks.opencraft.com/browse/BB-8560)

## Testing instructions

* Get master devstack up and running.
* Start lms and cms using `make {lms,cms}-up`.
* Go to http://localhost:18010/api-docs/
* Scroll down till you find documentation for `/contentstore/v1/course_index/{course_id}` api.
* Use `Try it out` and check `discussion_settings` field is included in API.


## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.