### PR TITLE
fix: infinite growth of cache when auto eviction is disabled

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2193,7 +2193,7 @@ CACHES = {
         'KEY_PREFIX': 'course_structure',
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '7200',
+        'TIMEOUT': '604800',  # 1 week
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'OPTIONS': {
             'no_delay': True,

--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -84,7 +84,7 @@ CACHES:
         KEY_PREFIX: course_structure
         LOCATION:
         - edx.devstack.memcached:11211
-        TIMEOUT: '7200'
+        TIMEOUT: '604800'
     default:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
         OPTIONS:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1148,7 +1148,7 @@ CACHES = {
         'KEY_PREFIX': 'course_structure',
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '7200',
+        'TIMEOUT': '604800',  # 1 week
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'OPTIONS': {
             'no_delay': True,

--- a/lms/envs/devstack-experimental.yml
+++ b/lms/envs/devstack-experimental.yml
@@ -102,7 +102,7 @@ CACHES:
         KEY_PREFIX: course_structure
         LOCATION:
         - edx.devstack.memcached:11211
-        TIMEOUT: '7200'
+        TIMEOUT: '604800'
     default:
         BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
         OPTIONS:

--- a/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -246,9 +246,10 @@ class CourseStructureCache:
             data_size = len(compressed_pickled_data)
             tagger.measure('compressed_size', data_size)
 
-            # Structures are immutable, so we set a timeout of "never"
+            # We rely on the course structure cache default timeout, which should be
+            # high by default (~ a few days).
             try:
-                self.cache.set(key, compressed_pickled_data, None)
+                self.cache.set(key, compressed_pickled_data)
             except Exception:  # pylint: disable=broad-except
                 total_bytes_in_one_mb = 1024 * 1024
                 chunk_size_in_mbs = round(data_size / total_bytes_in_one_mb, 2)


### PR DESCRIPTION
## Description

The course structure cache keys were previously set with an explicit timeout of `None` which was overriding the cache default timeout of 2h. This was OK in environments where the cache is configured with a maximum memory limit and an automatic key eviction strategy. But in others (such as Tutor), the course structure cache could grow infinitely.

It was agreed that course structure cache keys should be long-lived but should respect the default cache structure timeout. Thus, we set here the TTL to 1 week.

We can also configure Tutor to use a cache eviction policy. But that means we need to set a `maxmemory` value in Redis. It's not possible to set a value that will be appropriate for everyone:
- if it's higher than the total memory (e.g: in small instances), server will crash before the cache is filled.
- if it's too low (e.g: in large instances), the whole platform will abruptly slow down as many cache entries are suddenly evicted.

That question of whether Tutor should define a cache eviction policy is still under discussion, but it can be resolved independently of this change.

## Supporting information

See discussion here: https://github.com/overhangio/tutor/pull/984

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

ASAP. We would like to backport this change in Tutor.