### PR TITLE
Fix: sometimes, changes to subsections are not reflected in the Studio Search Index

### DIFF
--- a/xmodule/modulestore/mixed.py
+++ b/xmodule/modulestore/mixed.py
@@ -787,19 +787,24 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             fields (dict): A dictionary specifying initial values for some or all fields
                 in the newly created block
         """
-        modulestore = self._verify_modulestore_support(parent_usage_key.course_key, 'create_child')
-        xblock = modulestore.create_child(
+        course_key = parent_usage_key.course_key
+        store = self._verify_modulestore_support(course_key, 'create_child')
+        xblock = store.create_child(
             user_id, parent_usage_key, block_type, block_id=block_id, fields=fields, **kwargs
         )
-        # .. event_implemented_name: XBLOCK_CREATED
-        XBLOCK_CREATED.send_event(
-            time=datetime.now(timezone.utc),
-            xblock_info=XBlockData(
-                usage_key=xblock.location.for_branch(None),
-                block_type=block_type,
-                version=xblock.location
+
+        def send_created_event():
+            # .. event_implemented_name: XBLOCK_CREATED
+            XBLOCK_CREATED.send_event(
+                time=datetime.now(timezone.utc),
+                xblock_info=XBlockData(
+                    usage_key=xblock.location.for_branch(None),
+                    block_type=block_type,
+                    version=xblock.location
+                )
             )
-        )
+
+        store.on_commit_changes_to(course_key, send_created_event)
         return xblock
 
     @strip_key
@@ -828,17 +833,22 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         Update the xblock persisted to be the same as the given for all types of fields
         (content, children, and metadata) attribute the change to the given user.
         """
-        store = self._verify_modulestore_support(xblock.location.course_key, 'update_item')
+        course_key = xblock.location.course_key
+        store = self._verify_modulestore_support(course_key, 'update_item')
         xblock = store.update_item(xblock, user_id, allow_not_found, **kwargs)
