### PR TITLE
feat: Adds disable_progress_graph attribute to the returned course_me…

### DIFF
--- a/lms/djangoapps/course_home_api/progress/serializers.py
+++ b/lms/djangoapps/course_home_api/progress/serializers.py
@@ -145,3 +145,4 @@ class ProgressTabSerializer(VerifiedModeSerializer):
     username = serializers.CharField()
     user_has_passing_grade = serializers.BooleanField()
     verification_data = VerificationDataSerializer()
+    disable_progress_graph = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -230,6 +230,7 @@ class ProgressTabView(RetrieveAPIView):
 
         block = modulestore().get_course(course_key)
         grading_policy = block.grading_policy
+        disable_progress_graph = block.disable_progress_graph
         verification_status = IDVerificationService.user_status(student)
         verification_link = None
         if verification_status['status'] is None or verification_status['status'] == 'expired':
@@ -259,6 +260,7 @@ class ProgressTabView(RetrieveAPIView):
             'username': username,
             'user_has_passing_grade': user_has_passing_grade,
             'verification_data': verification_data,
+            'disable_progress_graph': disable_progress_graph,
         }
         context = self.get_serializer_context()
         context['staff_access'] = is_staff


### PR DESCRIPTION
## Description
**This is a backport from the master branch: https://github.com/openedx/edx-platform/pull/33308**

Fix an issue when the Progress Graph toggle change in the studio has no effect on the Learning MFE.

Related backport for the Learning MFE: https://github.com/openedx/frontend-app-learning/pull/1313

Please check the original PRs for more details.