### PR TITLE
feat: Always enable the "copy-paste units" functionality

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -198,22 +198,6 @@ def individualize_anonymous_user_id(course_id):
     return INDIVIDUALIZE_ANONYMOUS_USER_ID.is_enabled(course_id)
 
 
-# .. toggle_name: contentstore.enable_copy_paste_units
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Moves most unit-level actions into a submenu and adds new "Copy Unit" and "Paste
-#   Unit" actions which can be used to copy units within or among courses.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2023-08-01
-# .. toggle_target_removal_date: 2023-10-01
-# .. toggle_tickets: https://github.com/openedx/modular-learning/issues/11 https://github.com/openedx/modular-learning/issues/50
-ENABLE_COPY_PASTE_UNITS = WaffleFlag(
-    f'{CONTENTSTORE_NAMESPACE}.enable_copy_paste_units',
-    __name__,
-    CONTENTSTORE_LOG_PREFIX,
-)
-
-
 # .. toggle_name: contentstore.enable_studio_content_api
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -33,7 +33,7 @@ from xblock.core import XBlock
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
-from cms.djangoapps.contentstore.toggles import ENABLE_COPY_PASTE_UNITS, use_tagging_taxonomy_list_page
+from cms.djangoapps.contentstore.toggles import use_tagging_taxonomy_list_page
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.lib.ai_aside_summary_config import AiAsideSummaryConfig
 from common.djangoapps.static_replace import replace_static_urls
@@ -1254,8 +1254,8 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
         )
 
         if course_outline or is_xblock_unit:
-            # If the ENABLE_COPY_PASTE_UNITS feature flag is enabled, we show the newer menu that allows copying/pasting
-            xblock_info["enable_copy_paste_units"] = ENABLE_COPY_PASTE_UNITS.is_enabled()
+            # Previously, ENABLE_COPY_PASTE_UNITS was a feature flag; now it's always on.
+            xblock_info["enable_copy_paste_units"] = True
 
         if is_xblock_unit and summary_configuration.is_enabled():
             xblock_info["summary_configuration_enabled"] = summary_configuration.is_summary_enabled(xblock_info['id'])


### PR DESCRIPTION
## Description

This enables the "copy paste units" functionality in Studio, and removes the waffle flag that previously allowed toggling it on and off.

## Supporting information

I left the conditional code in place in the UI. We can remove it in a future PR post-Redwood or simply remove the whole legacy UI.

## Testing instructions

Make sure you can copy-paste units in Studio.

## Deadline

Redwood (tomorrow).

## Other information

