### PR TITLE
feat: support the core enrollment API's force_enrollment flag from enterprise_support

### DIFF
--- a/openedx/features/enterprise_support/enrollments/utils.py
+++ b/openedx/features/enterprise_support/enrollments/utils.py
@@ -28,6 +28,7 @@ def lms_update_or_create_enrollment(
     desired_mode,
     is_active,
     enterprise_uuid=None,
+    force_enrollment=False,
 ):
     """
     Update or create the user's course enrollment based on the existing enrollment mode.
@@ -50,6 +51,9 @@ def lms_update_or_create_enrollment(
      - is_active (bool): A Boolean value that indicates whether the
         enrollment is to be set to inactive (if False). Usually we want a True if enrolling anew.
      - enterprise_uuid (str): Optional. id to identify the enterprise to enroll under
+     - force_enrollment (bool):
+         Enroll user even if course enrollment_end date is expired (default False). This only has an effect when the
+         enrollment is being created, not when it is only updated.
 
     Returns: A serializable dictionary of the new or updated course enrollment. If it hits
      CourseEnrollmentError or CourseEnrollmentNotUpdatableError, it raises those exceptions.
@@ -105,6 +109,7 @@ def lms_update_or_create_enrollment(
                     is_active=is_active,
                     enrollment_attributes=None,
                     enterprise_uuid=enterprise_uuid,
+                    force_enrollment=force_enrollment,
                 )
                 if not response:
                     log.exception(


### PR DESCRIPTION
This enables enterprise-specific callers trying to create lms enrollments to be able to create enrollments even after the enrollment deadline. The target use case for this feature is the enterprise bulk enrollment endpoint in edx-enterprise. In turn, the ultimate goal is to support "late enrollments" from enterprise Learner Credit.

ENT-8525

This is one of three PRs which percolate this single boolean through multiple layers of code, all the way down to the core LMS enrollment API:

1. https://github.com/openedx/enterprise-subsidy/pull/219
2. https://github.com/openedx/edx-enterprise/pull/2048
3. [YOU ARE HERE] https://github.com/openedx/edx-platform/pull/34376