### PR TITLE
fix: Check consistency with python 3.8

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: ${{ env.RELEVANT == 'true' }}
         with:
-          python-version: '3.11'
+          python-version: '3.8'
 
       - name: "Recompile requirements"
         if: ${{ env.RELEVANT == 'true' }}


### PR DESCRIPTION
We need to do this until we're ready to compile requirements with python
3.11 some time next week.
