### PR TITLE
Revert "build: Python requirements upgrade and lxml build without binary"

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -42,11 +42,6 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: setup dev for lxml dependency
-        if: ${{ env.RELEVANT == 'true' }}
-        run: |
-            sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev
-  
       - name: "Recompile requirements"
         if: ${{ env.RELEVANT == 'true' }}
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,11 +64,7 @@ jobs:
           sudo mkdir -p /data/db
           sudo chmod -R a+rw /data/db
           mongod &
-  
-      - name: setup dev for lxml dependency
-        run: |
-          sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev
-      
+
       - name: install requirements
         run: |
           sudo make test-requirements

--- a/.github/workflows/units-test-scripts-user-retirement.yml
+++ b/.github/workflows/units-test-scripts-user-retirement.yml
@@ -23,10 +23,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: setup dev for lxml dependency
-        run: |
-          sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/upgrade-one-python-dependency.yml
+++ b/.github/workflows/upgrade-one-python-dependency.yml
@@ -41,10 +41,6 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: setup dev for lxml dependency
-        run: |
-            sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev
-      
       - name: Update any pinned dependencies
         env:
           NEW_VERSION: "${{ inputs.version }}"

--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -2,7 +2,7 @@
 
 chem                                # A helper library for chemistry calculations
 cryptography                        # Implementations of assorted cryptography algorithms
-lxml --no-binary lxml               # XML parser
+lxml                                # XML parser
 matplotlib                          # 2D plotting library
 networkx                            # Utilities for creating, manipulating, and studying network graphs
 nltk                                # Natural language processing; used by the chem package

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
---no-binary lxml
-
 cffi==1.16.0
     # via cryptography
 chem==1.3.0
@@ -24,11 +22,11 @@ cryptography==38.0.4
     #   -r requirements/edx-sandbox/base.in
 cycler==0.12.1
     # via matplotlib
-fonttools==4.51.0
+fonttools==4.49.0
     # via matplotlib
-importlib-resources==6.4.0
+importlib-resources==6.1.1
     # via matplotlib
-joblib==1.4.0
+joblib==1.3.2
     # via nltk
 kiwisolver==1.4.5
     # via matplotlib
@@ -61,21 +59,21 @@ openedx-calc==3.1.0
     # via -r requirements/edx-sandbox/base.in
 packaging==24.0
     # via matplotlib
-pillow==10.3.0
+pillow==10.2.0
     # via matplotlib
-pycparser==2.22
+pycparser==2.21
     # via cffi
-pyparsing==3.1.2
+pyparsing==3.1.1
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
     #   matplotlib
     #   openedx-calc
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via matplotlib
 random2==1.0.2
     # via -r requirements/edx-sandbox/base.in
-regex==2024.4.28
+regex==2024.4.16
     # via nltk
 scipy==1.7.3
     # via
@@ -93,5 +91,5 @@ sympy==1.12
     #   openedx-calc
 tqdm==4.66.2
     # via nltk
-zipp==3.18.1
+zipp==3.17.0
     # via importlib-resources

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,13 +4,11 @@
 #
 #    make upgrade
 #
---no-binary lxml
-
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via -r requirements/edx/github.in
-acid-xblock==0.3.1
+acid-xblock==0.3.0
     # via -r requirements/edx/kernel.in
-aiohttp==3.9.5
+aiohttp==3.9.3
     # via
     #   geoip2
     #   openai
@@ -28,7 +26,7 @@ annotated-types==0.6.0
     # via pydantic
 appdirs==1.4.4
     # via fs
-asgiref==3.8.1
+asgiref==3.7.2
     # via
     #   django
     #   django-cors-headers
@@ -79,22 +77,22 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.34.93
+boto3==1.34.45
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.34.93
+botocore==1.34.45
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/kernel.in
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==3.1.1
     # via meilisearch
-celery==5.4.0
+celery==5.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -137,7 +135,7 @@ click==8.1.6
     #   edx-django-utils
     #   nltk
     #   user-util
-click-didyoumean==0.3.1
+click-didyoumean==0.3.0
     # via celery
 click-plugins==1.1.1
     # via celery
@@ -170,7 +168,7 @@ cryptography==38.0.4
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.10.2
+cssutils==2.9.0
     # via pynliner
 defusedxml==0.7.1
     # via
@@ -179,7 +177,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.11
+django==4.2.10
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -290,7 +288,7 @@ django-filter==24.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==7.0.1
+django-ipware==6.0.4
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -323,7 +321,7 @@ django-mptt==0.14.0
     #   openedx-django-wiki
 django-multi-email-field==0.7.0
     # via edx-enterprise
-django-mysql==4.13.0
+django-mysql==4.12.0
     # via -r requirements/edx/kernel.in
 django-oauth-toolkit==1.7.1
     # via
@@ -351,7 +349,7 @@ django-simple-history==3.4.0
     #   edx-organizations
     #   edx-proctoring
     #   ora2
-django-statici18n==2.5.0
+django-statici18n==2.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
@@ -406,7 +404,7 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-nested-routers==0.93.5
     # via openedx-blockstore
-drf-spectacular==0.27.2
+drf-spectacular==0.27.1
     # via -r requirements/edx/kernel.in
 drf-yasg==1.21.5
     # via
@@ -424,7 +422,7 @@ edx-auth-backends==4.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-blockstore
-edx-braze-client==0.2.3
+edx-braze-client==0.2.2
     # via
     #   -r requirements/edx/bundled.in
     #   edx-enterprise
@@ -489,7 +487,7 @@ edx-event-bus-kafka==5.7.0
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/kernel.in
-edx-i18n-tools==1.6.0
+edx-i18n-tools==1.5.0
     # via
     #   -r requirements/edx/bundled.in
     #   ora2
@@ -572,7 +570,7 @@ event-tracking==2.4.0
     #   edx-search
 fastavro==1.9.4
     # via openedx-events
-filelock==3.13.4
+filelock==3.13.1
     # via snowflake-connector-python
 frozenlist==1.4.1
     # via
@@ -602,9 +600,9 @@ html5lib==1.1
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
-icalendar==5.0.12
+icalendar==5.0.11
     # via -r requirements/edx/kernel.in
-idna==3.7
+idna==3.6
     # via
     #   -r requirements/edx/paver.txt
     #   optimizely-sdk
@@ -640,7 +638,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.4.0
+joblib==1.3.2
     # via nltk
 jsondiff==2.0.0
     # via edx-enterprise
@@ -659,11 +657,11 @@ jsonschema==4.21.1
     #   optimizely-sdk
 jsonschema-specifications==2023.12.1
     # via jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.4
     # via
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.7
+kombu==5.3.5
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/kernel.in
@@ -680,26 +678,23 @@ libsass==0.10.0
     #   -r requirements/edx/paver.txt
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.11.0
+lti-consumer-xblock==9.10.0
     # via -r requirements/edx/kernel.in
-lxml[html-clean]==5.2.1
+lxml==4.9.4
     # via
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.1.1
-    # via lxml
 mailsnake==1.6.4
     # via -r requirements/edx/bundled.in
