### PR TITLE
feat: [FC-0044] refactoring xblock actions

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -123,7 +123,22 @@ class ChildVerticalContainerSerializer(serializers.Serializer):
         """
 
         can_manage_tags = use_tagging_taxonomy_list_page()
+        xblock = obj["xblock"]
+        is_course = xblock.scope_ids.usage_id.context_key.is_course
+        xblock_url = xblock_studio_url(xblock)
+        # Responsible for the ability to edit container xblock(copy, duplicate, move and manage access).
+        # It was used in the legacy and transferred here with simplification.
+        # After the investigation it was determined that the "show_other_action"
+        # condition below is sufficient to enable/disable actions on each xblock.
+        show_inline = xblock.has_children and not xblock_url
+        # All except delete and manage tags
+        show_other_action = not show_inline and is_course
         actions = {
+            "can_copy": show_other_action,
+            "can_duplicate": show_other_action,
+            "can_move": show_other_action,
+            "can_manage_access": show_other_action,
+            "can_delete": is_course,
             "can_manage_tags": can_manage_tags,
         }
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -196,6 +196,11 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
                 "user_partition_info": expected_user_partition_info,
                 "user_partitions": expected_user_partitions,
                 "actions": {
+                    "can_copy": True,
+                    "can_duplicate": True,
+                    "can_move": True,
+                    "can_manage_access": True,
+                    "can_delete": True,
                     "can_manage_tags": True,
                 },
                 "validation_messages": [],
@@ -206,6 +211,11 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
                 "block_id": str(self.html_unit_second.location),
                 "block_type": self.html_unit_second.location.block_type,
                 "actions": {
+                    "can_copy": True,
+                    "can_duplicate": True,
+                    "can_move": True,
+                    "can_manage_access": True,
+                    "can_delete": True,
                     "can_manage_tags": True,
                 },
                 "user_partition_info": expected_user_partition_info,


### PR DESCRIPTION
### Description
Each xblock component’s three dots menu on the Unit Page has buttons that will initiate action with xblock.
After the investigation it was determined that the condition `is_course` is sufficient to enable/disable actions on each xblock. Currently any action from the FE does not contain a condition for reflection so in the next FE PR it will be covered.

<img width="402" alt="image" src="https://github.com/openedx/edx-platform/assets/26650868/8a30a5f9-caa0-4f81-96e4-951e112e60bc">

### Testing instructions
1. Run master devstack.
2. Start platform `make dev.up.lms+cms` and make checkout on this branch.
3. Go to studio home page and choose the course.
4. Create Unit from the subsection and open it.
5. Copy location of the unit block.
6. Go to `http://localhost:18010/api-docs`.
7. Find the required API endpoint `/api/contentstore/v1/container/vertical/{usage_key_string}/children`.
8. Get `usage_key_string` from previous step and paste it to required API endpoint to get actions data for unit.