### PR TITLE
feat: [FC-0044] add waffle flag support

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -497,6 +497,66 @@ def use_new_course_team_page(course_key):
     return ENABLE_NEW_STUDIO_COURSE_TEAM_PAGE.is_enabled(course_key)
 
 
+# .. toggle_name: contentstore.new_studio_mfe.use_new_certificates_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new studio course certificates page mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-1-18
+# .. toggle_target_removal_date: 2023-4-31
+# .. toggle_tickets: https://github.com/openedx/platform-roadmap/issues/317
+# .. toggle_warning:
+ENABLE_NEW_STUDIO_CERTIFICATES_PAGE = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_new_certificates_page', __name__)
+
+
+def use_new_certificates_page(course_key):
+    """
+    Returns a boolean if new studio certificates mfe is enabled
+    """
+    return ENABLE_NEW_STUDIO_CERTIFICATES_PAGE.is_enabled(course_key)
+
+
+# .. toggle_name: contentstore.new_studio_mfe.use_new_textbooks_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new studio course textbooks page mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-1-18
+# .. toggle_target_removal_date: 2023-4-31
+# .. toggle_tickets: https://github.com/openedx/platform-roadmap/issues/319
+# .. toggle_warning:
+ENABLE_NEW_STUDIO_TEXTBOOKS_PAGE = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_new_textbooks_page', __name__)
+
+
+def use_new_textbooks_page(course_key):
+    """
+    Returns a boolean if new studio textbooks mfe is enabled
+    """
+    return ENABLE_NEW_STUDIO_TEXTBOOKS_PAGE.is_enabled(course_key)
+
+
+# .. toggle_name: contentstore.new_studio_mfe.use_new_group_configurations_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new studio course group configurations page mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-1-18
+# .. toggle_target_removal_date: 2023-4-31
+# .. toggle_tickets: https://github.com/openedx/platform-roadmap/issues/318
+# .. toggle_warning:
+ENABLE_NEW_STUDIO_GROUP_CONFIGURATIONS_PAGE = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_new_group_configurations_page', __name__)
+
+
+def use_new_group_configurations_page(course_key):
+    """
+    Returns a boolean if new studio group configurations mfe is enabled
+    """
+    return ENABLE_NEW_STUDIO_GROUP_CONFIGURATIONS_PAGE.is_enabled(course_key)
+
+
 # .. toggle_name: contentstore.mock_video_uploads
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -74,14 +74,17 @@ from cms.djangoapps.contentstore.toggles import (
     split_library_view_on_dashboard,
     use_new_advanced_settings_page,
     use_new_course_outline_page,
+    use_new_certificates_page,
     use_new_export_page,
     use_new_files_uploads_page,
     use_new_grading_page,
+    use_new_group_configurations_page,
     use_new_course_team_page,
     use_new_home_page,
     use_new_import_page,
     use_new_schedule_details_page,
     use_new_text_editor,
+    use_new_textbooks_page,
     use_new_unit_page,
     use_new_updates_page,
     use_new_video_editor,
@@ -427,6 +430,45 @@ def get_unit_url(course_locator, unit_locator) -> str:
     if use_new_unit_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
         course_mfe_url = f'{mfe_base_url}/course/{course_locator}/container/{unit_locator}'
+        if mfe_base_url:
+            unit_url = course_mfe_url
+    return unit_url
+
+
+def get_certificates_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for certificates page view.
+    """
+    unit_url = None
+    if use_new_certificates_page(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/certificates'
+        if mfe_base_url:
+            unit_url = course_mfe_url
+    return unit_url
+
+
+def get_textbooks_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for textbooks page view.
+    """
+    unit_url = None
+    if use_new_textbooks_page(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/pages-and-resources/textbooks'
+        if mfe_base_url:
+            unit_url = course_mfe_url
+    return unit_url
+
+
+def get_group_configurations_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for group configurations page view.
+    """
+    unit_url = None
+    if use_new_group_configurations_page(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/group_configurations'
         if mfe_base_url:
             unit_url = course_mfe_url
     return unit_url

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -439,39 +439,39 @@ def get_certificates_url(course_locator) -> str:
     """
     Gets course authoring microfrontend URL for certificates page view.
     """
-    unit_url = None
+    certificates_url = None
     if use_new_certificates_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
         course_mfe_url = f'{mfe_base_url}/course/{course_locator}/certificates'
         if mfe_base_url:
-            unit_url = course_mfe_url
-    return unit_url
+            certificates_url = course_mfe_url
+    return certificates_url
 
 
 def get_textbooks_url(course_locator) -> str:
     """
     Gets course authoring microfrontend URL for textbooks page view.
     """
-    unit_url = None
+    textbooks_url = None
     if use_new_textbooks_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
         course_mfe_url = f'{mfe_base_url}/course/{course_locator}/pages-and-resources/textbooks'
         if mfe_base_url:
-            unit_url = course_mfe_url
-    return unit_url
+            textbooks_url = course_mfe_url
+    return textbooks_url
 
 
 def get_group_configurations_url(course_locator) -> str:
     """
     Gets course authoring microfrontend URL for group configurations page view.
     """
-    unit_url = None
+    group_configurations_url = None
     if use_new_group_configurations_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
         course_mfe_url = f'{mfe_base_url}/course/{course_locator}/group_configurations'
         if mfe_base_url:
-            unit_url = course_mfe_url
-    return unit_url
+            group_configurations_url = course_mfe_url
+    return group_configurations_url
 
 
 def get_custom_pages_url(course_locator) -> str:


### PR DESCRIPTION
## Description
The main idea of this changes is dynamically changes the page links in Studio's header depending on the corresponding waffle flag. When the flag is enabled, the user will be navigated to the `course-authoring mfe`. If the flag is disabled, the user will remain in `studio`.
#### The functionality is available only in the creation mode, switching between `MFE` and `Legacy` will be enabled in the following PR's

### There were added following flags:
Textbooks - `contentstore.new_studio_mfe.use_new_textbooks_page`
Certificates - `contentstore.new_studio_mfe.use_new_certificates_page`
Group Configurations - `contentstore.new_studio_mfe.use_new_group_configurations_page`

## Testing instructions
1. Using Django admin, enable one of the flags listed above.