### PR TITLE
temp: trace celery tasks in dd

### DIFF
--- a/openedx/core/lib/celery/__init__.py
+++ b/openedx/core/lib/celery/__init__.py
@@ -19,6 +19,15 @@ over older code, and there is probably a better mechanism to be had.)
 
 from celery import Celery
 
+# TEMP: This code will be removed by ARCH-BOM on 4/22/24
+# ddtrace allows celery task logs to be traced by the dd agent.
+# TODO: remove this code.
+try:
+    from ddtrace import patch
+    patch(celery=True)
+except ImportError:
+    pass
+
 # WARNING: Do not refer to this unless you are cms.celery or
 # lms.celery. See module docstring!
 APP = Celery('proj')


### PR DESCRIPTION
## Description
this PR adds the ability for DD to gather traces in celery tasks, something NR does automatically. I know this is DD specific code, but a long-term solution will be coming soon.

## Supporting information
https://github.com/edx/edx-arch-experiments/issues/584

## Testing instructions

1. follow https://2u-internal.atlassian.net/wiki/spaces/~840928901/pages/813793298/OpenTelemetry+New+Relic+and+Datadog for devstack setup for DD, but set up the DD agent on CMS as usual
2. Follow https://2u-internal.atlassian.net/wiki/spaces/ENGAGE/pages/395673715/How+to+configure+Celery+worker+on+LMS+CMS+Devstack to set up celery workers on cms
3. Export a course
4. View the export on DD

## Deadline

This will be merged ASAP and reverted no later than 4/22. A revert PR will be linked in this PR soon.