### PR TITLE
feat: add more verbose logging around force_enrollment

### DIFF
--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -683,9 +683,10 @@ class CourseEnrollment(models.Model):
         if check_access:
             if cls.is_enrollment_closed(user, course) and not can_upgrade:
                 log.warning(
-                    "User %s failed to enroll in course %s because enrollment is closed",
+                    "User %s failed to enroll in course %s because enrollment is closed (can_upgrade=%s).",
                     user.username,
-                    str(course_key)
+                    str(course_key),
+                    can_upgrade,
                 )
                 raise EnrollmentClosedError
 

--- a/openedx/features/enterprise_support/enrollments/utils.py
+++ b/openedx/features/enterprise_support/enrollments/utils.py
@@ -133,12 +133,13 @@ def lms_update_or_create_enrollment(
         except (CourseEnrollmentError, CourseEnrollmentNotUpdatableError) as error:
             log.exception(
                 "Raising error [%s] for user "
-                "[%s]: course run = [%s], enterprise_uuid = [%s], is_active = [%s], ",
+                "[%s]: course run = [%s], enterprise_uuid = [%s], is_active = [%s], force_enrollment = [%s], ",
                 error,
                 username,
                 course_id,
                 str(enterprise_uuid),
                 is_active,
+                force_enrollment,
             )
             raise error
         finally:


### PR DESCRIPTION
After testing the enterprise bulk enrollment flow with force_enrollment=True, I'm finding that the enrollment is still not forced. This extra logging will hopefully help shed light on where this boolean might be accidentally ignored.