### PR TITLE
feat: warn when relative dates are past due and can't be shifted

### DIFF
--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -68,7 +68,8 @@ from openedx.core.djangolib.markup import HTML, Text
           </span>
           <span class="sr">(${submit_disabled_cta['description']})</span>
         % else:
-            <form class="submit-cta" method="post" action="${submit_disabled_cta['link']}">
+          <form class="submit-cta" method="post" action="${submit_disabled_cta.get('link')}">
+            % if submit_disabled_cta.get('link'):
               <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
               % for form_name, form_value in submit_disabled_cta['form_values'].items():
                   <input type="hidden" name="${form_name}" value="${form_value}">
@@ -76,13 +77,14 @@ from openedx.core.djangolib.markup import HTML, Text
               <button class="submit-cta-link-button btn-link btn-small">
                 ${submit_disabled_cta['link_name']}
               </button>
-              <span class="submit-cta-description" tabindex="0" role="note" aria-label="description">
-                <span data-tooltip="${submit_disabled_cta['description']}" data-tooltip-show-on-click="true"
-                  class="fa fa-info-circle fa-lg" aria-hidden="true">
-                </span>
+            % endif
+            <span class="submit-cta-description" tabindex="0" role="note" aria-label="description">
+              <span data-tooltip="${submit_disabled_cta['description']}" data-tooltip-show-on-click="true"
+                class="fa fa-info-circle fa-lg" aria-hidden="true">
               </span>
-              <span class="sr">(${submit_disabled_cta['description']})</span>
-            </form>
+            </span>
+            <span class="sr">(${submit_disabled_cta['description']})</span>
+          </form>
         % endif
       % endif
       <div class="submission-feedback ${'cta-enabled' if submit_disabled_cta else ''}" id="submission_feedback_${short_id}">

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -44,7 +44,7 @@ from openedx.core.djangolib.markup import HTML
         <div class="banner-cta-button">
             <button class="btn btn-outline-primary" onclick="emit_event(${vertical_banner_cta['event_data']})">${vertical_banner_cta['link_name']}</button>
         </div>
-      % else:
+      % elif vertical_banner_cta.get('link'):
         <div class="banner-cta-button">
           <form method="post" action="${vertical_banner_cta['link']}">
             <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -141,12 +141,18 @@ def get_start_block(block):
     return get_start_block(first_child)
 
 
-def dates_banner_should_display(course_key, user):
+def dates_banner_should_display(course_key, user, allow_warning=False):
     """
     Return whether or not the reset banner should display,
     determined by whether or not a course has any past-due,
     incomplete sequentials and which enrollment mode is being
     dealt with for the current user and course.
+
+    Args:
+        course_key (CourseKey)
+        user (User)
+        allow_warning (bool): whether to ignore relative_dates_disable_reset_flag, in order to render
+            warnings for past-due incomplete units.
 
     Returns:
         (missed_deadlines, missed_gated_content):
@@ -156,7 +162,7 @@ def dates_banner_should_display(course_key, user):
     if not RELATIVE_DATES_FLAG.is_enabled(course_key):
         return False, False
 
-    if RELATIVE_DATES_DISABLE_RESET_FLAG.is_enabled(course_key):
+    if RELATIVE_DATES_DISABLE_RESET_FLAG.is_enabled(course_key) and not allow_warning:
         # The `missed_deadlines` value is ignored by `reset_course_deadlines` views. Instead, they check the value of
         # `missed_gated_content` to determine if learners can reset the deadlines by themselves.
         # We could have added this logic directly to `reset_self_paced_schedule`, but this function is used in other


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

When the `course_experience.relative_dates_disable_reset` flag is set to true in self paced courses, warnings that otherwise allowed learners to shift deadlines don't appear. This PRs shows warnings in this case, with the sole difference of not allowing to shift dates.

Useful information to include:
- Which edX user roles will this change impact?: Learner

## Testing instructions

1. Add the following [Waffle Flags](http://localhost:18000/admin/waffle/flag/) (with `Everyone: Yes`):
   
   1. `studio.custom_relative_dates`
   2. `course_experience.relative_dates`
   3. `course_experience.relative_dates_disable_reset`

2. Go to [Course_Date_Signals -> Self paced relative dates configs](http://localhost:18000/admin/course_date_signals/selfpacedrelativedatesconfig/) and add a config with `Enabled: Yes`.

3. Create a new course in Studio.

4. Go to `Settings -> Schedule & Details` and set the pacing to `Self-Paced`. Click "Save Changes".

5. Set a past `Course Start Date`. Click "Save Changes".

6. Create a new subsection in the course. Mark it as graded as "Homework" and set "Due in" to 1 week.

7. Create a Problem Block (e.g., Checkboxes) in the subsection and publish it.

8. Log in as an `audit` user and enroll yourself in a course.

9. As an admin, go to [Schedules -> Schedules](http://localhost:18000/admin/schedules/schedule) and find the schedule for the `audit` user in this new course. Change the `Start date` to a year ago and `Save`.

10. As an `audit` user, visit the Problem and check that there's a warning about not being able to shift the relative dates (see screenshot bellow), that the `Submit` button can no longer be enabled, and that should be a "Past due" pill near the due date above this Problem.

12. You should also see these deadlines on the Course Outline page.

13. Set the `course_experience.relative_dates_disable_reset` to `No`

14. Revisit the Problem with the `audit` user. Check that the warning now lets you shift the relative dates. (second screenshot)


## Screenshots

`course_experience.relative_dates_disable_reset` set to false:
![image](https://github.com/openedx/edx-platform/assets/19278837/009d1a73-065a-42c9-881b-17b659fb6afb)

`course_experience.relative_dates_disable_reset` set to true (old behavior, but still good to check):
![image](https://github.com/openedx/edx-platform/assets/19278837/8d1aafad-f906-4020-8338-c6cbd349bd78)

Not past due date:
![image](https://github.com/openedx/edx-platform/assets/19278837/56a78b05-502d-4ef4-8d18-fcbedaab7bdb)


Private-ref: [BB-8542](https://tasks.opencraft.com/browse/BB-8542)