### PR TITLE
Revert "Revert "temp: trace celery tasks in dd""

### DIFF
--- a/openedx/core/lib/celery/__init__.py
+++ b/openedx/core/lib/celery/__init__.py
@@ -19,6 +19,15 @@ over older code, and there is probably a better mechanism to be had.)
 
 from celery import Celery
 
+# TEMP: This code will be removed by ARCH-BOM on 4/22/24
+# ddtrace allows celery task logs to be traced by the dd agent.
+# TODO: remove this code.
+try:
+    from ddtrace import patch
+    patch(celery=True)
+except ImportError:
+    pass
+
 # WARNING: Do not refer to this unless you are cms.celery or
 # lms.celery. See module docstring!
 APP = Celery('proj')

--- a/openedx/core/lib/celery/__init__.py
+++ b/openedx/core/lib/celery/__init__.py
@@ -19,7 +19,7 @@ over older code, and there is probably a better mechanism to be had.)
 
 from celery import Celery
 
-# TEMP: This code will be removed by ARCH-BOM on 4/22/24
+# TEMP: This code will be removed by ARCH-BOM on 4/23/24
 # ddtrace allows celery task logs to be traced by the dd agent.
 # TODO: remove this code.
 try:


### PR DESCRIPTION
We saw a production incident, and we reverted this out as a precaution. We want to reinstate it to get more data so we can remove it tomorrow.

Reverts openedx/edx-platform#34553