### PR TITLE
Fix: Use Locator property `block_id`.

### DIFF
--- a/cms/templates/checklists.html
+++ b/cms/templates/checklists.html
@@ -49,7 +49,7 @@
                     "id": "${context_course.id | n, js_escaped_string}",
                     "name": "${context_course.display_name_with_default | n, js_escaped_string}",
                     "is_course_self_paced": ${context_course.self_paced | n, dump_js_escaped_json},
-                    "url_name": "${context_course.location.name | n, js_escaped_string}",
+                    "url_name": "${context_course.location.block_id | n, js_escaped_string}",
                     "org": "${context_course.location.org | n, js_escaped_string}",
                     "num": "${context_course.location.course | n, js_escaped_string}",
                     "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -264,7 +264,7 @@ from openedx.core.djangolib.markup import HTML, Text
             "course": {
                 "id": "${context_course.id | n, js_escaped_string}",
                 "name": "${context_course.display_name_with_default | n, js_escaped_string}",
-                "url_name": "${context_course.location.name | n, js_escaped_string}",
+                "url_name": "${context_course.location.block_id | n, js_escaped_string}",
                 "org": "${context_course.location.org | n, js_escaped_string}",
                 "num": "${context_course.location.course | n, js_escaped_string}",
                 "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This change has been made to address 9 deprecation warnings which can be seen after the tests are run.

`name` property of Locators has been deprecated and replaced by the `block_id` property.

## Supporting information

Fixes https://github.com/openedx/public-engineering/issues/156.

This PR also replaces https://github.com/openedx/edx-platform/pull/34087 which was accidentally overwritten and closed while working on a separate issue.

## Testing instructions

Nine messages from [this deprecation warning ](https://github.com/openedx/public-engineering/issues/156) were being displayed after tests in the `cms-2` shard were run.

With this change, the nine deprecation warnings have been addressed.

This can be tested manually by running unit tests on the `cms-2` shard.

```
python -Wd -m pytest -p no:randomly --ds=cms.envs.test cms/djangoapps/contentstore/
```

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
