### PR TITLE
fix: unregistered task of type for email notification

### DIFF
--- a/openedx/core/djangoapps/notifications/apps.py
+++ b/openedx/core/djangoapps/notifications/apps.py
@@ -18,3 +18,4 @@ class NotificationsConfig(AppConfig):
         """
         # pylint: disable=unused-import
         from . import handlers
+        from .email import tasks


### PR DESCRIPTION
Email digest task was resulting in error "Received unregistered task of type"
Fixed the above mentioned issue by importing email task to app config class 