### PR TITLE
feat: emit new course passing status events

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -579,6 +579,14 @@ FEATURES = {
     # .. toggle_creation_date: 2024-03-22
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
+
+    # .. toggle_name: FEATURES['BADGES_ENABLED']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable the Badges feature.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-04-10
+    'BADGES_ENABLED': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE
@@ -2837,6 +2845,8 @@ SIMPLE_HISTORY_DATE_INDEX = False
 def _should_send_xblock_events(settings):
     return settings.FEATURES['ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS']
 
+def _should_send_learning_badge_events(settings):
+    return settings.FEATURES['BADGES_ENABLED']
 
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
 # .. setting_default: all events disabled
@@ -2887,6 +2897,18 @@ EVENT_BUS_PRODUCER_CONFIG = {
         'learning-certificate-lifecycle':
             {'event_key_field': 'certificate.course.course_key', 'enabled': False},
     },
+    "org.openedx.learning.course.passing.status.updated.v1": {
+        "learning-badges-lifecycle": {
+            "event_key_field": "course_passing_status.course.course_key",
+            "enabled": _should_send_learning_badge_events,
+        },
+    },
+    "org.openedx.learning.ccx.course.passing.status.updated.v1": {
+        "learning-badges-lifecycle": {
+            "event_key_field": "course_passing_status.course.course_key",
+            "enabled": _should_send_learning_badge_events,
+        },
+    },
 }
 
 
@@ -2897,6 +2919,18 @@ derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.content_autho
 derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.content_authoring.xblock.deleted.v1',
                          'course-authoring-xblock-lifecycle', 'enabled')
 
+derived_collection_entry(
+    "EVENT_BUS_PRODUCER_CONFIG",
+    "org.openedx.learning.course.passing.status.updated.v1",
+    "learning-badges-lifecycle",
+    "enabled",
+)
+derived_collection_entry(
+    "EVENT_BUS_PRODUCER_CONFIG",
+    "org.openedx.learning.ccx.course.passing.status.updated.v1",
+    "learning-badges-lifecycle",
+    "enabled",
+)
 
 ################### Authoring API ######################
 

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -4,16 +4,29 @@ Test that various events are fired for models in the grades app.
 
 from unittest import mock
 
+from ccx_keys.locator import CCXLocator
 from django.utils.timezone import now
 from openedx_events.learning.data import (
+    CcxCourseData,
+    CcxCoursePassingStatusData,
     CourseData,
-    PersistentCourseGradeData
+    CoursePassingStatusData,
+    PersistentCourseGradeData,
+    UserData,
+    UserPersonalData
 )
-from openedx_events.learning.signals import PERSISTENT_GRADE_SUMMARY_CHANGED
+from openedx_events.learning.signals import (
+    CCX_COURSE_PASSING_STATUS_UPDATED,
+    COURSE_PASSING_STATUS_UPDATED,
+    PERSISTENT_GRADE_SUMMARY_CHANGED
+)
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
-from common.djangoapps.student.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
+from lms.djangoapps.ccx.models import CustomCourseForEdX
+from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.models import PersistentCourseGrade
+from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -94,5 +107,136 @@ class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixi
                     passed_timestamp=grade.passed_timestamp
                 )
             },
