### PR TITLE
fix: update timeout for course reindexing

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -278,7 +278,7 @@ class SearchIndexerBase(metaclass=ABCMeta):
         (Re)index all content within the given structure (course or library),
         tracking the fact that a full reindex has taken place
         """
-        indexed_count = cls.index(modulestore, structure_key)
+        indexed_count = cls.index(modulestore, structure_key, timeout=180)
         if indexed_count:
             cls._track_index_request(cls.INDEX_EVENT['name'], cls.INDEX_EVENT['category'], indexed_count)
         return indexed_count


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

The Cosmonauts team has found that larger courses (like CS50x) take longer than a minute to index. In order to accommodate similar courses, the timeout value should be increased from the default value of 60 seconds to 180 seconds.