### PR TITLE
fix: gender field in create_user_gdpr_testing script

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/create_user_gdpr_testing.py
+++ b/openedx/core/djangoapps/user_api/management/commands/create_user_gdpr_testing.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
             'meta': '{}',
             'location': 'gdpr test location',
             'year_of_birth': 1950,
-            'gender': 'gdpr test gender',
+            'gender': 'o',
             'mailing_address': 'gdpr test mailing address',
             'city': 'Boston',
             'country': 'US',


### PR DESCRIPTION
## Description
In the create_user_gdpr_testing script, the gender property of the UserProfile was set to 'gdpr test gender', which is more than max_length=6 defined in User Model.

https://github.com/openedx/edx-platform/issues/34142

This PR fixes the issue to assign the correct choice 'o' (out of 'f', 'm', 'o'). 