### PR TITLE
feat: [FC-0044] add sequence_ids to container response

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -78,6 +78,7 @@ class ContainerHandlerSerializer(serializers.Serializer):
     assets_url = serializers.SerializerMethodField()
     unit_block_id = serializers.CharField(source="unit.location.block_id")
     subsection_location = serializers.CharField(source="subsection.location")
+    course_sequence_ids = serializers.ListField(child=serializers.CharField())
 
     def get_assets_url(self, obj):
         """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/vertical_block.py
@@ -123,6 +123,11 @@ class ContainerHandlerView(APIView):
             "assets_url": "/assets/course-v1:edX+DemoX+Demo_Course/",
             "unit_block_id": "d6cee45205a449369d7ef8f159b22bdf",
             "subsection_location": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@graded_simulations"
+            "course_sequence_ids": [
+                "block-v1:edX+DemoX+Demo_Course+type@sequential+block@graded_simulations",
+                "block-v1:edX+DemoX+Demo_Course+type@sequential+block@something_else",
+                ...
+            ],
         }
         ```
         """

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -595,6 +595,15 @@ def ancestor_has_staff_lock(xblock, parent_xblock=None):
     return parent_xblock.visible_to_staff_only
 
 
+def get_sequence_usage_keys(course):
+    """
+    Extracts a list of 'subsections' usage_keys
+    """
+    return [str(subsection.location)
+            for section in course.get_children()
+            for subsection in section.get_children()]
+
+
 def reverse_url(handler_name, key_name=None, key_value=None, kwargs=None):
     """
     Creates the URL for the given handler.
@@ -1815,6 +1824,7 @@ def get_container_handler_context(request, usage_key, course, xblock):  # pylint
     )
     from openedx.core.djangoapps.content_staging import api as content_staging_api
 
+    course_sequence_ids = get_sequence_usage_keys(course)
     component_templates = get_component_templates(course)
     ancestor_xblocks = []
     parent = get_parent_xblock(xblock)
@@ -1915,6 +1925,7 @@ def get_container_handler_context(request, usage_key, course, xblock):  # pylint
         # Status of the user's clipboard, exactly as would be returned from the "GET clipboard" REST API.
         'user_clipboard': user_clipboard,
         'is_fullwidth_content': is_library_xblock,
+        'course_sequence_ids': course_sequence_ids,
     }
     return context
 


### PR DESCRIPTION
## Settings
```
TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```

## Description
This PR addresses a need to fix the next button on the unit page, because it does not disabled when you are at the last unit.

## Testing instructions
1. Run master devstack.
2. Start platform make `dev.up.lms+cms+frontend-app-course-authoring` and make checkout on this branch.
3. Enable new Unit page by adding a waffle flag `contentstore.new_studio_mfe.use_new_unit_page` in CMS admin panel.
4. Go to Course Unit page from the Course Outline page.
5. Create few units and choose the last one in the unit navigation panel.

<img width="710" alt="image" src="https://github.com/openedx/edx-platform/assets/26650868/65dad599-c357-446c-a56a-8fd593f5c022">

## How it was before
<img width="949" alt="image" src="https://github.com/openedx/edx-platform/assets/26650868/01747917-20e8-485e-9555-b6f877df44b9">
