### PR TITLE
 fix: don't call signal handlers like XBLOCK_UPDATED before commit

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2953,13 +2953,13 @@ REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
 
 BEAMER_PRODUCT_ID = ""
 
-################### Studio Search (alpha, using Meilisearch) ###################
+################### Studio Search (beta), using Meilisearch ###################
 
 # Enable Studio search features (powered by Meilisearch) (beta, off by default)
 MEILISEARCH_ENABLED = False
 # Meilisearch URL that the python backend can use. Often points to another docker container or k8s service.
 MEILISEARCH_URL = "http://meilisearch"
-# URL that browsers (end users) can user to reach Meilisearch. Should be HTTPS in production.
+# URL that browsers (end users) can use to reach Meilisearch. Should be HTTPS in production.
 MEILISEARCH_PUBLIC_URL = "http://meilisearch.example.com"
 # To support multi-tenancy, you can prefix all indexes with a common key like "sandbox7-"
 # and use a restricted tenant token in place of an API key, so that this Open edX instance

--- a/xmodule/modulestore/__init__.py
+++ b/xmodule/modulestore/__init__.py
@@ -121,6 +121,7 @@ class BulkOpsRecord:
         self._active_count = 0
         self.has_publish_item = False
         self.has_library_updated_item = False
+        self._commit_callbacks = []
 
     @property
     def active(self):
@@ -147,6 +148,20 @@ class BulkOpsRecord:
         Return whether the bulk write is at the root (first) level of nesting
         """
         return self._active_count == 1
+
+    def defer_until_commit(self, fn):
+        """
+        Run some code when the changes from this bulk op are committed to the DB
+        """
+        self._commit_callbacks.append(fn)
+
+    def call_commit_callbacks(self):
+        """
+        When the changes have been committed to the DB, call this to run any queued callbacks
+        """
+        for fn in self._commit_callbacks:
+            fn()
+        self._commit_callbacks.clear()
 
 
 class ActiveBulkThread(threading.local):
@@ -290,14 +305,33 @@ class BulkOperationsMixin:
         # So re-nest until the signals are sent.
         bulk_ops_record.nest()
 
-        if emit_signals and dirty:
-            self.send_bulk_published_signal(bulk_ops_record, structure_key)
-            self.send_bulk_library_updated_signal(bulk_ops_record, structure_key)
+        if dirty:
+            # Call any "on commit" callback, regardless of if this was "published" or is still draft:
+            bulk_ops_record.call_commit_callbacks()
+            # Call any "on publish" handlers - emit_signals is usually false for draft-only changes:
+            if emit_signals:
+                self.send_bulk_published_signal(bulk_ops_record, structure_key)
+                self.send_bulk_library_updated_signal(bulk_ops_record, structure_key)
 
         # Signals are sent. Now unnest and clear the bulk op for good.
         bulk_ops_record.unnest()
 
         self._clear_bulk_ops_record(structure_key)
+
+    def on_commit_changes_to(self, course_key, fn):
+        """
+        Call some callback when the currently active bulk operation has saved
+        """
+        # Check if a bulk op is active. If so, defer fn(); otherwise call it immediately.
+        # Note: calling _get_bulk_ops_record() here and then checking .active can have side-effects in some cases
+        # because it creates an entry in the defaultdict if none exists, so we check if the record is active using
+        # the same code as _clear_bulk_ops_record(), which doesn't modify the defaultdict.
+        # so we check it this way:
+        if course_key and course_key.for_branch(None) in self._active_bulk_ops.records:
+            bulk_ops_record = self._active_bulk_ops.records[course_key.for_branch(None)]
+            bulk_ops_record.defer_until_commit(fn)
+        else:
+            fn()  # There is no active bulk operation - call fn() now.
 
     def _is_in_bulk_operation(self, course_key, ignore_case=False):
         """


### PR DESCRIPTION
## Description

This backports an import fix, #34800, to Redwood. I also included #34838, a tiny fix to some comments (no code changes).

Without this fix, authors may make changes to course content in Studio but won't see those changes when they use the new studio course search feature; the search index would only show an older version of the content.

## Supporting information

See #34800

## Testing instructions

1. Enable [Content Search beta](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3890380898/Next+Release+Redwood+-+Operator+Dev+Notes)
2. Make changes to a course in Studio - e.g. rename a subsection
3. Verify that the changes are always reflected (almost) right away in the [studio search results](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4247257093/BETA+Course+Search+-+Product+Release+Notes)

## Deadline

Ideally before Redwood official release


Private ref: FAL-3715
