### PR TITLE
feat: feature setting to gate courseware search to verified enrollments

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3748,6 +3748,8 @@ class TestPublicVideoXBlockEmbedView(TestBasePublicVideoXBlock):
             assert context['course'] == self.course
 
 
+@ddt.ddt
+@override_waffle_flag(COURSEWARE_MICROFRONTEND_SEARCH_ENABLED, active=True)
 class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
     """
     Tests the endpoint to fetch the Courseware Search waffle flag enabled status.
@@ -3761,12 +3763,36 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
         self.client = APIClient()
         self.apiUrl = reverse('courseware_search_enabled_view', kwargs={'course_id': str(self.course.id)})
 
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_SEARCH_ENABLED, active=True)
-    def test_courseware_mfe_search_enabled(self):
+    @ddt.data(
+        (CourseMode.AUDIT, False),
+        (CourseMode.VERIFIED, True),
+        (CourseMode.MASTERS, True),
+    )
+    @ddt.unpack
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': True})
+    def test_courseware_mfe_search_verified_only(self, mode, expected_enabled):
         """
-        Getter to check if user is allowed to use Courseware Search.
+        Only verified enrollees may use Courseware Search if ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED
+        is enabled.
         """
+        user = UserFactory()
+        CourseEnrollmentFactory.create(user=user, course_id=self.course.id, mode=mode)
 
+        self.client.login(username=user.username, password=TEST_PASSWORD)
+        response = self.client.get(self.apiUrl, content_type='application/json')
+        body = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body, {'enabled': expected_enabled})
+
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': True})
+    def test_courseware_mfe_search_staff_access(self):
+        """
+        Staff users may use Courseware Search regardless of their enrollment status.
+        """
+        user_staff = UserFactory(is_staff=True)  # not enrolled
+
+        self.client.login(username=user_staff.username, password=TEST_PASSWORD)
         response = self.client.get(self.apiUrl, content_type='application/json')
         body = json.loads(response.content.decode('utf-8'))
 
@@ -3774,11 +3800,12 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
         self.assertEqual(body, {'enabled': True})
 
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_SEARCH_ENABLED, active=False)
-    def test_is_mfe_search_disabled(self):
+    def test_is_mfe_search_waffle_disabled(self):
         """
-        Getter to check if user is allowed to use Courseware Search.
+        Courseware search is only available when the waffle flag is enabled.
         """
-
+        user_admin = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user_admin.username, password=TEST_PASSWORD)
         response = self.client.get(self.apiUrl, content_type='application/json')
         body = json.loads(response.content.decode('utf-8'))
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3805,6 +3805,7 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
         Courseware search is only available when the waffle flag is enabled.
         """
         user_admin = UserFactory(is_staff=True, is_superuser=True)
+        CourseEnrollmentFactory.create(user=user_admin, course_id=self.course.id, mode=CourseMode.VERIFIED)
         self.client.login(username=user_admin.username, password=TEST_PASSWORD)
         response = self.client.get(self.apiUrl, content_type='application/json')
         body = json.loads(response.content.decode('utf-8'))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1060,6 +1060,15 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
 
+    # .. toggle_name: FEATURES['ENABLE_COURSEWARE_SEARCH_VERIFIED_REQUIRED']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: When enabled, the courseware search feature will only be enabled
+    #   for users in a verified enrollment track.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-04-24
+    'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': False,
+
     # .. toggle_name: FEATURES['ENABLE_BLAKE2B_HASHING']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
@@ -1071,15 +1080,6 @@ FEATURES = {
     # .. toggle_warning: For consistency, keep the value in sync with the setting of the same name in the LMS and CMS.
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34442
     'ENABLE_BLAKE2B_HASHING': False,
-
-    # .. toggle_name: FEATURES['ENABLE_COURSEWARE_SEARCH_VERIFIED_REQUIRED']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: When enabled, the courseware search feature will only be enabled
-    #   for users in a verified enrollment track.
-    # .. toggle_use_cases: open_edx
-    # .. toggle_creation_date: 2024-04-24
-    'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1071,6 +1071,15 @@ FEATURES = {
     # .. toggle_warning: For consistency, keep the value in sync with the setting of the same name in the LMS and CMS.
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34442
     'ENABLE_BLAKE2B_HASHING': False,
+
+    # .. toggle_name: FEATURES['ENABLE_COURSEWARE_SEARCH_VERIFIED_REQUIRED']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: When enabled, the courseware search feature will only be enabled
+    #   for users in a verified enrollment track.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-04-24
+    'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
Adds a Django setting that limits courseware search to users in a [verified enrollment track](https://github.com/openedx/edx-platform/blob/958aabbed173130858e7e06b9323adbbe20ff90a/common/djangoapps/course_modes/models.py#L211).

This pairs with the existing temporary rollout waffle flag. If that flag is not enabled the user will not have courseware search available regardless of their role or enrollment.

2u-internal ticket: [COSMO-201](https://2u-internal.atlassian.net/browse/COSMO-201?atlOrigin=eyJpIjoiNThmNjk3NTgxM2YyNDk0YmJlNjU5MTNkYmJlZjA0NDAiLCJwIjoiaiJ9)