### PR TITLE
chore: Remove usage of deprecated `assertDictContainsSubset` unittest method.

### DIFF
--- a/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
+++ b/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
@@ -287,7 +287,10 @@ class CourseRunViewSetTests(ModuleStoreTestCase):
         response = self.client.post(self.list_url, data, format='json')
         self.assertEqual(response.status_code, 400)
         invalid_course_team_user = {'team': ['Course team user does not exist']}
-        self.assertTrue(invalid_course_team_user.items() <= response.data.items())
+        self.assertLessEqual(
+            invalid_course_team_user.items(),
+            response.data.items()
+        )
 
     def test_images_upload(self):
         # http://www.django-rest-framework.org/api-guide/parsers/#fileuploadparser

--- a/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
+++ b/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
@@ -286,7 +286,8 @@ class CourseRunViewSetTests(ModuleStoreTestCase):
         data['team'] = [{'user': 'invalid-username'}]
         response = self.client.post(self.list_url, data, format='json')
         self.assertEqual(response.status_code, 400)
-        self.assertDictContainsSubset({'team': ['Course team user does not exist']}, response.data)
+        invalid_course_team_user = {'team': ['Course team user does not exist']}
+        self.assertTrue(invalid_course_team_user.items() <= response.data.items())
 
     def test_images_upload(self):
         # http://www.django-rest-framework.org/api-guide/parsers/#fileuploadparser

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -862,8 +862,9 @@ class TestDuplicateItem(ItemTest, DuplicateHelper, OpenEdxEventsTestMixin):
                 source_usage_key=self.vert_usage_key,
             ),
         }
-        self.assertTrue(
-            duplicated_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            duplicated_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_ordering(self):

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -853,17 +853,17 @@ class TestDuplicateItem(ItemTest, DuplicateHelper, OpenEdxEventsTestMixin):
         XBLOCK_DUPLICATED.connect(event_receiver)
         usage_key = self._duplicate_and_verify(self.vert_usage_key, self.seq_usage_key)
         event_receiver.assert_called()
-        self.assertDictContainsSubset(
-            {
-                "signal": XBLOCK_DUPLICATED,
-                "sender": None,
-                "xblock_info": DuplicatedXBlockData(
-                    usage_key=usage_key,
-                    block_type=usage_key.block_type,
-                    source_usage_key=self.vert_usage_key,
-                ),
-            },
-            event_receiver.call_args.kwargs,
+        duplicated_event = {
+            "signal": XBLOCK_DUPLICATED,
+            "sender": None,
+            "xblock_info": DuplicatedXBlockData(
+                usage_key=usage_key,
+                block_type=usage_key.block_type,
+                source_usage_key=self.vert_usage_key,
+            ),
+        }
+        self.assertTrue(
+            duplicated_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_ordering(self):

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -293,8 +293,9 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
                 creation_date=enrollment.created,
             ),
         }
-        self.assertTrue(
-            enrollment_created_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            enrollment_created_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_enrollment_changed_event_emitted(self):
@@ -336,8 +337,9 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
                 creation_date=enrollment.created,
             ),
         }
-        self.assertTrue(
-            enrollment_changed_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            enrollment_changed_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_unenrollment_completed_event_emitted(self):
@@ -379,8 +381,9 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
                 creation_date=enrollment.created,
             ),
         }
-        self.assertTrue(
-            unenrollment_completed_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            unenrollment_completed_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
 
@@ -447,8 +450,9 @@ class TestCourseAccessRoleEvents(TestCase, OpenEdxEventsTestMixin):
                 role=role._role_name,  # pylint: disable=protected-access
             ),
         }
