### PR TITLE
feat: adaptive display of links for Quince

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -76,14 +76,18 @@ from django.urls import reverse
                 ${_("This course run is using an upgraded version of edx discussion forum. In order to display the discussions sidebar, discussions xBlocks will no longer be visible to learners.")}
             </div>
             <div style="margin-left:auto; width:fit-content;">
+              %if settings.DISCUSSIONS_INCONTEXT_LEARNMORE_URL:
                 <span>
                     <a href="${settings.DISCUSSIONS_INCONTEXT_LEARNMORE_URL}" target="_blank" rel="noreferrer noopener">${_(" Learn more")}</a>
                     <i class="fa fa-share-square-o" aria-hidden="true"></i>
                 </span>
+              %endif
+              %if settings.DISCUSSIONS_INCONTEXT_FEEDBACK_URL:
                 <span style="margin-left: 1rem">
                     <a href="${settings.DISCUSSIONS_INCONTEXT_FEEDBACK_URL}" target="_blank" rel="noreferrer noopener">${_("Share feedback")}</a>
                     <i class="fa fa-share-square-o" aria-hidden="true"></i>
                 </span>
+              %endif
             </div>
         </div>
       </div>


### PR DESCRIPTION
**This is a [backport](https://github.com/openedx/edx-platform/pull/34432) from the master.**

## Description

Do not display the 'Learn more' and 'Share feedback' links for the banner that is enabled by the context_course.discussions_settings flag if the URLs for these links are not set in the settings.
  - `DISCUSSIONS_INCONTEXT_LEARNMORE_URL`
  -  `DISCUSSIONS_INCONTEXT_FEEDBACK_URL`

<img width="782" alt="screen_50" src="https://github.com/openedx/edx-platform/assets/98233552/de531ab6-50cd-406f-8963-90e21bbc9c61">