### PR TITLE
fix: Unexpected "Copied_from_block" field in Advanced Settings #34370

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -3,8 +3,8 @@ Django module for Course Metadata class -- manages advanced settings and related
 """
 
 
-from datetime import datetime
 import logging
+from datetime import datetime
 
 import pytz
 from django.conf import settings
@@ -78,6 +78,7 @@ class CourseMetadata:
         'highlights_enabled_for_messaging',
         'is_onboarding_exam',
         'discussions_settings',
+        'copied_from_block',
     ]
 
     @classmethod


### PR DESCRIPTION
### Issue Description:
I noticed that a new Copied_from_block field has appeared in Advanced Settings.
![image](https://github.com/openedx/edx-platform/assets/19186089/afaceb3b-bd16-4c20-893e-e73cefe9d6b2)

However, having investigated this field, I still could not find an explanation for why it was needed here. At the moment it looks confusing.
Perhaps when adding this functionality, they simply forgot to include copied_from_block in FIELDS_EXCLUDE_LIST.

### Findings
I have investigated and it seems like an internal field which is automatically populating when pasting copied block in studio.

### Solution Implemented:
Added copy_from_block to the FIELDS_EXCLUDE_LIST and then this field will not be shown in Advanced Settings.