### PR TITLE
Python 3.11 package updates

### DIFF
--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -56,7 +56,7 @@ numpy==1.22.4
     #   matplotlib
     #   openedx-calc
     #   scipy
-openedx-calc==3.0.1
+openedx-calc==3.1.0
     # via -r requirements/edx-sandbox/py38.in
 packaging==23.2
     # via matplotlib

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -140,7 +140,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-code-annotations==1.6.0
+code-annotations==1.8.0
     # via
     #   edx-enterprise
     #   edx-toggles

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -550,7 +550,7 @@ edx-toggles==5.2.0
     #   ora2
 edx-token-utils==0.2.1
     # via -r requirements/edx/kernel.in
-edx-when==2.4.0
+edx-when==2.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -774,7 +774,7 @@ openedx-atlas==0.6.0
     # via -r requirements/edx/kernel.in
 openedx-blockstore==1.4.0
     # via -r requirements/edx/kernel.in
-openedx-calc==3.0.1
+openedx-calc==3.1.0
     # via -r requirements/edx/kernel.in
 openedx-django-pyfs==3.6.0
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -521,7 +521,7 @@ edx-proctoring==4.16.1
     #   edx-proctoring-proctortrack
 edx-rbac==1.8.0
     # via edx-enterprise
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1136,7 +1136,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.1.0
+super-csv==3.2.0
     # via edx-bulk-grades
 sympy==1.12
     # via openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -564,7 +564,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.2.0
     # via -r requirements/edx/kernel.in
-event-tracking==2.3.0
+event-tracking==2.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-completion

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -536,7 +536,7 @@ edx-submissions==3.7.0
     #   ora2
 edx-tincan-py35==1.0.0
     # via edx-enterprise
-edx-toggles==5.1.1
+edx-toggles==5.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-completion

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -152,7 +152,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-crowdsourcehinter-xblock==0.6
+crowdsourcehinter-xblock==0.7
     # via -r requirements/edx/bundled.in
 cryptography==38.0.4
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1990,7 +1990,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.1.0
+super-csv==3.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -259,7 +259,7 @@ click-repl==0.3.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   celery
-code-annotations==1.6.0
+code-annotations==1.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -856,7 +856,7 @@ edx-token-utils==0.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-when==2.4.0
+edx-when==2.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -289,7 +289,7 @@ coverage[toml]==7.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
-crowdsourcehinter-xblock==0.6
+crowdsourcehinter-xblock==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -839,7 +839,7 @@ edx-tincan-py35==1.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-edx-toggles==5.1.1
+edx-toggles==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -880,7 +880,7 @@ enmerkar-underscore==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-event-tracking==2.3.0
+event-tracking==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -815,7 +815,7 @@ edx-rbac==1.8.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1289,7 +1289,7 @@ openedx-blockstore==1.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-calc==3.0.1
+openedx-calc==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -600,7 +600,7 @@ edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -198,7 +198,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-crowdsourcehinter-xblock==0.6
+crowdsourcehinter-xblock==0.7
     # via -r requirements/edx/base.txt
 cryptography==38.0.4
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -648,7 +648,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.2.0
     # via -r requirements/edx/base.txt
-event-tracking==2.3.0
+event-tracking==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -631,7 +631,7 @@ edx-toggles==5.2.0
     #   ora2
 edx-token-utils==0.2.1
     # via -r requirements/edx/base.txt
-edx-when==2.4.0
+edx-when==2.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1378,7 +1378,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.1.0
+super-csv==3.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -617,7 +617,7 @@ edx-tincan-py35==1.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-toggles==5.1.1
+edx-toggles==5.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -911,7 +911,7 @@ openedx-atlas==0.6.0
     # via -r requirements/edx/base.txt
 openedx-blockstore==1.4.0
     # via -r requirements/edx/base.txt
-openedx-calc==3.0.1
+openedx-calc==3.1.0
     # via -r requirements/edx/base.txt
 openedx-django-pyfs==3.6.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -181,7 +181,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
-code-annotations==1.6.0
+code-annotations==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/doc.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -657,7 +657,7 @@ edx-toggles==5.2.0
     #   ora2
 edx-token-utils==0.2.1
     # via -r requirements/edx/base.txt
-edx-when==2.4.0
+edx-when==2.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -643,7 +643,7 @@ edx-tincan-py35==1.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-toggles==5.1.1
+edx-toggles==5.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -193,7 +193,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
-code-annotations==1.6.0
+code-annotations==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -626,7 +626,7 @@ edx-rbac==1.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -966,7 +966,7 @@ openedx-atlas==0.6.0
     # via -r requirements/edx/base.txt
 openedx-blockstore==1.4.0
     # via -r requirements/edx/base.txt
-openedx-calc==3.0.1
+openedx-calc==3.1.0
     # via -r requirements/edx/base.txt
 openedx-django-pyfs==3.6.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1466,7 +1466,7 @@ stevedore==5.1.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==3.1.0
+super-csv==3.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -217,7 +217,7 @@ coverage[toml]==7.4.1
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
-crowdsourcehinter-xblock==0.6
+crowdsourcehinter-xblock==0.7
     # via -r requirements/edx/base.txt
 cryptography==38.0.4
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -674,7 +674,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.2.0
     # via -r requirements/edx/base.txt
-event-tracking==2.3.0
+event-tracking==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -47,7 +47,7 @@ django-waffle==4.1.0
     # via edx-django-utils
 edx-django-utils==5.12.0
     # via edx-rest-api-client
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via -r scripts/user_retirement/requirements/base.in
 google-api-core==2.15.0
     # via google-api-python-client

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -75,7 +75,7 @@ edx-django-utils==5.12.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via -r scripts/user_retirement/requirements/base.txt
 exceptiongroup==1.2.0
     # via pytest


### PR DESCRIPTION
Update more packages that now have Python 3.11 compatability declared and tested.

- crowdsourcehinter-xblock
- acid-xblock
- edx-toggles
- edx-rest-api-client
- code-annotations
- openedx-calc
- super-csv
- edx-when
- event-tracking
