### PR TITLE
chore: pull_translations: use less Makefile commands and move it to Python | FC-0012

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,9 @@ pull_plugin_translations:  ## Pull translations from Transifex for edx_django_ut
 pull_xblock_translations:  ## pull xblock translations via atlas
 	rm -rf conf/plugins-locale/xblock.v1  # Clean up existing atlas translations
 	rm -rf lms/static/i18n/xblock.v1 cms/static/i18n/xblock.v1  # Clean up existing xblock compiled translations
-	mkdir -p conf/plugins-locale/xblock.v1/ lms/static/js/xblock.v1-i18n cms/static/js
 	python manage.py lms pull_xblock_translations --verbose $(ATLAS_OPTIONS)
 	python manage.py lms compile_xblock_translations
-	cp -r lms/static/js/xblock.v1-i18n cms/static/js
+	python manage.py cms compile_xblock_translations
 
 pull_translations: ## pull translations from Transifex
 	git clean -fdX conf/locale

--- a/openedx/core/djangoapps/plugins/i18n_api.py
+++ b/openedx/core/djangoapps/plugins/i18n_api.py
@@ -92,6 +92,7 @@ class BaseAtlasPullCommand(BaseCommand):
         Ensure the pull directory is empty before running atlas pull.
         """
         plugin_translations_root = directory
+        os.makedirs(plugin_translations_root, exist_ok=True)
         if os.listdir(plugin_translations_root):
             raise CommandError(f'"{plugin_translations_root}" should be empty before running atlas pull.')
 


### PR DESCRIPTION
`mkdir` should be in Python also replacing `cp -r` with a `cms` command to avoid confusing future maintainers. These are notes from Regis on Tutor, but needs an `edx-platform` fix.

## Testing

 - [x] Run `lms make OPENEDX_ATLAS_PULL=yes pull_translations` on your devstack and it should pull translations.


## Deadline

As soon as possible, to meet FC-0012 timeline and help merge Tutor PR:

 - https://github.com/overhangio/tutor/pull/993

## Other information

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
