### PR TITLE
feat: update task and signals responsible for cert available dates in Credentials

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -11,7 +11,8 @@ from django.dispatch import Signal
 from django.dispatch.dispatcher import receiver
 
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_DATE_CHANGE
-from xmodule.modulestore.django import SignalHandler  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.data import CertificatesDisplayBehaviors
+from xmodule.modulestore.django import SignalHandler
 
 from .models import CourseOverview
 
@@ -30,8 +31,8 @@ DELETE_COURSE_DETAILS = Signal()
 @receiver(SignalHandler.course_published)
 def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=unused-argument
     """
-    Catches the signal that a course has been published in Studio and
-    updates the corresponding CourseOverview cache entry.
+    Catches the signal that a course has been published in Studio and updates the corresponding CourseOverview cache
+    entry.
     """
     try:
         previous_course_overview = CourseOverview.objects.get(id=course_key)
@@ -72,13 +73,37 @@ def trigger_import_course_details_signal(sender, instance, created, **kwargs):  
 
 
 def _check_for_course_changes(previous_course_overview, updated_course_overview):
+    """
+    Utility function responsible for calling other utility functions that check for specific changes in a course
+    overview after a course run has been updated and published.
+
+    Args:
+        previous_course_overview (CourseOverview): the current course overview instance for a particular course run
+        updated_course_overview (CourseOverview): an updated course overview instance, reflecting the current state of
+        data from the modulestore/Mongo
+
+    Returns:
+        None
+    """
     if previous_course_overview:
-        _check_for_course_date_changes(previous_course_overview, updated_course_overview)
+        _check_for_course_start_date_changes(previous_course_overview, updated_course_overview)
         _check_for_pacing_changes(previous_course_overview, updated_course_overview)
