### PR TITLE
chore: Add github workflow and script to check python depencies source

### DIFF
--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -1,0 +1,47 @@
+name: Check Python Dependencies
+
+on:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+                    
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Install repo-tools
+        run: pip install git+https://github.com/salman2013/repo-tools.git@salman/add-script-for-python-dependencies
+      
+      - name: Install requirements parser module
+        run: pip install requirements-parser  
+      
+      - name: Install setuptool
+        run: pip install setuptools  
+
+      - name: Run Python script
+        run: |
+          find_python_dependencies \
+            --req-file requirements/edx/base.txt \
+            --req-file requirements/edx/testing.txt \
+            --ignore https://github.com/edx/codejail-includes \
+            --ignore https://github.com/edx/braze-client \
+            --ignore https://github.com/edx/edx-name-affirmation \
+            --ignore https://github.com/mitodl/edx-sga \
+            --ignore https://github.com/edx/token-utils \
+            --ignore https://github.com/open-craft/xblock-poll
+  

--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -3,10 +3,6 @@ name: Check Python Dependencies
 on:
   pull_request:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -26,6 +26,9 @@ jobs:
       
       - name: Install repo-tools
         run: pip install edx-repo-tools[find_dependencies]
+
+      - name: Install setuptool
+        run: pip install setuptools  
       
       - name: Run Python script
         run: |

--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -25,14 +25,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       
       - name: Install repo-tools
-        run: pip install git+https://github.com/salman2013/repo-tools.git@salman/add-script-for-python-dependencies
+        run: pip install edx-repo-tools[find_dependencies]
       
-      - name: Install requirements parser module
-        run: pip install requirements-parser  
-      
-      - name: Install setuptool
-        run: pip install setuptools  
-
       - name: Run Python script
         run: |
           find_python_dependencies \


### PR DESCRIPTION
Description: Add github action to run the [python script from repo tools](https://github.com/openedx/repo-tools/pull/509), which finds the python dependencies source and displays them if they belong to any third-party sources. 

Resolves https://github.com/openedx/edx-platform/issues/33189