### PR TITLE
fix: make `lis_person_contact_email_primary` matching case-insensitive (LTI Providers)

### DIFF
--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -166,7 +166,7 @@ class AuthenticateLtiUserTest(TestCase):
         create_user.assert_called_with(self.lti_user_id, self.lti_consumer)
 
         users.authenticate_lti_user(request, self.lti_user_id, self.auto_linking_consumer)
-        create_user.assert_called_with(self.lti_user_id, self.auto_linking_consumer, self.old_user.email.upper())
+        create_user.assert_called_with(self.lti_user_id, self.auto_linking_consumer, request.user.email)
 
     def test_raise_exception_trying_to_auto_link_unauthenticate_user(self, create_user, switch_user):
         request = RequestFactory().post("/")

--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -158,6 +158,16 @@ class AuthenticateLtiUserTest(TestCase):
         users.authenticate_lti_user(request, self.lti_user_id, self.auto_linking_consumer)
         create_user.assert_called_with(self.lti_user_id, self.auto_linking_consumer, self.old_user.email)
 
+    def test_auto_linking_of_users_using_lis_person_contact_email_primary_case_insensitive(self, create_user, switch_user):  # pylint: disable=line-too-long
+        request = RequestFactory().post("/", {"lis_person_contact_email_primary": self.old_user.email.upper()})
+        request.user = self.old_user
+
+        users.authenticate_lti_user(request, self.lti_user_id, self.lti_consumer)
+        create_user.assert_called_with(self.lti_user_id, self.lti_consumer)
+
+        users.authenticate_lti_user(request, self.lti_user_id, self.auto_linking_consumer)
+        create_user.assert_called_with(self.lti_user_id, self.auto_linking_consumer, self.old_user.email.upper())
+
     def test_raise_exception_trying_to_auto_link_unauthenticate_user(self, create_user, switch_user):
         request = RequestFactory().post("/")
         request.user = AnonymousUser()

--- a/lms/djangoapps/lti_provider/users.py
+++ b/lms/djangoapps/lti_provider/users.py
@@ -40,7 +40,7 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
         if lti_consumer.require_user_account:
             # Verify that the email from the LTI Launch and the logged-in user are the same
             # before linking the LtiUser with the edx_user.
-            if request.user.is_authenticated and request.user.email == lis_email:
+            if request.user.is_authenticated and request.user.email.lower() == lis_email.lower():
                 lti_user = create_lti_user(lti_user_id, lti_consumer, lis_email)
             else:
                 # Ask the user to login before linking.

--- a/lms/djangoapps/lti_provider/users.py
+++ b/lms/djangoapps/lti_provider/users.py
@@ -41,7 +41,7 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
             # Verify that the email from the LTI Launch and the logged-in user are the same
             # before linking the LtiUser with the edx_user.
             if request.user.is_authenticated and request.user.email.lower() == lis_email.lower():
-                lti_user = create_lti_user(lti_user_id, lti_consumer, lis_email)
+                lti_user = create_lti_user(lti_user_id, lti_consumer, request.user.email)
             else:
                 # Ask the user to login before linking.
                 raise PermissionDenied() from exc


### PR DESCRIPTION
## Related Ticket:
https://github.com/mitodl/hq/issues/3128

## Description

The edX user's email matching with the LTI providers doesn't check for email case insensitivity. Hence, It doesn't properly create and associate the LTI users with edX users. In return, the PermissionDenied exception is thrown every time and the users are requested to re-login even when they already have.

Useful information to include:
- This impacts the learners, interacting with LTI content.


## The problem:

When a user tries to access edX content on LTI consumer e.g. Canvas they are always asked to re-login every time even though they have the same email ID on both ends. This can happen when edX can't find a user against the LTI user in the system even though the emails are the same with only case-sensitive differences.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

If you are able to configure the LTI locally:

1. Create an account, enroll in a course 
2. Add content Unit(s)  in the course
3. Use this LTI content in the LTI
4. Try to access this content through LTI
5. A new LTI user should be created in edX and it should be associated with the user in edX
6. Change your LTI consumer to send `lis_person_contact_email_primary` in all caps or mixed small/capital characters. Idea is to test the email case insensitivity.
7. If this is an existing user, they should be able to load the content, if new user then a new LtiUser entry should be created with proper association with edX user



Please provide detailed step-by-step instructions for testing this change.

## Deadline
None
