### PR TITLE
revert: feat: Added XblockMixin for skill tagging

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -977,10 +977,15 @@ P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.x_module import XModuleMixin
 
-# These are the Mixins that should be added to every XBlock.
-# This should be moved into an XBlock Runtime/Application object
-# once the responsibility of XBlock creation is moved out of modulestore - cpennington
+# These are the Mixins that will be added to every Blocklike upon instantiation.
+# DO NOT EXPAND THIS LIST!! We want it eventually to be EMPTY. Why? Because dynamically adding functions/behaviors to
+# objects at runtime is confusing for both developers and static tooling (pylint/mypy). Instead...
+#  - to add special Blocklike behaviors just for your site: override `XBLOCK_EXTRA_MIXINS` with your own XBlockMixins.
+#  - to add new functionality to all Blocklikes: add it to the base Blocklike class in the core openedx/XBlock repo.
 XBLOCK_MIXINS = (
+    # TODO: For each of these, either
+    #  (a) merge their functionality into the base Blocklike class, or
+    #  (b) refactor their functionality out of the Blocklike objects and into the edx-platform block runtimes.
     LmsBlockMixin,
     InheritanceMixin,
     XModuleMixin,
@@ -988,6 +993,12 @@ XBLOCK_MIXINS = (
     AuthoringMixin,
     TaggedBlockMixin,
 )
+
+# .. setting_name: XBLOCK_EXTRA_MIXINS
+# .. setting_default: ()
+# .. setting_description: Custom mixins that will be dynamically added to every XBlock and XBlockAside instance.
+#     These can be classes or dotted-path references to classes.
+#     For example: `XBLOCK_EXTRA_MIXINS = ('my_custom_package.my_module.MyCustomMixin',)`
 XBLOCK_EXTRA_MIXINS = ()
 
 # Paths to wrapper methods which should be applied to every XBlock's FieldData.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -67,10 +67,6 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
 from openedx.core.lib.derived import derived, derived_collection_entry
 from openedx.core.release import doc_version
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
-try:
-    from skill_tagging.skill_tagging_mixin import SkillTaggingMixin
-except ImportError:
-    SkillTaggingMixin = None
 
 ################################### FEATURES ###################################
 # .. setting_name: PLATFORM_NAME
@@ -1645,8 +1641,6 @@ XBLOCK_MIXINS = (
     XModuleMixin,
     EditInfoMixin,
 )
-if SkillTaggingMixin:
-    XBLOCK_MIXINS += (SkillTaggingMixin,)
 
 # .. setting_name: XBLOCK_EXTRA_MIXINS
 # .. setting_default: ()

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1631,12 +1631,28 @@ from xmodule.modulestore.edit_info import EditInfoMixin  # lint-amnesty, pylint:
 from xmodule.modulestore.inheritance import InheritanceMixin  # lint-amnesty, pylint: disable=wrong-import-order, wrong-import-position
 from xmodule.x_module import XModuleMixin  # lint-amnesty, pylint: disable=wrong-import-order, wrong-import-position
 
-# These are the Mixins that should be added to every XBlock.
-# This should be moved into an XBlock Runtime/Application object
-# once the responsibility of XBlock creation is moved out of modulestore - cpennington
-XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin, XModuleMixin, EditInfoMixin)
+# These are the Mixins that will be added to every Blocklike upon instantiation.
+# DO NOT EXPAND THIS LIST!! We want it eventually to be EMPTY. Why? Because dynamically adding functions/behaviors to
+# objects at runtime is confusing for both developers and static tooling (pylint/mypy). Instead...
+#  - to add special Blocklike behaviors just for your site: override `XBLOCK_EXTRA_MIXINS` with your own XBlockMixins.
+#  - to add new functionality to all Blocklikes: add it to the base Blocklike class in the core openedx/XBlock repo.
+XBLOCK_MIXINS = (
+    # TODO: For each of these, either
+    #  (a) merge their functionality into the base Blocklike class, or
+    #  (b) refactor their functionality out of the Blocklike objects and into the edx-platform block runtimes.
+    LmsBlockMixin,
+    InheritanceMixin,
+    XModuleMixin,
+    EditInfoMixin,
+)
 if SkillTaggingMixin:
     XBLOCK_MIXINS += (SkillTaggingMixin,)
