### PR TITLE
feat: allow disabling user tours

### DIFF
--- a/lms/djangoapps/user_tours/toggles.py
+++ b/lms/djangoapps/user_tours/toggles.py
@@ -1,0 +1,15 @@
+"""
+Toggles for the User Tours Experience.
+"""
+
+from edx_toggles.toggles import WaffleFlag
+
+# .. toggle_name: user_tours.tours_disabled
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag disables user tours in LMS.
+# .. toggle_warnings: None
+# .. toggle_use_cases: opt_out
+# .. toggle_creation_date: 2024-02-06
+# .. toggle_target_removal_date: None
+USER_TOURS_DISABLED = WaffleFlag('user_tours.tours_disabled', module_name=__name__, log_prefix='user_tours')

--- a/lms/djangoapps/user_tours/v1/views.py
+++ b/lms/djangoapps/user_tours/v1/views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework import status
 
 from lms.djangoapps.user_tours.models import UserTour, UserDiscussionsTours
+from lms.djangoapps.user_tours.toggles import USER_TOURS_DISABLED
 from lms.djangoapps.user_tours.v1.serializers import UserTourSerializer, UserDiscussionsToursSerializer
 
 from rest_framework.views import APIView
@@ -41,9 +42,12 @@ class UserTourView(RetrieveUpdateAPIView):
 
             400 if there is a not allowed request (requesting a user you don't have access to)
             401 if unauthorized request
-            403 if waffle flag is not enabled
+            403 if tours are disabled
             404 if the UserTour does not exist (shouldn't happen, but safety first)
         """
+        if USER_TOURS_DISABLED.is_enabled():
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
         if request.user.username != username and not request.user.is_staff:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
@@ -66,8 +70,11 @@ class UserTourView(RetrieveUpdateAPIView):
 
             400 if update was unsuccessful or there was nothing to update
             401 if unauthorized request
-            403 if waffle flag is not enabled
+            403 if tours are disabled
         """
+        if USER_TOURS_DISABLED.is_enabled():
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
         if request.user.username != username:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
@@ -125,8 +132,11 @@ class UserDiscussionsToursView(APIView):
                     "user": 1
                 }
              ]
+            403 if the tours are disabled
 
         """
+        if USER_TOURS_DISABLED.is_enabled():
+            return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             with transaction.atomic():
                 tours = UserDiscussionsTours.objects.filter(user=request.user)
@@ -158,9 +168,11 @@ class UserDiscussionsToursView(APIView):
         Returns:
             200: The updated tour, serialized using the UserDiscussionsToursSerializer
             404: If the tour does not exist
-            403: If the user does not have permission to update the tour
+            403: If the user does not have permission to update the tour or the tours are disabled
             400: Validation error
         """
+        if USER_TOURS_DISABLED.is_enabled():
+            return Response(status=status.HTTP_403_FORBIDDEN)
         tour = get_object_or_404(UserDiscussionsTours, pk=tour_id)
         if tour.user != request.user:
             return Response(status=status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
## Description

Currently, there is no way to disable user tours. There used to be a similar waffle flag, but it was dropped in 20386337.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions
1. Run the following snippet in the Django shell:
   ```python
	from django.contrib.auth.models import User
	from lms.djangoapps.user_tours.models import UserTour

	UserTour.objects.update_or_create(user=User.objects.get(username='edx'), defaults=dict(course_home_tour_status='show-new-user-tour', show_courseware_tour=True))
   ```
1. Log in as an `edx` user.
1. In LMS, visit the Course Outline page of the Demo course and see that the user tour is displayed.
1. Create a Waffle flag (`/admin/waffle/flag/`) called `user_tours.tours_disabled` and set it to `Yes`.
1. Load the Course Outline page again and see that the tours are no longer displayed.

## Deadline

"None"

## Other information

_Private-ref: [BB-8396](https://tasks.opencraft.com/browse/BB-8396)_