### PR TITLE
fix: return a JSON object in JWKS endpoint response

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auth.py
@@ -1,6 +1,6 @@
 """ Views related to auth. """
 
-
+import json
 from common.djangoapps.util.json_request import JsonResponse
 from django.conf import settings
 
@@ -13,4 +13,5 @@ def get_public_signing_jwks(request):
     if not jwt_dict.get('JWT_PUBLIC_SIGNING_JWK_SET'):
         return JsonResponse({'error': 'JWK set is not found'}, status=400)
     jwks = jwt_dict['JWT_PUBLIC_SIGNING_JWK_SET']
-    return JsonResponse(jwks, status=200)
+    # jwks is a string here, need to convert it to dict
+    return JsonResponse(json.loads(jwks), status=200)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auth.py
@@ -20,7 +20,7 @@ class getPublicSigningJWKSFunctionTest(TestCase):
 
         return self.client.get(url, HTTP_ACCEPT=accepts)
 
-    @mock.patch.dict(settings.JWT_AUTH, {'JWT_PUBLIC_SIGNING_JWK_SET': None})
+    @mock.patch.dict(settings.JWT_AUTH, {'JWT_PUBLIC_SIGNING_JWK_SET': ''})
     def test_get_public_signing_jwks_with_no_jwk_set(self):
         """ Test JWT_PUBLIC_SIGNING_JWK_SET is undefined """
         resp = self._get_jwks()
@@ -28,7 +28,7 @@ class getPublicSigningJWKSFunctionTest(TestCase):
         assert resp.status_code == 400
         assert 'JWK set is not found' in content['error']
 
-    @mock.patch.dict(settings.JWT_AUTH, {'JWT_PUBLIC_SIGNING_JWK_SET': {'keys': []}})
+    @mock.patch.dict(settings.JWT_AUTH, {'JWT_PUBLIC_SIGNING_JWK_SET': '{"keys": []}'})
     def test_get_public_signing_jwks_with_jwk_set(self):
         """ Test JWT_PUBLIC_SIGNING_JWK_SET is defined """
         resp = self._get_jwks()


### PR DESCRIPTION
## Description

Return a JSON object instead of strings in JWKS endpoint response.
This is an improvement over [this PR](https://github.com/openedx/edx-platform/pull/34153) which was merged earlier. 