### PR TITLE
build: use constraints in scripts requirements as well

### DIFF
--- a/scripts/structures_pruning/requirements/base.in
+++ b/scripts/structures_pruning/requirements/base.in
@@ -1,3 +1,5 @@
+-c ../../../requirements/constraints.txt
+
 click
 click-log
 edx-opaque-keys

--- a/scripts/user_retirement/requirements/base.in
+++ b/scripts/user_retirement/requirements/base.in
@@ -1,3 +1,5 @@
+-c ../../../requirements/constraints.txt
+
 boto3
 click
 pyyaml

--- a/scripts/xblock/requirements.in
+++ b/scripts/xblock/requirements.in
@@ -1,1 +1,3 @@
+-c ../../../requirements/constraints.txt
+
 requests


### PR DESCRIPTION
## Description
- We have pinned some package requirements in `constraints.txt` but the requirement files in `scripts/` directory do not use the same constraints which causes conflicts when running `make upgrade`.
- Updating the requirements files inside `scripts/` directory to follow repo constraints as well.