### PR TITLE
feat: modified author labels to add moderator

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -203,14 +203,16 @@ class _ContentSerializer(serializers.Serializer):
 
     def _get_user_label(self, user_id):
         """
-        Returns the role label (i.e. "Staff" or "Community TA") for the user
+        Returns the role label (i.e. "Staff", "Moderator" or "Community TA") for the user
         with the given id.
         """
-        is_staff = user_id in self.context["course_staff_user_ids"] or user_id in self.context["moderator_user_ids"]
+        is_staff = user_id in self.context["course_staff_user_ids"]
+        is_moderator = user_id in self.context["moderator_user_ids"]
         is_ta = user_id in self.context["ta_user_ids"]
 
         return (
             "Staff" if is_staff else
+            "Moderator" if is_moderator else
             "Community TA" if is_ta else
             None
         )
@@ -218,7 +220,7 @@ class _ContentSerializer(serializers.Serializer):
     def _get_user_label_from_username(self, username):
         """
         Returns role label of user from username
-        Possible Role Labels: Staff, Community TA or None
+        Possible Role Labels: Staff, Moderator, Community TA or None
         """
         try:
             user = User.objects.get(username=username)

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -1930,7 +1930,7 @@ class CreateThreadTest(
         with self.assert_signal_sent(api, 'thread_created', sender=None, user=self.user, exclude_args=('post',)):
             actual = create_thread(self.request, self.minimal_data)
         expected = self.expected_thread_data({
-            "author_label": "Staff",
+            "author_label": "Moderator",
             "id": "test_id",
             "course_id": str(self.course.id),
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_id",
@@ -2339,7 +2339,7 @@ class CreateCommentTest(
             "thread_id": "test_thread",
             "parent_id": parent_id,
             "author": self.user.username,
-            "author_label": "Staff",
+            "author_label": "Moderator",
             "created_at": "2015-05-27T00:00:00Z",
             "updated_at": "2015-05-27T00:00:00Z",
             "raw_body": "Test body",

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -102,9 +102,9 @@ class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetM
         assert actual_serialized_anonymous == expected_serialized_anonymous
 
     @ddt.data(
-        (FORUM_ROLE_ADMINISTRATOR, False, "Staff"),
+        (FORUM_ROLE_ADMINISTRATOR, False, "Moderator"),
         (FORUM_ROLE_ADMINISTRATOR, True, None),
-        (FORUM_ROLE_MODERATOR, False, "Staff"),
+        (FORUM_ROLE_MODERATOR, False, "Moderator"),
         (FORUM_ROLE_MODERATOR, True, None),
         (FORUM_ROLE_COMMUNITY_TA, False, "Community TA"),
         (FORUM_ROLE_COMMUNITY_TA, True, None),
@@ -116,7 +116,7 @@ class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetM
         """
         Test correctness of the author_label field.
 
-        The label should be "Staff", "Staff", or "Community TA" for the
+        The label should be "Staff", "Moderator", or "Community TA" for the
         Administrator, Moderator, and Community TA roles, respectively, but
         the label should not be present if the content is anonymous.
 
@@ -274,7 +274,7 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
             "unread_comments_count": 3,
             "closed_by": moderator
         })
-        closed_by_label = "Staff" if visible else None
+        closed_by_label = "Moderator" if visible else None
         closed_by = moderator if visible else None
         can_delete = role != FORUM_ROLE_STUDENT
         editable_fields = ["abuse_flagged", "copy_link", "following", "read", "voted"]
@@ -329,7 +329,7 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
             "unread_comments_count": 3,
             "closed_by": None
         })
-        edit_by_label = "Staff" if visible else None
+        edit_by_label = "Moderator" if visible else None
         can_delete = role != FORUM_ROLE_STUDENT
         last_edit = None if role == FORUM_ROLE_STUDENT else {"editor_username": moderator}
         editable_fields = ["abuse_flagged", "copy_link", "following", "read", "voted"]
@@ -491,8 +491,8 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
         assert actual_endorser_anonymous == expected_endorser_anonymous
 
     @ddt.data(
-        (FORUM_ROLE_ADMINISTRATOR, "Staff"),
-        (FORUM_ROLE_MODERATOR, "Staff"),
+        (FORUM_ROLE_ADMINISTRATOR, "Moderator"),
+        (FORUM_ROLE_MODERATOR, "Moderator"),
         (FORUM_ROLE_COMMUNITY_TA, "Community TA"),
         (FORUM_ROLE_STUDENT, None),
     )
@@ -501,7 +501,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
         """
         Test correctness of the endorsed_by_label field.
 
-        The label should be "Staff", "Staff", or "Community TA" for the
+        The label should be "Staff", "Moderator", or "Community TA" for the
         Administrator, Moderator, and Community TA roles, respectively.
 
         role_name is the name of the author's role.


### PR DESCRIPTION
[INF-737](https://2u-internal.atlassian.net/browse/INF-737)

### Description

Modified author labels to add a moderator label. The three possible labels now include Staff, Moderator, and Community TA. 
Corresponding frontend PR: https://github.com/openedx/frontend-app-discussions/pull/664