### PR TITLE
feat: make FA form error messaging more descript

### DIFF
--- a/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
+++ b/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
@@ -165,7 +165,7 @@
             },
 
             // this.model.save() makes an ajax call, which, when it errors,
-            // should have its error messaged displayed in the banner on the page
+            // should have an error message displayed on the banner on the page
             handleAjaxError: function (event, request, settings, thrownError) {
                 this.saveError(request);
             }

--- a/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
+++ b/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
@@ -29,7 +29,7 @@
             el: '.financial-assistance-wrapper',
             events: {
                 'click .js-submit-form': 'submitForm',
-                'ajaxError': 'handleAjaxError',
+                'ajaxError': 'handleAjaxError'
             },
             tpl: formViewTpl,
             fieldTpl: formFieldTpl,
@@ -106,7 +106,7 @@
                     txt = [
                         'You must confirm your email to complete registration before applying for financial assistance.',
                         'If you continue to have issues please contact support.'
-                    ]
+                    ],
                     msg = gettext(txt.join(' '));
                 }
 

--- a/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
+++ b/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
@@ -28,7 +28,8 @@
         return FormView.extend({
             el: '.financial-assistance-wrapper',
             events: {
-                'click .js-submit-form': 'submitForm'
+                'click .js-submit-form': 'submitForm',
+                'ajaxError': 'handleAjaxError',
             },
             tpl: formViewTpl,
             fieldTpl: formFieldTpl,
@@ -101,6 +102,12 @@
 
                 if (error.status === 0) {
                     msg = gettext('An error has occurred. Check your Internet connection and try again.');
+                } else if (error.status === 403) {
+                    txt = [
+                        'You must confirm your email to complete registration before applying for financial assistance.',
+                        'If you continue to have issues please contact support.'
+                    ]
+                    msg = gettext(txt.join(' '));
                 }
 
                 this.errors = [HtmlUtils.joinHtml(
@@ -155,6 +162,12 @@
                         });
                     }
                 }
+            },
+
+            // this. model.save() makes an ajax call, which, when it errors,
+            // should have its error messaged approrpiately in the banner
+            handleAjaxError: function (event, request, settings, thrownError) {
+                this.saveError(request);
             }
         });
     }

--- a/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
+++ b/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
@@ -164,8 +164,8 @@
                 }
             },
 
-            // this. model.save() makes an ajax call, which, when it errors,
-            // should have its error messaged approrpiately in the banner
+            // this.model.save() makes an ajax call, which, when it errors,
+            // should have its error messaged displayed in the banner on the page
             handleAjaxError: function (event, request, settings, thrownError) {
                 this.saveError(request);
             }

--- a/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
+++ b/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
@@ -98,11 +98,11 @@ define([
             expect(view.$('.js-success-message').length).toEqual(1);
         };
 
-        failedSubmission = function() {
+        failedSubmission = function(statusCode) {
             expect(view.$('.js-success-message').length).toEqual(0);
             expect(view.$formFeedback.find('.' + view.formErrorsJsHook).length).toEqual(0);
             validSubmission();
-            view.model.trigger('error', {status: 500});
+            view.model.trigger('error', {status: statusCode});
             expect(view.$('.js-success-message').length).toEqual(0);
             expect(view.$formFeedback.find('.' + view.formErrorsJsHook).length).toEqual(1);
         };
@@ -166,7 +166,8 @@ define([
         });
 
         it('should submit the form and show an error message if content is valid and API returns error', function() {
-            failedSubmission();
+            failedSubmission(500);
+            failedSubmission(403);
         });
 
         it('should allow form resubmission after a front end validation failure', function() {
@@ -176,7 +177,7 @@ define([
         });
 
         it('should allow form resubmission after an API error is returned', function() {
-            failedSubmission();
+            failedSubmission(500);
             successfulSubmission();
         });
 

--- a/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
+++ b/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
@@ -171,6 +171,7 @@ define([
 
         it('should submit the form and show an error message if content is valid and API returns 403 error', function() {
             failedSubmission(403);
+            expect(view.$('.message-copy').text()).toContain('You must confirm your email');
         });
 
         it('should allow form resubmission after a front end validation failure', function() {

--- a/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
+++ b/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
@@ -167,6 +167,9 @@ define([
 
         it('should submit the form and show an error message if content is valid and API returns error', function() {
             failedSubmission(500);
+        });
+
+        it('should submit the form and show an error message if content is valid and API returns 403 error', function() {
             failedSubmission(403);
         });
 


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

If a user does not have their email verified with their edX user account, when they go to submit the financial assistance form, a 403 will be thrown. This change now displays a message telling the user to confirm their email with the 403 is encountered.

<img width="1005" alt="Screenshot 2024-02-15 at 10 28 31 AM" src="https://github.com/openedx/edx-platform/assets/7385292/d58feec7-a593-41c0-9150-5377ea05dd27">


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
