### PR TITLE
Add must_retry as valid status to approve_id_verifications management command.

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 class Command(BaseCommand):
     """
     This command manually approves ID verification attempts for a provided set of learners whose ID verification
-    attempt is in the submitted state.
+    attempt is in the submitted or must_retry state.
 
     This command differs from the similar manual_verifications command in that it approves the
     SoftwareSecurePhotoVerification instance instead of creating a ManualVerification instance. This is advantageous
@@ -32,7 +32,7 @@ class Command(BaseCommand):
     Example usage:
         $ ./manage.py lms idv_verifications <absolute path of file with user IDs (one per line)>
     """
-    help = 'Manually approves ID verifications for users with an ID verification attempt in the submitted state.'
+    help = 'Manually approve ID verifications for users with an attempt in the submitted or must_retry state.'
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -126,7 +126,7 @@ class Command(BaseCommand):
     def _approve_id_verifications(self, user_ids):
         """
         This command manually approves ID verification attempts for a provided set of learners whose ID verification
-        attempt is in the submitted state.
+        attempt is in the submitted or must_retry state.
 
         Arguments:
             user_ids (list): user IDs of the users whose ID verification attempt should be manually approved
@@ -136,7 +136,7 @@ class Command(BaseCommand):
         """
         existing_id_verifications = SoftwareSecurePhotoVerification.objects.filter(
             user_id__in=user_ids,
-            status='submitted',
+            status__in=['submitted', 'must_retry'],
             created_at__gte=earliest_allowed_verification_date(),
         )
 

--- a/lms/djangoapps/verify_student/management/commands/tests/test_approve_id_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_approve_id_verifications.py
@@ -2,7 +2,7 @@
 Tests for django admin commands in the verify_student module
 
 """
-
+import ddt
 import logging
 import os
 import tempfile
@@ -18,6 +18,7 @@ from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 LOGGER_NAME = 'lms.djangoapps.verify_student.management.commands.approve_id_verifications'
 
 
+@ddt.ddt
 class TestApproveIDVerificationsCommand(TestCase):
     """
     Tests for django admin commands in the verify_student module
@@ -50,7 +51,8 @@ class TestApproveIDVerificationsCommand(TestCase):
         with open(file_path, 'w') as temp_file:
             temp_file.write(str("\n".join(user_ids)))
 
-    def test_approve_id_verifications(self):
+    @ddt.data('submitted', 'must_retry')
+    def test_approve_id_verifications(self, status):
         """
         Tests that the approve_id_verifications management command executes successfully.
         """
@@ -59,7 +61,7 @@ class TestApproveIDVerificationsCommand(TestCase):
             SoftwareSecurePhotoVerification.objects.create(
                 user=user.user,
                 name=user.name,
-                status='submitted',
+                status=status,
             )
 
         assert SoftwareSecurePhotoVerification.objects.filter(status='approved').count() == 0


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Sometimes, submissions to an IDV provider fail, which results in an IDV attempt moving from the "ready" status into the "must_retry" status instead of the "submitted" status.

We would like to approve these attempts too.

## Supporting information

**Jira**: [COSMO-238](https://2u-internal.atlassian.net/browse/COSMO-238) (private)