### PR TITLE
refactor: update to use Learning Core's new public API

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1881,9 +1881,9 @@ INSTALLED_APPS = [
     'openedx_events',
 
     # Learning Core Apps, used by v2 content libraries (content_libraries app)
-    "openedx_learning.core.components",
-    "openedx_learning.core.contents",
-    "openedx_learning.core.publishing",
+    "openedx_learning.apps.authoring.components",
+    "openedx_learning.apps.authoring.contents",
+    "openedx_learning.apps.authoring.publishing",
 ]
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3385,9 +3385,9 @@ INSTALLED_APPS = [
     'openedx_events',
 
     # Learning Core Apps, used by v2 content libraries (content_libraries app)
-    "openedx_learning.core.components",
-    "openedx_learning.core.contents",
-    "openedx_learning.core.publishing",
+    "openedx_learning.apps.authoring.components",
+    "openedx_learning.apps.authoring.contents",
+    "openedx_learning.apps.authoring.publishing",
 ]
 
 

--- a/openedx/core/djangoapps/content_libraries/library_context.py
+++ b/openedx/core/djangoapps/content_libraries/library_context.py
@@ -10,7 +10,7 @@ from openedx.core.djangoapps.content_libraries import api, permissions
 from openedx.core.djangoapps.content_libraries.models import ContentLibrary
 from openedx.core.djangoapps.xblock.api import LearningContext
 
-from openedx_learning.core.components import api as components_api
+from openedx_learning.api import authoring as authoring_api
 
 log = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class LibraryContextImpl(LearningContext):
         if learning_package is None:
             return False
 
-        return components_api.component_exists_by_key(
+        return authoring_api.component_exists_by_key(
             learning_package.id,
             namespace='xblock.v1',
             type_name=usage_key.block_type,

--- a/openedx/core/djangoapps/content_libraries/models.py
+++ b/openedx/core/djangoapps/content_libraries/models.py
@@ -57,7 +57,7 @@ from openedx.core.djangoapps.content_libraries.constants import (
     LIBRARY_TYPES, COMPLEX, LICENSE_OPTIONS,
     ALL_RIGHTS_RESERVED,
 )
-from openedx_learning.core.publishing.models import LearningPackage
+from openedx_learning.api.authoring_models import LearningPackage
 from organizations.models import Organization  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .apps import ContentLibrariesConfig

--- a/openedx/core/djangoapps/xblock/api.py
+++ b/openedx/core/djangoapps/xblock/api.py
@@ -15,12 +15,10 @@ import threading
 
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from openedx_learning.core.components import api as components_api
-from openedx_learning.core.components.models import Component
-from openedx_learning.core.publishing import api as publishing_api
+from openedx_learning.api import authoring as authoring_api
+from openedx_learning.api.authoring_models import Component
 from opaque_keys.edx.keys import UsageKeyV2
 from opaque_keys.edx.locator import BundleDefinitionLocator, LibraryUsageLocatorV2
-
 from rest_framework.exceptions import NotFound
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchViewError
@@ -28,13 +26,10 @@ from xblock.plugin import PluginMissingError
 
 from openedx.core.djangoapps.xblock.apps import get_xblock_app_config
 from openedx.core.djangoapps.xblock.learning_context.manager import get_learning_context_impl
-
 from openedx.core.djangoapps.xblock.runtime.learning_core_runtime import (
     LearningCoreFieldData,
     LearningCoreXBlockRuntime,
 )
-
-
 from openedx.core.djangoapps.xblock.runtime.runtime import XBlockRuntimeSystem as _XBlockRuntimeSystem
 from .utils import get_secure_token_for_xblock_handler, get_xblock_id_for_anonymous_user
 
@@ -192,10 +187,10 @@ def get_component_from_usage_key(usage_key: UsageKeyV2) -> Component:
     This is a lower-level function that will return a Component even if there is
     no current draft version of that Component (because it's been soft-deleted).
     """
-    learning_package = publishing_api.get_learning_package_by_key(
+    learning_package = authoring_api.get_learning_package_by_key(
         str(usage_key.context_key)
     )
-    return components_api.get_component_by_key(
+    return authoring_api.get_component_by_key(
         learning_package.id,
         namespace='xblock.v1',
         type_name=usage_key.block_type,

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -10,9 +10,7 @@ from datetime import datetime, timezone
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.transaction import atomic
 
-from openedx_learning.core.components import api as components_api
-from openedx_learning.core.contents import api as contents_api
-from openedx_learning.core.publishing import api as publishing_api
+from openedx_learning.api import authoring as authoring_api
 
 from lxml import etree
 
@@ -239,16 +237,16 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
         usage_key = block.scope_ids.usage_id
         with atomic():
             component = self._get_component_from_usage_key(usage_key)
-            block_media_type = contents_api.get_or_create_media_type(
+            block_media_type = authoring_api.get_or_create_media_type(
                 f"application/vnd.openedx.xblock.v1.{usage_key.block_type}+xml"
             )
-            content = contents_api.get_or_create_text_content(
+            content = authoring_api.get_or_create_text_content(
                 component.learning_package_id,
                 block_media_type.id,
                 text=serialized.olx_str,
                 created=now,
             )
-            components_api.create_next_version(
+            authoring_api.create_next_version(
                 component.pk,
                 title=block.display_name,
                 content_to_replace={
@@ -267,9 +265,9 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
         TODO: This is the third place where we're implementing this. Figure out
         where the definitive place should be and have everything else call that.
         """
-        learning_package = publishing_api.get_learning_package_by_key(str(usage_key.lib_key))
+        learning_package = authoring_api.get_learning_package_by_key(str(usage_key.lib_key))
         try:
-            component = components_api.get_component_by_key(
+            component = authoring_api.get_component_by_key(
                 learning_package.id,
                 namespace='xblock.v1',
                 type_name=usage_key.block_type,

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,7 +97,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.9.4
+openedx-learning==0.10.0
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -775,7 +775,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.4
+openedx-learning==0.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1331,7 +1331,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.4
+openedx-learning==0.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -906,7 +906,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.4
+openedx-learning==0.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -991,7 +991,7 @@ openedx-filters==1.8.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.9.4
+openedx-learning==0.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ root_packages =
     lms
     cms
     openedx
+    openedx_learning
 include_external_packages = True
 contract_types =
     # Our custom contract which checks that we're only importing from 'api.py'
@@ -185,3 +186,14 @@ allowed_modules =
     # Only imports from api.py are allowed elsewhere in the code
     # See https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0049-django-app-patterns.html#api-py
     api
+
+[importlinter:contract:3]
+name = Do not import apps from openedx-learning (only import from openedx_learning.api.* and openedx_learning.lib.*).
+type = forbidden
+source_modules =
+    cms
+    lms
+    openedx
+forbidden_modules =
+    openedx_learning.apps
+allow_indirect_imports = True


### PR DESCRIPTION
Depends on https://github.com/openedx/openedx-learning/pull/184

This is a disruptive, backwards-incompatible change as far as code is concerned, but involves no database changes.

* We now import from the consolidated public API module `openedx_learning.api.authoring` instead of individual apps.
* Models come from `openedx_learning.api.authoring_models`.
* Import linting is added to enforce that `openedx_learning.apps` is intended to be private.