### PR TITLE
Python 3.11 Package Upgrades

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -776,7 +776,7 @@ openedx-blockstore==1.4.0
     # via -r requirements/edx/kernel.in
 openedx-calc==3.0.1
     # via -r requirements/edx/kernel.in
-openedx-django-pyfs==3.5.0
+openedx-django-pyfs==3.6.0
     # via
     #   lti-consumer-xblock
     #   xblock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -530,7 +530,7 @@ edx-search==3.9.1
     # via -r requirements/edx/kernel.in
 edx-sga==0.23.1
     # via -r requirements/edx/bundled.in
-edx-submissions==3.6.0
+edx-submissions==3.7.0
     # via
     #   -r requirements/edx/kernel.in
     #   ora2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -436,7 +436,7 @@ edx-ccx-keys==1.2.1
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-edx-celeryutils==1.2.5
+edx-celeryutils==1.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -452,7 +452,7 @@ edx-django-release-util==1.3.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/kernel.in
-edx-django-utils==5.10.1
+edx-django-utils==5.12.0
     # via
     #   -r requirements/edx/kernel.in
     #   django-config-models

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -526,7 +526,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.2
+edx-search==3.9.1
     # via -r requirements/edx/kernel.in
 edx-sga==0.23.1
     # via -r requirements/edx/bundled.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -987,7 +987,7 @@ pyyaml==6.0.1
     #   xblock
 random2==1.0.2
     # via -r requirements/edx/kernel.in
-recommender-xblock==2.1.1
+recommender-xblock==2.2.0
     # via -r requirements/edx/bundled.in
 redis==5.0.1
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1125,7 +1125,7 @@ sqlparse==0.4.4
     #   -r requirements/edx/kernel.in
     #   django
     #   openedx-blockstore
-staff-graded-xblock==2.2.0
+staff-graded-xblock==2.3.0
     # via -r requirements/edx/bundled.in
 stevedore==5.1.0
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -420,7 +420,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-blockstore

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -360,7 +360,7 @@ django-storages==1.14.2
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
-django-user-tasks==3.1.0
+django-user-tasks==3.2.0
     # via -r requirements/edx/kernel.in
 django-waffle==4.1.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -702,7 +702,7 @@ edx-ccx-keys==1.2.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-edx-celeryutils==1.2.5
+edx-celeryutils==1.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -829,7 +829,7 @@ edx-sga==0.23.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-submissions==3.6.0
+edx-submissions==3.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -726,7 +726,7 @@ edx-django-sites-extensions==4.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-utils==5.10.1
+edx-django-utils==5.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1293,7 +1293,7 @@ openedx-calc==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-django-pyfs==3.5.0
+openedx-django-pyfs==3.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1716,7 +1716,7 @@ random2==1.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-recommender-xblock==2.1.1
+recommender-xblock==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -682,7 +682,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1973,7 +1973,7 @@ sqlparse==0.4.4
     #   django
     #   django-debug-toolbar
     #   openedx-blockstore
-staff-graded-xblock==2.2.0
+staff-graded-xblock==2.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -589,7 +589,7 @@ django-stubs==1.16.0
     #   djangorestframework-stubs
 django-stubs-ext==4.2.7
     # via django-stubs
-django-user-tasks==3.1.0
+django-user-tasks==3.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -821,7 +821,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.2
+edx-search==3.9.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1368,7 +1368,7 @@ sqlparse==0.4.4
     #   -r requirements/edx/base.txt
     #   django
     #   openedx-blockstore
-staff-graded-xblock==2.2.0
+staff-graded-xblock==2.3.0
     # via -r requirements/edx/base.txt
 stevedore==5.1.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -426,7 +426,7 @@ django-storages==1.14.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.1.0
+django-user-tasks==3.2.0
     # via -r requirements/edx/base.txt
 django-waffle==4.1.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1170,7 +1170,7 @@ pyyaml==6.0.1
     #   xblock
 random2==1.0.2
     # via -r requirements/edx/base.txt