-mako==1.3.3
+mako==1.3.2
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock
@@ -721,13 +716,13 @@ markupsafe==2.1.5
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.6.1
+maxminddb==2.5.2
     # via geoip2
-meilisearch==0.31.0
+meilisearch==0.30.0
     # via -r requirements/edx/kernel.in
 mock==5.1.0
     # via -r requirements/edx/paver.txt
-mongoengine==0.28.2
+mongoengine==0.27.0
     # via -r requirements/edx/kernel.in
 monotonic==1.6
     # via
@@ -743,7 +738,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-blockstore
-newrelic==9.9.0
+newrelic==9.6.0
     # via
     #   -r requirements/edx/bundled.in
     #   edx-django-utils
@@ -838,7 +833,7 @@ pgpy==0.6.0
     # via edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/kernel.in
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -846,7 +841,7 @@ pillow==10.3.0
     #   edxval
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.1
+platformdirs==3.11.0
     # via snowflake-connector-python
 polib==1.2.0
     # via edx-i18n-tools
@@ -860,11 +855,11 @@ py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
-pyasn1==0.6.0
+pyasn1==0.5.1
     # via pgpy
 pycountry==23.12.11
     # via -r requirements/edx/kernel.in
-pycparser==2.22
+pycparser==2.21
     # via cffi
 pycryptodomex==3.20.0
     # via
@@ -872,9 +867,9 @@ pycryptodomex==3.20.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.7.1
+pydantic==2.6.3
     # via camel-converter
-pydantic-core==2.18.2
+pydantic-core==2.16.3
     # via pydantic
 pygments==2.17.2
     # via
@@ -920,7 +915,7 @@ pyopenssl==22.0.0
     #   -c requirements/edx/../constraints.txt
     #   optimizely-sdk
     #   snowflake-connector-python
-pyparsing==3.1.2
+pyparsing==3.1.1
     # via
     #   chem
     #   openedx-calc
@@ -930,7 +925,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   -r requirements/edx/kernel.in
     #   analytics-python
@@ -943,13 +938,13 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
-python-ipware==3.0.0
+python-ipware==2.0.1
     # via django-ipware
 python-memcached==1.62
     # via -r requirements/edx/paver.txt
 python-slugify==8.0.4
     # via code-annotations
-python-swiftclient==4.5.0
+python-swiftclient==4.4.0
     # via ora2
 python3-openid==3.2.0 ; python_version >= "3"
     # via
@@ -992,15 +987,15 @@ random2==1.0.2
     # via -r requirements/edx/kernel.in
 recommender-xblock==2.2.0
     # via -r requirements/edx/bundled.in
-redis==5.0.4
+redis==5.0.1
     # via
     #   -r requirements/edx/kernel.in
     #   walrus
-referencing==0.35.0
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.4.28
+regex==2024.4.16
     # via nltk
 requests==2.31.0
     # via
@@ -1045,7 +1040,7 @@ rules==3.3
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.1
+s3transfer==0.10.0
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
@@ -1056,7 +1051,7 @@ scipy==1.7.3
     #   openedx-calc
 semantic-version==2.10.0
     # via edx-drf-extensions
-shapely==2.0.4
+shapely==2.0.3
     # via -r requirements/edx/kernel.in
 simplejson==3.19.2
     # via
@@ -1099,7 +1094,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==3.9.1
+snowflake-connector-python==3.7.0
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via
@@ -1122,14 +1117,14 @@ sortedcontainers==2.4.0
     #   snowflake-connector-python
 soupsieve==2.5
     # via beautifulsoup4
-sqlparse==0.5.0
+sqlparse==0.4.4
     # via
     #   -r requirements/edx/kernel.in
     #   django
     #   openedx-blockstore
 staff-graded-xblock==2.3.0
     # via -r requirements/edx/bundled.in
-stevedore==5.2.0
+stevedore==5.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   -r requirements/edx/paver.txt
@@ -1142,19 +1137,19 @@ super-csv==3.2.0
     # via edx-bulk-grades
 sympy==1.12
     # via openedx-calc
-testfixtures==8.1.0
+testfixtures==8.0.0
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify
 tinycss2==1.2.1
     # via bleach
-tomlkit==0.12.4
+tomlkit==0.12.3
     # via snowflake-connector-python
 tqdm==4.66.2
     # via
     #   nltk
     #   openai
-typing-extensions==4.11.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/edx/paver.txt
     #   annotated-types
@@ -1224,7 +1219,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/paver.txt
-xblock[django]==4.0.1
+xblock[django]==4.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock
@@ -1242,7 +1237,7 @@ xblock[django]==4.0.1
     #   xblock-utils
 xblock-drag-and-drop-v2==4.0.2
     # via -r requirements/edx/bundled.in
-xblock-google-drive==0.7.0
+xblock-google-drive==0.6.1
     # via -r requirements/edx/bundled.in
 xblock-poll==1.13.0
     # via -r requirements/edx/bundled.in
@@ -1256,7 +1251,7 @@ xss-utils==0.6.0
     # via -r requirements/edx/kernel.in
 yarl==1.9.4
     # via aiohttp
-zipp==3.18.1
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 chardet==5.2.0
     # via diff-cover
-coverage==7.5.0
+coverage==7.4.1
     # via -r requirements/edx/coverage.in
 diff-cover==9.0.0
     # via -r requirements/edx/coverage.in
@@ -14,7 +14,7 @@ jinja2==3.1.3
     # via diff-cover
 markupsafe==2.1.5
     # via jinja2
-pluggy==1.5.0
+pluggy==1.4.0
     # via diff-cover
 pygments==2.17.2
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
---no-binary lxml
-
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via
     #   -r requirements/edx/doc.txt
@@ -14,11 +12,11 @@ accessible-pygments==0.0.4
     # via
     #   -r requirements/edx/doc.txt
     #   pydata-sphinx-theme
-acid-xblock==0.3.1
+acid-xblock==0.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-aiohttp==3.9.5
+aiohttp==3.9.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -65,7 +63,7 @@ appdirs==1.4.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.7.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -147,14 +145,14 @@ boto==2.49.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.34.93
+boto3==1.34.45
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.34.93
+botocore==1.34.45
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -164,20 +162,20 @@ bridgekeeper==0.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-build==1.2.1
+build==1.0.3
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   pip-tools
-cachetools==5.3.3
+cachetools==5.3.2
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   meilisearch
-celery==5.4.0
+celery==5.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
@@ -201,7 +199,6 @@ cffi==1.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cryptography
-    #   pact-python
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
@@ -244,7 +241,7 @@ click==8.1.6
     #   pip-tools
     #   user-util
     #   uvicorn
-click-didyoumean==0.3.1
+click-didyoumean==0.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -289,7 +286,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.5.0
+coverage[toml]==7.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -315,12 +312,12 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
-cssutils==2.10.2
+cssutils==2.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pynliner
-ddt==1.7.2
+ddt==1.7.1
     # via -r requirements/edx/testing.txt
 deepmerge==1.1.1
     # via
