### PR TITLE
fix: replace outdated webpack plugins

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -6,6 +6,7 @@ var Merge = require('webpack-merge');
 var webpack = require('webpack');
 var BundleTracker = require('webpack-bundle-tracker');
 var _ = require('underscore');
+const TerserPlugin = require("terser-webpack-plugin");
 
 var commonConfig = require('./webpack.common.config.js');
 
@@ -22,16 +23,14 @@ var optimizedConfig = Merge.smart(commonConfig, {
             }),
             new webpack.LoaderOptionsPlugin({ // This may not be needed; legacy option for loaders written for webpack 1
                 minimize: true
-            }),
-            new webpack.optimize.UglifyJsPlugin(),
-            new webpack.optimize.CommonsChunkPlugin({
-            // If the value below changes, update the render_bundle call in
-            // common/djangoapps/pipeline_mako/templates/static_content.html
-                name: 'commons',
-                filename: 'commons.[chunkhash].js',
-                minChunks: 3
             })
-        ]
+        ],
+        optimization: {
+            minimize: true,
+            minimizer: [
+                new TerserPlugin(),
+            ],
+        }
     }
 });
 
@@ -52,16 +51,7 @@ var requireCompatConfig = Merge.smart(optimizedConfig, {
     web: {
         output: {
             filename: '[name].js'
-        },
-        plugins: [
-            new webpack.optimize.CommonsChunkPlugin({
-            // If the value below changes, update the render_bundle call in
-            // common/djangoapps/pipeline_mako/templates/static_content.html
-                name: 'commons',
-                filename: 'commons.js',
-                minChunks: 3
-            })
-        ]
+        }
     }
 });
 


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This updates `webpack.prod.config` to no longer use outdated webpack plugins.

## Supporting information

* https://github.com/webpack/webpack/issues/6409#issuecomment-361337566
* https://stackoverflow.com/questions/65298689/uglifyjs-and-webpack-v5

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
