### PR TITLE
Python 3.9 unit testing

### DIFF
--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ "3.9" ]
         # 'pinned' is used to install the latest patch version of Django
         # within the global constraint i.e. Django==4.2.8 in current case
-        # because we have global constraint of Django<4.2 
+        # because we have global constraint of Django<4.2
         django-version: ["pinned"]
         mongo-version: ["4"]
         mysql-version: ["8"]
@@ -115,7 +115,7 @@ jobs:
         ./manage.py lms migrate
         echo "Running the CMS migrations."
         ./manage.py cms migrate
-  
+
   # This job aggregates test results. It's the required check for branch protection.
   # https://github.com/marketplace/actions/alls-green#why
   # https://github.com/orgs/community/discussions/33579

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -9,12 +9,11 @@ on:
 
 jobs:
   run-test:
-    if: (github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == true))
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.9' ]
         django-version:
           - "pinned"
         # When updating the shards, remember to make the same changes in
@@ -84,7 +83,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.9' ]
         django-version:
           - "pinned"
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
+          - "3.9"
         django-version:
           - "pinned"
         # When updating the shards, remember to make the same changes in
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.9 ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -1,2 +1,3 @@
 -r kernel.in        # Core dependencies required for the platform to run.
 -r bundled.in       # Additional packages usually bundled with the platform
+backports.zoneinfo;python_version<"3.9"

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -53,7 +53,7 @@ babel==2.14.0
     #   enmerkar-underscore
 backoff==1.10.0
     # via analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports.zoneinfo;python_version<"3.9"
     # via
     #   celery
     #   django

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -110,7 +110,7 @@ backoff==1.10.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports.zoneinfo;python_version<"3.9"
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -74,7 +74,7 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports.zoneinfo;python_version<"3.9"
     # via
     #   -r requirements/edx/base.txt
     #   backports-zoneinfo

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -76,7 +76,7 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports.zoneinfo;python_version<"3.9"
     # via
     #   -r requirements/edx/base.txt
     #   backports-zoneinfo


### PR DESCRIPTION
Right now its only running tests against python 3.9. 
Running tests againsts `gh hosted runners`. Unit tests has failures.

```
  def clear_registered_transformers_cache():
        """
        Test helper to clear out any cached values of registered transformers.
        """
>       TransformerRegistry.get_write_version_hash.cache.clear()  # lint-amnesty, pylint: disable=no-member
E       AttributeError: 'functools.partial' object has no attribute 'cache'

```
Python 3.9 = https://github.com/openedx/edx-platform/pull/34196
python 3.10 = https://github.com/openedx/edx-platform/pull/34201
python 3.11 = https://github.com/openedx/edx-platform/pull/34202