@@ -344,7 +341,7 @@ distlib==0.3.8
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.11
+django==4.2.10
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -484,7 +481,7 @@ django-filter==24.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==7.0.1
+django-ipware==6.0.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -528,7 +525,7 @@ django-multi-email-field==0.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-mysql==4.13.0
+django-mysql==4.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -570,7 +567,7 @@ django-simple-history==3.4.0
     #   edx-organizations
     #   edx-proctoring
     #   ora2
-django-statici18n==2.5.0
+django-statici18n==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -660,7 +657,7 @@ drf-nested-routers==0.93.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-blockstore
-drf-spectacular==0.27.2
+drf-spectacular==0.27.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -686,7 +683,7 @@ edx-auth-backends==4.3.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-blockstore
-edx-braze-client==0.2.3
+edx-braze-client==0.2.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -769,7 +766,7 @@ edx-event-bus-redis==0.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-i18n-tools==1.6.0
+edx-i18n-tools==1.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -886,22 +883,22 @@ event-tracking==2.4.0
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-exceptiongroup==1.2.1
+exceptiongroup==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   anyio
     #   pytest
-execnet==2.1.1
+execnet==2.0.2
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.txt
-faker==24.14.1
+faker==24.14.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.110.2
+fastapi==0.109.2
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -910,14 +907,14 @@ fastavro==1.9.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.13.4
+filelock==3.13.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-freezegun==1.5.0
+freezegun==1.4.0
     # via -r requirements/edx/testing.txt
 frozenlist==1.4.1
     # via
@@ -950,7 +947,7 @@ gitdb==4.0.11
     # via
     #   -r requirements/edx/doc.txt
     #   gitpython
-gitpython==3.1.43
+gitpython==3.1.42
     # via -r requirements/edx/doc.txt
 glob2==0.7
     # via
@@ -979,11 +976,11 @@ html5lib==1.1
     #   ora2
 httpretty==1.1.4
     # via -r requirements/edx/testing.txt
-icalendar==5.0.12
+icalendar==5.0.11
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-idna==3.7
+idna==3.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1062,7 +1059,7 @@ jmespath==1.0.1
     #   -r requirements/edx/testing.txt
     #   boto3
     #   botocore
-joblib==1.4.0
+joblib==1.3.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1094,13 +1091,13 @@ jsonschema-specifications==2023.12.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.7
+kombu==5.3.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1132,18 +1129,17 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.11.0
+lti-consumer-xblock==9.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-lxml[html-clean]==5.2.1
+lxml==4.9.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -1151,15 +1147,11 @@ lxml[html-clean]==5.2.1
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.1.1
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
 mailsnake==1.6.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-mako==1.3.3
+mako==1.3.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1184,7 +1176,7 @@ markupsafe==2.1.5
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.6.1
+maxminddb==2.5.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1193,11 +1185,11 @@ mccabe==0.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-meilisearch==0.31.0
+meilisearch==0.30.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-mistune==3.0.2
+mistune==2.0.5
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx-mdinclude
@@ -1205,7 +1197,7 @@ mock==5.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-mongoengine==0.28.2
+mongoengine==0.27.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1226,7 +1218,7 @@ multidict==6.0.5
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.10.0
+mypy==1.8.0
     # via
     #   -r requirements/edx/development.in
     #   django-stubs
@@ -1238,7 +1230,7 @@ mysqlclient==2.2.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-blockstore
-newrelic==9.9.0
+newrelic==9.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1352,7 +1344,7 @@ packaging==24.0
     #   snowflake-connector-python
     #   sphinx
     #   tox
-pact-python==2.2.0
+pact-python==2.1.1
     # via -r requirements/edx/testing.txt
 pansi==2020.7.3
     # via
@@ -1395,21 +1387,21 @@ piexif==1.1.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-pip-tools==7.4.1
+pip-tools==7.4.0
     # via -r requirements/edx/../pip-tools.txt
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jsonschema
-platformdirs==4.2.1
+platformdirs==3.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1417,7 +1409,7 @@ platformdirs==4.2.1
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   diff-cover
@@ -1447,7 +1439,7 @@ py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pyasn1==0.6.0
+pyasn1==0.5.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1460,7 +1452,7 @@ pycountry==23.12.11
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1472,13 +1464,13 @@ pycryptodomex==3.20.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.7.1
+pydantic==2.6.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   camel-converter
     #   fastapi
-pydantic-core==2.18.2
+pydantic-core==2.16.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1577,7 +1569,7 @@ pyopenssl==22.0.0
     #   -r requirements/edx/testing.txt
     #   optimizely-sdk
     #   snowflake-connector-python
-pyparsing==3.1.2
+pyparsing==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1587,7 +1579,7 @@ pyproject-api==1.6.1
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-pyproject-hooks==1.1.0
+pyproject-hooks==1.0.0
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   build
@@ -1604,7 +1596,7 @@ pysrt==1.1.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-pytest==8.2.0
+pytest==8.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   pylint-pytest
@@ -1629,9 +1621,9 @@ pytest-metadata==1.8.0
     #   pytest-json-report
 pytest-randomly==3.15.0
     # via -r requirements/edx/testing.txt
-pytest-xdist[psutil]==3.6.1
+pytest-xdist[psutil]==3.5.0
     # via -r requirements/edx/testing.txt
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1647,7 +1639,7 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
-python-ipware==3.0.0
+python-ipware==2.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1661,7 +1653,7 @@ python-slugify==8.0.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   code-annotations
-python-swiftclient==4.5.0
+python-swiftclient==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1701,7 +1693,7 @@ pyuca==1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pywatchman==2.0.0
+pywatchman==1.4.1
     # via -r requirements/edx/development.in
 pyyaml==6.0.1
     # via
@@ -1721,18 +1713,18 @@ recommender-xblock==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-redis==5.0.4
+redis==5.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   walrus
-referencing==0.35.0
+referencing==0.33.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.4.28
+regex==2024.4.16
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1794,7 +1786,7 @@ rules==3.3
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.1
+s3transfer==0.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1816,7 +1808,7 @@ semantic-version==2.10.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
-shapely==2.0.4
+shapely==2.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1873,7 +1865,7 @@ smmap==5.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   gitdb
-sniffio==1.3.1
+sniffio==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   anyio
@@ -1881,7 +1873,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==3.9.1
+snowflake-connector-python==3.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1928,7 +1920,7 @@ sphinx-book-theme==1.0.1
     # via -r requirements/edx/doc.txt
 sphinx-design==0.5.0
     # via -r requirements/edx/doc.txt
-sphinx-mdinclude==0.6.0
+sphinx-mdinclude==0.5.3
     # via
     #   -r requirements/edx/doc.txt
     #   sphinxcontrib-openapi
@@ -1966,7 +1958,7 @@ sphinxcontrib-serializinghtml==1.1.5
     #   sphinx
 sphinxext-rediraffe==0.2.7
     # via -r requirements/edx/doc.txt
-sqlparse==0.5.0
+sqlparse==0.4.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1977,11 +1969,11 @@ staff-graded-xblock==2.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-starlette==0.37.2
+starlette==0.36.3
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
-stevedore==5.2.0
+stevedore==5.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2000,7 +1992,7 @@ sympy==1.12
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-calc
-testfixtures==8.1.0
+testfixtures==8.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2027,16 +2019,17 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-api
+    #   pyproject-hooks
     #   pytest
     #   tox
     #   vulture
