### PR TITLE
feat: add optional xblock to outline settings

### DIFF
--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -1279,6 +1279,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'group_access': xblock.group_access,
             'user_partitions': user_partitions,
             'show_correctness': xblock.show_correctness,
+            'optional_content': xblock.optional_content,
         })
 
         if xblock.category == 'sequential':

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -78,6 +78,7 @@ class CourseMetadata:
         'highlights_enabled_for_messaging',
         'is_onboarding_exam',
         'discussions_settings',
+        'optional',
     ]
 
     @classmethod

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -18,7 +18,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         ReleaseDateEditor, DueDateEditor, SelfPacedDueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor,
         StaffLockEditor, UnitAccessEditor, ContentVisibilityEditor, TimedExaminationPreferenceEditor,
         AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor,
-        DiscussionEditor;
+        DiscussionEditor, OptionalContentEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -1206,6 +1206,46 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
+    OptionalContentEditor = AbstractEditor.extend(
+    {
+        templateName: 'optional-content-editor',
+        className: 'edit-optional-content',
+
+        afterRender: function() {
+            AbstractEditor.prototype.afterRender.call(this);
+            this.setValue(this.model.get("optional_content"));
+        },
+
+        setValue: function(value) {
+            this.$('input[name=optional_content]').prop('checked', value);
+        },
+                
+        currentValue: function() {
+            return this.$('input[name=optional_content]').is(':checked');
+        },
+
+        hasChanges: function() {
+            return this.model.get('optional_content') !== this.currentValue();
+        },
+
+        getRequestData: function() {
+            if (this.hasChanges()) {
+                return {
+                    publish: 'republish',
+                    metadata: {
+                        optional_content: this.currentValue()
+                    }
+                };
+            } else {
+                return {};
+            }
+        },
+        getContext: function() {
+            return {
+                optional_content: this.model.get('optional_content')
+            };
+        },
+    })
     return {
         getModal: function(type, xblockInfo, options) {
             if (type === 'edit') {
@@ -1245,10 +1285,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                     }
                 ];
                 if (xblockInfo.isChapter()) {
-                    tabs[0].editors = [ReleaseDateEditor];
+                    tabs[0].editors = [ReleaseDateEditor, OptionalContentEditor];
                     tabs[1].editors = [StaffLockEditor];
                 } else if (xblockInfo.isSequential()) {
-                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor];
+                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor, OptionalContentEditor];
                     tabs[1].editors = [ContentVisibilityEditor, ShowCorrectnessEditor];
                     if (course.get('self_paced') && course.get('is_custom_relative_dates_active')) {
                         tabs[0].editors.push(SelfPacedDueDateEditor);

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -747,6 +747,7 @@
 
     .edit-discussion,
     .edit-staff-lock,
+    .edit-optional-content,
     .edit-content-visibility,
     .edit-unit-access {
       margin-bottom: $baseline;
@@ -760,19 +761,20 @@
     // UI: staff lock and discussion
     .edit-discussion,
     .edit-staff-lock,
+    .edit-optional-content,
     .edit-settings-timed-examination,
     .edit-unit-access {
       .checkbox-cosmetic .input-checkbox {
         @extend %cont-text-sr;
 
         // CASE: unchecked
-        ~ .tip-warning {
+        ~.tip-warning {
           display: block;
         }
 
         // CASE: checked
         &:checked {
-          ~ .tip-warning {
+          ~.tip-warning {
             display: none;
           }
         }
@@ -832,6 +834,7 @@
 
   .edit-discussion,
   .edit-unit-access,
+  .edit-optional-content,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);
@@ -874,6 +877,7 @@
 
   .edit-discussion,
   .edit-unit-access,
+  .edit-optional-content,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -29,7 +29,7 @@ from django.urls import reverse
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable', 'optional-content-editor']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/js/optional-content-editor.underscore
+++ b/cms/templates/js/optional-content-editor.underscore
@@ -1,0 +1,5 @@
+<h3 class="modal-section-title">
+    <input type="checkbox" id="optional_content" name="optional_content"
+          class="input input-checkbox" />
+    <%- gettext('Mark as optional') %>
+</h3>

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -56,6 +56,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('has_score'),
     SupportedFieldType('has_scheduled_content'),
     SupportedFieldType('weight'),
+    SupportedFieldType('optional_content'),
     SupportedFieldType('show_correctness'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),

--- a/lms/djangoapps/course_api/blocks/transformers/block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/block_completion.py
@@ -43,7 +43,7 @@ class BlockCompletionTransformer(BlockStructureTransformer):
 
     @classmethod
     def collect(cls, block_structure):
-        block_structure.request_xblock_fields('completion_mode')
+        block_structure.request_xblock_fields('completion_mode', 'optional_content')
 
     @staticmethod
     def _is_block_excluded(block_structure, block_key):

--- a/lms/djangoapps/course_home_api/progress/serializers.py
+++ b/lms/djangoapps/course_home_api/progress/serializers.py
@@ -134,6 +134,7 @@ class ProgressTabSerializer(VerifiedModeSerializer):
     access_expiration = serializers.DictField()
     certificate_data = CertificateDataSerializer()
     completion_summary = serializers.DictField()
+    optional_completion_summary = serializers.DictField()
     course_grade = CourseGradeSerializer()
     credit_course_requirements = serializers.DictField()
     end = serializers.DateTimeField()

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -246,6 +246,7 @@ class ProgressTabView(RetrieveAPIView):
             'access_expiration': access_expiration,
             'certificate_data': get_cert_data(student, course, enrollment_mode, course_grade),
             'completion_summary': get_course_blocks_completion_summary(course_key, student),
+            'optional_completion_summary': get_course_blocks_completion_summary(course_key, student, optional=True),
             'course_grade': course_grade,
             'credit_course_requirements': credit_course_requirements(course_key, student),
             'end': course.end,

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -551,8 +551,7 @@ def get_course_assignment_date_blocks(course, user, request, num_return=None,
     return date_blocks
 
 
-@request_cached()
-def get_course_blocks_completion_summary(course_key, user):
+def get_course_blocks_completion_summary(course_key, user, optional=False):
     """
     Returns an object with the number of complete units, incomplete units, and units that contain gated content
     for the given course. The complete and incomplete counts only reflect units that are able to be completed by
@@ -566,10 +565,18 @@ def get_course_blocks_completion_summary(course_key, user):
     course_usage_key = store.make_course_usage_key(course_key)
     block_data = get_course_blocks(user, course_usage_key, allow_start_dates_in_future=True, include_completion=True)
 
+    def _is_optional(*keys):
+        for key in keys:
+            if block_data.get_xblock_field(key, 'optional_content', False):
+                return True
+        return False
+
     complete_count, incomplete_count, locked_count = 0, 0, 0
     for section_key in block_data.get_children(course_usage_key):  # pylint: disable=too-many-nested-blocks
         for subsection_key in block_data.get_children(section_key):
             for unit_key in block_data.get_children(subsection_key):
+                if optional != _is_optional(section_key, subsection_key, unit_key):
+                    continue
                 complete = block_data.get_xblock_field(unit_key, 'complete', False)
                 contains_gated_content = block_data.get_xblock_field(unit_key, 'contains_gated_content', False)
                 if contains_gated_content:

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -238,6 +238,17 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
 
+    optional_content = Boolean(
+        display_name=_('Optional'),
+        help=_(
+            'Set this to true to mark this block as optional.'
+            'Progress in this block won\'t count towards course completion progress'
+            'and will count as optional progress instead.'
+        ),
+        default=False,
+        scope=Scope.settings,
+    )
+
     @property
     def close_date(self):
         """


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
