### PR TITLE
feat: api function to delete learner's course grades

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -535,18 +535,24 @@ class PersistentSubsectionGrade(TimeStampedModel):
         return f"subsection_grades_cache.{course_id}"
 
     @classmethod
-    def clear_grade(cls, user_id, course_key):
+    def delete_subsection_grades_for_learner(cls, user_id, course_key):
         """
         Clears Subsection grade override for a learner in a course
         Arguments:
             user_id: The user associated with the desired grade
             course_id: The id of the course associated with the desired grade
         """
-        deleted_count, _ = cls.objects.filter(
-            user_id=user_id,
-            course_id=course_key,
-        ).delete()
-        cls.clear_prefetched_data(course_key)
+        try:
+            deleted_count, deleted_obj = cls.objects.filter(
+                user_id=user_id,
+                course_id=course_key,
+            ).delete()
+            get_cache(cls._CACHE_NAMESPACE)[cls._cache_key(course_key)].pop(user_id)
+            if deleted_obj['grades.PersistentSubsectionGradeOverride'] is not None:
+                PersistentSubsectionGradeOverride.clear_prefetched_overrides_for_learner(user_id, course_key)
+        except KeyError:
+            pass
+
         return deleted_count
 
 
@@ -697,16 +703,18 @@ class PersistentCourseGrade(TimeStampedModel):
         events.course_grade_calculated(grade)
 
     @classmethod
-    def clear_grade(cls, course_id, user_id):
+    def delete_course_grade_for_learner(cls, course_id, user_id):
         """
         Clears course grade for a learner in a course
         Arguments:
             course_id: The id of the course associated with the desired grade
             user_id: The user associated with the desired grade
         """
-        deleted_count, _ = cls.objects.filter(user_id=user_id, course_id=course_id).delete()
-        cls.clear_prefetched_data(course_id)
-        return deleted_count
+        try:
+            cls.objects.get(user_id=user_id, course_id=course_id).delete()
+            get_cache(cls._CACHE_NAMESPACE)[cls._cache_key(course_id)].pop(user_id)
+        except (PersistentCourseGrade.DoesNotExist, KeyError):
+            pass
 
     @staticmethod
     def _emit_openedx_persistent_grade_summary_changed_event(course_id, user_id, grade):
@@ -857,15 +865,5 @@ class PersistentSubsectionGradeOverride(models.Model):
         return cleaned_data
 
     @classmethod
-    def clear_override(cls, user_id, course_key):
-        """
-        Clears Subsection grade override for a learner in a course
-        Arguments:
-            user_id: The user associated with the desired grade
-            course_id: The id of the course associated with the desired grade
-        """
-        total, _ = cls.objects.filter(
-            grade__user_id=user_id,
-            grade__course_id=course_key
-        ).delete()
-        return total
+    def clear_prefetched_overrides_for_learner(cls, user_id, course_key):
+        get_cache(cls._CACHE_NAMESPACE).pop((user_id, str(course_key)), None)

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -537,7 +537,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
     @classmethod
     def delete_subsection_grades_for_learner(cls, user_id, course_key):
         """
-        Clears Subsection grade override for a learner in a course
+        Clears Subsection grades and overrides for a learner in a course
         Arguments:
             user_id: The user associated with the desired grade
             course_id: The id of the course associated with the desired grade

--- a/lms/djangoapps/grades/models_api.py
+++ b/lms/djangoapps/grades/models_api.py
@@ -107,9 +107,5 @@ def clear_user_course_grades(user_id, course_key):
     Given a user_id and course_key, clears persistent grades for a learner in a course
     """
     with transaction.atomic():
-        try:
-            _PersistentSubsectionGrade.delete_subsection_grades_for_learner(user_id, course_key)
-            _PersistentCourseGrade.delete_course_grade_for_learner(course_key, user_id)
-            return 'Grades deleted Successfully'
-        except Exception as e:  # pylint: disable=broad-except
-            return f'Error deleting grades: {str(e)}'
+        _PersistentSubsectionGrade.delete_subsection_grades_for_learner(user_id, course_key)
+        _PersistentCourseGrade.delete_course_grade_for_learner(course_key, user_id)

