### PR TITLE
feat: [FC-0056] Waffle flag for opening discussions/notifications by default

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -80,6 +80,7 @@ from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
 from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_SEARCH_ENABLED,
     COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
+    COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR,
 )
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.courseware.views.views import (
@@ -3812,3 +3813,39 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body, {'enabled': False})
+
+
+class TestMFEDiscussionSidebarEnabledAPI(SharedModuleStoreTestCase):
+    """
+    Tests the endpoint to fetch the Courseware Discussion/Notifications Sidebar waffle flag status.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.course = CourseFactory.create()
+
+        self.client = APIClient()
+        self.apiUrl = reverse('show_default_right_sidebar_enabled_view', kwargs={'course_id': str(self.course.id)})
+
+    @override_waffle_flag(COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR, active=False)
+    def test_is_mfe_show_default_right_sidebar_disabled(self):
+        """
+        Getter to check if Discussion/Notifications Sidebar shouldn't be opened by default.
+        """
+        response = self.client.get(self.apiUrl, content_type='application/json')
+        body = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body, {'enabled': False})
+
+    @override_waffle_flag(COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR, active=True)
+    def test_is_mfe_show_default_right_sidebar_enabled(self):
+        """
+        Getter to check if Discussion/Notifications Sidebar should be opened by default.
+        """
+        response = self.client.get(self.apiUrl, content_type='application/json')
+        body = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body, {'enabled': True})

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -78,6 +78,7 @@ from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin, get_expiration_banner_text, set_preview_mode
 from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
 from lms.djangoapps.courseware.toggles import (
+    COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED,
     COURSEWARE_MICROFRONTEND_SEARCH_ENABLED,
     COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
     COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR,
@@ -3813,6 +3814,42 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body, {'enabled': False})
+
+
+class TestCoursewareMFESidebarEnabledAPI(SharedModuleStoreTestCase):
+    """
+    Tests the endpoint to fetch the Courseware Sidebar waffle flag status.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.course = CourseFactory.create()
+
+        self.client = APIClient()
+        self.apiUrl = reverse('courseware_sidebar_enabled_view', kwargs={'course_id': str(self.course.id)})
+
+    @override_waffle_flag(COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED, active=True)
+    def test_courseware_mfe_sidebar_disabled(self):
+        """
+        Getter to check if user is allowed to show the Courseware navigation sidebar.
+        """
+        response = self.client.get(self.apiUrl, content_type='application/json')
+        body = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body, {'enabled': False})
+
+    @override_waffle_flag(COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED, active=False)
+    def test_is_mfe_sidebar_enabled(self):
+        """
+        Getter to check if user is allowed to show the Courseware navigation sidebar.
+        """
+        response = self.client.get(self.apiUrl, content_type='application/json')
+        body = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body, {'enabled': True})
 
 
 class TestMFEDiscussionSidebarEnabledAPI(SharedModuleStoreTestCase):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3840,7 +3840,7 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         body = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(body, {'enable_navigation_sidebar': True,  'always_open_auxiliary_sidebar': False})
+        self.assertEqual(body, {'enable_navigation_sidebar': True, 'always_open_auxiliary_sidebar': False})
 
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
@@ -3853,7 +3853,7 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         body = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(body, {'enable_navigation_sidebar': True,  'always_open_auxiliary_sidebar': True})
+        self.assertEqual(body, {'enable_navigation_sidebar': True, 'always_open_auxiliary_sidebar': True})
 
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
@@ -3866,7 +3866,7 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         body = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(body, {'enable_navigation_sidebar': False,  'always_open_auxiliary_sidebar': True})
+        self.assertEqual(body, {'enable_navigation_sidebar': False, 'always_open_auxiliary_sidebar': True})
 
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
@@ -3878,4 +3878,4 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         body = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(body, {'enable_navigation_sidebar': False,  'always_open_auxiliary_sidebar': False})
+        self.assertEqual(body, {'enable_navigation_sidebar': False, 'always_open_auxiliary_sidebar': False})

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -83,6 +83,21 @@ COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffl
     f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar_blocks_caching', __name__
 )
 
