### PR TITLE
feat: remove unused JS requirement in CMS

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1449,9 +1449,8 @@ base_vendor_js = [
     'edx-ui-toolkit/js/utils/string-utils.js',
     'edx-ui-toolkit/js/utils/html-utils.js',
 
-    # Load Bootstrap and supporting libraries
-    'common/js/vendor/popper.js',
-    'common/js/vendor/bootstrap.js',
+    # Here we were loading Bootstrap and supporting libraries, but it no longer seems to be needed for any Studio UI.
+    # 'common/js/vendor/bootstrap.bundle.js',
 
     # Finally load RequireJS
     'common/js/vendor/require.js'


### PR DESCRIPTION
## Description

In the legacy Studio UI's JS console on a tutor devstack, a couple 404 errors can be seen:

![popp.js and bootstrap.js 404](https://github.com/openedx/edx-platform/assets/945577/4e1b80a9-338d-430a-a2f0-43b00accd067)

I believe this error has been there for a long time, without causing any issues. That is, the legacy Studio UI does not seem to depend on the Bootstrap (or popper) JS.

Some LMS legacy UI pages _do_ depend on bootstrap+popper, which they get from

https://github.com/openedx/edx-platform/blob/68b3753948acb21123a238a92e61f637943e7d53/lms/templates/main.html#L117-L120

if needed. This file is not part of the repo's source code, but is created by 

https://github.com/openedx/edx-platform/blob/68b3753948acb21123a238a92e61f637943e7d53/scripts/copy-node-modules.sh#L58

## Testing instructions

You can go to the "bookmarks" page of a course in the legacy LMS UI (which is a page that uses bootstrap's JS), e.g. http://local.overhang.io:8000/courses/course-v1:A+B+C/bookmarks/ and in the JS console you can run `$.fn.modal` and `$.fn.carousel` to verify that Bootstrap's JS is active.

But, with or without the changes in this PR, if you run those same commands in any legacy Studio UI page, you'll see that Bootsrap's JS is not loaded, but the UI works fine.

Likewise on any production instance, you won't see the 404 error because popper/bootstrap are simply missing from the generated bundle `cms-base-vendor.x.js`. But you can open a JS console and verify that e.g. `$.fn.modal` and `$.fn.carousel` are not loaded on the page.

## Deadline

None

## Other information
