### PR TITLE
feat: fix pull_translations for production deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ else
 	atlas pull $(ATLAS_OPTIONS) translations/edx-platform/conf/locale:conf/locale
 	i18n_tool generate
 endif
-	paver i18n_compilejs
+	python manage.py lms compilejsi18n
+	python manage.py cms compilejsi18n
 
 
 detect_changed_source_translations: ## check if translation files are up-to-date


### PR DESCRIPTION
This came up during discussion with @timmc-edx [while trying to use `atlas` on 2U production](https://discuss.openedx.org/t/pulling-translations-for-non-tutor-deployments/12365/8?u=omar):

Makefile paver usage replaced with manage.py.
This avoids running the production-unsuitable
`pavelib.prereqs.install_prereqs` step during deployments.


## TODO

 - [x] Test on devstack (@OmarIthawi)

<details><summary>Seems to be working okay on devstack</summary>

```
....
processing language zh-hk
processing language zh-tw
python manage.py cms compilejsi18n
....

processing language en
processing language rtl
....
processing language zh-hk
processing language zh-tw

real	0m31.120s
user	0m0.016s
sys	0m0.028s
```


</details> 


 - [ ] Test on production deployment at 2U (@timmc-edx)


This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
