### PR TITLE
feat!: Upgrade SciPy and Numpy

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -48,9 +48,6 @@ django-webpack-loader==0.7.0
 # version of py2neo will work with Neo4j 3.5.
 py2neo<2022
 
-# scipy version 1.8 requires numpy>=1.17.3, we've pinned numpy to <1.17.0 in requirements/edx-sandbox/py38.in
-scipy<1.8.0
-
 # edx-enterprise, snowflake-connector-python require charset-normalizer==2.0.0
 # Can be removed once snowflake-connector-python>2.7.9 is released with the fix.
 charset-normalizer<2.1.0

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -49,7 +49,7 @@ nltk==3.8.1
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   chem
     #   contourpy

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -76,9 +76,8 @@ random2==1.0.2
     # via -r requirements/edx-sandbox/py38.in
 regex==2023.12.25
     # via nltk
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py38.in
     #   chem
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -745,7 +745,7 @@ nltk==3.8.1
     # via chem
 nodeenv==1.8.0
     # via -r requirements/edx/kernel.in
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   chem
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1035,9 +1035,8 @@ s3transfer==0.10.0
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   chem
     #   openedx-calc
 semantic-version==2.10.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1789,9 +1789,8 @@ sailthru-client==2.2.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   chem

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1245,7 +1245,7 @@ nodeenv==1.8.0
     #   -r requirements/edx/assets.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1223,9 +1223,8 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -876,7 +876,7 @@ nltk==3.8.1
     #   chem
 nodeenv==1.8.0
     # via -r requirements/edx/base.txt
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   -r requirements/edx/base.txt
     #   chem

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -933,7 +933,7 @@ nltk==3.8.1
     #   chem
 nodeenv==1.8.0
     # via -r requirements/edx/base.txt
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   -r requirements/edx/base.txt
     #   chem

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1349,9 +1349,8 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc


### PR DESCRIPTION
Scipy was constrained to prevent a numpy upgrade however the numpy
upgrade happened a while ago and this never got updated. Now the scipy
version is preventing us from going to an even newer numpy version that
would be compatible with both Python 3.8 and Python 3.12

BREAKING CHANGE: This will update scipy in the codejail sandbox from
1.7.3 to a newer version.  This contains many backwards incompatible
changes that are all documented in the SciPy changelogs:
https://docs.scipy.org/doc/scipy/release/1.8.0-notes.html

BREAKING CHANGE: Because numpy is available in the codejail sandbox, the
update from 1.22.4 to 1.24.4 does have completed deprecations, and more
details can be found in the Numpy Release Notes:
https://numpy.org/doc/stable/release/1.23.0-notes.html#expired-deprecations