### PR TITLE
docs: Update named edx-platform maintainers.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,6 +11,6 @@ metadata:
       title: "Documentation"
       icon: "Web"
 spec:
-  owner: group:2u-arch-bom
+  owner: group:wg-maintenance-edx-platform
   type: 'service'
   lifecycle: 'production'


### PR DESCRIPTION
Currently this group contains @feanil and @kdmccormick though more
maintainers can be added in the future.  While 2u-arch-bom has done a
great job thus far maintaining this repo, they don't currently have the
capacity to help drive maintenance of edx-platform moving forward.
This update should help make it easier to get help and coordinate work
on edx-platform moving forward.


It's not currently documented how one joins this group but I think some reasonable expectations of anyone who is interested is that they need to make a specific committment to leading maintenance of edx-platform.  In the cases of Kyle and myself, using the recent Python 3.11 Upgrade, Node 18, and Paver Deprecation work as examples, we're comitted to spending time both doing the work of keeping edx-platform up to date and cleaning up cruft and complexities that make it harder to work with.