+# .. toggle_name: courseware.show_default_right_sidebar
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: If waffle flag disabled
+# Discussions or Notifications sidebar shouldn't be displayed at all on Learning MFE.
+# If waffle flag enabled - Discussions opens always on the pages with discussions,
+# if user is in Audit and course has verified mode - show Notifications.# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-04-28
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: FC-0056
+# .. toggle_warning: None.
+COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.show_default_right_sidebar', __name__
+)
+
 # .. toggle_name: courseware.mfe_progress_milestones_streak_discount_enabled
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
@@ -192,3 +207,10 @@ def courseware_disable_navigation_sidebar_blocks_caching(course_key=None):
     Return whether the courseware.disable_navigation_sidebar_blocks_caching flag is on.
     """
     return COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING.is_enabled(course_key)
+
+
+def courseware_show_default_right_sidebar_is_enabled(course_key=None):
+    """
+    Return whether the courseware.show_default_right_sidebar flag is on.
+    """
+    return COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR.is_enabled(course_key)

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -83,6 +83,19 @@ COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffl
     f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar_blocks_caching', __name__
 )
 
+# .. toggle_name: courseware.disable_navigation_sidebar
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Disable navi sidebar on Learning MFE
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-03-07
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: AXIMST-611
+# .. toggle_warning: None.
+COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar', __name__
+)
+
 # .. toggle_name: courseware.show_default_right_sidebar
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
@@ -207,6 +220,13 @@ def courseware_disable_navigation_sidebar_blocks_caching(course_key=None):
     Return whether the courseware.disable_navigation_sidebar_blocks_caching flag is on.
     """
     return COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING.is_enabled(course_key)
+
+
+def courseware_mfe_sidebar_is_disabled(course_key=None):
+    """
+    Return whether the courseware.disable_navigation_sidebar flag is on.
+    """
+    return COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED.is_enabled(course_key)
 
 
 def courseware_show_default_right_sidebar_is_enabled(course_key=None):

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -85,20 +85,20 @@ COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffl
 
 # .. toggle_name: courseware.disable_navigation_sidebar
 # .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
+# .. toggle_default: True
 # .. toggle_description: Disable navi sidebar on Learning MFE
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2024-03-07
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: AXIMST-611
 # .. toggle_warning: None.
-COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED = CourseWaffleFlag(
+COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR = CourseWaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar', __name__
 )
 
 # .. toggle_name: courseware.show_default_right_sidebar
 # .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
+# .. toggle_default: True
 # .. toggle_description: If waffle flag disabled
 # Discussions or Notifications sidebar shouldn't be displayed at all on Learning MFE.
 # If waffle flag enabled - Discussions opens always on the pages with discussions,
@@ -107,7 +107,7 @@ COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED = CourseWaffleFlag(
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: FC-0056
 # .. toggle_warning: None.
-COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR = CourseWaffleFlag(
+COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR = CourseWaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.show_default_right_sidebar', __name__
 )
 

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -74,7 +74,7 @@ COURSEWARE_MICROFRONTEND_SEARCH_ENABLED = CourseWaffleFlag(
 # .. toggle_description: Disable caching of navigation sidebar blocks on Learning MFE.
 # It can be used when caching the structure of large courses for a large number of users
 # at the same time can overload the cache storage (memcache or redis).
-# .. toggle_use_cases: temporary
+# .. toggle_use_cases: opt_out, open_edx
 # .. toggle_creation_date: 2024-03-21
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: FC-0056
@@ -83,32 +83,29 @@ COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffl
     f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar_blocks_caching', __name__
 )
 
-# .. toggle_name: courseware.disable_navigation_sidebar
+# .. toggle_name: courseware.enable_navigation_sidebar
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: True
-# .. toggle_description: Disable navi sidebar on Learning MFE
-# .. toggle_use_cases: temporary
+# .. toggle_description: Enable navigation sidebar on Learning MFE
+# .. toggle_use_cases: opt_out, open_edx
 # .. toggle_creation_date: 2024-03-07
 # .. toggle_target_removal_date: None
-# .. toggle_tickets: AXIMST-611
-# .. toggle_warning: None.
+# .. toggle_tickets: FC-0056
 COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar', __name__
+    f'{WAFFLE_FLAG_NAMESPACE}.enable_navigation_sidebar', __name__
 )
 
