### PR TITLE
fix: Error message does not show  when  user clicks Dismiss button

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -90,7 +90,7 @@ from django.urls import reverse
 
       <ul class="nav-actions">
         <li class="action action-dismiss">
-          <a href="#" class="button dismiss-button" style="color:black; border-color:black">
+          <a href="#" class="button dismiss-button-announcement" style="color:black; border-color:black">
             <span class="icon fa fa-times-circle" aria-hidden="true"></span>
             <span class="button-copy">${_("Dismiss")}</span>
           </a>


### PR DESCRIPTION
[INF-1087](https://2u-internal.atlassian.net/browse/INF-1087)

**Description**
There was  a bug in Studio. There’s an error message that appears at the bottom of the course Outline. This error comes up when “Dismiss” button was clicked which contains a message where the studio is reminding the users that they’re running a course on an upgraded discussion forum

The error message was displayed due to class name  associated with "dismiss" button was binded with Error message, so changed class name from `dismiss-button` to `dismiss-button-announcement`