### PR TITLE
fix: register exams without due date or course end date

### DIFF
--- a/cms/djangoapps/contentstore/exams.py
+++ b/cms/djangoapps/contentstore/exams.py
@@ -71,6 +71,8 @@ def register_exams(course_key):
             timed_exam.is_onboarding_exam
         )
 
+        due_date = timed_exam.due.isoformat() if timed_exam.due else (course.end.isoformat() if course.end else None)
+
         exams_list.append({
             'course_id': str(course_key),
             'content_id': str(timed_exam.location),
@@ -83,7 +85,7 @@ def register_exams(course_key):
             # exam service. Also note that we no longer consider the pacing type of the course - this applies to both
             # self-paced and indstructor-paced courses. Therefore, this effectively opts out exams powered by edx-exams
             # from personalized learner schedules/relative dates.
-            'due_date': timed_exam.due.isoformat() if timed_exam.due else course.end.isoformat(),
+            'due_date': due_date,
             'exam_type': exam_type,
             'is_active': True,
             'hide_after_due': timed_exam.hide_after_due,

--- a/cms/djangoapps/contentstore/tests/test_exams.py
+++ b/cms/djangoapps/contentstore/tests/test_exams.py
@@ -147,15 +147,21 @@ class TestExamService(ModuleStoreTestCase):
         listen_for_course_publish(self, self.course.id)
         mock_patch_course_exams.assert_not_called()
 
-    @ddt.data(True, False)
-    def test_no_due_dates(self, is_self_paced, mock_patch_course_exams):
+    # MODIFY DUE DATE HERE
+    @ddt.data(
+        (True, datetime(2035, 1, 1, 0, 0, tzinfo=timezone.utc)),
+        (False, datetime(2035, 1, 1, 0, 0, tzinfo=timezone.utc)),
+        (True, None),
+        (False, None),
+    )
+    @ddt.unpack
+    def test_no_due_dates(self, is_self_paced, course_end_date, mock_patch_course_exams):
         """
         Test that the coures end date is registered as the due date when the subsection does not have a due date for
         both self-paced and instructor-paced exams.
         """
         self.course.self_paced = is_self_paced
-        end_date = datetime(2035, 1, 1, 0, 0, tzinfo=timezone.utc)
-        self.course.end = end_date
+        self.course.end = course_end_date
         self.course = self.update_course(self.course, 1)
         BlockFactory.create(
             parent=self.chapter,
@@ -173,7 +179,7 @@ class TestExamService(ModuleStoreTestCase):
 
         listen_for_course_publish(self, self.course.id)
         called_exams, called_course = mock_patch_course_exams.call_args[0]
-        assert called_exams[0]['due_date'] == end_date.isoformat()
+        assert called_exams[0]['due_date'] == (course_end_date.isoformat() if course_end_date else None)
 
     @ddt.data(True, False)
     def test_subsection_due_date_prioritized(self, is_self_paced, mock_patch_course_exams):


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

[COSMO-216](https://2u-internal.atlassian.net/browse/COSMO-216). If a course with LTI based exams is published, and an exam does not have a due date or a course end date, the task to register the exam to the backend service fails. 

Instead of erroring, if the exam has neither a due date nor a course end date defined, we should set the due date to `None`. The LTI exams backend `edx-exams` allows null values for the exam due date, and a `null` due date is interpreted as a course without an end date.