### PR TITLE
fix: Update output config for webworkers.

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -35,6 +35,7 @@ var workerConfig = function() {
                 // eslint-disable-next-line global-require
                 entry: require('../workers.json'),
                 output: {
+                    publicPath: "", // https://stackoverflow.com/a/65272040
                     filename: '[name].js',
                     path: path.resolve(__dirname, 'common/static/bundles')
                 },


### PR DESCRIPTION
We added a fix for generated bundles more generally. This adds the fix for webworkers specifically.

This is in support for the node 18 upgrade and https://github.com/openedx/edx-platform/pull/34503