### PR TITLE
fix: validation error for empty Batch Enrollment/Beta Tester to Quince

### DIFF
--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -503,14 +503,20 @@ such that the value can be defined later than this assignment (file load order).
                 }));
                 $idsList = $('<ul/>');
                 $taskResSection.append($idsList);
-                for (j = 0, len1 = ids.length; j < len1; j++) {
-                    identifier = ids[j];
-                    $idsList.append($('<li/>', {
-                        text: identifier
-                    }));
-                }
+                if (ids && ids.length > 0) {
+                    for (j = 0, len1 = ids.length; j < len1; j++) {
+                        identifier = ids[j];
+                        $idsList.append($('<li/>', {
+                            text: identifier
+                        }));
+                    }
+                } 
                 return displayResponse.$task_response.append($taskResSection);
             };
+            if (errors.length === 0 && successes.length === 0 && noUsers.length === 0) {
+                // Translators: For cases when the input field is empty;
+                renderList(gettext('This field must not be blank'), []);
+            }
             if (successes.length && dataFromServer.action === 'add') {
                 var j, len1, inActiveUsers, activeUsers; // eslint-disable-line vars-on-top
                 activeUsers = [];
@@ -585,6 +591,9 @@ such that the value can be defined later than this assignment (file load order).
                         sr = noUsers[j];
                         results.push(sr.identifier);
                     }
+                    results.unshift(
+                        gettext('Users must create and activate their account before they can be promoted to beta tester.')
+                    );
                     return results;
                 }()));
             }
@@ -699,14 +708,28 @@ such that the value can be defined later than this assignment (file load order).
                 }));
                 $idsList = $('<ul/>');
                 $taskResSection.append($idsList);
-                for (h = 0, len3 = ids.length; h < len3; h++) {
-                    identifier = ids[h];
-                    $idsList.append($('<li/>', {
-                        text: identifier
-                    }));
+                if (ids && ids.length > 0) {
+                    for (h = 0, len3 = ids.length; h < len3; h++) {
+                        identifier = ids[h];
+                        $idsList.append($('<li/>', {
+                            text: identifier
+                        }));
+                    }
                 }
                 return displayResponse.$task_response.append($taskResSection);
             };
+            if (
+                invalidIdentifier.length === 0
+                && errors.length === 0
+                && enrolled.length === 0
+                && allowed.length === 0
+                && autoenrolled.length === 0
+                && notenrolled.length === 0
+                && notunenrolled.length === 0
+            ) {
+                // Translators: For cases when the input field is empty;
+                renderList(gettext('This field must not be blank'), []);
+            }
             if (invalidIdentifier.length) {
                 renderList(gettext('The following email addresses and/or usernames are invalid:'), (function() {
                     var m, len4, results;


### PR DESCRIPTION
**This is a [backport](https://github.com/openedx/edx-platform/pull/32684) from the master.**

## Description

[Instructor Dashboard > Membership] Validation error for "empty" Batch Enrollment, Batch Beta Tester Addition fields is absent

Steps to Reproduce:
  1. Go to the Instructor Dashboard > Membership
  2. Leave input field for Batch Enrollment empty
  3. Click on [Enroll] button

![screen_14](https://github.com/openedx/edx-platform/assets/98233552/4a8a9193-36c5-4642-8d4c-223ccba688e6)

![screen_15](https://github.com/openedx/edx-platform/assets/98233552/42c426a5-80f1-43e8-90ce-120c223d1dc4)

Another bug found:

- if you add invalid users to Batch Enrollment:

<img width="1393" alt="screen_12" src="https://github.com/openedx/edx-platform/assets/98233552/02e24a07-b1f8-4757-beef-413db5e644af">

- if you add invalid users to Batch Beta Tester Addition:

<img width="1393" alt="screen_13" src="https://github.com/openedx/edx-platform/assets/98233552/c006b6cc-b44d-427b-8574-ecbd31e624d7">

#### Now everything works correctly:

<img width="983" alt="screen_16" src="https://github.com/openedx/edx-platform/assets/98233552/b64a5a66-d71e-4150-88d1-0f90ffaa79db">

<img width="1385" alt="screen_17" src="https://github.com/openedx/edx-platform/assets/98233552/f6159db7-32de-471a-85f3-986350b3a66c">



