### PR TITLE
fix: pin pytz version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -128,3 +128,6 @@ xmlsec<1.3.14
 
 # moto==5.0 contains breaking changes. Needs to be updated separately.
 moto<5.0
+
+# pytz==2024.1 contains breaking changes which is causing test failures
+pytz<2024.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -954,8 +954,9 @@ python3-openid==3.2.0 ; python_version >= "3"
     #   social-auth-core
 python3-saml==1.16.0
     # via -r requirements/edx/kernel.in
-pytz==2024.1
+pytz==2023.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   babel
     #   django-ses

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1672,8 +1672,9 @@ python3-saml==1.16.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pytz==2024.1
+pytz==2023.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   babel

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1136,8 +1136,9 @@ python3-openid==3.2.0 ; python_version >= "3"
     #   social-auth-core
 python3-saml==1.16.0
     # via -r requirements/edx/base.txt
-pytz==2024.1
+pytz==2023.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   babel
     #   django-ses

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1258,8 +1258,9 @@ python3-openid==3.2.0 ; python_version >= "3"
     #   social-auth-core
 python3-saml==1.16.0
     # via -r requirements/edx/base.txt
-pytz==2024.1
+pytz==2023.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   babel
     #   django-ses


### PR DESCRIPTION
## Description
- pytz latest version causing test failures related to timezones.