### PR TITLE
fix: blake2b feature flag name

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -581,7 +581,7 @@ FEATURES = {
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
 
     # See annotations in lms/envs/common.py for details.
-    'ENABLE_BLAKE2B_HASHiNG': False,
+    'ENABLE_BLAKE2B_HASHING': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR fixes the typo mistake in name of `ENABLE_BLAKE2B_HASHING`

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Course Author"

## Supporting information

Relevant PR: https://github.com/openedx/edx-platform/pull/34442

## Testing instructions

Enable this flag and validate that the memcache is using the correct hashing function.

## Deadline

"None"

