### PR TITLE
fix: replace username with name in contact us form

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
+++ b/lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
@@ -131,13 +131,14 @@ function LoggedInUser({
             <div className="row">
                 <div
                     className="col-sm-12 user-info"
+                    data-name={userInformation.fullName}
                     data-username={userInformation.username}
                     data-email={userInformation.email}
                 >
                     <p>
                         {StringUtils.interpolate(
-                            gettext('What can we help you with, {username}?'),
-                            { username: userInformation.username },
+                            gettext('What can we help you with, {fullName}?'),
+                            { fullName: userInformation.fullName },
                         )}
                     </p>
                 </div>
@@ -176,6 +177,7 @@ LoggedInUser.propTypes = {
     reDirectUser: PropTypes.func.isRequired,
     userInformation: PropTypes.shape({
         course_id: PropTypes.string,
+        fullName: PropTypes.string,
         username: PropTypes.string,
         email: PropTypes.string,
         // eslint-disable-next-line react/forbid-prop-types

--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -41,6 +41,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_j
 
         % if user.is_authenticated:
             context['user'] = {
+                'fullName': "${user.profile.name | n, js_escaped_string}",
                 'username': "${user.username | n, js_escaped_string}",
                 'email': "${user.email | n, js_escaped_string}",
                 'course_id': "${course_id | n, js_escaped_string}"


### PR DESCRIPTION
## Description

Replace username with name in contact us form


## Supporting information

[VAN-1822](https://2u-internal.atlassian.net/browse/VAN-1822)

## Testing instructions

It has been tested locally

## Other information

![image](https://github.com/openedx/edx-platform/assets/12580995/6c313215-c567-406f-883b-db71030c9734)
