### PR TITLE
fix: Added message to Course update notification in case of small text

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2251,7 +2251,7 @@ def send_course_update_notification(course_key, content, user):
     notification_data = CourseNotificationData(
         course_key=course_key,
         content_context={
-            "course_update_content": text_content,
+            "course_update_content": text_content if len(text_content.strip()) < 10 else "Click here to view",
             **extra_context,
         },
         notification_type="course_update",


### PR DESCRIPTION
## Description

In case the course update message has less than 10 chars after trimming, use this message `Click here to view`

## Ticket
https://2u-internal.atlassian.net/browse/INF-1381