### PR TITLE
chore: bump ora to 6.11.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -785,7 +785,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
-ora2==6.11.0
+ora2==6.11.1
     # via -r requirements/edx/bundled.in
 packaging==24.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1345,7 +1345,7 @@ optimizely-sdk==4.1.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.11.0
+ora2==6.11.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -916,7 +916,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-ora2==6.11.0
+ora2==6.11.1
     # via -r requirements/edx/base.txt
 packaging==24.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1001,7 +1001,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-ora2==6.11.0
+ora2==6.11.1
     # via -r requirements/edx/base.txt
 orjson==3.10.3
     # via fastapi


### PR DESCRIPTION
Had some wonkiness with the upgrade a single requirement action so I'm just doing it on my own.

release a bugfix version of ORA