--- a/lms/djangoapps/grades/models_api.py
+++ b/lms/djangoapps/grades/models_api.py
@@ -108,9 +108,8 @@ def clear_user_course_grades(user_id, course_key):
     """
     with transaction.atomic():
         try:
-            _PersistentSubsectionGradeOverride.clear_override(user_id, course_key)
-            _PersistentSubsectionGrade.clear_grade(user_id, course_key)
-            _PersistentCourseGrade.clear_grade(course_key, user_id)
+            _PersistentSubsectionGrade.delete_subsection_grades_for_learner(user_id, course_key)
+            _PersistentCourseGrade.delete_course_grade_for_learner(course_key, user_id)
             return 'Grades deleted Successfully'
         except Exception as e:  # pylint: disable=broad-except
             return f'Error deleting grades: {str(e)}'

--- a/lms/djangoapps/grades/tests/test_api.py
+++ b/lms/djangoapps/grades/tests/test_api.py
@@ -176,6 +176,7 @@ class ClearGradeTests(ModuleStoreTestCase):
         self.assertIsNotNone(override_obj)
 
         api.clear_user_course_grades(self.user.id, self.course.id)
+
         with self.assertRaises(PersistentCourseGrade.DoesNotExist):
             PersistentCourseGrade.read(self.user.id, self.course.id)
 
@@ -218,12 +219,10 @@ class ClearGradeTests(ModuleStoreTestCase):
 
     @patch('lms.djangoapps.grades.models_api._PersistentSubsectionGrade')
     @patch('lms.djangoapps.grades.models_api._PersistentCourseGrade')
-    @patch('lms.djangoapps.grades.models_api._PersistentSubsectionGradeOverride')
-    def test_assert_clear_grade_methods_called(self, mock_override, mock_course_grade, mock_subsection_grade):
+    def test_assert_clear_grade_methods_called(self, mock_course_grade, mock_subsection_grade):
         api.clear_user_course_grades(self.user.id, self.course.id)
-        mock_override.clear_override.assert_called_with(self.user.id, self.course.id)
-        mock_course_grade.clear_grade.assert_called_with(self.course.id, self.user.id)
-        mock_subsection_grade.clear_grade.assert_called_with(self.user.id, self.course.id)
+        mock_course_grade.delete_course_grade_for_learner.assert_called_with(self.course.id, self.user.id)
+        mock_subsection_grade.delete_subsection_grades_for_learner.assert_called_with(self.user.id, self.course.id)
 
     @patch('lms.djangoapps.grades.models_api._PersistentSubsectionGrade')
     @patch('lms.djangoapps.grades.models_api._PersistentCourseGrade')

--- a/lms/djangoapps/grades/tests/test_api.py
+++ b/lms/djangoapps/grades/tests/test_api.py
@@ -1,13 +1,17 @@
 """ Tests calling the grades api directly """
 
 
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import ddt
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.grades import api
-from lms.djangoapps.grades.models import PersistentSubsectionGrade, PersistentSubsectionGradeOverride
+from lms.djangoapps.grades.models import (
+    PersistentSubsectionGrade,
+    PersistentSubsectionGradeOverride,
+    PersistentCourseGrade
+)
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -56,7 +60,7 @@ class OverrideSubsectionGradeTests(ModuleStoreTestCase):
 
     def tearDown(self):
         super().tearDown()
-        PersistentSubsectionGradeOverride.objects.all().delete()  # clear out all previous overrides
+        PersistentSubsectionGradeOverride.objects.all().delete()
 
     @ddt.data(0.0, None, 3.0)
     def test_override_subsection_grade(self, earned_graded):
@@ -108,3 +112,127 @@ class OverrideSubsectionGradeTests(ModuleStoreTestCase):
             else:
                 assert history_entry.history_user is None
                 assert history_entry.history_user_id is None
+
+
+class ClearGradeTests(ModuleStoreTestCase):
+    """
+    Tests for the clearing grades api call
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = UserFactory()
+        cls.overriding_user = UserFactory()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(org='edX', number='DemoX', display_name='Demo_Course', run='Spring2019')
+        self.subsection = BlockFactory.create(parent=self.course, category="sequential", display_name="Subsection")
+        self.grade = PersistentSubsectionGrade.update_or_create_grade(
+            user_id=self.user.id,
+            course_id=self.course.id,
+            usage_key=self.subsection.location,
+            first_attempted=None,
+            visible_blocks=[],
+            earned_all=6.0,
+            possible_all=6.0,
+            earned_graded=5.0,
+            possible_graded=5.0
+        )
+        self.params = {
+            "user_id": self.user.id,
+            "course_id": self.course.id,
+            "course_version": "JoeMcEwing",
+            "percent_grade": 77.7,
+            "letter_grade": "Great job",
+            "passed": True,
+        }
+        PersistentCourseGrade.update_or_create(**self.params)
+
+    def tearDown(self):
+        super().tearDown()
+        PersistentSubsectionGradeOverride.objects.all().delete()  # clear out all previous overrides
+
+    def test_clear_user_course_grades(self):
+        api.override_subsection_grade(
+            self.user.id,
+            self.course.id,
+            self.subsection.location,
+            overrider=self.overriding_user,
+            earned_graded=0.0,
+            comment='Test Override Comment',
+        )
+        override_obj = api.get_subsection_grade_override(
+            self.user.id,
+            self.course.id,
+            self.subsection.location
+        )
+        course_grade = PersistentCourseGrade.read(self.user.id, self.course.id)
+        self.assertIsNotNone(course_grade)
+        self.assertIsNotNone(override_obj)
+
+        api.clear_user_course_grades(self.user.id, self.course.id)
+        with self.assertRaises(PersistentCourseGrade.DoesNotExist):
+            PersistentCourseGrade.read(self.user.id, self.course.id)
+
+        with self.assertRaises(PersistentSubsectionGrade.DoesNotExist):
+            api.get_subsection_grade_override(
+                self.user.id,
+                self.course.id,
+                self.subsection.location
+            )
+
+    def test_clear_wrong_user_course_grades(self):
+        wrong_user = UserFactory()
+        api.override_subsection_grade(
+            self.user.id,
+            self.course.id,
+            self.subsection.location,
+            overrider=self.overriding_user,
+            earned_graded=0.0,
+            comment='Test Override Comment',
+        )
+        override_obj = api.get_subsection_grade_override(
+            self.user.id,
+            self.course.id,
+            self.subsection.location
+        )
+        course_grade = PersistentCourseGrade.read(self.user.id, self.course.id)
+        self.assertIsNotNone(course_grade)
+        self.assertIsNotNone(override_obj)
+
+        api.clear_user_course_grades(wrong_user.id, self.course.id)
+
+        after_clear_override_obj = api.get_subsection_grade_override(
+            self.user.id,
+            self.course.id,
+            self.subsection.location
+        )
+        after_clear_course_grade = PersistentCourseGrade.read(self.user.id, self.course.id)
+        self.assertIsNotNone(after_clear_override_obj)
+        self.assertIsNotNone(after_clear_course_grade)
+
+    @patch('lms.djangoapps.grades.models_api._PersistentSubsectionGrade')
+    @patch('lms.djangoapps.grades.models_api._PersistentCourseGrade')
+    @patch('lms.djangoapps.grades.models_api._PersistentSubsectionGradeOverride')
+    def test_assert_clear_grade_methods_called(self, mock_override, mock_course_grade, mock_subsection_grade):
+        api.clear_user_course_grades(self.user.id, self.course.id)
+        mock_override.clear_override.assert_called_with(self.user.id, self.course.id)
+        mock_course_grade.clear_grade.assert_called_with(self.course.id, self.user.id)
+        mock_subsection_grade.clear_grade.assert_called_with(self.user.id, self.course.id)
+
+    @patch('lms.djangoapps.grades.models_api._PersistentSubsectionGrade')
+    @patch('lms.djangoapps.grades.models_api._PersistentCourseGrade')
+    def test_assert_clear_grade_exception(self, mock_course_grade, mock_subsection_grade):
+        with patch(
+            'lms.djangoapps.grades.models_api._PersistentSubsectionGradeOverride',
+            Mock(side_effect=Exception)
+        ) as mock_override:
+            api.clear_user_course_grades(self.user.id, self.course.id)
+            self.assertRaises(Exception, mock_override)
+            self.assertFalse(mock_course_grade.called)
+            self.assertFalse(mock_subsection_grade.called)

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -348,7 +348,9 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
 
     def test_clear_subsection_grade(self):
         PersistentSubsectionGrade.update_or_create_grade(**self.params)
