### PR TITLE
feat: add pagination to the HomePageCoursesV2 API

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -12,6 +12,32 @@ from cms.djangoapps.contentstore.utils import get_course_context_v2
 from cms.djangoapps.contentstore.rest_api.v2.serializers import CourseHomeTabSerializerV2
 
 
+class HomePageCoursesPaginator(PageNumberPagination):
+
+    def get_paginated_response(self, data):
+        """Return a paginated style `Response` object for the given output data."""
+        return Response(OrderedDict([
+            ('count', self.page.paginator.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data),
+        ]))
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """
+        Paginate a queryset if required, either returning a page object,
+        or `None` if pagination is not configured for this view.
+
+        This method is a modified version of the original `paginate_queryset` method
+        from the `PageNumberPagination` class. The original method was modified to
+        handle the case where the `queryset` is a `filter` object.
+        """
+        if isinstance(queryset, filter):
+            queryset = list(queryset)
+
+        return super().paginate_queryset(queryset, request, view)
+
+
 @view_auth_classes(is_authenticated=True)
 class HomePageCoursesViewV2(APIView):
     """View for getting all courses available to the logged in user."""
@@ -97,18 +123,15 @@ class HomePageCoursesViewV2(APIView):
         }
         ```
         """
-
         courses, in_process_course_actions = get_course_context_v2(request)
-        paginator = PageNumberPagination()
-        courses_page = paginator.paginate_queryset(courses, self.request, view=self)
+        paginator = HomePageCoursesPaginator()
+        courses_page = paginator.paginate_queryset(
+            courses,
+            self.request,
+            view=self
+        )
         serializer = CourseHomeTabSerializerV2({
             'courses': courses_page,
             'in_process_course_actions': in_process_course_actions,
         })
-        return Response(OrderedDict([
-            ('count', paginator.page.paginator.count),
-            ('num_pages', paginator.page.paginator.num_pages),
-            ('next', paginator.get_next_link()),
-            ('previous', paginator.get_previous_link()),
-            ('results', serializer.data),
-        ]))
+        return paginator.get_paginated_response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -1,5 +1,7 @@
 """HomePageCoursesViewV2 APIView for getting content available to the logged in user."""
 import edx_api_doc_tools as apidocs
+from collections import OrderedDict
+from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework.views import APIView
 from rest_framework.pagination import PageNumberPagination
@@ -103,4 +105,10 @@ class HomePageCoursesViewV2(APIView):
             'courses': courses_page,
             'in_process_course_actions': in_process_course_actions,
         })
-        return paginator.get_paginated_response(serializer.data)
+        return Response(OrderedDict([
+            ('count', paginator.page.paginator.count),
+            ('num_pages', paginator.page.paginator.num_pages),
+            ('next', paginator.get_next_link()),
+            ('previous', paginator.get_previous_link()),
+            ('results', serializer.data),
+        ]))

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -3,6 +3,8 @@ import edx_api_doc_tools as apidocs
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.pagination import PageNumberPagination
+
 from openedx.core.lib.api.view_utils import view_auth_classes
 
 from cms.djangoapps.contentstore.utils import get_course_context_v2
@@ -88,11 +90,11 @@ class HomePageCoursesViewV2(APIView):
         }
         ```
         """
-
         courses, in_process_course_actions = get_course_context_v2(request)
-        courses_context = {
-            "courses": courses,
-            "in_process_course_actions": in_process_course_actions,
-        }
-        serializer = CourseHomeTabSerializerV2(courses_context)
-        return Response(serializer.data)
+        paginator = PageNumberPagination()
+        courses_page = paginator.paginate_queryset(courses, self.request, view=self)
+        serializer = CourseHomeTabSerializerV2({
+            'courses': courses_page,
+            'in_process_course_actions': in_process_course_actions,
+        })
+        return paginator.get_paginated_response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -1,7 +1,6 @@
 """HomePageCoursesViewV2 APIView for getting content available to the logged in user."""
 import edx_api_doc_tools as apidocs
 from rest_framework.request import Request
-from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.pagination import PageNumberPagination
 

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -42,6 +42,11 @@ class HomePageCoursesViewV2(APIView):
                 apidocs.ParameterLocation.QUERY,
                 description="Query param to filter by archived courses only",
             ),
+            apidocs.integer_parameter(
+                "page",
+                apidocs.ParameterLocation.QUERY,
+                description="Query param to paginate the courses",
+            ),
         ],
         responses={
             200: CourseHomeTabSerializerV2,
@@ -60,6 +65,7 @@ class HomePageCoursesViewV2(APIView):
             GET /api/contentstore/v2/home/courses?order=-org
             GET /api/contentstore/v2/home/courses?active_only=true
             GET /api/contentstore/v2/home/courses?archived_only=true
+            GET /api/contentstore/v2/home/courses?page=2
 
         **Response Values**
 
@@ -90,6 +96,7 @@ class HomePageCoursesViewV2(APIView):
         }
         ```
         """
