### PR TITLE
docs: [FC-0056] change default value for a Navigation sidebar toggle

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -85,7 +85,7 @@ COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffl
 
 # .. toggle_name: courseware.enable_navigation_sidebar
 # .. toggle_implementation: WaffleFlag
-# .. toggle_default: True
+# .. toggle_default: False
 # .. toggle_description: Enable navigation sidebar on Learning MFE
 # .. toggle_use_cases: opt_out, open_edx
 # .. toggle_creation_date: 2024-03-07


### PR DESCRIPTION
## Description

This small PR correct the toggle_default value for the toggle `courseware.enable_navigation_sidebar`


## Supporting information

This feature is done as part of FC-0056. Related GH issue: https://github.com/openedx/platform-roadmap/issues/329


## Deadline

Redwood
