### PR TITLE
docs: document ENABLE_HIDE_FROM_TOC_UI feature toggle

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -551,6 +551,17 @@ FEATURES = {
     #   https://github.com/openedx/openedx-events/issues/265
     # .. toggle_tickets: https://github.com/edx/edx-arch-experiments/issues/381
     'ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS': False,
+
+    # .. toggle_name: FEATURES['ENABLE_HIDE_FROM_TOC_UI']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: When enabled, exposes hide_from_toc xblock attribute so course authors can configure it as
+    # a section visibility option in Studio.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-02-29
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33952
+    'ENABLE_HIDE_FROM_TOC_UI': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -556,10 +556,9 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: When enabled, exposes hide_from_toc xblock attribute so course authors can configure it as
-    # a section visibility option in Studio.
+    #  a section visibility option in Studio.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2024-02-29
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33952
     'ENABLE_HIDE_FROM_TOC_UI': False,
 }


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds documentation for the `ENABLE_HIDE_FROM_TOC_UI` feature toggle so it can be extracted by the feature toggle sphinx plugin.
