### PR TITLE
fix: add gradebook to devstack csrf trust list

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -561,6 +561,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:1991',  # frontend-app-admin-portal
     'http://localhost:1999',  # frontend-app-authn
     'http://localhost:18450',  # frontend-app-support-tools
+    'http://localhost:1994',  # frontend-app-gradebook
 ]
 
 


### PR DESCRIPTION
Adds frontend-app-gradebook to the lms trusted csrf list for devstack
This was preventing local gradebook from creating grade overrides in devstack