### PR TITLE
 revert: revert: build: finish replacing paver assets

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -39,6 +39,7 @@ When refering to XBlocks, we use the entry-point name. For example,
 # pylint: disable=unused-import, useless-suppression, wrong-import-order, wrong-import-position
 
 import importlib.util
+import json
 import os
 import sys
 
@@ -1275,14 +1276,11 @@ EDX_PLATFORM_REVISION = 'release'
 
 # Static content
 STATIC_URL = '/static/studio/'
-STATIC_ROOT = ENV_ROOT / "staticfiles" / 'studio'
+STATIC_ROOT = os.environ.get('STATIC_ROOT_CMS', ENV_ROOT / 'staticfiles' / 'studio')
 
 STATICFILES_DIRS = [
     COMMON_ROOT / "static",
     PROJECT_ROOT / "static",
-
-    # This is how you would use the textbook images locally
-    # ("book", ENV_ROOT / "book_images"),
 ]
 
 # Locale/Internationalization
@@ -1322,11 +1320,16 @@ COURSE_METADATA_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 EMBARGO_SITE_REDIRECT_URL = None
 
 ##### custom vendor plugin variables #####
-# JavaScript code can access this data using `process.env.JS_ENV_EXTRA_CONFIG`
-# One of the current use cases for this is enabling custom TinyMCE plugins
-# (TINYMCE_ADDITIONAL_PLUGINS) and overriding the TinyMCE configuration
-# (TINYMCE_CONFIG_OVERRIDES).
-JS_ENV_EXTRA_CONFIG = {}
+
+# .. setting_name: JS_ENV_EXTRA_CONFIG
+# .. setting_default: {}
+# .. setting_description: JavaScript code can access this dictionary using `process.env.JS_ENV_EXTRA_CONFIG`
+#   One of the current use cases for this is enabling custom TinyMCE plugins
+#   (TINYMCE_ADDITIONAL_PLUGINS) and overriding the TinyMCE configuration (TINYMCE_CONFIG_OVERRIDES).
+# .. setting_warning: This Django setting is DEPRECATED! Starting in Sumac, Webpack will no longer
+#   use Django settings. Please set the JS_ENV_EXTRA_CONFIG environment variable to an equivalent JSON
+#   string instead. For details, see: https://github.com/openedx/edx-platform/issues/31895
+JS_ENV_EXTRA_CONFIG = json.loads(os.environ.get('JS_ENV_EXTRA_CONFIG', '{}'))
 
 ############################### PIPELINE #######################################
 
@@ -1503,7 +1506,14 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(STATIC_ROOT, 'webpack-worker-stats.json')
     }
 }
-WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
+
+# .. setting_name: WEBPACK_CONFIG_PATH
+# .. setting_default: "webpack.prod.config.js"
+# .. setting_description: Path to the Webpack configuration file. Used by Paver scripts.
+# .. setting_warning: This Django setting is DEPRECATED! Starting in Sumac, Webpack will no longer
+#   use Django settings. Please set the WEBPACK_CONFIG_PATH environment variable instead. For details,
+#   see: https://github.com/openedx/edx-platform/issues/31895
+WEBPACK_CONFIG_PATH = os.environ.get('WEBPACK_CONFIG_PATH', 'webpack.prod.config.js')
 
 
 ############################ SERVICE_VARIANT ##################################
@@ -2180,8 +2190,11 @@ CREDIT_PROVIDER_SECRET_KEYS = {}
 
 # .. setting_name: COMPREHENSIVE_THEME_DIRS
 # .. setting_default: []
-# .. setting_description: See LMS annotation.
-COMPREHENSIVE_THEME_DIRS = []
+# .. setting_description: A list of paths to directories, each of which will
+#   be searched for comprehensive themes. Do not override this Django setting directly.
+#   Instead, set the COMPREHENSIVE_THEME_DIRS environment variable, using colons (:) to
+#   separate paths.
+COMPREHENSIVE_THEME_DIRS = os.environ.get("COMPREHENSIVE_THEME_DIRS", "").split(":")
 
 # .. setting_name: COMPREHENSIVE_THEME_LOCALE_PATHS
 # .. setting_default: []

