### PR TITLE
feanil/even more package updates

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -400,7 +400,7 @@ djangorestframework==3.14.0
     #   super-csv
 djangorestframework-xml==2.0.0
     # via edx-enterprise
-done-xblock==2.2.0
+done-xblock==2.3.0
     # via -r requirements/edx/bundled.in
 drf-jwt==1.19.2
     # via edx-drf-extensions

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -257,7 +257,7 @@ django-celery-results==2.5.1
     # via -r requirements/edx/kernel.in
 django-classy-tags==4.1.0
     # via django-sekizai
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -445,7 +445,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/kernel.in
 edx-completion==4.5.0
     # via -r requirements/edx/kernel.in
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   edxval

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -716,7 +716,7 @@ edx-completion==4.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -647,7 +647,7 @@ docutils==0.19
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-done-xblock==2.2.0
+done-xblock==2.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -436,7 +436,7 @@ django-classy-tags==4.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-sekizai
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -523,7 +523,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
 edx-completion==4.5.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -473,7 +473,7 @@ docutils==0.19
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-done-xblock==2.2.0
+done-xblock==2.3.0
     # via -r requirements/edx/base.txt
 drf-jwt==1.19.2
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -313,7 +313,7 @@ django-classy-tags==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   django-sekizai
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -497,7 +497,7 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-done-xblock==2.2.0
+done-xblock==2.3.0
     # via -r requirements/edx/base.txt
 drf-jwt==1.19.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -342,7 +342,7 @@ django-classy-tags==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   django-sekizai
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -547,7 +547,7 @@ edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
 edx-completion==4.5.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval


### PR DESCRIPTION
Update more packages to be Python 3.11 compatible.

- django-config-models
- edx-django-release-util
- done-xblock