-        _check_for_cert_availability_date_changes(previous_course_overview, updated_course_overview)
+        _check_for_cert_date_changes(previous_course_overview, updated_course_overview)
 
 
-def _check_for_course_date_changes(previous_course_overview, updated_course_overview):
+def _check_for_course_start_date_changes(previous_course_overview, updated_course_overview):
+    """
+    Checks if a course run's start date has been updated. If so, we emit the `COURSE_START_DATE_CHANGED` signal to
+    ensure other parts of the system are aware of the change.
+
+    Args:
+        previous_course_overview (CourseOverview): the current course overview instance for a particular course run
+        updated_course_overview (CourseOverview): an updated course overview instance, reflecting the current state of
+        data from the modulestore/Mongo
+
+    Returns:
+        None
+    """
     if previous_course_overview.start != updated_course_overview.start:
         _log_start_date_change(previous_course_overview, updated_course_overview)
         COURSE_START_DATE_CHANGED.send(
@@ -88,21 +113,46 @@ def _check_for_course_date_changes(previous_course_overview, updated_course_over
         )
 
 
-def _log_start_date_change(previous_course_overview, updated_course_overview):  # lint-amnesty, pylint: disable=missing-function-docstring
+def _log_start_date_change(previous_course_overview, updated_course_overview):
+    """
+    Utility function to log a course run's start date when updating a course overview. This log only appears when the
+    start date has been changed (see the `_check_for_course_date_changes` function above).
+
+    Args:
+        previous_course_overview (CourseOverview): the current course overview instance for a particular course run
+        updated_course_overview (CourseOverview): an updated course overview instance, reflecting the current state of
+        data from the modulestore/Mongo
+
+    Returns:
+        None
+    """
     previous_start_str = 'None'
     if previous_course_overview.start is not None:
         previous_start_str = previous_course_overview.start.isoformat()
     new_start_str = 'None'
     if updated_course_overview.start is not None:
         new_start_str = updated_course_overview.start.isoformat()
-    LOG.info('Course start date changed: course={} previous={} new={}'.format(
-        updated_course_overview.id,
-        previous_start_str,
-        new_start_str,
-    ))
+    LOG.info(
+        f"Course start date changed: course={updated_course_overview.id} previous={previous_start_str} "
+        f"new={new_start_str}"
+    )
 
 
 def _check_for_pacing_changes(previous_course_overview, updated_course_overview):
+    """
+    Checks if a course run's pacing has been updated. If so, we emit the `COURSE_PACING_CHANGED` signal to ensure other
+    parts of the system are aware of the change. The `programs` and `certificates` apps listen for this signal in
+    order to manage certificate generation features in the LMS and certificate visibility settings in the Credentials
+    IDA.
+
+    Args:
+        previous_course_overview (CourseOverview): the current course overview instance for a particular course run
+        updated_course_overview (CourseOverview): an updated course overview instance, reflecting the current state of
+        data from the modulestore/Mongo
+
+    Returns:
+        None
+    """
     if previous_course_overview.self_paced != updated_course_overview.self_paced:
         COURSE_PACING_CHANGED.send(
             sender=None,
@@ -111,19 +161,58 @@ def _check_for_pacing_changes(previous_course_overview, updated_course_overview)
         )
 
 
-def _check_for_cert_availability_date_changes(previous_course_overview, updated_course_overview):
-    """ Checks if the cert available date has changed and if so, sends a COURSE_CERT_DATE_CHANGE signal"""
-    if previous_course_overview.certificate_available_date != updated_course_overview.certificate_available_date:
+def _check_for_cert_date_changes(previous_course_overview, updated_course_overview):
+    """
+    Checks if the certificate available date (CAD) or the certificates display behavior (CDB) of a course run has
+    changed during a course overview update. If so, we emit the COURSE_CERT_DATE_CHANGE signal to ensure other parts of
+    the system are aware of the change. The `credentials` app listens for this signal in order to keep our certificate
+    visibility settings in the Credentials IDA up to date.
+
+    Args:
+        previous_course_overview (CourseOverview): the current course overview instance for a particular course run
+        updated_course_overview (CourseOverview): an updated course overview instance, reflecting the current state of
+            data from the modulestore/Mongo
+
+    Returns:
+        None
+    """
+    def _send_course_cert_date_change_signal():
+        """
+        A callback used to fire the COURSE_CERT_DATE_CHANGE Django signal *after* the ORM has successfully commited the
+        update.
+        """
+        COURSE_CERT_DATE_CHANGE.send_robust(sender=None, course_key=str(updated_course_overview.id))
+
+    course_run_id = str(updated_course_overview.id)
+    prev_available_date = previous_course_overview.certificate_available_date
+    prev_display_behavior = previous_course_overview.certificates_display_behavior
+    prev_end_date = previous_course_overview.end  # `end_date` is a deprecated field, use `end` instead
+    updated_available_date = updated_course_overview.certificate_available_date
+    updated_display_behavior = updated_course_overview.certificates_display_behavior
+    updated_end_date = updated_course_overview.end  # `end_date` is a deprecated field, use `end` instead
+    send_signal = False
+
+    if prev_available_date != updated_available_date:
         LOG.info(
-            f"Certificate availability date for {str(updated_course_overview.id)} has changed from " +
-            f"{previous_course_overview.certificate_available_date} to " +
-            f"{updated_course_overview.certificate_available_date}. Sending COURSE_CERT_DATE_CHANGE signal."
+            f"The certificate available date for {course_run_id} has changed from {prev_available_date} to "
+            f"{updated_available_date}"
         )
+        send_signal = True
 
-        def _send_course_cert_date_change_signal():
-            COURSE_CERT_DATE_CHANGE.send_robust(
-                sender=None,
-                course_key=updated_course_overview.id,
-            )
+    if prev_display_behavior != updated_display_behavior:
+        LOG.info(
+            f"The certificates display behavior for {course_run_id} has changed from {prev_display_behavior} to "
+            f"{updated_display_behavior}"
+        )
+        send_signal = True
 
+    # edge case -- if a course run with a cert display behavior of "End date of course" has changed its end date, we
+    # should fire our signal to ensure visibility of certificates managed by the Credentials IDA are corrected too
+    if (updated_display_behavior == CertificatesDisplayBehaviors.END and prev_end_date != updated_end_date):
+        LOG.info(
+            f"The end date for {course_run_id} has changed from {prev_end_date} to {updated_end_date}."
+        )
+        send_signal = True
+
+    if send_signal:
         transaction.on_commit(_send_course_cert_date_change_signal)

--- a/openedx/core/djangoapps/credentials/api.py
+++ b/openedx/core/djangoapps/credentials/api.py
@@ -1,0 +1,15 @@
+"""
+Python APIs exposed by the credentials app to other in-process apps.
+"""
+
+
+from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+
+
+def is_credentials_enabled():
+    """
+    A utility function wrapping the `is_learner_issurance_enabled` utility function of the CredentialsApiConfig model.
+    Intended to be an easier to read/grok utility function that informs the caller if use of the Credentials IDA is
+    enabled for this Open edX instance.
+    """
+    return CredentialsApiConfig.current().is_learner_issuance_enabled

--- a/openedx/core/djangoapps/credentials/tests/test_api.py
+++ b/openedx/core/djangoapps/credentials/tests/test_api.py
@@ -1,0 +1,46 @@
+"""
+Tests for the utility functions defined as part of the credentials app's public Python API.
+"""
+
+
+from django.test import TestCase
+
+from openedx.core.djangoapps.credentials.api import is_credentials_enabled
+from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+from openedx.core.djangoapps.credentials.tests.mixins import CredentialsApiConfigMixin
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+class CredentialsApiTests(CredentialsApiConfigMixin, TestCase):
+    """
+    Tests for the Public Pyton API exposed by the credentials Django app.
+    """
+    def setUp(self):
+        super().setUp()
+        CredentialsApiConfig.objects.all().delete()
+
+    @skip_unless_lms
+    def test_is_credentials_enabled_config_enabled(self):
+        """
+        A test that verifies the output of the `is_credentials_enabled` utility function when a CredentialsApiConfig
+        exists and is enabled.
+        """
+        self.create_credentials_config(enabled=True)
+        assert is_credentials_enabled()
+
+    @skip_unless_lms
+    def test_is_credentials_enabled_config_disabled(self):
+        """
+        A test that verifies the output of the `is_credentials_enabled` utility function when a CredentialsApiConfig
+        exists and is disabled.
+        """
+        self.create_credentials_config(enabled=False)
+        assert not is_credentials_enabled()
+
+    @skip_unless_lms
+    def test_is_credentials_enabled_config_absent(self):
+        """
+        A test that verifies the output of the `is_credentials_enabled` utility function when a CredentialsApiConfig
+        does not exist.
+        """
+        assert not is_credentials_enabled()

--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -7,6 +7,8 @@ import logging
 
 from django.dispatch import receiver
 
+from openedx.core.djangoapps.content.course_overviews.signals import COURSE_PACING_CHANGED
+from openedx.core.djangoapps.credentials.api import is_credentials_enabled
 from openedx.core.djangoapps.credentials.helpers import is_learner_records_enabled_for_org
 from openedx.core.djangoapps.signals.signals import (
     COURSE_CERT_AWARDED,
@@ -21,41 +23,24 @@ LOGGER = logging.getLogger(__name__)
 @receiver(COURSE_CERT_AWARDED)
 def handle_course_cert_awarded(sender, user, course_key, mode, status, **kwargs):  # pylint: disable=unused-argument
     """
-    If programs is enabled and a learner is awarded a course certificate,
-    schedule a celery task to process any programs certificates for which
-    the learner may now be eligible.
+    If use of the Credentials IDA is enabled and a learner is awarded a course certificate, schedule a celery task to
+    determine if the learner is also eligible to be awarded any program certificates.
 
     Args:
-        sender:
-            class of the object instance that sent this signal
-        user:
-            django.contrib.auth.User - the user to whom a cert was awarded
-        course_key:
-            refers to the course run for which the cert was awarded
-        mode:
-            mode / certificate type, e.g. "verified"
-        status:
-            either "downloadable" or "generating"
+        sender: class of the object instance that sent this signal
+        user(User): The user to whom a course certificate was awarded
+        course_key(CourseLocator): The course run key for which the course certificate was awarded
+        mode(str): The "mode" of the course (e.g. Audit, Honor, Verified, etc.)
+        status(str): The status of the course certificate that was awarded (e.g. "downloadable")
 
     Returns:
         None
-
     """
-    # Import here instead of top of file since this module gets imported before
-    # the credentials app is loaded, resulting in a Django deprecation warning.
-    from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
-
-    # Avoid scheduling new tasks if certification is disabled.
-    if not CredentialsApiConfig.current().is_learner_issuance_enabled:
+    if not is_credentials_enabled():
         return
 
-    # schedule background task to process
     LOGGER.debug(
-        'handling COURSE_CERT_AWARDED: username=%s, course_key=%s, mode=%s, status=%s',
-        user,
-        course_key,
-        mode,
-        status,
+        f"Handling COURSE_CERT_AWARDED: user={user}, course_key={course_key}, mode={mode}, status={status}"
     )
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
     from openedx.core.djangoapps.programs.tasks import award_program_certificates
@@ -63,75 +48,43 @@ def handle_course_cert_awarded(sender, user, course_key, mode, status, **kwargs)
 
 
 @receiver(COURSE_CERT_CHANGED)
-def handle_course_cert_changed(sender, user, course_key, mode, status, **kwargs):
+def handle_course_cert_changed(sender, user, course_key, mode, status, **kwargs):  # pylint: disable=unused-argument
     """
-        If a learner is awarded a course certificate,
-        schedule a celery task to process that course certificate
+    When the system updates a course certificate, enqueue a celery task responsible for syncing this change in the
+    Credentials IDA
 
-        Args:
-            sender:
-                class of the object instance that sent this signal
-            user:
-                django.contrib.auth.User - the user to whom a cert was awarded
-            course_key:
-                refers to the course run for which the cert was awarded
-            mode:
-                mode / certificate type, e.g. "verified"
-            status:
-                "downloadable"
+    ***** Important *****
+    While the current name of the enqueue'd task is `award_course_certificate` it is *actually* responsible for both
+    awarding and revocation of course certificates in Credentials.
+    *********************
 
-        Returns:
-            None
+    Args:
+        sender: class of the object instance that sent this signal
+        user(User): The user to whom a course certificate was awarded
+        course_key(CourseLocator): The course run key for which the course certificate was awarded
+        mode(str): The "mode" of the course (e.g. Audit, Honor, Verified, etc.)
+        status(str): The status of the course certificate that was awarded (e.g. "downloadable")
+
+    Returns:
+        None
     """
-    # Import here instead of top of file since this module gets imported before
-    # the credentials app is loaded, resulting in a Django deprecation warning.
-    from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
-
     verbose = kwargs.get('verbose', False)
     if verbose:
-        msg = "Starting handle_course_cert_changed with params: "\
-            "sender [{sender}], "\
-            "user [{username}], "\
-            "course_key [{course_key}], "\
-            "mode [{mode}], "\
-            "status [{status}], "\
-            "kwargs [{kw}]"\
-            .format(
-                sender=sender,
-                username=getattr(user, 'username', None),
-                course_key=str(course_key),
-                mode=mode,
-                status=status,
-                kw=kwargs
-            )
+        LOGGER.info(
+            f"Starting handle_course_cert_changed with params: sender [{sender}], user [{user}], course_key "
+            f"[{course_key}], mode [{mode}], status [{status}], kwargs [{kwargs}]"
+        )
 
-        LOGGER.info(msg)
-
-    # Avoid scheduling new tasks if certification is disabled.
-    if not CredentialsApiConfig.current().is_learner_issuance_enabled:
-        if verbose:
-            LOGGER.info("Skipping send cert: is_learner_issuance_enabled False")
+    if not is_credentials_enabled():
         return
 
     # Avoid scheduling new tasks if learner records are disabled for this site (right now, course certs are only
     # used for learner records -- when that changes, we can remove this bit and always send course certs).
     if not is_learner_records_enabled_for_org(course_key.org):
-        if verbose:
-            LOGGER.info(
-                "Skipping send cert: ENABLE_LEARNER_RECORDS False for org [{org}]".format(
-                    org=course_key.org
-                )
-            )
+        LOGGER.warning(f"Skipping send cert: the Learner Record feature is disabled for org [{course_key.org}]")
         return
 
-    # schedule background task to process
-    LOGGER.debug(
-        'handling COURSE_CERT_CHANGED: username=%s, course_key=%s, mode=%s, status=%s',
-        user,
-        course_key,
-        mode,
-        status,
-    )
+    LOGGER.debug(f"Handling COURSE_CERT_CHANGED: user={user}, course_key={course_key}, mode={mode}, status={status}")
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
     from openedx.core.djangoapps.programs.tasks import award_course_certificate
     award_course_certificate.delay(user.username, str(course_key))
@@ -140,68 +93,76 @@ def handle_course_cert_changed(sender, user, course_key, mode, status, **kwargs)
 @receiver(COURSE_CERT_REVOKED)
 def handle_course_cert_revoked(sender, user, course_key, mode, status, **kwargs):  # pylint: disable=unused-argument
     """
-    If programs is enabled and a learner's course certificate is revoked,
-    schedule a celery task to revoke any related program certificates.
+    If use of the Credentials IDA is enabled and a learner has a course certificate revoked, schedule a celery task
+    to determine if there are any program certificates that must be revoked too.
 
     Args:
-        sender:
-            class of the object instance that sent this signal
-        user:
-            django.contrib.auth.User - the user for which a cert was revoked
-        course_key:
-            refers to the course run for which the cert was revoked
-        mode:
-            mode / certificate type, e.g. "verified"
-        status:
-            revoked
+        sender: class of the object instance that sent this signal
+        user(User): The user to whom a course certificate was revoked
+        course_key(CourseLocator): The course run key for which the course certificate was revoked
+        mode(str): The "mode" of the course (e.g. "audit", "honor", "verified", etc.)
+        status(str): The status of the course certificate that was revoked (e.g. "revoked")
 
     Returns:
         None
-
     """
-    # Import here instead of top of file since this module gets imported before
-    # the credentials app is loaded, resulting in a Django deprecation warning.
-    from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
-
-    # Avoid scheduling new tasks if certification is disabled.
-    if not CredentialsApiConfig.current().is_learner_issuance_enabled:
+    if not is_credentials_enabled():
         return
 
-    # schedule background task to process
-    LOGGER.info(
-        f"handling COURSE_CERT_REVOKED: user={user.id}, course_key={course_key}, mode={mode}, status={status}"
-    )
+    LOGGER.info(f"Handling COURSE_CERT_REVOKED: user={user}, course_key={course_key}, mode={mode}, status={status}")
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
     from openedx.core.djangoapps.programs.tasks import revoke_program_certificates
     revoke_program_certificates.delay(user.username, str(course_key))
 
 
 @receiver(COURSE_CERT_DATE_CHANGE, dispatch_uid='course_certificate_date_change_handler')
-def handle_course_cert_date_change(sender, course_key, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
+def handle_course_cert_date_change(sender, course_key, **kwargs):  # pylint: disable=unused-argument
     """
-    If a course-run's `certificate_available_date` is updated, schedule a celery task to update the `visible_date`
-    attribute of all (course) credentials awarded in the Credentials service.
+    When a course run's configuration has been updated, and the system has detected an update related to the display
+    behavior or availability date of the certificates issued in that course, we should enqueue celery tasks responsible
+    for:
+        - updating the `visible_date` attribute of any previously awarded certificates the Credentials IDA manages
+        - updating the certificate available date of the course run's course certificate configuration in Credentials
 
     Args:
-        course_key(CourseLocator): refers to the course whose certificate_available_date was updated.
-    """
-    # Import here instead of top of file since this module gets imported before the credentials app is loaded, resulting
-    # in a Django deprecation warning.
-    from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+        sender: class of the object instance that sent this signal
+        course_key(CourseLocator): The course run key of the course run which was updated
 
-    # Avoid scheduling new tasks if we're not using the Credentials IDA
-    if not CredentialsApiConfig.current().is_learner_issuance_enabled:
-        LOGGER.warning(
-            f"Skipping handling of COURSE_CERT_DATE_CHANGE for course {course_key}. Use of the Credentials service is "
-            "disabled."
-        )
+    Returns:
+        None
+    """
+    if not is_credentials_enabled():
         return
 
     LOGGER.info(f"Handling COURSE_CERT_DATE_CHANGE for course {course_key}")
     # import here, because signal is registered at startup, but items in tasks are not yet loaded
-    from openedx.core.djangoapps.programs.tasks import update_certificate_visible_date_on_course_update
     from openedx.core.djangoapps.programs.tasks import update_certificate_available_date_on_course_update
-    # update the awarded credentials `visible_date` attribute in the Credentials service after a date update
+    from openedx.core.djangoapps.programs.tasks import update_certificate_visible_date_on_course_update
     update_certificate_visible_date_on_course_update.delay(str(course_key))
-    # update the (course) certificate configuration in the Credentials service after a date update
     update_certificate_available_date_on_course_update.delay(str(course_key))
+
+
+@receiver(COURSE_PACING_CHANGED, dispatch_uid="update_credentials_on_pacing_change")
+def handle_course_pacing_change(sender, updated_course_overview, **kwargs):  # pylint: disable=unused-argument
+    """
+    If the pacing of a course run has been updated, we should enqueue the tasks responsible for updating the certificate
+    available date (CAD) stored in the Credentials IDA's internal records. This ensures that we are correctly managing
+    the visibiltiy of certificates on learners' program records.
+
+    Args:
+        sender: class of the object instance that sent this signal
+        updated_course_overview(CourseOverview): The course overview of the course run which was just updated
+
+    Returns:
+        None
+    """
+    if not is_credentials_enabled():
+        return
+
+    course_id = str(updated_course_overview.id)
+    LOGGER.info(f"Handling COURSE_PACING_CHANGED for course {course_id}")
+    # import here, because signal is registered at startup, but items in tasks are not yet loaded
+    from openedx.core.djangoapps.programs.tasks import update_certificate_available_date_on_course_update
+    from openedx.core.djangoapps.programs.tasks import update_certificate_visible_date_on_course_update
+    update_certificate_available_date_on_course_update.delay(course_id)
+    update_certificate_visible_date_on_course_update.delay(course_id)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

[APER-3229]

The monolith and the Credentials IDA keep independent records of a course runs certificate availability/visibility preferences. This PR aims to improve the communication between the monolith and the Credentiala IDA to keep the availability date/preference in sync with the monoliths records.

The current code is too strict and actually prevents valid updates in some configurations.

Additionally, the Credentials IDA doesn't understand the concept of "course pacing" (instructor-paced vs self-paced) and has troubles with courses with an availability date of "end". Instead of having to add the concept of course pacing (and syncing more data between the two systems), this PR proposes sending the end date of a course as the "certificate available date" to Credentials.

This way, the Credentials IDA can manage the visibility of awarded credentials in a course run with a display behavior of "end" using the existing feature set and models of the Credentials service.