### PR TITLE
fix: cohorts api permissions

### DIFF
--- a/openedx/core/djangoapps/course_groups/permissions.py
+++ b/openedx/core/djangoapps/course_groups/permissions.py
@@ -8,7 +8,7 @@ from rest_framework import permissions
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR
 )
-from common.djangoapps.student.roles import GlobalStaff
+from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff, CourseInstructorRole
 from lms.djangoapps.discussion.django_comment_client.utils import get_user_role_names
 
 
@@ -19,15 +19,17 @@ class IsStaffOrAdmin(permissions.BasePermission):
 
     def has_permission(self, request, view):
         """Returns true if the user is admin or staff and request method is GET."""
+        if GlobalStaff().has_user(request.user) or request.user.is_superuser:
+            return True
         course_key = CourseKey.from_string(view.kwargs.get('course_key_string'))
         user_roles = get_user_role_names(request.user, course_key)
-        is_user_staff = bool(user_roles & {
+        has_discussion_privileges = bool(user_roles & {
             FORUM_ROLE_ADMINISTRATOR,
             FORUM_ROLE_MODERATOR,
             FORUM_ROLE_COMMUNITY_TA,
         })
         return (
-            GlobalStaff().has_user(request.user) or
-            request.user.is_staff or
-            is_user_staff and request.method == "GET"
+            CourseInstructorRole(course_key).has_user(request.user) or
+            CourseStaffRole(course_key).has_user(request.user) or
+            has_discussion_privileges and request.method == "GET"
         )


### PR DESCRIPTION
## Description

We've discovered a bug while using the Gradebook MFE - users with course staff/instructor roles can create and manage cohorts in the course's Instructor tab BUT they can't use the cohorts filter and the API request returns 403
<img width="835" alt="Screenshot 2024-03-20 at 15 31 07" src="https://github.com/openedx/edx-platform/assets/47273130/87e64209-b4f3-413a-9a04-90885110e1a8">

The issue isn't reproducible for the Global Staff role's users as well as for **users with Forum Moderator roles assigned**.

## Decision
Considering that the course staff/instructor has most of the permissions for the course data manipulation I decided to:
- Fix lack of the permissions for course staff/instructor roles. 
- Allow course staff/admin users to use cohorts API.

## Steps To Reproduce
- create a course
- assign any user without Global Staff or Superuser permissions a course staff or course instructor (aka course admin) role
- navigate to the course's Instructor tab > cohorts > enable and create any number of cohorts for the course. You can use both Global Staff or course staff user.
- switch to the course staff/instructor user
- navigate to the course's Instructor tab > Student Admin > click View Gradebook
- inspect the browser console and try to use the Cohorts filter

## Expected Result
Course Staff/Instructor users can use the Cohorts filter on the Gradebook MFE and there is no 403 error for the `.../cohorts/` API call in the browser console.
![image](https://github.com/openedx/edx-platform/assets/47273130/933876e1-4c43-4cdd-998e-c8c10798429d)

## Notes
- The Discussions MFE behavior was not affected. 
Interestingly, only those users who have the Forum Moderator roles assigned can create discussion posts separated by cohorts. 
Even the Global Staff has no such option!
Anyway, it is out of the scope and I left it as it is.
<img width="1207" alt="Screenshot 2024-03-20 at 15 50 55" src="https://github.com/openedx/edx-platform/assets/47273130/36eee0da-1c73-40af-846b-a8dd1e5390c9">



