### PR TITLE
fix: instructor info in course details api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -10,10 +10,10 @@ from openedx.core.lib.api.serializers import CourseKeyField
 class InstructorInfoSerializer(serializers.Serializer):
     """ Serializer for instructor info """
     name = serializers.CharField(allow_blank=True)
-    title = serializers.CharField(allow_blank=True)
-    organization = serializers.CharField(allow_blank=True)
-    image = serializers.CharField(allow_blank=True)
-    bio = serializers.CharField(allow_blank=True)
+    title = serializers.CharField(allow_blank=True, required=False)
+    organization = serializers.CharField(allow_blank=True, required=False)
+    image = serializers.CharField(allow_blank=True, required=False)
+    bio = serializers.CharField(allow_blank=True, required=False)
 
 
 class InstructorsSerializer(serializers.Serializer):


### PR DESCRIPTION
## Description

Scheduling and Details page will sometimes error out due to `KeyError: "Got KeyError when attempting to get a value for field `organization` on serializer `InstructorInfoSerializer`.\nThe serializer field might be named incorrectly and not match any attribute or key on the `dict` instance.\nOriginal exception text was: 'organization'."`. The `organization` field is missing when serializing instructor info, which causes this error.

This PR addresses this by making some fields in instructor info not required, mimicking legacy behavior.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11484

## Testing instructions

Smoke test Scheduling and Details page to make sure this change does not break anything.