### PR TITLE
fix: make lis_person_contact_email_primary matching case-insensitive (LTI Providers)

### DIFF
--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -158,6 +158,16 @@ class AuthenticateLtiUserTest(TestCase):
         users.authenticate_lti_user(request, self.lti_user_id, self.auto_linking_consumer)
         create_user.assert_called_with(self.lti_user_id, self.auto_linking_consumer, self.old_user.email)
 
+    def test_auto_linking_of_users_using_lis_person_contact_email_primary_case_insensitive(self, create_user, switch_user):  # pylint: disable=line-too-long
+        request = RequestFactory().post("/", {"lis_person_contact_email_primary": self.old_user.email.upper()})
+        request.user = self.old_user
+
+        users.authenticate_lti_user(request, self.lti_user_id, self.lti_consumer)
+        create_user.assert_called_with(self.lti_user_id, self.lti_consumer)
+
+        users.authenticate_lti_user(request, self.lti_user_id, self.auto_linking_consumer)
+        create_user.assert_called_with(self.lti_user_id, self.auto_linking_consumer, request.user.email)
+
     def test_raise_exception_trying_to_auto_link_unauthenticate_user(self, create_user, switch_user):
         request = RequestFactory().post("/")
         request.user = AnonymousUser()

--- a/lms/djangoapps/lti_provider/users.py
+++ b/lms/djangoapps/lti_provider/users.py
@@ -40,8 +40,8 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
         if lti_consumer.require_user_account:
             # Verify that the email from the LTI Launch and the logged-in user are the same
             # before linking the LtiUser with the edx_user.
-            if request.user.is_authenticated and request.user.email == lis_email:
-                lti_user = create_lti_user(lti_user_id, lti_consumer, lis_email)
+            if request.user.is_authenticated and request.user.email.lower() == lis_email.lower():
+                lti_user = create_lti_user(lti_user_id, lti_consumer, request.user.email)
             else:
                 # Ask the user to login before linking.
                 raise PermissionDenied() from exc


### PR DESCRIPTION
Backport of https://github.com/openedx/edx-platform/pull/34688 to Redwood. 

If you are looking for the PR details, Please visit the original PR https://github.com/openedx/edx-platform/pull/34688.