### PR TITLE
fix: problem editor content style

### DIFF
--- a/cms/static/sass/xmodule/_headings.scss
+++ b/cms/static/sass/xmodule/_headings.scss
@@ -41,7 +41,7 @@ $headings-base-color:                       $gray-d2;
 %hd-3 {
   margin-bottom: ($baseline / 2);
   font-size: 1.35em;
-  font-weight: $headings-font-weight-normal;
+  font-weight: $headings-font-weight-bold;
   line-height: 1.4em;
 }
 
@@ -105,15 +105,13 @@ $headings-base-color:                       $gray-d2;
   // ----------------------------
   // canned heading classes
   @for $i from 1 through $headings-count {
+    h#{$i},
     .hd-#{$i} {
       @extend %hd-#{$i};
     }
   }
 
   h3 {
-    @extend %hd-2;
-
-    font-weight: $headings-font-weight-normal;
     // override external modules and xblocks that use inline CSS
     text-transform: initial;
   }

--- a/lms/static/sass/base/_headings.scss
+++ b/lms/static/sass/base/_headings.scss
@@ -41,7 +41,7 @@ $headings-base-color:                       $gray-d2;
 %hd-3 {
   margin-bottom: ($baseline / 2);
   font-size: 1.35em;
-  font-weight: $headings-font-weight-normal;
+  font-weight: $headings-font-weight-bold;
   line-height: 1.4em;
 }
 
@@ -112,10 +112,13 @@ $headings-base-color:                       $gray-d2;
 // H3 was problematic in xblocks, we so we'll keep it as it was
 
 .xblock .xblock {
-  h2 {
-    @extend %hd-2;
+  @for $i from 1 through $headings-count {
+    h#{$i} {
+      @extend %hd-#{$i};
+    }
+  }
 
-    font-weight: $headings-font-weight-bold;
+  h2 {
     // override external modules and xblocks that use inline CSS
     text-transform: initial;
 

--- a/xmodule/assets/capa/_display.scss
+++ b/xmodule/assets/capa/_display.scss
@@ -572,10 +572,10 @@ div.problem {
       }
 
       .grading {
-        margin: 0px 7px 0 0;
+        margin: 0 7px 0 0;
         padding-left: 25px;
         background: url('#{$static-path}/images/info-icon.png') left center no-repeat;
-        text-indent: 0px;
+        text-indent: 0;
       }
 
       p {
@@ -646,7 +646,7 @@ div.problem {
     }
 
     .submit-message-container {
-      margin: $baseline 0px ;
+      margin: $baseline 0;
     }
   }
 
@@ -657,6 +657,7 @@ div.problem {
   }
 
   ul {
+    padding-left: 1em;
     margin-bottom: lh();
     margin-left: .75em;
     margin-left: .75rem;
@@ -664,6 +665,7 @@ div.problem {
   }
 
   ol {
+    padding-left: 1em;
     margin-bottom: lh();
     margin-left: .75em;
     margin-left: .75rem;
@@ -705,6 +707,8 @@ div.problem {
     margin: lh() 0;
     border-collapse: collapse;
     table-layout: auto;
+    max-width: 100%;
+    border: 1px solid;
 
     td, th {
       &.cont-justified-left {
@@ -745,6 +749,7 @@ div.problem {
 
     tr, td, th {
       vertical-align: middle;
+      border: 1px solid;
     }
   }
 
@@ -1155,10 +1160,10 @@ div.problem {
         color: $uxpl-gray-dark;
       }
 
-      li {
+      li[class*="hint-index-"] {
         color: $uxpl-gray-base;
 
-        strong {
+        & > strong {
           color: $uxpl-gray-dark;
         }
       }
@@ -1186,6 +1191,16 @@ div.problem {
         li:not(:last-child) {
           margin-bottom: $baseline / 4;
         }
+      }
+
+      li[class*="hint-index-"] ul,
+      li[class*="hint-index-"] ol {
+        padding: 0 0 0 1em;
+        margin-left: .75rem;
+      }
+
+      li[class*="hint-index-"] ol {
+        list-style: decimal outside none;
       }
     }
 


### PR DESCRIPTION
### Description
This pull request contains styling fixes of content editor for Problem xblock. For fields Question, Answers, Feedback, Hints:
- [1] Heading 3, Heading 4, Heading 5, Heading 6
- [2] Numbered list is displayed without numbers

#### Related Pull Requests
PR to the quince branch: https://github.com/openedx/edx-platform/pull/34870
PR to the master branch: https://github.com/openedx/frontend-lib-content-components/pull/478

#### Screenshots before:
| **[1]** <img width="1223" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/b9c54e70-2c45-4691-ba60-900db14aba93"> | **[1]** <img width="852" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/2916de16-483f-4501-9f04-60e108d7cdcb"> | **[2]** <img width="1223" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/2e835275-2a95-4872-b02e-75dffbf92826">  | **[2]** <img width="1157" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/24021321-7e74-4aad-a941-68159aab3827">  |
|---|---|---|---|

#### Screenshots after:
| **[1]** <img width="1286" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/f8b4790a-8abb-4c8d-a850-014e48f0d5db"> | **[1]** <img width="1309" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/bfb4c06a-c86a-41f9-a37f-a6e5ee973e6d"> | **[2]** <img width="1294" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/390c6d5d-0df7-4f0e-888d-94d65fedefaa">  | **[2]** <img width="1399" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/4d461fff-11ed-4d3f-b1a7-2be1ca4744de">  |
|---|---|---|---|

#### Steps to Reproduce: 
1. Enable new problem editor and sharing by adding in `/admin/waffle/flag/`
- [new_core_editors.use_new_problem_editor](http://localhost:18000/admin/waffle/flag/9/change/)
2. In studio open unit -> add new component -> Problem -> Single / Multiple select
3. Check problem displaying