### PR TITLE
feat: transition learner_home to aperture

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@ common/djangoapps/enrollment/
 lms/djangoapps/commerce/
 lms/djangoapps/experiments/
 lms/djangoapps/learner_dashboard/                                    @openedx/2U-aperture
-lms/djangoapps/learner_home/
+lms/djangoapps/learner_home/                                         @openedx/2U-aperture
 openedx/features/content_type_gating/
 openedx/features/course_duration_limits/
 openedx/features/discounts/


### PR DESCRIPTION
previously assigned `learner_dashboard` to aperture (which is correct, aperture owns this) but the purpose of this effort was to assign `learner_home`, which is the backend people are referring to when they refer to "learner dashboard".

FIXES: APER-3174
