### PR TITLE
fix: reduce cache timeot value to comply with usecase

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -670,11 +670,11 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
             serializer = StudentGradebookEntrySerializer(entries, many=True)
             return self.get_paginated_response(serializer.data, **users_counts)
 
-    def _get_user_count(self, query_args, cache_time=3600, annotations=None):
+    def _get_user_count(self, query_args, cache_time=600, annotations=None):
         """
         Return the user count for the given query arguments to CourseEnrollment.
 
-        caches the count for cache_time seconds.
+        Caches the count for cache_time seconds, the default value is 10 minutes.
         """
         queryset = CourseEnrollment.objects
         if annotations:


### PR DESCRIPTION
## Description
This PR reduces the default timeout value for caching of the users count on gradebook to 10 minutes, and also drops a cache key on enrollment status change, so the actual count of enrolled users on the course will be displayed.  


## Supporting information
The cached value can be seen on the gradebook page in gradebook MFE:
![image](https://github.com/openedx/edx-platform/assets/22370912/dae7432d-e349-40fd-8a27-5a9fb2449340)


## Testing instructions

1) Open Gradebook for a specific course, try to create several filtered views
2) Enroll several new users into the course
3) Open Gradebook page once again, the number of total users enrolled into the course should be updated, newly enrolled users appear in the paginated list of users

## Other information

The original PR that was removing cache completely to overcome this issue - https://github.com/openedx/edx-platform/pull/33617.
