### PR TITLE
chore: upgrade to XBlock==3.1.0

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -995,16 +995,27 @@ P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.x_module import XModuleMixin
 
-# These are the Mixins that should be added to every XBlock.
-# This should be moved into an XBlock Runtime/Application object
-# once the responsibility of XBlock creation is moved out of modulestore - cpennington
+# These are the Mixins that will be added to every Blocklike upon instantiation.
+# DO NOT EXPAND THIS LIST!! We want it eventually to be EMPTY. Why? Because dynamically adding functions/behaviors to
+# objects at runtime is confusing for both developers and static tooling (pylint/mypy). Instead...
+#  - to add special Blocklike behaviors just for your site: override `XBLOCK_EXTRA_MIXINS` with your own XBlockMixins.
+#  - to add new functionality to all Blocklikes: add it to the base Blocklike class in the core openedx/XBlock repo.
 XBLOCK_MIXINS = (
+    # TODO: For each of these, either
+    #  (a) merge their functionality into the base Blocklike class, or
+    #  (b) refactor their functionality out of the Blocklike objects and into the edx-platform block runtimes.
     LmsBlockMixin,
     InheritanceMixin,
     XModuleMixin,
     EditInfoMixin,
     AuthoringMixin,
 )
+
+# .. setting_name: XBLOCK_EXTRA_MIXINS
+# .. setting_default: ()
+# .. setting_description: Custom mixins that will be dynamically added to every XBlock and XBlockAside instance.
+#     These can be classes or dotted-path references to classes.
+#     For example: `XBLOCK_EXTRA_MIXINS = ('my_custom_package.my_module.MyCustomMixin',)`
 XBLOCK_EXTRA_MIXINS = ()
 
 # Paths to wrapper methods which should be applied to every XBlock's FieldData.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1640,12 +1640,28 @@ from xmodule.modulestore.edit_info import EditInfoMixin  # lint-amnesty, pylint:
 from xmodule.modulestore.inheritance import InheritanceMixin  # lint-amnesty, pylint: disable=wrong-import-order, wrong-import-position
 from xmodule.x_module import XModuleMixin  # lint-amnesty, pylint: disable=wrong-import-order, wrong-import-position
 
-# These are the Mixins that should be added to every XBlock.
-# This should be moved into an XBlock Runtime/Application object
-# once the responsibility of XBlock creation is moved out of modulestore - cpennington
-XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin, XModuleMixin, EditInfoMixin)
+# These are the Mixins that will be added to every Blocklike upon instantiation.
+# DO NOT EXPAND THIS LIST!! We want it eventually to be EMPTY. Why? Because dynamically adding functions/behaviors to
+# objects at runtime is confusing for both developers and static tooling (pylint/mypy). Instead...
+#  - to add special Blocklike behaviors just for your site: override `XBLOCK_EXTRA_MIXINS` with your own XBlockMixins.
+#  - to add new functionality to all Blocklikes: add it to the base Blocklike class in the core openedx/XBlock repo.
+XBLOCK_MIXINS = (
+    # TODO: For each of these, either
+    #  (a) merge their functionality into the base Blocklike class, or
+    #  (b) refactor their functionality out of the Blocklike objects and into the edx-platform block runtimes.
+    LmsBlockMixin,
+    InheritanceMixin,
+    XModuleMixin,
+    EditInfoMixin,
+)
 if SkillTaggingMixin:
     XBLOCK_MIXINS += (SkillTaggingMixin,)
+
+# .. setting_name: XBLOCK_EXTRA_MIXINS
+# .. setting_default: ()
+# .. setting_description: Custom mixins that will be dynamically added to every XBlock and XBlockAside instance.
+#     These can be classes or dotted-path references to classes.
+#     For example: `XBLOCK_EXTRA_MIXINS = ('my_custom_package.my_module.MyCustomMixin',)`
 XBLOCK_EXTRA_MIXINS = ()
 
 # .. setting_name: XBLOCK_FIELD_DATA_WRAPPERS

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1222,7 +1222,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/paver.txt
-xblock[django]==2.0.0
+xblock[django]==3.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2185,7 +2185,7 @@ wrapt==1.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-xblock[django]==2.0.0
+xblock[django]==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1488,7 +1488,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/base.txt
-xblock[django]==2.0.0
+xblock[django]==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1604,7 +1604,7 @@ wrapt==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   astroid
-xblock[django]==2.0.0
+xblock[django]==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/xmodule/modulestore/tests/test_api.py
+++ b/xmodule/modulestore/tests/test_api.py
@@ -46,7 +46,7 @@ def test_get_xblock_root_module_name():
 
     mixed_done_xblock = runtime.construct_xblock_from_class(DoneXBlock, Mock())
 
-    assert mixed_done_xblock.__module__ == 'xblock.internal'  # Mixed classes has a runtime generated module name.
+    assert mixed_done_xblock.__module__ == 'xblock.core'
     assert mixed_done_xblock.unmixed_class == DoneXBlock, 'The unmixed_class property retains the original property.'
 
     assert get_xblock_root_module_name(mixed_done_xblock) == 'done'

--- a/xmodule/modulestore/tests/test_inheritance.py
+++ b/xmodule/modulestore/tests/test_inheritance.py
@@ -15,7 +15,7 @@ from xblock.test.tools import TestRuntime
 from xmodule.modulestore.inheritance import InheritanceMixin
 
 
-class TestXBlock:
+class TestXBlock(XBlock):
     """
     An empty Xblock, to be used, when creating a block with mixins.
     """

--- a/xmodule/tests/xml/factories.py
+++ b/xmodule/tests/xml/factories.py
@@ -9,7 +9,6 @@ from tempfile import mkdtemp
 from factory import Factory, Sequence, lazy_attribute, post_generation
 from fs.osfs import OSFS
 from lxml import etree
-from xblock.mixins import HierarchyMixin
 
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.x_module import XModuleMixin
@@ -70,7 +69,7 @@ class XmlImportFactory(Factory):
         model = XmlImportData
 
     filesystem = OSFS(mkdtemp())
-    xblock_mixins = (InheritanceMixin, XModuleMixin, HierarchyMixin)
+    xblock_mixins = (InheritanceMixin, XModuleMixin)
     url_name = Sequence(str)
     attribs = {}
     policy = {}


### PR DESCRIPTION
## Description

Completes the upgrade from XBlock 2.0.0 to XBlock 3.1.0, incorporating changes from:
* https://github.com/openedx/XBlock/pull/718
* https://github.com/openedx/XBlock/pull/732

Closes:
* https://github.com/openedx/XBlock/issues/714

Blocked by:
* https://github.com/openedx/edx-platform/pull/34398


## Testing

The XBlock API changes were tested in https://github.com/openedx/XBlock/pull/718 . 

For this PR, I'll just use do some end-to-end smoke testing of the studio, author, and learner views of XBlocks in https://github.com/openedx/openedx-demo-course

**Note to reviewers:** The sandbox is currently failing for reasons unknown (it worked before). Please review anyway; you have my word that before merging, I'll either get the sandbox fixed, or test this out locally.