### PR TITLE
[FC-0049] feat: Update remove object-tag permission

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -274,6 +274,30 @@ def can_view_object_tag_objectid(user: UserType, object_id: str) -> bool:
 
 
 @rules.predicate
+def can_remove_object_tag_objectid(user: UserType, object_id: str) -> bool:
+    """
+    Everyone that has permission to edit the object should be able remove tags from it.
+    """
+    if not object_id:
+        raise ValueError("object_id must be provided")
+
+    if not user.is_authenticated:
+        return False
+
+    try:
+        context_key = get_context_key_from_key_string(object_id)
+        assert context_key.org
+    except (ValueError, AssertionError):
+        return False
+
+    if has_studio_write_access(user, context_key):
+        return True
+
+    object_org = rules_cache.get_orgs([context_key.org])
+    return bool(object_org) and is_org_admin(user, object_org)
+
+
+@rules.predicate
 def can_change_object_tag(
     user: UserType, perm_obj: oel_tagging.ObjectTagPermissionItem | None = None
 ) -> bool:
@@ -336,3 +360,4 @@ rules.set_perm("oel_tagging.view_objecttag_taxonomy", can_view_object_tag_taxono
 rules.set_perm("oel_tagging.view_objecttag_objectid", can_view_object_tag_objectid)
 rules.set_perm("oel_tagging.change_objecttag_taxonomy", can_view_object_tag_taxonomy)
 rules.set_perm("oel_tagging.change_objecttag_objectid", can_change_object_tag_objectid)
+rules.set_perm("oel_tagging.remove_objecttag_objectid", can_remove_object_tag_objectid)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,7 +97,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.9.2
+openedx-learning==0.9.3
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -792,7 +792,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.2
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -792,7 +792,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
+openedx-learning==0.9.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1312,7 +1312,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
+openedx-learning==0.9.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1312,7 +1312,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.2
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -928,7 +928,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
+openedx-learning==0.9.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -928,7 +928,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.2
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -117,7 +117,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
-openedx-learning                    # Open edX Learning core (experimental)
+git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag#egg=openedx-learning                      # Open edX Learning core
 openedx-mongodbproxy
 openedx-django-wiki
 openedx-blockstore

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -117,7 +117,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
-git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag#egg=openedx-learning                      # Open edX Learning core
+openedx-learning                    # Open edX Learning core (experimental)
 openedx-mongodbproxy
 openedx-django-wiki
 openedx-blockstore

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -983,7 +983,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.2
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -983,7 +983,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3720-permissions-to-remove-object-tag
+openedx-learning==0.9.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

- Overrides `can_remove_object_tag_objectid` rule
- Bump `openedx-learning` version

## Supporting information

- Github issue: https://github.com/openedx/modular-learning/issues/204
- Internal ticket: [FAL-3720](https://tasks.opencraft.com/browse/FAL-3720)
- Depends on:
    - https://github.com/openedx/frontend-app-course-authoring/pull/987
    - https://github.com/openedx/openedx-learning/pull/188

## Testing instructions

- Follow the testing instructions on https://github.com/openedx/frontend-app-course-authoring/pull/987

## Other information

- [ ] Bump `openedx-learning version`