-        # .. event_implemented_name: XBLOCK_UPDATED
-        XBLOCK_UPDATED.send_event(
-            time=datetime.now(timezone.utc),
-            xblock_info=XBlockData(
-                usage_key=xblock.location.for_branch(None),
-                block_type=xblock.location.block_type,
-                version=xblock.location
+
+        def send_updated_event():
+            # .. event_implemented_name: XBLOCK_UPDATED
+            XBLOCK_UPDATED.send_event(
+                time=datetime.now(timezone.utc),
+                xblock_info=XBlockData(
+                    usage_key=xblock.location.for_branch(None),
+                    block_type=xblock.location.block_type,
+                    version=xblock.location
+                )
             )
-        )
+
+        store.on_commit_changes_to(course_key, send_updated_event)
         return xblock
 
     @strip_key
@@ -846,16 +856,21 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         Delete the given item from persistence. kwargs allow modulestore specific parameters.
         """
-        store = self._verify_modulestore_support(location.course_key, 'delete_item')
+        course_key = location.course_key
+        store = self._verify_modulestore_support(course_key, 'delete_item')
         item = store.delete_item(location, user_id=user_id, **kwargs)
-        # .. event_implemented_name: XBLOCK_DELETED
-        XBLOCK_DELETED.send_event(
-            time=datetime.now(timezone.utc),
-            xblock_info=XBlockData(
-                usage_key=location,
-                block_type=location.block_type,
+
+        def send_deleted_event():
+            # .. event_implemented_name: XBLOCK_DELETED
+            XBLOCK_DELETED.send_event(
+                time=datetime.now(timezone.utc),
+                xblock_info=XBlockData(
+                    usage_key=location,
+                    block_type=location.block_type,
+                )
             )
-        )
+
+        store.on_commit_changes_to(course_key, send_deleted_event)
         return item
 
     def revert_to_published(self, location, user_id):

--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -233,13 +233,11 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
             raise TypeError(f'{course_key!r} is not a CourseLocator or LibraryLocator')
 
         if course_key.org and get_library_or_course_attribute(course_key) and course_key.run:
-            if course_key.replace(branch=None, version_guid=None) in self._active_bulk_ops.records:
-                del self._active_bulk_ops.records[course_key.replace(branch=None, version_guid=None)]
+            del self._active_bulk_ops.records[course_key.replace(branch=None, version_guid=None)]
         else:
-            if course_key.replace(org=None, course=None, run=None, branch=None) in self._active_bulk_ops.records:
-                del self._active_bulk_ops.records[
-                    course_key.replace(org=None, course=None, run=None, branch=None)
-                ]
+            del self._active_bulk_ops.records[
+                course_key.replace(org=None, course=None, run=None, branch=None)
+            ]
 
     def _start_outermost_bulk_operation(self, bulk_write_record, course_key, ignore_case=False):  # lint-amnesty, pylint: disable=arguments-differ
         """

--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -233,11 +233,13 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
             raise TypeError(f'{course_key!r} is not a CourseLocator or LibraryLocator')
 
         if course_key.org and get_library_or_course_attribute(course_key) and course_key.run:
-            del self._active_bulk_ops.records[course_key.replace(branch=None, version_guid=None)]
+            if course_key.replace(branch=None, version_guid=None) in self._active_bulk_ops.records:
+                del self._active_bulk_ops.records[course_key.replace(branch=None, version_guid=None)]
         else:
-            del self._active_bulk_ops.records[
-                course_key.replace(org=None, course=None, run=None, branch=None)
-            ]
+            if course_key.replace(org=None, course=None, run=None, branch=None) in self._active_bulk_ops.records:
+                del self._active_bulk_ops.records[
+                    course_key.replace(org=None, course=None, run=None, branch=None)
+                ]
 
     def _start_outermost_bulk_operation(self, bulk_write_record, course_key, ignore_case=False):  # lint-amnesty, pylint: disable=arguments-differ
         """


### PR DESCRIPTION
## Description

There is a race condition that causes some changes to not be reflected in the Studio search index.

## Technical Details

What's happening is that the XBlock is updated with `modulestore.update_item()` in the initial request, that function [immediately triggers the `XBLOCK_UPDATED` signal](https://github.com/openedx/edx-platform/blob/73d3995dae42526844e729d30c846cfb7c1e3c0a/xmodule/modulestore/mixed.py#L824-L842). However, when our handler [processes that](https://github.com/openedx/edx-platform/blob/73d3995dae42526844e729d30c846cfb7c1e3c0a/openedx/core/djangoapps/content/search/api.py#L389-L415) [in a worker](https://github.com/openedx/edx-platform/blob/73d3995dae42526844e729d30c846cfb7c1e3c0a/openedx/core/djangoapps/content/search/handlers.py#L78-L81), even though there is no active MySQL transaction, the modulestore "bulk operation" _may_ still be active, so the actual modulestore data in mongo/mysql hasn't been updated yet. The data only [gets committed](https://github.com/openedx/edx-platform/blob/73d3995dae42526844e729d30c846cfb7c1e3c0a/xmodule/modulestore/split_mongo/split.py#L284-L291) [when the outermost bulk operation scope is exited](https://github.com/openedx/edx-platform/blob/73d3995dae42526844e729d30c846cfb7c1e3c0a/xmodule/modulestore/__init__.py#L286).

I couldn't find any existing mechanism to listen for that "actual commit" of _draft_ content, because the code seems to assume that other parts of the system only need to know when new content has been _published_, not when new draft content has been committed to the DB. So I had to add that as a new capability.

## Testing instructions

In `cms/envs/devstack.py` set `CELERY_ALWAYS_EAGER = False`.

1. Rename any subsection in a course
2. Open the course search (from the header of the course authoring MFE, while viewing the same course outline)
3. Search for the name of the subsection
4. In some cases (especially if it's not the first time you've made a change since the CMS and CMS worker were restarted), you will see that the name of the subsection in the search index is out of date.

We have focused testing on renaming subsections, but this likely affects other types of edits.

## Deadline

TBD
