### PR TITLE
fix: gate lti tools frorm onboarding function

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1151,6 +1151,9 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                     supports_onboarding = does_backend_support_onboarding(
                         course.proctoring_provider
                     )
+                # NOTE: LTI proctoring doesn't support onboarding. If that changes, this value should change to True.
+                else:
+                    supports_onboarding = False
 
                 proctoring_exam_configuration_link = None
                 if xblock.is_proctored_exam:

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1145,9 +1145,12 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                 rules_url = settings.PROCTORING_SETTINGS.get("LINK_URLS", {}).get(
                     "online_proctoring_rules", ""
                 )
-                supports_onboarding = does_backend_support_onboarding(
-                    course.proctoring_provider
-                )
+
+                # Only call does_backend_support_onboarding if  not using an LTI proctoring provider
+                if course.proctoring_provider != 'lti_external':
+                    supports_onboarding = does_backend_support_onboarding(
+                        course.proctoring_provider
+                    )
 
                 proctoring_exam_configuration_link = None
                 if xblock.is_proctored_exam:

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -302,10 +302,14 @@ def _section_special_exams(course, access):
     proctoring_provider = course.proctoring_provider
     escalation_email = None
     mfe_view_url = None
-    if proctoring_provider == 'proctortrack':
-        escalation_email = course.proctoring_escalation_email
-    elif proctoring_provider == 'lti_external':
+    if proctoring_provider == 'lti_external':
         mfe_view_url = f'{settings.EXAMS_DASHBOARD_MICROFRONTEND_URL}/course/{course_key}/exams/embed'
+        show_onboarding = True
+    else:
+        # Only call does_backend_support_onboarding if  not using an LTI proctoring provider
+        show_onboarding = does_backend_support_onboarding(course.proctoring_provider)
+        if proctoring_provider == 'proctortrack':
+            escalation_email = course.proctoring_escalation_email
     from edx_proctoring.api import is_backend_dashboard_available
 
     section_data = {
@@ -315,7 +319,7 @@ def _section_special_exams(course, access):
         'course_id': course_key,
         'escalation_email': escalation_email,
         'show_dashboard': is_backend_dashboard_available(course_key),
-        'show_onboarding': does_backend_support_onboarding(course.proctoring_provider),
+        'show_onboarding': show_onboarding,
         'mfe_view_url': mfe_view_url,
     }
     return section_data

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -304,7 +304,8 @@ def _section_special_exams(course, access):
     mfe_view_url = None
     if proctoring_provider == 'lti_external':
         mfe_view_url = f'{settings.EXAMS_DASHBOARD_MICROFRONTEND_URL}/course/{course_key}/exams/embed'
-        show_onboarding = True
+        # NOTE: LTI proctoring doesn't support onboarding. If that changes, this value should change to True.
+        show_onboarding = False
     else:
         # Only call does_backend_support_onboarding if  not using an LTI proctoring provider
         show_onboarding = does_backend_support_onboarding(course.proctoring_provider)


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/jira/software/c/projects/COSMO/boards/895?assignee=63dd6e7028cddcc70772701a&selectedIssue=COSMO-193

- Block calls to does_backend_support_onboarding if the proctoring provider uses LTI

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