-tomlkit==0.12.4
+tomlkit==0.12.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.15.0
+tox==4.11.4
     # via -r requirements/edx/testing.txt
 tqdm==4.66.2
     # via
@@ -2044,9 +2037,9 @@ tqdm==4.66.2
     #   -r requirements/edx/testing.txt
     #   nltk
     #   openai
-types-pytz==2024.1.0.20240417
+types-pytz==2024.1.0.20240203
     # via django-stubs
-types-pyyaml==6.0.12.20240311
+types-pyyaml==6.0.12.12
     # via
     #   django-stubs
     #   djangorestframework-stubs
@@ -2054,7 +2047,7 @@ types-requests==2.31.0.6
     # via djangorestframework-stubs
 types-urllib3==1.26.25.14
     # via types-requests
-typing-extensions==4.11.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2075,7 +2068,6 @@ typing-extensions==4.11.0
     #   jwcrypto
     #   kombu
     #   mypy
-    #   pact-python
     #   pydantic
     #   pydantic-core
     #   pydata-sphinx-theme
@@ -2118,7 +2110,7 @@ user-util==1.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-uvicorn==0.29.0
+uvicorn==0.27.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -2129,7 +2121,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.0
+virtualenv==20.25.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -2176,7 +2168,7 @@ webob==1.8.7
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblock
-wheel==0.43.0
+wheel==0.42.0
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   pip-tools
@@ -2185,7 +2177,7 @@ wrapt==1.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-xblock[django]==4.0.1
+xblock[django]==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2206,7 +2198,7 @@ xblock-drag-and-drop-v2==4.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock-google-drive==0.7.0
+xblock-google-drive==0.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2234,8 +2226,7 @@ yarl==1.9.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
-    #   pact-python
-zipp==3.18.1
+zipp==3.17.0
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -4,15 +4,13 @@
 #
 #    make upgrade
 #
---no-binary lxml
-
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via -r requirements/edx/base.txt
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-acid-xblock==0.3.1
+acid-xblock==0.3.0
     # via -r requirements/edx/base.txt
-aiohttp==3.9.5
+aiohttp==3.9.3
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -43,7 +41,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.7.2
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -108,24 +106,24 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.34.93
+boto3==1.34.45
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.34.93
+botocore==1.34.45
     # via
     #   -r requirements/edx/base.txt
     #   boto3
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
-celery==5.4.0
+celery==5.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -172,7 +170,7 @@ click==8.1.6
     #   edx-django-utils
     #   nltk
     #   user-util
-click-didyoumean==0.3.1
+click-didyoumean==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -216,7 +214,7 @@ cryptography==38.0.4
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssutils==2.10.2
+cssutils==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
@@ -229,7 +227,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.11
+django==4.2.10
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -350,7 +348,7 @@ django-filter==24.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==7.0.1
+django-ipware==6.0.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -387,7 +385,7 @@ django-multi-email-field==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==4.13.0
+django-mysql==4.12.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
@@ -417,7 +415,7 @@ django-simple-history==3.4.0
     #   edx-organizations
     #   edx-proctoring
     #   ora2
-django-statici18n==2.5.0
+django-statici18n==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
@@ -483,7 +481,7 @@ drf-nested-routers==0.93.5
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-drf-spectacular==0.27.2
+drf-spectacular==0.27.1
     # via -r requirements/edx/base.txt
 drf-yasg==1.21.5
     # via
@@ -502,7 +500,7 @@ edx-auth-backends==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-edx-braze-client==0.2.3
+edx-braze-client==0.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -567,7 +565,7 @@ edx-event-bus-kafka==5.7.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.6.0
+edx-i18n-tools==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -658,7 +656,7 @@ fastavro==1.9.4
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.13.4
+filelock==3.13.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -685,7 +683,7 @@ geoip2==4.8.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.43
+gitpython==3.1.42
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
@@ -697,9 +695,9 @@ html5lib==1.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-icalendar==5.0.12
+icalendar==5.0.11
     # via -r requirements/edx/base.txt
-idna==3.7
+idna==3.6
     # via
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
@@ -750,7 +748,7 @@ jmespath==1.0.1
     #   -r requirements/edx/base.txt
     #   boto3
     #   botocore
-joblib==1.4.0
+joblib==1.3.2
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -777,12 +775,12 @@ jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.4
     # via
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.7
+kombu==5.3.5
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -803,26 +801,23 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.11.0
+lti-consumer-xblock==9.10.0
     # via -r requirements/edx/base.txt
-lxml[html-clean]==5.2.1
+lxml==4.9.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.1.1
-    # via -r requirements/edx/base.txt
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.3.3
+mako==1.3.2
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -844,17 +839,17 @@ markupsafe==2.1.5
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.6.1
+maxminddb==2.5.2
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
-meilisearch==0.31.0
+meilisearch==0.30.0
     # via -r requirements/edx/base.txt
-mistune==3.0.2
+mistune==2.0.5
     # via sphinx-mdinclude
 mock==5.1.0
     # via -r requirements/edx/base.txt
-mongoengine==0.28.2
+mongoengine==0.27.0
     # via -r requirements/edx/base.txt
 monotonic==1.6
     # via
@@ -874,7 +869,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-newrelic==9.9.0
+newrelic==9.6.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -983,7 +978,7 @@ picobox==4.0.0
     # via sphinxcontrib-openapi
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -993,7 +988,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-platformdirs==4.2.1
+platformdirs==3.11.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -1013,13 +1008,13 @@ py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-pyasn1==0.6.0
+pyasn1==0.5.1
     # via
     #   -r requirements/edx/base.txt
     #   pgpy
 pycountry==23.12.11
     # via -r requirements/edx/base.txt
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/edx/base.txt
     #   cffi
@@ -1029,11 +1024,11 @@ pycryptodomex==3.20.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.7.1
+pydantic==2.6.3
     # via
     #   -r requirements/edx/base.txt
     #   camel-converter
-pydantic-core==2.18.2
+pydantic-core==2.16.3
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
@@ -1091,7 +1086,7 @@ pyopenssl==22.0.0
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
     #   snowflake-connector-python
-pyparsing==3.1.2
+pyparsing==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1104,7 +1099,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
@@ -1117,7 +1112,7 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
-python-ipware==3.0.0
+python-ipware==2.0.1
     # via
     #   -r requirements/edx/base.txt
     #   django-ipware
@@ -1127,7 +1122,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
-python-swiftclient==4.5.0
+python-swiftclient==4.4.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1173,16 +1168,16 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==2.2.0
     # via -r requirements/edx/base.txt
-redis==5.0.4
+redis==5.0.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
-referencing==0.35.0
+referencing==0.33.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.4.28
+regex==2024.4.16
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1235,7 +1230,7 @@ rules==3.3
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.1
+s3transfer==0.10.0
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1253,7 +1248,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==2.0.4
+shapely==2.0.3
     # via -r requirements/edx/base.txt
 simplejson==3.19.2
     # via
