### PR TITLE
feat: add FrontendMonitoringMiddleware in lms and studio

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -915,6 +915,7 @@ MIDDLEWARE = [
     # Various monitoring middleware
     'edx_django_utils.monitoring.CookieMonitoringMiddleware',
     'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
+    'edx_django_utils.monitoring.FrontendMonitoringMiddleware',
     'edx_django_utils.monitoring.MonitoringMemoryMiddleware',
 
     # Before anything that looks at cookies, especially the session middleware

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2256,6 +2256,7 @@ MIDDLEWARE = [
     'edx_django_utils.monitoring.CodeOwnerMonitoringMiddleware',
     'edx_django_utils.monitoring.CookieMonitoringMiddleware',
     'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
+    'edx_django_utils.monitoring.FrontendMonitoringMiddleware',
 
     # Before anything that looks at cookies, especially the session middleware
     'openedx.core.djangoapps.cookie_metadata.middleware.CookieNameChange',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -436,7 +436,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/kernel.in
-edx-django-utils==5.13.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/edx/kernel.in
     #   django-config-models

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -713,7 +713,7 @@ edx-django-sites-extensions==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-utils==5.13.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -510,7 +510,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/base.txt
-edx-django-utils==5.13.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -68,8 +68,8 @@ edx-completion
 edx-django-release-util             # Release utils for the edx release pipeline
 edx-django-sites-extensions
 edx-codejail
-# edx-django-utils 5.4.0 adds CSP middleware
-edx-django-utils>=5.4.0             # Utilities for cache, monitoring, and plugins
+# edx-django-utils 5.14.1 adds FrontendMonitoringMiddleware
+edx-django-utils>=5.14.1             # Utilities for cache, monitoring, and plugins
 edx-drf-extensions
 edx-enterprise
 # edx-event-bus-kafka 5.6.0 adds support for putting client ids on event producers/consumers

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -543,7 +543,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/base.txt
-edx-django-utils==5.13.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -50,7 +50,7 @@ django-crum==0.7.9
     # via edx-django-utils
 django-waffle==4.1.0
     # via edx-django-utils
-edx-django-utils==5.13.0
+edx-django-utils==5.14.1
     # via edx-rest-api-client
 edx-rest-api-client==5.7.0
     # via -r scripts/user_retirement/requirements/base.in

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -70,7 +70,7 @@ django-waffle==4.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.13.0
+edx-django-utils==5.14.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client


### PR DESCRIPTION
Adds FrontendMonitoringMiddleware for inserting frontend monitoring scripts into the response

**Related PR:** 
- https://github.com/openedx/edx-django-utils/pull/415

**Issue:** 
- https://github.com/edx/edx-arch-experiments/issues/639