### PR TITLE
feat: show first and last name on the registration form (#34099)

### DIFF
--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -816,7 +816,7 @@ def user_post_save_callback(sender, **kwargs):
         user,
         user,
         sender._meta.db_table,
-        excluded_fields=['last_login', 'first_name', 'last_name'],
+        excluded_fields=['last_login'],
         hidden_fields=['password']
     )
 

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -172,14 +172,17 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
             self.user.save()
         self.assert_no_events_were_emitted()
 
-    def test_no_first_and_last_name_events(self):
+    def test_first_and_last_name_events(self):
         """
-        Verify that first_name and last_name events are not emitted.
+        Verify that first_name and last_name events are emitted.
         """
+        old_first_name = self.user.first_name
+        old_last_name = self.user.last_name
         self.user.first_name = "Donald"
         self.user.last_name = "Duck"
         self.user.save()
-        self.assert_no_events_were_emitted()
+        self.assert_user_setting_event_emitted(setting='first_name', old=old_first_name, new=self.user.first_name)
+        self.assert_user_setting_event_emitted(setting='last_name', old=old_last_name, new=self.user.last_name)
 
     def test_enrolled_after_email_change(self):
         """

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -313,7 +313,7 @@ class RegistrationFormFactory:
     Construct Registration forms and associated fields.
     """
 
-    DEFAULT_FIELDS = ["email", "name", "username", "password"]
+    DEFAULT_FIELDS = ["email", "first_name", "last_name", "username", "password"]
 
     def _is_field_visible(self, field_name):
         """Check whether a field is visible based on Django settings. """
@@ -331,8 +331,6 @@ class RegistrationFormFactory:
 
         self.EXTRA_FIELDS = [
             "confirm_email",
-            "first_name",
-            "last_name",
             "city",
             "state",
             "country",
@@ -915,9 +913,15 @@ class RegistrationFormFactory:
         # which allows the user to input the First Name
         first_name_label = _("First Name")
 
+        first_name_instructions = _("This name will be used on any certificates that you earn.")
+
         form_desc.add_field(
             "first_name",
             label=first_name_label,
+            instructions=first_name_instructions,
+            restrictions={
+                "max_length": accounts.NAME_MAX_LENGTH,
+            },
             required=required
         )
 
@@ -932,9 +936,15 @@ class RegistrationFormFactory:
         # which allows the user to input the First Name
         last_name_label = _("Last Name")
 
+        last_name_instructions = _("This name will be used on any certificates that you earn.")
+
         form_desc.add_field(
             "last_name",
             label=last_name_label,
+            instructions=last_name_instructions,
+            restrictions={
+                "max_length": accounts.NAME_MAX_LENGTH,
+            },
             required=required
         )
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -589,13 +589,27 @@ class RegistrationViewTestV1(
         self._assert_reg_field(
             no_extra_fields_setting,
             {
-                "name": "name",
+                "name": "first_name",
                 "type": "text",
                 "required": True,
-                "label": "Full Name",
+                "label": "First Name",
                 "instructions": "This name will be used on any certificates that you earn.",
                 "restrictions": {
-                    "max_length": 255
+                    "max_length": NAME_MAX_LENGTH
+                },
+            }
+        )
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                "name": "last_name",
+                "type": "text",
+                "required": True,
+                "label": "Last Name",
+                "instructions": "This name will be used on any certificates that you earn.",
+                "restrictions": {
+                    "max_length": NAME_MAX_LENGTH
                 },
             }
         )
@@ -1311,10 +1325,12 @@ class RegistrationViewTestV1(
 
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
+
         field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
             "email",
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "password",
             "city",
@@ -1343,13 +1359,12 @@ class RegistrationViewTestV1(
             "confirm_email": "required",
         },
         REGISTRATION_FIELD_ORDER=[
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "email",
             "confirm_email",
             "password",
-            "first_name",
-            "last_name",
             "city",
             "state",
             "country",
@@ -1374,8 +1389,9 @@ class RegistrationViewTestV1(
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['name', 'username', 'email', 'password', 'city', 'state', 'country', 'gender',
-                               'year_of_birth', 'level_of_education', 'mailing_address', 'goals', 'honor_code']
+        assert field_names == ['first_name', 'last_name', 'username', 'email', 'password',
+                               'city', 'state', 'country', 'gender', 'year_of_birth',
+                               'level_of_education', 'mailing_address', 'goals', 'honor_code']
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1392,11 +1408,10 @@ class RegistrationViewTestV1(
         },
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
         REGISTRATION_FIELD_ORDER=[
-            "name",
-            "confirm_email",
-            "password",
             "first_name",
             "last_name",
+            "confirm_email",
+            "password",
             "gender",
             "year_of_birth",
             "level_of_education",
@@ -1414,10 +1429,11 @@ class RegistrationViewTestV1(
 
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
-        field_names = [field["name"] for field in form_desc["fields"]]
 
+        field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
-            "name",
+            "first_name",
+            "last_name",
             "password",
             "gender",
             "year_of_birth",
@@ -1999,11 +2015,10 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         },
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
         REGISTRATION_FIELD_ORDER=[
-            "name",
-            "confirm_email",
-            "password",
             "first_name",
             "last_name",
+            "confirm_email",
+            "password",
             "gender",
             "year_of_birth",
             "level_of_education",
@@ -2024,7 +2039,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         field_names = [field["name"] for field in form_desc["fields"]]
 
         assert field_names == [
-            "name",
+            "first_name",
+            "last_name",
             "confirm_email",
             "password",
             "gender",
@@ -2055,13 +2071,12 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             "confirm_email": "required",
         },
         REGISTRATION_FIELD_ORDER=[
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "email",
             "confirm_email",
             "password",
-            "first_name",
-            "last_name",
             "city",
             "state",
             "country",
@@ -2086,8 +2101,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['name', 'username', 'email', 'confirm_email',
-                               'password', 'city', 'state', 'country',
+        assert field_names == ['first_name', 'last_name', 'username', 'email',
+                               'confirm_email', 'password', 'city', 'state', 'country',
                                'gender', 'year_of_birth', 'level_of_education',
                                'mailing_address', 'goals', 'honor_code']
 
@@ -2116,7 +2131,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
             "email",
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "password",
             "confirm_email",
@@ -2162,7 +2178,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         field_names = [field["name"] for field in form_desc["fields"]]
         assert field_names == [
             "email",
-            "name",
+            "first_name",
+            "last_name",
             "username",
             "password",
             "confirm_email",


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
