### PR TITLE
fix: remove setting toggle which might be causing bug with future course redirects

### DIFF
--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -9,7 +9,6 @@ from logging import getLogger
 
 from crum import get_current_request
 from django.conf import settings
-from edx_toggles.toggles import SettingToggle
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
 from pytz import UTC
 
@@ -105,7 +104,19 @@ def enterprise_learner_enrolled(request, user, course_key):
         enterprise_customer_user__user_id=user.id,
         enterprise_customer_user__enterprise_customer__uuid=enterprise_customer_data['uuid'],
     )
-    return enterprise_enrollments.exists()
+    enterprise_enrollment_exists = enterprise_enrollments.exists()
+    log.info(
+        (
+            '[enterprise_learner_enrolled] Checking for an enterprise enrollment for '
+            'lms_user_id=%s in course_key=%s via enterprise_customer_uuid=%s. '
+            'Exists: %s'
+        ),
+        user.id,
+        course_key,
+        enterprise_customer_data['uuid'],
+        enterprise_enrollment_exists,
+    )
+    return enterprise_enrollment_exists
 
 
 def check_start_date(user, days_early_for_beta, start, course_key, display_error_to_user=True, now=None):
@@ -138,10 +149,9 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
 
         # Before returning a StartDateError, determine if the learner should be redirected to the enterprise learner
         # portal by returning StartDateEnterpriseLearnerError instead.
-        if SettingToggle('COURSEWARE_COURSE_NOT_STARTED_ENTERPRISE_LEARNER_ERROR', default=False).is_enabled():
-            request = get_current_request()
-            if request and enterprise_learner_enrolled(request, user, course_key):
-                return StartDateEnterpriseLearnerError(start, display_error_to_user=display_error_to_user)
+        request = get_current_request()
+        if request and enterprise_learner_enrolled(request, user, course_key):
+            return StartDateEnterpriseLearnerError(start, display_error_to_user=display_error_to_user)
 
         return StartDateError(start, display_error_to_user=display_error_to_user)
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -903,7 +903,6 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
     )
     @ddt.unpack
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
-    @override_settings(COURSEWARE_COURSE_NOT_STARTED_ENTERPRISE_LEARNER_ERROR=True)
     def test_course_catalog_access_num_queries_enterprise(self, user_attr_name, course_attr_name):
         """
         Similar to test_course_catalog_access_num_queries_no_enterprise, except enable enterprise features and make the

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3262,7 +3262,6 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
     )
     @ddt.unpack
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
-    @override_settings(COURSEWARE_COURSE_NOT_STARTED_ENTERPRISE_LEARNER_ERROR=True)
     def test_is_course_open_for_learner(
         self,
         start_date_modifier,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4731,19 +4731,6 @@ DATA_CONSENT_SHARE_CACHE_TIMEOUT = 8 * 60 * 60  # 8 hours
 ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS = {}
 ENTERPRISE_TAGLINE = ''
 
-# .. toggle_name: COURSEWARE_COURSE_NOT_STARTED_ENTERPRISE_LEARNER_ERROR
-# .. toggle_implementation: SettingToggle
-# .. toggle_default: False
-# .. toggle_description: If disabled (False), this switch causes the CourseTabView API (or whatever else calls
-#    check_course_open_for_learner()) to always return the legacy `course_not_started` error code in ALL cases where the
-#    course has not started.  If enabled (True), the API will respond with `course_not_started_enterprise_learner` in a
-#    subset of cases where the learner is enrolled via subsidy, and `course_not_started` in all other cases.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2023-12-18
-# .. toggle_target_removal_date: 2023-12-19
-# .. toggle_tickets: ENT-8078
-COURSEWARE_COURSE_NOT_STARTED_ENTERPRISE_LEARNER_ERROR = False
-
 ############## Settings for Course Enrollment Modes ######################
 # The min_price key refers to the minimum price allowed for an instance
 # of a particular type of course enrollment mode. This is not to be confused


### PR DESCRIPTION
We've long rolled out the `COURSEWARE_COURSE_NOT_STARTED_ENTERPRISE_LEARNER_ERROR` setting toggle so it should be safe to remove.

I'm completely at a loss as to why course access checks are not returning the `course_not_started_enterprise_learner` error code when it should, but it does in stage/local, so this PR is grasping at straws.

ENT-8766