### PR TITLE
feat: update first and last name to segment

### DIFF
--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -816,7 +816,7 @@ def user_post_save_callback(sender, **kwargs):
         user,
         user,
         sender._meta.db_table,
-        excluded_fields=['last_login', 'first_name', 'last_name'],
+        excluded_fields=['last_login'],
         hidden_fields=['password']
     )
 

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -172,14 +172,17 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
             self.user.save()
         self.assert_no_events_were_emitted()
 
-    def test_no_first_and_last_name_events(self):
+    def test_first_and_last_name_events(self):
         """
-        Verify that first_name and last_name events are not emitted.
+        Verify that first_name and last_name events are emitted.
         """
+        old_first_name = self.user.first_name
+        old_last_name = self.user.last_name
         self.user.first_name = "Donald"
         self.user.last_name = "Duck"
         self.user.save()
-        self.assert_no_events_were_emitted()
+        self.assert_user_setting_event_emitted(setting='first_name', old=old_first_name, new=self.user.first_name)
+        self.assert_user_setting_event_emitted(setting='last_name', old=old_last_name, new=self.user.last_name)
 
     def test_enrolled_after_email_change(self):
         """


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

When first and last name are changed, update these on segment too. 

## Supporting information

Once we add first and last name to the `SOCIAL_AUTH_PROTECTED_USER_FIELDS` settings, it will protect these fields to cause multiple updates anytime a user logs in.

[VAN-1831](https://2u-internal.atlassian.net/browse/VAN-1831)

## Testing instructions

Updated tests.
