### PR TITLE
Fix  libraries performance problem

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/home.py
@@ -215,4 +215,5 @@ class HomePageLibrariesView(APIView):
 
         library_context = get_library_context(request)
         serializer = LibraryTabSerializer(library_context)
+
         return Response(serializer.data)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -52,7 +52,7 @@ from common.djangoapps.student.roles import (
     CourseStaffRole,
     GlobalStaff,
     UserBasedRole,
-    OrgStaffRole
+    OrgStaffRole,
 )
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
 from common.djangoapps.util.string_utils import _has_non_ascii_characters

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -23,7 +23,7 @@ from common.djangoapps.student.roles import (
     OrgContentCreatorRole,
     OrgInstructorRole,
     OrgLibraryUserRole,
-    OrgStaffRole
+    OrgStaffRole,
 )
 
 # Studio permissions:
@@ -106,6 +106,7 @@ def get_user_permissions(user, course_key, org=None):
     # Staff have all permissions except EDIT_ROLES:
     if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
         return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
+
     # Otherwise, for libraries, users can view only:
     if course_key and isinstance(course_key, LibraryLocator):
         if OrgLibraryUserRole(org=org).has_user(user) or user_has_role(user, LibraryUserRole(course_key)):

--- a/common/djangoapps/student/role_helpers.py
+++ b/common/djangoapps/student/role_helpers.py
@@ -75,4 +75,4 @@ def get_course_roles(user: User) -> list[CourseAccessRole]:
     """
     # pylint: disable=protected-access
     role_cache = get_role_cache(user)
-    return list(role_cache._roles)
+    return list(role_cache.all_roles_set)


### PR DESCRIPTION
## Context (skip if you are only interested in the actual changes)

This is an attempt to fix a performance problem on the libraries home page. When you go to studio home and click on the libraries tab, on prod it will be quick for admins but extremely slow for course instructors (> 12 seconds) and leads to timeouts. It grows with the number of libraries that are assigned to the instructor.

My hypothesis is that this is due to slow Python code in the `BulkRoleCache` and `RoleCache` classes which was suspiciously slow locally. Complexity for admins is O(n) where n is the total number of libraries that exist, but for course instructors it's O(n * m) where m is the number of courses and libraries that this instructor has access to, which can be > 1000. The reason is that for every library that exists, there's a lookup in the `RoleCache` to see whether the user has a role for this library. This used to be an iteration over a set.

I changed the cache to store roles per user in a dict that groups roles by course id if they have one. That changes the complexity of the lookup to O(1), so total complexity for loading the libraries home page is reduced to O(n).

I observed that locally with a user that only had a small number of libraries assigned it cut the request time to a third.

Even if this does not fix the described performance problem it's an improvement of code performance and good to have. So fixing the described bug is not a requirement for merging this PR.

## Description

This is a python performance improvement. I want to change the lookup time in the RoleCache to O(1) when there's a cache hit.
I changed the RoleCache / BulkRoleCache to store roles per user in a dict that groups roles by course id if they have one. I then transformed it into a flat set like it was before to keep the `_.roles` property the same to avoid breaking anything that relied on this.

## Caveats

This will improve code performance but since the ungrouped set of all roles is also needed, I'm caching it as a set as well in the `_roles` variable of `RoleCache`. That means that the `RoleCache` takes up twice as much memory while it's being used, but I think it's request-scoped and should reset when the request is finished if I'm not mistaken (correct me if I'm wrong?), so it should not be a big deal.

## Supporting information

[Internal JIRA](https://2u-internal.atlassian.net/browse/TNL-11106)

## Testing instructions

- Log into studio as a course instructor
- assign two libraries to that instructor
- go to studio and click on the libraries tab
- courses and libraries should load without any errors
- otherwise, we really just want to make sure I'm not introducing regression bugs.

## Other information

- While the cache now stores user roles in a dict, I also kept the original `._roles` property of the RolesCache and made it so it transforms the roles into a set that's stored in this variable. One reason for this is not to break any existing code.
- Most unexpected errors I had to deal with came from calculating or using the key for this course dict. Some roles didn't have a CourseKey and some of the course keys - for example of V2 libraries - didn't have an `html_id()` function, and this threw errors. I think I dealt with this problem sufficiently now.
- The RoleCache is pretty central so it's really important to avoid breaking any existing functionality that relies on it. Please pay close attention to that in the review.