### PR TITLE
fix: Support running pull_translations with base dependencies

### DIFF
--- a/lms/envs/minimal.yml
+++ b/lms/envs/minimal.yml
@@ -33,3 +33,6 @@ DATA_DIR: "/tmp/edx-platform/data_dir/"
 # For just the CMS
 LMS_ROOT_URL: "http://localhost"
 LMS_INTERNAL_ROOT_URL: "http://localhost"
+
+# So that Swagger config code doesn't complain
+API_ACCESS_MANAGER_EMAIL: "api-access@example.com"

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -485,7 +485,9 @@ edx-event-bus-kafka==5.6.0
 edx-event-bus-redis==0.3.3
     # via -r requirements/edx/kernel.in
 edx-i18n-tools==1.3.0
-    # via ora2
+    # via
+    #   -r requirements/edx/bundled.in
+    #   ora2
 edx-milestones==0.5.0
     # via -r requirements/edx/kernel.in
 edx-name-affirmation==2.3.7

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -26,6 +26,8 @@
 https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 
 pygments                            # Used to support colors in paver command output
+# i18n_tool is needed at build time for pulling translations
+edx-i18n-tools>=0.4.6               # Commands for developers and translators to extract, compile and validate translations
 
 ## Third party integrations
 algoliasearch                       # Algolia’s API client for indexed searching

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -21,7 +21,6 @@ beautifulsoup4            # Library for extracting data from HTML and XML files
 code-annotations          # Perform code annotation checking, such as for PII annotations
 cssselect                 # Used to extract HTML fragments via CSS selectors in 2 test cases and pyquery
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
-edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
 edx-lint                  # pylint extensions for Open edX repositories
 factory-boy               # Library for creating test fixtures, used in many tests
 # Pinning the freezegun version because 0.3.13 is causing failures which have also been reported on the git repo by public.

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -587,7 +587,6 @@ edx-event-bus-redis==0.3.3
 edx-i18n-tools==1.3.0
     # via
     #   -r requirements/edx/base.txt
-    #   -r requirements/edx/testing.in
     #   ora2
 edx-lint==5.3.6
     # via -r requirements/edx/testing.in


### PR DESCRIPTION
Since `make pull_translations` is now performed at build time (in the new Atlas workflow), it will generally only have access to base dependencies. However, it depends on the `i18n_tools` command that was only installed at the testing layer. This moves the dependency from testing to base.

(There is no increase in artifact size, as ora2 already depends on it and is installed at the base later.)

This also includes a change to the minimal-settings file to allow testing this in a development environment.