### PR TITLE
fix: infinite load for library content block view

### DIFF
--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -21,7 +21,6 @@ section_class = "level-nesting" if show_inline else "level-element"
 label = determine_label(xblock.display_name_with_default, xblock.scope_ids.block_type)
 messages = xblock.validate().to_json()
 has_not_configured_message = messages.get('summary',{}).get('type', None) == 'not-configured'
-print(messages, has_not_configured_message)
 block_is_unit = is_unit(xblock)
 %>
 

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -20,6 +20,8 @@ show_inline = xblock.has_children and not xblock_url
 section_class = "level-nesting" if show_inline else "level-element"
 label = determine_label(xblock.display_name_with_default, xblock.scope_ids.block_type)
 messages = xblock.validate().to_json()
+has_not_configured_message = messages.get('summary',{}).get('type', None) == 'not-configured'
+print(messages, has_not_configured_message)
 block_is_unit = is_unit(xblock)
 %>
 
@@ -190,7 +192,7 @@ block_is_unit = is_unit(xblock)
     </div>
     % if not is_root:
         <div class="wrapper-xblock-message xblock-validation-messages" data-locator="${xblock.location}"/>
-        % if xblock_url:
+        % if xblock_url and not has_not_configured_message:
         <div class="xblock-header-secondary">
             <div class="meta-info">${_('This block contains multiple components.')}</div>
             <ul class="actions-list">

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -451,7 +451,12 @@ class LibraryContentBlock(
         context['is_loading'] = is_updating
 
         # The following JS is used to make the "Update now" button work on the unit page and the container view:
-        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_edit.js'))
+        if 'library' in root_xblock.category:
+            if root_xblock.source_library_id and len(root_xblock.children) > 0:
+                fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_edit.js'))
+        else:
+            fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_edit.js'))
+
         fragment.initialize_js('LibraryContentAuthorView')
         return fragment
 

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -451,7 +451,7 @@ class LibraryContentBlock(
         context['is_loading'] = is_updating
 
         # The following JS is used to make the "Update now" button work on the unit page and the container view:
-        if 'library' in root_xblock.category:
+        if root_xblock and 'library' in root_xblock.category:
             if root_xblock.source_library_id and len(root_xblock.children) > 0:
                 fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_edit.js'))
         else:


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
This PR makes two changes:
1. hides the view button for library content xblocks when a library has not been selected
2. fixes the infinite load of a page if no children are present or no library is selected. 

The view button is hidden when a library is not selected because there is no content to view before the selection has been made. All of the functionality via the view button is available in the xblock view on the unit page. In the case that the user circumvents the hidden view button, the library page now checks if the block has an associated library id and  for the children before it tries to adds in javascript that constantly checks if the block needs to be synced. The syncing javscript was running on a timer that infinitely caused the loading ui to bounce between the select library button or no children warning. This change impacts Authors.

#### Before (view button)
<img width="950" alt="Screenshot 2024-03-22 at 11 06 54 AM" src="https://github.com/openedx/edx-platform/assets/42981026/eef10e36-3aad-450f-ba92-fa3181a7813b">

#### After (hiding view button)
<img width="950" alt="Screenshot 2024-03-22 at 10 51 07 AM" src="https://github.com/openedx/edx-platform/assets/42981026/3042836c-49e8-4183-8eaa-5ea3a4acaea6">


## Supporting information
JIRA Ticket: [TNL-11238](https://2u-internal.atlassian.net/browse/TNL-11238)
>One recurring problem is a significant delay in loading libraries, which displays an empty pop-up window causing confusion and sometimes appearing as if the system is frozen. 
>
>Error messages such as 'Failed to load resource: the server responded with a status of 504' or 'Failed to initialize Beamer: beamer_config is not defined' have been observed during this delay.
>
> Additionally, there's another scenario where selecting 'View' directly after adding a new library component leads to a non-stop loop between the Loading icon and the 'Select a library' button, preventing the page from fully loading.

## Testing instructions

#### View button visibility
1. Open a course
2. Add a new Library component
3. Click ‘Select a Library' or 'EDIT.'
4. Should render edit modal with no issues
5. Click cancel
6. Should not see view button
7. Select a library
8. Should see view button

#### Infinite page load

1. Click view on newly created library block
2. Click "Edit"
3. In the modal, find "Problem Type" and select one that does not appear in your library
4. Click "Save"
5. Should see loading message
6. After load, should see no block warning
7. Stay on page for about 15 seconds to confirm loading loop does not occur.

## Deadline

None
