### PR TITLE
fix: handle countries not recognized by geoip2 DB

### DIFF
--- a/openedx/core/djangoapps/geoinfo/api.py
+++ b/openedx/core/djangoapps/geoinfo/api.py
@@ -22,7 +22,7 @@ def country_code_from_ip(ip_addr: str) -> str:
     try:
         response = reader.country(ip_addr)
         # pylint: disable=no-member
-        country_code = response.country.iso_code
+        country_code = response.country.iso_code or ""
     except geoip2.errors.AddressNotFoundError:
         country_code = ""
     reader.close()


### PR DESCRIPTION
## Description

The `geoip2` library returns `None` when it only identifies the continent related to the IP address.

## Supporting information

We cannot provide the exact IP address to reproduce this, but we can rely on the typing in `geoip2` that states that [the `iso_code` is an optional attribute](https://github.com/maxmind/GeoIP2-python/blob/v4.8.0/geoip2/records.py#L215).

## Testing instructions

If you'd like to test it manually, you can add `return None` [here](https://github.com/openedx/edx-platform/blob/b1fa2bd/openedx/core/djangoapps/geoinfo/api.py#L21) and load the `/dashboard`.

## Deadline

"None"

## Other information

The relevant traceback looks like this:
```python
2024-02-05 20:13:34,406 ERROR 1037 [django.request] [user None] [ip None] log.py:241 - Internal Server Error: /dashboard
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapper_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 134, in _wrapper_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/util/maintenance_banner.py", line 42, in _decorated
    return func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/views/dashboard.py", line 791, in student_dashboard
    country_code = country_code_from_ip(ip_address).upper()
AttributeError: 'NoneType' object has no attribute 'upper'
```


I wanted to add some tests to this PR, but this actually fixes the behavior of the `country_code_from_ip` function that, according to its typing, should always return a string. Therefore, if we can guarantee that this function will match its typing, checking if the variable is `None` [here](https://github.com/openedx/edx-platform/blob/caf8e45/common/djangoapps/student/views/dashboard.py#L791-L791) would be redundant.

_Private-ref: [BB-8396](https://tasks.opencraft.com/browse/BB-8396)_