### PR TITLE
docs: fix minor typos in the meilisearch feature configuration

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2958,13 +2958,13 @@ REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
 
 BEAMER_PRODUCT_ID = ""
 
-################### Studio Search (alpha, using Meilisearch) ###################
+################### Studio Search (beta), using Meilisearch ###################
 
 # Enable Studio search features (powered by Meilisearch) (beta, off by default)
 MEILISEARCH_ENABLED = False
 # Meilisearch URL that the python backend can use. Often points to another docker container or k8s service.
 MEILISEARCH_URL = "http://meilisearch"
-# URL that browsers (end users) can user to reach Meilisearch. Should be HTTPS in production.
+# URL that browsers (end users) can use to reach Meilisearch. Should be HTTPS in production.
 MEILISEARCH_PUBLIC_URL = "http://meilisearch.example.com"
 # To support multi-tenancy, you can prefix all indexes with a common key like "sandbox7-"
 # and use a restricted tenant token in place of an API key, so that this Open edX instance


### PR DESCRIPTION
No code changes; just fix a typos and inconsistency in the comments related to the "Studio Search (beta)" feature.