--- a/docs/decisions/0017-reimplement-asset-processing.rst
+++ b/docs/decisions/0017-reimplement-asset-processing.rst
@@ -11,16 +11,14 @@ Overview
 Status
 ******
 
-**Provisional**
+**Accepted**
 
-This was `originally authored <https://github.com/openedx/edx-platform/pull/31790>`_ in March 2023. We `modified it in July 2023 <https://github.com/openedx/edx-platform/pull/32804>`_ based on learnings from the implementation process.
+This was `originally authored <https://github.com/openedx/edx-platform/pull/31790>`_ in March 2023. We `modified it in July 2023 <https://github.com/openedx/edx-platform/pull/32804>`_ based on learnings from the implementation process, and then `modified and it again in May 2024 <https://github.com/openedx/edx-platform/pull/34554>`_ to make the migration easier for operators to understand.
 
-The status will be moved to *Accepted* upon completion of reimplementation. Related work:
+Related deprecation tickets:
 
 * `[DEPR]: Asset processing in Paver <https://github.com/openedx/edx-platform/issues/31895>`_
-* `Process edx-platform assets without Paver <https://github.com/openedx/edx-platform/issues/31798>`_
-* `Process edx-platform assets without Python <https://github.com/openedx/edx-platform/issues/31800>`_
-
+* `[DEPR]: Paver <https://github.com/openedx/edx-platform/issues/34467>`_
 
 Context
 *******
@@ -92,7 +90,6 @@ Three particular issues have surfaced in Developer Experience Working Group disc
 
 All of these potential solutions would involve refactoring or entirely replacing parts of the current asset processing system.
 
-
 Decision
 ********
 
@@ -113,6 +110,9 @@ Reimplementation Specification
 
 Commands and stages
 -------------------
+
+**May 2024 update:** See the `static assets reference <../references/static-assets.rst>`_ for
+the latest commands.
 
 The three top-level edx-platform asset processing actions are *build*, *collect*, and *watch*. The build action can be further broken down into five stages. Here is how those actions and stages will be reimplemented:
 
@@ -226,6 +226,9 @@ The three top-level edx-platform asset processing actions are *build*, *collect*
 Build Configuration
 -------------------
 
+**May 2024 update:** See the `static assets reference <../references/static-assets.rst>`_ for
+the latest configuration settings.
+
 To facilitate a generally Python-free build reimplementation, we will require that certain Django settings now be specified as environment variables, which can be passed to the build like so::
 
   MY_ENV_VAR="my value" npm run build    # Set for the whole build.
@@ -266,7 +269,7 @@ Some of these options will remain as Django settings because they are used in ed
    * - ``COMPREHENSIVE_THEME_DIRS``
      - Directories that will be searched when compiling themes.
      - ``COMPREHENSIVE_THEME_DIRS``
-     - ``EDX_PLATFORM_THEME_DIRS``
+     - ``COMPREHENSIVE_THEME_DIRS``
 
 Migration
 =========
@@ -285,37 +288,16 @@ As a consequence of this ADR, Tutor will either need to:
 * reimplement the script as a thin wrapper around the new asset processing commands, or
 * deprecate and remove the script.
 
