### PR TITLE
fix(AU-1855): Fix email WCR email subject variable text

### DIFF
--- a/lms/templates/support/edx_ace/wholecoursereset/email/body.html
+++ b/lms/templates/support/edx_ace/wholecoursereset/email/body.html
@@ -7,7 +7,9 @@
   <tr>
     <td>
       <h1>
-        {% blocktrans %}The course {{ course_title }} has been reset !{% endblocktrans %}
+        {% filter force_escape %}
+          {% blocktrans %}The course {{ course_title }} has been reset !{% endblocktrans %}
+          {% endfilter %}
       </h1>
       <p style="color: rgba(0,0,0,.75);">
         {% filter force_escape %}

--- a/lms/templates/support/edx_ace/wholecoursereset/email/body.html
+++ b/lms/templates/support/edx_ace/wholecoursereset/email/body.html
@@ -7,7 +7,7 @@
   <tr>
     <td>
       <h1>
-        {% trans "The course {{ course_title }} has been reset !" as tmsg %}{{ tmsg | force_escape }}
+        {% blocktrans %}The course {{ course_title }} has been reset !{% endblocktrans %}
       </h1>
       <p style="color: rgba(0,0,0,.75);">
         {% filter force_escape %}


### PR DESCRIPTION
## Description

Fix WCR email title
<img width="985" alt="Screenshot 2024-04-08 at 12 42 30" src="https://github.com/openedx/edx-platform/assets/7064472/d69b6f4e-c037-4a0f-a77f-c630b265f87f">

It's not possible to mix a template variable inside a string within {% trans %}. If your translations require strings with variables (placeholders), use {% blocktrans %} instead.

https://2u-internal.atlassian.net/browse/AU-1855