### PR TITLE
feat: include units when calculating completion percentage (#34816)

### DIFF
--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -66,6 +66,8 @@ class CourseBlockSerializer(serializers.Serializer):
         }
         if 'special_exam_info' in self.context.get('extra_fields', []) and block.get('special_exam_info'):
             serialized[block_key]['special_exam_info'] = block.get('special_exam_info').get('short_description')
+        if 'completion_stat' in self.context.get('extra_fields', []):
+            serialized[block_key]['completion_stat'] = block.get('completion_stat', {})
 
         for child in children:
             serialized.update(self.get_blocks(child))


### PR DESCRIPTION
## Description

**This is a redwood backport PR for the - https://github.com/openedx/edx-platform/pull/34816**

This is an enhancement to the API used for the courseware navigation sidebar. This PR adds the calculation of user progress to the API for navigating the sidebar that returns the course structure.


Also, additional completion data being added to the backend response to address a bug that was uncovered during the release candidate testing process.



## Testing instructions

- Create a course with different access rights to course blocks (sections/subsections/subsections) for different users.
- Make GET requests to the API (/api/course_home/v1/navigation/{course_id}) and check if the API returns the correct progress(completion_stat field) on the compliments for the user.
- Get new completions in a test course
- Make GET requests to the API again and check that the progress has changed.



## Supporting information

This feature is done as part of FC-0056. Related GH issue: https://github.com/openedx/platform-roadmap/issues/329


## Deadline

June 2024 / Redwood release

