### PR TITLE
feat: add clear grades to course reset task

### DIFF
--- a/lms/djangoapps/support/tasks.py
+++ b/lms/djangoapps/support/tasks.py
@@ -12,6 +12,7 @@ from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor.enrollment import reset_student_attempts
 from lms.djangoapps.support.models import CourseResetAudit
+from lms.djangoapps.grades.api import clear_user_course_grades
 
 log = logging.getLogger(__name__)
 
@@ -67,6 +68,8 @@ def reset_student_course(course_id, learner_email, reset_by_user_email):
 
         # Clear block completion data
         BlockCompletion.objects.clear_learning_context_completion(user, course.id)
+        # Clear a student grades for a course
+        clear_user_course_grades(user.id, course.id)
 
         update_audit_status(course_reset_audit, CourseResetAudit.CourseResetStatus.COMPLETE)
     except Exception as e:  # pylint: disable=broad-except

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -2428,7 +2428,7 @@ class TestResetCourseCreateView(ResetCourseViewTestBase):
             'display_name': self.course.display_name
         })
         # The reset task should be queued
-        mock_reset_student_course.delay.assert_called_once_with(self.course_id, self.learner.id, self.user.id)
+        mock_reset_student_course.delay.assert_called_once_with(self.course_id, self.learner.email, self.user.email)
         # And an audit should be created as ENQUEUED
         self.assertEqual(
             self.enrollment.courseresetaudit_set.first().status,
@@ -2453,7 +2453,7 @@ class TestResetCourseCreateView(ResetCourseViewTestBase):
             'comment': '',
             'display_name': self.course.display_name
         })
-        mock_reset_student_course.delay.assert_called_once_with(self.course_id, self.learner.id, self.user.id)
+        mock_reset_student_course.delay.assert_called_once_with(self.course_id, self.learner.email, self.user.email)
 
     def test_course_reset_already_reset(self):
         """ A course that has an audit that hasn't failed should not be allowed to be run again """

--- a/lms/djangoapps/support/views/course_reset.py
+++ b/lms/djangoapps/support/views/course_reset.py
@@ -160,5 +160,5 @@ class CourseResetAPIView(APIView):
             'display_name': course_enrollment.course_overview.display_name
         }
 
-        reset_student_course.delay(course_id, user.id, request.user.id)
+        reset_student_course.delay(course_id, user.email, request.user.email)
         return Response(resp, status=201)


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Clear learner grades as a part of the full course reset

## Supporting information

https://2u-internal.atlassian.net/browse/AU-1945