### PR TITLE
chore: Upgrade the `lti-consumer-xblock` to unpin lxml.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -679,7 +679,7 @@ libsass==0.10.0
     #   -r requirements/edx/paver.txt
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.10.0
+lti-consumer-xblock==9.11.0
     # via -r requirements/edx/kernel.in
 lxml==4.9.4
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1130,7 +1130,7 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.10.0
+lti-consumer-xblock==9.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -802,7 +802,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.10.0
+lti-consumer-xblock==9.11.0
     # via -r requirements/edx/base.txt
 lxml==4.9.4
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -855,7 +855,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.10.0
+lti-consumer-xblock==9.11.0
     # via -r requirements/edx/base.txt
 lxml==4.9.4
     # via


### PR DESCRIPTION
Upgrade just the ltx-consumer-xblock to pickup an unpin of lxml.