### PR TITLE
fix: Include script requirements in upgrade.

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -28,7 +28,7 @@ jobs:
           echo $'Paths touched in PR:\n'"$paths"
 
           # The ^"? is because git may quote weird file paths
-          matched="$(echo "$paths" | grep -P '^"?requirements/' || true)"
+          matched="$(echo "$paths" | grep -P '^"?((requirements/)|(scripts/.*?/requirements/))' || true)"
           echo $'Relevant paths:\n'"$matched"
           if [[ -n "$matched" ]]; then
               echo "RELEVANT=true" >> "$GITHUB_ENV"

--- a/.github/workflows/upgrade-one-python-dependency.yml
+++ b/.github/workflows/upgrade-one-python-dependency.yml
@@ -86,7 +86,9 @@ jobs:
         with:
           branch: "${{ github.triggering_actor }}/upgrade-${{ inputs.package }}"
           branch-suffix: short-commit-hash
-          add-paths: requirements
+          add-paths: |
+            requirements
+            scripts/**/requirements
           commit-message: |
             feat: Upgrade Python dependency ${{ inputs.package }}
 


### PR DESCRIPTION
The `upgrade-one-python-dependency` workflow would fail if there were
changes in the scripts directory because they wouldn't get added to the
PR.  Update the list of `add-paths` for the workflow so that it doesn't
fail like this in the future.