-Either way, the migration path is straightforward:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Existing Tutor-provided command
-     - New upstream command
-   * - ``openedx-assets build``
-     - ``npm run build``
-   * - ``openedx-assets npm``
-     - ``scripts/copy-node-modules.sh  # (automatically invoked by 'npm install'!)``
-   * - ``openedx-assets xmodule``
-     - (no longer needed)
-   * - ``openedx-assets common``
-     - ``npm run compile-sass -- --skip-themes``
-   * - ``openedx-assets themes``
-     - ``npm run compile-sass -- --skip-default``
-   * - ``openedx-assets webpack``
-     - ``npm run webpack``
-   * - ``openedx-assets collect``
-     - ``./manage.py [lms|cms] collectstatic --noinput``
-   * - ``openedx-assets watch-themes``
-     - ``npm run watch``
-
-The options accepted by ``openedx-assets`` will all be valid inputs to ``scripts/build-assets.sh``.
+**May 2024 update:** The ``openedx-assets`` script will be removed from Tutor,
+with migration instructions documented in
+`Tutor's changelog <https://github.com/overhangio/tutor/blob/master/CHANGELOG.md>`_.
 
 non-Tutor migration guide
 -------------------------
 
-Operators using distributions other than Tutor should refer to the upstream edx-platform changes described above in **Reimplementation Specification**, and adapt them accordingly to their distribution.
-
+A migration guide for site operators who are directly referencing Paver will be
+included in the
+`Paver deprecation ticket <https://github.com/openedx/edx-platform/issues/34467>`_.
 
 See also
 ********

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1928,7 +1928,7 @@ MANAGERS = ADMINS
 
 # Static content
 STATIC_URL = '/static/'
-STATIC_ROOT = ENV_ROOT / "staticfiles"
+STATIC_ROOT = os.environ.get('STATIC_ROOT_LMS', ENV_ROOT / "staticfiles")
 STATIC_URL_BASE = '/static/'
 
 STATICFILES_DIRS = [
@@ -2822,7 +2822,14 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(STATIC_ROOT, 'webpack-worker-stats.json')
     }
 }
-WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
+
+# .. setting_name: WEBPACK_CONFIG_PATH
+# .. setting_default: "webpack.prod.config.js"
+# .. setting_description: Path to the Webpack configuration file. Used by Paver scripts.
+# .. setting_warning: This Django setting is DEPRECATED! Starting in Sumac, Webpack will no longer
+#   use Django settings. Please set the WEBPACK_CONFIG_PATH environment variable instead. For details,
+#   see: https://github.com/openedx/edx-platform/issues/31895
+WEBPACK_CONFIG_PATH = os.environ.get('WEBPACK_CONFIG_PATH', 'webpack.prod.config.js')
 
 ########################## DJANGO DEBUG TOOLBAR ###############################
 
@@ -4549,9 +4556,11 @@ SITE_ID = 1
 
 # .. setting_name: COMPREHENSIVE_THEME_DIRS
 # .. setting_default: []
-# .. setting_description: A list of directories containing themes folders,
-#   each entry should be a full path to the directory containing the theme folder.
-COMPREHENSIVE_THEME_DIRS = []
+# .. setting_description: A list of paths to directories, each of which will
+#   be searched for comprehensive themes. Do not override this Django setting directly.
+#   Instead, set the COMPREHENSIVE_THEME_DIRS environment variable, using colons (:) to
+#   separate paths.
+COMPREHENSIVE_THEME_DIRS = os.environ.get("COMPREHENSIVE_THEME_DIRS", "").split(":")
 
 # .. setting_name: COMPREHENSIVE_THEME_LOCALE_PATHS
 # .. setting_default: []

--- a/openedx/core/djangoapps/theming/management/commands/compile_sass.py
+++ b/openedx/core/djangoapps/theming/management/commands/compile_sass.py
@@ -73,8 +73,8 @@ class Command(BaseCommand):
             {"lms": "lms", "cms": "cms", "studio": "cms"}[sys]
             for sys in options.get("system", ["lms", "cms"])
         )
-        theme_dirs = options.get("theme_dirs", settings.COMPREHENSIVE_THEME_DIRS) or []
-        themes_option = options.get("themes", [])  # '[]' means 'all'
+        theme_dirs = options.get("theme_dirs") or settings.COMPREHENSIVE_THEME_DIRS or []
+        themes_option = options.get("themes") or []  # '[]' means 'all'
         if not settings.ENABLE_COMPREHENSIVE_THEMING:
             compile_themes = False
             themes = []

