### PR TITLE
feat: optional xblocks

### DIFF
--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -1279,6 +1279,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'group_access': xblock.group_access,
             'user_partitions': user_partitions,
             'show_correctness': xblock.show_correctness,
+            'optional_content': xblock.optional_content,
         })
 
         if xblock.category == 'sequential':

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -78,6 +78,7 @@ class CourseMetadata:
         'highlights_enabled_for_messaging',
         'is_onboarding_exam',
         'discussions_settings',
+        'optional',
     ]
 
     @classmethod

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -18,7 +18,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         ReleaseDateEditor, DueDateEditor, SelfPacedDueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor,
         StaffLockEditor, UnitAccessEditor, ContentVisibilityEditor, TimedExaminationPreferenceEditor,
         AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor,
-        DiscussionEditor;
+        DiscussionEditor, OptionalContentEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -1206,6 +1206,46 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
+    OptionalContentEditor = AbstractEditor.extend(
+    {
+        templateName: 'optional-content-editor',
+        className: 'edit-optional-content',
+
+        afterRender: function() {
+            AbstractEditor.prototype.afterRender.call(this);
+            this.setValue(this.model.get("optional_content"));
+        },
+
+        setValue: function(value) {
+            this.$('input[name=optional_content]').prop('checked', value);
+        },
+                
+        currentValue: function() {
+            return this.$('input[name=optional_content]').is(':checked');
+        },
+
+        hasChanges: function() {
+            return this.model.get('optional_content') !== this.currentValue();
+        },
+
+        getRequestData: function() {
+            if (this.hasChanges()) {
+                return {
+                    publish: 'republish',
+                    metadata: {
+                        optional_content: this.currentValue()
+                    }
+                };
+            } else {
+                return {};
+            }
+        },
+        getContext: function() {
+            return {
+                optional_content: this.model.get('optional_content')
+            };
+        },
+    })
     return {
         getModal: function(type, xblockInfo, options) {
             if (type === 'edit') {
@@ -1245,10 +1285,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                     }
                 ];
                 if (xblockInfo.isChapter()) {
-                    tabs[0].editors = [ReleaseDateEditor];
+                    tabs[0].editors = [ReleaseDateEditor, OptionalContentEditor];
                     tabs[1].editors = [StaffLockEditor];
                 } else if (xblockInfo.isSequential()) {
-                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor];
+                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor, OptionalContentEditor];
                     tabs[1].editors = [ContentVisibilityEditor, ShowCorrectnessEditor];
                     if (course.get('self_paced') && course.get('is_custom_relative_dates_active')) {
                         tabs[0].editors.push(SelfPacedDueDateEditor);

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -747,6 +747,7 @@
 
     .edit-discussion,
     .edit-staff-lock,
+    .edit-optional-content,
     .edit-content-visibility,
     .edit-unit-access {
       margin-bottom: $baseline;
@@ -760,19 +761,20 @@
     // UI: staff lock and discussion
     .edit-discussion,
     .edit-staff-lock,
+    .edit-optional-content,
     .edit-settings-timed-examination,
     .edit-unit-access {
       .checkbox-cosmetic .input-checkbox {
         @extend %cont-text-sr;
 
         // CASE: unchecked
-        ~ .tip-warning {
+        ~.tip-warning {
           display: block;
         }
 
         // CASE: checked
         &:checked {
-          ~ .tip-warning {
+          ~.tip-warning {
             display: none;
           }
         }
@@ -832,6 +834,7 @@
 
   .edit-discussion,
   .edit-unit-access,
+  .edit-optional-content,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);
@@ -874,6 +877,7 @@
 
   .edit-discussion,
   .edit-unit-access,
+  .edit-optional-content,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -29,7 +29,7 @@ from django.urls import reverse
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable', 'optional-content-editor']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -225,6 +225,9 @@ if (is_proctored_exam) {
                             <% if (xblockInfo.get('release_date')) { %>
                                 <%- xblockInfo.get('release_date') %>
                             <% } %>
+                            <% if (xblockInfo.get('optional_content')) { %>
+                                - <%- gettext('Optional') %>
+                            <% } %>
                         <% } %>
                     </span>
                 </p>

--- a/cms/templates/js/optional-content-editor.underscore
+++ b/cms/templates/js/optional-content-editor.underscore
@@ -1,0 +1,5 @@
+<h3 class="modal-section-title">
+    <input type="checkbox" id="optional_content" name="optional_content"
+          class="input input-checkbox" />
+    <%- gettext('Mark as optional') %>
+</h3>

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -56,6 +56,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('has_score'),
     SupportedFieldType('has_scheduled_content'),
     SupportedFieldType('weight'),
+    SupportedFieldType('optional_content'),
     SupportedFieldType('show_correctness'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),

--- a/lms/djangoapps/course_api/blocks/transformers/block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/block_completion.py
@@ -43,7 +43,7 @@ class BlockCompletionTransformer(BlockStructureTransformer):
 
     @classmethod
     def collect(cls, block_structure):
-        block_structure.request_xblock_fields('completion_mode')
+        block_structure.request_xblock_fields('completion_mode', 'optional_content')
 
     @staticmethod
     def _is_block_excluded(block_structure, block_key):

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -54,6 +54,7 @@ class CourseBlockSerializer(serializers.Serializer):
                 'resume_block': block.get('resume_block', False),
                 'type': block_type,
                 'has_scheduled_content': block.get('has_scheduled_content'),
+                'optional_content': block.get('optional_content'),
             },
         }
         for child in children:

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -437,3 +437,18 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.update_course_and_overview()
         CourseEnrollment.enroll(UserFactory(), self.course.id)  # grr, some rando took our spot!
         self.assert_can_enroll(False)
+
+    def test_optional_content(self):
+        CourseEnrollment.enroll(self.user, self.course.id)
+        assert not self.course.optional_content
+        response = self.client.get(self.url)
+        for block in response.data['course_blocks']['blocks'].values():
+            assert not block['optional_content']
+
+    def test_optional_content_true(self):
+        self.course.optional_content = True
+        self.update_course_and_overview()
+        CourseEnrollment.enroll(self.user, self.course.id)
+        response = self.client.get(self.url)
+        for block in response.data['course_blocks']['blocks'].values():
+            assert block['optional_content']

--- a/lms/djangoapps/course_home_api/progress/serializers.py
+++ b/lms/djangoapps/course_home_api/progress/serializers.py
@@ -134,6 +134,7 @@ class ProgressTabSerializer(VerifiedModeSerializer):
     access_expiration = serializers.DictField()
     certificate_data = CertificateDataSerializer()
     completion_summary = serializers.DictField()
+    optional_completion_summary = serializers.DictField()
     course_grade = CourseGradeSerializer()
     credit_course_requirements = serializers.DictField()
     end = serializers.DateTimeField()

--- a/lms/djangoapps/course_home_api/progress/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_views.py
@@ -314,3 +314,13 @@ class ProgressTabTestViews(BaseCourseHomeTests):
         assert response.status_code == 200
         assert response.data['course_grade']['percent'] == expected_percent
         assert response.data['course_grade']['is_passing'] == (expected_percent >= 0.5)
+
+    def test_optional_content(self):
+        CourseEnrollment.enroll(self.user, self.course.id)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.data['optional_completion_summary'] == {
+            'complete_count': 0,
+            'incomplete_count': 0,
+            'locked_count': 0,
+        }

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -246,6 +246,7 @@ class ProgressTabView(RetrieveAPIView):
             'access_expiration': access_expiration,
             'certificate_data': get_cert_data(student, course, enrollment_mode, course_grade),
             'completion_summary': get_course_blocks_completion_summary(course_key, student),
+            'optional_completion_summary': get_course_blocks_completion_summary(course_key, student, optional=True),
             'course_grade': course_grade,
             'credit_course_requirements': credit_course_requirements(course_key, student),
             'end': course.end,

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -115,6 +115,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
             'completion',
             'complete',
             'resume_block',
+            'optional_content',
         ],
         allow_start_dates_in_future=allow_start_dates_in_future,
     )

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -238,6 +238,17 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
 