@@ -1300,7 +1295,7 @@ smmap==5.0.1
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.9.1
+snowflake-connector-python==3.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1341,7 +1336,7 @@ sphinx-book-theme==1.0.1
     # via -r requirements/edx/doc.in
 sphinx-design==0.5.0
     # via -r requirements/edx/doc.in
-sphinx-mdinclude==0.6.0
+sphinx-mdinclude==0.5.3
     # via sphinxcontrib-openapi
 sphinx-reredirects==0.1.3
     # via -r requirements/edx/doc.in
@@ -1363,14 +1358,14 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxext-rediraffe==0.2.7
     # via -r requirements/edx/doc.in
-sqlparse==0.5.0
+sqlparse==0.4.4
     # via
     #   -r requirements/edx/base.txt
     #   django
     #   openedx-blockstore
 staff-graded-xblock==2.3.0
     # via -r requirements/edx/base.txt
-stevedore==5.2.0
+stevedore==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1386,7 +1381,7 @@ sympy==1.12
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==8.1.0
+testfixtures==8.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1398,7 +1393,7 @@ tinycss2==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   bleach
-tomlkit==0.12.4
+tomlkit==0.12.3
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -1407,7 +1402,7 @@ tqdm==4.66.2
     #   -r requirements/edx/base.txt
     #   nltk
     #   openai
-typing-extensions==4.11.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/edx/base.txt
     #   annotated-types
@@ -1488,7 +1483,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/base.txt
-xblock[django]==4.0.1
+xblock[django]==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -1506,7 +1501,7 @@ xblock[django]==4.0.1
     #   xblock-utils
 xblock-drag-and-drop-v2==4.0.2
     # via -r requirements/edx/base.txt
-xblock-google-drive==0.7.0
+xblock-google-drive==0.6.1
     # via -r requirements/edx/base.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
@@ -1525,7 +1520,7 @@ yarl==1.9.4
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==3.18.1
+zipp==3.17.0
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -102,7 +102,7 @@ icalendar                           # .ics generator, used by calendar_sync
 ipaddress                           # Ip network support for Embargo feature
 jsonfield                           # Django model field for validated JSON; used in several apps
 laboratory                          # Library for testing that code refactors/infrastructure changes produce identical results
-lxml --no-binary lxml               # XML parser
+lxml                                # XML parser
 lti-consumer-xblock>=7.3.0
 mako                                # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -12,7 +12,7 @@ charset-normalizer==2.0.12
     #   requests
 edx-opaque-keys==2.9.0
     # via -r requirements/edx/paver.in
-idna==3.7
+idna==3.6
     # via requests
 lazy==1.6
     # via -r requirements/edx/paver.in
@@ -49,11 +49,11 @@ six==1.16.0
     # via
     #   libsass
     #   paver
-stevedore==5.2.0
+stevedore==5.1.0
     # via
     #   -r requirements/edx/paver.in
     #   edx-opaque-keys
-typing-extensions==4.11.0
+typing-extensions==4.9.0
     # via edx-opaque-keys
 urllib3==1.26.18
     # via

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -38,9 +38,9 @@ face==22.0.0
     # via glom
 glom==22.1.0
     # via semgrep
-idna==3.7
+idna==3.6
     # via requests
-importlib-resources==6.4.0
+importlib-resources==6.1.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -54,19 +54,19 @@ mdurl==0.1.2
     # via markdown-it-py
 packaging==24.0
     # via semgrep
-peewee==3.17.3
+peewee==3.17.1
     # via semgrep
 pkgutil-resolve-name==1.3.10
     # via jsonschema
 pygments==2.17.2
     # via rich
-referencing==0.35.0
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via semgrep
-rich==13.7.1
+rich==13.7.0
     # via semgrep
 rpds-py==0.18.0
     # via
@@ -80,7 +80,7 @@ semgrep==1.52.0
     # via -r requirements/edx/semgrep.in
 tomli==2.0.1
     # via semgrep
-typing-extensions==4.11.0
+typing-extensions==4.9.0
     # via
     #   rich
     #   semgrep
@@ -89,7 +89,7 @@ urllib3==1.26.18
     #   -c requirements/edx/../constraints.txt
     #   requests
     #   semgrep
-wcmatch==8.5.1
+wcmatch==8.5
     # via semgrep
-zipp==3.18.1
+zipp==3.17.0
     # via importlib-resources

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,13 +4,11 @@
 #
 #    make upgrade
 #
---no-binary lxml
-
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via -r requirements/edx/base.txt
-acid-xblock==0.3.1
+acid-xblock==0.3.0
     # via -r requirements/edx/base.txt
-aiohttp==3.9.5
+aiohttp==3.9.3
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -41,7 +39,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.7.2
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -108,26 +106,26 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.34.93
+boto3==1.34.45
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.34.93
+botocore==1.34.45
     # via
     #   -r requirements/edx/base.txt
     #   boto3
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
-cachetools==5.3.3
+cachetools==5.3.2
     # via tox
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
-celery==5.4.0
+celery==5.3.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -148,7 +146,6 @@ cffi==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   cryptography
-    #   pact-python
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
@@ -183,7 +180,7 @@ click==8.1.6
     #   pact-python
     #   user-util
     #   uvicorn
-click-didyoumean==0.3.1
+click-didyoumean==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -217,7 +214,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.5.0
+coverage[toml]==7.4.1
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -240,11 +237,11 @@ cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
-cssutils==2.10.2
+cssutils==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
-ddt==1.7.2
+ddt==1.7.1
     # via -r requirements/edx/testing.in
 defusedxml==0.7.1
     # via
@@ -259,7 +256,7 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-django==4.2.11
+django==4.2.10
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -380,7 +377,7 @@ django-filter==24.2
     #   edx-enterprise
     #   lti-consumer-xblock
     #   openedx-blockstore
-django-ipware==7.0.1
+django-ipware==6.0.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -417,7 +414,7 @@ django-multi-email-field==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==4.13.0
+django-mysql==4.12.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
@@ -447,7 +444,7 @@ django-simple-history==3.4.0
     #   edx-organizations
     #   edx-proctoring
     #   ora2
-django-statici18n==2.5.0
+django-statici18n==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
@@ -508,7 +505,7 @@ drf-nested-routers==0.93.5
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-drf-spectacular==0.27.2
+drf-spectacular==0.27.1
     # via -r requirements/edx/base.txt
 drf-yasg==1.21.5
     # via
@@ -527,7 +524,7 @@ edx-auth-backends==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-edx-braze-client==0.2.3
+edx-braze-client==0.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -592,7 +589,7 @@ edx-event-bus-kafka==5.7.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.6.0
+edx-i18n-tools==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -681,29 +678,29 @@ event-tracking==2.4.0
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-exceptiongroup==1.2.1
+exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
-execnet==2.1.1
+execnet==2.0.2
     # via pytest-xdist
 factory-boy==3.3.0
     # via -r requirements/edx/testing.in
-faker==24.14.1
+faker==24.14.0
     # via factory-boy
-fastapi==0.110.2
+fastapi==0.109.2
     # via pact-python
 fastavro==1.9.4
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.13.4
+filelock==3.13.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-freezegun==1.5.0
+freezegun==1.4.0
     # via -r requirements/edx/testing.in
 frozenlist==1.4.1
     # via
