### PR TITLE
feat: add ORA MFE to devstack CSRF trusted origins

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -313,6 +313,7 @@ AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 CSRF_TRUSTED_ORIGINS = [
     'http://localhost:3001',  # frontend-app-library-authoring
     'http://localhost:2001',  # frontend-app-course-authoring
+    'http://localhost:1992',  # frontend-app-ora
 ]
 
 #################### Event bus backend ########################

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -544,6 +544,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:2000',  # frontend-app-learning
     'http://localhost:1997',  # frontend-app-account
     'http://localhost:1995',  # frontend-app-profile
+    'http://localhost:1992',  # frontend-app-ora
 ]
 
 


### PR DESCRIPTION
## Description

Adding on to #34192, add [frontend-app-ora](https://github.com/openedx/frontend-app-ora)  (`http://localhost:1992`) to the list of CSRF trusted origins for devstack. Unblocks use of new ORA MFE in devstack.
