### PR TITLE
feat: add a feature flag to disable dates tab for all courses

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -315,6 +315,12 @@ class DatesTab(EnrolledTab):
         tab_dict['link_func'] = link_func
         super().__init__(tab_dict)
 
+    @classmethod
+    def is_enabled(cls, course, user=None):
+        if settings.FEATURES.get('DISABLE_DATES_TAB'):
+            return False
+        return super().is_enabled(course, user)
+
 
 def get_course_tab_list(user, course):
     """

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -885,3 +885,16 @@ class DatesTabTestCase(TabListTestCase):
             if tab.type == 'dates':
                 num_dates_tabs += 1
         assert num_dates_tabs == 1
+
+    def test_dates_tab_is_enabled_by_default(self):
+        """Test dates tab is enabled by default."""
+        tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
+        user = self.create_mock_user()
+        assert self.is_tab_enabled(tab, self.course, user)
+
+    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_DATES_TAB": True})
+    def test_dates_tab_disabled_by_feature_flag(self):
+        """Test dates tab is disabled by the feature flag."""
+        tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
+        user = self.create_mock_user()
+        assert not self.is_tab_enabled(tab, self.course, user)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1059,6 +1059,15 @@ FEATURES = {
     # .. toggle_creation_date: 2024-03-22
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
+
+    # .. toggle_name: FEATURES['DISABLE_DATES_TAB']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Disables dates tab for all courses.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-04-15
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34511
+    'DISABLE_DATES_TAB': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds a feature flag that allows disabling dates tab for all courses.

## Testing instructions

1. Run the platform in a way that is convenient for you - `tutor`, `devstack`, etc.
2. Checkout this PR
3. Check that by default courses have dates tab (you might need to run `./manage.py cms backfill_course_tabs` for them to appear, for example if running on devstack)
4. Set the `DISABLE_DATES_TAB` flag to `True`.
5. Validate that all courses now have the dates tab hidden, as it is no longer enabled.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.