-        self.assertTrue(
-            access_role_created_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            access_role_created_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     @ddt.data(

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -271,30 +271,30 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         enrollment = CourseEnrollment.enroll(self.user, self.course.id)
 
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": COURSE_ENROLLMENT_CREATED,
-                "sender": None,
-                "enrollment": CourseEnrollmentData(
-                    user=UserData(
-                        pii=UserPersonalData(
-                            username=self.user.username,
-                            email=self.user.email,
-                            name=self.user.profile.name,
-                        ),
-                        id=self.user.id,
-                        is_active=self.user.is_active,
+        enrollment_created_event = {
+            "signal": COURSE_ENROLLMENT_CREATED,
+            "sender": None,
+            "enrollment": CourseEnrollmentData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        name=self.user.profile.name,
                     ),
-                    course=CourseData(
-                        course_key=self.course.id,
-                        display_name=self.course.display_name,
-                    ),
-                    mode=enrollment.mode,
-                    is_active=enrollment.is_active,
-                    creation_date=enrollment.created,
+                    id=self.user.id,
+                    is_active=self.user.is_active,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                course=CourseData(
+                    course_key=self.course.id,
+                    display_name=self.course.display_name,
+                ),
+                mode=enrollment.mode,
+                is_active=enrollment.is_active,
+                creation_date=enrollment.created,
+            ),
+        }
+        self.assertTrue(
+            enrollment_created_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_enrollment_changed_event_emitted(self):
@@ -314,30 +314,30 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         enrollment.update_enrollment(mode="verified")
 
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": COURSE_ENROLLMENT_CHANGED,
-                "sender": None,
-                "enrollment": CourseEnrollmentData(
-                    user=UserData(
-                        pii=UserPersonalData(
-                            username=self.user.username,
-                            email=self.user.email,
-                            name=self.user.profile.name,
-                        ),
-                        id=self.user.id,
-                        is_active=self.user.is_active,
+        enrollment_changed_event = {
+            "signal": COURSE_ENROLLMENT_CHANGED,
+            "sender": None,
+            "enrollment": CourseEnrollmentData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        name=self.user.profile.name,
                     ),
-                    course=CourseData(
-                        course_key=self.course.id,
-                        display_name=self.course.display_name,
-                    ),
-                    mode=enrollment.mode,
-                    is_active=enrollment.is_active,
-                    creation_date=enrollment.created,
+                    id=self.user.id,
+                    is_active=self.user.is_active,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                course=CourseData(
+                    course_key=self.course.id,
+                    display_name=self.course.display_name,
+                ),
+                mode=enrollment.mode,
+                is_active=enrollment.is_active,
+                creation_date=enrollment.created,
+            ),
+        }
+        self.assertTrue(
+            enrollment_changed_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_unenrollment_completed_event_emitted(self):
@@ -357,30 +357,30 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         CourseEnrollment.unenroll(self.user, self.course.id)
 
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": COURSE_UNENROLLMENT_COMPLETED,
-                "sender": None,
-                "enrollment": CourseEnrollmentData(
-                    user=UserData(
-                        pii=UserPersonalData(
-                            username=self.user.username,
-                            email=self.user.email,
-                            name=self.user.profile.name,
-                        ),
-                        id=self.user.id,
-                        is_active=self.user.is_active,
+        unenrollment_completed_event = {
+            "signal": COURSE_UNENROLLMENT_COMPLETED,
+            "sender": None,
+            "enrollment": CourseEnrollmentData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        name=self.user.profile.name,
                     ),
-                    course=CourseData(
-                        course_key=self.course.id,
-                        display_name=self.course.display_name,
-                    ),
-                    mode=enrollment.mode,
-                    is_active=False,
-                    creation_date=enrollment.created,
+                    id=self.user.id,
+                    is_active=self.user.is_active,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                course=CourseData(
+                    course_key=self.course.id,
+                    display_name=self.course.display_name,
+                ),
+                mode=enrollment.mode,
+                is_active=False,
+                creation_date=enrollment.created,
+            ),
+        }
+        self.assertTrue(
+            unenrollment_completed_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
 
@@ -430,25 +430,25 @@ class TestCourseAccessRoleEvents(TestCase, OpenEdxEventsTestMixin):
         role.add_users(self.user)
 
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": COURSE_ACCESS_ROLE_ADDED,
-                "sender": None,
-                "course_access_role_data": CourseAccessRoleData(
-                    user=UserData(
-                        pii=UserPersonalData(
-                            username=self.user.username,
-                            email=self.user.email,
-                        ),
-                        id=self.user.id,
-                        is_active=self.user.is_active,
+        access_role_created_event = {
+            "signal": COURSE_ACCESS_ROLE_ADDED,
+            "sender": None,
+            "course_access_role_data": CourseAccessRoleData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
                     ),
-                    course_key=self.course_key,
-                    org_key=self.course_key.org,
-                    role=role._role_name,  # pylint: disable=protected-access
+                    id=self.user.id,
+                    is_active=self.user.is_active,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                course_key=self.course_key,
+                org_key=self.course_key.org,
+                role=role._role_name,  # pylint: disable=protected-access
+            ),
+        }
+        self.assertTrue(
+            access_role_created_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     @ddt.data(

--- a/common/djangoapps/terrain/stubs/tests/test_edxnotes.py
+++ b/common/djangoapps/terrain/stubs/tests/test_edxnotes.py
@@ -82,7 +82,7 @@ class StubEdxNotesServiceTest(unittest.TestCase):
         assert 'created' in response_content
         assert 'updated' in response_content
         assert 'annotator_schema_version' in response_content
-        self.assertTrue(dummy_note.items() <= response_content.items())
+        self.assertLessEqual(dummy_note.items(), response_content.items())
 
     def test_note_read(self):
         notes = self._get_notes()

--- a/common/djangoapps/terrain/stubs/tests/test_edxnotes.py
+++ b/common/djangoapps/terrain/stubs/tests/test_edxnotes.py
@@ -82,7 +82,7 @@ class StubEdxNotesServiceTest(unittest.TestCase):
         assert 'created' in response_content
         assert 'updated' in response_content
         assert 'annotator_schema_version' in response_content
-        self.assertDictContainsSubset(dummy_note, response_content)
+        self.assertTrue(dummy_note.items() <= response_content.items())
 
     def test_note_read(self):
         notes = self._get_notes()

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -396,9 +396,13 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             assert msg.startswith('SAML login %s')
             assert action_type == 'request'
             assert idp_name == self.PROVIDER_IDP_SLUG
-            self.assertDictContainsSubset(
-                {"idp": idp_name, "auth_entry": "login", "next": expected_next_url},
-                request_data
+            partial_request_data = {
+                "idp": idp_name,
+                "auth_entry": "login",
+                "next": expected_next_url
+            }
+            self.assertTrue(
+                partial_request_data.items() <= request_data.dict().items()
             )
             assert next_url == expected_next_url
             assert '<samlp:AuthnRequest' in xml
@@ -407,7 +411,12 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             assert msg.startswith('SAML login %s')
             assert action_type == 'response'
             assert idp_name == self.PROVIDER_IDP_SLUG
-            self.assertDictContainsSubset({"RelayState": idp_name}, response_data)
+            partial_response_data = {
+                "RelayState": idp_name
+            }
+            self.assertTrue(
+                partial_response_data.items() <= response_data.dict().items()
+            )
             assert 'SAMLResponse' in response_data
             assert next_url == expected_next_url
             assert '<saml2p:Response' in xml

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -401,8 +401,9 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
                 "auth_entry": "login",
                 "next": expected_next_url
             }
-            self.assertTrue(
-                partial_request_data.items() <= request_data.dict().items()
+            self.assertLessEqual(
+                partial_request_data.items(),
+                request_data.dict().items()
             )
             assert next_url == expected_next_url
             assert '<samlp:AuthnRequest' in xml
@@ -414,8 +415,9 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             partial_response_data = {
                 "RelayState": idp_name
             }
-            self.assertTrue(
-                partial_response_data.items() <= response_data.dict().items()
+            self.assertLessEqual(
+                partial_response_data.items(),
+                response_data.dict().items()
             )
             assert 'SAMLResponse' in response_data
             assert next_url == expected_next_url

--- a/common/djangoapps/third_party_auth/tests/test_identityserver3.py
+++ b/common/djangoapps/third_party_auth/tests/test_identityserver3.py
@@ -104,6 +104,7 @@ class IdentityServer3Test(testutil.TestCase):
             "last_name": "Openid",
             "fullname": "Edx Openid"
         }
-        self.assertTrue(
-            user_details.items() <= provider_config.backend_class().get_user_details(self.response).items()
+        self.assertLessEqual(
+            user_details.items(),
+            provider_config.backend_class().get_user_details(self.response).items()
         )

--- a/common/djangoapps/third_party_auth/tests/test_identityserver3.py
+++ b/common/djangoapps/third_party_auth/tests/test_identityserver3.py
@@ -97,13 +97,13 @@ class IdentityServer3Test(testutil.TestCase):
         Test user details fields are mapped to default keys
         """
         provider_config = self.configure_identityServer3_provider(enabled=True)
-        self.assertDictContainsSubset(
-            {
-                "username": "Edx",
-                "email": "edxopenid@example.com",
-                "first_name": "Edx",
-                "last_name": "Openid",
-                "fullname": "Edx Openid"
-            },
-            provider_config.backend_class().get_user_details(self.response)
+        user_details = {
+            "username": "Edx",
+            "email": "edxopenid@example.com",
+            "first_name": "Edx",
+            "last_name": "Openid",
+            "fullname": "Edx Openid"
+        }
+        self.assertTrue(
+            user_details.items() <= provider_config.backend_class().get_user_details(self.response).items()
         )

--- a/common/djangoapps/third_party_auth/tests/test_lti.py
+++ b/common/djangoapps/third_party_auth/tests/test_lti.py
@@ -59,7 +59,7 @@ class UnitTestLTI(unittest.TestCase, ThirdPartyAuthTestMixin):
             'custom_extra': 'parameter',
             'user_id': '292832126'
         }
-        self.assertTrue(subset_params.items() <= parameters.items())
+        self.assertLessEqual(subset_params.items(), parameters.items())
 
     def test_validate_lti_valid_request_with_get_params(self):
         request = Request(
@@ -77,7 +77,7 @@ class UnitTestLTI(unittest.TestCase, ThirdPartyAuthTestMixin):
             'custom_extra': 'parameter',
             'user_id': '292832126'
         }
-        self.assertTrue(subset_params.items() <= parameters.items())
+        self.assertLessEqual(subset_params.items(), parameters.items())
 
     def test_validate_lti_old_timestamp(self):
         request = Request(

--- a/common/djangoapps/third_party_auth/tests/test_lti.py
+++ b/common/djangoapps/third_party_auth/tests/test_lti.py
@@ -55,10 +55,11 @@ class UnitTestLTI(unittest.TestCase, ThirdPartyAuthTestMixin):
             lti_max_timestamp_age=10
         )
         assert parameters
-        self.assertDictContainsSubset({
+        subset_params = {
             'custom_extra': 'parameter',
             'user_id': '292832126'
-        }, parameters)
+        }
+        self.assertTrue(subset_params.items() <= parameters.items())
 
     def test_validate_lti_valid_request_with_get_params(self):
         request = Request(
@@ -72,10 +73,11 @@ class UnitTestLTI(unittest.TestCase, ThirdPartyAuthTestMixin):
             lti_max_timestamp_age=10
         )
         assert parameters
-        self.assertDictContainsSubset({
+        subset_params = {
             'custom_extra': 'parameter',
             'user_id': '292832126'
-        }, parameters)
+        }
+        self.assertTrue(subset_params.items() <= parameters.items())
 
     def test_validate_lti_old_timestamp(self):
         request = Request(

--- a/lms/djangoapps/certificates/tests/test_events.py
+++ b/lms/djangoapps/certificates/tests/test_events.py
@@ -94,31 +94,31 @@ class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         )
 
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": CERTIFICATE_CREATED,
-                "sender": None,
-                "certificate": CertificateData(
-                    user=UserData(
-                        pii=UserPersonalData(
-                            username=certificate.user.username,
-                            email=certificate.user.email,
-                            name=certificate.user.profile.name,
-                        ),
-                        id=certificate.user.id,
-                        is_active=certificate.user.is_active,
+        certificate_created_event = {
+            "signal": CERTIFICATE_CREATED,
+            "sender": None,
+            "certificate": CertificateData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=certificate.user.username,
+                        email=certificate.user.email,
+                        name=certificate.user.profile.name,
                     ),
-                    course=CourseData(
-                        course_key=certificate.course_id,
-                    ),
-                    mode=certificate.mode,
-                    grade=certificate.grade,
-                    current_status=certificate.status,
-                    download_url=certificate.download_url,
-                    name=certificate.name,
+                    id=certificate.user.id,
+                    is_active=certificate.user.is_active,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                course=CourseData(
+                    course_key=certificate.course_id,
+                ),
+                mode=certificate.mode,
+                grade=certificate.grade,
+                current_status=certificate.status,
+                download_url=certificate.download_url,
+                name=certificate.name,
+            ),
+        }
+        self.assertTrue(
+            certificate_created_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_send_certificate_changed_event(self):
@@ -147,31 +147,31 @@ class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         certificate.save()
 
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": CERTIFICATE_CHANGED,
-                "sender": None,
-                "certificate": CertificateData(
-                    user=UserData(
-                        pii=UserPersonalData(
-                            username=certificate.user.username,
-                            email=certificate.user.email,
-                            name=certificate.user.profile.name,
-                        ),
-                        id=certificate.user.id,
-                        is_active=certificate.user.is_active,
+        certificate_changed_event = {
+            "signal": CERTIFICATE_CHANGED,
+            "sender": None,
+            "certificate": CertificateData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=certificate.user.username,
+                        email=certificate.user.email,
+                        name=certificate.user.profile.name,
                     ),
-                    course=CourseData(
-                        course_key=certificate.course_id,
-                    ),
-                    mode=certificate.mode,
-                    grade=certificate.grade,
-                    current_status=certificate.status,
-                    download_url=certificate.download_url,
-                    name=certificate.name,
+                    id=certificate.user.id,
+                    is_active=certificate.user.is_active,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                course=CourseData(
+                    course_key=certificate.course_id,
+                ),
+                mode=certificate.mode,
+                grade=certificate.grade,
+                current_status=certificate.status,
+                download_url=certificate.download_url,
+                name=certificate.name,
+            ),
+        }
+        self.assertTrue(
+            certificate_changed_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_send_certificate_revoked_event(self):
@@ -199,29 +199,29 @@ class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         certificate.invalidate()
 
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": CERTIFICATE_REVOKED,
-                "sender": None,
-                "certificate": CertificateData(
-                    user=UserData(
-                        pii=UserPersonalData(
-                            username=certificate.user.username,
-                            email=certificate.user.email,
-                            name=certificate.user.profile.name,
-                        ),
-                        id=certificate.user.id,
-                        is_active=certificate.user.is_active,
+        certificate_revoked_event = {
+            "signal": CERTIFICATE_REVOKED,
+            "sender": None,
+            "certificate": CertificateData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=certificate.user.username,
+                        email=certificate.user.email,
+                        name=certificate.user.profile.name,
                     ),
-                    course=CourseData(
-                        course_key=certificate.course_id,
-                    ),
-                    mode=certificate.mode,
-                    grade=certificate.grade,
-                    current_status=certificate.status,
-                    download_url=certificate.download_url,
-                    name=certificate.name,
+                    id=certificate.user.id,
+                    is_active=certificate.user.is_active,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                course=CourseData(
+                    course_key=certificate.course_id,
+                ),
+                mode=certificate.mode,
+                grade=certificate.grade,
+                current_status=certificate.status,
+                download_url=certificate.download_url,
+                name=certificate.name,
+            ),
+        }
+        self.assertTrue(
+            certificate_revoked_event.items() <= event_receiver.call_args.kwargs.items()
         )

--- a/lms/djangoapps/certificates/tests/test_events.py
+++ b/lms/djangoapps/certificates/tests/test_events.py
@@ -117,8 +117,9 @@ class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
                 name=certificate.name,
             ),
         }
-        self.assertTrue(
-            certificate_created_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            certificate_created_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_send_certificate_changed_event(self):
@@ -170,8 +171,9 @@ class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
                 name=certificate.name,
             ),
         }
-        self.assertTrue(
-            certificate_changed_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            certificate_changed_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_send_certificate_revoked_event(self):
@@ -222,6 +224,7 @@ class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
                 name=certificate.name,
             ),
         }
-        self.assertTrue(
-            certificate_revoked_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            certificate_revoked_event.items(),
+            event_receiver.call_args.kwargs.items()
         )

--- a/lms/djangoapps/commerce/tests/test_signals.py
+++ b/lms/djangoapps/commerce/tests/test_signals.py
@@ -314,7 +314,7 @@ class TestRefundSignal(ModuleStoreTestCase):
         #  it to `dict` because newer style dict comparison only works when both
         # objects support mapping (https://docs.python.org/3.8/glossary.html#term-mapping)
         headers_dict = dict(last_request.headers.items())
-        self.assertTrue(expected.items() <= headers_dict.items())
+        self.assertLessEqual(expected.items(), headers_dict.items())
 
         # Verify the content
         expected = {

--- a/lms/djangoapps/commerce/tests/test_signals.py
+++ b/lms/djangoapps/commerce/tests/test_signals.py
@@ -309,7 +309,12 @@ class TestRefundSignal(ModuleStoreTestCase):
                 f'{ZENDESK_USER}/token:{ZENDESK_API_KEY}'.encode('utf8')).decode('utf8')
             )
         }
-        self.assertDictContainsSubset(expected, last_request.headers)
+
+        # `last_request.headers` is of type `http.client.HTTPMessage`. Convert
+        #  it to `dict` because newer style dict comparison only works when both
+        # objects support mapping (https://docs.python.org/3.8/glossary.html#term-mapping)
+        headers_dict = dict(last_request.headers.items())
+        self.assertTrue(expected.items() <= headers_dict.items())
 
         # Verify the content
         expected = {

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1676,10 +1676,8 @@ class TestVideoBlockStudentViewJson(BaseTestVideoXBlock, CacheIsolationTestCase)
         """
         Verifies the result is as expected when returning video data from VAL.
         """
-        self.assertDictContainsSubset(
-            result.pop("encoded_videos")[self.TEST_PROFILE],
-            self.TEST_ENCODED_VIDEO,
-        )
+        test_profile = result.pop("encoded_videos")[self.TEST_PROFILE]
+        self.assertTrue(test_profile.items() <= self.TEST_ENCODED_VIDEO.items())
         self.assertDictEqual(
             result,
             {
@@ -2041,32 +2039,38 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         assert video_data['encoded_videos'][0]['bitrate'] == 333
 
         # Verify that VAL transcript is imported.
-        self.assertDictContainsSubset(
-            self.get_video_transcript_data(
-                edx_video_id,
-                language_code=val_transcript_language_code,
-                provider=val_transcript_provider
-            ),
-            get_video_transcript(video.edx_video_id, val_transcript_language_code)
+        val_transcript_data = self.get_video_transcript_data(
+            edx_video_id,
+            language_code=val_transcript_language_code,
+            provider=val_transcript_provider
         )
+        video_transcript_from_val = get_video_transcript(
+            video.edx_video_id,
+            val_transcript_language_code
+        )
+        self.assertTrue(val_transcript_data.items() <= video_transcript_from_val.items())
 
         # Verify that transcript from sub field is imported.
-        self.assertDictContainsSubset(
-            self.get_video_transcript_data(
-                edx_video_id,
-                language_code=self.block.transcript_language
-            ),
-            get_video_transcript(video.edx_video_id, self.block.transcript_language)
+        sub_transcript_data = self.get_video_transcript_data(
+            edx_video_id,
+            language_code=self.block.transcript_language
         )
+        video_transcript_from_sub = get_video_transcript(
+            video.edx_video_id,
+            self.block.transcript_language
+        )
+        self.assertTrue(sub_transcript_data.items() <= video_transcript_from_sub.items())
 
         # Verify that transcript from transcript field is imported.
-        self.assertDictContainsSubset(
-            self.get_video_transcript_data(
-                edx_video_id,
-                language_code=external_transcript_language_code
-            ),
-            get_video_transcript(video.edx_video_id, external_transcript_language_code)
+        field_transcript_data = self.get_video_transcript_data(
+            edx_video_id,
+            language_code=external_transcript_language_code
         )
+        video_transcript_from_field = get_video_transcript(
+            video.edx_video_id,
+            external_transcript_language_code
+        )
+        self.assertTrue(field_transcript_data.items() <= video_transcript_from_field.items())
 
     def test_import_no_video_id(self):
         """
@@ -2137,14 +2141,16 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         assert video_data['status'] == 'external'
 
         # Verify that VAL transcript is imported.
-        self.assertDictContainsSubset(
-            self.get_video_transcript_data(
-                edx_video_id,
-                language_code=val_transcript_language_code,
-                provider=val_transcript_provider
-            ),
-            get_video_transcript(video.edx_video_id, val_transcript_language_code)
+        val_transcript_data = self.get_video_transcript_data(
+            edx_video_id,
+            language_code=val_transcript_language_code,
+            provider=val_transcript_provider
         )
+        video_transcript_from_val = get_video_transcript(
+            video.edx_video_id,
+            val_transcript_language_code
+        )
+        self.assertTrue(val_transcript_data.items() <= video_transcript_from_val.items())
 
     @ddt.data(
         (
@@ -2279,10 +2285,8 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         assert video_data['status'] == 'external'
 
         # Verify that correct transcripts are imported.
-        self.assertDictContainsSubset(
-            expected_transcript,
-            get_video_transcript(video.edx_video_id, language_code)
-        )
+        video_transcript = get_video_transcript(video.edx_video_id, language_code)
+        self.assertTrue(expected_transcript.items() <= video_transcript.items())
 
     def test_import_val_data_invalid(self):
         create_profile('mobile')

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1677,7 +1677,10 @@ class TestVideoBlockStudentViewJson(BaseTestVideoXBlock, CacheIsolationTestCase)
         Verifies the result is as expected when returning video data from VAL.
         """
         test_profile = result.pop("encoded_videos")[self.TEST_PROFILE]
-        self.assertTrue(test_profile.items() <= self.TEST_ENCODED_VIDEO.items())
+        self.assertLessEqual(
+            test_profile.items(),
+            self.TEST_ENCODED_VIDEO.items()
+        )
         self.assertDictEqual(
             result,
             {
@@ -2048,7 +2051,10 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             video.edx_video_id,
             val_transcript_language_code
         )
-        self.assertTrue(val_transcript_data.items() <= video_transcript_from_val.items())
+        self.assertLessEqual(
+            val_transcript_data.items(),
+            video_transcript_from_val.items()
+        )
 
         # Verify that transcript from sub field is imported.
         sub_transcript_data = self.get_video_transcript_data(
@@ -2059,7 +2065,10 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             video.edx_video_id,
             self.block.transcript_language
         )
-        self.assertTrue(sub_transcript_data.items() <= video_transcript_from_sub.items())
+        self.assertLessEqual(
+            sub_transcript_data.items(),
+            video_transcript_from_sub.items()
+        )
 
         # Verify that transcript from transcript field is imported.
         field_transcript_data = self.get_video_transcript_data(
@@ -2070,7 +2079,10 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             video.edx_video_id,
             external_transcript_language_code
         )
-        self.assertTrue(field_transcript_data.items() <= video_transcript_from_field.items())
+        self.assertLessEqual(
+            field_transcript_data.items(),
+            video_transcript_from_field.items()
+        )
 
     def test_import_no_video_id(self):
         """
@@ -2150,7 +2162,10 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             video.edx_video_id,
             val_transcript_language_code
         )
-        self.assertTrue(val_transcript_data.items() <= video_transcript_from_val.items())
+        self.assertLessEqual(
+            val_transcript_data.items(),
+            video_transcript_from_val.items()
+        )
 
     @ddt.data(
         (
@@ -2286,7 +2301,10 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
 
         # Verify that correct transcripts are imported.
         video_transcript = get_video_transcript(video.edx_video_id, language_code)
-        self.assertTrue(expected_transcript.items() <= video_transcript.items())
+        self.assertLessEqual(
+            expected_transcript.items(),
+            video_transcript.items()
+        )
 
     def test_import_val_data_invalid(self):
         create_profile('mobile')

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1816,12 +1816,12 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
 
         event_receiver.assert_called_once()
 
-        self.assertDictContainsSubset(
-            {
-                "signal": FORUM_THREAD_RESPONSE_CREATED,
-                "sender": None,
-            },
-            event_receiver.call_args.kwargs
+        thread_response_created_event = {
+            "signal": FORUM_THREAD_RESPONSE_CREATED,
+            "sender": None,
+        }
+        self.assertTrue(
+            thread_response_created_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
         self.assertIn(
@@ -1858,12 +1858,12 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
         assert event['user_course_roles'] == ['Wizard']
         assert event['options']['followed'] is False
 
-        self.assertDictContainsSubset(
-            {
-                "signal": FORUM_RESPONSE_COMMENT_CREATED,
-                "sender": None,
-            },
-            event_receiver.call_args.kwargs
+        response_comment_created_event = {
+            "signal": FORUM_RESPONSE_COMMENT_CREATED,
+            "sender": None,
+        }
+        self.assertTrue(
+            response_comment_created_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
         self.assertIn(
@@ -1919,12 +1919,12 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
         assert name == event_name
         assert event['team_id'] == team.team_id
 
-        self.assertDictContainsSubset(
-            {
-                "signal": forum_event,
-                "sender": None,
-            },
-            event_receiver.call_args.kwargs
+        forum_event_created = {
+            "signal": forum_event,
+            "sender": None,
+        }
+        self.assertTrue(
+            forum_event_created.items() <= event_receiver.call_args.kwargs.items()
         )
 
         self.assertIn(

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1820,8 +1820,9 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
             "signal": FORUM_THREAD_RESPONSE_CREATED,
             "sender": None,
         }
-        self.assertTrue(
-            thread_response_created_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            thread_response_created_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
         self.assertIn(
@@ -1862,8 +1863,9 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
             "signal": FORUM_RESPONSE_COMMENT_CREATED,
             "sender": None,
         }
-        self.assertTrue(
-            response_comment_created_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            response_comment_created_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
         self.assertIn(
@@ -1923,8 +1925,9 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
             "signal": forum_event,
             "sender": None,
         }
-        self.assertTrue(
-            forum_event_created.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            forum_event_created.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
         self.assertIn(

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -42,7 +42,7 @@ class ExperimentDataViewSetTests(APITestCase, ModuleStoreTestCase):  # lint-amne
         ExperimentData.objects.get(user=user)
 
         data['user'] = user.username
-        self.assertTrue(data.items() <= response.data.items())
+        self.assertLessEqual(data.items(), response.data.items())
 
     def test_list_permissions(self):
         """ Users should only be able to list their own data. """

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -42,7 +42,7 @@ class ExperimentDataViewSetTests(APITestCase, ModuleStoreTestCase):  # lint-amne
         ExperimentData.objects.get(user=user)
 
         data['user'] = user.username
-        self.assertDictContainsSubset(data, response.data)
+        self.assertTrue(data.items() <= response.data.items())
 
     def test_list_permissions(self):
         """ Users should only be able to list their own data. """

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -77,22 +77,22 @@ class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixi
         PERSISTENT_GRADE_SUMMARY_CHANGED.connect(event_receiver)
         grade = PersistentCourseGrade.update_or_create(**self.params)
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": PERSISTENT_GRADE_SUMMARY_CHANGED,
-                "sender": None,
-                "grade": PersistentCourseGradeData(
-                    user_id=self.params["user_id"],
-                    course=CourseData(
-                        course_key=self.params["course_id"],
-                    ),
-                    course_edited_timestamp=self.params["course_edited_timestamp"],
-                    course_version=self.params["course_version"],
-                    grading_policy_hash='',
-                    percent_grade=self.params["percent_grade"],
-                    letter_grade=self.params["letter_grade"],
-                    passed_timestamp=grade.passed_timestamp
-                )
-            },
-            event_receiver.call_args.kwargs
+        persistent_grade_changed_event = {
+            "signal": PERSISTENT_GRADE_SUMMARY_CHANGED,
+            "sender": None,
+            "grade": PersistentCourseGradeData(
+                user_id=self.params["user_id"],
+                course=CourseData(
+                    course_key=self.params["course_id"],
+                ),
+                course_edited_timestamp=self.params["course_edited_timestamp"],
+                course_version=self.params["course_version"],
+                grading_policy_hash='',
+                percent_grade=self.params["percent_grade"],
+                letter_grade=self.params["letter_grade"],
+                passed_timestamp=grade.passed_timestamp
+            )
+        }
+        self.assertTrue(
+            persistent_grade_changed_event.items() <= event_receiver.call_args.kwargs.items()
         )

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -93,6 +93,7 @@ class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixi
                 passed_timestamp=grade.passed_timestamp
             )
         }
-        self.assertTrue(
-            persistent_grade_changed_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            persistent_grade_changed_event.items(),
+            event_receiver.call_args.kwargs.items()
         )

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -583,7 +583,8 @@ class TestGradeReportConditionalContent(TestReportMixin, TestConditionalContent,
         Arguments:
             task_result (dict): Return value of `CourseGradeReport.generate`.
         """
-        self.assertDictContainsSubset({'attempted': 2, 'succeeded': 2, 'failed': 0}, task_result)
+        expected_successful_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_successful_result.items() <= task_result.items())
 
     def verify_grades_in_csv(self, students_grades, ignore_other_columns=False):
         """

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -584,7 +584,10 @@ class TestGradeReportConditionalContent(TestReportMixin, TestConditionalContent,
             task_result (dict): Return value of `CourseGradeReport.generate`.
         """
         expected_successful_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_successful_result.items() <= task_result.items())
+        self.assertLessEqual(
+            expected_successful_result.items(),
+            task_result.items()
+        )
 
     def verify_grades_in_csv(self, students_grades, ignore_other_columns=False):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -97,7 +97,7 @@ class InstructorGradeReportTestCase(TestReportMixin, InstructorTaskCourseTestCas
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = CourseGradeReport.generate(None, None, course_id, {}, 'graded')
             expected_result = {'attempted': num_rows, 'succeeded': num_rows, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
             report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
             report_csv_filename = report_store.links_for(course_id)[0][0]
             report_path = report_store.path_to(course_id, report_csv_filename)
@@ -136,7 +136,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
                 result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
         num_students = len(emails)
         expected_result = {'attempted': num_students, 'succeeded': num_students, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
     @ddt.data(True, False)
     @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
@@ -152,7 +152,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
         expected_result = {'attempted': 1, 'succeeded': 0, 'failed': 1}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
         report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
         assert any(('grade_report_err' in item[0]) for item in report_store.links_for(self.course.id))
@@ -337,7 +337,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
         ]
         result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
         expected_result = {'attempted': 1, 'succeeded': 1, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
     def test_certificate_eligibility(self):
         """
@@ -432,7 +432,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
 
         expected_students = 2
         expected_result = {'attempted': expected_students, 'succeeded': expected_students, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
 
 @ddt.ddt
@@ -545,7 +545,10 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'block_key': 'block-v1:edx+1.23x+test_course+type@problem+block@Problem1',
             'title': 'Problem1',
         }
-        self.assertTrue(expected_student_data.items() <= student_data[0].items())
+        self.assertLessEqual(
+            expected_student_data.items(),
+            student_data[0].items()
+        )
         assert 'state' in student_data[0]
         assert student_data_keys_list == ['username', 'title', 'location', 'block_key', 'state']
         mock_list_problem_responses.assert_called_with(self.course.id, ANY, ANY)
@@ -578,7 +581,10 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'some': 'state1',
             'more': 'state1!',
         }
-        self.assertTrue(expected_student_data_0.items() <= student_data[0].items())
+        self.assertLessEqual(
+            expected_student_data_0.items(),
+            student_data[0].items()
+        )
         expected_student_data_1 = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
@@ -587,7 +593,10 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'some': 'state2',
             'more': 'state2!',
         }
-        self.assertTrue(expected_student_data_1.items() <= student_data[1].items())
+        self.assertLessEqual(
+            expected_student_data_1.items(),
+            student_data[1].items()
+        )
         assert student_data[0]['state'] == student_data[1]['state']
         assert student_data_keys_list == ['username', 'title', 'location', 'more', 'some', 'block_key', 'state']
 
@@ -621,7 +630,10 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'some': 'state1',
             'more': 'state1!',
         }
-        self.assertTrue(expected_student_data_0.items() <= student_data[0].items())
+        self.assertLessEqual(
+            expected_student_data_0.items(),
+            student_data[0].items()
+        )
         expected_student_data_1 = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
@@ -630,7 +642,10 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'some': 'state2',
             'more': 'state2!',
         }
-        self.assertTrue(expected_student_data_1.items() <= student_data[1].items())
+        self.assertLessEqual(
+            expected_student_data_1.items(),
+            student_data[1].items()
+        )
         assert student_data[0]['state'] == student_data[1]['state']
         assert student_data_keys_list == ['username', 'title', 'location', 'some', 'more', 'block_key', 'state']
 
@@ -657,7 +672,10 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'Correct Answer': 'Option 1',
             'Question': 'The correct answer is Option 1',
         }
-        self.assertTrue(expected_student_data.items() <= student_data[0].items())
+        self.assertLessEqual(
+            expected_student_data.items(),
+            student_data[0].items()
+        )
         assert 'state' in student_data[0]
         assert student_data_keys_list == ['username', 'title', 'location', 'Answer', 'Answer ID', 'Correct Answer',
                                           'Question', 'block_key', 'state']
@@ -687,7 +705,10 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
                 'Correct Answer': 'Option 1',
                 'Question': 'The correct answer is Option 1',
             }
-            self.assertTrue(expected_student_data.items() <= student_data[idx - 1].items())
+            self.assertLessEqual(
+                expected_student_data.items(),
+                student_data[idx - 1].items()
+            )
             assert 'state' in student_data[(idx - 1)]
 
     @ddt.data(
@@ -827,7 +848,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
         expected_result = {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv([
             dict(list(zip(
                 self.csv_header_row,
@@ -854,7 +875,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
         expected_result = {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         problem_name = 'Homework 1: Subsection - Problem1'
         header_row = self.csv_header_row + [problem_name + ' (Earned)', problem_name + ' (Possible)']
         self.verify_rows_in_csv([
@@ -901,7 +922,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
             expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
 
     @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
     @ddt.data(True, False)
@@ -922,7 +943,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
         expected_result = {'action_name': 'graded', 'attempted': 3, 'succeeded': 3, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         problem_name = 'Homework 1: Subsection - Problem1'
         header_row = self.csv_header_row + [problem_name + ' (Earned)', problem_name + ' (Possible)']
         self.verify_rows_in_csv([
@@ -997,7 +1018,7 @@ class TestProblemReportSplitTestContent(TestReportMixin, TestConditionalContent,
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
             expected_result = {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
 
         problem_names = ['Homework 1: Subsection - problem_a_url', 'Homework 1: Subsection - problem_b_url']
         header_row = ['Student ID', 'Email', 'Username', 'Enrollment Status', 'Grade']
@@ -1152,7 +1173,7 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
             expected_result = {'action_name': 'graded', 'attempted': 5, 'succeeded': 5, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
         problem_names = ['Homework 1: Subsection - Problem0', 'Homework 1: Subsection - Problem1']
         header_row = ['Student ID', 'Email', 'Username', 'Enrollment Status', 'Grade']
         for problem in problem_names:
@@ -1236,7 +1257,7 @@ class TestCourseSurveyReport(TestReportMixin, InstructorTaskCourseTestCase):
                 task_input, 'generating course survey report'
             )
         expected_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
     def test_generate_course_survey_report(self):
         """
@@ -1271,7 +1292,7 @@ class TestCourseSurveyReport(TestReportMixin, InstructorTaskCourseTestCase):
         expected_data = [header_row, student1_row, student2_row]
 
         expected_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self._verify_csv_file_report(report_store, expected_data)
 
     def _verify_csv_file_report(self, report_store, expected_data):
@@ -1307,7 +1328,7 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
 
         assert len(links) == 1
         expected_result = {'attempted': 1, 'succeeded': 1, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
     def test_custom_directory(self):
         self.create_student('student', 'student@example.com')
@@ -1363,7 +1384,7 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
         # This assertion simply confirms that the generation completed with no errors
         num_students = len(students)
         expected_result = {'attempted': num_students, 'succeeded': num_students, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
 
 class TestTeamStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
@@ -1394,7 +1415,7 @@ class TestTeamStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
             mock_current_task.return_value = current_task
             result = upload_students_csv(None, None, self.course.id, task_input, 'calculated')
             expected_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
             report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
             report_csv_filename = report_store.links_for(self.course.id)[0][0]
             report_path = report_store.path_to(self.course.id, report_csv_filename)
@@ -1460,7 +1481,7 @@ class TestListMayEnroll(TestReportMixin, InstructorTaskCourseTestCase):
 
         assert len(links) == 1
         expected_result = {'attempted': 1, 'succeeded': 1, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
     def test_unicode_email_addresses(self):
         """
@@ -1477,7 +1498,7 @@ class TestListMayEnroll(TestReportMixin, InstructorTaskCourseTestCase):
         # This assertion simply confirms that the generation completed with no errors
         num_enrollments = len(enrollments)
         expected_result = {'attempted': num_enrollments, 'succeeded': num_enrollments, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
 
 
 class MockDefaultStorage:
@@ -1525,7 +1546,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2,,Cohort 2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1541,7 +1562,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             ',student_2@example.com,Cohort 2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1557,7 +1578,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2,student_2@example.com,Cohort 2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1579,7 +1600,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'Invalid,student_2@example.com,Cohort 2'      # invalid username, valid email
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1594,7 +1615,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'Invalid,,Cohort 1\n'
         )
         expected_result = {'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 1}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', 'Invalid', '', '']))),
@@ -1609,7 +1630,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2,,Cohort 2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 1, 'failed': 1}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Does Not Exist', 'False', '0', '', '', '']))),
@@ -1624,7 +1645,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             ',example_email@example.com,Cohort 1'
         )
         expected_result = {'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', '', '', 'example_email@example.com']))),
@@ -1638,7 +1659,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             ',student_1@,Cohort 1\n'
         )
         expected_result = {'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 1}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', '', 'student_1@', '']))),
@@ -1664,7 +1685,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 0, 'failed': 2}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['', 'False', '0', '', '', '']))),
@@ -1677,7 +1698,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'username,email,cohort'
         )
         expected_result = {'total': 0, 'attempted': 0, 'succeeded': 0, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv([])
 
     def test_carriage_return(self):
@@ -1690,7 +1711,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2,,Cohort 2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1709,7 +1730,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2,,Cohort 2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1730,7 +1751,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2,,Cohort 1'
         )
         expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1751,7 +1772,7 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_2,,Cohort 2'
         )
         expected_result = {'total': 2, 'attempted': 2, 'skipped': 2, 'failed': 0}
-        self.assertTrue(expected_result.items() <= result.items())
+        self.assertLessEqual(expected_result.items(), result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', '', '', '']))),
@@ -1837,7 +1858,7 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
             expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
             self.verify_rows_in_csv(
                 [
                     {
@@ -1894,7 +1915,7 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
             expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
             self.verify_rows_in_csv(
                 [
                     {
@@ -1936,7 +1957,7 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             self.submit_student_answer(student_verified.username, 'Problem4', ['Option 1'])
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
             expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
-            self.assertTrue(expected_result.items() <= result.items())
+            self.assertLessEqual(expected_result.items(), result.items())
 
     @ddt.data(True, False)
     def test_fast_generation(self, create_non_zero_grade):
@@ -2539,7 +2560,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
                     None, None, self.course.id, task_input, 'certificates generated'
                 )
 
-        self.assertTrue(expected_results.items() <= result.items())
+        self.assertLessEqual(expected_results.items(), result.items())
 
     def _create_students(self, number_of_students):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -96,7 +96,8 @@ class InstructorGradeReportTestCase(TestReportMixin, InstructorTaskCourseTestCas
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = CourseGradeReport.generate(None, None, course_id, {}, 'graded')
-            self.assertDictContainsSubset({'attempted': num_rows, 'succeeded': num_rows, 'failed': 0}, result)
+            expected_result = {'attempted': num_rows, 'succeeded': num_rows, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
             report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
             report_csv_filename = report_store.links_for(course_id)[0][0]
             report_path = report_store.path_to(course_id, report_csv_filename)
@@ -134,7 +135,8 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
         num_students = len(emails)
-        self.assertDictContainsSubset({'attempted': num_students, 'succeeded': num_students, 'failed': 0}, result)
+        expected_result = {'attempted': num_students, 'succeeded': num_students, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
     @ddt.data(True, False)
     @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
@@ -149,7 +151,8 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
         ]
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
-        self.assertDictContainsSubset({'attempted': 1, 'succeeded': 0, 'failed': 1}, result)
+        expected_result = {'attempted': 1, 'succeeded': 0, 'failed': 1}
+        self.assertTrue(expected_result.items() <= result.items())
 
         report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
         assert any(('grade_report_err' in item[0]) for item in report_store.links_for(self.course.id))
@@ -333,7 +336,8 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
             )
         ]
         result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
-        self.assertDictContainsSubset({'attempted': 1, 'succeeded': 1, 'failed': 0}, result)
+        expected_result = {'attempted': 1, 'succeeded': 1, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
     def test_certificate_eligibility(self):
         """
@@ -427,9 +431,8 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
         self._verify_cell_data_for_user('inactive-student', self.course.id, 'Enrollment Status', NOT_ENROLLED_IN_COURSE)
 
         expected_students = 2
-        self.assertDictContainsSubset(
-            {'attempted': expected_students, 'succeeded': expected_students, 'failed': 0}, result
-        )
+        expected_result = {'attempted': expected_students, 'succeeded': expected_students, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
 
 @ddt.ddt
@@ -536,12 +539,13 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
                 usage_key_str_list=[str(problem.location)],
             )
         assert len(student_data) == 1
-        self.assertDictContainsSubset({
+        expected_student_data = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'block-v1:edx+1.23x+test_course+type@problem+block@Problem1',
             'title': 'Problem1',
-        }, student_data[0])
+        }
+        self.assertTrue(expected_student_data.items() <= student_data[0].items())
         assert 'state' in student_data[0]
         assert student_data_keys_list == ['username', 'title', 'location', 'block_key', 'state']
         mock_list_problem_responses.assert_called_with(self.course.id, ANY, ANY)
@@ -566,22 +570,24 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             usage_key_str_list=[str(self.course.location)],
         )
         assert len(student_data) == 2
-        self.assertDictContainsSubset({
+        expected_student_data_0 = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'block-v1:edx+1.23x+test_course+type@problem+block@Problem1',
             'title': 'Problem1',
             'some': 'state1',
             'more': 'state1!',
-        }, student_data[0])
-        self.assertDictContainsSubset({
+        }
+        self.assertTrue(expected_student_data_0.items() <= student_data[0].items())
+        expected_student_data_1 = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'block-v1:edx+1.23x+test_course+type@problem+block@Problem1',
             'title': 'Problem1',
             'some': 'state2',
             'more': 'state2!',
-        }, student_data[1])
+        }
+        self.assertTrue(expected_student_data_1.items() <= student_data[1].items())
         assert student_data[0]['state'] == student_data[1]['state']
         assert student_data_keys_list == ['username', 'title', 'location', 'more', 'some', 'block_key', 'state']
 
@@ -607,22 +613,24 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             usage_key_str_list=[str(self.course.location)],
         )
         assert len(student_data) == 2
-        self.assertDictContainsSubset({
+        expected_student_data_0 = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'block-v1:edx+1.23x+test_course+type@problem+block@Problem1',
             'title': 'Problem1',
             'some': 'state1',
             'more': 'state1!',
-        }, student_data[0])
-        self.assertDictContainsSubset({
+        }
+        self.assertTrue(expected_student_data_0.items() <= student_data[0].items())
+        expected_student_data_1 = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'block-v1:edx+1.23x+test_course+type@problem+block@Problem1',
             'title': 'Problem1',
             'some': 'state2',
             'more': 'state2!',
-        }, student_data[1])
+        }
+        self.assertTrue(expected_student_data_1.items() <= student_data[1].items())
         assert student_data[0]['state'] == student_data[1]['state']
         assert student_data_keys_list == ['username', 'title', 'location', 'some', 'more', 'block_key', 'state']
 
@@ -639,7 +647,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             usage_key_str_list=[str(self.course.location)],
         )
         assert len(student_data) == 1
-        self.assertDictContainsSubset({
+        expected_student_data = {
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'block-v1:edx+1.23x+test_course+type@problem+block@Problem1',
@@ -648,7 +656,8 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'Answer': 'Option 1',
             'Correct Answer': 'Option 1',
             'Question': 'The correct answer is Option 1',
-        }, student_data[0])
+        }
+        self.assertTrue(expected_student_data.items() <= student_data[0].items())
         assert 'state' in student_data[0]
         assert student_data_keys_list == ['username', 'title', 'location', 'Answer', 'Answer ID', 'Correct Answer',
                                           'Question', 'block_key', 'state']
@@ -668,7 +677,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         )
         assert len(student_data) == 2
         for idx in range(1, 3):
-            self.assertDictContainsSubset({
+            expected_student_data = {
                 'username': 'student',
                 'location': f'test_course > Section > Subsection > Problem{idx}',
                 'block_key': f'block-v1:edx+1.23x+test_course+type@problem+block@Problem{idx}',
@@ -677,7 +686,8 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
                 'Answer': 'Option 1',
                 'Correct Answer': 'Option 1',
                 'Question': 'The correct answer is Option 1',
-            }, student_data[idx - 1])
+            }
+            self.assertTrue(expected_student_data.items() <= student_data[idx - 1].items())
             assert 'state' in student_data[(idx - 1)]
 
     @ddt.data(
@@ -816,7 +826,8 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         """
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
-        self.assertDictContainsSubset({'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv([
             dict(list(zip(
                 self.csv_header_row,
@@ -842,7 +853,8 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         self.submit_student_answer(self.student_1.username, 'Problem1', ['Option 1'])
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
-        self.assertDictContainsSubset({'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         problem_name = 'Homework 1: Subsection - Problem1'
         header_row = self.csv_header_row + [problem_name + ' (Earned)', problem_name + ' (Possible)']
         self.verify_rows_in_csv([
@@ -888,9 +900,8 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             self.submit_student_answer(student_verified.username, 'Problem1', ['Option 1'])
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
-            self.assertDictContainsSubset(
-                {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}, result
-            )
+            expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
 
     @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
     @ddt.data(True, False)
@@ -910,7 +921,8 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         self.submit_student_answer(self.student_1.username, 'Problem1', ['Option 1'])
         with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
             result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
-        self.assertDictContainsSubset({'action_name': 'graded', 'attempted': 3, 'succeeded': 3, 'failed': 0}, result)
+        expected_result = {'action_name': 'graded', 'attempted': 3, 'succeeded': 3, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         problem_name = 'Homework 1: Subsection - Problem1'
         header_row = self.csv_header_row + [problem_name + ' (Earned)', problem_name + ' (Possible)']
         self.verify_rows_in_csv([
@@ -984,9 +996,8 @@ class TestProblemReportSplitTestContent(TestReportMixin, TestConditionalContent,
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
-            self.assertDictContainsSubset(
-                {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}, result
-            )
+            expected_result = {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
 
         problem_names = ['Homework 1: Subsection - problem_a_url', 'Homework 1: Subsection - problem_b_url']
         header_row = ['Student ID', 'Email', 'Username', 'Enrollment Status', 'Grade']
@@ -1140,9 +1151,8 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with patch(USE_ON_DISK_GRADE_REPORT, return_value=use_tempfile):
                 result = ProblemGradeReport.generate(None, None, self.course.id, {}, 'graded')
-            self.assertDictContainsSubset(
-                {'action_name': 'graded', 'attempted': 5, 'succeeded': 5, 'failed': 0}, result
-            )
+            expected_result = {'action_name': 'graded', 'attempted': 5, 'succeeded': 5, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
         problem_names = ['Homework 1: Subsection - Problem0', 'Homework 1: Subsection - Problem1']
         header_row = ['Student ID', 'Email', 'Username', 'Enrollment Status', 'Grade']
         for problem in problem_names:
@@ -1225,7 +1235,8 @@ class TestCourseSurveyReport(TestReportMixin, InstructorTaskCourseTestCase):
                 None, None, self.course.id,
                 task_input, 'generating course survey report'
             )
-        self.assertDictContainsSubset({'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
     def test_generate_course_survey_report(self):
         """
@@ -1259,7 +1270,8 @@ class TestCourseSurveyReport(TestReportMixin, InstructorTaskCourseTestCase):
         ])
         expected_data = [header_row, student1_row, student2_row]
 
-        self.assertDictContainsSubset({'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self._verify_csv_file_report(report_store, expected_data)
 
     def _verify_csv_file_report(self, report_store, expected_data):
@@ -1294,7 +1306,8 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
         links = report_store.links_for(self.course.id)
 
         assert len(links) == 1
-        self.assertDictContainsSubset({'attempted': 1, 'succeeded': 1, 'failed': 0}, result)
+        expected_result = {'attempted': 1, 'succeeded': 1, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
     def test_custom_directory(self):
         self.create_student('student', 'student@example.com')
@@ -1349,7 +1362,8 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
             result = upload_students_csv(None, None, self.course.id, task_input, 'calculated')
         # This assertion simply confirms that the generation completed with no errors
         num_students = len(students)
-        self.assertDictContainsSubset({'attempted': num_students, 'succeeded': num_students, 'failed': 0}, result)
+        expected_result = {'attempted': num_students, 'succeeded': num_students, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
 
 class TestTeamStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
@@ -1379,7 +1393,8 @@ class TestTeamStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task') as mock_current_task:
             mock_current_task.return_value = current_task
             result = upload_students_csv(None, None, self.course.id, task_input, 'calculated')
-            self.assertDictContainsSubset({'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+            expected_result = {'attempted': 2, 'succeeded': 2, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
             report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
             report_csv_filename = report_store.links_for(self.course.id)[0][0]
             report_path = report_store.path_to(self.course.id, report_csv_filename)
@@ -1444,7 +1459,8 @@ class TestListMayEnroll(TestReportMixin, InstructorTaskCourseTestCase):
         links = report_store.links_for(self.course.id)
 
         assert len(links) == 1
-        self.assertDictContainsSubset({'attempted': 1, 'succeeded': 1, 'failed': 0}, result)
+        expected_result = {'attempted': 1, 'succeeded': 1, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
     def test_unicode_email_addresses(self):
         """
@@ -1460,7 +1476,8 @@ class TestListMayEnroll(TestReportMixin, InstructorTaskCourseTestCase):
             result = upload_may_enroll_csv(None, None, self.course.id, task_input, 'calculated')
         # This assertion simply confirms that the generation completed with no errors
         num_enrollments = len(enrollments)
-        self.assertDictContainsSubset({'attempted': num_enrollments, 'succeeded': num_enrollments, 'failed': 0}, result)
+        expected_result = {'attempted': num_enrollments, 'succeeded': num_enrollments, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
 
 
 class MockDefaultStorage:
@@ -1507,7 +1524,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,,Cohort 1\n'
             'student_2,,Cohort 2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1522,7 +1540,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             ',student_1@example.com,Cohort 1\n'
             ',student_2@example.com,Cohort 2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1537,7 +1556,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,student_1@example.com,Cohort 1\n'
             'student_2,student_2@example.com,Cohort 2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1558,7 +1578,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,student_1@example.com,Cohort 1\n'  # valid username and email
             'Invalid,student_2@example.com,Cohort 2'      # invalid username, valid email
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1572,7 +1593,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'username,email,cohort\n'
             'Invalid,,Cohort 1\n'
         )
-        self.assertDictContainsSubset({'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 1}, result)
+        expected_result = {'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 1}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', 'Invalid', '', '']))),
@@ -1586,7 +1608,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             ',student_1@example.com,Does Not Exist\n'
             'student_2,,Cohort 2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 1, 'failed': 1}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 1, 'failed': 1}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Does Not Exist', 'False', '0', '', '', '']))),
@@ -1600,8 +1623,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'username,email,cohort\n'
             ',example_email@example.com,Cohort 1'
         )
-        self.assertDictContainsSubset({'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 0},
-                                      result)
+        expected_result = {'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', '', '', 'example_email@example.com']))),
@@ -1614,7 +1637,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'username,email,cohort\n'
             ',student_1@,Cohort 1\n'
         )
-        self.assertDictContainsSubset({'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 1}, result)
+        expected_result = {'total': 1, 'attempted': 1, 'succeeded': 0, 'failed': 1}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', '', 'student_1@', '']))),
@@ -1639,7 +1663,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,\n'
             'student_2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 0, 'failed': 2}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 0, 'failed': 2}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['', 'False', '0', '', '', '']))),
@@ -1651,7 +1676,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
         result = self._cohort_students_and_upload(
             'username,email,cohort'
         )
-        self.assertDictContainsSubset({'total': 0, 'attempted': 0, 'succeeded': 0, 'failed': 0}, result)
+        expected_result = {'total': 0, 'attempted': 0, 'succeeded': 0, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv([])
 
     def test_carriage_return(self):
@@ -1663,7 +1689,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,,Cohort 1\r'
             'student_2,,Cohort 2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1681,7 +1708,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,,Cohort 1\r\n'
             'student_2,,Cohort 2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1701,7 +1729,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,,Cohort 2\n'
             'student_2,,Cohort 1'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'succeeded': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '1', '', '', '']))),
@@ -1721,7 +1750,8 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
             'student_1\xec,,Cohort 1\n'
             'student_2,,Cohort 2'
         )
-        self.assertDictContainsSubset({'total': 2, 'attempted': 2, 'skipped': 2, 'failed': 0}, result)
+        expected_result = {'total': 2, 'attempted': 2, 'skipped': 2, 'failed': 0}
+        self.assertTrue(expected_result.items() <= result.items())
         self.verify_rows_in_csv(
             [
                 dict(list(zip(self.csv_header_row, ['Cohort 1', 'True', '0', '', '', '']))),
@@ -1806,10 +1836,8 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
 
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
-            self.assertDictContainsSubset(
-                {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0},
-                result,
-            )
+            expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
             self.verify_rows_in_csv(
                 [
                     {
@@ -1865,10 +1893,8 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
 
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
-            self.assertDictContainsSubset(
-                {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0},
-                result,
-            )
+            expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
             self.verify_rows_in_csv(
                 [
                     {
@@ -1909,9 +1935,8 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             self.submit_student_answer(student_1.username, 'Problem4', ['Option 1'])
             self.submit_student_answer(student_verified.username, 'Problem4', ['Option 1'])
             result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
-            self.assertDictContainsSubset(
-                {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}, result
-            )
+            expected_result = {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}
+            self.assertTrue(expected_result.items() <= result.items())
 
     @ddt.data(True, False)
     def test_fast_generation(self, create_non_zero_grade):
@@ -2514,10 +2539,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
                     None, None, self.course.id, task_input, 'certificates generated'
                 )
 
-        self.assertDictContainsSubset(
-            expected_results,
-            result
-        )
+        self.assertTrue(expected_results.items() <= result.items())
 
     def _create_students(self, number_of_students):
         """

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -343,14 +343,15 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))
         assert len(data) == 1
-        self.assertDictContainsSubset({
+        expected_data = {
             'mode': CourseMode.AUDIT,
             'manual_enrollment': {},
             'user': self.student.username,
             'course_id': str(self.course.id),
             'is_active': True,
             'verified_upgrade_deadline': None,
-        }, data[0])
+        }
+        self.assertTrue(expected_data.items(), data[0].items())
         assert {CourseMode.VERIFIED, CourseMode.AUDIT, CourseMode.HONOR, CourseMode.NO_ID_PROFESSIONAL_MODE,
                 CourseMode.PROFESSIONAL, CourseMode.CREDIT_MODE} == {mode['slug'] for mode in data[0]['course_modes']}
         assert 'enterprise_course_enrollments' not in data[0]
@@ -453,10 +454,12 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
         )
         response = self.client.get(self.url)
         assert response.status_code == 200
-        self.assertDictContainsSubset({
+        data = json.loads(response.content.decode('utf-8'))[0]['manual_enrollment']
+        expected_data = {
             'enrolled_by': self.user.email,
             'reason': 'Financial Assistance',
-        }, json.loads(response.content.decode('utf-8'))[0]['manual_enrollment'])
+        }
+        self.assertTrue(expected_data.items() <= data.items())
 
     @disable_signal(signals, 'post_save')
     @ddt.data('username', 'email')

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -351,7 +351,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             'is_active': True,
             'verified_upgrade_deadline': None,
         }
-        self.assertTrue(expected_data.items(), data[0].items())
+        self.assertLessEqual(expected_data.items(), data[0].items())
         assert {CourseMode.VERIFIED, CourseMode.AUDIT, CourseMode.HONOR, CourseMode.NO_ID_PROFESSIONAL_MODE,
                 CourseMode.PROFESSIONAL, CourseMode.CREDIT_MODE} == {mode['slug'] for mode in data[0]['course_modes']}
         assert 'enterprise_course_enrollments' not in data[0]
@@ -459,7 +459,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             'enrolled_by': self.user.email,
             'reason': 'Financial Assistance',
         }
-        self.assertTrue(expected_data.items() <= data.items())
+        self.assertLessEqual(expected_data.items(), data.items())
 
     @disable_signal(signals, 'post_save')
     @ddt.data('username', 'email')

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -685,8 +685,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 update_blocks=False,
             ),
         }
-        self.assertTrue(
-            library_created_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_created_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_content_library_update_event(self):
@@ -713,8 +714,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 update_blocks=False,
             ),
         }
-        self.assertTrue(
-            library_updated_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_updated_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_content_library_delete_event(self):
@@ -741,8 +743,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 update_blocks=False,
             ),
         }
-        self.assertTrue(
-            library_deleted_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_deleted_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_library_block_create_event(self):
@@ -775,8 +778,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 usage_key=usage_key
             ),
         }
-        self.assertTrue(
-            library_block_created_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_block_created_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_library_block_olx_update_event(self):
@@ -828,8 +832,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 usage_key=usage_key
             ),
         }
-        self.assertTrue(
-            library_block_updated_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_block_updated_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     @skip("We still need to re-implement static asset handling.")
@@ -868,8 +873,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 usage_key=usage_key
             ),
         }
-        self.assertTrue(
-            library_block_updated_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_block_updated_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     @skip("We still need to re-implement static asset handling.")
@@ -910,8 +916,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 usage_key=usage_key
             ),
         }
-        self.assertTrue(
-            library_block_updated_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_block_updated_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
     def test_library_block_delete_event(self):
@@ -949,8 +956,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 usage_key=usage_key
             ),
         }
-        self.assertTrue(
-            library_block_deleted_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            library_block_deleted_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
 

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -677,16 +677,16 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         library_key = LibraryLocatorV2.from_string(lib['id'])
 
         event_receiver.assert_called_once()
-        self.assertDictContainsSubset(
-            {
-                "signal": CONTENT_LIBRARY_CREATED,
-                "sender": None,
-                "content_library": ContentLibraryData(
-                    library_key=library_key,
-                    update_blocks=False,
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_created_event = {
+            "signal": CONTENT_LIBRARY_CREATED,
+            "sender": None,
+            "content_library": ContentLibraryData(
+                library_key=library_key,
+                update_blocks=False,
+            ),
+        }
+        self.assertTrue(
+            library_created_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_content_library_update_event(self):
@@ -705,16 +705,16 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         library_key = LibraryLocatorV2.from_string(lib2['id'])
 
         event_receiver.assert_called_once()
-        self.assertDictContainsSubset(
-            {
-                "signal": CONTENT_LIBRARY_UPDATED,
-                "sender": None,
-                "content_library": ContentLibraryData(
-                    library_key=library_key,
-                    update_blocks=False,
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_updated_event = {
+            "signal": CONTENT_LIBRARY_UPDATED,
+            "sender": None,
+            "content_library": ContentLibraryData(
+                library_key=library_key,
+                update_blocks=False,
+            ),
+        }
+        self.assertTrue(
+            library_updated_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_content_library_delete_event(self):
@@ -733,16 +733,16 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         self._delete_library(lib["id"])
 
         event_receiver.assert_called_once()
-        self.assertDictContainsSubset(
-            {
-                "signal": CONTENT_LIBRARY_DELETED,
-                "sender": None,
-                "content_library": ContentLibraryData(
-                    library_key=library_key,
-                    update_blocks=False,
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_deleted_event = {
+            "signal": CONTENT_LIBRARY_DELETED,
+            "sender": None,
+            "content_library": ContentLibraryData(
+                library_key=library_key,
+                update_blocks=False,
+            ),
+        }
+        self.assertTrue(
+            library_deleted_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_library_block_create_event(self):
@@ -767,21 +767,21 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         )
 
         event_receiver.assert_called_once()
-        self.assertDictContainsSubset(
-            {
-                "signal": LIBRARY_BLOCK_CREATED,
-                "sender": None,
-                "library_block": LibraryBlockData(
-                    library_key=library_key,
-                    usage_key=usage_key
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_block_created_event = {
+            "signal": LIBRARY_BLOCK_CREATED,
+            "sender": None,
+            "library_block": LibraryBlockData(
+                library_key=library_key,
+                usage_key=usage_key
+            ),
+        }
+        self.assertTrue(
+            library_block_created_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_library_block_olx_update_event(self):
         """
-        Check that LIBRARY_BLOCK_CREATED event is sent when the OLX source is updated.
+        Check that LIBRARY_BLOCK_UPDATED event is sent when the OLX source is updated.
         """
         event_receiver = Mock()
         LIBRARY_BLOCK_UPDATED.connect(event_receiver)
@@ -820,22 +820,22 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         self._set_library_block_olx(block_id, new_olx)
 
         event_receiver.assert_called_once()
-        self.assertDictContainsSubset(
-            {
-                "signal": LIBRARY_BLOCK_UPDATED,
-                "sender": None,
-                "library_block": LibraryBlockData(
-                    library_key=library_key,
-                    usage_key=usage_key
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_block_updated_event = {
+            "signal": LIBRARY_BLOCK_UPDATED,
+            "sender": None,
+            "library_block": LibraryBlockData(
+                library_key=library_key,
+                usage_key=usage_key
+            ),
+        }
+        self.assertTrue(
+            library_block_updated_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     @skip("We still need to re-implement static asset handling.")
     def test_library_block_add_asset_update_event(self):
         """
-        Check that LIBRARY_BLOCK_CREATED event is sent when a static asset is
+        Check that LIBRARY_BLOCK_UPDATED event is sent when a static asset is
         uploaded associated with the XBlock.
         """
         event_receiver = Mock()
@@ -860,22 +860,22 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         )
 
         event_receiver.assert_called_once()
-        self.assertDictContainsSubset(
-            {
-                "signal": LIBRARY_BLOCK_UPDATED,
-                "sender": None,
-                "library_block": LibraryBlockData(
-                    library_key=library_key,
-                    usage_key=usage_key
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_block_updated_event = {
+            "signal": LIBRARY_BLOCK_UPDATED,
+            "sender": None,
+            "library_block": LibraryBlockData(
+                library_key=library_key,
+                usage_key=usage_key
+            ),
+        }
+        self.assertTrue(
+            library_block_updated_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     @skip("We still need to re-implement static asset handling.")
     def test_library_block_del_asset_update_event(self):
         """
-        Check that LIBRARY_BLOCK_CREATED event is sent when a static asset is
+        Check that LIBRARY_BLOCK_UPDATED event is sent when a static asset is
         removed from XBlock.
         """
         event_receiver = Mock()
@@ -902,16 +902,16 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         )
 
         event_receiver.assert_called()
-        self.assertDictContainsSubset(
-            {
-                "signal": LIBRARY_BLOCK_UPDATED,
-                "sender": None,
-                "library_block": LibraryBlockData(
-                    library_key=library_key,
-                    usage_key=usage_key
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_block_updated_event = {
+            "signal": LIBRARY_BLOCK_UPDATED,
+            "sender": None,
+            "library_block": LibraryBlockData(
+                library_key=library_key,
+                usage_key=usage_key
+            ),
+        }
+        self.assertTrue(
+            library_block_updated_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
     def test_library_block_delete_event(self):
@@ -941,16 +941,16 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         self._delete_library_block(block_id)
 
         event_receiver.assert_called()
-        self.assertDictContainsSubset(
-            {
-                "signal": LIBRARY_BLOCK_DELETED,
-                "sender": None,
-                "library_block": LibraryBlockData(
-                    library_key=library_key,
-                    usage_key=usage_key
-                ),
-            },
-            event_receiver.call_args.kwargs
+        library_block_deleted_event = {
+            "signal": LIBRARY_BLOCK_DELETED,
+            "sender": None,
+            "library_block": LibraryBlockData(
+                library_key=library_key,
+                usage_key=usage_key
+            ),
+        }
+        self.assertTrue(
+            library_block_deleted_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
 

--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -134,7 +134,7 @@ class ContentLibraryRuntimeTestMixin(ContentLibraryContentTestMixin):
             "content_type": "CAPA",
             "problem_types": ["multiplechoiceresponse"],
         }
-        self.assertTrue(index_dictionary_subset.items() <= index_dictionary.items())
+        self.assertLessEqual(index_dictionary_subset.items(), index_dictionary.items())
         assert metadata_view_result.data['student_view_data'] is None
         # Capa doesn't provide student_view_data
 
@@ -423,7 +423,7 @@ class ContentLibraryXBlockUserStateTestMixin(ContentLibraryContentTestMixin):
             "total_possible": 1,
             "attempts_used": 1,
         }
-        self.assertTrue(submit_subset_data.items() <= submit_data.items())
+        self.assertLessEqual(submit_subset_data.items(), submit_data.items())
 
         # Now test that the score is also persisted in StudentModule:
         # If we add a REST API to get an individual block's score, that should be checked instead of StudentModule.
@@ -440,7 +440,7 @@ class ContentLibraryXBlockUserStateTestMixin(ContentLibraryContentTestMixin):
             "total_possible": 1,
             "attempts_used": 2,
         }
-        self.assertTrue(submit_subset_data.items(), submit_data.items())
+        self.assertLessEqual(submit_subset_data.items(), submit_data.items())
         # Now test that the score is also updated in StudentModule:
         # If we add a REST API to get an individual block's score, that should be checked instead of StudentModule.
         sm = get_score(self.student_a, block_id)

--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -129,10 +129,12 @@ class ContentLibraryRuntimeTestMixin(ContentLibraryContentTestMixin):
         assert metadata_view_result.data['display_name'] == 'New Multi Choice Question'
         assert 'children' not in metadata_view_result.data
         assert 'editable_children' not in metadata_view_result.data
-        self.assertDictContainsSubset({
+        index_dictionary = metadata_view_result.data["index_dictionary"]
+        index_dictionary_subset = {
             "content_type": "CAPA",
             "problem_types": ["multiplechoiceresponse"],
-        }, metadata_view_result.data["index_dictionary"])
+        }
+        self.assertTrue(index_dictionary_subset.items() <= index_dictionary.items())
         assert metadata_view_result.data['student_view_data'] is None
         # Capa doesn't provide student_view_data
 

--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -418,11 +418,12 @@ class ContentLibraryXBlockUserStateTestMixin(ContentLibraryContentTestMixin):
         submit_result = client.post(problem_check_url, data={problem_key: "choice_3"})
         assert submit_result.status_code == 200
         submit_data = json.loads(submit_result.content.decode('utf-8'))
-        self.assertDictContainsSubset({
+        submit_subset_data = {
             "current_score": 0,
             "total_possible": 1,
             "attempts_used": 1,
-        }, submit_data)
+        }
+        self.assertTrue(submit_subset_data.items() <= submit_data.items())
 
         # Now test that the score is also persisted in StudentModule:
         # If we add a REST API to get an individual block's score, that should be checked instead of StudentModule.
@@ -434,11 +435,12 @@ class ContentLibraryXBlockUserStateTestMixin(ContentLibraryContentTestMixin):
         submit_result = client.post(problem_check_url, data={problem_key: "choice_1"})
         assert submit_result.status_code == 200
         submit_data = json.loads(submit_result.content.decode('utf-8'))
-        self.assertDictContainsSubset({
+        submit_subset_data = {
             "current_score": 1,
             "total_possible": 1,
             "attempts_used": 2,
-        }, submit_data)
+        }
+        self.assertTrue(submit_subset_data.items(), submit_data.items())
         # Now test that the score is also updated in StudentModule:
         # If we add a REST API to get an individual block's score, that should be checked instead of StudentModule.
         sm = get_score(self.student_a, block_id)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -88,7 +88,7 @@ class AccessTokenMixin:
 
         expected['grant_type'] = grant_type or ''
 
-        self.assertTrue(expected.items() <= payload.items())
+        self.assertLessEqual(expected.items(), payload.items())
 
         if expires_in:
             assert payload['exp'] == payload['iat'] + expires_in

--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -88,7 +88,7 @@ class AccessTokenMixin:
 
         expected['grant_type'] = grant_type or ''
 
-        self.assertDictContainsSubset(expected, payload)
+        self.assertTrue(expected.items() <= payload.items())
 
         if expires_in:
             assert payload['exp'] == payload['iat'] + expires_in

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_api.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_api.py
@@ -48,7 +48,7 @@ class TestOAuthDispatchAPI(TestCase):
             'expires_in': EXPECTED_DEFAULT_EXPIRES_IN,
             'scope': '',
         }
-        self.assertTrue(expected_token_subset.items() <= token.items())
+        self.assertLessEqual(expected_token_subset.items(), token.items())
         self._assert_stored_token(token['access_token'], self.user, self.client)
 
     def test_create_token_another_user(self):
@@ -65,4 +65,4 @@ class TestOAuthDispatchAPI(TestCase):
             'scope': 'profile',
             'expires_in': expires_in
         }
-        self.assertTrue(expected_token_subset.items() <= token.items())
+        self.assertLessEqual(expected_token_subset.items(), token.items())

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_api.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_api.py
@@ -43,14 +43,12 @@ class TestOAuthDispatchAPI(TestCase):
         token = api.create_dot_access_token(HttpRequest(), self.user, self.client)
         assert token['access_token']
         assert token['refresh_token']
-        self.assertDictContainsSubset(
-            {
-                'token_type': 'Bearer',
-                'expires_in': EXPECTED_DEFAULT_EXPIRES_IN,
-                'scope': '',
-            },
-            token,
-        )
+        expected_token_subset = {
+            'token_type': 'Bearer',
+            'expires_in': EXPECTED_DEFAULT_EXPIRES_IN,
+            'scope': '',
+        }
+        self.assertTrue(expected_token_subset.items() <= token.items())
         self._assert_stored_token(token['access_token'], self.user, self.client)
 
     def test_create_token_another_user(self):
@@ -63,5 +61,8 @@ class TestOAuthDispatchAPI(TestCase):
         token = api.create_dot_access_token(
             HttpRequest(), self.user, self.client, expires_in=expires_in, scopes=['profile'],
         )
-        self.assertDictContainsSubset({'scope': 'profile'}, token)
-        self.assertDictContainsSubset({'expires_in': expires_in}, token)
+        expected_token_subset = {
+            'scope': 'profile',
+            'expires_in': expires_in
+        }
+        self.assertTrue(expected_token_subset.items() <= token.items())

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
@@ -144,7 +144,7 @@ class TestCreateJWTs(AccessTokenMixin, TestCase):
         token_payload = self.assert_valid_jwt_access_token(
             jwt_token, self.user, self.default_scopes, aud=aud, secret=secret,
         )
-        self.assertTrue(additional_claims.items() <= token_payload.items())
+        self.assertLessEqual(additional_claims.items(), token_payload.items())
         assert user_email_verified == token_payload['email_verified']
         assert token_payload['roles'] == mock_create_roles.return_value
 

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
@@ -144,7 +144,7 @@ class TestCreateJWTs(AccessTokenMixin, TestCase):
         token_payload = self.assert_valid_jwt_access_token(
             jwt_token, self.user, self.default_scopes, aud=aud, secret=secret,
         )
-        self.assertDictContainsSubset(additional_claims, token_payload)
+        self.assertTrue(additional_claims.items() <= token_payload.items())
         assert user_email_verified == token_payload['email_verified']
         assert token_payload['roles'] == mock_create_roles.return_value
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -182,13 +182,11 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
         for key in ['created_status', 'username', 'email', 'password', 'user_id', 'anonymous_id']:
             assert key in response_data
         user = User.objects.get(username=response_data['username'])
-        self.assertDictContainsSubset(
-            {
-                'created_status': 'Logged in',
-                'anonymous_id': anonymous_id_for_user(user, None),
-            },
-            response_data
-        )
+        expected_response_subset = {
+            'created_status': 'Logged in',
+            'anonymous_id': anonymous_id_for_user(user, None),
+        }
+        self.assertTrue(expected_response_subset.items() <= response_data.items())
 
     @ddt.data(*COURSE_IDS_DDT)
     @ddt.unpack

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -186,7 +186,7 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
             'created_status': 'Logged in',
             'anonymous_id': anonymous_id_for_user(user, None),
         }
-        self.assertTrue(expected_response_subset.items() <= response_data.items())
+        self.assertLessEqual(expected_response_subset.items(), response_data.items())
 
     @ddt.data(*COURSE_IDS_DDT)
     @ddt.unpack

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -83,21 +83,21 @@ class RegistrationEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
 
         user = User.objects.get(username=self.user_info.get("username"))
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": STUDENT_REGISTRATION_COMPLETED,
-                "sender": None,
-                "user": UserData(
-                    pii=UserPersonalData(
-                        username=user.username,
-                        email=user.email,
-                        name=user.profile.name,
-                    ),
-                    id=user.id,
-                    is_active=user.is_active,
+        registration_completed_event = {
+            "signal": STUDENT_REGISTRATION_COMPLETED,
+            "sender": None,
+            "user": UserData(
+                pii=UserPersonalData(
+                    username=user.username,
+                    email=user.email,
+                    name=user.profile.name,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                id=user.id,
+                is_active=user.is_active,
+            ),
+        }
+        self.assertTrue(
+            registration_completed_event.items() <= event_receiver.call_args.kwargs.items()
         )
 
 
@@ -165,19 +165,19 @@ class LoginSessionEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
 
         user = User.objects.get(username=self.user.username)
         self.assertTrue(self.receiver_called)
-        self.assertDictContainsSubset(
-            {
-                "signal": SESSION_LOGIN_COMPLETED,
-                "sender": None,
-                "user": UserData(
-                    pii=UserPersonalData(
-                        username=user.username,
-                        email=user.email,
-                        name=user.profile.name,
-                    ),
-                    id=user.id,
-                    is_active=user.is_active,
+        login_completed_event = {
+            "signal": SESSION_LOGIN_COMPLETED,
+            "sender": None,
+            "user": UserData(
+                pii=UserPersonalData(
+                    username=user.username,
+                    email=user.email,
+                    name=user.profile.name,
                 ),
-            },
-            event_receiver.call_args.kwargs
+                id=user.id,
+                is_active=user.is_active,
+            ),
+        }
+        self.assertTrue(
+            login_completed_event.items() <= event_receiver.call_args.kwargs.items()
         )

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -96,8 +96,9 @@ class RegistrationEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
                 is_active=user.is_active,
             ),
         }
-        self.assertTrue(
-            registration_completed_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            registration_completed_event.items(),
+            event_receiver.call_args.kwargs.items()
         )
 
 
@@ -178,6 +179,7 @@ class LoginSessionEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
                 is_active=user.is_active,
             ),
         }
-        self.assertTrue(
-            login_completed_event.items() <= event_receiver.call_args.kwargs.items()
+        self.assertLessEqual(
+            login_completed_event.items(),
+            event_receiver.call_args.kwargs.items()
         )

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -531,7 +531,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
         expected = {
             'target': '/',
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
     def test_logout_logging_no_pii(self):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -531,7 +531,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
         expected = {
             'target': '/',
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
     def test_logout_logging_no_pii(self):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -76,14 +76,14 @@ class LogoutTests(TestCase):
         expected = {
             'target': urllib.parse.unquote(redirect_url),
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     def test_no_redirect_supplied(self):
         response = self.client.get(reverse('logout'), HTTP_HOST='testserver')
         expected = {
             'target': '/',
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     @ddt.data(
         ('https://www.amazon.org', 'edx.org'),
@@ -100,7 +100,7 @@ class LogoutTests(TestCase):
         expected = {
             'target': '/',
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     def test_client_logout(self):
         """ Verify the context includes a list of the logout URIs of the authenticated OpenID Connect clients.
@@ -113,7 +113,7 @@ class LogoutTests(TestCase):
             'logout_uris': [],
             'target': '/',
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     @mock.patch(
         'django.conf.settings.IDA_LOGOUT_URI_LIST',
@@ -138,7 +138,7 @@ class LogoutTests(TestCase):
             'logout_uris': expected_logout_uris,
             'target': '/',
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     @mock.patch(
         'django.conf.settings.IDA_LOGOUT_URI_LIST',
@@ -161,7 +161,7 @@ class LogoutTests(TestCase):
             'logout_uris': expected_logout_uris,
             'target': '/',
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     def test_filter_referring_service(self):
         """ Verify that, if the user is directed to the logout page from a service, that service's logout URL
@@ -174,7 +174,7 @@ class LogoutTests(TestCase):
             'target': '/',
             'show_tpa_logout_link': False,
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
     def test_learner_portal_logout_having_idp_logout_url(self):
         """
@@ -194,7 +194,7 @@ class LogoutTests(TestCase):
                 'tpa_logout_url': idp_logout_url,
                 'show_tpa_logout_link': True,
             }
-            self.assertTrue(expected.items() <= response.context_data.items())
+            self.assertLessEqual(expected.items(), response.context_data.items())
 
     @mock.patch('django.conf.settings.TPA_AUTOMATIC_LOGOUT_ENABLED', True)
     def test_automatic_tpa_logout_url_redirect(self):
@@ -239,4 +239,4 @@ class LogoutTests(TestCase):
         expected = {
             'target': bleach.clean(urllib.parse.unquote(redirect_url)),
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -76,14 +76,14 @@ class LogoutTests(TestCase):
         expected = {
             'target': urllib.parse.unquote(redirect_url),
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     def test_no_redirect_supplied(self):
         response = self.client.get(reverse('logout'), HTTP_HOST='testserver')
         expected = {
             'target': '/',
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     @ddt.data(
         ('https://www.amazon.org', 'edx.org'),
@@ -100,7 +100,7 @@ class LogoutTests(TestCase):
         expected = {
             'target': '/',
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     def test_client_logout(self):
         """ Verify the context includes a list of the logout URIs of the authenticated OpenID Connect clients.
@@ -113,7 +113,7 @@ class LogoutTests(TestCase):
             'logout_uris': [],
             'target': '/',
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     @mock.patch(
         'django.conf.settings.IDA_LOGOUT_URI_LIST',
@@ -138,7 +138,7 @@ class LogoutTests(TestCase):
             'logout_uris': expected_logout_uris,
             'target': '/',
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     @mock.patch(
         'django.conf.settings.IDA_LOGOUT_URI_LIST',
@@ -161,7 +161,7 @@ class LogoutTests(TestCase):
             'logout_uris': expected_logout_uris,
             'target': '/',
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     def test_filter_referring_service(self):
         """ Verify that, if the user is directed to the logout page from a service, that service's logout URL
@@ -174,7 +174,7 @@ class LogoutTests(TestCase):
             'target': '/',
             'show_tpa_logout_link': False,
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
     def test_learner_portal_logout_having_idp_logout_url(self):
         """
@@ -194,7 +194,7 @@ class LogoutTests(TestCase):
                 'tpa_logout_url': idp_logout_url,
                 'show_tpa_logout_link': True,
             }
-            self.assertDictContainsSubset(expected, response.context_data)
+            self.assertTrue(expected.items() <= response.context_data.items())
 
     @mock.patch('django.conf.settings.TPA_AUTOMATIC_LOGOUT_ENABLED', True)
     def test_automatic_tpa_logout_url_redirect(self):
@@ -239,4 +239,4 @@ class LogoutTests(TestCase):
         expected = {
             'target': bleach.clean(urllib.parse.unquote(redirect_url)),
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())

--- a/openedx/features/enterprise_support/tests/test_logout.py
+++ b/openedx/features/enterprise_support/tests/test_logout.py
@@ -60,7 +60,7 @@ class EnterpriseLogoutTests(EnterpriseServiceMockMixin, CacheIsolationTestCase, 
         expected = {
             'enterprise_target': enterprise_target,
         }
-        self.assertDictContainsSubset(expected, response.context_data)
+        self.assertTrue(expected.items() <= response.context_data.items())
 
         if enterprise_target:
             self.assertContains(response, 'We are signing you in.')

--- a/openedx/features/enterprise_support/tests/test_logout.py
+++ b/openedx/features/enterprise_support/tests/test_logout.py
@@ -60,7 +60,7 @@ class EnterpriseLogoutTests(EnterpriseServiceMockMixin, CacheIsolationTestCase, 
         expected = {
             'enterprise_target': enterprise_target,
         }
-        self.assertTrue(expected.items() <= response.context_data.items())
+        self.assertLessEqual(expected.items(), response.context_data.items())
 
         if enterprise_target:
             self.assertContains(response, 'We are signing you in.')

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -752,17 +752,14 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         test_course = self.store.create_course('test_org', 'test_course', 'test_run', self.user_id)
 
         event_receiver.assert_called()
-
-        self.assertDictContainsSubset(
-            {
-                "signal": COURSE_CREATED,
-                "sender": None,
-                "course": CourseData(
-                    course_key=test_course.id,
-                ),
-            },
-            event_receiver.call_args.kwargs
-        )
+        course_created_event = {
+            "signal": COURSE_CREATED,
+            "sender": None,
+            "course": CourseData(
+                course_key=test_course.id,
+            ),
+        }
+        self.assertTrue(course_created_event.items() <= event_receiver.call_args.kwargs.items())
 
     @ddt.data(ModuleStoreEnum.Type.split)
     def test_xblock_create_event(self, default_ms):
@@ -831,17 +828,15 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         self.store.publish(sequential.location, self.user_id)
 
         event_receiver.assert_called()
-        self.assertDictContainsSubset(
-            {
-                "signal": XBLOCK_PUBLISHED,
-                "sender": None,
-                "xblock_info": XBlockData(
-                    usage_key=sequential.location,
-                    block_type=sequential.location.block_type,
-                ),
-            },
-            event_receiver.call_args.kwargs
-        )
+        xblock_published_event = {
+            "signal": XBLOCK_PUBLISHED,
+            "sender": None,
+            "xblock_info": XBlockData(
+                usage_key=sequential.location,
+                block_type=sequential.location.block_type,
+            ),
+        }
+        self.assertTrue(xblock_published_event.items() <= event_receiver.call_args.kwargs.items())
 
     @ddt.data(ModuleStoreEnum.Type.split)
     def test_xblock_delete_event(self, default_ms):
@@ -865,17 +860,15 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         self.store.delete_item(vertical.location, self.user_id)
 
         event_receiver.assert_called()
-        self.assertDictContainsSubset(
-            {
-                "signal": XBLOCK_DELETED,
-                "sender": None,
-                "xblock_info": XBlockData(
-                    usage_key=vertical.location,
-                    block_type=vertical.location.block_type,
-                ),
-            },
-            event_receiver.call_args.kwargs
-        )
+        xblock_deleted_event ={
+            "signal": XBLOCK_DELETED,
+            "sender": None,
+            "xblock_info": XBlockData(
+                usage_key=vertical.location,
+                block_type=vertical.location.block_type,
+            ),
+        }
+        self.assertTrue(xblock_deleted_event.items() <= event_receiver.call_args.kwargs.items())
 
     def setup_has_changes(self, default_ms):
         """

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -759,7 +759,10 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
                 course_key=test_course.id,
             ),
         }
-        self.assertTrue(course_created_event.items() <= event_receiver.call_args.kwargs.items())
+        self.assertLessEqual(
+            course_created_event.items(),
+            event_receiver.call_args.kwargs.items()
+        )
 
     @ddt.data(ModuleStoreEnum.Type.split)
     def test_xblock_create_event(self, default_ms):
@@ -836,7 +839,10 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
                 block_type=sequential.location.block_type,
             ),
         }
-        self.assertTrue(xblock_published_event.items() <= event_receiver.call_args.kwargs.items())
+        self.assertLessEqual(
+            xblock_published_event.items(),
+            event_receiver.call_args.kwargs.items()
+        )
 
     @ddt.data(ModuleStoreEnum.Type.split)
     def test_xblock_delete_event(self, default_ms):
@@ -860,7 +866,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         self.store.delete_item(vertical.location, self.user_id)
 
         event_receiver.assert_called()
-        xblock_deleted_event ={
+        xblock_deleted_event = {
             "signal": XBLOCK_DELETED,
             "sender": None,
             "xblock_info": XBlockData(
@@ -868,7 +874,10 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
                 block_type=vertical.location.block_type,
             ),
         }
-        self.assertTrue(xblock_deleted_event.items() <= event_receiver.call_args.kwargs.items())
+        self.assertLessEqual(
+            xblock_deleted_event.items(),
+            event_receiver.call_args.kwargs.items()
+        )
 
     def setup_has_changes(self, default_ms):
         """


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

[`assertDictContainsSubset` has been deprecated since Python 3.2](https://docs.python.org/3.2/library/unittest.html#unittest.TestCase.assertDictContainsSubset) and [was removed in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#id3).

This PR removes all usage of `assertDictContainsSubset` and uses the set operator, `<=`,  on dictionary method `items()` for subset comparisons.

## Supporting information

https://github.com/openedx/public-engineering/issues/90

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
