### PR TITLE
feat: add list endpoint for course reset enabled enrollments

### DIFF
--- a/lms/djangoapps/support/models.py
+++ b/lms/djangoapps/support/models.py
@@ -28,6 +28,14 @@ class CourseResetCourseOptIn(TimeStampedModel):
     def __str__(self):
         return f'{self.course_id} - {"ACTIVE" if self.active else "INACTIVE"}'
 
+    @staticmethod
+    def all_active():
+        return CourseResetCourseOptIn.objects.filter(active=True)
+
+    @staticmethod
+    def all_active_course_ids():
+        return [course.course_id for course in CourseResetCourseOptIn.all_active()]
+
 
 class CourseResetAudit(TimeStampedModel):
     """
@@ -57,3 +65,15 @@ class CourseResetAudit(TimeStampedModel):
         default=CourseResetStatus.ENQUEUED,
     )
     completed_at = DateTimeField(default=None, null=True, blank=True)
+
+    def status_message(self):
+        """ Return a string message about the status of this audit """
+        if self.status == self.CourseResetStatus.FAILED:
+            return f"Failed on {self.modified}"
+        if self.status == self.CourseResetStatus.ENQUEUED:
+            return f"Enqueued - Created {self.created} by {self.reset_by.username}"
+        if self.status == self.CourseResetStatus.COMPLETE:
+            return f"Completed on {self.completed_at} by {self.reset_by.username}"
+        if self.status == self.CourseResetStatus.IN_PROGRESS:
+            return f"In progress - Started on {self.modified} by {self.reset_by.username}"
+        return self.status

--- a/lms/djangoapps/support/tests/factories.py
+++ b/lms/djangoapps/support/tests/factories.py
@@ -1,0 +1,29 @@
+""" Factories for course reset models """
+import factory
+from factory.django import DjangoModelFactory
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+
+
+from lms.djangoapps.support.models import (
+    CourseResetCourseOptIn,
+    CourseResetAudit
+)
+
+
+class CourseResetCourseOptInFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+    class Meta:
+        model = CourseResetCourseOptIn
+
+    course_id = None
+    active = True
+
+
+class CourseResetAuditFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+    class Meta:
+        model = CourseResetAudit
+
+    course = factory.SubFactory(CourseResetCourseOptInFactory)
+    course_enrollment = factory.SubFactory(CourseEnrollmentFactory)
+    reset_by = factory.SubFactory(UserFactory)
+    status = CourseResetAudit.CourseResetStatus.ENQUEUED
+    completed_at = None

--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -8,6 +8,7 @@ from django.urls import path, re_path
 from .views.certificate import CertificatesSupportView
 from .views.contact_us import ContactUsView
 from .views.course_entitlements import EntitlementSupportView
+from .views.course_reset import CourseResetAPIView
 from .views.enrollments import EnrollmentSupportListView, EnrollmentSupportView
 from .views.feature_based_enrollments import FeatureBasedEnrollmentsSupportView, FeatureBasedEnrollmentSupportAPIView
 from .views.index import index
@@ -23,6 +24,7 @@ from .views.sso_records import (
     SsoView,
 )
 from .views.onboarding_status import OnboardingView
+
 
 COURSE_ENTITLEMENTS_VIEW = EntitlementSupportView.as_view()
 
@@ -83,5 +85,10 @@ urlpatterns = [
     re_path(
         r'onboarding_status/(?P<username_or_email>[\w.@+-]+)?$',
         OnboardingView.as_view(), name='onboarding_status'
+    ),
+    re_path(
+        r'course_reset/(?P<username_or_email>[\w.@+-]+)?$',
+        CourseResetAPIView.as_view(),
+        name='course_reset'
     ),
 ]

--- a/lms/djangoapps/support/views/course_reset.py
+++ b/lms/djangoapps/support/views/course_reset.py
@@ -1,0 +1,100 @@
+""" Views for the course reset feature """
+
+from rest_framework.response import Response
+from django.contrib.auth import get_user_model
+from django.utils.decorators import method_decorator
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+
+
+from common.djangoapps.student.models import CourseEnrollment, get_user_by_username_or_email
+from common.djangoapps.student.helpers import user_has_passing_grade_in_course
+from lms.djangoapps.support.decorators import require_support_permission
+from lms.djangoapps.support.models import (
+    CourseResetCourseOptIn,
+    CourseResetAudit
+)
+
+User = get_user_model()
+
+
+def can_enrollment_be_reset(course_enrollment):
+    """
+    Args: enrollment (CourseEnrollment)
+    Returns: tuple (boolean, string)
+        [0]: whether or not the course can be reset
+        [1]: a status message to present to the learner
+             or None if there is nothing notable about the enrollment and it can be reset
+    """
+    course_overview = course_enrollment.course_overview
+    if not course_overview.has_started():
+        return False, "Course Not Started"
+    if course_overview.has_ended():
+        return False, "Course Ended"
+    if user_has_passing_grade_in_course(course_enrollment):
+        return False, "Learner Has Passing Grade"
+
+    try:
+        audit = course_enrollment.courseresetaudit_set.latest('modified')
+    except CourseResetAudit.DoesNotExist:
+        return True, None
+
+    audit_status_message = audit.status_message()
+    if audit.status == CourseResetAudit.CourseResetStatus.FAILED:
+        return True, audit_status_message
+    return False, audit_status_message
+
+
+class CourseResetAPIView(APIView):
+    """
+    A view to handle requests related to the course reset feature.
+    GET: List applicable courses, their statuses, and if they can be reset
+    POST: Reset a course for the given learner
+    """
+
+    permission_classes = (
+        IsAuthenticated,
+    )
+
+    @method_decorator(require_support_permission)
+    def get(self, request, username_or_email):
+        """
+        List the enrollments for this user that are in courses that have opted into the
+        course reset feature, including information about past resets or resets in progress, and
+        whether or not the reset will be allowed to be done for each returned enrollment
+
+        returns a list of dicts with the format [
+            {
+                'course_id': <course id>
+                'display_name': <course display name>
+                'status': <status of the enrollment wrt/reset, to be displayed to user>
+                'can_reset': (boolean) <can the course be reset for this learner>
+            }
+        ]
+        """
+        try:
+            user = get_user_by_username_or_email(username_or_email)
+        except User.DoesNotExist:
+            return Response([])
+        all_enabled_resettable_course_ids = CourseResetCourseOptIn.all_active_course_ids()
+        course_enrollments = CourseEnrollment.objects.filter(
+            is_active=True,
+            user=user,
+            course__id__in=all_enabled_resettable_course_ids
+        ).select_related("course").prefetch_related("courseresetaudit_set")
+
+        result = []
+        for course_enrollment in course_enrollments:
+            course_overview = course_enrollment.course_overview
+            can_reset, status_message = can_enrollment_be_reset(course_enrollment)
+            result.append({
+                'course_id': str(course_overview.id),
+                'display_name': course_overview.display_name,
+                'can_reset': can_reset,
+                'status': status_message if status_message else "Available"
+            })
+        return Response(result)
+
+    @method_decorator(require_support_permission)
+    def post(self, request, username_or_email):
+        """ Other Ticket """


### PR DESCRIPTION

## Description

Added an endpoint for the support MFE to list a learner's enrollments in courses that have opted into the course reset feature. The endpoint returns course information, the status of the enrollment with regard to course reset (has already been completed, is in progress, course has not yet started, course ended, learner has a passing grade, available) and a boolean for whether or not the learner's course can be reset

## Supporting information

https://2u-internal.atlassian.net/browse/AU-1846
