### PR TITLE
feat: add usage_key for breadcrumbs in search index [FC-0049]

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -117,7 +117,13 @@ def _fields_from_block(block) -> dict:
                 # this would be very inefficient. Better to recurse the tree top-down with the parent blocks loaded.
                 log.warning(f"Updating Studio search index for XBlock {block.usage_key} but ancestors weren't cached.")
             cur_block = cur_block.get_parent()
-            block_data[Fields.breadcrumbs].insert(0, {"display_name": xblock_api.get_block_display_name(cur_block)})
+            block_data[Fields.breadcrumbs].insert(
+                0,
+                {
+                    "display_name": xblock_api.get_block_display_name(cur_block),
+                    "usage_key": str(cur_block.usage_key),
+                },
+            )
     try:
         content_data = block.index_dictionary()
         # Will be something like:
@@ -218,12 +224,13 @@ def searchable_doc_for_library_block(xblock_metadata: lib_api.LibraryXBlockMetad
     doc = {
         Fields.id: meili_id_from_opaque_key(xblock_metadata.usage_key),
         Fields.type: DocType.library_block,
+        Fields.breadcrumbs: []
     }
 
     doc.update(_fields_from_block(block))
 
     # Add the breadcrumbs. In v2 libraries, the library itself is not a "parent" of the XBlocks so we add it here:
-    doc[Fields.breadcrumbs] = [{"display_name": library_name}]
+    doc[Fields.breadcrumbs] = [{"display_name": library_name, "usage_key": str(xblock_metadata.usage_key.context_key)}]
 
     return doc
 

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -117,12 +117,14 @@ def _fields_from_block(block) -> dict:
                 # this would be very inefficient. Better to recurse the tree top-down with the parent blocks loaded.
                 log.warning(f"Updating Studio search index for XBlock {block.usage_key} but ancestors weren't cached.")
             cur_block = cur_block.get_parent()
+            parent_data = {
+                "display_name": xblock_api.get_block_display_name(cur_block),
+            }
+            if cur_block.scope_ids.block_type != "course":
+                parent_data["usage_key"] = str(cur_block.usage_key)
             block_data[Fields.breadcrumbs].insert(
                 0,
-                {
-                    "display_name": xblock_api.get_block_display_name(cur_block),
-                    "usage_key": str(cur_block.usage_key),
-                },
+                parent_data,
             )
     try:
         content_data = block.index_dictionary()
@@ -230,7 +232,7 @@ def searchable_doc_for_library_block(xblock_metadata: lib_api.LibraryXBlockMetad
     doc.update(_fields_from_block(block))
 
     # Add the breadcrumbs. In v2 libraries, the library itself is not a "parent" of the XBlocks so we add it here:
-    doc[Fields.breadcrumbs] = [{"display_name": library_name, "usage_key": str(xblock_metadata.usage_key.context_key)}]
+    doc[Fields.breadcrumbs] = [{"display_name": library_name}]
 
     return doc
 

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -74,7 +74,6 @@ class TestSearchApi(ModuleStoreTestCase):
             "breadcrumbs": [
                 {
                     "display_name": "Test Course",
-                    "usage_key": "block-v1:org1+test_course+test_run+type@course+block@course",
                 },
             ],
             "content": {},
@@ -93,7 +92,6 @@ class TestSearchApi(ModuleStoreTestCase):
             "breadcrumbs": [
                 {
                     "display_name": "Test Course",
-                    "usage_key": "block-v1:org1+test_course+test_run+type@course+block@course",
                 },
                 {
                     "display_name": "sequential",
@@ -122,7 +120,7 @@ class TestSearchApi(ModuleStoreTestCase):
             "block_type": "problem",
             "context_key": "lib:org1:lib",
             "org": "org1",
-            "breadcrumbs": [{"display_name": "Library", "usage_key": "lib:org1:lib"}],
+            "breadcrumbs": [{"display_name": "Library"}],
             "content": {"problem_types": [], "capa_content": " "},
             "type": "library_block",
             "access_id": lib_access.id,

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -63,34 +63,45 @@ class TestSearchApi(ModuleStoreTestCase):
         # Create XBlocks
         self.sequential = self.store.create_child(self.user_id, self.course.location, "sequential", "test_sequential")
         self.doc_sequential = {
-            'id': 'block-v1org1test_coursetest_runtypesequentialblocktest_sequential-f702c144',
-            'type': 'course_block',
-            'usage_key': 'block-v1:org1+test_course+test_run+type@sequential+block@test_sequential',
-            'block_id': 'test_sequential',
-            'display_name': 'sequential',
-            'block_type': 'sequential',
-            'context_key': 'course-v1:org1+test_course+test_run',
-            'org': 'org1',
-            'breadcrumbs': [{'display_name': 'Test Course'}],
-            'content': {},
-            'access_id': course_access.id,
+            "id": "block-v1org1test_coursetest_runtypesequentialblocktest_sequential-f702c144",
+            "type": "course_block",
+            "usage_key": "block-v1:org1+test_course+test_run+type@sequential+block@test_sequential",
+            "block_id": "test_sequential",
+            "display_name": "sequential",
+            "block_type": "sequential",
+            "context_key": "course-v1:org1+test_course+test_run",
+            "org": "org1",
+            "breadcrumbs": [
+                {
+                    "display_name": "Test Course",
+                    "usage_key": "block-v1:org1+test_course+test_run+type@course+block@course",
+                },
+            ],
+            "content": {},
+            "access_id": course_access.id,
         }
         self.store.create_child(self.user_id, self.sequential.location, "vertical", "test_vertical")
         self.doc_vertical = {
-            'id': 'block-v1org1test_coursetest_runtypeverticalblocktest_vertical-e76a10a4',
-            'type': 'course_block',
-            'usage_key': 'block-v1:org1+test_course+test_run+type@vertical+block@test_vertical',
-            'block_id': 'test_vertical',
-            'display_name': 'vertical',
-            'block_type': 'vertical',
-            'context_key': 'course-v1:org1+test_course+test_run',
-            'org': 'org1',
-            'breadcrumbs': [
-                {'display_name': 'Test Course'},
-                {'display_name': 'sequential'}
+            "id": "block-v1org1test_coursetest_runtypeverticalblocktest_vertical-e76a10a4",
+            "type": "course_block",
+            "usage_key": "block-v1:org1+test_course+test_run+type@vertical+block@test_vertical",
+            "block_id": "test_vertical",
+            "display_name": "vertical",
+            "block_type": "vertical",
+            "context_key": "course-v1:org1+test_course+test_run",
+            "org": "org1",
+            "breadcrumbs": [
+                {
+                    "display_name": "Test Course",
+                    "usage_key": "block-v1:org1+test_course+test_run+type@course+block@course",
+                },
+                {
+                    "display_name": "sequential",
+                    "usage_key": "block-v1:org1+test_course+test_run+type@sequential+block@test_sequential",
+                },
             ],
-            'content': {},
-            'access_id': course_access.id,
+            "content": {},
+            "access_id": course_access.id,
         }
 
         # Create a content library:
@@ -111,7 +122,7 @@ class TestSearchApi(ModuleStoreTestCase):
             "block_type": "problem",
             "context_key": "lib:org1:lib",
             "org": "org1",
-            "breadcrumbs": [{"display_name": "Library"}],
+            "breadcrumbs": [{"display_name": "Library", "usage_key": "lib:org1:lib"}],
             "content": {"problem_types": [], "capa_content": " "},
             "type": "library_block",
             "access_id": lib_access.id,

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -98,7 +98,6 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "breadcrumbs": [
                 {
                     'display_name': 'Toy Course',
-                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@course+block@course',
                 },
                 {
                     'display_name': 'chapter',
@@ -147,7 +146,6 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "breadcrumbs": [
                 {
                     'display_name': 'Toy Course',
-                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@course+block@course',
                 },
                 {
                     'display_name': 'Overview',
@@ -191,7 +189,6 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "breadcrumbs": [
                 {
                     'display_name': 'Toy Course',
-                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@course+block@course',
                 },
                 {
                     'display_name': 'Overview',

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -96,10 +96,22 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "access_id": self.toy_course_access_id,
             "display_name": "Test Problem",
             "breadcrumbs": [
-                {"display_name": "Toy Course"},
-                {"display_name": "chapter"},
-                {"display_name": "sequential"},
-                {"display_name": "vertical"},
+                {
+                    'display_name': 'Toy Course',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@course+block@course',
+                },
+                {
+                    'display_name': 'chapter',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@chapter+block@vertical_container',
+                },
+                {
+                    'display_name': 'sequential',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@sequential+block@vertical_sequential',
+                },
+                {
+                    'display_name': 'vertical',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@vertical+block@vertical_test',
+                },
             ],
             "content": {
                 "capa_content": "What is a test?",
@@ -133,9 +145,18 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "access_id": self.toy_course_access_id,
             "display_name": "Text",
             "breadcrumbs": [
-                {"display_name": "Toy Course"},
-                {"display_name": "Overview"},
-                {"display_name": "Toy Videos"},
+                {
+                    'display_name': 'Toy Course',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@course+block@course',
+                },
+                {
+                    'display_name': 'Overview',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@chapter+block@Overview',
+                },
+                {
+                    "display_name": "Toy Videos",
+                    "usage_key": "block-v1:edX+toy+2012_Fall+type@sequential+block@Toy_Videos",
+                },
             ],
             "content": {
                 "html_content": (
@@ -168,8 +189,14 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "access_id": self.toy_course_access_id,
             "display_name": "Welcome",
             "breadcrumbs": [
-                {"display_name": "Toy Course"},
-                {"display_name": "Overview"},
+                {
+                    'display_name': 'Toy Course',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@course+block@course',
+                },
+                {
+                    'display_name': 'Overview',
+                    'usage_key': 'block-v1:edX+toy+2012_Fall+type@chapter+block@Overview',
+                },
             ],
             "content": {},
             # This video has no tags.

--- a/openedx/core/djangoapps/content/search/tests/test_handlers.py
+++ b/openedx/core/djangoapps/content/search/tests/test_handlers.py
@@ -75,7 +75,6 @@ class TestUpdateIndexHandlers(
             "breadcrumbs": [
                 {
                     "display_name": "Test Course",
-                    "usage_key": "block-v1:orgA+test_course+test_run+type@course+block@course",
                 },
             ],
             "content": {},
@@ -96,7 +95,6 @@ class TestUpdateIndexHandlers(
             "breadcrumbs": [
                 {
                     "display_name": "Test Course",
-                    "usage_key": "block-v1:orgA+test_course+test_run+type@course+block@course",
                 },
                 {
                     "display_name": "sequential",
@@ -149,7 +147,7 @@ class TestUpdateIndexHandlers(
             "block_type": "problem",
             "context_key": "lib:orgA:lib_a",
             "org": "orgA",
-            "breadcrumbs": [{"display_name": "Library Org A", "usage_key": "lib:orgA:lib_a"}],
+            "breadcrumbs": [{"display_name": "Library Org A"}],
             "content": {"problem_types": [], "capa_content": " "},
             "access_id": lib_access.id,
         }

--- a/openedx/core/djangoapps/content/search/tests/test_handlers.py
+++ b/openedx/core/djangoapps/content/search/tests/test_handlers.py
@@ -72,7 +72,13 @@ class TestUpdateIndexHandlers(
             "block_type": "sequential",
             "context_key": "course-v1:orgA+test_course+test_run",
             "org": "orgA",
-            "breadcrumbs": [{"display_name": "Test Course"}], "content": {},
+            "breadcrumbs": [
+                {
+                    "display_name": "Test Course",
+                    "usage_key": "block-v1:orgA+test_course+test_run+type@course+block@course",
+                },
+            ],
+            "content": {},
             "access_id": course_access.id,
 
         }
@@ -87,7 +93,16 @@ class TestUpdateIndexHandlers(
             "block_type": "vertical",
             "context_key": "course-v1:orgA+test_course+test_run",
             "org": "orgA",
-            "breadcrumbs": [{"display_name": "Test Course"}, {"display_name": "sequential"}],
+            "breadcrumbs": [
+                {
+                    "display_name": "Test Course",
+                    "usage_key": "block-v1:orgA+test_course+test_run+type@course+block@course",
+                },
+                {
+                    "display_name": "sequential",
+                    "usage_key": "block-v1:orgA+test_course+test_run+type@sequential+block@test_sequential",
+                },
+            ],
             "content": {},
             "access_id": course_access.id,
         }
@@ -134,7 +149,7 @@ class TestUpdateIndexHandlers(
             "block_type": "problem",
             "context_key": "lib:orgA:lib_a",
             "org": "orgA",
-            "breadcrumbs": [{"display_name": "Library Org A"}],
+            "breadcrumbs": [{"display_name": "Library Org A", "usage_key": "lib:orgA:lib_a"}],
             "content": {"problem_types": [], "capa_content": " "},
             "access_id": lib_access.id,
         }


### PR DESCRIPTION
## Description

This PR adds the `usage_key` for each item in the block breadcrumbs of an index document. This will allow us to have information on the parent to redirect to the right page in the Search Modal. 

## More Information:

Part of:
- https://github.com/openedx/modular-learning/issues/210

## Testing Instructions
1. Run your local stack on this branch
2. Make sure you have `meilisearch` setup locally, follow the setup instructions here https://github.com/open-craft/tutor-contrib-meilisearch, **but use the following branch for the plugin** (https://github.com/rpenido/tutor-contrib-meilisearch/tree/rpenido/fal-3693-pass-meilisearch-enabled-env-to-mfe-config) to make sure the `MEILISEARCH_ENABLED` is configured in the MFEs.
3. Run `tutor dev run cms bash` and `./manage.py cms reindex_studio`
4. Access `http://meilisearch.local.edly.io:7700/` and check if the created documents have the `usage_key` field

---
Private ref: [FAL-3709](https://tasks.opencraft.com/browse/FAL-3709)