### PR TITLE
feat: replace la waffle flag with django setting

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -367,7 +367,7 @@ class CoursewareMeta:
         """
         Returns a boolean representing whether the requesting user should have access to the Xpert Learning Assistant.
         """
-        return learning_assistant_is_active(self.course_key)
+        return getattr(settings, 'LEARNING_ASSISTANT_AVAILABLE', False) or learning_assistant_is_active(self.course_key)
 
 
 @method_decorator(transaction.non_atomic_requests, name='dispatch')


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

### [COSMO-191](https://2u-internal.atlassian.net/browse/COSMO-191)

As we prepare for a wider release of the learning assistant, the feature should be controlled by a django setting as opposed to a per-course flag.

This PR should not be merged until https://github.com/edx/learning-assistant/pull/67 has been merged, and a new release of the plugin has been deployed to production.
