### PR TITLE
Feanil/fix one upgrade

### DIFF
--- a/.github/workflows/upgrade-one-python-dependency.yml
+++ b/.github/workflows/upgrade-one-python-dependency.yml
@@ -82,13 +82,13 @@ jobs:
 
       - name: Make a PR
         id: make-pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           branch: "${{ github.triggering_actor }}/upgrade-${{ inputs.package }}"
           branch-suffix: short-commit-hash
           add-paths: |
             requirements
-            scripts/**/requirements
+            scripts/**/requirements*
           commit-message: |
             feat: Upgrade Python dependency ${{ inputs.package }}
 


### PR DESCRIPTION
We were seeing the following error:

```
  /usr/bin/git add -- requirements scripts/**/requirements
  fatal: pathspec 'scripts/**/requirements' did not match any files
```

Once we introduce wildcards, the whole path needs to be valid so adding
a trailing wildcard to catch all the relevant directories and files.