### PR TITLE
feat: [FC-0044] Update path for MFE Textbook page

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -456,7 +456,7 @@ def get_textbooks_url(course_locator) -> str:
     textbooks_url = None
     if use_new_textbooks_page(course_locator):
         mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/pages-and-resources/textbooks'
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/textbooks'
         if mfe_base_url:
             textbooks_url = course_mfe_url
     return textbooks_url


### PR DESCRIPTION
## Description

This PR updates the path to textbook page for redirect to Course Authoring MFE Studio. 

The path change was introduced as part of https://github.com/openedx/frontend-app-course-authoring/pull/890


## Supporting information

Issue: https://github.com/openedx/platform-roadmap/issues/319

## Testing instructions

1. Enable the new Textbook page redirect using a waffle flag contentstore.new_studio_mfe.use_new_textbooks_page in the admin panel.
2. Go to the Textbooks page from the Studio > Pages & Resources page.
<img width="395" alt="image" src="https://github.com/openedx/edx-platform/assets/22370912/a3337e73-c527-4298-ae1a-12f0687180be">


## Other information

This PR should be merged before https://github.com/openedx/frontend-app-course-authoring/pull/890