### PR TITLE
fix: change deprecated defusedxml.lxml to defusedxml.common

### DIFF
--- a/openedx/core/lib/safe_lxml/tests.py
+++ b/openedx/core/lib/safe_lxml/tests.py
@@ -4,7 +4,7 @@ Test that we have defused XML.
 
 
 from lxml import etree
-from defusedxml.lxml import EntitiesForbidden
+from defusedxml.common import EntitiesForbidden
 from .xmlparser import fromstring
 
 import pytest

--- a/openedx/core/lib/safe_lxml/xmlparser.py
+++ b/openedx/core/lib/safe_lxml/xmlparser.py
@@ -8,7 +8,7 @@ import threading
 
 from lxml import etree as _etree
 
-from defusedxml.lxml import DTDForbidden, EntitiesForbidden, NotSupportedError
+from defusedxml.common import DTDForbidden, EntitiesForbidden, NotSupportedError
 
 LXML3 = _etree.LXML_VERSION[0] >= 3
 


### PR DESCRIPTION
[Deprecation Warning]: defusedxml.lxml is no longer supported and will be removed in a future release
https://github.com/openedx/public-engineering/issues/146

## Description

defusedxml.lxml has been deprecated and will be removed in future.
So i have changed the imports to use defusedxml.common, which doesn't give the above warning.