### PR TITLE
feat: updated api to get all question type reponses

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -399,6 +399,7 @@ class ViewsQueryCountTestCase(
         Decorates test methods to count mongo and SQL calls for a
         particular modulestore.
         """
+
         def inner(self, default_store, block_count, mongo_calls, sql_queries, *args, **kwargs):
             with modulestore().default_store(default_store):
                 self.set_up_course(block_count=block_count)
@@ -794,7 +795,8 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False,
+                               'merge_question_type_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -812,7 +814,8 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False,
+                               'merge_question_type_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -871,7 +874,8 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False,
+                               'merge_question_type_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -889,7 +893,8 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False,
+                               'merge_question_type_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }

--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -130,6 +130,7 @@ class CommentListGetForm(_PaginationForm):
     flagged = BooleanField(required=False)
     endorsed = ExtendedNullBooleanField(required=False)
     requested_fields = MultiValueField(required=False)
+    merge_question_type_responses = BooleanField(required=False)
 
 
 class UserCommentListGetForm(_PaginationForm):

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -1260,13 +1260,15 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
         overrides.setdefault("course_id", str(self.course.id))
         return make_minimal_cs_thread(overrides)
 
-    def get_comment_list(self, thread, endorsed=None, page=1, page_size=1):
+    def get_comment_list(self, thread, endorsed=None, page=1, page_size=1,
+                         merge_question_type_responses=False):
         """
         Register the appropriate comments service response, then call
         get_comment_list and return the result.
         """
         self.register_get_thread_response(thread)
-        return get_comment_list(self.request, thread["id"], endorsed, page, page_size)
+        return get_comment_list(self.request, thread["id"], endorsed, page, page_size,
+                                merge_question_type_responses=merge_question_type_responses)
 
     def test_nonexistent_thread(self):
         thread_id = "nonexistent_thread"
@@ -1398,10 +1400,14 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
                 "resp_limit": ["14"],
                 "with_responses": ["True"],
                 "reverse_order": ["False"],
+                "merge_question_type_responses": ["False"],
             }
         )
 
-    def test_discussion_content(self):
+    def get_source_and_expected_comments(self):
+        """
+        Returns the source comments and expected comments for testing purposes.
+        """
         source_comments = [
             {
                 "type": "comment",
@@ -1414,7 +1420,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
                 "created_at": "2015-05-11T00:00:00Z",
                 "updated_at": "2015-05-11T11:11:11Z",
                 "body": "Test body",
-                "endorsed": False,
+                "endorsed": True,
                 "abuse_flaggers": [],
                 "votes": {"up_count": 4},
                 "child_count": 0,
@@ -1449,7 +1455,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
                 "updated_at": "2015-05-11T11:11:11Z",
                 "raw_body": "Test body",
                 "rendered_body": "<p>Test body</p>",
-                "endorsed": False,
+                "endorsed": True,
                 "endorsed_by": None,
                 "endorsed_by_label": None,
                 "endorsed_at": None,
@@ -1508,12 +1514,26 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
                 },
             },
         ]
+        return source_comments, expected_comments
+
+    def test_discussion_content(self):
+        source_comments, expected_comments = self.get_source_and_expected_comments()
         actual_comments = self.get_comment_list(
             self.make_minimal_cs_thread({"children": source_comments})
         ).data["results"]
         assert actual_comments == expected_comments
 
-    def test_question_content(self):
+    def test_question_content_with_merge_question_type_responses(self):
+        source_comments, expected_comments = self.get_source_and_expected_comments()
+        actual_comments = self.get_comment_list(
+            self.make_minimal_cs_thread({
+                "thread_type": "question",
+                "children": source_comments,
+                "resp_total": len(source_comments)
+            }), merge_question_type_responses=True).data["results"]
+        assert actual_comments == expected_comments
+
+    def test_question_content_(self):
         thread = self.make_minimal_cs_thread({
             "thread_type": "question",
             "endorsed_responses": [make_minimal_cs_comment({"id": "endorsed_comment", "username": self.user.username})],
@@ -1547,11 +1567,13 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
         assert actual_comments[0]['endorsed_by'] is None
 
     @ddt.data(
-        ("discussion", None, "children", "resp_total"),
-        ("question", False, "non_endorsed_responses", "non_endorsed_resp_total"),
+        ("discussion", None, "children", "resp_total", False),
+        ("question", False, "non_endorsed_responses", "non_endorsed_resp_total", False),
+        ("question", None, "children", "resp_total", True),
     )
     @ddt.unpack
-    def test_cs_pagination(self, thread_type, endorsed_arg, response_field, response_total_field):
+    def test_cs_pagination(self, thread_type, endorsed_arg, response_field,
+                           response_total_field, merge_question_type_responses):
         """
         Test cases in which pagination is done by the comments service.
 
@@ -1571,22 +1593,26 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
         })
 
         # Only page
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=5).data
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=5,
+                                       merge_question_type_responses=merge_question_type_responses).data
         assert actual['pagination']['next'] is None
         assert actual['pagination']['previous'] is None
 
         # First page of many
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=2).data
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=2,
+                                       merge_question_type_responses=merge_question_type_responses).data
         assert actual['pagination']['next'] == 'http://testserver/test_path?page=2'
         assert actual['pagination']['previous'] is None
 
         # Middle page of many
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=2, page_size=2).data
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=2, page_size=2,
+                                       merge_question_type_responses=merge_question_type_responses).data
         assert actual['pagination']['next'] == 'http://testserver/test_path?page=3'
         assert actual['pagination']['previous'] == 'http://testserver/test_path?page=1'
 
         # Last page of many
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=3, page_size=2).data
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=3, page_size=2,
+                                       merge_question_type_responses=merge_question_type_responses).data
         assert actual['pagination']['next'] is None
         assert actual['pagination']['previous'] == 'http://testserver/test_path?page=2'
 
