### PR TITLE
fix: Course blocks API with param return_type=list

### DIFF
--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -17,8 +17,9 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseDataResearcherRole
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
-from xmodule.modulestore.tests.django_utils import \
-    SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: disable=wrong-import-order
+    SharedModuleStoreTestCase
+)
 from xmodule.modulestore.tests.factories import (  # lint-amnesty, pylint: disable=wrong-import-order
     BlockFactory,
     ToyCourseFactory

--- a/lms/djangoapps/course_api/blocks/utils.py
+++ b/lms/djangoapps/course_api/blocks/utils.py
@@ -1,6 +1,8 @@
 """
    Utils for Blocks
 """
+from rest_framework.utils.serializer_helpers import ReturnList
+
 from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
     Provider,
@@ -15,16 +17,28 @@ def filter_discussion_xblocks_from_response(response, course_key):
     provider = configuration.provider_type
     if provider == Provider.OPEN_EDX:
         # Finding ids of discussion xblocks
-        discussion_xblocks = [
-            key for key, value in response.data.get('blocks', {}).items()
-            if value.get('type') == 'discussion'
-        ]
+        if isinstance(response.data, ReturnList):
+            discussion_xblocks = [
+                value.get('id') for value in response.data if value.get('type') == 'discussion'
+            ]
+        else:
+            discussion_xblocks = [
+                key for key, value in response.data.get('blocks', {}).items()
+                if value.get('type') == 'discussion'
+            ]
         # Filtering discussion xblocks keys from blocks
-        filtered_blocks = {
-            key: value
-            for key, value in response.data.get('blocks', {}).items()
-            if value.get('type') != 'discussion'
-        }
+        if isinstance(response.data, ReturnList):
+            filtered_blocks = {
+                value.get('id'): value
+                for value in response.data
+                if value.get('type') != 'discussion'
+            }
+        else:
+            filtered_blocks = {
+                key: value
+                for key, value in response.data.get('blocks', {}).items()
+                if value.get('type') != 'discussion'
+            }
         # Removing reference of discussion xblocks from unit
         # These references needs to be removed because they no longer exist
         for _, block_data in filtered_blocks.items():
@@ -36,5 +50,8 @@ def filter_discussion_xblocks_from_response(response, course_key):
                         if descendant not in discussion_xblocks
                     ]
                     block_data[key] = descendants
-        response.data['blocks'] = filtered_blocks
+        if isinstance(response.data, ReturnList):
+            response.data = filtered_blocks
+        else:
+            response.data['blocks'] = filtered_blocks
     return response


### PR DESCRIPTION
**Discussion: edx (New).**
[Issue Link](https://github.com/openedx/edx-platform/issues/34379)
Endpoint: {LMS_HOST}/api/courses/v1/blocks/?course_id={COURSE_ID}&return_type=list

**Root cause**
When `return_type` is set to list in querystring the api endpoint is crashing because it is calling `dict` method on `ReturnList` type instance to get blocks. 

**Solution**
I have added a type check before fetching blocks if it is getting `ReturnList` I am treating it as list. otherwise following the old path.


**Stacktrace**
```Traceback (most recent call last):
File "/opened/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 55, in inner
response = get_response (request)
File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py",line 197, in _get_response
response = wrapped_callback(request,
*callback_args,
**callback_kwargs)
File "/opened/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py",line 56, in wrapper_view return view_func(*args,
**kwargs)
File "/opened/venv/lib/python3.8/site-packages/django/views/generic/base.py",line 104, in view return self.dispatch(request, *args,
**kwargs)
File "/opened/venv/lib/python3.8/site-packages/django/utils/decorators.py",line46,in_wrapper return bound_method(*args
**kwargs)
File "/opened×/venv/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
response = self. handle_exception (exc)
File "/opened/venv/lib/python3.8/site-packages/rest_framework/views.py",line 506, in dispatch
response = handler(request, *args, **kwargs)
File "/opened/venv/lib/python3.8/site-packages/rest_framework/generics.py", line 199, in get return self.list(request, *args, **kwargs)
File "/opened×/edx-platform/./lms/djangoapps/course_api/blocks/views.py", line 315, in list
response = filter_discussion_blocks_from_response(response,
course_key)
File "/opened/edx-platform/./lms/djangoapps/course_api/blocks/utils.py",line19,infilter_discussion_xblocks_from_response key for key, value in response.data.get('blocks' {}).items()
AttributeError:
'ReturnList' object has no attribute
'get'
```