### PR TITLE
feanil/test on 3.11

### DIFF
--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.8', '3.11']
         os: ['ubuntu-20.04']
 
     steps:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         node-version: [ 18 ]
-        python-version: [ 3.8 ]
+        python-version: [ '3.8', '3.11' ]
 
     steps:
 

--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Install system requirements
         run: sudo apt update && sudo apt install -y libxmlsec1-dev

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ '3.8', '3.11' ]
         # 'pinned' is used to install the latest patch version of Django
         # within the global constraint i.e. Django==4.2.8 in current case
-        # because we have global constraint of Django<4.2 
+        # because we have global constraint of Django<4.2
         django-version: ["pinned"]
         mongo-version: ["4", "7"]
         mysql-version: ["8"]
@@ -115,7 +115,7 @@ jobs:
         ./manage.py lms migrate
         echo "Running the CMS migrations."
         ./manage.py cms migrate
-  
+
   # This job aggregates test results. It's the required check for branch protection.
   # https://github.com/marketplace/actions/alls-green#why
   # https://github.com/orgs/community/discussions/33579

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Get pip cache dir
         id: pip-cache-dir

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ '3.8', '3.11' ]
         node-version: [ 18 ]
 
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-20.04" ]
-        python-version: [ "3.8" ]
+        python-version: [ "3.8", '3.11' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ '3.8', '3.11' ]
         node-version: [ 18 ]
         npm-version: [ 10.5.x ]
         mongo-version: ["4.4", "7.0"]

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.8', '3.11' ]
         django-version:
           - "pinned"
         # When updating the shards, remember to make the same changes in

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.11' ]
         django-version:
           - "pinned"
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         python-version:
           - "3.8"
+          - "3.11"
         django-version:
           - "pinned"
         # When updating the shards, remember to make the same changes in

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,14 +57,19 @@ jobs:
             sudo apt-get update && sudo apt-get install -y mongodb-org="${{ matrix.mongo-version }}.*"
           fi
 
-      - name: checkout repo
-        uses: actions/checkout@v3
-
       - name: start mongod server for tests
         run: |
           sudo mkdir -p /data/db
           sudo chmod -R a+rw /data/db
           mongod &
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: checkout repo
+        uses: actions/checkout@v3
 
       - name: install requirements
         run: |

--- a/.github/workflows/units-test-scripts-structures-pruning.yml
+++ b/.github/workflows/units-test-scripts-structures-pruning.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8', '3.12' ]
+        python-version: [ '3.8', '3.11', '3.12' ]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/units-test-scripts-user-retirement.yml
+++ b/.github/workflows/units-test-scripts-user-retirement.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.8', '3.11', '3.12']
 
     steps:
       - name: Checkout code

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -48,9 +48,6 @@ django-webpack-loader==0.7.0
 # version of py2neo will work with Neo4j 3.5.
 py2neo<2022
 
-# scipy version 1.8 requires numpy>=1.17.3, we've pinned numpy to <1.17.0 in requirements/edx-sandbox/py38.in
-scipy<1.8.0
-
 # edx-enterprise, snowflake-connector-python require charset-normalizer==2.0.0
 # Can be removed once snowflake-connector-python>2.7.9 is released with the fix.
 charset-normalizer<2.1.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -130,3 +130,6 @@ moto<5.0
 # path==16.12.0 breaks the unit test collections check
 # needs to be investigated and fixed separately
 path<16.12.0
+
+# Temporary to Support the python 3.11 Upgrade
+backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -49,7 +49,7 @@ nltk==3.8.1
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   chem
     #   contourpy

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -76,9 +76,8 @@ random2==1.0.2
     # via -r requirements/edx-sandbox/base.in
 regex==2024.4.16
     # via nltk
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/base.in
     #   chem
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -55,7 +55,7 @@ babel==2.14.0
     #   enmerkar-underscore
 backoff==1.10.0
     # via analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/edx/../constraints.txt
     #   celery

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,6 +57,7 @@ backoff==1.10.0
     # via analytics-python
 backports-zoneinfo[tzdata]==0.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   celery
     #   django
     #   edx-milestones
@@ -1045,9 +1046,8 @@ s3transfer==0.10.0
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   chem
     #   openedx-calc
 semantic-version==2.10.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -748,7 +748,7 @@ nltk==3.8.1
     # via chem
 nodeenv==1.8.0
     # via -r requirements/edx/kernel.in
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   chem
     #   openedx-calc

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -113,6 +113,7 @@ backoff==1.10.0
     #   analytics-python
 backports-zoneinfo[tzdata]==0.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   celery
@@ -1797,9 +1798,8 @@ sailthru-client==2.2.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   chem

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1247,7 +1247,7 @@ nodeenv==1.8.0
     #   -r requirements/edx/assets.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -111,7 +111,7 @@ backoff==1.10.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -78,7 +78,7 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -881,7 +881,7 @@ nltk==3.8.1
     #   chem
 nodeenv==1.8.0
     # via -r requirements/edx/base.txt
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   -r requirements/edx/base.txt
     #   chem

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -80,6 +80,7 @@ backoff==1.10.0
     #   analytics-python
 backports-zoneinfo[tzdata]==0.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   celery
     #   django
@@ -1239,9 +1240,8 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -78,7 +78,7 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -936,7 +936,7 @@ nltk==3.8.1
     #   chem
 nodeenv==1.8.0
     # via -r requirements/edx/base.txt
-numpy==1.22.4
+numpy==1.24.4
     # via
     #   -r requirements/edx/base.txt
     #   chem

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -80,6 +80,7 @@ backoff==1.10.0
     #   analytics-python
 backports-zoneinfo[tzdata]==0.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   celery
     #   django
@@ -1360,9 +1361,8 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.7.3
+scipy==1.10.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -10,8 +10,9 @@ attrs==23.2.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-backports-zoneinfo==0.2.1
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
+    #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
     #   django
     #   pendulum
 boto3==1.34.26

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -14,7 +14,7 @@ attrs==23.2.0
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-backports-zoneinfo==0.2.1
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, quality
+envlist = py{38,311} quality
 
 # This is needed to prevent the lms, cms, and openedx packages inside the "Open
 # edX" package (defined in setup.py) from getting installed into site-packages


### PR DESCRIPTION
This PR adds testing for python 3.11 wherever possible alongside python 3.8. 

Major updates include the unpinning and upgrade fo SciPy and Numpy in both the platform requirements as well as the codejail (edx-sandbox) requirements.  If you are using the latest edx-sandbox/base.txt to operate codejail environments, this may break your instructor code that utilizes sci-py/numpy.