-# .. toggle_name: courseware.show_default_right_sidebar
+# .. toggle_name: courseware.always_open_auxiliary_sidebar
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: True
-# .. toggle_description: If waffle flag disabled
-# Discussions or Notifications sidebar shouldn't be displayed at all on Learning MFE.
-# If waffle flag enabled - Discussions opens always on the pages with discussions,
-# if user is in Audit and course has verified mode - show Notifications.# .. toggle_use_cases: temporary
+# .. toggle_description: TBD
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2024-04-28
-# .. toggle_target_removal_date: None
+# .. toggle_target_removal_date: 2024-07-28
 # .. toggle_tickets: FC-0056
-# .. toggle_warning: None.
+# .. toggle_warning: This toggle will have effect only if navigation sidebar is enabled
 COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.show_default_right_sidebar', __name__
+    f'{WAFFLE_FLAG_NAMESPACE}.always_open_auxiliary_sidebar', __name__
 )
 
 # .. toggle_name: courseware.mfe_progress_milestones_streak_discount_enabled
@@ -220,17 +217,3 @@ def courseware_disable_navigation_sidebar_blocks_caching(course_key=None):
     Return whether the courseware.disable_navigation_sidebar_blocks_caching flag is on.
     """
     return COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING.is_enabled(course_key)
-
-
-def courseware_mfe_sidebar_is_disabled(course_key=None):
-    """
-    Return whether the courseware.disable_navigation_sidebar flag is on.
-    """
-    return COURSEWARE_MICROFRONTEND_SIDEBAR_DISABLED.is_enabled(course_key)
-
-
-def courseware_show_default_right_sidebar_is_enabled(course_key=None):
-    """
-    Return whether the courseware.show_default_right_sidebar flag is on.
-    """
-    return COURSEWARE_SHOW_DEFAULT_RIGHT_SIDEBAR.is_enabled(course_key)

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -72,8 +72,8 @@ COURSEWARE_MICROFRONTEND_SEARCH_ENABLED = CourseWaffleFlag(
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Disable caching of navigation sidebar blocks on Learning MFE.
-# It can be used when caching the structure of large courses for a large number of users
-# at the same time can overload the cache storage (memcache or redis).
+#   It can be used when caching the structure of large courses for a large number of users
+#   at the same time can overload the cache storage (memcache or redis).
 # .. toggle_use_cases: opt_out, open_edx
 # .. toggle_creation_date: 2024-03-21
 # .. toggle_target_removal_date: None
@@ -98,12 +98,14 @@ COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR = CourseWaffleFlag(
 # .. toggle_name: courseware.always_open_auxiliary_sidebar
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: True
-# .. toggle_description: TBD
+# .. toggle_description: Waffle flag that determines whether the auxiliary sidebar,
+#   such as discussion or notification, should automatically expand
+#   on each course unit page within the Learning MFE, without preserving
+#   the previous state of the sidebar.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2024-04-28
 # .. toggle_target_removal_date: 2024-07-28
 # .. toggle_tickets: FC-0056
-# .. toggle_warning: This toggle will have effect only if navigation sidebar is enabled
 COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR = CourseWaffleFlag(
     f'{WAFFLE_FLAG_NAMESPACE}.always_open_auxiliary_sidebar', __name__
 )

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -88,7 +88,11 @@ from lms.djangoapps.courseware.masquerade import is_masquerading_as_specific_stu
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
 from lms.djangoapps.courseware.permissions import MASQUERADE_AS_STUDENT, VIEW_COURSE_HOME, VIEW_COURSEWARE
-from lms.djangoapps.courseware.toggles import course_is_invitation_only, courseware_mfe_search_is_enabled
+from lms.djangoapps.courseware.toggles import (
+    course_is_invitation_only,
+    courseware_mfe_search_is_enabled,
+    courseware_show_default_right_sidebar_is_enabled,
+)
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.courseware.utils import (
     _use_new_financial_assistance_flow,
@@ -2282,3 +2286,19 @@ def courseware_mfe_search_enabled(request, course_id=None):
 
     payload = {"enabled": courseware_mfe_search_is_enabled(course_key) if enabled else False}
     return JsonResponse(payload)
+
+
+@api_view(['GET'])
+def courseware_mfe_show_default_right_sidebar_is_enabled(request, course_id=None):
+    """
+    Simple GET endpoint to expose whether the course may open discussion sidebar by default.
+    """
+    try:
+        course_key = CourseKey.from_string(course_id) if course_id else None
+    except InvalidKeyError:
+        return JsonResponse({"error": "Invalid course_id"})
+
+    return JsonResponse({
+        "enabled": courseware_show_default_right_sidebar_is_enabled(course_key)
+    })
+

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -92,6 +92,7 @@ from lms.djangoapps.courseware.toggles import (
     course_is_invitation_only,
     courseware_mfe_search_is_enabled,
     courseware_show_default_right_sidebar_is_enabled,
+    courseware_mfe_sidebar_is_disabled,
 )
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.courseware.utils import (
@@ -2289,6 +2290,21 @@ def courseware_mfe_search_enabled(request, course_id=None):
 
 
 @api_view(['GET'])
+def courseware_mfe_sidebar_enabled(request, course_id=None):
+    """
+    GET endpoint to expose whether the course may display navigation sidebar.
+    """
+    try:
+        course_key = CourseKey.from_string(course_id) if course_id else None
+    except InvalidKeyError:
+        return JsonResponse({"error": "Invalid course_id"})
+
+    return JsonResponse({
+        "enabled": not courseware_mfe_sidebar_is_disabled(course_key)
+    })
+
+
+@api_view(['GET'])
 def courseware_mfe_show_default_right_sidebar_is_enabled(request, course_id=None):
     """
     Simple GET endpoint to expose whether the course may open discussion sidebar by default.
