### PR TITLE
feat: add celery task to reset course progress for learner

### DIFF
--- a/lms/djangoapps/support/tasks.py
+++ b/lms/djangoapps/support/tasks.py
@@ -9,18 +9,28 @@ from common.djangoapps.student.models.course_enrollment import CourseEnrollment
 from common.djangoapps.student.models.user import get_user_by_username_or_email
 from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.courseware.models import StudentModule
-from lms.djangoapps.grades.rest_api.v1.views import SubmissionHistoryView
 from lms.djangoapps.instructor.enrollment import reset_student_attempts
 from lms.djangoapps.support.models import CourseResetAudit
 
 log = logging.getLogger(__name__)
 
 
-def update_audit_status(audit_instance, status, completed_at=False):
+def update_audit_status(audit_instance, status):
     audit_instance.status = status
-    if completed_at:
+    if status == CourseResetAudit.CourseResetStatus.COMPLETE:
         audit_instance.completed_at = datetime.now()
     audit_instance.save()
+
+
+def get_blocks(course):
+    """ Get a list of problem xblock for the course."""
+    blocks = []
+    for section in course.get_children():
+        for subsection in section.get_children():
+            for vertical in subsection.get_children():
+                for block in vertical.get_children():
+                    blocks.append(block)
+    return blocks
 
 
 @shared_task
@@ -34,21 +44,24 @@ def reset_student_course(course_id, learner_email, reset_by_user_email):
     enrollment = CourseEnrollment.objects.get(
         course=course_id,
         user=user,
-        is_active=True
+        is_active=True,
     )
     course_overview = enrollment.course_overview
-    course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=enrollment).first()
+    course_reset_audit = CourseResetAudit.objects.get(
+        course_enrollment=enrollment,
+        status=CourseResetAudit.CourseResetStatus.ENQUEUED
+    )
     update_audit_status(course_reset_audit, CourseResetAudit.CourseResetStatus.IN_PROGRESS)
 
     try:
         course = get_course(course_overview.id, depth=4)
-        history = SubmissionHistoryView.get_problem_blocks(course)
-        for data in history:
+        blocks = get_blocks(course)
+        for data in blocks:
             try:
                 reset_student_attempts(course.id, user, data.scope_ids.usage_id, reset_by_user, True)
             except StudentModule.DoesNotExist:
                 pass
-        update_audit_status(course_reset_audit, CourseResetAudit.CourseResetStatus.COMPLETE, True)
+        update_audit_status(course_reset_audit, CourseResetAudit.CourseResetStatus.COMPLETE)
     except Exception as e:  # pylint: disable=broad-except
-        logging.exception(e)
+        logging.exception(f'Error occurred for Course Audit with ID {course_reset_audit.id}: {e}.')
         update_audit_status(course_reset_audit, CourseResetAudit.CourseResetStatus.FAILED)

--- a/lms/djangoapps/support/tasks.py
+++ b/lms/djangoapps/support/tasks.py
@@ -1,0 +1,55 @@
+""" Celery Tasks for the Instructor App. """
+
+from datetime import datetime
+import logging
+from celery import shared_task
+from submissions import api as sub_api
+from edx_django_utils.monitoring import set_code_owner_attribute
+
+from common.djangoapps.student.models.course_enrollment import CourseEnrollment
+from common.djangoapps.student.models.user import get_user_by_username_or_email
+from lms.djangoapps.courseware.courses import get_course
+from lms.djangoapps.courseware.models import StudentModule
+from lms.djangoapps.grades.rest_api.v1.views import SubmissionHistoryView
+from lms.djangoapps.instructor.enrollment import reset_student_attempts
+from lms.djangoapps.support.models import CourseResetAudit
+
+log = logging.getLogger(__name__)
+
+
+def update_audit_fields(audit_instance, status, completed_at=False):
+    audit_instance.status = status
+    if completed_at:
+        audit_instance.completed_at = datetime.now()
+    audit_instance.save()
+
+
+@shared_task
+@set_code_owner_attribute
+def reset_student_course(course_id, learner_email, reset_by_user_email):
+    """
+    Resets a learner's course progress
+    """
+    user = get_user_by_username_or_email(learner_email)
+    reset_by_user = get_user_by_username_or_email(reset_by_user_email)
+    enrollment = CourseEnrollment.objects.get(
+        course=course_id,
+        user=user,
+        is_active=True
+    )
+    course_overview = enrollment.course_overview
+    course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=enrollment).first()
+    update_audit_fields(course_reset_audit, CourseResetAudit.CourseResetStatus.IN_PROGRESS)
+
+    try:
+        course = get_course(course_overview.id, depth=4)
+        history = SubmissionHistoryView.get_problem_blocks(course)
+        for data in history:
+            try:
+                reset_student_attempts(course.id, user, data.scope_ids.usage_id, reset_by_user, True)
+            except StudentModule.DoesNotExist:
+                pass
+        update_audit_fields(course_reset_audit, CourseResetAudit.CourseResetStatus.COMPLETE, True)
+    except sub_api.SubmissionError as e:
+        logging.exception(e)
+        update_audit_fields(course_reset_audit, CourseResetAudit.CourseResetStatus.FAILED)

