### PR TITLE
chore: Update edx-enterprise version to 4.11.8

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ click>=8.0,<9.0
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==4.11.7
+edx-enterprise==4.11.8
 
 # Stay on LTS version, remove once this is added to common constraint
 Django<5.0
@@ -115,7 +115,7 @@ openai<=0.28.1
 
 # optimizely-sdk 5.0.0 is breaking following test with segmentation fault
 # common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest::test_secure_key_configuration
-# needs to be fixed in the follow up issue 
+# needs to be fixed in the follow up issue
 # https://github.com/openedx/edx-platform/issues/34103
 optimizely-sdk<5.0
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -477,7 +477,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.11.7
+edx-enterprise==4.11.8
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -757,7 +757,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.11.7
+edx-enterprise==4.11.8
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -555,7 +555,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.11.7
+edx-enterprise==4.11.8
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -581,7 +581,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.11.7
+edx-enterprise==4.11.8
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
# Description
Update edx-enterprise to 4.11.8 for dependent package upgrades. 