+
+# .. setting_name: XBLOCK_EXTRA_MIXINS
+# .. setting_default: ()
+# .. setting_description: Custom mixins that will be dynamically added to every XBlock and XBlockAside instance.
+#     These can be classes or dotted-path references to classes.
+#     For example: `XBLOCK_EXTRA_MIXINS = ('my_custom_package.my_module.MyCustomMixin',)`
 XBLOCK_EXTRA_MIXINS = ()
 
 # .. setting_name: XBLOCK_FIELD_DATA_WRAPPERS

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1208,7 +1208,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/paver.txt
-xblock[django]==1.10.0
+xblock[django]==3.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2171,7 +2171,7 @@ wrapt==1.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-xblock[django]==1.10.0
+xblock[django]==3.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1466,7 +1466,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/base.txt
-xblock[django]==1.10.0
+xblock[django]==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1590,7 +1590,7 @@ wrapt==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   astroid
-xblock[django]==1.10.0
+xblock[django]==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/xmodule/modulestore/tests/test_api.py
+++ b/xmodule/modulestore/tests/test_api.py
@@ -46,7 +46,7 @@ def test_get_xblock_root_module_name():
 
     mixed_done_xblock = runtime.construct_xblock_from_class(DoneXBlock, Mock())
 
-    assert mixed_done_xblock.__module__ == 'xblock.internal'  # Mixed classes has a runtime generated module name.
+    assert mixed_done_xblock.__module__ == 'xblock.core'
     assert mixed_done_xblock.unmixed_class == DoneXBlock, 'The unmixed_class property retains the original property.'
 
     assert get_xblock_root_module_name(mixed_done_xblock) == 'done'

--- a/xmodule/modulestore/tests/test_inheritance.py
+++ b/xmodule/modulestore/tests/test_inheritance.py
@@ -15,7 +15,7 @@ from xblock.test.tools import TestRuntime
 from xmodule.modulestore.inheritance import InheritanceMixin
 
 
-class TestXBlock:
+class TestXBlock(XBlock):
     """
     An empty Xblock, to be used, when creating a block with mixins.
     """

--- a/xmodule/tests/xml/factories.py
+++ b/xmodule/tests/xml/factories.py
@@ -9,7 +9,6 @@ from tempfile import mkdtemp
 from factory import Factory, Sequence, lazy_attribute, post_generation
 from fs.osfs import OSFS
 from lxml import etree
-from xblock.mixins import HierarchyMixin
 
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.x_module import XModuleMixin
@@ -70,7 +69,7 @@ class XmlImportFactory(Factory):
         model = XmlImportData
 
     filesystem = OSFS(mkdtemp())
-    xblock_mixins = (InheritanceMixin, XModuleMixin, HierarchyMixin)
+    xblock_mixins = (InheritanceMixin, XModuleMixin)
     url_name = Sequence(str)
     attribs = {}
     policy = {}


### PR DESCRIPTION
DRAFT -- This is blocked by https://github.com/openedx/edx-platform/pull/34231.

## Description

This reverts commit https://github.com/openedx/edx-platform/commit/0b7e27390c1769adaa09c6b1a05f6c6a8d2104bf , added in:
* https://github.com/openedx/edx-platform/pull/34130

We remove SkillTaggingMixin from common.py's XBLOCK_MIXINS because:

* Skill tagging did not go through product review, so its code should
  not be referenced in a core repository like edx-platform.

* The skill_tagging package is not a listed dependency of
  edx-platform, so it should not be referenced in edx-platform,
  regardless of whether it technically can be imported using a
  try-except clause.

* Adding new classes to XBLOCK_MIXINS is strongly discouraged
  (although, to be fair, this guidance did not exist when
   SkillTaggingMixin was added; it was SkillTaggingMixin that made
   us realize we needed to add the guidance).

## Migration steps for operators

Fortunately, the XBLOCK_EXTRA_MIXINS Django setting exists for
this exact purpose. Site operators who wish to use skill tagging
can do so with these steps.

1. Install skill_tagging as a private edx-platform requirement.
2. Set XBLOCK_EXTRA_MIXINS to a list or tuple containing the string:
   'skill_tagging.skill_tagging_mixin.SkillTaggingMixin'

## Merge deadline

We will merge this on **Tuesday April 16th** so that it is fixed before the Redwood cut.

2U devs -- please apply the migration steps to your internal settings and verify ahead of that date. Let us know if you need any help or clarification! We can also merge on an earlier date if that's better--let us know when you're ready.