### PR TITLE
fix: removed waffle switch around oep-50 filter

### DIFF
--- a/xmodule/tests/test_vertical.py
+++ b/xmodule/tests/test_vertical.py
@@ -14,12 +14,10 @@ import ddt
 import pytz
 from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
-from edx_toggles.toggles.testutils import override_waffle_switch
 from fs.memoryfs import MemoryFS
 from openedx_filters import PipelineStep
 from openedx_filters.learning.filters import VerticalBlockChildRenderStarted, VerticalBlockRenderCompleted
 
-from ..vertical_block import XBLOCK_SKILL_TAG_VERIFICATION_SWITCH
 from ..x_module import AUTHOR_VIEW, PUBLIC_VIEW, STUDENT_VIEW
 from . import prepare_block_runtime
 from .helpers import StubUserService
@@ -362,7 +360,6 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
             },
         },
     )
-    @override_waffle_switch(XBLOCK_SKILL_TAG_VERIFICATION_SWITCH, True)
     def test_vertical_block_child_render_started_filter_execution(self):
         """
         Test the VerticalBlockChildRenderStarted filter's effects on student view.
@@ -385,7 +382,6 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
             },
         },
     )
-    @override_waffle_switch(XBLOCK_SKILL_TAG_VERIFICATION_SWITCH, True)
     def test_vertical_block_child_render_is_skipped_on_filter_exception(self):
         """
         Test VerticalBlockChildRenderStarted filter can be used to skip child blocks.
@@ -409,7 +405,6 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
             },
         },
     )
-    @override_waffle_switch(XBLOCK_SKILL_TAG_VERIFICATION_SWITCH, True)
     def test_vertical_block_render_completed_filter_execution(self):
         """
         Test the VerticalBlockRenderCompleted filter's execution.
@@ -432,7 +427,6 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
             },
         },
     )
-    @override_waffle_switch(XBLOCK_SKILL_TAG_VERIFICATION_SWITCH, True)
     def test_vertical_block_render_output_is_changed_on_filter_exception(self):
         """
         Test VerticalBlockRenderCompleted filter can be used to prevent vertical block from rendering.

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from functools import reduce
 
 import pytz
-from edx_toggles.toggles import WaffleSwitch
 from lxml import etree
 from openedx_filters.learning.filters import VerticalBlockChildRenderStarted, VerticalBlockRenderCompleted
 from web_fragments.fragment import Fragment
@@ -34,17 +33,6 @@ _ = lambda text: text
 # HACK: This shouldn't be hard-coded to two types
 # OBSOLETE: This obsoletes 'type'
 CLASS_PRIORITY = ['video', 'problem']
-WAFFLE_NAMESPACE = 'xblocks'
-# .. toggle_name: xblocks.xblock_skill_tag_verification'
-# .. toggle_implementation: WaffleSwitch
-# .. toggle_default: False
-# .. toggle_description: Set to True to get learner verification of the skills associated with the xblock.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2023-10-04
-# .. toggle_target_removal_date: None
-XBLOCK_SKILL_TAG_VERIFICATION_SWITCH = WaffleSwitch(  # lint-amnesty, pylint: disable=toggle-missing-annotation
-    f'{WAFFLE_NAMESPACE}.xblock_skill_tag_verification', __name__
-)
 
 
 class VerticalFields:
@@ -129,16 +117,15 @@ class VerticalBlock(
                 child_block_context['wrap_xblock_data'] = {
                     'mark-completed-on-view-after-delay': complete_on_view_delay
                 }
-            if XBLOCK_SKILL_TAG_VERIFICATION_SWITCH.is_enabled():
-                try:
-                    # .. filter_implemented_name: VerticalBlockChildRenderStarted
-                    # .. filter_type: org.openedx.learning.vertical_block_child.render.started.v1
-                    child, child_block_context = VerticalBlockChildRenderStarted.run_filter(
-                        block=child, context=child_block_context
-                    )
-                except VerticalBlockChildRenderStarted.PreventChildBlockRender as exc:
-                    log.info("Skipping %s from vertical block. Reason: %s", child, exc.message)
-                    continue
+            try:
+                # .. filter_implemented_name: VerticalBlockChildRenderStarted
+                # .. filter_type: org.openedx.learning.vertical_block_child.render.started.v1
+                child, child_block_context = VerticalBlockChildRenderStarted.run_filter(
+                    block=child, context=child_block_context
+                )
+            except VerticalBlockChildRenderStarted.PreventChildBlockRender as exc:
+                log.info("Skipping %s from vertical block. Reason: %s", child, exc.message)
+                continue
 
             rendered_child = child.render(view, child_block_context)
             fragment.add_fragment_resources(rendered_child)
@@ -180,16 +167,15 @@ class VerticalBlock(
         add_webpack_js_to_fragment(fragment, 'VerticalStudentView')
         fragment.initialize_js('VerticalStudentView')
 
-        if XBLOCK_SKILL_TAG_VERIFICATION_SWITCH.is_enabled():
-            try:
-                # .. filter_implemented_name: VerticalBlockRenderCompleted
-                # .. filter_type: org.openedx.learning.vertical_block.render.completed.v1
-                _, fragment, context, view = VerticalBlockRenderCompleted.run_filter(
-                    block=self, fragment=fragment, context=context, view=view
-                )
-            except VerticalBlockRenderCompleted.PreventVerticalBlockRender as exc:
-                log.info("VerticalBlock rendering stopped. Reason: %s", exc.message)
-                fragment.content = exc.message
+        try:
+            # .. filter_implemented_name: VerticalBlockRenderCompleted
+            # .. filter_type: org.openedx.learning.vertical_block.render.completed.v1
+            _, fragment, context, view = VerticalBlockRenderCompleted.run_filter(
+                block=self, fragment=fragment, context=context, view=view
+            )
+        except VerticalBlockRenderCompleted.PreventVerticalBlockRender as exc:
+            log.info("VerticalBlock rendering stopped. Reason: %s", exc.message)
+            fragment.content = exc.message
 
         return fragment
 


### PR DESCRIPTION
## Description

This PR removes the waffle switch around the OEP-filter for VerticalBlockChildRenderStarted and VerticalBlockRenderCompleted. The switch was added  after a downtime in Discovery and LMS due to delayed response originating from the XBlockSkillsAPI list endpoint that is responsible for gathering any skills linked to an xblock. The toggle and the conditional code would now go inside that plugin.

## Supporting information

https://github.com/openedx/edx-platform/pull/33399#discussion_r1518112955

## Deadline

2024-04-02