### PR TITLE
feat: third party authentication automatic logout with a single redirect

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -211,8 +211,10 @@ class LogoutTests(TestCase):
             mock_idp_logout_url.return_value = idp_logout_url
             self._authenticate_with_oauth(client)
             response = self.client.get(reverse('logout'))
-            assert response.status_code == 302
-            assert response.url == idp_logout_url
+            expected = {
+                'target': idp_logout_url,
+            }
+            self.assertDictContainsSubset(expected, response.context_data)
 
     @mock.patch('django.conf.settings.TPA_AUTOMATIC_LOGOUT_ENABLED', True)
     def test_no_automatic_tpa_logout_without_logout_url(self):


### PR DESCRIPTION
## Description

Current Third Party Authentication logout requires a redirect from the SSO IDP to the LMS  to handle IDAs logout, i.e. we need to visit the `<LMS>/logout` twice. This PR attempts to handle the TPA logout with only one visit to `<LMS>/logout`.

## Testing instructions

1. Add `TPA_AUTOMATIC_LOGOUT_ENABLED = True` to `edx-platform/lms/envs/devstack.py`
2. Replace `self.tpa_logout_url = tpa_pipeline.get_idp_logout_url_from_running_pipeline(request)` in `edx-platform/openedx/core/djangoapps/user_authn/views/logout.py` with  `self.tpa_logout_url = "https://example.com/logout"` (to simplify testing)
3. Launch LMS  and Studio e.g. `make dev.up.lms+cms` 
4. Check the network tab and ensure that the user is logged out from both the LMS and Studio before being redirected to `https://example.com/logout` (fake IDP logout URL)

## Supporting information
Private ref BB-8759

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

