### PR TITLE
docs: Update README with new Mongo Version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Services:
 
 * MySQL 5.7
 
-* Mongo 4.x
+* Mongo 7.x
 
 * Memcached
 


### PR DESCRIPTION
Support was verified via https://github.com/openedx/edx-platform/pull/34213
but we forgot to update the README with this info.