-recommender-xblock==2.1.1
+recommender-xblock==2.2.0
     # via -r requirements/edx/base.txt
 redis==5.0.1
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -514,7 +514,7 @@ edx-ccx-keys==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-edx-celeryutils==1.2.5
+edx-celeryutils==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -605,7 +605,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.2
+edx-search==3.9.1
     # via -r requirements/edx/base.txt
 edx-sga==0.23.1
     # via -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -498,7 +498,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -530,7 +530,7 @@ edx-django-release-util==1.3.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/base.txt
-edx-django-utils==5.10.1
+edx-django-utils==5.12.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -609,7 +609,7 @@ edx-search==3.9.1
     # via -r requirements/edx/base.txt
 edx-sga==0.23.1
     # via -r requirements/edx/base.txt
-edx-submissions==3.6.0
+edx-submissions==3.7.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -913,7 +913,7 @@ openedx-blockstore==1.4.0
     # via -r requirements/edx/base.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-django-pyfs==3.5.0
+openedx-django-pyfs==3.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -522,7 +522,7 @@ edx-api-doc-tools==1.7.0
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   openedx-blockstore
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -554,7 +554,7 @@ edx-django-release-util==1.3.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.2
     # via -r requirements/edx/base.txt
-edx-django-utils==5.10.1
+edx-django-utils==5.12.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -635,7 +635,7 @@ edx-search==3.9.1
     # via -r requirements/edx/base.txt
 edx-sga==0.23.1
     # via -r requirements/edx/base.txt
-edx-submissions==3.6.0
+edx-submissions==3.7.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -631,7 +631,7 @@ edx-rest-api-client==5.6.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.8.2
+edx-search==3.9.1
     # via -r requirements/edx/base.txt
 edx-sga==0.23.1
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1454,7 +1454,7 @@ sqlparse==0.4.4
     #   -r requirements/edx/base.txt
     #   django
     #   openedx-blockstore
-staff-graded-xblock==2.2.0
+staff-graded-xblock==2.3.0
     # via -r requirements/edx/base.txt
 starlette==0.36.3
     # via fastapi

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -538,7 +538,7 @@ edx-ccx-keys==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-edx-celeryutils==1.2.5
+edx-celeryutils==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1291,7 +1291,7 @@ pyyaml==6.0.1
     #   xblock
 random2==1.0.2
     # via -r requirements/edx/base.txt
-recommender-xblock==2.1.1
+recommender-xblock==2.2.0
     # via -r requirements/edx/base.txt
 redis==5.0.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -455,7 +455,7 @@ django-storages==1.14.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.1.0
+django-user-tasks==3.2.0
     # via -r requirements/edx/base.txt
 django-waffle==4.1.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -968,7 +968,7 @@ openedx-blockstore==1.4.0
     # via -r requirements/edx/base.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-django-pyfs==3.5.0
+openedx-django-pyfs==3.6.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -45,7 +45,7 @@ django-crum==0.7.9
     # via edx-django-utils
 django-waffle==4.1.0
     # via edx-django-utils
-edx-django-utils==5.10.1
+edx-django-utils==5.12.0
     # via edx-rest-api-client
 edx-rest-api-client==5.6.1
     # via -r scripts/user_retirement/requirements/base.in

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -71,7 +71,7 @@ django-waffle==4.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.10.1
+edx-django-utils==5.12.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client


### PR DESCRIPTION
All the libraries listed below have released a new version that has been tested on python 3.11 We upgrade them individually so we can merge them outside the usual make upgrade process so we can mark this work as done.

- openedx-django-pyfs 
- django-user-tasks 
- edx-django-utils 
- recommender-xblock 
- edx-search 
- edx-auth-backends
- staff-graded-xblock
- edx-submissions
- edx-celeryutils