### PR TITLE
fix: Course blocks API with param return_type=list 34379

### DIFF
--- a/lms/djangoapps/course_api/blocks/utils.py
+++ b/lms/djangoapps/course_api/blocks/utils.py
@@ -1,6 +1,8 @@
 """
    Utils for Blocks
 """
+from rest_framework.utils.serializer_helpers import ReturnList
+
 from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
     Provider,
@@ -15,16 +17,28 @@ def filter_discussion_xblocks_from_response(response, course_key):
     provider = configuration.provider_type
     if provider == Provider.OPEN_EDX:
         # Finding ids of discussion xblocks
-        discussion_xblocks = [
-            key for key, value in response.data.get('blocks', {}).items()
-            if value.get('type') == 'discussion'
-        ]
+        if isinstance(response.data, ReturnList):
+            discussion_xblocks = [
+                value.get('id') for value in response.data if value.get('type') == 'discussion'
+            ]
+        else:
+            discussion_xblocks = [
+                key for key, value in response.data.get('blocks', {}).items()
+                if value.get('type') == 'discussion'
+            ]
         # Filtering discussion xblocks keys from blocks
-        filtered_blocks = {
-            key: value
-            for key, value in response.data.get('blocks', {}).items()
-            if value.get('type') != 'discussion'
-        }
+        if isinstance(response.data, ReturnList):
+            filtered_blocks = {
+                value.get('id'): value
+                for value in response.data
+                if value.get('type') != 'discussion'
+            }
+        else:
+            filtered_blocks = {
+                key: value
+                for key, value in response.data.get('blocks', {}).items()
+                if value.get('type') != 'discussion'
+            }
         # Removing reference of discussion xblocks from unit
         # These references needs to be removed because they no longer exist
         for _, block_data in filtered_blocks.items():
@@ -36,5 +50,8 @@ def filter_discussion_xblocks_from_response(response, course_key):
                         if descendant not in discussion_xblocks
                     ]
                     block_data[key] = descendants
-        response.data['blocks'] = filtered_blocks
+        if isinstance(response.data, ReturnList):
+            response.data = filtered_blocks
+        else:
+            response.data['blocks'] = filtered_blocks
     return response


### PR DESCRIPTION
### Issue Description
**Version:** Quince.1
**Discussion:** edx (New).
**Endpoint:** {LMS_HOST}/api/courses/v1/blocks/?course_id={COURSE_ID}&return_type=list
### Console log:
<img width="807" alt="image" src="https://github.com/openedx/edx-platform/assets/19186089/0817e1a1-5b9d-412f-9c89-39a992cb326c">