@@ -742,9 +739,9 @@ html5lib==1.1
     #   ora2
 httpretty==1.1.4
     # via -r requirements/edx/testing.in
-icalendar==5.0.12
+icalendar==5.0.11
     # via -r requirements/edx/base.txt
-idna==3.7
+idna==3.6
     # via
     #   -r requirements/edx/base.txt
     #   anyio
@@ -803,7 +800,7 @@ jmespath==1.0.1
     #   -r requirements/edx/base.txt
     #   boto3
     #   botocore
-joblib==1.4.0
+joblib==1.3.2
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -829,12 +826,12 @@ jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-jwcrypto==1.5.6
+jwcrypto==1.5.4
     # via
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.3.7
+kombu==5.3.5
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -857,15 +854,14 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.11.0
+lti-consumer-xblock==9.10.0
     # via -r requirements/edx/base.txt
-lxml[html-clean]==5.2.1
+lxml==4.9.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -873,11 +869,9 @@ lxml[html-clean]==5.2.1
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.1.1
-    # via -r requirements/edx/base.txt
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.3.3
+mako==1.3.2
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -900,17 +894,17 @@ markupsafe==2.1.5
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.6.1
+maxminddb==2.5.2
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
 mccabe==0.7.0
     # via pylint
-meilisearch==0.31.0
+meilisearch==0.30.0
     # via -r requirements/edx/base.txt
 mock==5.1.0
     # via -r requirements/edx/base.txt
-mongoengine==0.28.2
+mongoengine==0.27.0
     # via -r requirements/edx/base.txt
 monotonic==1.6
     # via
@@ -930,7 +924,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-newrelic==9.9.0
+newrelic==9.6.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1010,7 +1004,7 @@ packaging==24.0
     #   pytest
     #   snowflake-connector-python
     #   tox
-pact-python==2.2.0
+pact-python==2.1.1
     # via -r requirements/edx/testing.in
 pansi==2020.7.3
     # via
@@ -1040,7 +1034,7 @@ pgpy==0.6.0
     #   edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1050,14 +1044,14 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-platformdirs==4.2.1
+platformdirs==3.11.0
     # via
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.4.0
     # via
     #   -r requirements/edx/coverage.txt
     #   diff-cover
@@ -1084,7 +1078,7 @@ py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-pyasn1==0.6.0
+pyasn1==0.5.1
     # via
     #   -r requirements/edx/base.txt
     #   pgpy
@@ -1094,7 +1088,7 @@ pycodestyle==2.8.0
     #   -r requirements/edx/testing.in
 pycountry==23.12.11
     # via -r requirements/edx/base.txt
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/edx/base.txt
     #   cffi
@@ -1104,12 +1098,12 @@ pycryptodomex==3.20.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.7.1
+pydantic==2.6.3
     # via
     #   -r requirements/edx/base.txt
     #   camel-converter
     #   fastapi
-pydantic-core==2.18.2
+pydantic-core==2.16.3
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
@@ -1181,7 +1175,7 @@ pyopenssl==22.0.0
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
     #   snowflake-connector-python
-pyparsing==3.1.2
+pyparsing==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1198,7 +1192,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-pytest==8.2.0
+pytest==8.1.2
     # via
     #   -r requirements/edx/testing.in
     #   pylint-pytest
@@ -1223,9 +1217,9 @@ pytest-metadata==1.8.0
     #   pytest-json-report
 pytest-randomly==3.15.0
     # via -r requirements/edx/testing.in
-pytest-xdist[psutil]==3.6.1
+pytest-xdist[psutil]==3.5.0
     # via -r requirements/edx/testing.in
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
@@ -1240,7 +1234,7 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
-python-ipware==3.0.0
+python-ipware==2.0.1
     # via
     #   -r requirements/edx/base.txt
     #   django-ipware
@@ -1250,7 +1244,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
-python-swiftclient==4.5.0
+python-swiftclient==4.4.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1295,16 +1289,16 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==2.2.0
     # via -r requirements/edx/base.txt
-redis==5.0.4
+redis==5.0.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
-referencing==0.35.0
+referencing==0.33.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.4.28
+regex==2024.4.16
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1357,7 +1351,7 @@ rules==3.3
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.1
+s3transfer==0.10.0
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1375,7 +1369,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==2.0.4
+shapely==2.0.3
     # via -r requirements/edx/base.txt
 simplejson==3.19.2
     # via
@@ -1421,9 +1415,9 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-sniffio==1.3.1
+sniffio==1.3.0
     # via anyio
-snowflake-connector-python==3.9.1
+snowflake-connector-python==3.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1450,16 +1444,16 @@ soupsieve==2.5
     # via
     #   -r requirements/edx/base.txt
     #   beautifulsoup4
-sqlparse==0.5.0
+sqlparse==0.4.4
     # via
     #   -r requirements/edx/base.txt
     #   django
     #   openedx-blockstore
 staff-graded-xblock==2.3.0
     # via -r requirements/edx/base.txt
-starlette==0.37.2
+starlette==0.36.3
     # via fastapi
-stevedore==5.2.0
+stevedore==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1475,7 +1469,7 @@ sympy==1.12
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==8.1.0
+testfixtures==8.0.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1496,19 +1490,19 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.4
+tomlkit==0.12.3
     # via
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.15.0
+tox==4.11.4
     # via -r requirements/edx/testing.in
 tqdm==4.66.2
     # via
     #   -r requirements/edx/base.txt
     #   nltk
     #   openai
-typing-extensions==4.11.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/edx/base.txt
     #   annotated-types
@@ -1524,7 +1518,6 @@ typing-extensions==4.11.0
     #   import-linter
     #   jwcrypto
     #   kombu
-    #   pact-python
     #   pydantic
     #   pydantic-core
     #   pylint
@@ -1560,7 +1553,7 @@ urllib3==1.26.18
     #   snowflake-connector-python
 user-util==1.1.0
     # via -r requirements/edx/base.txt
-uvicorn==0.29.0
+uvicorn==0.27.1
     # via pact-python
 vine==5.1.0
     # via
@@ -1568,7 +1561,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.0
+virtualenv==20.25.0
     # via tox
 voluptuous==0.14.2
     # via
@@ -1606,7 +1599,7 @@ wrapt==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   astroid
-xblock[django]==4.0.1
+xblock[django]==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -1624,7 +1617,7 @@ xblock[django]==4.0.1
     #   xblock-utils
 xblock-drag-and-drop-v2==4.0.2
     # via -r requirements/edx/base.txt
-xblock-google-drive==0.7.0
+xblock-google-drive==0.6.1
     # via -r requirements/edx/base.txt
 xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
@@ -1643,8 +1636,7 @@ yarl==1.9.4
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-    #   pact-python
-zipp==3.18.1
+zipp==3.17.0
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-build==1.2.1
+build==1.0.3
     # via pip-tools
 click==8.1.6
     # via
@@ -16,9 +16,9 @@ importlib-metadata==6.11.0
     #   build
 packaging==24.0
     # via build
-pip-tools==7.4.1
+pip-tools==7.4.0
     # via -r requirements/pip-tools.in
