### PR TITLE
chore: unpin django-stubs now that we're on django 4.2

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -60,13 +60,6 @@ django-webpack-loader==0.7.0
 # Adding pin to avoid any major upgrade
 djangorestframework<3.15.0
 
-# Date: 2023-07-19
-# The version of django-stubs we can use depends on which Django release we're using
-# 1.16.0 works with Django 3.2 through 4.1
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35275
-django-stubs==1.16.0
-djangorestframework-stubs==3.14.0  # Pinned to match django-stubs. Remove this when we can remove the above pin.
-
 # Date: 2024-07-23
 # django-storages==1.14.4 breaks course imports
 # Two lines were added in 1.14.4 that make file_exists_in_storage function always return False,

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -76,6 +76,7 @@ asgiref==3.8.1
     #   django
     #   django-cors-headers
     #   django-countries
+    #   django-stubs
 asn1crypto==1.5.1
     # via
     #   -r requirements/edx/doc.txt
@@ -575,9 +576,8 @@ django-storages==1.14.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-django-stubs==1.16.0
+django-stubs==5.1.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
     #   djangorestframework-stubs
 django-stubs-ext==5.1.1
@@ -622,9 +622,8 @@ djangorestframework==3.14.0
     #   openedx-learning
     #   ora2
     #   super-csv
-djangorestframework-stubs==3.14.0
+djangorestframework-stubs==3.15.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
 djangorestframework-xml==2.0.0
     # via
@@ -1296,7 +1295,6 @@ mypy==1.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
-    #   django-stubs
     #   djangorestframework-stubs
 mypy-extensions==1.0.0
     # via mypy
@@ -2108,8 +2106,6 @@ tinycss2==1.2.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   bleach
-tomli==2.0.2
-    # via django-stubs
 tomlkit==0.13.2
     # via
     #   -r requirements/edx/doc.txt
@@ -2124,8 +2120,6 @@ tqdm==4.66.6
     #   -r requirements/edx/testing.txt
     #   nltk
     #   openai
-types-pytz==2024.2.0.20241003
-    # via django-stubs
 types-pyyaml==6.0.12.20240917
     # via
     #   django-stubs


### PR DESCRIPTION
django-stubs, which provides better type hinting for Django projects, was pinned to an old version (1.16.0) in order to support Django versions <=4.

Now that we have upgraded edx-platform to 4.2, we can remove the django-stubs pin, and use the latest version. This will allow us to use type hints more aggressively, especially in the content_libraries app.

Unpinning django-stubs will create some type errors, which we need to fix before merging this PR.