### PR TITLE
feat: add discussion configuration redirect in unit settings

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
@@ -10,7 +10,7 @@ from edx_toggles.toggles.testutils import override_waffle_flag
 from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
 from cms.djangoapps.contentstore.rest_api.v1.mixins import PermissionAccessMixin
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
-from cms.djangoapps.contentstore.utils import get_lms_link_for_item
+from cms.djangoapps.contentstore.utils import get_lms_link_for_item, get_pages_and_resources_url
 from cms.djangoapps.contentstore.views.course import _course_outline_json
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
@@ -82,6 +82,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
                 "enable_in_context": True,
                 "enable_graded_units": False,
                 "unit_level_visibility": True,
+                'discussion_configuration_url': f'{get_pages_and_resources_url(self.course.id)}/discussion/settings',
             },
             "advance_settings_url": f"/settings/advanced/{self.course.id}",
         }
@@ -128,6 +129,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
                 "enable_in_context": True,
                 "enable_graded_units": False,
                 "unit_level_visibility": True,
+                'discussion_configuration_url': f'{get_pages_and_resources_url(self.course.id)}/discussion/settings',
             },
             "advance_settings_url": f"/settings/advanced/{self.course.id}",
         }

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1756,6 +1756,9 @@ def _get_course_index_context(request, course_key, course_block):
     proctoring_errors = CourseMetadata.validate_proctoring_settings(course_block, advanced_dict, request.user)
 
     user_clipboard = content_staging_api.get_user_clipboard_json(request.user.id, request)
+    course_block.discussions_settings['discussion_configuration_url'] = (
+        f'{get_pages_and_resources_url(course_block.id)}/discussion/settings'
+    )
 
     course_index_context = {
         'language_code': request.LANGUAGE_CODE,

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -985,9 +985,14 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }
         },
         getContext: function() {
-            return {
-                hasDiscussionEnabled: this.currentValue()
-            };
+            return $.extend(
+                {},
+                AbstractEditor.prototype.getContext.call(this),
+                {
+                    hasDiscussionEnabled: this.currentValue(),
+                    discussion_configuration_url: course.get('discussions_settings').discussion_configuration_url
+                }
+            );
         }
     });
 

--- a/cms/templates/js/discussion-editor.underscore
+++ b/cms/templates/js/discussion-editor.underscore
@@ -12,7 +12,19 @@
         <%- gettext('Topics for unpublished units would not be created') %>
     </p>
     <p class="graded-tip tip tip-inline">
-        <%- gettext('Please enable discussions for graded units from course authoring app') %>
+        <span>
+            <%- gettext('Please enable discussions for graded units from the') %>
+            <a
+                id="discussion_configuration_url"
+                name="discussion_configuration_url"
+                rel="noreferrer noopener"
+                target="_blank"
+                href="<%- discussion_configuration_url %>"
+            >
+                <%- gettext('Discussion Configuration') %>
+                <i class="fa fa-share-square-o" aria-hidden="true"></i>
+            </a>
+        </span>
     </p>
 </div>
 </div>


### PR DESCRIPTION
**[INF-1247](https://2u-internal.atlassian.net/browse/INF-1247)**

### Description:
Modify the sentence 'Please enable discussions for graded units from course authoring app'. It is confusing for the course teams to find out about course authoring apps. So, we added discussion configuration redirection in unit settings. It will help the course team to easily navigate to discussion configuration to enable discussions for graded units.

### Before:
It was just a plain text.
<img width="691" alt="2024-02-12_11-00-17" src="https://github.com/openedx/edx-platform/assets/79941147/cb6a968e-2ac7-44ad-8538-479f4ed617cf">

### After
Added settings redirection.
<img width="1382" alt="Screenshot 2024-02-21 at 1 25 03 PM" src="https://github.com/openedx/edx-platform/assets/79941147/0086cb75-b26c-4b91-b71d-3ceba4c4ab44">
