### PR TITLE
feat: add is_after_due to sequence metadata

### DIFF
--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -488,6 +488,7 @@ class SequenceApiTestViews(MasqueradeMixin, BaseCoursewareTests):
         response = self.client.get(f'/api/courseware/sequence/{sequence.location}')
         assert response.status_code == 200
         assert response.data['is_hidden_after_due'] == expected_hidden
+        assert response.data['is_after_due'] == is_past_due
         assert bool(response.data['banner_text']) == expected_banner
 
 

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -403,6 +403,7 @@ class SequenceBlock(
         meta['display_name'] = self.display_name_with_default
         meta['format'] = getattr(self, 'format', '')
         meta['is_hidden_after_due'] = is_hidden_after_due
+        meta['is_after_due'] = self.due is not None and self.due < datetime.now(UTC)
         return meta
 
     @classmethod


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

In order to show an alert if a unit is after due in the MFA,  we need to send if the content is after due in the metadata.

This is in order to support this PR: https://github.com/openedx/frontend-app-learning/pull/1300
