### PR TITLE
feat: [FC-0044] display error notifications on the Unit page

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -12,6 +12,15 @@ from cms.djangoapps.contentstore.helpers import (
 )
 
 
+class MessageValidation(serializers.Serializer):
+    """
+    Serializer for representing XBlock error.
+    """
+
+    text = serializers.CharField()
+    type = serializers.CharField()
+
+
 class ChildAncestorSerializer(serializers.Serializer):
     """
     Serializer for representing child blocks in the ancestor XBlock.
@@ -105,6 +114,8 @@ class ChildVerticalContainerSerializer(serializers.Serializer):
     user_partition_info = serializers.DictField()
     user_partitions = serializers.ListField()
     actions = serializers.SerializerMethodField()
+    validation_messages = MessageValidation(many=True)
+    render_error = serializers.CharField()
 
     def get_actions(self, obj):  # pylint: disable=unused-argument
         """

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2234,3 +2234,60 @@ def send_course_update_notification(course_key, content, user):
         audience_filters={},
     )
     COURSE_NOTIFICATION_REQUESTED.send_event(course_notification_data=notification_data)
+
+
+def get_xblock_validation_messages(xblock):
+    """
+    Retrieves validation messages for a given xblock.
+
+    Args:
+        xblock: The xblock object to validate.
+
+    Returns:
+        list: A list of validation error messages.
+    """
+    validation_json = xblock.validate().to_json()
+    return validation_json['messages']
+
+
+def get_xblock_render_error(request, xblock):
+    """
+    Checks if there are any rendering errors for a given block and return these.
+
+    Args:
+        request: WSGI request object
+        xblock: The xblock object to rendering.
+
+    Returns:
+        str: Error message which happened while rendering of xblock.
+    """
+    from cms.djangoapps.contentstore.views.preview import _load_preview_block
+    from xmodule.studio_editable import has_author_view
+    from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
+
+    def get_xblock_render_context(request, block):
+        """
+        Return a dict of the data needs for render of each block.
+        """
+        can_edit = has_studio_write_access(request.user, block.usage_key.course_key)
+
+        return {
+            "is_unit_page": False,
+            "can_edit": can_edit,
+            "root_xblock": xblock,
+            "reorderable_items": set(),
+            "paging": None,
+            "force_render": None,
+            "item_url": "/container/{block.location}",
+            "tags_count_map": {},
+        }
+
+    try:
+        block = _load_preview_block(request, xblock)
+        preview_view = AUTHOR_VIEW if has_author_view(block) else STUDENT_VIEW
+        render_context = get_xblock_render_context(request, block)
+        block.render(preview_view, render_context)
+    except Exception as exc:  # pylint: disable=broad-except
+        return str(exc)
+
+    return ""


### PR DESCRIPTION
### Description
This PR addresses a need in the displaying error notifications on the Unit page. A list of validation error messages returns when xblock has some problem. FE feature for error rendering will be implemented in the future PR's. Looks like this.
<img width="981" alt="image" src="https://github.com/openedx/edx-platform/assets/26650868/4347be38-c0c4-43fc-80ae-43069ae9f8df">

### Testing instructions
1. Run master devstack.
2. Start platform `make dev.up.lms+cms+frontend-app-course-authoring` and make checkout on this branch.
3. Go to Studio Course Unit page from the Course Outline page.
4. Create Unit from the subsection and open it.
5. Add problem xblock.
6. Make syntax error in the `lms/templates/problem.html` file. (or any other xblock/file).
7. Copy location of the unit block.
8. Go to http://localhost:18010/api-docs.
10. Make sure the error is returned in the API response.
