### PR TITLE
feat: add filter to hook render of XBlock

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1672,8 +1672,14 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
                 context=context, student_view_context=student_view_context
             )
         except RenderXBlockStarted.PreventXBlockBlockRender as exc:
-            log.info("Skipping rendering block %s. Reason: %s", usage_key_string, exc.message)
+            log.info("Halted rendering block %s. Reason: %s", usage_key_string, exc.message)
             return render_500()
+        except RenderXBlockStarted.RenderCustomResponse as exc:
+            log.info("Rendering custom exception for block %s. Reason: %s", usage_key_string, exc.message)
+            context.update({
+                'fragment': Fragment(exc.response)
+            })
+            return render_to_response('courseware/courseware-chromeless.html', context, request=request)
 
         fragment = block.render(requested_view, context=student_view_context)
         optimization_flags = get_optimization_flags_for_content(block, fragment)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -37,7 +37,7 @@ from lms.djangoapps.static_template_view.views import render_500
 from markupsafe import escape
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from openedx_filters.learning.filters import CourseAboutRenderStarted, RenderXBlockCompleted
+from openedx_filters.learning.filters import CourseAboutRenderStarted, RenderXBlockStarted
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from pytz import UTC
 from rest_framework import status
@@ -1674,10 +1674,10 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
         try:
             # .. filter_implemented_name: RenderXBlockStarted
             # .. filter_type: org.openedx.learning.xblock.render.started.v1
-            context, student_view_context = RenderXBlockCompleted.run_filter(
+            context, student_view_context = RenderXBlockStarted.run_filter(
                 context=context, student_view_context=student_view_context
             )
-        except RenderXBlockCompleted.PreventXBlockBlockRender as exc:
+        except RenderXBlockStarted.PreventXBlockBlockRender as exc:
             log.info("Skipping rendering block %s. Reason: %s", usage_key_string, exc.message)
             return render_500()
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -37,7 +37,7 @@ from lms.djangoapps.static_template_view.views import render_500
 from markupsafe import escape
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from openedx_filters.learning.filters import CourseAboutRenderStarted, RenderXBlockStarted
+from openedx_filters.learning.filters import CourseAboutRenderStarted, RenderXBlockCompleted
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from pytz import UTC
 from rest_framework import status
@@ -1674,10 +1674,10 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
         try:
             # .. filter_implemented_name: RenderXBlockStarted
             # .. filter_type: org.openedx.learning.xblock.render.started.v1
-            context, student_view_context = RenderXBlockStarted.run_filter(
+            context, student_view_context = RenderXBlockCompleted.run_filter(
                 context=context, student_view_context=student_view_context
             )
-        except RenderXBlockStarted.PreventXBlockBlockRender as exc:
+        except RenderXBlockCompleted.PreventXBlockBlockRender as exc:
             log.info("Skipping rendering block %s. Reason: %s", usage_key_string, exc.message)
             return render_500()
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1533,7 +1533,7 @@ def _check_sequence_exam_access(request, location):
 @xframe_options_exempt
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
-def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_staff_debug_info=False):
+def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_staff_debug_info=False):  # pylint: disable=too-many-statements
     """
     Returns an HttpResponse with HTML content for the xBlock with the given usage_key.
     The returned HTML is a chromeless rendering of the xBlock (excluding content of the containing courseware).

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1673,7 +1673,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
             )
         except RenderXBlockStarted.PreventXBlockBlockRender as exc:
             log.info("Halted rendering block %s. Reason: %s", usage_key_string, exc.message)
-            return render_500()
+            return render_500(request)
         except RenderXBlockStarted.RenderCustomResponse as exc:
             log.info("Rendering custom exception for block %s. Reason: %s", usage_key_string, exc.message)
             context.update({

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1642,11 +1642,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
                 if not _check_sequence_exam_access(request, seq_block.location):
                     return HttpResponseForbidden("Access to exam content is restricted")
 
-        fragment = block.render(requested_view, context=student_view_context)
-        optimization_flags = get_optimization_flags_for_content(block, fragment)
-
         context = {
-            'fragment': fragment,
             'course': course,
             'block': block,
             'disable_accordion': True,
@@ -1667,8 +1663,6 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
             'is_learning_mfe': is_learning_mfe,
             'is_mobile_app': is_mobile_app,
             'render_course_wide_assets': True,
-
-            **optimization_flags,
         }
 
         try:
@@ -1680,6 +1674,14 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
         except RenderXBlockStarted.PreventXBlockBlockRender as exc:
             log.info("Skipping rendering block %s. Reason: %s", usage_key_string, exc.message)
             return render_500()
+
+        fragment = block.render(requested_view, context=student_view_context)
+        optimization_flags = get_optimization_flags_for_content(block, fragment)
+
+        context.update({
+            'fragment': fragment,
+            **optimization_flags,
+        })
 
         return render_to_response('courseware/courseware-chromeless.html', context, request=request)
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -746,7 +746,7 @@ openedx-events==9.10.0
     #   edx-event-bus-redis
     #   event-tracking
     #   ora2
-openedx-filters==1.8.1
+openedx-filters==1.9.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1284,7 +1284,7 @@ openedx-events==9.10.0
     #   edx-event-bus-redis
     #   event-tracking
     #   ora2
-openedx-filters==1.8.1
+openedx-filters==1.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -872,7 +872,7 @@ openedx-events==9.10.0
     #   edx-event-bus-redis
     #   event-tracking
     #   ora2
-openedx-filters==1.8.1
+openedx-filters==1.9.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -951,7 +951,7 @@ openedx-events==9.10.0
     #   edx-event-bus-redis
     #   event-tracking
     #   ora2
-openedx-filters==1.8.1
+openedx-filters==1.9.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock


### PR DESCRIPTION
## Description

Implement filter for PR: https://github.com/openedx/openedx-filters/pull/171

For our particular use case, this allows us to read / update information on the request object for an XBlock render.

## Testing instructions

1. Check out related openedx-filters branch: [nsprenkle:nsprenke/render-xblock-filter](https://github.com/nsprenkle/openedx-filters/tree/nsprenke/render-xblock-filter)
2. Update edx-platform to this PR branch.
3. Install local copy of openedx-filters.
4. Attempt to render an xblobk: `http://{lms}/xblock/block-v1:{block-id}?view=student_view`
5. Verify filter step is run.