### PR TITLE
chore: upgrade edx-enterprise to 4.13.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ click>=8.0,<9.0
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==4.12.6
+edx-enterprise==4.13.0
 
 # Stay on LTS version, remove once this is added to common constraint
 Django<5.0
@@ -115,7 +115,7 @@ openai<=0.28.1
 
 # optimizely-sdk 5.0.0 is breaking following test with segmentation fault
 # common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest::test_secure_key_configuration
-# needs to be fixed in the follow up issue 
+# needs to be fixed in the follow up issue
 # https://github.com/openedx/edx-platform/issues/34103
 optimizely-sdk<5.0
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -115,7 +115,7 @@ openai<=0.28.1
 
 # optimizely-sdk 5.0.0 is breaking following test with segmentation fault
 # common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest::test_secure_key_configuration
-# needs to be fixed in the follow up issue
+# needs to be fixed in the follow up issue 
 # https://github.com/openedx/edx-platform/issues/34103
 optimizely-sdk<5.0
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -476,7 +476,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.12.6
+edx-enterprise==4.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -750,7 +750,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.12.6
+edx-enterprise==4.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -550,7 +550,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.12.6
+edx-enterprise==4.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -576,7 +576,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.12.6
+edx-enterprise==4.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Bumps the version of `edx-enterprise` to latest `v4.13.0` to pull in changes related to `EnterpriseCustomerUserViewSet` serializing `enterprise_features` in its paginated API response.