### PR TITLE
feat: making lms.djangoapps.ccx AppConfig ready.

### DIFF
--- a/lms/djangoapps/ccx/apps.py
+++ b/lms/djangoapps/ccx/apps.py
@@ -15,4 +15,4 @@ class CCXConfig(AppConfig):
         """
         Connect signal handlers.
         """
-        from . import tasks # pylint: disable=unused-import
+        from . import tasks  # pylint: disable=unused-import

--- a/lms/djangoapps/ccx/apps.py
+++ b/lms/djangoapps/ccx/apps.py
@@ -1,0 +1,18 @@
+"""
+LMS CCX application configuration
+Signal handlers are connected here.
+"""
+from django.apps import AppConfig
+
+
+class CCXConfig(AppConfig):
+    """
+    Application Configuration for CCX.
+    """
+    name = 'lms.djangoapps.ccx'
+
+    def ready(self):
+        """
+        Connect signal handlers.
+        """
+        from . import tasks # pylint: disable=unused-import


### PR DESCRIPTION
## Description

The CCX app uses a signal receiver (lms.djangoapps.ccx.course_published_handler) to know whenever the outline of a course is updated, the receiver listens to the signal "course_published". Right now, the lms.djangoapps.ccx app does not count with an AppConfig module to import the receivers, and the course_published signal can't be aware of them. This causes an unexpected behavior where the outline of the CCX is not updated. This PR aims to add an apps.py module containing an AppConfig class that imports the signal receivers of the app.

Useful information to include:
- As an useful note, the lms.djangoapps.ccx is not installed in Studio, it should also be added to the INSTALLED_APPS for the signal to be aware of the receiver. Installing lms.djangoapps.ccx also requires to install lms.djangoapps.program_enrollments.

## Testing instructions

1. Verify that currently, the CCX outline is not updated whenever the parent course is changed (you can follow the steps 8-11 below to create a CCX).
2. Install a Tutor 17 (https://docs.tutor.edly.io/install.html).
3. Build a custom image using this branch (https://docs.tutor.edly.io/configuration.html#running-a-fork-of-edx-platform).
4. Create a tutor plugin (https://docs.tutor.edly.io/tutorials/plugin.html) that has the following structure.

```
from tutor import hooks

hooks.Filters.ENV_PATCHES.add_items([
    (
        "openedx-common-settings",
        "FEATURES['CUSTOM_COURSES_EDX'] = True",
    ),
    (
        "openedx-lms-common-settings",
        """
INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig', 'user_tasks', 'cms.djangoapps.contentstore.apps.ContentstoreConfig']
COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
COURSEGRAPH_DUMP_COURSE_ON_PUBLISH = False
MODULESTORE_FIELD_OVERRIDE_PROVIDERS += ('lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',)
"""
    ),
    (
        "openedx-cms-common-settings",
        """
INSTALLED_APPS += ['lms.djangoapps.ccx', 'lms.djangoapps.program_enrollments']
BULK_EMAIL_DEFAULT_RETRY_DELAY = 30
BULK_EMAIL_MAX_RETRIES = 5
"""
    ),
])
```
It will suffice to add the settings stated in there to enable all features.

7. Start tutor with the custom image and settings (https://docs.tutor.edly.io/quickstart.html).
8. In studio, create a course and go to advanced settings, once you are there, toggle the "Enable CCX" setting.
9. Go to the course and in the instructor dashboard go to the membership tab and add a CCX coach.
10. Login with your CCX coach, go to the course that you created, go to the CCX coach tab and create a CCX.
11. Now all changes that you make in the parent course outline (sections, subsections) should be reflected in the CCX course. (All the steps to create a CCX can be viewed in the docs https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/set_up_course/studio_add_course_information/custom_courses.html)

