### PR TITLE
fix: pin moto<5.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -125,3 +125,6 @@ lxml<5.0
 
 # xmlsec==1.3.14 breaking tests for all builds, can be removed once a fix is available
 xmlsec<1.3.14
+
+# moto==5.0 contains breaking changes. Needs to be updated separately.
+moto<5.0

--- a/scripts/user_retirement/requirements/testing.in
+++ b/scripts/user_retirement/requirements/testing.in
@@ -1,6 +1,6 @@
 -r base.txt
 
-moto
+moto<5.0   # moto==5.0 contains breaking changes. needs to be fixed separately.
 pytest
 requests_mock
 responses


### PR DESCRIPTION
## Description
- `moto==5.0` contain breaking changes so pinning the version to `moto<5.0` for now
- Failing tests can be fixed in a later PR to resolve the constraint.