--- a/openedx/core/djangoapps/theming/management/commands/compile_sass.py
+++ b/openedx/core/djangoapps/theming/management/commands/compile_sass.py
@@ -1,13 +1,14 @@
 """
 Management command for compiling sass.
+
+DEPRECATED in favor of `npm run compile-sass`.
 """
+import shlex
 
+from django.core.management import BaseCommand
+from django.conf import settings
 
-from django.core.management import BaseCommand, CommandError
-from paver.easy import call_task
-
-from openedx.core.djangoapps.theming.helpers import get_theme_base_dirs, get_themes, is_comprehensive_theming_enabled
-from pavelib.assets import ALL_SYSTEMS
+from pavelib.assets import run_deprecated_command_wrapper
 
 
 class Command(BaseCommand):
@@ -15,7 +16,7 @@ class Command(BaseCommand):
     Compile theme sass and collect theme assets.
     """
 
-    help = 'Compile and collect themed assets...'
+    help = "DEPRECATED. Use 'npm run compile-sass' instead."
 
     # NOTE (CCB): This allows us to compile static assets in Docker containers without database access.
     requires_system_checks = []
@@ -28,7 +29,7 @@ class Command(BaseCommand):
                 parser (django.core.management.base.CommandParser): parsed for parsing command line arguments.
         """
         parser.add_argument(
-            'system', type=str, nargs='*', default=ALL_SYSTEMS,
+            'system', type=str, nargs='*', default=["lms", "cms"],
             help="lms or studio",
         )
 
@@ -55,7 +56,7 @@ class Command(BaseCommand):
             '--force',
             action='store_true',
             default=False,
-            help="Force full compilation",
+            help="DEPRECATED. Full recompilation is now always forced.",
         )
         parser.add_argument(
             '--debug',
@@ -64,77 +65,48 @@ class Command(BaseCommand):
             help="Disable Sass compression",
         )
 
-    @staticmethod
-    def parse_arguments(*args, **options):  # pylint: disable=unused-argument
-        """
-        Parse and validate arguments for compile_sass command.
-
-        Args:
-            *args: Positional arguments passed to the update_assets command
-            **options: optional arguments passed to the update_assets command
-        Returns:
-            A tuple containing parsed values for themes, system, source comments and output style.
-            1. system (list): list of system names for whom to compile theme sass e.g. 'lms', 'cms'
-            2. theme_dirs (list): list of Theme objects
-            3. themes (list): list of Theme objects
-            4. force (bool): Force full compilation
-            5. debug (bool): Disable Sass compression
-        """
-        system = options.get("system", ALL_SYSTEMS)
-        given_themes = options.get("themes", ["all"])
-        theme_dirs = options.get("theme_dirs", None)
-
-        force = options.get("force", True)
-        debug = options.get("debug", True)
-
-        if theme_dirs:
-            available_themes = {}
-            for theme_dir in theme_dirs:
-                available_themes.update({t.theme_dir_name: t for t in get_themes(theme_dir)})
-        else:
-            theme_dirs = get_theme_base_dirs()
-            available_themes = {t.theme_dir_name: t for t in get_themes()}
-
-        if 'no' in given_themes or 'all' in given_themes:
-            # Raise error if 'all' or 'no' is present and theme names are also given.
-            if len(given_themes) > 1:
-                raise CommandError("Invalid themes value, It must either be 'all' or 'no' or list of themes.")
-        # Raise error if any of the given theme name is invalid
-        # (theme name would be invalid if it does not exist in themes directory)
-        elif (not set(given_themes).issubset(list(available_themes.keys()))) and is_comprehensive_theming_enabled():
-            raise CommandError(
-                "Given themes '{themes}' do not exist inside any of the theme directories '{theme_dirs}'".format(
-                    themes=", ".join(set(given_themes) - set(available_themes.keys())),
-                    theme_dirs=theme_dirs,
-                ),
-            )
-
-        if "all" in given_themes:
-            themes = list(available_themes.values())
-        elif "no" in given_themes:
-            themes = []
-        else:
-            # convert theme names to Theme objects, this will remove all themes if theming is disabled
-            themes = [available_themes.get(theme) for theme in given_themes if theme in available_themes]
-
-        return system, theme_dirs, themes, force, debug
-
     def handle(self, *args, **options):
         """
         Handle compile_sass command.
         """
