### PR TITLE
test: only run Mongo 4.4 tests on xmodule directory

### DIFF
--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -9,12 +9,14 @@ on:
 
 jobs:
   run-test:
+    name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     if: (github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == true))
     runs-on: ubuntu-20.04
     strategy:
-      fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.11' ]
+        python-version:
+          - "3.8"
+          - "3.11"
         django-version:
           - "pinned"
         # When updating the shards, remember to make the same changes in
@@ -39,7 +41,19 @@ jobs:
         mongo-version:
           - "4.4"
           - "7.0"
-    name: gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},mongo-${{ matrix.mongo-version }}${{ matrix.shard_name }}
+
+        # We only need to test Mongo 4.4 for modules that directly interface with Mongo (that is: xmodule.modulestore)
+        exclude:
+          - mongo-version: "4.4"
+        include:
+          - shard_name: "xmodule-with-cms"
+            python-version: "3.11"
+            django-version: "pinned"
+            mongo-version: "4.4"
+          - shard_name: "xmodule-with-lms"
+            python-version: "3.11"
+            django-version: "pinned"
+            mongo-version: "4.4"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-tests:
-    name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},mongo-${{ matrix.mongo-version }},${{ matrix.shard_name }}
+    name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     strategy:
@@ -40,8 +40,19 @@ jobs:
         mongo-version:
           - "4.4"
           - "7.0"
-    # We expect Django 4.0 to fail, so don't stop when it fails.
-    continue-on-error: ${{ matrix.django-version == '4.0' }}
+
+        # We only need to test Mongo 4.4 for modules that directly interface with Mongo (that is: xmodule.modulestore)
+        exclude:
+          - mongo-version: "4.4"
+        include:
+          - shard_name: "xmodule-with-cms"
+            python-version: "3.11"
+            django-version: "pinned"
+            mongo-version: "4.4"
+          - shard_name: "xmodule-with-lms"
+            python-version: "3.11"
+            django-version: "pinned"
+            mongo-version: "4.4"
 
     steps:
       - name: sync directory owner


### PR DESCRIPTION
Cuts the number of unit test checks from 64 down to 34

Also, rename test contexts so that they're easier to read in GHA

![image](https://github.com/openedx/edx-platform/assets/3628148/0f7ad7ac-bbe6-4d14-8005-3238c2b4c07f)
