### PR TITLE
refactor: Update tags drawer listener for a Json message

### DIFF
--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -375,7 +375,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
                 "message", (event) => {
                     // Listen any message from Manage tags drawer.
                     var data = event.data;
-                    var courseAuthoringUrl = this.model.get("course_authoring_url")
+                    var courseAuthoringUrl = new URL(this.model.get("course_authoring_url")).origin;
                     if (event.origin == courseAuthoringUrl
                         && data.type == 'authoring.events.tags.updated') {
                         // This message arrives when there is a change in the tag list.

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -377,13 +377,12 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
                     var data = event.data;
                     var courseAuthoringUrl = this.model.get("course_authoring_url")
                     if (event.origin == courseAuthoringUrl
-                        && data.includes('[Manage tags drawer] Tags updated:')) {
+                        && data.type == 'authoring.events.tags.updated') {
                         // This message arrives when there is a change in the tag list.
                         // The message contains the new list of tags.
-                        let jsonData = data.replace(/\[Manage tags drawer\] Tags updated: /g, "");
-                        jsonData = JSON.parse(jsonData);
-                        if (jsonData.contentId == this.model.id) {
-                            this.model.set('tags', this.buildTaxonomyTree(jsonData));
+                        data = data.data
+                        if (data.contentId == this.model.id) {
+                            this.model.set('tags', this.buildTaxonomyTree(data));
                             this.render();
                         }
                     }

--- a/cms/static/js/views/tag_count.js
+++ b/cms/static/js/views/tag_count.js
@@ -21,7 +21,7 @@ function($, _, BaseView, HtmlUtils) {
                 'message', (event) => {
                     // Listen any message from Manage tags drawer.
                     var data = event.data;
-                    var courseAuthoringUrl = this.model.get("course_authoring_url")
+                    var courseAuthoringUrl = new URL(this.model.get("course_authoring_url")).origin;
                     if (event.origin == courseAuthoringUrl
                         && data.type == 'authoring.events.tags.count.updated') {
                         // This message arrives when there is a change in the tag list.

--- a/cms/static/js/views/tag_count.js
+++ b/cms/static/js/views/tag_count.js
@@ -23,13 +23,12 @@ function($, _, BaseView, HtmlUtils) {
                     var data = event.data;
                     var courseAuthoringUrl = this.model.get("course_authoring_url")
                     if (event.origin == courseAuthoringUrl
-                        && data.includes('[Manage tags drawer] Count updated:')) {
+                        && data.type == 'authoring.events.tags.count.updated') {
                         // This message arrives when there is a change in the tag list.
                         // The message contains the new count of tags.
-                        let jsonData = data.replace(/\[Manage tags drawer\] Count updated: /g, "");
-                        jsonData = JSON.parse(jsonData);
-                        if (jsonData.contentId == this.model.get("content_id")) {
-                            this.model.set('tags_count', jsonData.count);
+                        data = data.data
+                        if (data.contentId == this.model.get("content_id")) {
+                            this.model.set('tags_count', data.count);
                             this.render();
                         }
                     }


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

### Blocked: Check this https://github.com/openedx/frontend-app-course-authoring/pull/800#issuecomment-1954978625

The drawer tag listener code has been changed to accept messages in JSON structure.
This is a small refactor of the code in response to this comment: https://github.com/openedx/frontend-app-course-authoring/pull/800#pullrequestreview-1864822898

## Supporting information

Internal ticket: [FAL-3601](https://tasks.opencraft.com/browse/FAL-3601)
Github issue: https://github.com/openedx/modular-learning/issues/167
Related PRs:
- https://github.com/openedx/frontend-app-course-authoring/pull/800
- https://github.com/openedx/edx-platform/pull/34059

## Testing instructions

Follow the testing instructions of https://github.com/openedx/edx-platform/pull/34059
