### PR TITLE
Fix: registering a new user with a full name longer than 255 characters

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -148,6 +148,7 @@ class AccountCreationForm(forms.Form):
 
     _EMAIL_INVALID_MSG = _("A properly formatted e-mail is required")
     _NAME_TOO_SHORT_MSG = _("Your legal name must be a minimum of one character long")
+    _NAME_TOO_LONG_MSG = _("Your legal name is too long. It must not exceed %(max_length)s characters")
 
     # TODO: Resolve repetition
 
@@ -167,9 +168,11 @@ class AccountCreationForm(forms.Form):
 
     name = forms.CharField(
         min_length=accounts.NAME_MIN_LENGTH,
+        max_length=accounts.NAME_MAX_LENGTH,
         error_messages={
             "required": _NAME_TOO_SHORT_MSG,
             "min_length": _NAME_TOO_SHORT_MSG,
+            "max_length": _NAME_TOO_LONG_MSG % {"max_length": accounts.NAME_MAX_LENGTH},
         },
         validators=[validate_name]
     )

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -316,6 +316,30 @@ class RegistrationViewValidationErrorTest(
             }
         )
 
+    def test_register_fullname_max_lenghth_validation_error(self):
+        """
+        Full name error detection test if the length exceeds 255 characters.
+        """
+        expected_error_message = f"Your legal name is too long. It must not exceed {NAME_MAX_LENGTH} characters"
+
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": "x" * 256,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+        })
+        assert response.status_code == 400
+
+        response_json = json.loads(response.content.decode('utf-8'))
+        self.assertDictEqual(
+            response_json,
+            {
+                "name": [{"user_message": expected_error_message}],
+                "error_code": "validation-error"
+            }
+        )
+
     def test_register_fullname_html_validation_error(self):
         """
         Test for catching invalid full name errors


### PR DESCRIPTION
## Description

Fixing an error when a new user tries registering on the platform with a name longer than 255 characters.

```
edx.quince-rg.lms  | The above exception was the direct cause of the following exception:
edx.quince-rg.lms  | 
edx.quince-rg.lms  | Traceback (most recent call last):
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 55, in inner
edx.quince-rg.lms  |     response = get_response(request)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 197, in _get_response
edx.quince-rg.lms  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
edx.quince-rg.lms  |     return view_func(*args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 104, in view
edx.quince-rg.lms  |     return self.dispatch(request, *args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 46, in _wrapper
edx.quince-rg.lms  |     return bound_method(*args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 46, in _wrapper
edx.quince-rg.lms  |     return bound_method(*args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/debug.py", line 92, in sensitive_post_parameters_wrapper
edx.quince-rg.lms  |     return view(request, *args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/views/register.py", line 531, in dispatch
edx.quince-rg.lms  |     return super().dispatch(request, *args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
edx.quince-rg.lms  |     response = self.handle_exception(exc)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
edx.quince-rg.lms  |     self.raise_uncaught_exception(exc)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
edx.quince-rg.lms  |     raise exc
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
edx.quince-rg.lms  |     response = handler(request, *args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 46, in _wrapper
edx.quince-rg.lms  |     return bound_method(*args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
edx.quince-rg.lms  |     return view_func(*args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 46, in _wrapper
edx.quince-rg.lms  |     return bound_method(*args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django_ratelimit/decorators.py", line 27, in _wrapped
edx.quince-rg.lms  |     return fn(request, *args, **kw)
edx.quince-rg.lms  |   File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/views/register.py", line 587, in post
edx.quince-rg.lms  |     response, user = self._create_account(request, data)
edx.quince-rg.lms  |   File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/views/register.py", line 666, in _create_account
edx.quince-rg.lms  |     user = create_account_with_params(request, data)
edx.quince-rg.lms  |   File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/views/register.py", line 211, in create_account_with_params
edx.quince-rg.lms  |     (user, profile, registration) = do_create_account(form, custom_form)
edx.quince-rg.lms  |   File "/edx/app/edxapp/edx-platform/common/djangoapps/student/helpers.py", line 753, in do_create_account
edx.quince-rg.lms  |     profile.save()
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 814, in save
edx.quince-rg.lms  |     self.save_base(
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 877, in save_base
edx.quince-rg.lms  |     updated = self._save_table(
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 1020, in _save_table
edx.quince-rg.lms  |     results = self._do_insert(
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 1061, in _do_insert
edx.quince-rg.lms  |     return manager._insert(
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/manager.py", line 87, in manager_method
edx.quince-rg.lms  |     return getattr(self.get_queryset(), name)(*args, **kwargs)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 1805, in _insert
edx.quince-rg.lms  |     return query.get_compiler(using=using).execute_sql(returning_fields)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1822, in execute_sql
edx.quince-rg.lms  |     cursor.execute(sql, params)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/debug_toolbar/panels/sql/tracking.py", line 252, in execute
edx.quince-rg.lms  |     return self._record(super().execute, sql, params)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/debug_toolbar/panels/sql/tracking.py", line 177, in _record
edx.quince-rg.lms  |     return method(sql, params)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 102, in execute
edx.quince-rg.lms  |     return super().execute(sql, params)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 67, in execute
edx.quince-rg.lms  |     return self._execute_with_wrappers(
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
edx.quince-rg.lms  |     return executor(sql, params, many, context)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 89, in _execute
edx.quince-rg.lms  |     return self.cursor.execute(sql, params)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/utils.py", line 91, in __exit__
edx.quince-rg.lms  |     raise dj_exc_value.with_traceback(traceback) from exc_value
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 89, in _execute
edx.quince-rg.lms  |     return self.cursor.execute(sql, params)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/mysql/base.py", line 75, in execute
edx.quince-rg.lms  |     return self.cursor.execute(query, args)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/cursors.py", line 179, in execute
edx.quince-rg.lms  |     res = self._query(mogrified_query)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/cursors.py", line 330, in _query
edx.quince-rg.lms  |     db.query(q)
edx.quince-rg.lms  |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/connections.py", line 255, in query
edx.quince-rg.lms  |     _mysql.connection.query(self, query)
edx.quince-rg.lms  | django.db.utils.DataError: (1406, "Data too long for column 'name' at row 1")
edx.quince-rg.lms  | [23/Apr/2024 11:26:00] "POST /api/user/v2/account/registration/ HTTP/1.1" 500 561223
```

Error 500 is returned to the user
<img width="1786" alt="500" src="https://github.com/openedx/edx-platform/assets/98233552/b075ae12-3465-4f01-bfe8-504ea326a7bf">

I will also make a fix in Authn MFE so that a request with such a long name will not be sent. But this fix will protect the backend from errors in writing to the database.

In this case, a 400 response will be sent to the user:
<img width="1786" alt="400" src="https://github.com/openedx/edx-platform/assets/98233552/4d253b11-f31f-439a-83d7-efa20c574287">

---
**PS: [MR#1242 to Authn MFE](https://github.com/openedx/frontend-app-authn/pull/1242)**