-pyproject-hooks==1.1.0
+pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
@@ -26,9 +26,10 @@ tomli==2.0.1
     # via
     #   build
     #   pip-tools
-wheel==0.43.0
+    #   pyproject-hooks
+wheel==0.42.0
     # via pip-tools
-zipp==3.18.1
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.43.0
+wheel==0.42.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.5.1
+setuptools==69.1.0
     # via -r requirements/pip.in

--- a/scripts/structures_pruning/requirements/base.txt
+++ b/scripts/structures_pruning/requirements/base.txt
@@ -11,7 +11,7 @@ click==8.1.6
     #   click-log
 click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.in
-edx-opaque-keys==2.9.0
+edx-opaque-keys==2.5.1
     # via -r scripts/structures_pruning/requirements/base.in
 pbr==6.0.0
     # via stevedore
@@ -22,5 +22,5 @@ pymongo==3.13.0
     #   edx-opaque-keys
 stevedore==5.2.0
     # via edx-opaque-keys
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via edx-opaque-keys

--- a/scripts/structures_pruning/requirements/testing.txt
+++ b/scripts/structures_pruning/requirements/testing.txt
@@ -12,9 +12,9 @@ click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.txt
 ddt==1.7.2
     # via -r scripts/structures_pruning/requirements/testing.in
-edx-opaque-keys==2.9.0
+edx-opaque-keys==2.5.1
     # via -r scripts/structures_pruning/requirements/base.txt
-exceptiongroup==1.2.1
+exceptiongroup==1.2.0
     # via pytest
 iniconfig==2.0.0
     # via pytest
@@ -24,13 +24,13 @@ pbr==6.0.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   stevedore
-pluggy==1.5.0
+pluggy==1.4.0
     # via pytest
 pymongo==3.13.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys
-pytest==8.2.0
+pytest==8.1.1
     # via -r scripts/structures_pruning/requirements/testing.in
 stevedore==5.2.0
     # via
@@ -38,7 +38,7 @@ stevedore==5.2.0
     #   edx-opaque-keys
 tomli==2.0.1
     # via pytest
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys

--- a/scripts/user_retirement/requirements/base.in
+++ b/scripts/user_retirement/requirements/base.in
@@ -11,4 +11,3 @@ unicodecsv
 simplejson
 simple-salesforce
 google-api-python-client
-lxml --no-binary lxml

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -4,25 +4,25 @@
 #
 #    make upgrade
 #
---no-binary lxml
-
-asgiref==3.8.1
+asgiref==3.7.2
     # via django
 attrs==23.2.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
 backports-zoneinfo==0.2.1
-    # via django
-boto3==1.34.93
+    # via
+    #   django
+    #   pendulum
+boto3==1.34.26
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.34.93
+botocore==1.34.26
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.3.2
     # via google-auth
-certifi==2024.2.2
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -40,8 +40,8 @@ click==8.1.6
 cryptography==38.0.4
     # via
     #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
-    #   pyjwt
-django==4.2.11
+    #   simple-salesforce
+django==4.2.9
     # via
     #   -c scripts/user_retirement/requirements/../../../requirements/common_constraints.txt
     #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
@@ -56,25 +56,27 @@ edx-django-utils==5.12.0
     # via edx-rest-api-client
 edx-rest-api-client==5.7.0
     # via -r scripts/user_retirement/requirements/base.in
-google-api-core==2.18.0
+google-api-core==2.15.0
     # via google-api-python-client
-google-api-python-client==2.127.0
+google-api-python-client==2.115.0
     # via -r scripts/user_retirement/requirements/base.in
-google-auth==2.29.0
+google-auth==2.26.2
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
 google-auth-httplib2==0.2.0
     # via google-api-python-client
-googleapis-common-protos==1.63.0
+googleapis-common-protos==1.62.0
     # via google-api-core
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.7
+idna==3.6
     # via requests
+importlib-resources==6.1.1
+    # via pendulum
 isodate==0.6.1
     # via zeep
 jenkinsapi==0.3.13
@@ -83,46 +85,46 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lxml==5.2.1
-    # via
-    #   -r scripts/user_retirement/requirements/base.in
-    #   zeep
+lxml==4.9.3
+    # via zeep
 more-itertools==10.2.0
     # via simple-salesforce
-newrelic==9.9.0
+newrelic==9.5.0
     # via edx-django-utils
 pbr==6.0.0
     # via stevedore
-platformdirs==4.2.1
+pendulum==3.0.0
+    # via simple-salesforce
+platformdirs==4.1.0
     # via zeep
-proto-plus==1.23.0
-    # via google-api-core
-protobuf==4.25.3
+protobuf==4.25.2
     # via
     #   google-api-core
     #   googleapis-common-protos
-    #   proto-plus
 psutil==5.9.8
     # via edx-django-utils
-pyasn1==0.6.0
+pyasn1==0.5.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.3.0
     # via google-auth
-pycparser==2.22
+pycparser==2.21
     # via cffi
-pyjwt[crypto]==2.8.0
+pyjwt==2.8.0
     # via
     #   edx-rest-api-client
     #   simple-salesforce
 pynacl==1.5.0
     # via edx-django-utils
-pyparsing==3.1.2
+pyparsing==3.1.1
     # via httplib2
-python-dateutil==2.9.0.post0
-    # via botocore
-pytz==2024.1
+python-dateutil==2.8.2
+    # via
+    #   botocore
+    #   pendulum
+    #   time-machine
+pytz==2023.3.post1
     # via
     #   jenkinsapi
     #   zeep
@@ -139,15 +141,15 @@ requests==2.31.0
     #   simple-salesforce
     #   slumber
     #   zeep
-requests-file==2.0.0
+requests-file==1.5.1
     # via zeep
 requests-toolbelt==1.0.0
     # via zeep
 rsa==4.9
     # via google-auth
-s3transfer==0.10.1
+s3transfer==0.10.0
     # via boto3
-simple-salesforce==1.12.6
+simple-salesforce==1.12.5
     # via -r scripts/user_retirement/requirements/base.in
 simplejson==3.19.2
     # via -r scripts/user_retirement/requirements/base.in
@@ -156,16 +158,19 @@ six==1.16.0
     #   isodate
     #   jenkinsapi
     #   python-dateutil
+    #   requests-file
 slumber==0.7.1
     # via edx-rest-api-client
-sqlparse==0.5.0
+sqlparse==0.4.4
     # via django
-stevedore==5.2.0
+stevedore==5.1.0
     # via edx-django-utils
-typing-extensions==4.11.0
-    # via
-    #   asgiref
-    #   simple-salesforce
+time-machine==2.13.0
+    # via pendulum
+typing-extensions==4.9.0
+    # via asgiref
+tzdata==2023.4
+    # via pendulum
 unicodecsv==0.14.1
     # via -r scripts/user_retirement/requirements/base.in
 uritemplate==4.1.1
@@ -177,3 +182,5 @@ urllib3==1.26.18
     #   requests
 zeep==4.2.1
     # via simple-salesforce
+zipp==3.17.0
+    # via importlib-resources

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -4,9 +4,7 @@
 #
 #    make upgrade
 #
