### PR TITLE
build: Drop testing with Mongo 4.4 and Python 3.8

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: ${{ env.RELEVANT == 'true' }}
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: "Recompile requirements"
         if: ${{ env.RELEVANT == 'true' }}

--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version:
+          - '3.11'
         os: ['ubuntu-20.04']
 
     steps:

--- a/.github/workflows/compile-python-requirements.yml
+++ b/.github/workflows/compile-python-requirements.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Run make compile-requirements
         env:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -14,7 +14,8 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         node-version: [ 18 ]
-        python-version: [ '3.8', '3.11' ]
+        python-version:
+          - '3.11'
 
     steps:
 

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -14,12 +14,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ '3.8', '3.11' ]
+        python-version:
+          - '3.11'
         # 'pinned' is used to install the latest patch version of Django
         # within the global constraint i.e. Django==4.2.8 in current case
         # because we have global constraint of Django<4.2
         django-version: ["pinned"]
-        mongo-version: ["4", "7"]
+        mongo-version:
+          - "7"
         mysql-version: ["8"]
     services:
       mongo:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ '3.8', '3.11' ]
+        python-version:
+          - '3.11'
         node-version: [ 18 ]
 
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-20.04" ]
-        python-version: [ "3.8", '3.11' ]
+        python-version:
+          - '3.11'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -13,10 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ '3.8', '3.11' ]
+        python-version:
+          - '3.11'
         node-version: [ 18 ]
         npm-version: [ 10.5.x ]
-        mongo-version: ["4.4", "7.0"]
+        mongo-version:
+          - "7.0"
 
     services:
       mongo:

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.11"
         django-version:
           - "pinned"
@@ -39,21 +38,23 @@ jobs:
           - "xmodule-with-lms"
           - "xmodule-with-cms"
         mongo-version:
-          - "4.4"
           - "7.0"
 
-        # We only need to test Mongo 4.4 for modules that directly interface with Mongo (that is: xmodule.modulestore)
-        exclude:
-          - mongo-version: "4.4"
-        include:
-          - shard_name: "xmodule-with-cms"
-            python-version: "3.11"
-            django-version: "pinned"
-            mongo-version: "4.4"
-          - shard_name: "xmodule-with-lms"
-            python-version: "3.11"
-            django-version: "pinned"
-            mongo-version: "4.4"
+        # We only need to test older versions of Mongo with modules that directly interface with Mongo (that is: xmodule.modulestore)
+        # This code is left here as an example for future refernce in case we need to reduce the number of shards we're
+        # testing but still have good confidence with older versions of mongo.  We use Mongo 4.4 in the example.
+        #
+        # exclude:
+        #   - mongo-version: "4.4"
+        # include:
+        #   - shard_name: "xmodule-with-cms"
+        #     python-version: "3.11"
+        #     django-version: "pinned"
+        #     mongo-version: "4.4"
+        #   - shard_name: "xmodule-with-lms"
+        #     python-version: "3.11"
+        #     django-version: "pinned"
+        #     mongo-version: "4.4"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.11"
         django-version:
           - "pinned"
@@ -38,21 +37,23 @@ jobs:
           - "xmodule-with-lms"
           - "xmodule-with-cms"
         mongo-version:
-          - "4.4"
           - "7.0"
 
-        # We only need to test Mongo 4.4 for modules that directly interface with Mongo (that is: xmodule.modulestore)
-        exclude:
-          - mongo-version: "4.4"
-        include:
-          - shard_name: "xmodule-with-cms"
-            python-version: "3.11"
-            django-version: "pinned"
-            mongo-version: "4.4"
-          - shard_name: "xmodule-with-lms"
-            python-version: "3.11"
-            django-version: "pinned"
-            mongo-version: "4.4"
+        # We only need to test older versions of Mongo with modules that directly interface with Mongo (that is: xmodule.modulestore)
+        # This code is left here as an example for future refernce in case we need to reduce the number of shards we're
+        # testing but still have good confidence with older versions of mongo.  We use Mongo 4.4 in the example.
+        #
+        # exclude:
+        #   - mongo-version: "4.4"
+        # include:
+        #   - shard_name: "xmodule-with-cms"
+        #     python-version: "3.11"
+        #     django-version: "pinned"
+        #     mongo-version: "4.4"
+        #   - shard_name: "xmodule-with-lms"
+        #     python-version: "3.11"
+        #     django-version: "pinned"
+        #     mongo-version: "4.4"
 
     steps:
       - name: sync directory owner
@@ -157,7 +158,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version:
+          - 3.11
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/units-test-scripts-structures-pruning.yml
+++ b/.github/workflows/units-test-scripts-structures-pruning.yml
@@ -12,7 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8', '3.11', '3.12' ]
+        python-version:
+          - '3.12'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/units-test-scripts-user-retirement.yml
+++ b/.github/workflows/units-test-scripts-user-retirement.yml
@@ -12,7 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8', '3.11', '3.12']
+        python-version:
+          - '3.12'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/upgrade-one-python-dependency.yml
+++ b/.github/workflows/upgrade-one-python-dependency.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Update any pinned dependencies
         env:

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -14,6 +14,11 @@ jobs:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - uses: actions/checkout@v2
       - name: install requirements
         run: |


### PR DESCRIPTION
Redwood is the last release that supports Python 3.8 and mongo 4.4 so we no longer need to test with either of these.
