### PR TITLE
feat: Added upgrage deadline in blocks api

### DIFF
--- a/lms/djangoapps/mobile_api/course_info/serializers.py
+++ b/lms/djangoapps/mobile_api/course_info/serializers.py
@@ -82,7 +82,7 @@ class MobileCourseEnrollmentSerializer(serializers.ModelSerializer):
     """
 
     class Meta:
-        fields = ('created', 'mode', 'is_active')
+        fields = ('created', 'mode', 'is_active', 'upgrade_deadline')
         model = CourseEnrollment
         lookup_field = 'username'
 


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Added upgrade deadline in blocks api.

## Supporting information
https://2u-internal.atlassian.net/browse/LEARNER-9949

## Testing instructions
Hit /api/mobile/v3/course_info/blocks/ and see upgrade_deadline in response.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
