### PR TITLE
feat: use profile name in navbar if available

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -19,7 +19,9 @@ from openedx.features.enterprise_support.utils import get_enterprise_learner_gen
 self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
-displayname = get_enterprise_learner_generic_name(request) or username
+profile = getattr(self.real_user, 'profile', None)
+name = getattr(profile, 'name', username)
+displayname = get_enterprise_learner_generic_name(request) or name
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Makes use of name field from user profile field if it is not empty

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner".



## Supporting information

* `Private-ref`: [BB-8772](https://tasks.opencraft.com/browse/BB-8772)
* frontend-app-learner-dashboard: https://github.com/openedx/frontend-app-learner-dashboard/pull/313
* frontend-component-header: https://github.com/openedx/frontend-component-header/pull/483

## Testing instructions

* Update `Name` field via account settings.
* Go to any non-mfe page in LMS and right side of navbar. The profile name should be displayed instead of username.