### PR TITLE
fix: Space around techers images on course about page

### DIFF
--- a/common/test/data/course_after_rename/about/overview.html
+++ b/common/test/data/course_after_rename/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/course_before_rename/about/overview.html
+++ b/common/test/data/course_before_rename/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/course_info_updates/about/overview.html
+++ b/common/test/data/course_info_updates/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/manual-testing-complete/about/overview.html
+++ b/common/test/data/manual-testing-complete/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/common/test/data/scoreable/about/overview.html
+++ b/common/test/data/scoreable/about/overview.html
@@ -14,7 +14,7 @@
   <h2>Course Staff</h2>
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #1" />
     </div>
 
     <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
   <article class="teacher">
     <div class="teacher-image">
-      <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
+      <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #2" />
     </div>
 
     <h3>Staff Member #2</h3>

--- a/xmodule/templates/about/overview.yaml
+++ b/xmodule/templates/about/overview.yaml
@@ -19,7 +19,7 @@ data: |
       <h2>Course Staff</h2>
       <article class="teacher">
         <div class="teacher-image">
-          <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #1" />
+          <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #1" />
         </div>
 
         <h3>Staff Member #1</h3>
@@ -28,7 +28,7 @@ data: |
 
       <article class="teacher">
         <div class="teacher-image">
-          <img src="/static/images/placeholder-faculty.png" align="left" style="margin: 0 20px 0;" alt="Course Staff Image #2" />
+          <img src="/static/images/placeholder-faculty.png" align="left" alt="Course Staff Image #2" />
         </div>
 
         <h3>Staff Member #2</h3>


### PR DESCRIPTION
## Description

This is a strange bug. It is related to a typo in the inline styles `style="margin:0 20 px 0"` - there was a space between `20` and `px` in the course about page template, which is the default for new courses. These styles did not work, so we could not see the bug. Then, in this pull request - https://github.com/openedx/edx-platform/pull/32890/ - this typo was fixed, and now we are observing this bug (as shown in the screenshot below). We believe that this margin is completely unnecessary for the `<img>` tag, as the border and margin are set on the parent div `teacher-image`

Before fix
<img width="1840" alt="Снимок экрана 2024-03-12 в 23 38 31" src="https://github.com/openedx/edx-platform/assets/19806032/e1368d8b-0b93-4e13-b1a3-0c1d20276c01">

After fix
<img width="1840" alt="Снимок экрана 2024-03-12 в 17 08 20" src="https://github.com/openedx/edx-platform/assets/19806032/0dc93b41-abbc-4598-9c45-bac6ee538f00">

Also RTL version
<img width="1840" alt="Снимок экрана 2024-03-12 в 23 49 48" src="https://github.com/openedx/edx-platform/assets/19806032/e7451709-24b1-4020-b7ba-d35da70486dd">
