### PR TITLE
fix: "Course Number Display String" option doesn't influence certificate

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -407,14 +407,15 @@ def _update_organization_context(context, course):
     Updates context with organization related info.
     """
     partner_long_name, organization_logo = None, None
-    partner_short_name = course.display_organization if course.display_organization else course.org
+    course_org_display = course.display_organization
     organizations = organizations_api.get_course_organizations(course_key=course.id)
     if organizations:
         # TODO Need to add support for multiple organizations, Currently we are interested in the first one.
         organization = organizations[0]
         partner_long_name = organization.get('name', partner_long_name)
-        partner_short_name = organization.get('short_name', partner_short_name)
+        course_org_display = course_org_display or organization.get('short_name')
         organization_logo = organization.get('logo', None)
+    partner_short_name = course_org_display or course.org
 
     context['organization_long_name'] = partner_long_name
     context['organization_short_name'] = partner_short_name


### PR DESCRIPTION
## Description

In **Advanced Settings**, it is possible to redefine the name for the Course Organization as well as for the Course Number. However, a bug was discovered in replacing this name on the certificate:
<img width="1216" alt="c_1" src="https://github.com/openedx/edx-platform/assets/98233552/61028852-2a54-4282-96b4-98e248ac8b52">

For **Course Number Display String** everything works correctly:
<img width="1470" alt="c_2" src="https://github.com/openedx/edx-platform/assets/98233552/d11bd606-ce6f-4dc6-bb0d-665b2c4c7926">

But the name of the organization is always taken from the Organizations model. In this case, the definition from Advanced Settings is ignored:
<img width="949" alt="c_4" src="https://github.com/openedx/edx-platform/assets/98233552/e3700516-7dc9-498f-8046-b95134911288">

For other pages, the override works correctly for both settings:
<img width="886" alt="c_3png" src="https://github.com/openedx/edx-platform/assets/98233552/94e7e77e-422d-4401-b230-b2f24ef5c96b">

I slightly changed the logic for prioritizing the selection of the organization name for the certificate. Now everything is replaced correctly:
<img width="1470" alt="c_5" src="https://github.com/openedx/edx-platform/assets/98233552/26112c6f-76af-4096-aa86-9f1c187e085d">
