### PR TITLE
feat: add flag for showing/hiding new discussion sidebar view on course home page.

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/serializers.py
@@ -57,3 +57,4 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     user_timezone = serializers.CharField()
     can_view_certificate = serializers.BooleanField()
     course_modes = CourseModeSerrializer(many=True)
+    is_new_discussion_sidebar_view_enabled = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from lms.djangoapps.certificates.api import certificates_viewable_for_course
+from lms.djangoapps.course_home_api.toggles import new_discussion_sidebar_view_is_enabled
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.djangoapps.courseware_api.utils import get_celebrations_dict
 
@@ -137,6 +138,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'user_timezone': user_timezone,
             'can_view_certificate': certificates_viewable_for_course(course),
             'course_modes': course_modes,
+            'is_new_discussion_sidebar_view_enabled': new_discussion_sidebar_view_is_enabled(course_key),
         }
         context = self.get_serializer_context()
         context['course'] = course

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -21,6 +21,21 @@ COURSE_HOME_MICROFRONTEND_PROGRESS_TAB = CourseWaffleFlag(
 )
 
 
+# Waffle flag to enable new discussion sidebar view on course home page
+#
+# .. toggle_name: course_home.new_discussion_sidebar_view
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This toggle controls the user interface behavior of the discussion sidebar on course home page.
+# .. toggle_use_cases: open_edx, temporary
+# .. toggle_creation_date: 2024-04-22
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: INF-1338
+COURSE_HOME_NEW_DISCUSSION_SIDEBAR_VIEW = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.new_discussion_sidebar_view', __name__
+)
+
+
 def course_home_mfe_progress_tab_is_active(course_key):
     # Avoiding a circular dependency
     from .models import DisableProgressPageStackedConfig
@@ -29,3 +44,10 @@ def course_home_mfe_progress_tab_is_active(course_key):
         COURSE_HOME_MICROFRONTEND_PROGRESS_TAB.is_enabled(course_key) and
         not DisableProgressPageStackedConfig.current(course_key=course_key).disabled
     )
+
+
+def new_discussion_sidebar_view_is_enabled(course_key):
+    """
+    Returns True if the new discussion sidebar view is enabled for the given course.
+    """
+    return COURSE_HOME_NEW_DISCUSSION_SIDEBAR_VIEW.is_enabled(course_key)


### PR DESCRIPTION
### [INF-1338](https://2u-internal.atlassian.net/browse/INF-1338)

### Description
- Add new flag param to control the new discussion sidebar view on the course home page.
- Frontend Implementation [PR](https://github.com/openedx/frontend-app-learning/pull/1373).

**Note**
- We need to merge this PR first then frontend PR.

**Clean-up**

- Removed `ENABLE_NEW_SIDEBAR`from [edx-internal](https://github.com/edx/edx-internal/pull/10714).
- Removed `ENABLE_NEW_SIDEBAR`from [edge-internal](https://github.com/edx/edge-internal/pull/692).