### PR TITLE
fix: fixing the prompt view cancel button style for color and cursor …

### DIFF
--- a/cms/static/sass/elements/_system-feedback.scss
+++ b/cms/static/sass/elements/_system-feedback.scss
@@ -325,6 +325,12 @@
 
       .action-secondary {
         @extend %t-action4;
+        cursor: pointer;
+        color: $white;
+
+        &:hover {
+          color: $gray-l3;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

This is a backport of #33895 to quince.

## Supporting information

Fixes https://github.com/openedx/wg-build-test-release/issues/322 in quince.

## Testing instructions

Follow steps in #33895 except first step will be to install the quince release using tutor instead of the nightly release. This can be done by executing the following:

> pip install "tutor[full]==17.0.0"

...instead of...

> pip install -e "./tutor[full]"

## Deadline

N/A

## Other information

This is a screenshot showing that the issue was reproduced in quince:
<img width="1792" alt="reproducing_in_quince" src="https://github.com/openedx/edx-platform/assets/8575685/d1f91712-d7f8-4e97-8a17-4c32ee64c2a3">

This is a screenshot after the fix was applied to quince:
<img width="1792" alt="fixing_in_quince" src="https://github.com/openedx/edx-platform/assets/8575685/e294a181-b28c-4f51-b063-6aba2118fd66">
