### PR TITLE
feat: update meilisearch configuration needed for tags filter [FC-0040]

### DIFF
--- a/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
+++ b/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
@@ -83,6 +83,11 @@ class Command(MeiliCommandMixin, BaseCommand):
                 Fields.context_key,
                 Fields.org,
                 Fields.tags,
+                Fields.tags + "." + Fields.tags_taxonomy,
+                Fields.tags + "." + Fields.tags_level0,
+                Fields.tags + "." + Fields.tags_level1,
+                Fields.tags + "." + Fields.tags_level2,
+                Fields.tags + "." + Fields.tags_level3,
                 Fields.type,
             ])
             # Mark which attributes are used for keyword search, in order of importance:


### PR DESCRIPTION
## Description

This updates the Meilisearch configuration during index building, so that we can use the "facet search" API on the tags content.

Without this change, we cannot properly get the list of tags to filter by in the (beta) Studio Content Search:
![Screenshot 2024-04-17 at 9 49 26 AM](https://github.com/openedx/edx-platform/assets/945577/cfad7887-8801-4fb9-9276-eac5faf20612)

But with this change in place, we can:

![Screenshot 2024-04-17 at 9 49 40 AM](https://github.com/openedx/edx-platform/assets/945577/f773a2aa-32c0-45da-94a1-597e7cff8517)


## Supporting information

Part of https://github.com/openedx/modular-learning/issues/201

This only affects instances that have the `MEILISEARCH_ENABLED` flag on (default is off).

## Testing instructions

To test this, you need to use https://github.com/openedx/frontend-app-course-authoring/pull/945

## Deadline

Neeeded for Redwood, so ASAP

Private ref: [FAL-3704](https://tasks.opencraft.com/browse/FAL-3704)