### PR TITLE
fix: endorsed post notification audiance updated

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -240,10 +240,8 @@ class DiscussionNotificationSender:
         Sends a notification to the author of the thread
         response on his thread has been endorsed
         """
-        context = {
-            "username": self.creator.username,
-        }
-        self._send_notification([self.thread.user_id], "response_endorsed_on_thread", context)
+        if self.creator.id != int(self.thread.user_id):
+            self._send_notification([self.thread.user_id], "response_endorsed_on_thread")
 
     def send_response_endorsed_notification(self):
         """

--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -191,8 +191,7 @@ def create_response_endorsed_on_thread_notification(*args, **kwargs):
     and another notification for response author when response is endorsed
     """
     comment = kwargs['post']
-    comment_author_id = comment.attributes['user_id']
     thread_id = comment.attributes['thread_id']
     course_key_str = comment.attributes['course_id']
-
-    send_response_endorsed_notifications.apply_async(args=[thread_id, course_key_str, comment_author_id])
+    endorsed_by = kwargs['user'].id
+    send_response_endorsed_notifications.apply_async(args=[thread_id, kwargs['post'].id, course_key_str, endorsed_by])

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -145,11 +145,11 @@ COURSE_NOTIFICATION_TYPES = {
         'is_core': True,
         'info': '',
         'non_editable': [],
-        'content_template': _('<{p}><{strong}>{username}</{strong}> response has been endorsed in your post '
+        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> response has been endorsed in your post '
                               '<{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',
-            'username': 'Response author name',
+            'replier_name': 'Endorsed by',
         },
         'email_template': '',
         'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE]


### PR DESCRIPTION
## Description 
Updated endorsed response notification  logic

- If the endorsed response and thread have the same user, only send one notification.
- if the response is endorsed by the creator or response, do not send a notification. 

##  Ticket 
https://2u-internal.atlassian.net/browse/INF-1311