@@ -1597,7 +1623,8 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
             response_total_field: 5
         })
         with pytest.raises(PageNotFoundError):
-            self.get_comment_list(thread, endorsed=endorsed_arg, page=2, page_size=5)
+            self.get_comment_list(thread, endorsed=endorsed_arg, page=2, page_size=5,
+                                  merge_question_type_responses=merge_question_type_responses)
 
     def test_question_endorsed_pagination(self):
         thread = self.make_minimal_cs_thread({
@@ -4078,6 +4105,7 @@ class CourseTopicsV2Test(ModuleStoreTestCase):
     """
     Tests for discussions topic API v2 code.
     """
+
     def setUp(self) -> None:
         super().setUp()
         self.course = CourseFactory.create(

--- a/lms/djangoapps/discussion/rest_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_forms.py
@@ -207,7 +207,8 @@ class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
             'page': 2,
             'page_size': 13,
             'flagged': False,
-            'requested_fields': set()
+            'requested_fields': set(),
+            'merge_question_type_responses': False
         }
 
     def test_missing_thread_id(self):

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -948,6 +948,7 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
             form.cleaned_data["page_size"],
             form.cleaned_data["flagged"],
             form.cleaned_data["requested_fields"],
+            form.cleaned_data["merge_question_type_responses"]
         )
 
     def list_by_user(self, request):

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -145,6 +145,7 @@ class Thread(models.Model):
             'resp_skip': kwargs.get('response_skip'),
             'resp_limit': kwargs.get('response_limit'),
             'reverse_order': kwargs.get('reverse_order', False),
+            'merge_question_type_responses': kwargs.get('merge_question_type_responses', False)
         }
         request_params = utils.strip_none(request_params)
 


### PR DESCRIPTION
[INF-1240](https://2u-internal.atlassian.net/browse/INF-1240)

utilized new param `merge_question_type_responses` added  to cs_comment_service threads api [PR](https://github.com/openedx/cs_comments_service/pull/425) to  allow ordering on endorsed status 
