### PR TITLE
fix: an issue where changing the transcript language code

### DIFF
--- a/xmodule/video_block/video_handlers.py
+++ b/xmodule/video_block/video_handlers.py
@@ -467,6 +467,7 @@ class VideoStudioViewHandlers:
 
         return error
 
+    # pylint: disable=too-many-statements
     @XBlock.handler
     def studio_transcript(self, request, dispatch):
         """
@@ -534,6 +535,10 @@ class VideoStudioViewHandlers:
                             'edx_video_id': edx_video_id,
                             'language_code': new_language_code
                         }
+                        # If a new transcript is added, then both new_language_code and
+                        # language_code fields will have the same value.
+                        if language_code != new_language_code:
+                            self.transcripts.pop(language_code, None)
                         self.transcripts[new_language_code] = f'{edx_video_id}-{new_language_code}.srt'
                         response = Response(json.dumps(payload), status=201)
                     except (TranscriptsGenerationException, UnicodeDecodeError):


### PR DESCRIPTION
## Description

Fixed an issue where changing the transcript language code would cause both the old and new transcript to be displayed. But in this case, you won’t be able to download the transcript from the old code, since the link is invalid.

The current MR is a consequence of [this MR](https://github.com/openedx/edx-platform/pull/32099).

To reproduce, do the following:
1. The Course Authoring MFE must be configured, and the `new_core_editors.use_new_video_editor` flag must be enabled in the admin panel.
2. Add a video to the Unit.
3. Go to the editor. Add a valid transcript.
4. Now you can change the language in an existing transcript.
5. Now, when changing the language, the old one will remain in place and a new one will be added. You will see this when you reload the page.

![tr_0](https://github.com/openedx/edx-platform/assets/98233552/198fe0c5-fca8-4699-939b-03c4da99e9cb)

![tr_1](https://github.com/openedx/edx-platform/assets/98233552/8c231f1f-3ff5-40ba-b3c2-319f5c737064)

![tr_2](https://github.com/openedx/edx-platform/assets/98233552/17c4aaa4-0c7d-4cc9-89ad-20e5c72b09db)

6. Also, make sure you download the transcripts to your computer. It will only work for the last selected language. For other x there will be an error.