+    optional_content = Boolean(
+        display_name=_('Optional'),
+        help=_(
+            'Set this to true to mark this block as optional.'
+            'Progress in this block won\'t count towards course completion progress'
+            'and will count as optional progress instead.'
+        ),
+        default=False,
+        scope=Scope.settings,
+    )
+
     @property
     def close_date(self):
         """


### PR DESCRIPTION
## Description

This PR implements separating optional progress from normal progress, and also displaying optional chapters and sequences in the outline.

- Impacts: Learners and authors

## Supporting information

- Fontend App Learning PR: https://github.com/openedx/frontend-app-learning/pull/1296

## Testing instructions

1. Run the MFE from this branch: https://github.com/openedx/frontend-app-learning/pull/1296
2. Add  "done" to the advanced module list
3. As a non-staff user go to the progress tab and assert only the typical progress donut appears 
4. As a staff user, on the cms open the settings of any sequence or chapter and mark as optional
5. As a non-staff user, complete some units, and also the optional unit
6. Navigate to the progress tab again and assert a new optional donut appears with your progress

# Screenshots

![optional-outline](https://github.com/openedx/edx-platform/assets/19278837/acc01f1c-cb0a-423c-afea-87b0dd559a6e)

![cms-optional](https://github.com/openedx/edx-platform/assets/19278837/07c7fb7a-8c9b-4b8a-8261-43b2ecf6e94d)


![progress](https://github.com/openedx/edx-platform/assets/19278837/d0428b24-26c4-43ae-ba90-8e20eeaa139f)

![course-settings](https://github.com/openedx/edx-platform/assets/19278837/53e8efcf-eec5-442a-9dbc-6e9b9e2be590)


Private-ref: [BB-8586](https://tasks.opencraft.com/browse/BB-8586)