--- a/lms/djangoapps/support/tests/test_tasks.py
+++ b/lms/djangoapps/support/tests/test_tasks.py
@@ -3,22 +3,20 @@ Unit tests for reset_student_course task
 """
 
 
-from datetime import datetime, timedelta
-from pytz import UTC
+from unittest.mock import patch, Mock
 
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-
-from xmodule.modulestore.tests.factories import CourseFactory
-
+from xmodule.modulestore.tests.factories import BlockFactory
+from lms.djangoapps.courseware.tests.test_submitting_problems import TestSubmittingProblems
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.support.tasks import reset_student_course
 from lms.djangoapps.support.tests.factories import CourseResetAuditFactory, CourseResetCourseOptInFactory
 from lms.djangoapps.support.models import CourseResetAudit
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from common.djangoapps.student.models.course_enrollment import CourseEnrollment
 from common.djangoapps.student.roles import SupportStaffRole
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import UserFactory
 
 
-class ResetStudentCourse(ModuleStoreTestCase):
+class ResetStudentCourse(TestSubmittingProblems):
     """ Test expire_waiting_enrollments task """
     USERNAME = "support"
     EMAIL = "support@example.com"
@@ -31,16 +29,8 @@ class ResetStudentCourse(ModuleStoreTestCase):
         super().setUp()
         self.user = UserFactory(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
         SupportStaffRole().add_users(self.user)
-        self.now = datetime.now().replace(tzinfo=UTC)
-
-        self.course = CourseFactory.create(
-            start=self.now - timedelta(days=90),
-            end=self.now + timedelta(days=90),
-        )
         self.course_id = str(self.course.id)
-        self.course_overview = CourseOverview.get_from_id(self.course.id)
-        self.learner = UserFactory.create()
-        self.enrollment = CourseEnrollmentFactory.create(user=self.learner, course_id=self.course.id)
+        self.enrollment = CourseEnrollment.objects.filter(user=self.student_user, course_id=self.course.id).first()
         self.opt_in = CourseResetCourseOptInFactory.create(course_id=self.course.id)
         self.audit = CourseResetAuditFactory.create(
             course=self.opt_in,
@@ -49,7 +39,61 @@ class ResetStudentCourse(ModuleStoreTestCase):
             status=CourseResetAudit.CourseResetStatus.FAILED
         )
 
+    def basic_setup(self, late=False, reset=False, showanswer=False):
+        """
+        Set up a simple course for testing basic grading functionality.
+        """
+        grading_policy = {
+            "GRADER": [{
+                "type": "Homework",
+                "min_count": 1,
+                "drop_count": 0,
+                "short_label": "HW",
+                "weight": 1.0
+            }],
+            "GRADE_CUTOFFS": {
+                'A': .9,
+                'B': .33
+            }
+        }
+        self.add_grading_policy(grading_policy)
+
+        # set up a simple course with four problems
+        homework = self.add_graded_section_to_course('homework', late=late, reset=reset, showanswer=showanswer)
+        vertical = BlockFactory.create(
+            parent_location=homework.location,
+            category='vertical',
+            display_name='Subsection 1',
+        )
+        self.add_dropdown_to_section(vertical.location, 'p1', 1)
+        self.add_dropdown_to_section(vertical.location, 'p2', 1)
+        self.add_dropdown_to_section(vertical.location, 'p3', 1)
+
+        self.refresh_course()
+
     def test_reset_student_course(self):
-        reset_student_course(self.course_id, self.learner.email, self.user.email)
+        self.basic_setup()
+        reset_student_course(self.course_id, self.student_user.email, self.user.email)
         course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=self.enrollment).first()
         self.assertTrue(course_reset_audit.completed_at)
+        self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.COMPLETE)
+
+    def test_reset_student_course_student_module_not_found(self):
+        with patch(
+                'lms.djangoapps.support.tasks.reset_student_attempts',
+                Mock(side_effect=StudentModule.DoesNotExist('An error occurred'))
+        ):
+            reset_student_course(self.course_id, self.student_user.email, self.user.email)
+            course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=self.enrollment).first()
+            self.assertTrue(course_reset_audit.completed_at)
+            self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.COMPLETE)
+
+    def test_reset_student_course_fail(self):
+        with patch(
+                'lms.djangoapps.support.tasks.SubmissionHistoryView.get_problem_blocks',
+                Mock(side_effect=Exception('An error occurred'))
+        ):
+            reset_student_course(self.course_id, self.student_user.email, self.user.email)
+            course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=self.enrollment).first()
+            self.assertFalse(course_reset_audit.completed_at)
+            self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.FAILED)

--- a/lms/djangoapps/support/tests/test_tasks.py
+++ b/lms/djangoapps/support/tests/test_tasks.py
@@ -14,6 +14,7 @@ from lms.djangoapps.support.models import CourseResetAudit
 from common.djangoapps.student.models.course_enrollment import CourseEnrollment
 from common.djangoapps.student.roles import SupportStaffRole
 from common.djangoapps.student.tests.factories import UserFactory
+from xmodule.video_block import VideoBlock
 
 
 class ResetStudentCourse(TestSubmittingProblems):
@@ -41,6 +42,7 @@ class ResetStudentCourse(TestSubmittingProblems):
         self.p1 = ''
         self.p2 = ''
         self.p3 = ''
+        self.video = ''
 
     def basic_setup(self):
         """
