### PR TITLE
Backport: fix: handle paste of library content blocks correctly

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -341,7 +341,7 @@ def _import_xml_node_to_parent(
         # Special case handling for library content. If we need this for other blocks in the future, it can be made into
         # an API, and we'd call new_block.studio_post_paste() instead of this code.
         # In this case, we want to pull the children from the library and let library_tools assign their IDs.
-        new_xblock.sync_from_library(upgrade_to_latest=False)
+        new_xblock.tools.update_children(new_xblock, version=new_xblock.source_library_version)
     else:
         for child_node in child_nodes:
             _import_xml_node_to_parent(child_node, new_xblock, store, user_id=user_id)

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -5,7 +5,6 @@ APIs.
 """
 import ddt
 from django.test import LiveServerTestCase
-from django.urls import reverse
 from opaque_keys.edx.keys import UsageKey
 from rest_framework.test import APIClient
 from xmodule.modulestore.django import contentstore, modulestore
@@ -235,7 +234,7 @@ class ClipboardLibraryContentPasteTestCase(LiveServerTestCase, ModuleStoreTestCa
             'category': 'html',
             'display_name': 'HTML Content',
         }
-        response = self.client.ajax_post(reverse('xblock_handler'), data)
+        response = self.client.ajax_post(XBLOCK_ENDPOINT, data)
         self.assertEqual(response.status_code, 200)
         course = CourseFactory.create(display_name='Course')
         orig_lc_block = BlockFactory.create(
@@ -255,10 +254,10 @@ class ClipboardLibraryContentPasteTestCase(LiveServerTestCase, ModuleStoreTestCa
         assert copy_response.status_code == 200
 
         # Paste the Library content block:
-        paste_response = self.client.post(XBLOCK_ENDPOINT, {
+        paste_response = self.client.ajax_post(XBLOCK_ENDPOINT, {
             "parent_locator": str(course.location),
             "staged_content": "clipboard",
-        }, format="json")
+        })
         assert paste_response.status_code == 200
         dest_lc_block_key = UsageKey.from_string(paste_response.json()["locator"])
 

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -4,6 +4,7 @@ allow users to paste XBlocks that were copied using the staged_content/clipboard
 APIs.
 """
 import ddt
+import unittest
 from django.test import LiveServerTestCase
 from opaque_keys.edx.keys import UsageKey
 from rest_framework.test import APIClient
@@ -268,6 +269,7 @@ class ClipboardLibraryContentPasteTestCase(BlockstoreAppTestMixin, LiveServerTes
         orig_child = self.store.get_item(self.orig_lc_block.children[0])
         assert orig_child.display_name == "MCQ"
 
+    @unittest.skip("Quince doesn't support using V2 libraries via library content block; this test was backported")
     def test_paste_library_content_block(self):
         """
         Test the special handling of copying and pasting library content

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -13,7 +13,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, upload_f
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory, LibraryFactory, ToyCourseFactory
 
 from cms.djangoapps.contentstore.utils import reverse_usage_url
-from openedx.core.lib.blockstore_api.tests.base import BlockstoreAppTestMixin
+from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
 
 CLIPBOARD_ENDPOINT = "/api/content-staging/v1/clipboard/"
 XBLOCK_ENDPOINT = "/xblock/"
@@ -211,7 +211,7 @@ class ClipboardPasteTestCase(ModuleStoreTestCase):
         assert source_pic2_hash != dest_pic2_hash  # Because there was a conflict, this file was unchanged.
 
 
-class ClipboardLibraryContentPasteTestCase(BlockstoreAppTestMixin, LiveServerTestCase, ModuleStoreTestCase):
+class ClipboardLibraryContentPasteTestCase(LiveServerTestCase, ModuleStoreTestCase):
     """
     Test Clipboard Paste functionality with library content
     """
@@ -221,7 +221,7 @@ class ClipboardLibraryContentPasteTestCase(BlockstoreAppTestMixin, LiveServerTes
         Set up a v2 Content Library and a library content block
         """
         super().setUp()
-        self.client = APIClient()
+        self.client = AjaxEnabledTestClient()
         self.client.login(username=self.user.username, password=self.user_password)
         self.store = modulestore()
 

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -4,20 +4,16 @@ allow users to paste XBlocks that were copied using the staged_content/clipboard
 APIs.
 """
 import ddt
-import unittest
 from django.test import LiveServerTestCase
 from django.urls import reverse
 from opaque_keys.edx.keys import UsageKey
 from rest_framework.test import APIClient
-from organizations.models import Organization
 from xmodule.modulestore.django import contentstore, modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, upload_file_to_course
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory, LibraryFactory, ToyCourseFactory
 
 from cms.djangoapps.contentstore.utils import reverse_usage_url
 from openedx.core.lib.blockstore_api.tests.base import BlockstoreAppTestMixin
-from openedx.core.djangoapps.content_libraries import api as library_api
-from blockstore.apps import api as blockstore_api
 
 CLIPBOARD_ENDPOINT = "/api/content-staging/v1/clipboard/"
 XBLOCK_ENDPOINT = "/xblock/"
@@ -228,77 +224,6 @@ class ClipboardLibraryContentPasteTestCase(BlockstoreAppTestMixin, LiveServerTes
         self.client = APIClient()
         self.client.login(username=self.user.username, password=self.user_password)
         self.store = modulestore()
-
-    @unittest.skip("Quince doesn't support using V2 libraries via library content block; this test was backported")
-    def test_paste_library_content_block(self):
-        """
-        Test the special handling of copying and pasting library content
-        """
-        # Create a content library:
-        library = library_api.create_library(
-            collection_uuid=blockstore_api.create_collection("Collection").uuid,
-            library_type=library_api.COMPLEX,
-            org=Organization.objects.create(name="Test Org", short_name="CL-TEST"),
-            slug="lib",
-            title="Library",
-            description="",
-            allow_public_learning=False,
-            allow_public_read=False,
-            library_license=library_api.ALL_RIGHTS_RESERVED,
-        )
-        # Populate it with a problem:
-        problem_key = library_api.create_library_block(library.key, "problem", "p1").usage_key
-        library_api.set_library_block_olx(problem_key, """
-        <problem display_name="MCQ" max_attempts="1">
-            <multiplechoiceresponse>
-                <label>Q</label>
-                <choicegroup type="MultipleChoice">
-                    <choice correct="false">Wrong</choice>
-                    <choice correct="true">Right</choice>
-                </choicegroup>
-            </multiplechoiceresponse>
-        </problem>
-        """)
-        library_api.publish_changes(library.key)
-
-        # Create a library content block (lc), point it out our library, and sync it.
-        self.course = CourseFactory.create(display_name='Course')
-        self.orig_lc_block = BlockFactory.create(
-            parent=self.course,
-            category="library_content",
-            source_library_id=str(library.key),
-            display_name="LC Block",
-            publish_item=False,
-        )
-        self.dest_lc_block = None
-
-        self._sync_lc_block_from_library('orig_lc_block')
-        orig_child = self.store.get_item(self.orig_lc_block.children[0])
-        assert orig_child.display_name == "MCQ"
-        # Copy a library content block that has children:
-        copy_response = self.client.post(CLIPBOARD_ENDPOINT, {
-            "usage_key": str(self.orig_lc_block.location)
-        }, format="json")
-        assert copy_response.status_code == 200
-
-        # Paste the Library content block:
-        paste_response = self.client.post(XBLOCK_ENDPOINT, {
-            "parent_locator": str(self.course.location),
-            "staged_content": "clipboard",
-        }, format="json")
-        assert paste_response.status_code == 200
-        dest_lc_block_key = UsageKey.from_string(paste_response.json()["locator"])
-
-        # Get the ID of the new child:
-        self.dest_lc_block = self.store.get_item(dest_lc_block_key)
-        dest_child = self.store.get_item(self.dest_lc_block.children[0])
-        assert dest_child.display_name == "MCQ"
-
-        # Importantly, the ID of the child must not changed when the library content is synced.
-        # Otherwise, user state saved against this child will be lost when it syncs.
-        self._sync_lc_block_from_library('dest_lc_block')
-        updated_dest_child = self.store.get_item(self.dest_lc_block.children[0])
-        assert dest_child.location == updated_dest_child.location
 
     def test_paste_library_content_block_v1(self):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -4,11 +4,18 @@ allow users to paste XBlocks that were copied using the staged_content/clipboard
 APIs.
 """
 import ddt
+from django.test import LiveServerTestCase
 from opaque_keys.edx.keys import UsageKey
 from rest_framework.test import APIClient
-from xmodule.modulestore.django import contentstore
+from organizations.models import Organization
+from xmodule.modulestore.django import contentstore, modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, upload_file_to_course
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory, ToyCourseFactory
+
+from cms.djangoapps.contentstore.utils import reverse_usage_url
+from openedx.core.lib.blockstore_api.tests.base import BlockstoreAppTestMixin
+from openedx.core.djangoapps.content_libraries import api as library_api
+from blockstore.apps import api as blockstore_api
 
 CLIPBOARD_ENDPOINT = "/api/content-staging/v1/clipboard/"
 XBLOCK_ENDPOINT = "/xblock/"
@@ -109,7 +116,7 @@ class ClipboardPasteTestCase(ModuleStoreTestCase):
         """
         Test copying a component (XBlock) from one course into another
         """
-        source_course = CourseFactory.create(display_name='Destination Course')
+        source_course = CourseFactory.create(display_name='Source Course')
         source_block = BlockFactory.create(parent_location=source_course.location, **block_args)
 
         dest_course = CourseFactory.create(display_name='Destination Course')
@@ -204,3 +211,97 @@ class ClipboardPasteTestCase(ModuleStoreTestCase):
         source_pic2_hash = contentstore().find(source_course.id.make_asset_key("asset", "picture2.jpg")).content_digest
         dest_pic2_hash = contentstore().find(dest_course_key.make_asset_key("asset", "picture2.jpg")).content_digest
         assert source_pic2_hash != dest_pic2_hash  # Because there was a conflict, this file was unchanged.
+
+
+class ClipboardLibraryContentPasteTestCase(BlockstoreAppTestMixin, LiveServerTestCase, ModuleStoreTestCase):
+    """
+    Test Clipboard Paste functionality with library content
+    """
+
+    def setUp(self):
+        """
+        Set up a v2 Content Library and a library content block
+        """
+        super().setUp()
+        self.client = APIClient()
+        self.client.login(username=self.user.username, password=self.user_password)
+        self.store = modulestore()
+        # Create a content library:
+        library = library_api.create_library(
+            collection_uuid=blockstore_api.create_collection("Collection").uuid,
+            library_type=library_api.COMPLEX,
+            org=Organization.objects.create(name="Test Org", short_name="CL-TEST"),
+            slug="lib",
+            title="Library",
+        )
+        # Populate it with a problem:
+        problem_key = library_api.create_library_block(library.key, "problem", "p1").usage_key
+        library_api.set_library_block_olx(problem_key, """
+        <problem display_name="MCQ" max_attempts="1">
+            <multiplechoiceresponse>
+                <label>Q</label>
+                <choicegroup type="MultipleChoice">
+                    <choice correct="false">Wrong</choice>
+                    <choice correct="true">Right</choice>
+                </choicegroup>
+            </multiplechoiceresponse>
+        </problem>
+        """)
+        library_api.publish_changes(library.key)
+
+        # Create a library content block (lc), point it out our library, and sync it.
+        self.course = CourseFactory.create(display_name='Course')
+        self.orig_lc_block = BlockFactory.create(
+            parent=self.course,
+            category="library_content",
+            source_library_id=str(library.key),
+            display_name="LC Block",
+            publish_item=False,
+        )
+        self.dest_lc_block = None
+
+        self._sync_lc_block_from_library('orig_lc_block')
+        orig_child = self.store.get_item(self.orig_lc_block.children[0])
+        assert orig_child.display_name == "MCQ"
+
+    def test_paste_library_content_block(self):
+        """
+        Test the special handling of copying and pasting library content
+        """
+        # Copy a library content block that has children:
+        copy_response = self.client.post(CLIPBOARD_ENDPOINT, {
+            "usage_key": str(self.orig_lc_block.location)
+        }, format="json")
+        assert copy_response.status_code == 200
+
+        # Paste the Library content block:
+        paste_response = self.client.post(XBLOCK_ENDPOINT, {
+            "parent_locator": str(self.course.location),
+            "staged_content": "clipboard",
+        }, format="json")
+        assert paste_response.status_code == 200
+        dest_lc_block_key = UsageKey.from_string(paste_response.json()["locator"])
+
+        # Get the ID of the new child:
+        self.dest_lc_block = self.store.get_item(dest_lc_block_key)
+        dest_child = self.store.get_item(self.dest_lc_block.children[0])
+        assert dest_child.display_name == "MCQ"
+
+        # Importantly, the ID of the child must not changed when the library content is synced.
+        # Otherwise, user state saved against this child will be lost when it syncs.
+        self._sync_lc_block_from_library('dest_lc_block')
+        updated_dest_child = self.store.get_item(self.dest_lc_block.children[0])
+        assert dest_child.location == updated_dest_child.location
+
+    def _sync_lc_block_from_library(self, attr_name):
+        """
+        Helper method to "sync" a Library Content Block by [re-]fetching its
+        children from the library.
+        """
+        usage_key = getattr(self, attr_name).location
+        # It's easiest to do this via the REST API:
+        handler_url = reverse_usage_url('preview_handler', usage_key, kwargs={'handler': 'upgrade_and_sync'})
+        response = self.client.post(handler_url)
+        assert response.status_code == 200
+        # Now reload the block and make sure the child is in place
+        setattr(self, attr_name, self.store.get_item(usage_key))  # we must reload after upgrade_and_sync

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -233,6 +233,10 @@ class ClipboardLibraryContentPasteTestCase(BlockstoreAppTestMixin, LiveServerTes
             org=Organization.objects.create(name="Test Org", short_name="CL-TEST"),
             slug="lib",
             title="Library",
+            description="",
+            allow_public_learning=False,
+            allow_public_read=False,
+            library_license=library_api.ALL_RIGHTS_RESERVED,
         )
         # Populate it with a problem:
         problem_key = library_api.create_library_block(library.key, "problem", "p1").usage_key

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -425,6 +425,8 @@ def create_library(
 
     allow_public_read: Allow anyone to view blocks (including source) in Studio?
 
+    library_type: Deprecated parameter, not really used. Set to COMPLEX.
+
     Returns a ContentLibraryMetadata instance.
     """
     assert isinstance(collection_uuid, UUID)

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -91,7 +91,15 @@ from xblock.core import XBlock
 from xblock.exceptions import XBlockNotFoundError
 from edx_rest_api_client.client import OAuthAPIClient
 from openedx.core.djangoapps.content_libraries import permissions
-from openedx.core.djangoapps.content_libraries.constants import DRAFT_NAME, COMPLEX
+# pylint: disable=unused-import
+from openedx.core.djangoapps.content_libraries.constants import (
+    ALL_RIGHTS_RESERVED,
+    CC_4_BY,
+    COMPLEX,
+    DRAFT_NAME,
+    PROBLEM,
+    VIDEO,
+)
 from openedx.core.djangoapps.content_libraries.library_bundle import LibraryBundle
 from openedx.core.djangoapps.content_libraries.libraries_index import ContentLibraryIndexer, LibraryBlockIndexer
 from openedx.core.djangoapps.content_libraries.models import (


### PR DESCRIPTION
This backports https://github.com/openedx/edx-platform/pull/33926 to Quince - please see that PR's description. This is a bugfix PR.

The commit/code is mostly the same but I removed:
* the breaking changes to the `create_library()` API - this backport doesn't move the `library_type` parameter to the end of the parameter list nor make it optional like the master PR did.
* The changes to the `content_tagging` `test_views` were excluded as the library part of that code isn't present on Quince.
* I had to skip the test for this change, because the test depends on v2 libraries which don't work properly in quince. However, the fix should apply to both v1 and v2 so is still useful to backport.

Private ref: MNG-4161