### PR TITLE
feat: customize sock links

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2874,3 +2874,32 @@ derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.content_autho
 REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
 
 BEAMER_PRODUCT_ID = ""
+
+
+################## Studio Sock URLs #####################
+
+SHOW_SOCK_LINKS_BTN = True
+
+SOCK_LINKS = [
+            {
+                'href': 'http://docs.edx.org',
+                'sr_mouseover_text': 'Access documentation on http://docs.edx.org',
+                'text': 'edX Documentation',
+                'condition': True
+            }, {
+                'href': 'https://open.edx.org',
+                'sr_mouseover_text': 'Access the Open edX Portal',
+                'text': 'Open edX Portal',
+                'condition': True
+            }, {
+                'href': 'https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VO4eaLPF-n1',
+                'sr_mouseover_text': 'Enroll in edX101: Overview of Creating an edX Course',
+                'text': 'Enroll in edX101',
+                'condition': True
+            }, {
+                'href': 'https://www.edx.org/course/creating-course-edx-studio-edx-studiox',
+                'sr_mouseover_text': 'Enroll in StudioX: Creating a Course with edX Studio',
+                'text': 'Enroll in StudioX',
+                'condition': True
+            }
+        ]

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -5,6 +5,7 @@ from django.utils.translation import gettext as _
 %>
 <%namespace file="sock_links.html" import="get_sock_links" />
 
+% if settings.SHOW_SOCK_LINKS_BTN:
 <div class="wrapper-sock wrapper">
   <ul class="list-actions list-cta">
     <li class="action-item">
@@ -26,7 +27,7 @@ from django.utils.translation import gettext as _
           % for link in links:
             % if link['condition']:
               <li class="action-item">
-                <a href="${link['href']}" title="${link['sr_mouseover_text']}" rel="external" class="action action-primary">${link['text']}</a>
+                <a href="${link['href']}" title="${link['sr_mouseover_text']}" rel="external" class="action action-primary">${_(link['text'])}</a>
                 <span class="tip">${link['sr_mouseover_text']}</span>
               </li>
             %endif
@@ -36,3 +37,4 @@ from django.utils.translation import gettext as _
     </section>
   </div>
 </div>
+% endif

--- a/cms/templates/widgets/sock_links.html
+++ b/cms/templates/widgets/sock_links.html
@@ -8,34 +8,7 @@ from django.utils.translation import gettext as _
 <%def name="get_sock_links()">
     <%
         partner_email = settings.PARTNER_SUPPORT_EMAIL
-        links = [
-            {
-                'href': 'http://docs.edx.org',
-                'sr_mouseover_text': _('Access documentation on http://docs.edx.org'),
-                'text': _('edX Documentation'),
-                'condition': True
-            }, {
-                'href': 'https://open.edx.org',
-                'sr_mouseover_text': _('Access the Open edX Portal'),
-                'text': _('Open edX Portal'),
-                'condition': True
-            }, {
-                'href': 'https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VO4eaLPF-n1',
-                'sr_mouseover_text': _('Enroll in edX101: Overview of Creating an edX Course'),
-                'text': _('Enroll in edX101'),
-                'condition': True
-            }, {
-                'href': 'https://www.edx.org/course/creating-course-edx-studio-edx-studiox',
-                'sr_mouseover_text': _('Enroll in StudioX: Creating a Course with edX Studio'),
-                'text': _('Enroll in StudioX'),
-                'condition': True
-            }, {
-                'href': 'mailto:{email}'.format(email=partner_email),
-                'sr_mouseover_text': _('Send an email to {email}').format(email=partner_email),
-                'text': _('Contact Us'),
-                'condition': bool(partner_email)
-            }
-        ]
+        links = settings.SOCK_LINKS
         links_extra = get_sock_links_extra()
         links += links_extra
         return links


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR enables the customization of sock links in studio. Currently the sock links are hard coded in [sock_links.html](https://github.com/openedx/edx-platform/blob/master/cms/templates/widgets/sock_links.html) and two of them are redirecting to a 404 error page. This PR makes them configurable by adding the sock links in the settings and then using them in the `sock_links.html`

Useful information to include:
- Which edX user roles will this change impact? "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
Before
<img width="1437" alt="Screenshot 2024-03-07 at 5 58 08 PM" src="https://github.com/openedx/edx-platform/assets/88967643/e612db6b-ac9c-4bcf-923f-6bf192daa3d6">

After
          1) When `SHOW_SOCK_LINKS_BTN = False`
<img width="1437" alt="Screenshot 2024-03-07 at 5 49 27 PM" src="https://github.com/openedx/edx-platform/assets/88967643/44f46bc9-9458-4545-aea1-c4789aff9e31">
          2) Customized links
<img width="1437" alt="Screenshot 2024-03-07 at 5 56 24 PM" src="https://github.com/openedx/edx-platform/assets/88967643/e5d4dc9e-f764-47ed-93f0-35bf42c5ab86">

- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Issue: https://github.com/openedx/platform-roadmap/issues/325

## Testing instructions

- In your private.py, include `SHOW_SOCK_LINKS_BTN = False`. Now go to studio home and you will not see the `Looking for help with studio?` dropdown.
- In your private.py, include 
     - `SOCK_LINKS = [
            {
                'href': 'http://docs.edx.org',
                'sr_mouseover_text': 'Access documentation on http://docs.edx.org',
                'text': 'edX Documentation',
                'condition': True
            }, {
                'href': 'https://open.edx.org',
                'sr_mouseover_text': 'Access the Open edX Portal',
                'text': 'Open edX Portal',
                'condition': True
            }, {
                'href': 'https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VO4eaLPF-n1',
                'sr_mouseover_text': 'Enroll in edX101: Overview of Creating an edX Course',
                'text': 'Enroll in edX101',
                'condition': True
            }, {
                'href': 'https://www.edx.org/course/creating-course-edx-studio-edx-studiox',
                'sr_mouseover_text': 'Enroll in StudioX: Creating a Course with edX Studio',
                'text': 'Enroll in StudioX',
                'condition': True
            }
        ]`
        You will see the customized links on your studio home like this
         <img width="1437" alt="Screenshot 2024-03-07 at 5 56 24 PM" src="https://github.com/openedx/edx-platform/assets/88967643/e5d4dc9e-f764-47ed-93f0-35bf42c5ab86">

## Deadline

None