### PR TITLE
feat: remove learning assistant waffle flag

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -109,18 +109,6 @@ COURSEWARE_OPTIMIZED_RENDER_XBLOCK = CourseWaffleFlag(
 # .. toggle_status: unsupported
 COURSES_INVITE_ONLY = SettingToggle('COURSES_INVITE_ONLY', default=False)
 
-# .. toggle_name: courseware.learning_assistant
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: This flag enables an the visibility of an LTI-based learning assistant
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2023-07-05
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: MST-1977
-COURSEWARE_LEARNING_ASSISTANT = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.learning_assistant', __name__
-)
-
 
 ENABLE_OPTIMIZELY_IN_COURSEWARE = WaffleSwitch(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     'RET.enable_optimizely_in_courseware', __name__
@@ -175,10 +163,6 @@ def course_is_invitation_only(courselike) -> bool:
     """Returns whether the course is invitation only or not."""
     # We also mark Old Mongo courses (deprecated keys) as invitation only to cut off enrollment
     return COURSES_INVITE_ONLY.is_enabled() or courselike.invitation_only or courselike.id.deprecated
-
-
-def learning_assistant_is_active(course_key):
-    return COURSEWARE_LEARNING_ASSISTANT.is_enabled(course_key)
 
 
 def courseware_mfe_search_is_enabled(course_key=None):

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -2,7 +2,6 @@
 Tests for courseware API
 """
 
-import itertools
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 from typing import Optional
@@ -34,7 +33,6 @@ from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.courseware.tabs import ExternalLinkCourseTab
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.courseware.toggles import (
-    COURSEWARE_LEARNING_ASSISTANT,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
 )
@@ -432,16 +430,16 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         assert 'can_access_proctored_exams' in courseware_data
         assert courseware_data['can_access_proctored_exams'] == result
 
-    @ddt.idata(itertools.product((True, False), (True, False)))
-    @ddt.unpack
-    def test_learning_assistant_enabled(self, setting_enabled, flag_enabled):
-        with override_settings(LEARNING_ASSISTANT_AVAILABLE=setting_enabled), \
-                override_waffle_flag(COURSEWARE_LEARNING_ASSISTANT, active=flag_enabled):
+    @ddt.data(
+        True,
+        False
+    )
+    def test_learning_assistant_enabled(self, setting_enabled):
+        with override_settings(LEARNING_ASSISTANT_AVAILABLE=setting_enabled):
             response = self.client.get(self.url)
 
         learning_assistant_enabled = response.json()['learning_assistant_enabled']
-        expected_value = setting_enabled or flag_enabled
-        self.assertEqual(learning_assistant_enabled, expected_value)
+        self.assertEqual(learning_assistant_enabled, setting_enabled)
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -43,7 +43,7 @@ from lms.djangoapps.courseware.masquerade import (
 )
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.courseware.block_render import get_block_by_usage_id
-from lms.djangoapps.courseware.toggles import course_exit_page_is_active, learning_assistant_is_active
+from lms.djangoapps.courseware.toggles import course_exit_page_is_active
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.gating.api import get_entrance_exam_score, get_entrance_exam_usage_key
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -367,7 +367,7 @@ class CoursewareMeta:
         """
         Returns a boolean representing whether the requesting user should have access to the Xpert Learning Assistant.
         """
-        return getattr(settings, 'LEARNING_ASSISTANT_AVAILABLE', False) or learning_assistant_is_active(self.course_key)
+        return getattr(settings, 'LEARNING_ASSISTANT_AVAILABLE', False)
 
 
 @method_decorator(transaction.non_atomic_requests, name='dispatch')


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
The waffle flag `courseware.learning_assistant` has been replaced by the django setting `LEARNING_ASSISTANT_AVAILABLE`, so the waffle flag can now be removed. 
