### PR TITLE
feat: Avoid to close tag drawer when click outside

### DIFF
--- a/cms/static/js/views/utils/tagging_drawer_utils.js
+++ b/cms/static/js/views/utils/tagging_drawer_utils.js
@@ -25,11 +25,6 @@ function($) {
         const drawer = document.querySelector("#manage-tags-drawer");
         const drawerCover = document.querySelector(".drawer-cover");
 
-        // Add handler to close drawer when dark background is clicked
-        $(drawerCover).click(function() {
-            closeDrawer(drawer, drawerCover);
-        }.bind(this));
-
         // Add event listen to close drawer when close button is clicked from within the Iframe
         window.addEventListener("message", function (event) {
             if (event.data === 'closeManageTagsDrawer') {


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Deletes the code for close tag drawer when click outside.

## Supporting information

- Github Issue: https://github.com/openedx/modular-learning/issues/209

## Testing instructions

- Run `make cms-static` to rebuild static content.
- Go to a course in the studio legacy UI (not the course-authoring MFE).
- Open the manage drawer of a unit.
- Verify that you can't close the drawer clicking outside. Verify that you can close the darwer clicking on the Close button
