### PR TITLE
fix: pin xmlsec version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -122,3 +122,6 @@ optimizely-sdk<5.0
 # lxml 5.1.0 introduced a breaking change in unit test shards
 # This constraint can probably be removed once lxml==5.1.1 is released on PyPI
 lxml<5.0
+
+# xmlsec==1.3.14 breaking tests for all builds, can be removed once a fix is available
+xmlsec<1.3.14

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1246,7 +1246,9 @@ xblock-poll==1.13.0
 xblock-utils==4.0.0
     # via edx-sga
 xmlsec==1.3.13
-    # via python3-saml
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/kernel.in
 yarl==1.9.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2218,6 +2218,7 @@ xblock-utils==4.0.0
     #   edx-sga
 xmlsec==1.3.13
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1515,6 +1515,7 @@ xblock-utils==4.0.0
     #   edx-sga
 xmlsec==1.3.13
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1631,6 +1631,7 @@ xblock-utils==4.0.0
     #   edx-sga
 xmlsec==1.3.13
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0


### PR DESCRIPTION
## Description
- Pinning `xmlsec==1.3.13` because `xmlsec==1.3.14` is a breaking version for build installation. 
- Can be removed once the issue is fixed in a new version of `xmlsec`.