### PR TITLE
feat: add heartbeat to authoring api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
 
     # Authoring API
     re_path(
-        fr'^heartbeat$', heartbeat, name='heartbeat'
+        r'^heartbeat$', heartbeat, name='heartbeat'
     ),
     re_path(
         fr'^file_assets/{settings.COURSE_ID_PATTERN}$',

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.urls import re_path, path
 
 from openedx.core.constants import COURSE_ID_PATTERN
+from openedx.core.djangoapps.heartbeat.views import heartbeat
 
 from .views import (
     AdvancedCourseSettingsView,
@@ -45,6 +46,9 @@ urlpatterns = [
     ),
 
     # Authoring API
+    re_path(
+        fr'^heartbeat$', heartbeat, name='heartbeat'
+    ),
     re_path(
         fr'^file_assets/{settings.COURSE_ID_PATTERN}$',
         assets.AssetsCreateRetrieveView.as_view(), name='cms_api_create_retrieve_assets'

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.urls import re_path, path
 
 from openedx.core.constants import COURSE_ID_PATTERN
-from openedx.core.djangoapps.heartbeat.views import heartbeat
 
 from .views import (
     AdvancedCourseSettingsView,
@@ -14,6 +13,7 @@ from .views import (
     TranscriptView,
     YoutubeTranscriptCheckView,
     YoutubeTranscriptUploadView,
+    APIHeartBeatView
 )
 from .views import assets
 from .views import authoring_videos
@@ -47,7 +47,7 @@ urlpatterns = [
 
     # Authoring API
     re_path(
-        r'^heartbeat$', heartbeat, name='heartbeat'
+        r'^heartbeat$', APIHeartBeatView, name='heartbeat'
     ),
     re_path(
         fr'^file_assets/{settings.COURSE_ID_PATTERN}$',

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
 
     # Authoring API
     re_path(
-        r'^heartbeat$', APIHeartBeatView, name='heartbeat'
+        r'^heartbeat$', APIHeartBeatView.as_view(), name='heartbeat'
     ),
     re_path(
         fr'^file_assets/{settings.COURSE_ID_PATTERN}$',

--- a/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
@@ -4,3 +4,4 @@ Views for v0 contentstore API.
 from .advanced_settings import AdvancedCourseSettingsView
 from .tabs import CourseTabSettingsView, CourseTabListView, CourseTabReorderView
 from .transcripts import TranscriptView, YoutubeTranscriptCheckView, YoutubeTranscriptUploadView
+from .api_heartbeat import APIHeartBeatView

--- a/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
@@ -4,12 +4,14 @@ from rest_framework.views import APIView
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 import cms.djangoapps.contentstore.toggles as toggles
 
-class APIHeartBeatView(APIView):
+class APIHeartBeatView(DeveloperErrorViewMixin, APIView):
     """
     View for getting the Authoring API's status
     """
+
     @apidocs.schema(
         parameters=[],
         responses={
@@ -18,6 +20,7 @@ class APIHeartBeatView(APIView):
             403: "The API is not availible",
         },
     )
+    @view_auth_classes(is_authenticated=True)
     def get(self, request: Request):
         """
         Get an object containing the Authoring API's status

--- a/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
@@ -15,7 +15,7 @@ class APIHeartBeatView(DeveloperErrorViewMixin, APIView):
     @apidocs.schema(
         parameters=[],
         responses={
-            200: ,
+            200: "The API is online",
             401: "The requester is not authenticated.",
             403: "The API is not availible",
         },

--- a/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
@@ -1,0 +1,44 @@
+""" View For Getting the Status of The Authoring API """
+import edx_api_doc_tools as apidocs
+from rest_framework.views import APIView
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework import status
+import cms.djangoapps.contentstore.toggles as toggles
+
+class APIHeartBeatView(APIView):
+    """
+    View for getting the Authoring API's status
+    """
+    @apidocs.schema(
+        parameters=[],
+        responses={
+            200: ,
+            401: "The requester is not authenticated.",
+            403: "The API is not availible",
+        },
+    )
+    def get(self, request: Request):
+        """
+        Get an object containing the Authoring API's status
+
+        **Example Request**
+
+            GET /api/contentstore/v0/heartbeat
+
+        **Response Values**
+
+        If the request is successful, an HTTP 200 "OK" response is returned.
+        The HTTP 200 response contains a single dict with the  "authoring_api_enabled" value "True".
+
+        **Example Response**
+
+        ```json
+        {
+            "authoring_api_enabled": "True"
+        }
+        ```
+        """
+        if toggles.use_studio_content_api():
+            return Response({'status': 'heartbeat successful'}, status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_403_FORBIDDEN)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 import cms.djangoapps.contentstore.toggles as toggles
 
+
 class APIHeartBeatView(DeveloperErrorViewMixin, APIView):
     """
     View for getting the Authoring API's status


### PR DESCRIPTION
## Description

This adds the a heartbeat check to the authoring api. This heartbeat simply returns service status (200 or 403).
This will allow for us to check if the authoring api is turned on, before performing any actual computation. I did not end up using the boilerplate heartbeat code because it would have required request forwarding for no added value.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11516

## Testing instructions

1. use CMS admin to disable the following DJANGO-WAFFLE flag: "contentstore.enable_studio_content_api" on your platform of choice.
2. setup ingestion engine to point at that platform, checkout this PR: 
3. Run ingestion engine'
4. It should fail fast.
5. use CMS admin to enable the following DJANGO-WAFFLE flag: "contentstore.enable_studio_content_api"
6. Run ingestion engine
7. It should run as usual.

## Deadline

"None"