### PR TITLE
update edx platform codeowners for aperture ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,11 +15,11 @@ lms/djangoapps/grades/
 lms/djangoapps/instructor/
 lms/djangoapps/instructor_task/
 lms/djangoapps/mobile_api/
-openedx/core/djangoapps/credentials                                 @edx/edx-aperture
-openedx/core/djangoapps/credit                                      @edx/edx-aperture
+openedx/core/djangoapps/credentials                                 @openedx/2U-aperture
+openedx/core/djangoapps/credit                                      @openedx/2U-aperture
 openedx/core/djangoapps/heartbeat/
 openedx/core/djangoapps/oauth_dispatch
-openedx/core/djangoapps/user_api/                                   @edx/edx-aperture
+openedx/core/djangoapps/user_api/                                   @openedx/2U-aperture
 openedx/core/djangoapps/user_authn/
 openedx/features/course_experience/
 xmodule/
@@ -32,14 +32,14 @@ lms/djangoapps/edxnotes
 common/djangoapps/track/
 
 # Credentials
-lms/djangoapps/certificates/                                        @edx/edx-aperture
+lms/djangoapps/certificates/                                        @openedx/2U-aperture
 
 # Discovery
 common/djangoapps/course_modes/
 common/djangoapps/enrollment/
 lms/djangoapps/commerce/
 lms/djangoapps/experiments/
-lms/djangoapps/learner_dashboard/                                    @edx/edx-aperture
+lms/djangoapps/learner_dashboard/                                    @openedx/2U-aperture
 lms/djangoapps/learner_home/
 openedx/features/content_type_gating/
 openedx/features/course_duration_limits/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,11 @@ lms/djangoapps/grades/
 lms/djangoapps/instructor/
 lms/djangoapps/instructor_task/
 lms/djangoapps/mobile_api/
+openedx/core/djangoapps/credentials                                 @edx/edx-aperture
+openedx/core/djangoapps/credit                                      @edx/edx-aperture
 openedx/core/djangoapps/heartbeat/
 openedx/core/djangoapps/oauth_dispatch
-openedx/core/djangoapps/user_api/
+openedx/core/djangoapps/user_api/                                   @edx/edx-aperture
 openedx/core/djangoapps/user_authn/
 openedx/features/course_experience/
 xmodule/
@@ -30,14 +32,14 @@ lms/djangoapps/edxnotes
 common/djangoapps/track/
 
 # Credentials
-lms/djangoapps/certificates/
+lms/djangoapps/certificates/                                        @edx/edx-aperture
 
 # Discovery
 common/djangoapps/course_modes/
 common/djangoapps/enrollment/
 lms/djangoapps/commerce/
 lms/djangoapps/experiments/
-lms/djangoapps/learner_dashboard/
+lms/djangoapps/learner_dashboard/                                    @edx/edx-aperture
 lms/djangoapps/learner_home/
 openedx/features/content_type_gating/
 openedx/features/course_duration_limits/


### PR DESCRIPTION
## Description

This adds aperture as codeowners of the repositories the team is responsible for.

FIXES: APER-3192