### PR TITLE
feat: Add course price in mobile enrollment api

### DIFF
--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -179,3 +179,4 @@ class ModeSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     sku = serializers.CharField()
     android_sku = serializers.CharField()
     ios_sku = serializers.CharField()
+    min_price = serializers.IntegerField()

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -319,6 +319,12 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
                 assert 'audit_access_expires' not in courses[0]
         else:
             assert 'audit_access_expires' in courses[0]
+
+            for course_mode in courses[0]['course_modes']:
+                assert 'android_sku' in course_mode
+                assert 'ios_sku' in course_mode
+                assert 'min_price' in course_mode
+
             if gating_enabled:
                 assert courses[0].get('audit_access_expires') is not None
 


### PR DESCRIPTION

## Description
Add course price in mobile enrollment api

Useful information to include:
-This PR will effect all mobile clients using endpoint /api/mobile/v1/users/{user-name}/course_enrollments/.

## Supporting information
https://2u-internal.atlassian.net/browse/LEARNER-9830


## Deadline

We will be closing our sprint tomorrow, need to merge this today.
