### PR TITLE
feat: add authn mfe in csrf trusted origins list

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -314,6 +314,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:3001',  # frontend-app-library-authoring
     'http://localhost:2001',  # frontend-app-course-authoring
     'http://localhost:1992',  # frontend-app-ora
+    'http://localhost:1999',  # frontend-app-authn
 ]
 
 #################### Event bus backend ########################

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -559,6 +559,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:1992',  # frontend-app-ora
     'http://localhost:2002',  # frontend-app-discussions
     'http://localhost:1991',  # frontend-app-admin-portal
+    'http://localhost:1999',  # frontend-app-authn
 ]
 
 


### PR DESCRIPTION
Adding on to https://github.com/openedx/edx-platform/pull/34192, add [frontend-app-authn](https://github.com/openedx/frontend-app-authn) (http://localhost:1999) to the list of CSRF trusted origins for devstack. 