@@ -72,6 +74,23 @@ class ResetStudentCourse(TestSubmittingProblems):
         self.p1 = self.add_dropdown_to_section(vertical.location, 'p1', 1)
         self.p2 = self.add_dropdown_to_section(vertical.location, 'p2', 1)
         self.p3 = self.add_dropdown_to_section(vertical.location, 'p3', 1)
+        video_sample_xml = """
+        <video display_name="Test Video"
+                youtube="1.0:p2Q6BrNhdh8,0.75:izygArpw-Qo,1.25:1EeWXzPdhSA,1.5:rABDYkeK0x8"
+                show_captions="false"
+                from="1.0"
+                to="60.0">
+            <source src="http://www.example.com/file.mp4"/>
+            <track src="http://www.example.com/track"/>
+        </video>
+        """
+        video_data = VideoBlock.parse_video_xml(video_sample_xml)
+        video_data.pop('source')
+        self.video = BlockFactory.create(
+            category='video',
+            parent_location=vertical.location,
+            **video_data
+        )
 
         self.refresh_course()
 
@@ -102,6 +121,13 @@ class ResetStudentCourse(TestSubmittingProblems):
                     self.course.id,
                     self.student_user,
                     self.p3.location,
+                    self.user,
+                    True
+                ),
+                call(
+                    self.course.id,
+                    self.student_user,
+                    self.video.location,
                     self.user,
                     True
                 )

