### PR TITLE
chore: add mongo 7 to testing matrix

### DIFF
--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -19,7 +19,7 @@ jobs:
         # within the global constraint i.e. Django==4.2.8 in current case
         # because we have global constraint of Django<4.2 
         django-version: ["pinned"]
-        mongo-version: ["4"]
+        mongo-version: ["4", "7"]
         mysql-version: ["8"]
     services:
       mongo:
@@ -27,9 +27,9 @@ jobs:
         ports:
           - 27017:27017
         # Note: Calling mongo here only works with mongo 4, in newer versions of mongo
-        # we'll have to use `mongosh`
+        # we'll have to use `mongosh`, hence the 'which mongosh mongo'.
         options: >-
-          --health-cmd "mongo --quiet --eval 'db.runCommand(\"ping\")'"
+          --health-cmd "$(which mongosh mongo) --quiet --eval 'db.runCommand(\"ping\")'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 3

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -16,6 +16,20 @@ jobs:
         python-version: [ 3.8 ]
         node-version: [ 16 ]
         npm-version: [ 8.5.x ]
+        mongo-version: ["4.4", "7.0"]
+
+    services:
+      mongo:
+        image: mongo:${{ matrix.mongo-version }}
+        ports:
+          - 27017:27017
+        # Note: Calling mongo here only works with mongo 4, in newer versions of mongo
+        # we'll have to use `mongosh`, hence the 'which mongosh mongo'.
+        options: >-
+          --health-cmd "$(which mongosh mongo) --quiet --eval 'db.runCommand(\"ping\")'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -36,7 +36,10 @@ jobs:
           - "common-with-cms"
           - "xmodule-with-lms"
           - "xmodule-with-cms"
-    name: gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
+        mongo-version:
+          - "4.4"
+          - "7.0"
+    name: gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},mongo-${{ matrix.mongo-version }}${{ matrix.shard_name }}
     steps:
       - uses: actions/checkout@v2
 
@@ -46,7 +49,7 @@ jobs:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0
         with:
-          mongodb-version: 4.4
+          mongodb-version: ${{ matrix.mongo-version}}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-tests:
-    name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
+    name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},mongo-${{ matrix.mongo-version }},${{ matrix.shard_name }}
     if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     strategy:
@@ -36,12 +36,25 @@ jobs:
           - "common-with-cms"
           - "xmodule-with-lms"
           - "xmodule-with-cms"
+        mongo-version:
+          - "4.4"
+          - "7.0"
     # We expect Django 4.0 to fail, so don't stop when it fails.
     continue-on-error: ${{ matrix.django-version == '4.0' }}
 
     steps:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
+
+      - name: install mongo version
+        run: |
+          if [[ "${{ matrix.mongo-version }}" != "4.4" ]]; then
+            sudo apt-get purge -y "mongodb-org*"
+            sudo apt-get remove -y mongodb-org
+            wget -qO - https://www.mongodb.org/static/pgp/server-${{ matrix.mongo-version }}.asc | sudo apt-key add -
+            echo "deb https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/${{ matrix.mongo-version }} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${{ matrix.mongo-version }}.list
+            sudo apt-get update && sudo apt-get install -y mongodb-org="${{ matrix.mongo-version }}.*"
+          fi
 
       - name: checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

MongoDB will enter EOL in February 2024. Because of this, depending on the vendor, managed mongo atlas instances will be forced to upgrade to newer releases. We've been testing mongo 7.0 and it works fine in a local and atlas environment.

Impacted user roles: developers

## Supporting information

- https://www.mongodb.com/legal/support-policy/lifecycles

## Testing instructions

Open a PR and verify that CI runs well.

## Deadline

None.

## Other notes

_Private-ref: [BB-8450](https://tasks.opencraft.com/browse/BB-8450)_