### PR TITLE
fix: fix cadence value for instant cadence and update version

### DIFF
--- a/openedx/core/djangoapps/notifications/email_notifications.py
+++ b/openedx/core/djangoapps/notifications/email_notifications.py
@@ -10,12 +10,12 @@ class EmailCadence:
     """
     DAILY = 'Daily'
     WEEKLY = 'Weekly'
-    INSTANTLY = 'Instantly'
+    IMMEDIATELY = 'Immediately'
     NEVER = 'Never'
     EMAIL_CADENCE_CHOICES = [
         (DAILY, _('Daily')),
         (WEEKLY, _('Weekly')),
-        (INSTANTLY, _('Instantly')),
+        (IMMEDIATELY, _('Immediately')),
         (NEVER, _('Never')),
     ]
     EMAIL_CADENCE_CHOICES_DICT = dict(EMAIL_CADENCE_CHOICES)

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -23,7 +23,7 @@ NOTIFICATION_CHANNELS = ['web', 'push', 'email']
 ADDITIONAL_NOTIFICATION_CHANNEL_SETTINGS = ['email_cadence']
 
 # Update this version when there is a change to any course specific notification type or app.
-COURSE_NOTIFICATION_CONFIG_VERSION = 7
+COURSE_NOTIFICATION_CONFIG_VERSION = 8
 
 
 def get_course_notification_preference_config():


### PR DESCRIPTION
### [INF-1360](https://2u-internal.atlassian.net/browse/INF-1360)

### Description

This PR does the following:

- Updates `COURSE_NOTIFICATION_CONFIG_VERSION` to 8. This update will include the `email_cadence` setting for each notification type in preferences
- Updates the value of instant email cadence from `Instantly` to `Immediately`