### PR TITLE
[BACKPORT] Fix reverse error for renamed `session_language` URL

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -324,7 +324,7 @@
               % if user.is_authenticated:
               <input title="preference api" type="hidden" id="preference-api-url" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
               % else:
-              <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+              <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
               % endif
               <label><span class="sr">${_("Choose Language")}</span>
               <select class="input select language-selector" id="settings-language-value" name="language">

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -90,7 +90,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             % if user.is_authenticated:
                 <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
             % else:
-                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
             % endif
             <label><span class="sr">${_("Choose Language")}</span>
             <select class="input select language-selector" id="settings-language-value" name="language">

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -58,7 +58,7 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
                 % if user.is_authenticated:
                   <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
                 % else:
-                  <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                  <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
                 % endif
                 <label><span class="sr">${_("Choose Language")}</span>
                   <select class="input select language-selector" id="settings-language-value" name="language">


### PR DESCRIPTION
## This is a backport from https://github.com/openedx/edx-platform/pull/33729

## Description
The URL was renamed, but some templates use the old name.

## Steps to reproduce
1. Add several language codes to the Dark Lang Config using the LMS admin (e.g. `en, uk`)
2. Log out

## Actual result
NoReverseMatch error

![image](https://github.com/openedx/edx-platform/assets/47273130/aa78f22c-76a6-4525-a084-042c1a22ca1e)
