### PR TITLE
fix: newline and alignment bug in survey option mobile view

### DIFF
--- a/lms/static/sass/lms-course.scss
+++ b/lms/static/sass/lms-course.scss
@@ -25,6 +25,12 @@
     }
 }
 
-.percentage {
-    white-space: nowrap;
+@media only screen and (max-width: 767px) {
+    .survey-table .survey-option .visible-mobile-only {
+        width: calc(100% - 21px) !important;
+    }
+
+    .survey-percentage .percentage {
+        width: 54px !important;
+    }
 }


### PR DESCRIPTION
[INF-1230](https://2u-internal.atlassian.net/jira/software/c/projects/INF/boards/742?selectedIssue=INF-1230)

Fixed issues with the Survey xBlock's display inside mobile apps. Updated Elements width according to [Andriod](https://github.com/openedx/openedx-app-android/blob/8c57627d3b4ebeeb1f79d7540647310a91fce0a0/course/src/main/assets/js_injection/survey_css.js#L7) and [IOS](https://github.com/openedx/openedx-app-ios/blob/05d3073a822ed12783140aa2744dca939185fe08/Core/Core/View/Base/Webview/Models/SurveyCssInjection.swift#L21) app elements width.

### Before fix:

| New Line Bug | Percentage Break Bug | Alignment Bug |
| --- | --- | --- |
| ![image](https://github.com/openedx/edx-platform/assets/57627710/43c16d44-2be3-4545-9967-ad4f7d86959a) | ![image](https://github.com/openedx/edx-platform/assets/57627710/b0cde594-0df3-4c63-a8ee-8bd62c278533)| ![image](https://github.com/openedx/edx-platform/assets/57627710/e103be32-dec7-40e5-9008-baae4f239dab) |



### After fix:

|  | New Line Bug | Percentage Break/ Alignment Bug |
| --- | --- | --- |
| App View | <img width="373" alt="Screenshot 2024-02-20 at 5 58 53 PM" src="https://github.com/openedx/edx-platform/assets/57627710/5885e606-34b9-4365-9be7-716d63e8aa80"> | <img width="373" alt="Screenshot 2024-02-20 at 5 57 52 PM" src="https://github.com/openedx/edx-platform/assets/57627710/265d109a-e122-4e23-ac00-c40cce89d943"> | 
| Chrome Mobile Site View (with variable dimensions) | <img width="498" alt="Screenshot 2024-02-20 at 5 56 35 PM" src="https://github.com/openedx/edx-platform/assets/57627710/2990f5f4-41a2-43c9-aeb5-14155483cd2e"> <img width="220" alt="Screenshot 2024-02-20 at 5 56 49 PM" src="https://github.com/openedx/edx-platform/assets/57627710/9196fdbc-e4dd-4201-a727-fb5d5edad4dc"> | <img width="537" alt="Screenshot 2024-02-20 at 5 54 20 PM" src="https://github.com/openedx/edx-platform/assets/57627710/d833ada6-9a18-4a28-920c-ee0ba0cc872b"> <img width="191" alt="Screenshot 2024-02-20 at 5 54 36 PM" src="https://github.com/openedx/edx-platform/assets/57627710/9009c731-540b-445f-87b4-8610ea167340"> | 