+
         courses, in_process_course_actions = get_course_context_v2(request)
         paginator = PageNumberPagination()
         courses_page = paginator.paginate_queryset(courses, self.request, view=self)

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -18,6 +18,7 @@ class HomePageCoursesPaginator(PageNumberPagination):
         """Return a paginated style `Response` object for the given output data."""
         return Response(OrderedDict([
             ('count', self.page.paginator.count),
+            ('num_pages', self.page.paginator.num_pages),
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),
             ('results', data),

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -42,7 +42,7 @@ class HomePageCoursesViewV2(APIView):
                 apidocs.ParameterLocation.QUERY,
                 description="Query param to filter by archived courses only",
             ),
-            apidocs.integer_parameter(
+            apidocs.string_parameter(
                 "page",
                 apidocs.ParameterLocation.QUERY,
                 description="Query param to paginate the courses",

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for home page view.
+"""
+import ddt
+from django.conf import settings
+from django.urls import reverse
+from edx_toggles.toggles.testutils import (
+    override_waffle_switch,
+)
+from rest_framework import status
+
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.views.course import ENABLE_GLOBAL_STAFF_OPTIMIZATION
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+@ddt.ddt
+class HomePageCoursesViewTest(CourseTestCase):
+    """
+    Tests for HomePageView.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("cms.djangoapps.contentstore:v2:courses")
+
+    def test_home_page_response(self):
+        """Check successful response content"""
+        response = self.client.get(self.url)
+        course_id = str(self.course.id)
+
+        expected_response = {
+            "courses": [{
+                "course_key": course_id,
+                "display_name": self.course.display_name,
+                "lms_link": f'//{settings.LMS_BASE}/courses/{course_id}/jump_to/{self.course.location}',
+                "number": self.course.number,
+                "org": self.course.org,
+                "rerun_link": f'/course_rerun/{course_id}',
+                "run": self.course.id.run,
+                "url": f'/course/{course_id}',
+            }],
+            "in_process_course_actions": [],
+        }
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(expected_response, response.data)
+
+    @override_waffle_switch(ENABLE_GLOBAL_STAFF_OPTIMIZATION, True)
+    def test_org_query_if_passed(self):
+        """Test home page when org filter passed as a query param"""
+        foo_course = self.store.make_course_key('foo-org', 'bar-number', 'baz-run')
+        test_course = CourseFactory.create(
+            org=foo_course.org,
+            number=foo_course.course,
+            run=foo_course.run
+        )
+        CourseOverviewFactory.create(id=test_course.id, org='foo-org')
+        response = self.client.get(self.url, {"org": "foo-org"})
+        self.assertEqual(len(response.data['courses']), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @override_waffle_switch(ENABLE_GLOBAL_STAFF_OPTIMIZATION, True)
+    def test_org_query_if_empty(self):
+        """Test home page with an empty org query param"""
+        response = self.client.get(self.url)
+        self.assertEqual(len(response.data['courses']), 0)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR builds pagination capabilities on top of the new HomePageCourses API version. These changes are intended to be used by the new Course Home MFE. The new API is based on HomePageCourses with tweaks, so it gets courses with Course Overview helpers that allow filtering, ordering, and pagination with Django/DRF methods and classes.

### API changes compared to V1

Besides the changes mentioned [here](https://github.com/openedx/edx-platform/pull/34173) that add filtering/ordering capabilities, we:
1. Used a simple paginator object before returning the courses list; this paginator only considers the list of CourseOverviews returned by the contentstore utilities.
2. Since iterators don't have length, they can't be paginated. So we had to convert the [filter(course_filter, courses_summary)](https://github.com/openedx/edx-platform/pull/34175/files#diff-937adee5129f53ead6b3c7c988d70db9e9e95862f17a6f85a1eea2388d12b461R421) iterator into a list to paginate later.
3. We added a setting configuration for the API page size.

## Supporting information

For more information on this enhancement, please check:
https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4032856101/Studio+Home+incremental+upgrades+-+product+approach

## Testing instructions

Login as an administrator or as course staff (they should both work), then:
You can use your browser to get your list of courses from Studio `HTTP(s)://<CMS_HOST>/api/contentstore/v2/home/courses` where the list of courses will appear paginated:
![image](https://github.com/openedx/edx-platform/assets/64440265/8003357d-9e0f-48a6-bfe6-2bdba4ebfc42)

## Deadline

This effort is part of the Spanish consortium project, so it'd be ideal to merge this before the end of the project.

## Other information

There are still some architectural decisions to be made around how to present data to the Studio Home MFE, ie. how to split active/archived courses. So, we'll be updating this PR accordingly. 
