### PR TITLE
feat: [FC-0044] manage tags on block level

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -5,6 +5,7 @@ API Serializers for unit page
 from django.urls import reverse
 from rest_framework import serializers
 
+from cms.djangoapps.contentstore.toggles import use_tagging_taxonomy_list_page
 from cms.djangoapps.contentstore.helpers import (
     xblock_studio_url,
     xblock_type_display_name,
@@ -103,6 +104,19 @@ class ChildVerticalContainerSerializer(serializers.Serializer):
     block_type = serializers.CharField()
     user_partition_info = serializers.DictField()
     user_partitions = serializers.ListField()
+    actions = serializers.SerializerMethodField()
+
+    def get_actions(self, obj):  # pylint: disable=unused-argument
+        """
+        Method to get actions for each child xlock of the unit.
+        """
+
+        can_manage_tags = use_tagging_taxonomy_list_page()
+        actions = {
+            "can_manage_tags": can_manage_tags,
+        }
+
+        return actions
 
 
 class VerticalContainerSerializer(serializers.Serializer):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -3,8 +3,10 @@ Unit tests for the vertical block.
 """
 from django.urls import reverse
 from rest_framework import status
+from edx_toggles.toggles.testutils import override_waffle_flag
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.toggles import ENABLE_TAGGING_TAXONOMY_LIST_PAGE
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
 from xmodule.modulestore.django import (
     modulestore,
@@ -148,6 +150,7 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
         response = self.client.get(url)
         self.assertTrue(response.data["is_published"])
 
+    @override_waffle_flag(ENABLE_TAGGING_TAXONOMY_LIST_PAGE, True)
     def test_children_content(self):
         """
         Check that returns valid response with children of vertical container.
@@ -183,7 +186,10 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
                 "block_id": str(self.html_unit_first.location),
                 "block_type": self.html_unit_first.location.block_type,
                 "user_partition_info": expected_user_partition_info,
-                "user_partitions": expected_user_partitions
+                "user_partitions": expected_user_partitions,
+                "actions": {
+                    "can_manage_tags": True,
+                },
             },
             {
                 "name": self.html_unit_second.display_name_with_default,
@@ -191,6 +197,9 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
                 "block_type": self.html_unit_second.location.block_type,
                 "user_partition_info": expected_user_partition_info,
                 "user_partitions": expected_user_partitions,
+                "actions": {
+                    "can_manage_tags": True,
+                },
             },
         ]
         self.assertEqual(response.data["children"], expected_response)
@@ -204,4 +213,14 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
         )
         url = self.get_reverse_url(usage_key_string)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @override_waffle_flag(ENABLE_TAGGING_TAXONOMY_LIST_PAGE, False)
+    def test_actions_with_turned_off_taxonomy_flag(self):
+        """
+        Check that action manage_tags for each child item has the same value as taxonomy flag.
+        """
+        url = self.get_reverse_url(self.vertical.location)
+        response = self.client.get(url)
+        for children in response.data["children"]:
+            self.assertFalse(children["actions"]["can_manage_tags"])

--- a/cms/djangoapps/contentstore/rest_api/v1/views/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/vertical_block.py
@@ -192,6 +192,9 @@ class VerticalContainerView(APIView, ContainerHandlerMixin):
                     "block_type": "drag-and-drop-v2",
                     "user_partition_info": {},
                     "user_partitions": {}
+                    "actions": {
+                        "can_manage_tags": true,
+                    }
                 },
                 {
                     "name": "Video",
@@ -199,14 +202,20 @@ class VerticalContainerView(APIView, ContainerHandlerMixin):
                     "block_type": "video",
                     "user_partition_info": {},
                     "user_partitions": {}
+                    "actions": {
+                        "can_manage_tags": true,
+                    }
                 },
                 {
                     "name": "Text",
                     "block_id": "block-v1:org+101+101+type@html+block@3e3fa1f88adb4a108cd14e9002143690",
                     "block_type": "html",
                     "user_partition_info": {},
-                    "user_partitions": {}
-                }
+                    "user_partitions": {},
+                    "actions": {
+                        "can_manage_tags": true,
+                    }
+                },
             ],
             "is_published": false
         }


### PR DESCRIPTION
**Settings**

```yaml
TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```

## Description
Each component’s three dots menu on the Unit Page has a “Manage Tags” button that will open the tagging drawer. It controls by feature flag `new_studio_mfe.use_tagging_taxonomy_list_page`
<img width="295" alt="image" src="https://github.com/openedx/edx-platform/assets/26650868/dd94d7fc-4139-45be-9520-5fc235e6c837">

## Testing instructions
1. Run master devstack.
2. Start platform `make dev.up.lms+cms` and make checkout on this branch.
3. Go to `http://localhost:18010/api-docs`.
4. Find the required API endpoint `/api/contentstore/v1/container/vertical/{usage_key_string}/children`.
5. Copy `usage_key_string` from previous step and paste it to required API endpoint to get actions data for unit.