### PR TITLE
fix: should remove username from form when auto generated flag is on

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -125,6 +125,7 @@ from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.courses import get_course_by_id
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 from openedx.features.course_duration_limits.access import generate_course_expired_fragment
+from openedx.core.djangoapps.user_authn.toggles import should_enable_auto_generated_username
 from openedx.features.course_experience import course_home_url
 from openedx.features.course_experience.url_helpers import (
     get_courseware_url,
@@ -2147,7 +2148,7 @@ def financial_assistance_form(request, course_id=None):
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
         'user_details': {
             'email': user.email,
-            'username': user.username,
+            'username': '' if should_enable_auto_generated_username() else user.username,
             'name': user.profile.name,
             'country': str(user.profile.country.name),
         },

--- a/lms/templates/financial-assistance/financial_assessment_form.underscore
+++ b/lms/templates/financial-assistance/financial_assessment_form.underscore
@@ -16,10 +16,12 @@
 			gettext("The following information is already a part of your {platform} profile and is required for your application. To edit this information go to "),
 			{platform: platform_name}
 		) %><a href="<%- account_settings_url %>"><%- gettext("Account Settings") %></a>.</p>
-		<div class="info-column">
-			<div class="title"><%- gettext('Username') %></div>
-			<div class="data"><%- username %></div>
-		</div>
+		<% if (username) { %>
+			<div class="info-column">
+				<div class="title"><%- gettext('Username') %></div>
+				<div class="data"><%- username %></div>
+			</div>
+		<% } %>
 		<div class="info-column">
 			<div class="title"><%- gettext('Email address') %></div>
 			<div class="data"><%- email %></div>


### PR DESCRIPTION
## Description

Remove username from financial assistance form 

## Supporting information

[VAN-1821](https://2u-internal.atlassian.net/browse/VAN-1821)

## Testing instructions

It has been tested locally.

## Screenshot 

![image](https://github.com/openedx/edx-platform/assets/12580995/85ef80cf-ed08-4cef-b881-891b152009e7)
