### PR TITLE
[FC-0049] chore: Bump version of openedx-learning for taxonomy import improvements

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,7 +97,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.9.3
+openedx-learning==0.9.4
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -774,7 +774,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
+openedx-learning==0.9.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -774,7 +774,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.3
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1331,7 +1331,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
+openedx-learning==0.9.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1331,7 +1331,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.3
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -906,7 +906,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
+openedx-learning==0.9.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -906,7 +906,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.3
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -117,7 +117,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
-git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy#egg=openedx-learning                      # Open edX Learning core
+openedx-learning                    # Open edX Learning core (experimental)
 openedx-mongodbproxy
 openedx-django-wiki
 path

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -117,7 +117,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
-openedx-learning                    # Open edX Learning core (experimental)
+git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy#egg=openedx-learning                      # Open edX Learning core
 openedx-mongodbproxy
 openedx-django-wiki
 path

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -991,7 +991,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
+openedx-learning==0.9.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -991,7 +991,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.3
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-3721-issues-importing-large-taxonomy
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
Bump version of `openedx-learning`. The new version improves the time and memory usage of taxonomy import

## Supporting information

- Github issue: https://github.com/openedx/modular-learning/issues/213
- Depends on: https://github.com/openedx/openedx-learning/pull/189
- Internal ticket: https://tasks.opencraft.com/browse/FAL-3721

## Testing instructions

- Follow the testing instructions on: https://github.com/openedx/openedx-learning/pull/189

## Other information

- [ ] Bump version of `openedx-learning` after merge https://github.com/openedx/openedx-learning/pull/189