@@ -2301,4 +2317,3 @@ def courseware_mfe_show_default_right_sidebar_is_enabled(request, course_id=None
     return JsonResponse({
         "enabled": courseware_show_default_right_sidebar_is_enabled(course_key)
     })
-

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -91,8 +91,8 @@ from lms.djangoapps.courseware.permissions import MASQUERADE_AS_STUDENT, VIEW_CO
 from lms.djangoapps.courseware.toggles import (
     course_is_invitation_only,
     courseware_mfe_search_is_enabled,
-    courseware_show_default_right_sidebar_is_enabled,
-    courseware_mfe_sidebar_is_disabled,
+    COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR,
+    COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR,
 )
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.courseware.utils import (
@@ -2290,24 +2290,9 @@ def courseware_mfe_search_enabled(request, course_id=None):
 
 
 @api_view(['GET'])
-def courseware_mfe_sidebar_enabled(request, course_id=None):
+def courseware_mfe_navigation_sidebar_toggles(request, course_id=None):
     """
-    GET endpoint to expose whether the course may display navigation sidebar.
-    """
-    try:
-        course_key = CourseKey.from_string(course_id) if course_id else None
-    except InvalidKeyError:
-        return JsonResponse({"error": "Invalid course_id"})
-
-    return JsonResponse({
-        "enabled": not courseware_mfe_sidebar_is_disabled(course_key)
-    })
-
-
-@api_view(['GET'])
-def courseware_mfe_show_default_right_sidebar_is_enabled(request, course_id=None):
-    """
-    Simple GET endpoint to expose whether the course may open discussion sidebar by default.
+    GET endpoint to return navigation sidebar toggles.
     """
     try:
         course_key = CourseKey.from_string(course_id) if course_id else None
@@ -2315,5 +2300,6 @@ def courseware_mfe_show_default_right_sidebar_is_enabled(request, course_id=None
         return JsonResponse({"error": "Invalid course_id"})
 
     return JsonResponse({
-        "enabled": courseware_show_default_right_sidebar_is_enabled(course_key)
+        "enable_navigation_sidebar": COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR.is_enabled(course_key),
+        "always_open_auxiliary_sidebar": COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR.is_enabled(course_key),
     })

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -749,6 +749,11 @@ urlpatterns += [
         courseware_views.courseware_mfe_search_enabled,
         name='courseware_search_enabled_view',
     ),
+    re_path(
+        fr'^courses/{settings.COURSE_ID_PATTERN}/discussion-sidebar/enabled/$',
+        courseware_views.courseware_mfe_show_default_right_sidebar_is_enabled,
+        name='show_default_right_sidebar_enabled_view',
+    ),
 ]
 
 urlpatterns += [

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -750,6 +750,11 @@ urlpatterns += [
         name='courseware_search_enabled_view',
     ),
     re_path(
+        fr'^courses/{settings.COURSE_ID_PATTERN}/courseware-sidebar/enabled/$',
+        courseware_views.courseware_mfe_sidebar_enabled,
+        name='courseware_sidebar_enabled_view',
+    ),
+    re_path(
         fr'^courses/{settings.COURSE_ID_PATTERN}/discussion-sidebar/enabled/$',
         courseware_views.courseware_mfe_show_default_right_sidebar_is_enabled,
         name='show_default_right_sidebar_enabled_view',

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -750,12 +750,12 @@ urlpatterns += [
         name='courseware_search_enabled_view',
     ),
     re_path(
-        fr'^courses/{settings.COURSE_ID_PATTERN}/courseware-sidebar/enabled/$',
+        fr'^courses/{settings.COURSE_ID_PATTERN}/courseware-navigation-sidebar/enabled/$',
         courseware_views.courseware_mfe_sidebar_enabled,
         name='courseware_sidebar_enabled_view',
     ),
     re_path(
-        fr'^courses/{settings.COURSE_ID_PATTERN}/discussion-sidebar/enabled/$',
+        fr'^courses/{settings.COURSE_ID_PATTERN}/courseware-auxiliary-sidebar/enabled/$',
         courseware_views.courseware_mfe_show_default_right_sidebar_is_enabled,
         name='show_default_right_sidebar_enabled_view',
     ),

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -750,14 +750,9 @@ urlpatterns += [
         name='courseware_search_enabled_view',
     ),
     re_path(
-        fr'^courses/{settings.COURSE_ID_PATTERN}/courseware-navigation-sidebar/enabled/$',
-        courseware_views.courseware_mfe_sidebar_enabled,
-        name='courseware_sidebar_enabled_view',
-    ),
-    re_path(
-        fr'^courses/{settings.COURSE_ID_PATTERN}/courseware-auxiliary-sidebar/enabled/$',
-        courseware_views.courseware_mfe_show_default_right_sidebar_is_enabled,
-        name='show_default_right_sidebar_enabled_view',
+        fr'^courses/{settings.COURSE_ID_PATTERN}/courseware-navigation-sidebar/toggles/$',
+        courseware_views.courseware_mfe_navigation_sidebar_toggles,
+        name='courseware_navigation_sidebar_toggles_view',
     ),
 ]
 


### PR DESCRIPTION
## Settings
```
COURSEWARE_WAFFLE_FLAGS:
  - name: courseware.enable_navigation_sidebar
    everyone: true
  - name: courseware.always_open_auxiliary_sidebar
    everyone: true
 ```

## Description

This PR adding a waffle toggles for the Navigation and auxiliary sidebar features within the learning MFE.
The main goal is to implement two WaffleFlags and create an endpoint to get the enabled status for them.

GH ticket for tracking - https://github.com/openedx/platform-roadmap/issues/329

## How to configure waffle flag:
- Go to /admin/waffle/flag/.
- Add courseware.enable_navigation_sidebar waffle flag
- Add courseware.always_open_auxiliary_sidebar waffle flag


## API to get waffle flag state:
[{LMS_DOMAIN}/courses/{course_id}/courseware-navigation-sidebar/toggles/]({LMS_DOMAIN}/courses/{course_id}/courseware-navigation-sidebar/toggles/)

## Testing API instructions:

- Set waffle flags as described in "How to configure waffle flag"
- Go to the API endpoint `/courses/{course_id}/courseware-navigation-sidebar/toggles/`
- Assess the returned result. The API endpoint should return the correct WaffleFlags statuses.