### PR TITLE
fix: avoid removing Open_edX.egg-info/ with `git clean` | FC-0012

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ pull_xblock_translations:  ## pull xblock translations via atlas
 
 pull_translations: ## pull translations via atlas
 	# Clean up the existing translations
-	git clean -fdX conf/locale conf/plugins-locale */static/js/i18n/ */static/js/xblock.v1-i18n/
-
+	git clean -fdX conf/locale
+	rm -rf conf/plugins-locale cms/static/js/i18n/ lms/static/js/i18n/ cms/static/js/xblock.v1-i18n/ lms/static/js/xblock.v1-i18n/
 	make pull_xblock_translations
 	make pull_plugin_translations
 	atlas pull $(ATLAS_OPTIONS) \


### PR DESCRIPTION
git clean when used with glob pattern (*/) removes non-translations files.

using `$ rm` to fix the issue.

Related to issue reported by @timmc-edx https://github.com/openedx/edx-platform/pull/34355/files#r1525457187 .

### Testing
### Run the new command multiple times
It keeps `Open_edX.egg-info/`

```
edx-platform# rm -rf conf/plugins-locale cms/static/js/i18n/ lms/static/js/i18n/ cms/static/js/xblock.v1-i18n/ lms/static/js/xblock.v1-i18n/
edx-platform# git clean -fdX conf/locale
edx-platform# rm -rf conf/plugins-locale cms/static/js/i18n/ lms/static/js/i18n/ cms/static/js/xblock.v1-i18n/ lms/static/js/xblock.v1-i18n/
edx-platform# git clean -fdX conf/locale
edx-platform# rm -rf conf/plugins-locale cms/static/js/i18n/ lms/static/js/i18n/ cms/static/js/xblock.v1-i18n/ lms/static/js/xblock.v1-i18n/
edx-platform# ll Open_edX.egg-info/
total 40
drwxr-xr-x  2 app root 4096 Feb 20 08:53 ./
drwxrwx--- 23 app  138 4096 Mar 15 12:29 ../
-rw-r--r--  1 app root    1 Feb 20 08:53 dependency_links.txt
-rw-r--r--  1 app root 9265 Feb 20 08:53 entry_points.txt
-rw-r--r--  1 app root   99 Feb 20 08:53 PKG-INFO
-rw-r--r--  1 app root   11 Feb 20 08:53 requires.txt
-rw-r--r--  1 app root 1654 Feb 20 08:53 SOURCES.txt
-rw-r--r--  1 app root   31 Feb 20 08:53 top_level.txt
```

### Run the old commmand
It removes `Open_edX.egg-info/`, confirming the faulty behavior.

```
edx-platform $ git clean -fdX conf/locale conf/plugins-locale */static/js/i18n/ */static/js/xblock.v1-i18n/
Removing .prereqs_cache/
Removing .pytest_cache/
Removing .tox/
Removing Open_edX.egg-info/
Removing cms/static/css/
Removing common/static/bundles/
Removing common/static/common/css/vendor/
Removing common/static/common/js/vendor/
Removing lms/static/certificates/css/
Removing lms/static/css/bootstrap/
Removing lms/static/css/discussion/
Removing node_modules/
Removing openedx/core/djangoapps/cache_toolbox/__pycache__/
```

### Refs
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