---no-binary lxml
-
-asgiref==3.8.1
+asgiref==3.7.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
@@ -20,21 +18,22 @@ backports-zoneinfo==0.2.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
-boto3==1.34.93
+    #   pendulum
+boto3==1.34.26
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.34.93
+botocore==1.34.26
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
     #   moto
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.3.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-certifi==2024.2.2
+certifi==2023.11.17
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
@@ -55,10 +54,10 @@ cryptography==38.0.4
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-    #   pyjwt
-ddt==1.7.2
+    #   simple-salesforce
+ddt==1.7.1
     # via -r scripts/user_retirement/requirements/testing.in
-django==4.2.11
+django==4.2.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django-crum
@@ -78,15 +77,15 @@ edx-django-utils==5.12.0
     #   edx-rest-api-client
 edx-rest-api-client==5.7.0
     # via -r scripts/user_retirement/requirements/base.txt
-exceptiongroup==1.2.1
+exceptiongroup==1.2.0
     # via pytest
-google-api-core==2.18.0
+google-api-core==2.15.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.127.0
+google-api-python-client==2.115.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-auth==2.29.0
+google-auth==2.26.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
@@ -96,7 +95,7 @@ google-auth-httplib2==0.2.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-googleapis-common-protos==1.63.0
+googleapis-common-protos==1.62.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
@@ -105,10 +104,14 @@ httplib2==0.22.0
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.7
+idna==3.6
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
+importlib-resources==6.1.1
+    # via
+    #   -r scripts/user_retirement/requirements/base.txt
+    #   pendulum
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
@@ -124,11 +127,11 @@ jmespath==1.0.1
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
     #   botocore
-lxml==5.2.1
+lxml==4.9.3
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-markupsafe==2.1.5
+markupsafe==2.1.4
     # via
     #   jinja2
     #   werkzeug
@@ -138,52 +141,51 @@ more-itertools==10.2.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce
-moto==4.2.14
+moto==4.2.13
     # via -r scripts/user_retirement/requirements/testing.in
-newrelic==9.9.0
+newrelic==9.5.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-packaging==24.0
+packaging==23.2
     # via pytest
 pbr==6.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   stevedore
-platformdirs==4.2.1
+pendulum==3.0.0
+    # via
+    #   -r scripts/user_retirement/requirements/base.txt
+    #   simple-salesforce
+platformdirs==4.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-pluggy==1.5.0
+pluggy==1.3.0
     # via pytest
-proto-plus==1.23.0
-    # via
-    #   -r scripts/user_retirement/requirements/base.txt
-    #   google-api-core
-protobuf==4.25.3
+protobuf==4.25.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
     #   googleapis-common-protos
-    #   proto-plus
 psutil==5.9.8
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-pyasn1==0.6.0
+pyasn1==0.5.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.3.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   cffi
-pyjwt[crypto]==2.8.0
+pyjwt==2.8.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
@@ -192,18 +194,20 @@ pynacl==1.5.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-pyparsing==3.1.2
+pyparsing==3.1.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   httplib2
-pytest==8.2.0
+pytest==7.4.4
     # via -r scripts/user_retirement/requirements/testing.in
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   botocore
     #   moto
-pytz==2024.1
+    #   pendulum
+    #   time-machine
+pytz==2023.3.post1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   jenkinsapi
@@ -226,17 +230,17 @@ requests==2.31.0
     #   simple-salesforce
     #   slumber
     #   zeep
-requests-file==2.0.0
+requests-file==1.5.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-requests-mock==1.12.1
+requests-mock==1.11.0
     # via -r scripts/user_retirement/requirements/testing.in
 requests-toolbelt==1.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-responses==0.25.0
+responses==0.24.1
     # via
     #   -r scripts/user_retirement/requirements/testing.in
     #   moto
@@ -244,11 +248,11 @@ rsa==4.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-s3transfer==0.10.1
+s3transfer==0.10.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
-simple-salesforce==1.12.6
+simple-salesforce==1.12.5
     # via -r scripts/user_retirement/requirements/base.txt
 simplejson==3.19.2
     # via -r scripts/user_retirement/requirements/base.txt
@@ -258,25 +262,34 @@ six==1.16.0
     #   isodate
     #   jenkinsapi
     #   python-dateutil
+    #   requests-file
+    #   requests-mock
 slumber==0.7.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
-sqlparse==0.5.0
+sqlparse==0.4.4
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
-stevedore==5.2.0
+stevedore==5.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
+time-machine==2.13.0
+    # via
+    #   -r scripts/user_retirement/requirements/base.txt
+    #   pendulum
 tomli==2.0.1
     # via pytest
-typing-extensions==4.11.0
+typing-extensions==4.9.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   asgiref
-    #   simple-salesforce
+tzdata==2023.4
+    # via
+    #   -r scripts/user_retirement/requirements/base.txt
+    #   pendulum
 unicodecsv==0.14.1
     # via -r scripts/user_retirement/requirements/base.txt
 uritemplate==4.1.1
@@ -289,7 +302,7 @@ urllib3==1.26.18
     #   botocore
     #   requests
     #   responses
-werkzeug==3.0.2
+werkzeug==3.0.1
     # via moto
 xmltodict==0.13.0
     # via moto
@@ -297,3 +310,7 @@ zeep==4.2.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce
+zipp==3.17.0
+    # via
+    #   -r scripts/user_retirement/requirements/base.txt
+    #   importlib-resources

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
     # via
     #   -c scripts/xblock/../../requirements/constraints.txt
     #   requests
-idna==3.7
+idna==3.6
     # via requests
 requests==2.31.0
     # via -r scripts/xblock/requirements.in


### PR DESCRIPTION
Reverts openedx/edx-platform#34655 because we were getting this in the build pipeline:

```
WARNING: lxml 5.2.1 does not provide the extra 'html-clean'
ERROR: Exception:
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 173, in _main
    status = self.run(options, args)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_internal/cli/req_command.py", line 203, in wrapper
    return func(self, options, args)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_internal/commands/install.py", line 315, in run
    requirement_set = resolver.resolve(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 94, in resolve
    result = self._result = resolver.resolve(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_vendor/resolvelib/resolvers.py", line 472, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_vendor/resolvelib/resolvers.py", line 366, in resolve
    failure_causes = self._attempt_to_pin_criterion(name)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_vendor/resolvelib/resolvers.py", line 221, in _attempt_to_pin_criterion
    satisfied = all(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_vendor/resolvelib/resolvers.py", line 222, in <genexpr>
    self._p.is_satisfied_by(requirement=r, candidate=candidate)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/provider.py", line 178, in is_satisfied_by
    return requirement.is_satisfied_by(candidate)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pip/_internal/resolution/resolvelib/requirements.py", line 84, in is_satisfied_by
    assert candidate.name == self.name, (
AssertionError: Internal issue: Candidate is not for this requirement lxml[html-clean,html-clean] vs lxml[html-clean]
WARNING: You are using pip version 21.2.1; however, version 24.0 is available.
You should consider upgrading via the '/edx/app/edxapp/venvs/edxapp/bin/python -m pip install --upgrade pip' command.
```