### PR TITLE
fix: updated email notifications task and ui fixes

### DIFF
--- a/openedx/core/djangoapps/notifications/email/tests/test_tasks.py
+++ b/openedx/core/djangoapps/notifications/email/tests/test_tasks.py
@@ -153,6 +153,7 @@ class TestEmailDigestAudience(ModuleStoreTestCase):
             assert mock_func.called is email_value
 
 
+@ddt.ddt
 class TestPreferences(ModuleStoreTestCase):
     """
     Tests preferences
@@ -176,10 +177,26 @@ class TestPreferences(ModuleStoreTestCase):
         config = self.preference.notification_preference_config
         types = config['discussion']['notification_types']
         types['new_discussion_post']['email_cadence'] = EmailCadence.DAILY
+        types['new_discussion_post']['email'] = True
         self.preference.save()
         with override_waffle_flag(ENABLE_EMAIL_NOTIFICATIONS, True):
             send_digest_email_to_user(self.user, EmailCadence.DAILY)
         assert mock_func.called
+
+    @ddt.data(True, False)
+    @patch('edx_ace.ace.send')
+    def test_email_send_for_email_preference_value(self, pref_value, mock_func):
+        """
+        Tests email is sent iff preference value is True
+        """
+        config = self.preference.notification_preference_config
+        types = config['discussion']['notification_types']
+        types['new_discussion_post']['email_cadence'] = EmailCadence.DAILY
+        types['new_discussion_post']['email'] = pref_value
+        self.preference.save()
+        with override_waffle_flag(ENABLE_EMAIL_NOTIFICATIONS, True):
+            send_digest_email_to_user(self.user, EmailCadence.DAILY)
+        assert mock_func.called is pref_value
 
     @patch('edx_ace.ace.send')
     def test_email_not_send_if_different_digest_preference(self, mock_func):

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -224,7 +224,7 @@ def get_enabled_notification_types_for_cadence(preferences, cadence_type=EmailCa
         config = preference.notification_preference_config
         for app_data in config.values():
             for notification_type, type_dict in app_data['notification_types'].items():
-                if type_dict['email_cadence'] == cadence_type:
+                if (type_dict['email_cadence'] == cadence_type) and type_dict['email']:
                     value.append(notification_type)
             if 'core' in value:
                 value.remove('core')

--- a/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
@@ -39,7 +39,7 @@
                             <p style="color:#707070; margin: 0">
                                 <span style="float: left">
                                     <span>{{ notification.course_name }}</span>
-                                    <span style="padding: 0 0.375rem">&middot</span>
+                                    <span style="padding: 0 0.375rem">{{ "&middot;"|safe }}</span>
                                     <span>{{ notification.time_ago }}</span>
                                 </span>
                                 <span style="float: right">

--- a/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
@@ -1,4 +1,4 @@
-<div style="margin:0; padding:0; min-width: 100%; background-color: background-color:#C9C9C9">
+<div style="margin:0; padding:0; min-width: 100%; background-color:#C9C9C9">
     <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:1.5; max-width:600px; font-family:Inter">
         <tbody style="background-color:#f5f5f5">
             <tr>
@@ -18,5 +18,4 @@
             </tr>
         </tbody>
     </table>
-
 </div>


### PR DESCRIPTION
Updated the following 

- Email filter will use `email` value with `email_cadence` value. Added test case for this change
- Fixed background color
- `&middot;` will be rendered as &middot; not as `&ampmiddot;` 