-        deleted = PersistentSubsectionGrade.clear_grade(self.user.id, self.course_key)
+        deleted = PersistentSubsectionGrade.delete_subsection_grades_for_learner(
+            self.user.id, self.course_key
+        )
         self.assertEqual(deleted, 1)
 
     def test_clear_subsection_grade_override(self):
@@ -360,8 +362,8 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
             earned_graded_override=0.0,
             feature=GradeOverrideFeatureEnum.gradebook,
         )
-        deleted = PersistentSubsectionGradeOverride.clear_override(self.user.id, self.course_key)
-        self.assertEqual(deleted, 1)
+        deleted = PersistentSubsectionGrade.delete_subsection_grades_for_learner(self.user.id, self.course_key)
+        self.assertEqual(deleted, 2)
 
 
 @ddt.ddt
@@ -533,8 +535,11 @@ class PersistentCourseGradesTest(GradesModelTestCase):
         PersistentCourseGrade.update_or_create(**self.params)
         PersistentCourseGrade.update_or_create(**another_params)
 
-        deleted_user_grades = PersistentCourseGrade.clear_grade(self.course_key, self.params['user_id'])
-        another_user_grade = PersistentCourseGrade.read(another_params['user_id'], self.course_key)
+        PersistentCourseGrade.delete_course_grade_for_learner(
+            self.course_key, self.params['user_id']
+        )
+        with self.assertRaises(PersistentCourseGrade.DoesNotExist):
+            PersistentCourseGrade.read(self.params['user_id'], self.course_key)
 
-        self.assertEqual(deleted_user_grades, 1)
+        another_user_grade = PersistentCourseGrade.read(another_params['user_id'], self.course_key)
         self.assertIsNotNone(another_user_grade)

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -560,6 +560,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:2002',  # frontend-app-discussions
     'http://localhost:1991',  # frontend-app-admin-portal
     'http://localhost:1999',  # frontend-app-authn
+    'http://localhost:18450',  # frontend-app-support-tools
 ]
 
 


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR creates a function to delete learner's course grades as a part of reset. See https://2u-internal.atlassian.net/browse/AU-1912

## Supporting information

https://github.com/openedx/platform-roadmap/issues/331