### PR TITLE
feat: fix missing `gettext` functions if translations aren't pulled in development environments

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -60,7 +60,12 @@ from openedx.core.release import RELEASE_LINE
         </script>
     % endif
 
-    <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+    % if LANGUAGE_CODE != 'en':
+      <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+    % elif settings.DEBUG or LANGUAGE_CODE == 'en':
+      ## Provides a fallback for gettext functions for English and in debug mode
+      <script type="text/javascript" src="${static.url('js/src/gettext_fallback.js')}"></script>
+    % endif
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
     <%block name="header_meta"></%block>

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -60,10 +60,9 @@ from openedx.core.release import RELEASE_LINE
         </script>
     % endif
 
-    % if LANGUAGE_CODE != 'en':
-      <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
-    % elif settings.DEBUG or LANGUAGE_CODE == 'en':
-      ## Provides a fallback for gettext functions for English and in debug mode
+    <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+    % if settings.DEBUG:
+      ## Provides a fallback for gettext functions in development environment
       <script type="text/javascript" src="${static.url('js/src/gettext_fallback.js')}"></script>
     % endif
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/common/static/js/src/gettext_fallback.js
+++ b/common/static/js/src/gettext_fallback.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * This is a fallback file for the Django JavaScript internationalization library if the language gettext catalog
+ * is not available.
+ */
+
+(function(globals) {
+    const django = globals.django || (globals.django = {});
+
+    /* gettext library */
+    if (!django.jsi18n_initialized) {
+        django.catalog = django.catalog || {};
+
+        django.pluralidx = function(n) {
+            const v = (n != 1);
+            if (typeof v === 'boolean') {
+                return v ? 1 : 0;
+            } else {
+                return v;
+            }
+        };
+
+        django.gettext = function(msgid) {
+            const value = django.catalog[msgid];
+            if (typeof value === 'undefined') {
+                return msgid;
+            } else {
+                return (typeof value === 'string') ? value : value[0];
+            }
+        };
+
+        django.ngettext = function(singular, plural, count) {
+            const value = django.catalog[singular];
+            if (typeof value === 'undefined') {
+                return (count == 1) ? singular : plural;
+            } else {
+                return value.constructor === Array ? value[django.pluralidx(count)] : value;
+            }
+        };
+
+        django.gettext_noop = function(msgid) {
+            return msgid;
+        };
+
+        django.pgettext = function(context, msgid) {
+            let value = django.gettext(context + '\x04' + msgid);
+            if (value.includes('\x04')) {
+                value = msgid;
+            }
+            return value;
+        };
+
+        django.npgettext = function(context, singular, plural, count) {
+            let value = django.ngettext(context + '\x04' + singular, context + '\x04' + plural, count);
+            if (value.includes('\x04')) {
+                value = django.ngettext(singular, plural, count);
+            }
+            return value;
+        };
+
+        django.interpolate = function(fmt, obj, named) {
+            if (named) {
+                return fmt.replace(/%\(\w+\)s/g, function(match) {
+                    return String(obj[match.slice(2, -2)])
+                });
+            } else {
+                return fmt.replace(/%s/g, function(match) {
+                    return String(obj.shift())
+                });
+            }
+        };
+
+        /* formatting library */
+        django.formats = {
+            DATETIME_FORMAT: 'N j, Y, P',
+            DATETIME_INPUT_FORMATS: [
+                '%Y-%m-%d %H:%M:%S',
+                '%Y-%m-%d %H:%M:%S.%f',
+                '%Y-%m-%d %H:%M',
+                '%m/%d/%Y %H:%M:%S',
+                '%m/%d/%Y %H:%M:%S.%f',
+                '%m/%d/%Y %H:%M',
+                '%m/%d/%y %H:%M:%S',
+                '%m/%d/%y %H:%M:%S.%f',
+                '%m/%d/%y %H:%M',
+                '%Y-%m-%d'
+            ],
+            DATE_FORMAT: 'N j, Y',
+            DATE_INPUT_FORMATS: [
+                '%Y-%m-%d',
+                '%m/%d/%Y',
+                '%m/%d/%y'
+            ],
+            DECIMAL_SEPARATOR: '.',
+            FIRST_DAY_OF_WEEK: 0,
+            MONTH_DAY_FORMAT: 'F j',
+            NUMBER_GROUPING: 3,
+            SHORT_DATETIME_FORMAT: 'm/d/Y P',
+            SHORT_DATE_FORMAT: 'm/d/Y',
+            THOUSAND_SEPARATOR: ',',
+            TIME_FORMAT: 'P',
+            TIME_INPUT_FORMATS: [
+                '%H:%M:%S',
+                '%H:%M:%S.%f',
+                '%H:%M'
+            ],
+            YEAR_MONTH_FORMAT: 'F Y'
+        };
+
+        django.get_format = function(format_type) {
+            const value = django.formats[format_type];
+            if (typeof value === 'undefined') {
+                return format_type;
+            } else {
+                return value;
+            }
+        };
+
+        /* add to global namespace */
+        globals.pluralidx = django.pluralidx;
+        globals.gettext = django.gettext;
+        globals.ngettext = django.ngettext;
+        globals.gettext_noop = django.gettext_noop;
+        globals.pgettext = django.pgettext;
+        globals.npgettext = django.npgettext;
+        globals.interpolate = django.interpolate;
+        globals.get_format = django.get_format;
+
+        django.jsi18n_initialized = true;
+    }
+}(this));

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -79,7 +79,12 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
       }
     </script>
   % endif
-  <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+  % if LANGUAGE_CODE != 'en':
+    <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+  % elif settings.DEBUG or LANGUAGE_CODE == 'en':
+    ## Provides a fallback for gettext functions for English and in debug mode
+    <script type="text/javascript" src="${static.url('js/src/gettext_fallback.js')}"></script>
+  % endif
   <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
   <% favicon_url = branding_api.get_favicon_url() %>
   <link rel="icon" type="image/x-icon" href="${favicon_url}"/>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -79,10 +79,9 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
       }
     </script>
   % endif
-  % if LANGUAGE_CODE != 'en':
-    <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
-  % elif settings.DEBUG or LANGUAGE_CODE == 'en':
-    ## Provides a fallback for gettext functions for English and in debug mode
+  <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+  % if settings.DEBUG:
+    ## Provides a fallback for gettext functions in development environment
     <script type="text/javascript" src="${static.url('js/src/gettext_fallback.js')}"></script>
   % endif
   <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>


### PR DESCRIPTION
### Problem

After https://github.com/openedx/edx-platform/pull/34355 LMS and CMS broke due to missing `djangojs.js` file for English and other languages. The current workaround is to run `make pull_translations` which is rather inconvenient for development and might not be ran in production builds. 

### Solution
This is a proposed fix to address the issue in Tutor builds (https://github.com/overhangio/tutor/pull/1024). It works only in development mode and if English is used because `atlas pull` provides not English translations.

### TODO
 - [x] Test locally without pull translations on English
 - [x] Test locally without pull translations on Arabic

<details><summary>Details</summary>
<p>

![image](https://github.com/openedx/edx-platform/assets/645156/80af1461-8c65-473b-9ead-07d359cb1f08)


</p>
</details> 

 - [x] Test locally with pull translations on English
 - [x] Test locally with pull translations on Arabic

### Refs
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
