### PR TITLE
chore: add language and translation flag to courseware api

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/serializers.py
@@ -48,3 +48,5 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     username = serializers.CharField()
     user_timezone = serializers.CharField()
     can_view_certificate = serializers.BooleanField()
+    language = serializers.CharField()
+    whole_course_translation_enabled = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -23,6 +23,7 @@ from lms.djangoapps.courseware.context_processor import user_timezone_locale_pre
 from lms.djangoapps.courseware.courses import check_course_access
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.courseware.tabs import get_course_tab_list
+from lms.djangoapps.ai_translation.waffle import whole_course_translations_enabled_for_course
 
 
 @method_decorator(transaction.non_atomic_requests, name='dispatch')
@@ -133,6 +134,8 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'celebrations': celebrations,
             'user_timezone': user_timezone,
             'can_view_certificate': certificates_viewable_for_course(course),
+            'language': course.language,
+            'whole_course_translation_enabled': whole_course_translations_enabled_for_course(course_key),
         }
         context = self.get_serializer_context()
         context['course'] = course


### PR DESCRIPTION
## Description

- add `whole_course_translations_enabled` flag and `language` fields to send to courseware api

Note: 
- this pr should merge into https://github.com/openedx/edx-platform/pull/34302
- the frontend pr https://github.com/openedx/frontend-app-learning/pull/1305
