### PR TITLE
fix: [FC-0044] provide with can_paste_component in serializers

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -152,3 +152,4 @@ class VerticalContainerSerializer(serializers.Serializer):
 
     children = ChildVerticalContainerSerializer(many=True)
     is_published = serializers.BooleanField()
+    can_paste_component = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -153,6 +153,7 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["children"]), 2)
         self.assertFalse(response.data["is_published"])
+        self.assertTrue(response.data["can_paste_component"])
 
     def test_xblock_is_published(self):
         """


### PR DESCRIPTION
### Description
The field `can_paste_component` was omitted in previous PRs, so now it has been added to the serializers.

### Testing instructions
1. Run master devstack.
2. Start platform `make dev.up.lms+cms` and make checkout on this branch.
3. Go to studio home page and choose the course.
4. Create Unit from the subsection and open it.
5. Copy location of the unit block.
6. Go to `http://localhost:18010/api-docs`.
7. Find the required API endpoint `/api/contentstore/v1/container/vertical/{usage_key_string}/children`.