--- a/lms/djangoapps/support/tests/test_tasks.py
+++ b/lms/djangoapps/support/tests/test_tasks.py
@@ -2,10 +2,10 @@
 Unit tests for reset_student_course task
 """
 
-
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, call
 
 from xmodule.modulestore.tests.factories import BlockFactory
+
 from lms.djangoapps.courseware.tests.test_submitting_problems import TestSubmittingProblems
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.support.tasks import reset_student_course
@@ -17,7 +17,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 
 
 class ResetStudentCourse(TestSubmittingProblems):
-    """ Test expire_waiting_enrollments task """
+    """ Test reset_student_course task """
     USERNAME = "support"
     EMAIL = "support@example.com"
     PASSWORD = "support"
@@ -36,10 +36,13 @@ class ResetStudentCourse(TestSubmittingProblems):
             course=self.opt_in,
             course_enrollment=self.enrollment,
             reset_by=self.user,
-            status=CourseResetAudit.CourseResetStatus.FAILED
+            status=CourseResetAudit.CourseResetStatus.ENQUEUED
         )
+        self.p1 = ''
+        self.p2 = ''
+        self.p3 = ''
 
-    def basic_setup(self, late=False, reset=False, showanswer=False):
+    def basic_setup(self):
         """
         Set up a simple course for testing basic grading functionality.
         """
@@ -59,41 +62,112 @@ class ResetStudentCourse(TestSubmittingProblems):
         self.add_grading_policy(grading_policy)
 
         # set up a simple course with four problems
-        homework = self.add_graded_section_to_course('homework', late=late, reset=reset, showanswer=showanswer)
+        homework = self.add_graded_section_to_course('homework')
         vertical = BlockFactory.create(
             parent_location=homework.location,
             category='vertical',
-            display_name='Subsection 1',
+            display_name='Unit 1',
         )
-        self.add_dropdown_to_section(vertical.location, 'p1', 1)
-        self.add_dropdown_to_section(vertical.location, 'p2', 1)
-        self.add_dropdown_to_section(vertical.location, 'p3', 1)
+
+        self.p1 = self.add_dropdown_to_section(vertical.location, 'p1', 1)
+        self.p2 = self.add_dropdown_to_section(vertical.location, 'p2', 1)
+        self.p3 = self.add_dropdown_to_section(vertical.location, 'p3', 1)
 
         self.refresh_course()
 
     def test_reset_student_course(self):
-        self.basic_setup()
-        reset_student_course(self.course_id, self.student_user.email, self.user.email)
-        course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=self.enrollment).first()
-        self.assertTrue(course_reset_audit.completed_at)
-        self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.COMPLETE)
-
-    def test_reset_student_course_student_module_not_found(self):
+        """ Test that it resets student attempts  """
         with patch(
                 'lms.djangoapps.support.tasks.reset_student_attempts',
-                Mock(side_effect=StudentModule.DoesNotExist('An error occurred'))
-        ):
+        ) as mock_reset_student_attempts:
+            self.basic_setup()
             reset_student_course(self.course_id, self.student_user.email, self.user.email)
-            course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=self.enrollment).first()
-            self.assertTrue(course_reset_audit.completed_at)
+
+            mock_reset_student_attempts.assert_has_calls([
+                call(
+                    self.course.id,
+                    self.student_user,
+                    self.p1.location,
+                    self.user,
+                    True
+                ),
+                call(
+                    self.course.id,
+                    self.student_user,
+                    self.p2.location,
+                    self.user,
+                    True
+                ),
+                call(
+                    self.course.id,
+                    self.student_user,
+                    self.p3.location,
+                    self.user,
+                    True
+                )
+            ])
+
+            course_reset_audit = CourseResetAudit.objects.get(course_enrollment=self.enrollment)
+            self.assertIsNotNone(course_reset_audit.completed_at)
             self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.COMPLETE)
 
-    def test_reset_student_course_fail(self):
+    def test_reset_student_course_student_module_not_found(self):
+
         with patch(
-                'lms.djangoapps.support.tasks.SubmissionHistoryView.get_problem_blocks',
-                Mock(side_effect=Exception('An error occurred'))
+                'lms.djangoapps.support.tasks.reset_student_attempts',
+                Mock(side_effect=StudentModule.DoesNotExist())
+        ) as mock_reset_student_attempts:
+            self.basic_setup()
+            reset_student_course(self.course_id, self.student_user.email, self.user.email)
+            mock_reset_student_attempts.assert_has_calls([
+                call(
+                    self.course.id,
+                    self.student_user,
+                    self.p1.location,
+                    self.user,
+                    True
+                ),
+                call(
+                    self.course.id,
+                    self.student_user,
+                    self.p2.location,
+                    self.user,
+                    True
+                ),
+                call(
+                    self.course.id,
+                    self.student_user,
+                    self.p3.location,
+                    self.user,
+                    True
+                )
+            ])
+
+            course_reset_audit = CourseResetAudit.objects.get(course_enrollment=self.enrollment)
+            self.assertRaises(StudentModule.DoesNotExist, mock_reset_student_attempts)
+            self.assertIsNotNone(course_reset_audit.completed_at)
+            self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.COMPLETE)
+
+    @patch('lms.djangoapps.support.tasks.reset_student_attempts')
+    def test_reset_student_course_fail(self, mock_reset_student_attempts):
+        with patch(
+                'lms.djangoapps.support.tasks.get_blocks',
+                Mock(side_effect=Exception())
         ):
             reset_student_course(self.course_id, self.student_user.email, self.user.email)
-            course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=self.enrollment).first()
-            self.assertFalse(course_reset_audit.completed_at)
+            mock_reset_student_attempts.assert_not_called()
+            course_reset_audit = CourseResetAudit.objects.get(course_enrollment=self.enrollment)
+            self.assertIsNone(course_reset_audit.completed_at)
+            self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.FAILED)
+
+    def test_reset_student_attempts_raise_exception(self):
+        with patch(
+                'lms.djangoapps.support.tasks.reset_student_attempts',
+                Mock(side_effect=Exception())
+        ) as mock_reset_student_attempts:
+            self.basic_setup()
+            reset_student_course(self.course_id, self.student_user.email, self.user.email)
+            mock_reset_student_attempts.assert_called_once()
+            course_reset_audit = CourseResetAudit.objects.get(course_enrollment=self.enrollment)
+            self.assertIsNone(course_reset_audit.completed_at)
             self.assertEqual(course_reset_audit.status, CourseResetAudit.CourseResetStatus.FAILED)

--- a/lms/djangoapps/support/tests/test_tasks.py
+++ b/lms/djangoapps/support/tests/test_tasks.py
@@ -1,0 +1,55 @@
+"""
+Unit tests for reset_student_course task
+"""
+
+
+from datetime import datetime, timedelta
+from pytz import UTC
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from lms.djangoapps.support.tasks import reset_student_course
+from lms.djangoapps.support.tests.factories import CourseResetAuditFactory, CourseResetCourseOptInFactory
+from lms.djangoapps.support.models import CourseResetAudit
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from common.djangoapps.student.roles import SupportStaffRole
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+
+
+class ResetStudentCourse(ModuleStoreTestCase):
+    """ Test expire_waiting_enrollments task """
+    USERNAME = "support"
+    EMAIL = "support@example.com"
+    PASSWORD = "support"
+
+    def setUp(self):
+        """
+        Set permissions, create a course and learner, enroll learner and opt into course reset
+        """
+        super().setUp()
+        self.user = UserFactory(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
+        SupportStaffRole().add_users(self.user)
+        self.now = datetime.now().replace(tzinfo=UTC)
+
+        self.course = CourseFactory.create(
+            start=self.now - timedelta(days=90),
+            end=self.now + timedelta(days=90),
+        )
+        self.course_id = str(self.course.id)
+        self.course_overview = CourseOverview.get_from_id(self.course.id)
+        self.learner = UserFactory.create()
+        self.enrollment = CourseEnrollmentFactory.create(user=self.learner, course_id=self.course.id)
+        self.opt_in = CourseResetCourseOptInFactory.create(course_id=self.course.id)
+        self.audit = CourseResetAuditFactory.create(
+            course=self.opt_in,
+            course_enrollment=self.enrollment,
+            reset_by=self.user,
+            status=CourseResetAudit.CourseResetStatus.FAILED
+        )
+
+    def test_reset_student_course(self):
+        reset_student_course(self.course_id, self.learner.email, self.user.email)
+        course_reset_audit = CourseResetAudit.objects.filter(course_enrollment=self.enrollment).first()
+        self.assertTrue(course_reset_audit.completed_at)

--- a/lms/djangoapps/support/views/course_reset.py
+++ b/lms/djangoapps/support/views/course_reset.py
@@ -14,6 +14,7 @@ from lms.djangoapps.support.models import (
     CourseResetCourseOptIn,
     CourseResetAudit
 )
+from ..tasks import reset_student_course
 
 User = get_user_model()
 
@@ -131,7 +132,8 @@ class CourseResetAPIView(APIView):
         ):
             course_reset_audit.status = CourseResetAudit.CourseResetStatus.ENQUEUED
             course_reset_audit.save()
-            # Call celery task
+            reset_student_course.delay(course_id, user.email, request.user.email)
+
             resp = {
                 'course_id': course_id,
                 'status': course_reset_audit.status_message(),
@@ -159,7 +161,7 @@ class CourseResetAPIView(APIView):
                 'display_name': course_overview.display_name
             }
 
-            # Call celery task
+            reset_student_course.delay(course_id, user.email, request.user.email)
             return Response(resp, status=201)
         else:
             return Response(None, status=400)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR uses celery task to reset learner's course progress

## Supporting information

Roadmap issue: https://github.com/openedx/platform-roadmap/issues/331

[Celery task to reset individual learner](https://2u-internal.atlassian.net/browse/AU-1848)

