### PR TITLE
fix: fix lxml constraint issue

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -119,6 +119,10 @@ openai<=0.28.1
 # https://github.com/openedx/edx-platform/issues/34103
 optimizely-sdk<5.0
 
+# lxml 5.1.0 introduced a breaking change in unit test shards
+# This constraint can probably be removed once lxml==5.1.1 is released on PyPI
+lxml<5.0
+
 # xmlsec==1.3.14 breaking tests for all builds, can be removed once a fix is available
 xmlsec<1.3.14
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -119,8 +119,9 @@ openai<=0.28.1
 # https://github.com/openedx/edx-platform/issues/34103
 optimizely-sdk<5.0
 
-# lxml 5.1.0 introduced a breaking change in unit test shards
-# This constraint can probably be removed once lxml==5.1.1 is released on PyPI
+# lxml>=5.0 introduced breaking changes related to system dependencies
+# lxml==5.2.1 introduced new extra so we'll nee to rename lxml --> lxml[html-clean] 
+# This constraint can be removed once we upgrade to Python 3.11
 lxml<5.0
 
 # xmlsec==1.3.14 breaking tests for all builds, can be removed once a fix is available

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -30,8 +30,9 @@ joblib==1.3.2
     # via nltk
 kiwisolver==1.4.5
     # via matplotlib
-lxml==5.2.1
+lxml==4.9.4
     # via
+    #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/base.in
     #   openedx-calc
 markupsafe==2.1.5

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -682,6 +682,7 @@ lti-consumer-xblock==9.10.0
     # via -r requirements/edx/kernel.in
 lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   edxval

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1135,6 +1135,7 @@ lti-consumer-xblock==9.10.0
     #   -r requirements/edx/testing.txt
 lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -805,6 +805,7 @@ lti-consumer-xblock==9.10.0
     # via -r requirements/edx/base.txt
 lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -858,6 +858,7 @@ lti-consumer-xblock==9.10.0
     # via -r requirements/edx/base.txt
 lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -86,7 +86,9 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 lxml==4.9.3
-    # via zeep
+    # via
+    #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
+    #   zeep
 more-itertools==10.2.0
     # via simple-salesforce
 newrelic==9.5.0


### PR DESCRIPTION
## Description
- pin lxml versin again in constraints to resolve failures introduced in last PR
- Updating lxml constraint caused the build pipeline to fail due to the new system dependencies requirement. 