### PR TITLE
fix: added table tags in allowed tags

### DIFF
--- a/lms/djangoapps/discussion/rest_api/render.py
+++ b/lms/djangoapps/discussion/rest_api/render.py
@@ -9,7 +9,7 @@ import markdown
 
 ALLOWED_TAGS = bleach.ALLOWED_TAGS | {
     'br', 'dd', 'del', 'dl', 'dt', 'h1', 'h2', 'h3', 'h4', 'hr', 'img', 'kbd', 'p', 'pre', 's',
-    'strike', 'sub', 'sup'
+    'strike', 'sub', 'sup', 'table', 'thead', 'th', 'tbody', 'tr', 'td', 'tfoot'
 }
 ALLOWED_PROTOCOLS = {"http", "https", "ftp", "mailto"}
 ALLOWED_ATTRIBUTES = {


### PR DESCRIPTION
[INF-1148](https://2u-internal.atlassian.net/browse/INF-1148)

**Description**
**Issue**
Partner Support received a report that pasting Excel or CSV formatted tables works in preview mode when posting to the discussion forum, but the formatting gets stripped when the post is submitted, and looks disorganized in the live view.

**Solution**
Added table tags [**'table', 'thead', 'th', 'tbody', 'tr', 'td', 'tfoot'**] in ALLOWED_TAGS.