### PR TITLE
build: Update renovate config.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,34 @@
 {
   "extends": [
     "config:base",
-    "schedule:weekdays",
-    ":preserveSemverRanges"
+    "schedule:weekly",
+    ":automergeLinters",
+    ":automergeMinor",
+    ":automergeTesters",
+    ":enableVulnerabilityAlerts",
+    ":semanticCommits",
+    ":updateNotScheduled"
   ],
-  "prConcurrentLimit": 5,
-  "includePaths": [
-    "package.json"
-  ]
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance",
+        "minor",
+        "patch",
+        "pin"
+      ],
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["@edx", "@openedx"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ],
+  "timezone": "America/New_York",
+  "prConcurrentLimit": 3,
+  "enabledManagers": ["npm"]
 }


### PR DESCRIPTION
Update the renovate config in edx-platform to match the standard config
in most of our other frontend repos, with the exception of 1 settings:

Given the size of edx-platform I want to limit the number of concurrent
renovate PRs to a very small number so that we don't overwhelm our CI
resources.  If we find that it would be useful to get more PRs at a
time, we can change this setting in the future.
