### PR TITLE
fix: handle error permissions in initialize endpoint in ora api

### DIFF
--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -34,7 +34,12 @@ def get_submissions(request, usage_id):
     if response.status_code != 200:
         raise XBlockInternalError(context={"handler": handler_name})
 
-    return json.loads(response.content)
+    try:
+        return json.loads(response.content)
+    except json.JSONDecodeError as exc:
+        raise XBlockInternalError(
+            context={"handler": handler_name, "details": response.content}
+        ) from exc
 
 
 def get_assessments(request: Request, usage_id: str, handler_name: str, submission_uuid: str):


### PR DESCRIPTION
## Description

This PR handles error permission in the `initialize` endpoint in ORA API, for example, when a student consumes it, similar to how it was done [here](https://github.com/openedx/edx-platform/blob/20570ff4175e96896531438bd3cd47b5ac1bb272/lms/djangoapps/ora_staff_grader/ora_api.py#L68-L73).

## Before
![image](https://github.com/openedx/edx-platform/assets/64033729/cf7702eb-e45b-4d46-8fd9-3f3e07b4ddbd)
![image](https://github.com/openedx/edx-platform/assets/64033729/c54a71c3-9589-43be-9d00-877344274446)

## After
![image](https://github.com/openedx/edx-platform/assets/64033729/290f563d-b1e5-476b-8d3e-778a84140179)
![image](https://github.com/openedx/edx-platform/assets/64033729/46c557e6-fe29-4735-a705-02654a344bad)

## Testing Instructions
1. Consume `api/ora_staff_grader/initialize` endpoint.
2. See the response and logs in LMS.