### PR TITLE
build: clean_translations without .git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ pull_xblock_translations:  ## pull xblock translations via atlas
 
 clean_translations: ## Remove existing translations to prepare for a fresh pull
 	# Removes core edx-platform translations but keeps config files and Esperanto (eo) test translations
-	cd conf/locale && find . -type d -a ! -path . -a ! -path ./eo ! -path ./eo/* -exec rm -rf {} +
+	find conf/locale -mindepth 1 -maxdepth 1 -type d -a ! -name eo -exec rm -rf {} +
 	# Removes the xblocks/plugins and js-compiled translations
 	rm -rf conf/plugins-locale cms/static/js/i18n/ lms/static/js/i18n/ cms/static/js/xblock.v1-i18n/ lms/static/js/xblock.v1-i18n/
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ pull_xblock_translations:  ## pull xblock translations via atlas
 	python manage.py cms compile_xblock_translations
 
 clean_translations: ## Remove existing translations to prepare for a fresh pull
-	git clean -fdX conf/locale  # Removes core edx-platform translations but keeps Esperanto (eo) test translations
+	# Removes core edx-platform translations but keeps config files and Esperanto (eo) test translations
+	cd conf/locale && find . -type d -a ! -path . -a ! -path ./eo ! -path ./eo/* -exec rm -rf {} +
 	# Removes the xblocks/plugins and js-compiled translations
 	rm -rf conf/plugins-locale cms/static/js/i18n/ lms/static/js/i18n/ cms/static/js/xblock.v1-i18n/ lms/static/js/xblock.v1-i18n/
 


### PR DESCRIPTION
## Background

This amends:
* https://github.com/openedx/edx-platform/pull/34428

in order to unblock:
* https://github.com/overhangio/tutor/pull/1026

## Description

We reimplement `make translations` so that it does not depend on the presence of the `.git` directory. This fixes the Tutor build error:

     > [production 18/34] RUN make clean_translations:
    git clean -fdX conf/locale
    fatal: not a git repository (or any of the parent directories): .git
    make: *** [Makefile:57: clean_translations] Error 128

Why is the .git directory missing during the Tutor translations build? Because if it were present, it would tie the translations' layer cache up with git state, which would lead to the Docker layer being rebuilt any time there was any change to git state.

## Testing

I tested this locally, both in the Tutor build, and using the Makefile directly in the LMS shell.