### PR TITLE
fix: fix content param for course_update event

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2194,11 +2194,19 @@ class StudioPermissionsService:
         return has_studio_write_access(self._user, course_key)
 
 
-def track_course_update_event(course_key, user, event_data=None):
+def track_course_update_event(course_key, user, course_update_content=None):
     """
     Track course update event
     """
     event_name = 'edx.contentstore.course_update'
+    event_data = {}
+    html_content = course_update_content.get("content", "")
+    str_content = re.sub(r"(\s|&nbsp;|//)+", " ", html_to_text(html_content))
+
+    event_data['content'] = str_content
+    event_data['date'] = course_update_content.get("date", "")
+    event_data['id'] = course_update_content.get("id", "")
+    event_data['status'] = course_update_content.get("status", "")
     event_data['course_id'] = str(course_key)
     event_data['user_id'] = str(user.id)
     event_data['user_forums_roles'] = [
@@ -2207,6 +2215,7 @@ def track_course_update_event(course_key, user, event_data=None):
     event_data['user_course_roles'] = [
         role.role for role in user.courseaccessrole_set.filter(course_id=str(course_key))
     ]
+
     context = contexts.course_context_from_course_id(course_key)
     with tracker.get_tracker().context(event_name, context):
         tracker.emit(event_name, event_data)


### PR DESCRIPTION
### Description

Fix `course_update` event, as it contains html content, that needs to be in str format for events to fire properly.