### PR TITLE
chore: update Django to 4.2.11 for Quince - Security Patch

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -17,10 +17,19 @@
 
 
 # using LTS django version
-
+Django<5.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+
+# opentelemetry requires version 6.x at the moment:
+# https://github.com/open-telemetry/opentelemetry-python/issues/3570
+# Normally this could be added as a constraint in edx-django-utils, where we're
+# adding the opentelemetry dependency. However, when we compile pip-tools.txt,
+# that uses version 7.x, and then there's no undoing that when compiling base.txt.
+# So we need to pin it globally, for now.
+# Ticket for unpinning: https://github.com/openedx/edx-lint/issues/407
+importlib-metadata<7

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -181,7 +181,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.14
     # via jwcrypto
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements/edx/kernel.in
     #   django-appconf

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -183,6 +183,7 @@ deprecated==1.2.14
     # via jwcrypto
 django==4.2.11
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-appconf
     #   django-celery-results
@@ -610,7 +611,9 @@ idna==3.4
     #   snowflake-connector-python
     #   yarl
 importlib-metadata==6.8.0
-    # via markdown
+    # via
+    #   -c requirements/edx/../common_constraints.txt
+    #   markdown
 importlib-resources==6.1.0
     # via
     #   jsonschema

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -343,7 +343,7 @@ distlib==0.3.7
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -345,6 +345,7 @@ distlib==0.3.7
     #   virtualenv
 django==4.2.11
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
@@ -1011,6 +1012,7 @@ import-linter==1.12.0
     # via -r requirements/edx/testing.txt
 importlib-metadata==6.8.0
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/../pip-tools.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -232,6 +232,7 @@ deprecated==1.2.14
     #   jwcrypto
 django==4.2.11
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
     #   django-celery-results
@@ -711,6 +712,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.8.0
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   markdown
     #   sphinx

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -230,7 +230,7 @@ deprecated==1.2.14
     # via
     #   -r requirements/edx/base.txt
     #   jwcrypto
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements/edx/base.txt
     #   django-appconf

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -263,7 +263,7 @@ dill==0.3.7
     # via pylint
 distlib==0.3.7
     # via virtualenv
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements/edx/base.txt
     #   django-appconf

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -265,6 +265,7 @@ distlib==0.3.7
     # via virtualenv
 django==4.2.11
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
     #   django-celery-results
@@ -767,6 +768,7 @@ import-linter==1.12.0
     # via -r requirements/edx/testing.in
 importlib-metadata==6.8.0
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   markdown
     #   pytest-randomly

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -11,7 +11,9 @@ click==8.1.6
     #   -c requirements/constraints.txt
     #   pip-tools
 importlib-metadata==6.8.0
-    # via build
+    # via
+    #   -c requirements/common_constraints.txt
+    #   build
 packaging==23.2
     # via build
 pip-tools==7.3.0


### PR DESCRIPTION
See: https://github.com/openedx/wg-build-test-release/issues/341