### PR TITLE
feat: [FC-0044] Manage access API

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -98,8 +98,11 @@ class ChildVerticalContainerSerializer(serializers.Serializer):
     Serializer for representing a xblock child of vertical container.
     """
 
-    name = serializers.CharField(source="display_name_with_default")
-    block_id = serializers.CharField(source="location")
+    name = serializers.CharField()
+    block_id = serializers.CharField()
+    block_type = serializers.CharField()
+    user_partition_info = serializers.DictField()
+    user_partitions = serializers.ListField()
 
 
 class VerticalContainerSerializer(serializers.Serializer):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
 from xmodule.modulestore.django import (
     modulestore,
 )  # lint-amnesty, pylint: disable=wrong-import-order
@@ -154,14 +155,42 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
         url = self.get_reverse_url(self.vertical.location)
         response = self.client.get(url)
 
+        expected_user_partition_info = {
+            "selectable_partitions": [],
+            "selected_partition_index": -1,
+            "selected_groups_label": ""
+        }
+
+        expected_user_partitions = [
+            {
+                "id": ENROLLMENT_TRACK_PARTITION_ID,
+                "name": "Enrollment Track Groups",
+                "scheme": "enrollment_track",
+                "groups": [
+                    {
+                        "id": 1,
+                        "name": "Audit",
+                        "selected": False,
+                        "deleted": False
+                    }
+                ]
+            }
+        ]
+
         expected_response = [
             {
                 "name": self.html_unit_first.display_name_with_default,
                 "block_id": str(self.html_unit_first.location),
+                "block_type": self.html_unit_first.location.block_type,
+                "user_partition_info": expected_user_partition_info,
+                "user_partitions": expected_user_partitions
             },
             {
                 "name": self.html_unit_second.display_name_with_default,
                 "block_id": str(self.html_unit_second.location),
+                "block_type": self.html_unit_second.location.block_type,
+                "user_partition_info": expected_user_partition_info,
+                "user_partitions": expected_user_partitions,
             },
         ]
         self.assertEqual(response.data["children"], expected_response)


### PR DESCRIPTION
**Settings**

```yaml
TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```

## Description
This PR addresses a need in the data for the "Manage access" modal. Right now we need JSON response for the "Restrict access to" (data + value) dropdown and 2 checkboxes (values). There is similar modal for "Unit settings"
<img width="618" alt="image" src="https://github.com/openedx/edx-platform/assets/26650868/49f0c125-8927-4b09-a83c-e23de420da37">
<img width="606" alt="image" src="https://github.com/openedx/edx-platform/assets/26650868/05ab95d5-7482-4600-ad57-d050c2b7109d">


This PR also includes:
- adding block type to `VerticalContainerView` handler. It needs to display type of xblock on the unit page.

## Testing instructions
1. Run master devstack.
2. Start platform `make dev.up.lms+cms` and make checkout on this branch.
3. Go to `http://localhost:18010/api-docs`.
4. Find the required API endpoint `/api/contentstore/v1/container/vertical/{usage_key_string}/children`.
5. Open needed unit page in cms `http://localhost:18010/container/{usage_key_string}` and make sure nothing has changed.
6. Copy `usage_key_string` from previous step and paste it to required API endpoint to get data for unit.