### PR TITLE
Add supplemental logging to debug IDV issues.

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1072,6 +1072,18 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
     reason = body_dict.get("Reason", "")
     error_code = body_dict.get("MessageType", "")
 
+    # TODO: These logs must be removed once the investigation in COSMO-184 is complete.
+    #       COSMO-196 was created to track the cleanup of these logs.
+    log.info(
+        "[COSMO-184] Software Secure review received for receipt_id={receipt_id}, "
+        "with result={result} and reason={reason}."
+        .format(
+            receipt_id=receipt_id,
+            result=result,
+            reason=reason,
+        )
+    )
+
     try:
         attempt = SoftwareSecurePhotoVerification.objects.get(receipt_id=receipt_id)
     except SoftwareSecurePhotoVerification.DoesNotExist:
@@ -1099,6 +1111,10 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
                 SoftwareSecurePhotoVerification.objects.filter(pk=previous_verification.pk
                                                                ).update(expiry_email_date=None)
         log.debug(f'Approving verification for {receipt_id}')
+
+        # TODO: These logs must be removed once the investigation in COSMO-184 is complete.
+        #       COSMO-196 was created to track the cleanup of these logs.
+        log.info("[COSMO-184] Approved verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
         attempt.approve()
 
         expiration_datetime = attempt.expiration_datetime.date()
@@ -1121,6 +1137,11 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
 
     elif result == "FAIL":
         log.debug("Denying verification for %s", receipt_id)
+
+        # TODO: These logs must be removed once the investigation in COSMO-184 is complete.
+        #       COSMO-196 was created to track the cleanup of these logs.
+        log.info("[COSMO-184] Denied verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
+
         attempt.deny(json.dumps(reason), error_code=error_code)
         reverify_url = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
         verification_status_email_vars['reasons'] = reason


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This commit adds some supplemental, more verbose logging to the `results_callback` view in the `verify_student` Djangoapp. This endpoint is called by identity verification (IDV) providers to POST an IDV review to edX.

We are experiencing issues with receiving IDV reviews from our IDV provider, and these logs will help us diagnose whether there is an issue in edX's systems.

These logs will be removed after our investigation is complete.

## Supporting information

Jira:
* [COSMO-184](https://2u-internal.atlassian.net/browse/COSMO-184) (private)
* [COSMO-196](https://2u-internal.atlassian.net/browse/COSMO-196) (private - clean up ticket)

## Testing instructions

None.

## Deadline

None.

## Other information

None.