### PR TITLE
fix: update lxml dependency

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: setup dev for lxml dependency
         run: |
-          apt-get update && apt-get install libxml2-dev libxslt-dev
+          sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev
   
       - name: install requirements
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -65,6 +65,10 @@ jobs:
           sudo chmod -R a+rw /data/db
           mongod &
 
+      - name: setup dev for lxml dependency
+        run: |
+          apt-get update && apt-get install libxml2-dev libxslt-dev
+  
       - name: install requirements
         run: |
           sudo make test-requirements
@@ -76,7 +80,7 @@ jobs:
       - name: list installed package versions
         run: |
           sudo pip freeze
-
+      
       - name: Setup and run tests
         uses: ./.github/actions/unit-tests
 

--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -2,7 +2,7 @@
 
 chem                                # A helper library for chemistry calculations
 cryptography                        # Implementations of assorted cryptography algorithms
-lxml                                # XML parser
+lxml --no-binary lxml               # XML parser
 matplotlib                          # 2D plotting library
 networkx                            # Utilities for creating, manipulating, and studying network graphs
 nltk                                # Natural language processing; used by the chem package

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -680,7 +680,7 @@ loremipsum==1.0.5
     # via ora2
 lti-consumer-xblock==9.10.0
     # via -r requirements/edx/kernel.in
-lxml==4.9.4
+lxml==5.2.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1133,7 +1133,7 @@ lti-consumer-xblock==9.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-lxml==4.9.4
+lxml==5.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -803,7 +803,7 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.10.0
     # via -r requirements/edx/base.txt
-lxml==4.9.4
+lxml==5.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -102,7 +102,7 @@ icalendar                           # .ics generator, used by calendar_sync
 ipaddress                           # Ip network support for Embargo feature
 jsonfield                           # Django model field for validated JSON; used in several apps
 laboratory                          # Library for testing that code refactors/infrastructure changes produce identical results
-lxml                                # XML parser
+lxml --no-binary lxml               # XML parser
 lti-consumer-xblock>=7.3.0
 mako                                # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -856,7 +856,7 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.10.0
     # via -r requirements/edx/base.txt
-lxml==4.9.4
+lxml==5.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools


### PR DESCRIPTION
## Description
- lxml>5.0 needs to be build with `--no-binary` flag so updated the requirements and test workflows to resolve this issue.
- Copied solution from https://stackoverflow.com/a/25974164.