### PR TITLE
feat: add first and last name to settings page

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4195,6 +4195,8 @@ ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
     ACCOUNT_VISIBILITY_CONFIGURATION["custom_shareable_fields"] + [
         "email",
         "id",
+        "first_name",
+        "last_name",
         "verified_name",
         "extended_profile",
         "gender",
@@ -4210,6 +4212,7 @@ ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
         "phone_number",
         "activation_key",
         "pending_name_change",
+        "are_first_and_last_name_required_in_registration",
     ]
 )
 

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -18,6 +18,7 @@ from social_django.models import UserSocialAuth
 
 from common.djangoapps.student.models import AccountRecovery, Registration, get_retired_email_by_email
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings, get_current_site
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_models
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -258,3 +259,18 @@ def handle_retirement_cancellation(retirement, email_address=None):
     retirement.user.save()
 
     retirement.delete()
+
+
+def are_first_and_last_name_required_in_registration():
+    """
+    Returns True if the first_name and last_name fields are required in the
+    REGISTRATION_EXTRA_FIELDS setting otherwise false.
+    """
+    registration_extra_fields = configuration_helpers.get_value(
+        'REGISTRATION_EXTRA_FIELDS',
+        getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})
+    )
+    return (
+        registration_extra_fields.get('first_name', None) == 'required'
+        and registration_extra_fields.get('last_name', None) == 'required'
+    )

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -472,12 +472,15 @@ class NameChangeView(ViewSet):
         """
         user = request.user
         new_name = request.data.get('name', None)
+        new_first_name = request.data.get('first_name', None)
+        new_last_name = request.data.get('last_name', None)
+
         rationale = f'Name change requested through account API by {user.username}'
 
         serializer = PendingNameChangeSerializer(data={'new_name': new_name})
 
         if serializer.is_valid():
-            pending_name_change = do_name_change_request(user, new_name, rationale)[0]
+            pending_name_change = do_name_change_request(user, new_name, rationale, new_first_name, new_last_name)[0]
             if pending_name_change:
                 return Response(status=status.HTTP_201_CREATED)
             else:


### PR DESCRIPTION
## Description

This PR adds the following functionality

- Adding `first_name`, `last_name` and `are_first_and_last_name_required_in_registration ` fields in `ACCOUNT_VISIBILITY_CONFIGURATION` so that It can be viewed on the accounts settings page of the user
- Sending `first_name`, `last_name` and `are_first_and_last_name_required_in_registration` in account settings view if first_name and last_name are enabled in `REGISTRATION_EXTRA_FIELDS`
- Getting and storing the user's first and last name in the `UserProfile` meta on the user name change request. 
- Deleting the user's first and last name from the `UserProfile meta` when the `PendingNameChange` object is deleted.
- Adding `first_name` and `last_name` and editable fields in the user serializer of accounts settings view.
