### PR TITLE
[FC-0036] fix: Update tag counts when changes are saved in the tag drawer

### DIFF
--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -376,15 +376,14 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
                 "message", (event) => {
                     // Listen any message from Manage tags drawer.
                     var data = event.data;
-                    var courseAuthoringUrl = this.model.get("course_authoring_url")
+                    var courseAuthoringUrl = new URL(this.model.get("course_authoring_url")).origin;
                     if (event.origin == courseAuthoringUrl
-                        && data.includes('[Manage tags drawer] Tags updated:')) {
+                        && data.type == 'authoring.events.tags.updated') {
                         // This message arrives when there is a change in the tag list.
                         // The message contains the new list of tags.
-                        let jsonData = data.replace(/\[Manage tags drawer\] Tags updated: /g, "");
-                        jsonData = JSON.parse(jsonData);
-                        if (jsonData.contentId == this.model.id) {
-                            this.model.set('tags', this.buildTaxonomyTree(jsonData));
+                        data = data.data
+                        if (data.contentId == this.model.id) {
+                            this.model.set('tags', this.buildTaxonomyTree(data));
                             this.render();
                         }
                     }

--- a/cms/static/js/views/tag_count.js
+++ b/cms/static/js/views/tag_count.js
@@ -21,15 +21,14 @@ function($, _, BaseView, HtmlUtils) {
                 'message', (event) => {
                     // Listen any message from Manage tags drawer.
                     var data = event.data;
-                    var courseAuthoringUrl = this.model.get("course_authoring_url")
+                    var courseAuthoringUrl = new URL(this.model.get("course_authoring_url")).origin;
                     if (event.origin == courseAuthoringUrl
-                        && data.includes('[Manage tags drawer] Count updated:')) {
+                        && data.type == 'authoring.events.tags.count.updated') {
                         // This message arrives when there is a change in the tag list.
                         // The message contains the new count of tags.
-                        let jsonData = data.replace(/\[Manage tags drawer\] Count updated: /g, "");
-                        jsonData = JSON.parse(jsonData);
-                        if (jsonData.contentId == this.model.get("content_id")) {
-                            this.model.set('tags_count', jsonData.count);
+                        data = data.data
+                        if (data.contentId == this.model.get("content_id")) {
+                            this.model.set('tags_count', data.count);
                             this.render();
                         }
                     }


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Update tag counts and content tags when changes are saved in the tag drawer.

## Supporting information

- This PR is based on: https://github.com/openedx/edx-platform/pull/34223
- Github Issue: https://github.com/openedx/modular-learning/issues/216
- Internal ticket: https://tasks.opencraft.com/browse/FAL-3734

## Testing instructions

- Use this branch of https://github.com/openedx/frontend-app-course-authoring/pull/975
- Go to a [sample course](http://localhost:18010/course/course-v1:SampleTaxonomyOrg2+STC1+2023_1) and go to a unit. Click on Manage tags to open the drawer.
- Add and remove tags.
- Close the drawer and verify that the TagList is updated.
- Open the manage tags drawer for a component of the unit.
- Add and remove tags.
- Verify that the count of tags is updated.
- Go to a [sample course](http://localhost:18010/course/course-v1:SampleTaxonomyOrg2+STC1+2023_1) and open the outline.
- Click on the tag count of any unit and open the manage tags drawer.
- Add and remove tags
- Verify that the count of tags is updated.