### PR TITLE
feat: [FC-0044] textbooks API DRF

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
@@ -14,6 +14,7 @@ from .proctoring import (
     ProctoringErrorsSerializer
 )
 from .settings import CourseSettingsSerializer
+from .textbooks import CourseTextbooksSerializer
 from .videos import (
     CourseVideosSerializer,
     VideoUploadSerializer,

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/textbooks.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/textbooks.py
@@ -1,0 +1,32 @@
+"""
+API Serializers for textbooks page
+"""
+
+from rest_framework import serializers
+
+
+class CourseTextbookChapterSerializer(serializers.Serializer):
+    """
+    Serializer for representing textbook chapter.
+    """
+
+    title = serializers.CharField()
+    url = serializers.CharField()
+
+
+class CourseTextbookItemSerializer(serializers.Serializer):
+    """
+    Serializer for representing textbook item.
+    """
+
+    id = serializers.CharField()
+    chapters = CourseTextbookChapterSerializer(many=True)
+    tab_title = serializers.CharField()
+
+
+class CourseTextbooksSerializer(serializers.Serializer):
+    """
+    Serializer for representing course's textbooks.
+    """
+
+    textbooks = serializers.ListField()

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/textbooks.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/textbooks.py
@@ -29,4 +29,4 @@ class CourseTextbooksSerializer(serializers.Serializer):
     Serializer for representing course's textbooks.
     """
 
-    textbooks = serializers.ListField()
+    textbooks = CourseTextbookItemSerializer(many=True)

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -9,6 +9,7 @@ from .views import (
     ContainerHandlerView,
     CourseDetailsView,
     CourseTeamView,
+    CourseTextbooksView,
     CourseIndexView,
     CourseGradingView,
     CourseRerunView,
@@ -102,6 +103,11 @@ urlpatterns = [
         fr'^course_rerun/{COURSE_ID_PATTERN}$',
         CourseRerunView.as_view(),
         name="course_rerun"
+    ),
+    re_path(
+        fr'^textbooks/{COURSE_ID_PATTERN}$',
+        CourseTextbooksView.as_view(),
+        name="textbooks"
     ),
     re_path(
         fr'^container_handler/{settings.USAGE_KEY_PATTERN}$',

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -9,6 +9,7 @@ from .grading import CourseGradingView
 from .proctoring import ProctoredExamSettingsView, ProctoringErrorsView
 from .home import HomePageView, HomePageCoursesView, HomePageLibrariesView
 from .settings import CourseSettingsView
+from .textbooks import CourseTextbooksView
 from .videos import (
     CourseVideosView,
     VideoUsageView,

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_textbooks.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_textbooks.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for the course's textbooks.
+"""
+from django.urls import reverse
+from rest_framework import status
+
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+
+from ...mixins import PermissionAccessMixin
+
+
+class CourseTextbooksViewTest(CourseTestCase, PermissionAccessMixin):
+    """
+    Tests for CourseTextbooksView.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(
+            "cms.djangoapps.contentstore:v1:textbooks",
+            kwargs={"course_id": self.course.id},
+        )
+
+    def test_success_response(self):
+        """
+        Check that endpoint is valid and success response.
+        """
+        expected_textbook = [
+            {
+                "tab_title": "Textbook Name",
+                "chapters": [
+                    {"title": "Chapter 1", "url": "/static/book.pdf"},
+                    {"title": "Chapter 2", "url": "/static/story.pdf"},
+                ],
+                "id": "Textbook_Name",
+            }
+        ]
+        self.course.pdf_textbooks = expected_textbook
+        self.save_course()
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["textbooks"], expected_textbook)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -121,7 +121,7 @@ class ContainerHandlerViewTest(BaseXBlockContainer):
         )
         url = self.get_reverse_url(usage_key_string)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class ContainerVerticalViewTest(BaseXBlockContainer):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/textbooks.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/textbooks.py
@@ -1,0 +1,90 @@
+""" API Views for course textbooks """
+
+import edx_api_doc_tools as apidocs
+from opaque_keys.edx.keys import CourseKey
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from cms.djangoapps.contentstore.utils import get_textbooks_context
+from cms.djangoapps.contentstore.rest_api.v1.serializers import (
+    CourseTextbooksSerializer,
+)
+from common.djangoapps.student.auth import has_studio_read_access
+from openedx.core.lib.api.view_utils import (
+    DeveloperErrorViewMixin,
+    verify_course_exists,
+    view_auth_classes,
+)
+from xmodule.modulestore.django import modulestore
+
+
+@view_auth_classes(is_authenticated=True)
+class CourseTextbooksView(DeveloperErrorViewMixin, APIView):
+    """
+    View for course textbooks page.
+    """
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                "course_id", apidocs.ParameterLocation.PATH, description="Course ID"
+            ),
+        ],
+        responses={
+            200: CourseTextbooksSerializer,
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    @verify_course_exists()
+    def get(self, request: Request, course_id: str):
+        """
+        Get an object containing course's textbooks.
+
+        **Example Request**
+
+            GET /api/contentstore/v1/textbooks/{course_id}
+
+        **Response Values**
+
+        If the request is successful, an HTTP 200 "OK" response is returned.
+
+        The HTTP 200 response contains a single dict that contains keys that
+        are the course's textbooks.
+
+        **Example Response**
+
+        ```json
+        {
+            "textbooks": [
+                {
+                    "tab_title": "Textbook Name",
+                    "chapters": [
+                        {
+                            "title": "Chapter 1",
+                            "url": "/static/Present_Perfect.pdf"
+                        },
+                        {
+                            "title": "Chapter 2",
+                            "url": "/static/Lear.pdf"
+                        }
+                    ],
+                    "id": "Textbook_Name"
+                }
+            ]
+        }
+        ```
+        """
+        course_key = CourseKey.from_string(course_id)
+        store = modulestore()
+
+        if not has_studio_read_access(request.user, course_key):
+            self.permission_denied(request)
+
+        with store.bulk_operations(course_key):
+            course = modulestore().get_course(course_key)
+            textbooks_context = get_textbooks_context(course)
+            serializer = CourseTextbooksSerializer(textbooks_context)
+            return Response(serializer.data)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2016,6 +2016,22 @@ def get_container_handler_context(request, usage_key, course, xblock):  # pylint
     return context
 
 
+def get_textbooks_context(course):
+    """
+    Utils is used to get context for textbooks for course.
+    It is used for both DRF and django views.
+    """
+
+    upload_asset_url = reverse_course_url('assets_handler', course.id)
+    textbook_url = reverse_course_url('textbooks_list_handler', course.id)
+    return {
+        'context_course': course,
+        'textbooks': course.pdf_textbooks,
+        'upload_asset_url': upload_asset_url,
+        'textbook_url': textbook_url,
+    }
+
+
 class StudioPermissionsService:
     """
     Service that can provide information about a user's permissions.

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -92,7 +92,8 @@ from ..toggles import (
     use_new_updates_page,
     use_new_advanced_settings_page,
     use_new_grading_page,
-    use_new_schedule_details_page
+    use_new_schedule_details_page,
+    use_new_textbooks_page,
 )
 from ..utils import (
     add_instructor,
@@ -110,6 +111,8 @@ from ..utils import (
     get_grading_url,
     get_schedule_details_url,
     get_course_rerun_context,
+    get_textbooks_context,
+    get_textbooks_url,
     initialize_permissions,
     remove_all_instructors,
     reverse_course_url,
@@ -1466,14 +1469,10 @@ def textbooks_list_handler(request, course_key_string):
 
         if "application/json" not in request.META.get('HTTP_ACCEPT', 'text/html'):
             # return HTML page
-            upload_asset_url = reverse_course_url('assets_handler', course_key)
-            textbook_url = reverse_course_url('textbooks_list_handler', course_key)
-            return render_to_response('textbooks.html', {
-                'context_course': course,
-                'textbooks': course.pdf_textbooks,
-                'upload_asset_url': upload_asset_url,
-                'textbook_url': textbook_url,
-            })
+            if use_new_textbooks_page(course_key):
+                return redirect(get_textbooks_url(course_key))
+            textbooks_context = get_textbooks_context(course)
+            return render_to_response('textbooks.html', textbooks_context)
 
         # from here on down, we know the client has requested JSON
         if request.method == 'GET':


### PR DESCRIPTION
**Settings**

```yaml
TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_textbooks_page
    everyone: true
```

## Description
This PR addresses a need in the development of the Course Textbooks Page feature within the **frontend-app-course-authoring** repository. The core objective is the implement of a DRF endpoint designed to render and deliver textbooks data for course.

## Learn about textbooks:
-  **open edX** - https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/textbooks.html

## Textbooks Pages:
1. Legacy cms - `http://localhost:18010/textbooks/{location}`.
2. MFE - `http://localhost:2001/course/{location}/pages-and-resources/textbooks`.

## Testing API instructions:
1. Run master devstack.
2. Start platform `make dev.up.lms+cms` and make checkout on this branch.
3. Go to `http://localhost:18010/api-docs`.
4. Find the required API endpoint `/api/contentstore/v1/textbooks/{location}`.

## Testing MFE instructions:
1. Run master devstack.
2. Start platform `make dev.up.lms+cms+frontend-app-course-authoring` and make checkout on this branch.
3. Enable the **MFE Textbooks Page** feature by adding a waffle flag `contentstore.new_studio_mfe.use_new_textbooks_page` on the `http://localhost:18010/admin/waffle/flag/`
4. Go to `http://localhost:2001/course/{location}/pages-and-resources/textbooks`.

### Related PR's:
- [x] Waffle flags for MFE - https://github.com/openedx/edx-platform/pull/34338
- [ ] MFE textbooks page - https://github.com/openedx/frontend-app-course-authoring/pull/890

### Textbooks issue
https://github.com/openedx/platform-roadmap/issues/319