-        system, theme_dirs, themes, force, debug = self.parse_arguments(*args, **options)
-        themes = [theme.theme_dir_name for theme in themes]
-
-        if options.get("themes", None) and not is_comprehensive_theming_enabled():
-            # log a warning message to let the user know that asset compilation for themes is skipped
-            self.stdout.write(
-                self.style.WARNING(
-                    "Skipping theme asset compilation: enable theming to process themed assets"
+        systems = set(
+            {"lms": "lms", "cms": "cms", "studio": "cms"}[sys]
+            for sys in options.get("system", ["lms", "cms"])
+        )
+        theme_dirs = options.get("theme_dirs", settings.COMPREHENSIVE_THEME_DIRS) or []
+        themes_option = options.get("themes", [])  # '[]' means 'all'
+        if not settings.ENABLE_COMPREHENSIVE_THEMING:
+            compile_themes = False
+            themes = []
+        elif "no" in themes_option:
+            compile_themes = False
+            themes = []
+        elif "all" in themes_option:
+            compile_themes = True
+            themes = []
+        else:
+            compile_themes = True
+            themes = themes_option
+        run_deprecated_command_wrapper(
+            old_command="./manage.py [lms|cms] compile_sass",
+            ignored_old_flags=list(set(["force"]) & set(options)),
+            new_command=shlex.join([
+                "npm",
+                "run",
+                ("compile-sass-dev" if options.get("debug") else "compile-sass"),
+                "--",
+                *(["--skip-lms"] if "lms" not in systems else []),
+                *(["--skip-cms"] if "cms" not in systems else []),
+                *(["--skip-themes"] if not compile_themes else []),
+                *(
+                    arg
+                    for theme_dir in theme_dirs
+                    for arg in ["--theme-dir", str(theme_dir)]
                 ),
-            )
-
-        call_task(
-            'pavelib.assets.compile_sass',
-            options={'system': system, 'theme_dirs': theme_dirs, 'themes': themes, 'force': force, 'debug': debug},
+                *(
+                    arg
+                    for theme in themes
+                    for arg in ["--theme", theme]
+                ),
+            ]),
         )

--- a/openedx/core/djangoapps/theming/tests/test_commands.py
+++ b/openedx/core/djangoapps/theming/tests/test_commands.py
@@ -2,57 +2,23 @@
 Tests for Management commands of comprehensive theming.
 """
 
-import pytest
-from django.core.management import CommandError, call_command
-from django.test import TestCase
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+from unittest.mock import patch
 
-from openedx.core.djangoapps.theming.helpers import get_themes
-from openedx.core.djangoapps.theming.management.commands.compile_sass import Command
+import pavelib.assets
 
 
 class TestUpdateAssets(TestCase):
     """
     Test comprehensive theming helper functions.
     """
-    def setUp(self):
-        super().setUp()
-        self.themes = get_themes()
 
-    def test_errors_for_invalid_arguments(self):
-        """
-        Test update_asset command.
-        """
-        # make sure error is raised for invalid theme list
-        with pytest.raises(CommandError):
-            call_command("compile_sass", themes=["all", "test-theme"])
-
-        # make sure error is raised for invalid theme list
-        with pytest.raises(CommandError):
-            call_command("compile_sass", themes=["no", "test-theme"])
-
-        # make sure error is raised for invalid theme list
-        with pytest.raises(CommandError):
-            call_command("compile_sass", themes=["all", "no"])
-
-        # make sure error is raised for invalid theme list
-        with pytest.raises(CommandError):
-            call_command("compile_sass", themes=["test-theme", "non-existing-theme"])
-
-    def test_parse_arguments(self):
-        """
-        Test parse arguments method for update_asset command.
-        """
-        # make sure compile_sass picks all themes when called with 'themes=all' option
-        parsed_args = Command.parse_arguments(themes=["all"])
-        self.assertCountEqual(parsed_args[2], get_themes())
-
-        # make sure compile_sass picks no themes when called with 'themes=no' option
-        parsed_args = Command.parse_arguments(themes=["no"])
-        self.assertCountEqual(parsed_args[2], [])
-
-        # make sure compile_sass picks only specified themes
-        parsed_args = Command.parse_arguments(themes=["test-theme"])
-        self.assertCountEqual(
-            parsed_args[2],
-            [theme for theme in get_themes() if theme.theme_dir_name == "test-theme"]
+    @patch.object(pavelib.assets, 'sh')
+    @override_settings(COMPREHENSIVE_THEME_DIRS='common/test')
+    def test_deprecated_wrapper(self, mock_sh):
+        call_command('compile_sass', '--themes', 'fake-theme1', 'fake-theme2')
+        assert mock_sh.called_once_with(
+            "npm run compile-sass -- " +
+            "--theme-dir common/test --theme fake-theme-1 --theme fake-theme-2"
         )

--- a/scripts/compile_sass.py
+++ b/scripts/compile_sass.py
@@ -67,14 +67,12 @@ NORMALIZED_ENVS = {
     "theme_dirs",
     metavar="PATH",
     multiple=True,
-    envvar="EDX_PLATFORM_THEME_DIRS",
-    type=click.Path(
-        exists=True, file_okay=False, readable=True, writable=True, path_type=Path
-    ),
+    envvar="COMPREHENSIVE_THEME_DIRS",
+    type=click.Path(path_type=Path),
     help=(
         "Consider sub-dirs of PATH as themes. "
         "Multiple theme dirs are accepted. "
-        "If none are provided, we look at colon-separated paths on the EDX_PLATFORM_THEME_DIRS env var."
+        "If none are provided, we look at colon-separated paths on the COMPREHENSIVE_THEME_DIRS env var."
     ),
 )
 @click.option(

--- a/scripts/watch_sass.sh
+++ b/scripts/watch_sass.sh
@@ -4,11 +4,11 @@
 # Invoke from repo root as `npm run watch-sass`.
 
 # By default, only watches default Sass.
-# To watch themes too, provide colon-separated paths in the EDX_PLATFORM_THEME_DIRS environment variable.
+# To watch themes too, provide colon-separated paths in the COMPREHENSIVE_THEME_DIRS environment variable.
 # Each path will be treated as a "theme dir", which means that every immediate child directory is watchable as a theme.
 # For example:
 #
-#   EDX_PLATFORM_THEME_DIRS=/openedx/themes:./themes npm run watch-sass
+#   COMPREHENSIVE_THEME_DIRS=/openedx/themes:./themes npm run watch-sass
 #
 # would watch default Sass as well as /openedx/themes/indigo, /openedx/themes/mytheme, ./themes/red-theme, etc.
 


### PR DESCRIPTION
Re-merges:
* https://github.com/openedx/edx-platform/pull/34554

plus a fix, in its own commit:
________________________________

 fix: fall back to settings.COMPREHENSIVE_THEME_DIRS correctly

There was a logical error in the compile_sass management command:
instead of falling back to settings.COMPREHENSIVE_THEME_DIRS when
--theme-dirs was *None or missing*, we only fell back to it when
--theme-dirs was *missing*.

This caused theme compilation to be skipped when COMREHENSIVE_THEME_DIRS
*is not set* in the environment, even though
settings.COMPREHENSIVE_THEME_DIRS *is set* in Django settings, which
is currently the case for edx.org.