### PR TITLE
Make Tests Python 3.11 Compatible

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -713,7 +713,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         """
         Try uploading some non-CSV file and verify that it is rejected
         """
-        uploaded_file = SimpleUploadedFile("temp.csv", io.BytesIO(b"some initial binary data: \x00\x01").read())
+        uploaded_file = SimpleUploadedFile("temp.csv", io.BytesIO(b"some initial binary data: \xC3\x01").read())
         response = self.client.post(self.url, {'students_list': uploaded_file})
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -920,15 +920,16 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         manual_enrollments = ManualEnrollmentAudit.objects.all()
         assert manual_enrollments.count() == 2
 
-    @patch('lms.djangoapps.instructor.views.api', 'generate_random_string',
-           Mock(side_effect=['first', 'first', 'second']))
     def test_generate_unique_password_no_reuse(self):
         """
         generate_unique_password should generate a unique password string that hasn't been generated before.
         """
-        generated_password = ['first']
-        password = generate_unique_password(generated_password, 12)
-        assert password != 'first'
+        with patch('lms.djangoapps.instructor.views.api.generate_random_string') as mock:
+            mock.side_effect = ['first', 'first', 'second']
+
+            generated_password = ['first']
+            password = generate_unique_password(generated_password, 12)
+            assert password != 'first'
 
     @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': False})
     def test_allow_automated_signups_flag_not_set(self):

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -888,7 +888,7 @@ class TestCertificatesInstructorApiBulkAllowlist(SharedModuleStoreTestCase):
         """
         Try uploading CSV file with invalid binary data and verify that it is rejected
         """
-        uploaded_file = SimpleUploadedFile("temp.csv", io.BytesIO(b"some initial binary data: \x00\x01").read())
+        uploaded_file = SimpleUploadedFile("temp.csv", io.BytesIO(b"some initial binary data: \xC3\x01").read())
         response = self.client.post(self.url, {'students_list': uploaded_file})
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))

--- a/openedx/core/lib/cache_utils.py
+++ b/openedx/core/lib/cache_utils.py
@@ -126,7 +126,7 @@ class process_cached:  # pylint: disable=invalid-name
         self.cache = {}
 
     def __call__(self, *args):
-        if not isinstance(args, collections.Hashable):
+        if not isinstance(args, collections.abc.Hashable):
             # uncacheable. a list, for instance.
             # better to not cache than blow up.
             return self.func(*args)

--- a/openedx/core/lib/cache_utils.py
+++ b/openedx/core/lib/cache_utils.py
@@ -147,7 +147,10 @@ class process_cached:  # pylint: disable=invalid-name
         """
         Support instance methods.
         """
-        return functools.partial(self.__call__, obj)
+        partial = functools.partial(self.__call__, obj)
+        # Make the cache accessible on the wrapped object so it can be cleared if needed.
+        partial.cache = self.cache
+        return partial
 
 
 class CacheInvalidationManager:

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -221,7 +221,7 @@ class LibraryContentBlock(
         overlimit_block_keys = set()
         if len(selected_keys) > max_count:
             num_to_remove = len(selected_keys) - max_count
-            overlimit_block_keys = set(rand.sample(selected_keys, num_to_remove))
+            overlimit_block_keys = set(rand.sample(list(selected_keys), num_to_remove))
             selected_keys -= overlimit_block_keys
 
         # Do we have enough blocks now?
@@ -233,7 +233,7 @@ class LibraryContentBlock(
             pool = valid_block_keys - selected_keys
             if mode == "random":
                 num_to_add = min(len(pool), num_to_add)
-                added_block_keys = set(rand.sample(pool, num_to_add))
+                added_block_keys = set(rand.sample(list(pool), num_to_add))
                 # We now have the correct n random children to show for this user.
             else:
                 raise NotImplementedError("Unsupported mode.")

--- a/xmodule/tests/xml/factories.py
+++ b/xmodule/tests/xml/factories.py
@@ -57,7 +57,7 @@ class XmlImportData:
 
 # Extract all argument names used to construct XmlImportData objects,
 # so that the factory doesn't treat them as XML attributes
-XML_IMPORT_ARGS = inspect.getargspec(XmlImportData.__init__).args  # lint-amnesty, pylint: disable=deprecated-method
+XML_IMPORT_ARGS = inspect.getfullargspec(XmlImportData.__init__).args
 
 
 class XmlImportFactory(Factory):


### PR DESCRIPTION
Multiple edx-platform Python tests fail when running on 3.11  Update those tests so that they will work correctly when we start testing on 3.11.

This PR does not introduce 3.11 testing because there are other costs and complexities to doing that so it is just making modifications to the tests so that they will be compatible with both versions of the code.

The goal is to land this ahead of the other parts of https://github.com/openedx/edx-platform/pull/34374 so that we can reduce the size of the breaking change PR.

- **fix: Be able to clear the process_cache manually in Python 3.11**
- **fix: Provide a sequence to random.sample**
- **fix: Create a bad unicode file differently.**
- **fix: Fix function mocking.**
- **fix: Don't use the deprecated location for Hashable**
- **fix: Remove deprecated getargspec call.**
