### PR TITLE
fix: replace resize event with ResizeObserver in xblock iframe

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -209,7 +209,9 @@ ${HTML(fragment.foot_html())}
       observer.observe(document.body, { attributes: true, childList: true, subtree: true });
 
       window.addEventListener('load', dispatchResizeMessage);
-      window.addEventListener('resize', dispatchResizeMessage);
+
+      const resizeObserver = new ResizeObserver(dispatchResizeMessage);
+      resizeObserver.observe(document.body);
     }
   }());
 </script>


### PR DESCRIPTION
## Description

When a Xblock is shown in the learning MFE, its iframe relies on the `resize` event to inform the MFE about height and width changes. This poses a problem because the [resize event](https://developer.mozilla.org/en-US/docs/Web/API/Window/resize_event) is only triggered when the `window`'s size changes, but not other elements. This can result in an iframe whose height doesn't account for all its content and thus have hidden elements.
## Supporting information
BB-8736

## Testing instructions
- In CMS, upload an image with generous dimensions so you can use it in your xblock. 
- Create a blank problem with the following content:
```
<problem>
<multiplechoiceresponse>
  <p>Test Test Test Test? </p>
<choicegroup type="MultipleChoice">
    <choice correct="false">A. Top 3</choice>
    <choice correct="false">B. Middle (4th to 7th)</choice>
    <choice correct="true">C. Bottom 4 (8th to 11th)</choice>
  </choicegroup>
<solution>
<div class="detailed-solution">
<p>Explanation</p>
<img src="/static/Your_Cool_Image_830x550.png" height="auto" alt=""/>
</div>
</solution>
</multiplechoiceresponse>
</problem>
```
- Access the unit containing the problem in the Learning MFE then click on `Show Answer`.

You should only see part of the image. The MFE is not notified on the `body`'s resize because the event only reacts to the `window`'s resize. You can confirm this if you resize your browser's window in a manner such as the iframe is also resized, the image will be fully displayed.


# Screenshots
<details><summary>Test image and its display in the xblock iframe</summary>

<img width="323" alt="test_table" src="https://github.com/openedx/edx-platform/assets/28169169/6cd40a26-a3e9-4950-b076-02be066c8cb1">


![Screenshot from 2024-03-19 08-42-40](https://github.com/openedx/edx-platform/assets/28169169/c14f51fa-d4ba-4f9c-96af-11997238911d)



</details>