### PR TITLE
feat: allow scopes from application access for api users

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
+++ b/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
@@ -3,6 +3,7 @@ Adapter to isolate django-oauth-toolkit dependencies
 """
 
 from oauth2_provider import models
+from openedx.core.djangoapps.oauth_dispatch.models import ApplicationAccess
 
 from openedx.core.djangoapps.oauth_dispatch.models import RestrictedApplication
 
@@ -78,6 +79,16 @@ class DOTAdapter:
             user=user,
             expires=expires,
         )
+
+    def get_scopes_from_application_access(self, client_id):
+        """
+        Get the scopes for the given client_id.
+        """
+        try:
+            application_access = ApplicationAccess.objects.get(application__client_id=client_id)
+            return list(application_access.scopes)
+        except ApplicationAccess.DoesNotExist:
+            return None
 
     def get_token_scope_names(self, token):
         """

--- a/openedx/core/djangoapps/oauth_dispatch/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/views.py
@@ -125,7 +125,13 @@ class AccessTokenView(_DispatchingView):
         """
         opaque_token_dict = json.loads(response.content.decode('utf-8'))
         use_asymmetric_key = request.POST.get('asymmetric_jwt', False)
-        jwt_token_dict = create_jwt_token_dict(opaque_token_dict, self.get_adapter(request),
+        adapter = self.get_adapter(request)
+        client_id = request.POST.get('client_id')
+        access_scopes = adapter.get_scopes_from_application_access(client_id)
+        if access_scopes is not None:
+            access_scopes_string = ' '.join(access_scopes)
+            opaque_token_dict['scope'] = access_scopes_string
+        jwt_token_dict = create_jwt_token_dict(opaque_token_dict, adapter,
                                                use_asymmetric_key=use_asymmetric_key)
         return json.dumps(jwt_token_dict)
 


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

- This change will impact API users with Application Access.
- Defined `scopes` in `ApplicationAccess` were not affecting the jwt info before, but now it should be working and embedding the scope attributes to the access token.

## Supporting information

Ticket: [ENT-8426: Let API users get a `user_id` in their JWTs](https://2u-internal.atlassian.net/browse/ENT-8426)

## Testing instructions

1.  Create an `Application` for a user with a grant type of `client credentials`.
2. Create an `ApplicationAccess` record for that Application and add its scope attribute, which is delimited by a comma.
3. Request access token from the API. It should only embed data in the access token, defined in the scope attributes.
