### PR TITLE
[FC-0040] fix: Stop autotagging the course base XBlock id

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -55,6 +55,8 @@ LOCK_EXPIRE = 24 * 60 * 60  # Lock expires in 24 hours
 MAX_ACCESS_IDS_IN_FILTER = 1_000
 MAX_ORGS_IN_FILTER = 1_000
 
+EXCLUDED_XBLOCK_TYPES = ['course', 'course_info']
+
 
 @contextmanager
 def _index_rebuild_lock() -> Generator[str, None, None]:
@@ -372,6 +374,7 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
                 docs.append(doc)  # pylint: disable=cell-var-from-loop
                 _recurse_children(block, add_with_children)  # pylint: disable=cell-var-from-loop
 
+            # Index course children
             _recurse_children(course, add_with_children)
 
             if docs:
@@ -393,6 +396,10 @@ def upsert_xblock_index_doc(usage_key: UsageKey, recursive: bool = True) -> None
         recursive (bool): If True, also index all children of the XBlock
     """
     xblock = modulestore().get_item(usage_key)
+    xblock_type = xblock.scope_ids.block_type
+
+    if xblock_type in EXCLUDED_XBLOCK_TYPES:
+        return
 
     docs = []
 

--- a/openedx/core/djangoapps/content_tagging/handlers.py
+++ b/openedx/core/djangoapps/content_tagging/handlers.py
@@ -67,9 +67,14 @@ def auto_tag_xblock(**kwargs):
     if not CONTENT_TAGGING_AUTO.is_enabled(xblock_info.usage_key.course_key):
         return
 
+    if xblock_info.block_type == 'course_info':
+        # We want to add tags only to the course id, not with its XBlock
+        return
+
     if xblock_info.block_type == "course":
         # Course update is handled by XBlock of course type
         update_course_tags.delay(str(xblock_info.usage_key.course_key))
+        return
 
     update_xblock_tags.delay(str(xblock_info.usage_key))
 


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

- Stop auto-tagging for `course` and `course_info` blocks.
- Stop index for `course` and `course_info` blocks.

## Supporting information

- Requirements:

> When we create/update a course, our auto-tagging handler also associates tags with the course XBlock ID (the one with block-v1:**type@course**).
>
> We want to add tags only to the course id (course-v1:***), not with its XBlock.
>
> Also, make sure the root block is never included in the search index.

- Internal ticket: [FAL-3716](https://tasks.opencraft.com/browse/FAL-3716)

## Testing instructions

- Set the `content_tagging.auto` waffle flag
- Make sure you have meilisearch setup locally, follow the setup instructions here https://github.com/open-craft/tutor-contrib-meilisearch
- Go to studio and create a course.
- On python shell on cms bash run:

```
from openedx_tagging.core.tagging.models import ObjectTag
object_tags = ObjectTag.objects.filter(object_id__contains="SampleTaxonomyOrg1+5+new_course")
object_tags

<QuerySet [<ObjectTag> course-v1:SampleTaxonomyOrg1+5+new_course: Languages=English]>
```

- Verify that only `course-v1:...` is tagged.
- Run `tutor dev run cms bash` and `./manage.py cms reindex_studio --experimental`
- Go to http://meilisearch.local.edly.io:7700/ and verify that any course block are indexed.
- Go to Studio and create a course
- Go to http://meilisearch.local.edly.io:7700/ and verify that any course block are indexed.

