### PR TITLE
chore: update actions runner

### DIFF
--- a/scripts/ci-runner.Dockerfile
+++ b/scripts/ci-runner.Dockerfile
@@ -45,6 +45,8 @@ COPY setup.py setup.py
 COPY openedx/core/lib openedx/core/lib
 COPY lms lms
 COPY cms cms
+COPY common common
+COPY xmodule xmodule
 COPY requirements/pip.txt requirements/pip.txt
 COPY requirements/pip-tools.txt requirements/pip-tools.txt
 COPY requirements/edx/testing.txt requirements/edx/testing.txt

--- a/scripts/ci-runner.Dockerfile
+++ b/scripts/ci-runner.Dockerfile
@@ -1,4 +1,4 @@
-FROM summerwind/actions-runner:v2.288.1-ubuntu-20.04-c221b6e as base
+FROM summerwind/actions-runner:v2.316.0-ubuntu-20.04-49490c4 as base
 
 USER root
 


### PR DESCRIPTION
- Connects https://github.com/openedx/edx-platform/issues/34748

Fixes:
- `'using: node20' is not supported, use 'docker', 'node12' or 'node16' instead.` on new [GitHub Actions](https://pipelinesghubeus2.actions.githubusercontent.com/Dxro1FLYwwaYoTvxXxrOP6MlKDWB8jnvCh9RqeQWY1bZ0SbUcd/_apis/pipelines/1/runs/413610/signedlogcontent/12?urlExpires=2024-05-08T08%3A58%3A24.9851551Z&urlSigningMethod=HMACV1&urlSignature=HK1OqM1HcU0dM1FwSmx2vafwc%2Fg04BRUL5d7KQhVMRY%3D)
- `error: package directory 'common' does not exist` on [Push CI Runner Docker Image](https://github.com/openedx/edx-platform/actions/runs/8994702956/job/24708554357#step:6:2439)