### PR TITLE
fix: fix default credentials internal service url in devstack settings

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -298,7 +298,7 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 CLOSEST_CLIENT_IP_FROM_HEADERS = []
 
 #################### Credentials Settings ####################
-CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:18150'
+CREDENTIALS_INTERNAL_SERVICE_URL = 'http://edx.devstack.credentials:18150'
 CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:18150'
 
 ########################## ORA MFE APP ##############################


### PR DESCRIPTION
## Description

I was trying to test a communication pathway between the CMS and Credentials and requests were failing with the following error:
```
2024-02-07 19:25:46,524 ERROR 202 [celery.app.trace] [user 3] [ip 192.168.16.1] trace.py:270 - Task openedx.core.djangoapps.programs.tasks.update_credentials_course_certificate_configuration_available_date[898eae19-cd38-4857-a656-dc080d64a3c5] raised unexpected: ConnectionError(MaxRetryError("HTTPConnectionPool(host='localhost', port=18150): Max retries exceeded with url: /api/v2/course_certificates/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fc5b2c357c0>: Failed to establish a new connection: [Errno 111] Connection refused'))"))
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/urllib3/util/connection.py", line 95, in create_connection
    raise err
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/urllib3/util/connection.py", line 85, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
```

I have updated the default value of the `CREDENTIALS_INTERNAL_SERVICE_URL` in our devstack settings to use the internal server URL and this fixed the issue.