### PR TITLE
feat: update authn mfe devstack settings

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -238,6 +238,9 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and (
 ):
     AUTHENTICATION_BACKENDS = ['common.djangoapps.third_party_auth.dummy.DummyBackend'] + list(AUTHENTICATION_BACKENDS)
 
+########################## Authn MFE Context API #######################
+ENABLE_DYNAMIC_REGISTRATION_FIELDS = True
+
 ############## ECOMMERCE API CONFIGURATION SETTINGS ###############
 ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:18130'
 ECOMMERCE_API_URL = 'http://edx.devstack.ecommerce:18130/api/v2'


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This setting in devstack will enable Authn to get information on required fields beside name, email, username, password from the backend.

## Supporting information

Currently, Authn MFE doesn't work by default with devstack. This change fixes that.

