### PR TITLE
fix: get topics for blocks with discussions enabled

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -698,15 +698,16 @@ def get_course_topics_v2(
     ).exists()
 
     with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, course_key):
-        blocks = store.get_items(
+        blocks = [block for block in store.get_items(
             course_key,
             qualifiers={'category': 'vertical'},
             fields=['usage_key', 'discussion_enabled', 'display_name'],
-        )
-        accessible_vertical_keys = [
-            block.usage_key for block in blocks
-            if block.discussion_enabled
-        ] + [None]
+        )]
+        accessible_vertical_keys = []
+        for block in blocks:
+            if block.discussion_enabled and (not block.visible_to_staff_only or user_is_privileged):
+                accessible_vertical_keys.append(block.usage_key)
+        accessible_vertical_keys.append(None)
 
     topics_query = DiscussionTopicLink.objects.filter(
         context_key=course_key,

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -698,11 +698,11 @@ def get_course_topics_v2(
     ).exists()
 
     with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, course_key):
-        blocks = [block for block in store.get_items(
+        blocks = store.get_items(
             course_key,
             qualifiers={'category': 'vertical'},
             fields=['usage_key', 'discussion_enabled', 'display_name'],
-        )]
+        )
         accessible_vertical_keys = []
         for block in blocks:
             if block.discussion_enabled and (not block.visible_to_staff_only or user_is_privileged):

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -33,7 +33,6 @@ from common.djangoapps.student.roles import (
 )
 
 from lms.djangoapps.course_api.blocks.api import get_blocks
-from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE


### PR DESCRIPTION
## Description:
Sometimes while topics exist for Units (verticals) that have discussion_enabled flag value set to False, To fix this issue now Topics API will filter out topics according to the block's discussion_enabled Flag

## Ticket
https://2u-internal.atlassian.net/browse/INF-1248