### PR TITLE
test: check both dev and prod asset builds (with npm run)

### DIFF
--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -68,9 +68,9 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
-    - name: Install Required Python Dependencies
+    - name: Install Limited Python Deps for Build
       run: |
-        make base-requirements
+        pip install -r requirements/edx/assets.txt
 
     - name: Initiate Mongo DB Service
       run: sudo systemctl start mongod
@@ -78,11 +78,29 @@ jobs:
     - name: Add node_modules bin to $Path
       run: echo $GITHUB_WORKSPACE/node_modules/.bin >> $GITHUB_PATH
 
-    - name: Run Static Assets Check
+    - name: Check Dev Assets Build
+      env:
+        COMPREHENSIVE_THEMES_DIR: ./themes
+      run: |
+        npm clean-install --dev
+        npm run build-dev
+
+    - name: Check Prod Assets Build
+      env:
+        COMPREHENSIVE_THEMES_DIR: ./themes
+      run: |
+        npm clean-install
+        npm run build
+
+    - name: Install Full Python Deps for Collection
+      run: |
+        pip install -r requirements/edx/base.txt -e .
+
+    - name: Check Assets Collection
       env:
         LMS_CFG: lms/envs/minimal.yml
         CMS_CFG: lms/envs/minimal.yml
-
+        DJANGO_SETTINGS_MODULE: lms.envs.production
       run: |
-        paver update_assets lms --theme-dirs ./themes
-        paver update_assets cms --theme-dirs ./themes
+        ./manage.py lms collectstatic --noinput
+        ./manage.py cms collectstatic --noinput

--- a/docs/references/static-assets.rst
+++ b/docs/references/static-assets.rst
@@ -139,7 +139,7 @@ skip this section.
 First, ensure you have a Python enironment with all edx-platform dependencies
 installed::
 
-  pip install -r requirements/edx/base.txt
+  pip install -r requirements/edx/base.txt -e .
 
 Next, download localized versions of edx-platform assets. Under the hood, this
 command uses the `Open edX Atlas`_ tool, which manages aggregated translations


### PR DESCRIPTION
This switches the static asset check over from the deprecated paver commands to the new 'npm run build' command. Doing so allows us to check both the prod AND dev build, whereas before we were only checking the prod build.

Please note that, as before, the "check" is only ensuring that the build returns 0. It is not checking the contents of the build output.

Closes: https://github.com/openedx/edx-platform/issues/34834