### PR TITLE
Upgrade more packages to be Python 3.11 compatible

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -513,7 +513,7 @@ edx-opaque-keys[django]==2.5.1
     #   lti-consumer-xblock
     #   openedx-events
     #   ora2
-edx-organizations==6.12.1
+edx-organizations==6.13.0
     # via -r requirements/edx/kernel.in
 edx-proctoring==4.16.1
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1203,7 +1203,7 @@ watchdog==4.0.0
     # via -r requirements/edx/paver.txt
 wcwidth==0.2.13
     # via prompt-toolkit
-web-fragments==2.1.0
+web-fragments==2.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   crowdsourcehinter-xblock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -415,7 +415,7 @@ drf-yasg==1.21.5
     #   edx-api-doc-tools
 edx-ace==1.7.0
     # via -r requirements/edx/kernel.in
-edx-api-doc-tools==1.7.0
+edx-api-doc-tools==1.8.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -676,7 +676,7 @@ edx-ace==1.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-api-doc-tools==1.7.0
+edx-api-doc-tools==1.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2155,7 +2155,7 @@ wcwidth==0.2.13
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   prompt-toolkit
-web-fragments==2.1.0
+web-fragments==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -801,7 +801,7 @@ edx-opaque-keys[django]==2.5.1
     #   lti-consumer-xblock
     #   openedx-events
     #   ora2
-edx-organizations==6.12.1
+edx-organizations==6.13.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -590,7 +590,7 @@ edx-opaque-keys[django]==2.5.1
     #   lti-consumer-xblock
     #   openedx-events
     #   ora2
-edx-organizations==6.12.1
+edx-organizations==6.13.0
     # via -r requirements/edx/base.txt
 edx-proctoring==4.16.1
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1468,7 +1468,7 @@ wcwidth==0.2.13
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==2.1.0
+web-fragments==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   crowdsourcehinter-xblock

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -493,7 +493,7 @@ drf-yasg==1.21.5
     #   edx-api-doc-tools
 edx-ace==1.7.0
     # via -r requirements/edx/base.txt
-edx-api-doc-tools==1.7.0
+edx-api-doc-tools==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -517,7 +517,7 @@ drf-yasg==1.21.5
     #   edx-api-doc-tools
 edx-ace==1.7.0
     # via -r requirements/edx/base.txt
-edx-api-doc-tools==1.7.0
+edx-api-doc-tools==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -616,7 +616,7 @@ edx-opaque-keys[django]==2.5.1
     #   lti-consumer-xblock
     #   openedx-events
     #   ora2
-edx-organizations==6.12.1
+edx-organizations==6.13.0
     # via -r requirements/edx/base.txt
 edx-proctoring==4.16.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1582,7 +1582,7 @@ wcwidth==0.2.13
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==2.1.0
+web-fragments==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   crowdsourcehinter-xblock


### PR DESCRIPTION
Upgrade just the packages that are testing on Python 3.11 and 3.8
- web-fragments
- edx-api-doc-tools
- edx-organizations
