### PR TITLE
Removed ENABLE_USER_ID_SCOPE flag from validator

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -5,7 +5,6 @@ Classes that override default django-oauth-toolkit behavior
 
 from datetime import datetime, timedelta
 
-from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.db.models.signals import pre_save
 from django.dispatch import receiver

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -100,22 +100,12 @@ class EdxOAuth2Validator(OAuth2Validator):
         client credentials, add `user_id` as a default scope if it is an allowed scope.
         """
         default_scopes = super().get_default_scopes(client_id, request, *args, **kwargs)
-        # .. toggle_name: ENABLE_USER_ID_SCOPE
-        # .. toggle_implementation:DjangoSetting
-        # .. toggle_description: If enabled, the user_id scope will be added to the default scopes for client_credentials grant type.
-        # .. toggle_default: False
-        # .. toggle_use_cases: temporary
-        # .. toggle_creation_date: 2024-03-16
-        # .. toggle_target_removal_date: 2024-04-16
-        # .. toggle_warnings: This feature flag is temporary and will be removed once the feature is fully tested.
-        # .. toggle_tickets: https://github.com/openedx/edx-platform/issues/34381 (toggle removal ticket)
-        if settings.FEATURES.get('ENABLE_USER_ID_SCOPE', False):
-            if request.grant_type == 'client_credentials' and not request.scopes:
-                if get_scopes_backend().has_user_id_in_application_scopes(application=request.client):
-                    # copy the default scopes and add user_id to it to avoid modifying the original list
-                    extended_default_scopes = default_scopes.copy()
-                    extended_default_scopes.append('user_id')
-                    return extended_default_scopes
+        if request.grant_type == 'client_credentials' and not request.scopes:
+            if get_scopes_backend().has_user_id_in_application_scopes(application=request.client):
+                # copy the default scopes and add user_id to it to avoid modifying the original list
+                extended_default_scopes = default_scopes.copy()
+                extended_default_scopes.append('user_id')
+                return extended_default_scopes
         return default_scopes
 
     def validate_scopes(self, client_id, scopes, client, request, *args, **kwargs):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -81,7 +81,6 @@ class CustomValidationTestCase(TestCase):
         request = self.request_factory.get('/')
         assert self.validator.validate_user('darkhelmet', self.TEST_PASSWORD, client=None, request=request)
 
-    @mock.patch.dict(settings.FEATURES, ENABLE_USER_ID_SCOPE=True)
     def test_get_default_scopes_with_user_id(self):
         """
         Test that get_default_scopes returns the default scopes plus the user_id scope if it's available.
@@ -93,20 +92,6 @@ class CustomValidationTestCase(TestCase):
 
         self.assertEqual(overriden_default_scopes, self.default_scopes + ['user_id'])
 
-    @mock.patch.dict(settings.FEATURES, ENABLE_USER_ID_SCOPE=False)
-    def test_get_default_scopes_without_user_id(self):
-        """
-        Test that if `ENABLE_USER_ID_SCOPE` flag is turned off, the get_default_scopes returns
-        the default scopes without `user_id` even if it's allowed.
-        """
-        application_access = ApplicationAccessFactory(scopes=['user_id'])
-
-        request = mock.Mock(grant_type='client_credentials', client=application_access.application, scopes=None)
-        overriden_default_scopes = self.validator.get_default_scopes(request=request, client_id='client_id')
-
-        self.assertEqual(overriden_default_scopes, self.default_scopes)
-
-    @mock.patch.dict(settings.FEATURES, ENABLE_USER_ID_SCOPE=True)
     def test_get_default_scopes(self):
         """
         Test that get_default_scopes returns the default scopes if user_id scope is not available.


### PR DESCRIPTION
Setting feature flag after test this [PR](https://github.com/openedx/edx-platform/pull/34300) on Prod.

ENT-8641