### PR TITLE
fix: remove instructor info serializer validation

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -40,7 +40,7 @@ class CourseDetailsSerializer(serializers.Serializer):
     entrance_exam_enabled = serializers.CharField(allow_blank=True)
     entrance_exam_id = serializers.CharField(allow_blank=True)
     entrance_exam_minimum_score_pct = serializers.CharField(allow_blank=True)
-    instructor_info = InstructorsSerializer(allow_empty=True, allow_null=True)
+    instructor_info = InstructorsSerializer(allow_empty=True)
     intro_video = serializers.CharField(allow_null=True)
     language = serializers.CharField(allow_null=True)
     learning_info = serializers.ListField(child=serializers.CharField(allow_blank=True))

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -18,7 +18,7 @@ class InstructorInfoSerializer(serializers.Serializer):
 
 class InstructorsSerializer(serializers.Serializer):
     """ Serializer for instructors """
-    instructors = InstructorInfoSerializer(many=True, allow_empty=True, required=False)
+    instructors = InstructorInfoSerializer(many=True, allow_empty=True, allow_blank=True, allow_null=True, required=False)
 
 
 class CourseDetailsSerializer(serializers.Serializer):
@@ -40,7 +40,7 @@ class CourseDetailsSerializer(serializers.Serializer):
     entrance_exam_enabled = serializers.CharField(allow_blank=True)
     entrance_exam_id = serializers.CharField(allow_blank=True)
     entrance_exam_minimum_score_pct = serializers.CharField(allow_blank=True)
-    instructor_info = InstructorsSerializer(allow_null=True)
+    instructor_info = InstructorsSerializer()
     intro_video = serializers.CharField(allow_null=True)
     language = serializers.CharField(allow_null=True)
     learning_info = serializers.ListField(child=serializers.CharField(allow_blank=True))

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -40,7 +40,7 @@ class CourseDetailsSerializer(serializers.Serializer):
     entrance_exam_enabled = serializers.CharField(allow_blank=True)
     entrance_exam_id = serializers.CharField(allow_blank=True)
     entrance_exam_minimum_score_pct = serializers.CharField(allow_blank=True)
-    instructor_info = InstructorsSerializer(allow_empty=True)
+    instructor_info = InstructorsSerializer(allow_blank=True)
     intro_video = serializers.CharField(allow_null=True)
     language = serializers.CharField(allow_null=True)
     learning_info = serializers.ListField(child=serializers.CharField(allow_blank=True))

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -40,7 +40,7 @@ class CourseDetailsSerializer(serializers.Serializer):
     entrance_exam_enabled = serializers.CharField(allow_blank=True)
     entrance_exam_id = serializers.CharField(allow_blank=True)
     entrance_exam_minimum_score_pct = serializers.CharField(allow_blank=True)
-    instructor_info = InstructorsSerializer(allow_blank=True)
+    instructor_info = InstructorsSerializer(allow_null=True)
     intro_video = serializers.CharField(allow_null=True)
     language = serializers.CharField(allow_null=True)
     learning_info = serializers.ListField(child=serializers.CharField(allow_blank=True))

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -18,7 +18,7 @@ class InstructorInfoSerializer(serializers.Serializer):
 
 class InstructorsSerializer(serializers.Serializer):
     """ Serializer for instructors """
-    instructors = InstructorInfoSerializer(many=True, allow_empty=True, allow_blank=True, allow_null=True, required=False)
+    instructors = InstructorInfoSerializer(many=True, allow_empty=True, allow_null=True, required=False)
 
 
 class CourseDetailsSerializer(serializers.Serializer):

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -7,20 +7,6 @@ from rest_framework import serializers
 from openedx.core.lib.api.serializers import CourseKeyField
 
 
-class InstructorInfoSerializer(serializers.Serializer):
-    """ Serializer for instructor info """
-    name = serializers.CharField(allow_blank=True)
-    title = serializers.CharField(allow_blank=True, required=False)
-    organization = serializers.CharField(allow_blank=True, required=False)
-    image = serializers.CharField(allow_blank=True, required=False)
-    bio = serializers.CharField(allow_blank=True, required=False)
-
-
-class InstructorsSerializer(serializers.Serializer):
-    """ Serializer for instructors """
-    instructors = InstructorInfoSerializer(many=True, allow_empty=True)
-
-
 class CourseDetailsSerializer(serializers.Serializer):
     """ Serializer for course details """
     about_sidebar_html = serializers.CharField(allow_null=True, allow_blank=True)
@@ -40,7 +26,7 @@ class CourseDetailsSerializer(serializers.Serializer):
     entrance_exam_enabled = serializers.CharField(allow_blank=True)
     entrance_exam_id = serializers.CharField(allow_blank=True)
     entrance_exam_minimum_score_pct = serializers.CharField(allow_blank=True)
-    instructor_info = InstructorsSerializer()
+    instructor_info = serializers.DictField(allow_empty=True)
     intro_video = serializers.CharField(allow_null=True)
     language = serializers.CharField(allow_null=True)
     learning_info = serializers.ListField(child=serializers.CharField(allow_blank=True))

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -7,6 +7,20 @@ from rest_framework import serializers
 from openedx.core.lib.api.serializers import CourseKeyField
 
 
+class InstructorInfoSerializer(serializers.Serializer):
+    """ Serializer for instructor info """
+    name = serializers.CharField(allow_blank=True, required=False)
+    title = serializers.CharField(allow_blank=True, required=False)
+    organization = serializers.CharField(allow_blank=True, required=False)
+    image = serializers.CharField(allow_blank=True, required=False)
+    bio = serializers.CharField(allow_blank=True, required=False)
+
+
+class InstructorsSerializer(serializers.Serializer):
+    """ Serializer for instructors """
+    instructors = InstructorInfoSerializer(many=True, allow_empty=True, required=False)
+
+
 class CourseDetailsSerializer(serializers.Serializer):
     """ Serializer for course details """
     about_sidebar_html = serializers.CharField(allow_null=True, allow_blank=True)
@@ -26,7 +40,7 @@ class CourseDetailsSerializer(serializers.Serializer):
     entrance_exam_enabled = serializers.CharField(allow_blank=True)
     entrance_exam_id = serializers.CharField(allow_blank=True)
     entrance_exam_minimum_score_pct = serializers.CharField(allow_blank=True)
-    instructor_info = serializers.DictField(allow_empty=True)
+    instructor_info = InstructorsSerializer(allow_empty=True, allow_null=True)
     intro_video = serializers.CharField(allow_null=True)
     language = serializers.CharField(allow_null=True)
     learning_info = serializers.ListField(child=serializers.CharField(allow_blank=True))


### PR DESCRIPTION
## Description

This PR removes serializer validation for `instructor_info` on the course details authoring page. When `instructor_info` is not fetched properly, the api errors and does not return data to the page. 

The typical form for `instructor_info` is:
```
"instructor_info": {
        "instructors": [
            {
                "name": "Instructor Name",
                "title": "",
                "organization: "",
                "image": "",
                "bio": ""
            }
        ]
    },
```

The simplest I've seen is:
```
"instructor_info": {}
```

I've also used `Professeurs` used in place of `instructors`.

Since `instructor_info` comes in so many forms, it is best to just leave it as a `DictField` with its children unvalidated.


## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11484

## Testing instructions

Navigate to the course details page of a course and ensure it loads as expected.

