### PR TITLE
temp: adding DeprecationWarning to remove neo4j.

### DIFF
--- a/cms/djangoapps/coursegraph/apps.py
+++ b/cms/djangoapps/coursegraph/apps.py
@@ -3,7 +3,7 @@ Coursegraph Application Configuration
 
 Signal handlers are connected here.
 """
-
+import warnings
 
 from django.apps import AppConfig
 
@@ -15,3 +15,11 @@ class CoursegraphConfig(AppConfig):
     name = 'cms.djangoapps.coursegraph'
 
     from cms.djangoapps.coursegraph import tasks
+
+    def ready(self) -> None:
+        warnings.warn(
+            "Neo4j support is going to be dropped after Sumac release,"
+            "to read more here is a github issue https://github.com/openedx/edx-platform/issues/34342",
+            DeprecationWarning,
+            stacklevel=2
+        )


### PR DESCRIPTION
### Issue
**Proposal Date:** 2024-03-07
**Target Ticket Acceptance Date:** 2024-03-21
Earliest Open edX Named Release Without This Functionality: Sumac 2024-10
### Rationale
This pull request addresses the depreciation of Neo4j support from the edx-platform.

### Changes Made

1. Added deprecation warning to cms.djangpapps.coursegraph.apps

### Discussion Thread
[Discuss thread](https://discuss.openedx.org/t/deprecation-removal-coursegraph-neo4j-support/12480)

