### PR TITLE
feat: add discussions MFE to CSRF Trusted origin list for devstack

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -557,6 +557,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:1997',  # frontend-app-account
     'http://localhost:1995',  # frontend-app-profile
     'http://localhost:1992',  # frontend-app-ora
+    'http://localhost:2002',  # frontend-app-discussions
 ]
 
 


### PR DESCRIPTION
Adding on to https://github.com/openedx/edx-platform/pull/34192, add [frontend-app-discussions](https://github.com/openedx/frontend-app-discussions) (http://localhost:2002) to the list of CSRF trusted origins for devstack. Unblocks use of new discussions MFE in devstack.