### PR TITLE
fix: add support to Group Configuration view for Teams partitions

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -21,6 +21,7 @@ from help_tokens.core import HelpUrlExpert
 from lti_consumer.models import CourseAllowPIISharingInLTIFlag
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import LibraryLocator
+from openedx.core.lib.teams_config import CONTENT_GROUPS_FOR_TEAMS, TEAM_SCHEME
 from openedx_events.content_authoring.data import DuplicatedXBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DUPLICATED
 from openedx_events.learning.data import CourseNotificationData
@@ -2146,6 +2147,12 @@ def get_group_configurations_context(course, store):
             # Add it to the front of the list if it should be shown.
             if should_show_enrollment_track:
                 displayable_partitions.insert(0, partition)
+        elif partition['scheme'] == TEAM_SCHEME:
+            should_show_team_partitions = len(partition['groups']) > 0 and CONTENT_GROUPS_FOR_TEAMS.is_enabled(
+                course_key
+            )
+            if should_show_team_partitions:
+                displayable_partitions.append(partition)
         elif partition['scheme'] != RANDOM_SCHEME:
             # Experiment group configurations are handled explicitly above. We don't
             # want to display their groups twice.

--- a/cms/static/js/views/pages/group_configurations.js
+++ b/cms/static/js/views/pages/group_configurations.js
@@ -25,6 +25,7 @@ function($, _, gettext, BasePage, GroupConfigurationsListView, PartitionGroupLis
                 currentScheme = this.allGroupConfigurations[i].get('scheme');
                 this.allGroupViewList.push(
                     new PartitionGroupListView({
+                        id: this.allGroupConfigurations[i].get('id'),
                         collection: this.allGroupConfigurations[i].get('groups'),
                         restrictEditing: this.allGroupConfigurations[i].get('read_only'),
                         scheme: currentScheme
@@ -43,7 +44,7 @@ function($, _, gettext, BasePage, GroupConfigurationsListView, PartitionGroupLis
 
             // Render the remaining Configuration groups
             for (i = 0; i < this.allGroupViewList.length; i++) {
-                currentClass = '.wrapper-groups.content-groups.' + this.allGroupViewList[i].scheme;
+                currentClass = `.wrapper-groups.content-groups.${this.allGroupViewList[i].scheme}.${this.allGroupViewList[i].id}`;
                 this.$(currentClass).append(this.allGroupViewList[i].render().el);
             }
 

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -54,7 +54,7 @@ from six.moves.urllib.parse import quote
       <article class="content-primary" role="main">
 
         % for config in all_group_configurations:
-          <div class="wrapper-groups content-groups ${config['scheme']}">
+          <div class="wrapper-groups content-groups ${config['scheme']} ${config['id']}">
             <h3 class="title">${config['name']}</h3>
               <div class="ui-loading">
                   <p><span class="spin"><span class="icon fa fa-refresh" aria-hidden="true"></span></span> <span class="copy">${_("Loading")}</span></p>

--- a/lms/djangoapps/teams/team_partition_scheme.py
+++ b/lms/djangoapps/teams/team_partition_scheme.py
@@ -64,6 +64,8 @@ class TeamPartitionScheme:
     - A user is assigned to a group if they are a member of the team.
     """
 
+    read_only = True
+
     @classmethod
     def get_group_for_user(cls, course_key, user, user_partition):
         """Get the (Content) Group from the specified user partition for the user.


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds support for viewing Content Groups associated with teams in Studio's Group Configurations view. Before this change, after turning the content groups + teams connection on, the view didn't render correctly:

https://github.com/openedx/edx-platform/assets/64440265/6bb12743-d3ad-491b-8ba6-fa7384b5d6e0

Although partitions and their groups were displayed, the frontend implementation only supported one partition per scheme. This PR supports multiple partitions per scheme by using the partition ID:

![image](https://github.com/openedx/edx-platform/assets/64440265/4869eaca-0c11-4ccd-8e77-c690048374fd)

Also, it modifies the team partition scheme to be read-only, so the user doesn't modify it since partitions are created dynamically.

## Supporting information

Following up: #33788 

## Testing instructions

## Testing instructions

1. After creating your course, you'll need to turn on a course-level flag that enables content groups for teams:
Go to /admin/waffle_utils/waffleflagcourseoverridemodel
Add new flag using your new course ID:  **teams.content_groups_for_teams**

2. Enable teams for the course: Studio > Select course > Content > Pages & resources > Teams > Teams toggle
![image](https://github.com/openedx/edx-platform/assets/64440265/adff75c1-d9aa-47b2-aeb8-76d938bbc57b)

3. Create a few team sets (or groups) from the Course Authoring MFE for your course:
![image](https://github.com/openedx/edx-platform/assets/64440265/d635b2a2-464e-41ed-9e8c-a21ebdcca4c5)

4. Then, go to the LMS and create a few teams within those team-set (or topics, or groups): 
![image](https://github.com/openedx/edx-platform/assets/64440265/5a3011e1-6937-4677-96d1-8e3760afb6c7)
![image](https://github.com/openedx/edx-platform/assets/64440265/8af17988-d652-4334-9d9b-3f2b38ddf095)

5. Go to the Group Configurations view in Studio for the course you just configured.

## Deadline

This effort is part of the Spanish consortium project, so it'd be ideal to merge this before the end of the project.

## Other information

**More technical info on teams:** https://openedx.atlassian.net/wiki/spaces/AC/pages/160611195
**Course author docs on teams:** https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/teams/teams_setup.html#teams-overview

### PR Sandbox

**Settings**

```yaml
TUTOR_GROVE_WAFFLE_FLAGS:
- name: teams.content_groups_for_teams
  everyone: true
- name: teams.enable_teams_app
  everyone: true
```