### PR TITLE
fix: replaced md4 with blake2b

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -579,6 +579,9 @@ FEATURES = {
     # .. toggle_creation_date: 2024-03-22
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
+
+    # See annotations in lms/envs/common.py for details.
+    'ENABLE_BLAKE2B_HASHiNG': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/common/djangoapps/util/memcache.py
+++ b/common/djangoapps/util/memcache.py
@@ -7,6 +7,7 @@ so that we can cache any keys, not just ones that memcache would ordinarily acce
 import hashlib
 from urllib.parse import quote_plus
 
+from django.conf import settings
 from django.utils.encoding import smart_str
 
 
@@ -14,9 +15,12 @@ def fasthash(string):
     """
     Hashes `string` into a string representation of a 128-bit digest.
     """
-    md4 = hashlib.new("md4")
-    md4.update(string.encode('utf-8'))
-    return md4.hexdigest()
+    if settings.FEATURES.get("ENABLE_BLAKE2B_HASHING", False):
+        hash_obj = hashlib.new("blake2b", digest_size=16)
+    else:
+        hash_obj = hashlib.new("md4")
+    hash_obj.update(string.encode('utf-8'))
+    return hash_obj.hexdigest()
 
 
 def cleaned_string(val):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1059,6 +1059,18 @@ FEATURES = {
     # .. toggle_creation_date: 2024-03-22
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
+
+    # .. toggle_name: FEATURES['ENABLE_BLAKE2B_HASHING']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Enables the memcache to use the blake2b hash algorithm instead of depreciated md4 for keys
+    #   exceeding 250 characters
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-04-02
+    # .. toggle_target_removal_date: 2024-12-09
+    # .. toggle_warning: For consistency, keep the value in sync with the setting of the same name in the LMS and CMS.
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34442
+    'ENABLE_BLAKE2B_HASHING': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR replaces md4 with blake2b in memcache. At MIT, we recently encountered an issue after upgrading our base image from a debian-buster image to a debian-bookworm image. This uncovered an incompatibility between the newer version of openssl and one of the hash digests that edx-platform is using (1.1.1d-0+deb10u7). Basically, openssl + hashlib are saying that md4 is supported and available but if you actually try to invoke openssl md4 you’ll get an error saying it is not available. This PR resolves this issue by updating the hash function to something a bit newer and more widely supported.

Useful information to include:
- Which edX user roles will this change impact? Learner, Course Author

## Supporting information

https://discuss.openedx.org/t/openssl-upgrade-md4-hashing/12654

## Testing instructions

- In the lms container run `python manage.py lms shell`
- In the python shell run:
```
>>> import hashlib
>>> blake2b = hashlib.new("blake2b", digest_size=16)
>>> string = "abc"
>>> blake2b.update(string.encode('utf-8'))
>>> blake2b.hexdigest()
```
- You should get the hash without any errors in the above statements.

## Deadline

"None" 

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Relevant openssl issue: https://github.com/openssl/openssl/issues/21247