### PR TITLE
feat: ROLES-54 - Permissions Definition - Set 5 - Back-End - Aurora

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1524,7 +1524,13 @@ def group_configurations_list_handler(request, course_key_string):
     course_key = CourseKey.from_string(course_key_string)
     store = modulestore()
     with store.bulk_operations(course_key):
-        course = get_course_and_check_access(course_key, request.user)
+        if (
+            not request.user.has_perm(CourseRolesPermission.MANAGE_COURSE_SETTINGS.perm_name, course_key) and
+            not request.user.has_perm(CourseRolesPermission.VIEW_COURSE_SETTINGS.perm_name, course_key)
+        ):
+            course = get_course_and_check_access(course_key, request.user)
+        else:
+            course = store.get_course(course_key, depth=0)
 
         if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
             group_configuration_url = reverse_course_url('group_configurations_list_handler', course_key)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1106,6 +1106,7 @@ def grading_handler(request, course_key_string, grader_index=None):
                     return JsonResponse(CourseGradingModel.fetch_grader(course_key, grader_index))
             elif request.method in ('POST', 'PUT'):  # post or put, doesn't matter.
                 if (
+                    not has_studio_write_access(request.user, course_key) and
                     not request.user.has_perm(CourseRolesPermission.MANAGE_COURSE_SETTINGS.perm_name, course_key)
                 ):
                     raise PermissionDenied()
@@ -1125,6 +1126,11 @@ def grading_handler(request, course_key_string, grader_index=None):
                         CourseGradingModel.update_grader_from_json(course_key, request.json, request.user)
                     )
             elif request.method == "DELETE" and grader_index is not None:
+                if (
+                    not has_studio_write_access(request.user, course_key) and
+                    not request.user.has_perm(CourseRolesPermission.MANAGE_COURSE_SETTINGS.perm_name, course_key)
+                ):
+                    raise PermissionDenied()
                 CourseGradingModel.delete_grader(course_key, grader_index, request.user)
                 return JsonResponse()
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1105,6 +1105,10 @@ def grading_handler(request, course_key_string, grader_index=None):
                 else:
                     return JsonResponse(CourseGradingModel.fetch_grader(course_key, grader_index))
             elif request.method in ('POST', 'PUT'):  # post or put, doesn't matter.
+                if (
+                    not request.user.has_perm(CourseRolesPermission.MANAGE_COURSE_SETTINGS.perm_name, course_key)
+                ):
+                    raise PermissionDenied()
                 # update credit course requirements if 'minimum_grade_credit'
                 # field value is changed
                 if 'minimum_grade_credit' in request.json:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1622,7 +1622,12 @@ def group_configurations_detail_handler(request, course_key_string, group_config
     course_key = CourseKey.from_string(course_key_string)
     store = modulestore()
     with store.bulk_operations(course_key):
-        course = get_course_and_check_access(course_key, request.user)
+        if (
+            not request.user.has_perm(CourseRolesPermission.MANAGE_COURSE_SETTINGS.perm_name, course_key)
+        ):
+            course = get_course_and_check_access(course_key, request.user)
+        else:
+            course = store.get_course(course_key, depth=0)
         matching_id = [p for p in course.user_partitions
                        if str(p.id) == str(group_configuration_id)]
         if matching_id:

--- a/openedx/core/djangoapps/course_roles/api.py
+++ b/openedx/core/djangoapps/course_roles/api.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db.models import Q
 from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import LibraryLocator
 
 from edx_django_utils.cache import RequestCache
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -26,6 +27,8 @@ def get_all_user_permissions_for_a_course(
         return set()
     if not isinstance(course_key, CourseKey):
         raise TypeError(f'course_key must be a CourseKey, not {type(course_key)}')
+    if isinstance(course_key, LibraryLocator):
+        return set()
     if not isinstance(user, User):
         raise TypeError(f'user must be a User, not {type(user)}')
     cache = RequestCache("course_roles")

--- a/openedx/core/djangoapps/course_roles/permissions.py
+++ b/openedx/core/djangoapps/course_roles/permissions.py
@@ -23,6 +23,9 @@ perms[CourseRolesPermission.MANAGE_COURSE_SETTINGS.perm_name] = (
 perms[CourseRolesPermission.MANAGE_ADVANCED_SETTINGS.perm_name] = (
     HasPermissionRule(CourseRolesPermission.MANAGE_ADVANCED_SETTINGS)
 )
+perms[CourseRolesPermission.VIEW_COURSE_SETTINGS.perm_name] = (
+    HasPermissionRule(CourseRolesPermission.VIEW_COURSE_SETTINGS)
+)
 perms[CourseRolesPermission.VIEW_ALL_CONTENT.perm_name] = HasPermissionRule(CourseRolesPermission.VIEW_ALL_CONTENT)
 perms[CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT.perm_name] = (
     HasPermissionRule(CourseRolesPermission.VIEW_LIVE_PUBLISHED_CONTENT)


### PR DESCRIPTION
This PR adds permissions checks for course level permissions in grading and group configurations. The permissions checks are in places where access was not previously granted/limited by role. These permissions are designed to be assigned to course level roles that will be assigned to a user.

This PR should have no immediate impact on any users. Later PRs will create new course_roles and migrate existing student_courseaccessrole user roles to the new course_roles user roles. Only after that time will these permissions grant or block access to grading and group configurations.

Supporting information
[course_roles tech spec](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3824648277/RBAC+Tech+Spec)

Testing instructions
Testing will be completed on the feature branch once additional services have been updated to add permissions checks. Testing will involve creating a course_roles role and assigning it to a user. This user will then be used to confirm the correct access is granted to the user.

Other information
This is a PR to a [feature branch](https://github.com/openedx/edx-platform/tree/CourseRoles).