### PR TITLE
feat: Support Django 4.2 in devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -307,6 +307,14 @@ ORA_MICROFRONTEND_URL = 'http://localhost:1992'
 ############################ AI_TRANSLATIONS ##################################
 AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
+############################ CSRF ##################################
+
+# MFEs that will call this service in devstack
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:3001',  # frontend-app-library-authoring
+    'http://localhost:2001',  # frontend-app-course-authoring
+]
+
 #################### Event bus backend ########################
 
 EVENT_BUS_PRODUCER = 'edx_event_bus_redis.create_producer'

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -537,6 +537,16 @@ AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/lat
 ############################ AI_TRANSLATIONS ##################################
 AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
+############################ CSRF ##################################
+
+# MFEs that will call this service in devstack
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:2000',  # frontend-app-learning
+    'http://localhost:1997',  # frontend-app-account
+    'http://localhost:1995',  # frontend-app-profile
+]
+
+
 ################# New settings must go ABOVE this line #################
 ########################################################################
 # See if the developer has any local overrides.


### PR DESCRIPTION
With the Django 4.2 upgrade, devstack needs `CSRF_TRUSTED_ORIGINS` for MFEs to work. This PR is probably not a complete list, but gets us started.

Ticket: https://github.com/openedx/edx-platform/issues/34180
