### PR TITLE
fix: fix typo in share embed link editor

### DIFF
--- a/cms/templates/js/embed-link-share-link-editor.underscore
+++ b/cms/templates/js/embed-link-share-link-editor.underscore
@@ -2,7 +2,7 @@
     <div class="subsection-share-link-container">
         <div>
             <p>
-                <%- gettext('Embed your subsection content directly on a page using an iframe, and view it withput the LMS header and footer.') %>
+                <%- gettext('Embed your subsection content directly on a page using an iframe, and view it without the LMS header and footer.') %>
             </p>
             <button
                 type="button"


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR fixes a typo found in Studio's Share Embed Link editor when using the Hide From TOC functionality.