### PR TITLE
fix: Be able to extract translations again.

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -44,7 +44,7 @@ ignore_dirs:
     - src/pystache-custom
     - src/rate-xblock
     - src/xblock-google-drive
-    # Ignore the file we use translations are not setup.
+    # Ignore the file we use when translations are not setup in development environments.
     - common/static/js/src/gettext_fallback.js
 
 

--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -44,6 +44,8 @@ ignore_dirs:
     - src/pystache-custom
     - src/rate-xblock
     - src/xblock-google-drive
+    # Ignore the file we use translations are not setup.
+    - common/static/js/src/gettext_fallback.js
 
 
 # Third-party installed apps that we also extract strings from.  When adding a

--- a/conf/locale/en/LC_MESSAGES/.gitignore
+++ b/conf/locale/en/LC_MESSAGES/.gitignore
@@ -1,0 +1,3 @@
+# We want to ignore files in this directory which we do in the
+# top-level .gitignore file but we still want this directory to
+# be automatically created.


### PR DESCRIPTION
* The `conf/locale/en/LC_MESSAGES` folder does not get automatically
  created by other tooling so message extraction to that folder fails.

* The `gettext_fallback.js` file should not be getting picked up for
  translation.
