### PR TITLE
fix: Correct shard count verification.

### DIFF
--- a/.github/actions/verify-tests-count/action.yml
+++ b/.github/actions/verify-tests-count/action.yml
@@ -6,8 +6,8 @@ runs:
     - name: collect tests from all modules
       shell: bash
       run: |
-        echo "root_cms_unit_tests_count=$(pytest --collect-only --ds=cms.envs.test cms/ -q | head -n -2 | wc -l)" >> $GITHUB_ENV
-        echo "root_lms_unit_tests_count=$(pytest --collect-only --ds=lms.envs.test lms/ openedx/ common/djangoapps/ xmodule/ -q | head -n -2 | wc -l)" >> $GITHUB_ENV
+        echo "root_cms_unit_tests_count=$(pytest --disable-warnings --collect-only --ds=cms.envs.test cms/ -q | head -n -2 | wc -l)" >> $GITHUB_ENV
+        echo "root_lms_unit_tests_count=$(pytest --disable-warnings --collect-only --ds=lms.envs.test lms/ openedx/ common/djangoapps/ xmodule/ -q | head -n -2 | wc -l)" >> $GITHUB_ENV
 
     - name: get GHA unit test paths
       shell: bash
@@ -19,8 +19,8 @@ runs:
     - name: collect tests from GHA unit test shards
       shell: bash
       run: |
-        echo "cms_unit_tests_count=$(pytest --collect-only --ds=cms.envs.test ${{ env.cms_unit_test_paths }} -q | head -n -2 | wc -l)" >> $GITHUB_ENV
-        echo "lms_unit_tests_count=$(pytest --collect-only --ds=lms.envs.test ${{ env.lms_unit_test_paths }} -q | head -n -2 | wc -l)" >> $GITHUB_ENV
+        echo "cms_unit_tests_count=$(pytest --disable-warnings --collect-only --ds=cms.envs.test ${{ env.cms_unit_test_paths }} -q | head -n -2 | wc -l)" >> $GITHUB_ENV
+        echo "lms_unit_tests_count=$(pytest --disable-warnings --collect-only --ds=lms.envs.test ${{ env.lms_unit_test_paths }} -q | head -n -2 | wc -l)" >> $GITHUB_ENV
 
 
     - name: add unit tests count


### PR DESCRIPTION
The test count was off because without warnings disabled, it was also
counting warning lines as tests.

The `head -n -2` grabs everything but the last two lines which contain a
count (not sure why this isn't used).  If you run without
`--disable-warnings` this will include any warnings that occur during
test collection which we don't want in this case.