-            event_receiver.call_args.kwargs
+            event_receiver.call_args.kwargs,
+        )
+
+
+class CoursePassingStatusEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):  # pylint: disable=missing-class-docstring
+    ENABLED_OPENEDX_EVENTS = [
+        "org.openedx.learning.course.passing.status.updated.v1",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.user = UserFactory.create()
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_course_passing_status_updated_emitted(self):
+        event_receiver = mock.Mock(side_effect=self._event_receiver_side_effect)
+        COURSE_PASSING_STATUS_UPDATED.connect(event_receiver)
+        grade_factory = CourseGradeFactory()
+
+        with mock_passing_grade():
+            grade_factory.update(self.user, self.course)
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": COURSE_PASSING_STATUS_UPDATED,
+                "sender": None,
+                "course_passing_status": CoursePassingStatusData(
+                    status=CoursePassingStatusData.PASSING,
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=self.user.username,
+                            email=self.user.email,
+                            name=self.user.get_full_name(),
+                        ),
+                        id=self.user.id,
+                        is_active=self.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=self.course.id,
+                    ),
+                ),
+            },
+            event_receiver.call_args.kwargs,
+        )
+
+
+class CCXCoursePassingStatusEventsTest(  # pylint: disable=missing-class-docstring
+    SharedModuleStoreTestCase, OpenEdxEventsTestMixin
+):
+    ENABLED_OPENEDX_EVENTS = [
+        "org.openedx.learning.ccx.course.passing.status.updated.v1",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.user = UserFactory.create()
+        self.coach = AdminFactory.create()
+        self.ccx = ccx = CustomCourseForEdX(
+            course_id=self.course.id, display_name="Test CCX", coach=self.coach
+        )
+        ccx.save()
+        self.ccx_locator = CCXLocator.from_course_locator(self.course.id, ccx.id)
+
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_ccx_course_passing_status_updated_emitted(self):
+        event_receiver = mock.Mock(side_effect=self._event_receiver_side_effect)
+        CCX_COURSE_PASSING_STATUS_UPDATED.connect(event_receiver)
+        grade_factory = CourseGradeFactory()
+
+        with mock_passing_grade():
+            grade_factory.update(self.user, self.store.get_course(self.ccx_locator))
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": CCX_COURSE_PASSING_STATUS_UPDATED,
+                "sender": None,
+                "course_passing_status": CcxCoursePassingStatusData(
+                    status=CcxCoursePassingStatusData.PASSING,
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=self.user.username,
+                            email=self.user.email,
+                            name=self.user.get_full_name(),
+                        ),
+                        id=self.user.id,
+                        is_active=self.user.is_active,
+                    ),
+                    course=CcxCourseData(
+                        ccx_course_key=self.ccx_locator,
+                        master_course_key=self.course.id,
+                        display_name="",
+                        coach_email="",
+                        start=None,
+                        end=None,
+                        max_students_allowed=self.ccx.max_student_enrollments_allowed,
+                    ),
+                ),
+            },
+            event_receiver.call_args.kwargs,
         )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1059,6 +1059,15 @@ FEATURES = {
     # .. toggle_creation_date: 2024-03-22
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
+
+    # .. toggle_name: FEATURES['BADGES_ENABLED']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable badges functionality.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-04-02
+    # .. toggle_target_removal_date: None
+    'BADGES_ENABLED': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
@@ -5418,7 +5427,12 @@ SIMPLE_HISTORY_DATE_INDEX = False
 def _should_send_certificate_events(settings):
     return settings.FEATURES['SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS']
 
+
 #### Event bus producing ####
+
+def _should_send_learning_badge_events(settings):
+    return settings.FEATURES['BADGES_ENABLED']
+
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
 # .. setting_default: all events disabled
 # .. setting_description: Dictionary of event_types mapped to dictionaries of topic to topic-related configuration.
@@ -5491,11 +5505,37 @@ EVENT_BUS_PRODUCER_CONFIG = {
         'course-authoring-xblock-lifecycle':
             {'event_key_field': 'xblock_info.usage_key', 'enabled': False},
     },
+    "org.openedx.learning.course.passing.status.updated.v1": {
+        "learning-badges-lifecycle": {
+            "event_key_field": "course_passing_status.course.course_key",
+            "enabled": _should_send_learning_badge_events,
+        },
+    },
+    "org.openedx.learning.ccx.course.passing.status.updated.v1": {
+        "learning-badges-lifecycle": {
+            "event_key_field": "course_passing_status.course.course_key",
+            "enabled": _should_send_learning_badge_events,
+        },
+    },
 }
 derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.learning.certificate.created.v1',
                          'learning-certificate-lifecycle', 'enabled')
 derived_collection_entry('EVENT_BUS_PRODUCER_CONFIG', 'org.openedx.learning.certificate.revoked.v1',
                          'learning-certificate-lifecycle', 'enabled')
+
+derived_collection_entry(
+    "EVENT_BUS_PRODUCER_CONFIG",
+    "org.openedx.learning.course.passing.status.updated.v1",
+    "learning-badges-lifecycle",
+    "enabled",
+)
+derived_collection_entry(
+    "EVENT_BUS_PRODUCER_CONFIG",
+    "org.openedx.learning.ccx.course.passing.status.updated.v1",
+    "learning-badges-lifecycle",
+    "enabled",
+)
+
 BEAMER_PRODUCT_ID = ""
 
 #### Survey Report ####


### PR DESCRIPTION
This pull request waits for merging [openedx-events PR](https://github.com/openedx/openedx-events/pull/303). Once it will be merged corresponding requirements will be added and unit-tests wil work.

## Description
Add new event bus events to produce related to grades and badges. 


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
