### PR TITLE
feat!: remove SkillTaggingMixin from common XBLOCK_MIXINS

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -67,10 +67,6 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
 from openedx.core.lib.derived import derived, derived_collection_entry
 from openedx.core.release import doc_version
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
-try:
-    from skill_tagging.skill_tagging_mixin import SkillTaggingMixin
-except ImportError:
-    SkillTaggingMixin = None
 
 ################################### FEATURES ###################################
 # .. setting_name: PLATFORM_NAME
@@ -1654,8 +1650,6 @@ XBLOCK_MIXINS = (
     XModuleMixin,
     EditInfoMixin,
 )
-if SkillTaggingMixin:
-    XBLOCK_MIXINS += (SkillTaggingMixin,)
 
 # .. setting_name: XBLOCK_EXTRA_MIXINS
 # .. setting_default: ()


### PR DESCRIPTION
## Description 

Skill tagging [1] is not a core feature, and it is not installed into core requirements, evidenced by the fact that a try-except clause must be used to import it into common settings. Setting overrides like this should be made in each operator's private settings file rather than the upstream common settings file.

BREAKING CHANGE: Operators who install the xblock-skilltagging package will need to add SkillTaggingMixin to XBLOCK_MIXINS_EXTRA (or XBLOCK_MIXINS) in a private settings/YAML file, as it will no longer be done automatically in common settings. The README for xblock-skilltagging has an example [2]

[1] https://github.com/openedx/xblock-skill-tagging
[2] https://github.com/openedx/xblock-skill-tagging?tab=readme-ov-file#configuration

## Other information

Essentially, this reverts https://github.com/openedx/edx-platform/pull/34130

## Merge considerations

We'll give 2U a chance to update their private YAML file before merging.

However, this needs to merge before the Redwood cut, which is happening between May 1 and May 9. So, I plan to merge this **April 29th**.