### PR TITLE
Send IDV approval email in approve_id_verifications management command

### DIFF
--- a/lms/djangoapps/verify_student/api.py
+++ b/lms/djangoapps/verify_student/api.py
@@ -1,0 +1,35 @@
+"""
+API module.
+"""
+from django.conf import settings
+from django.utils.translation import gettext as _
+
+from lms.djangoapps.verify_student.emails import send_verification_approved_email
+from lms.djangoapps.verify_student.tasks import send_verification_status_email
+
+
+def send_approval_email(attempt):
+    """
+    Send an approval email to the learner associated with the IDV attempt.
+    """
+    verification_status_email_vars = {
+        'platform_name': settings.PLATFORM_NAME,
+    }
+
+    expiration_datetime = attempt.expiration_datetime.date()
+    if settings.VERIFY_STUDENT.get('USE_DJANGO_MAIL'):
+        verification_status_email_vars['expiration_datetime'] = expiration_datetime.strftime("%m/%d/%Y")
+        verification_status_email_vars['full_name'] = attempt.user.profile.name
+        subject = _("Your {platform_name} ID verification was approved!").format(
+            platform_name=settings.PLATFORM_NAME
+        )
+        context = {
+            'subject': subject,
+            'template': 'emails/passed_verification_email.txt',
+            'email': attempt.user.email,
+            'email_vars': verification_status_email_vars
+        }
+        send_verification_status_email.delay(context)
+    else:
+        email_context = {'user': attempt.user, 'expiration_datetime': expiration_datetime.strftime("%m/%d/%Y")}
+        send_verification_approved_email(context=email_context)

--- a/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
@@ -11,6 +11,7 @@ from pprint import pformat
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand, CommandError
 
+from lms.djangoapps.verify_student.api import send_approval_email
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from lms.djangoapps.verify_student.utils import earliest_allowed_verification_date
 
@@ -125,8 +126,8 @@ class Command(BaseCommand):
 
     def _approve_id_verifications(self, user_ids):
         """
-        This command manually approves ID verification attempts for a provided set of learners whose ID verification
-        attempt is in the submitted or must_retry state.
+        This method manually approves ID verification attempts for a provided set of user IDs so long as the attempt
+        is in the submitted or must_retry state. This method also send an IDV approval email to the user.
 
         Arguments:
             user_ids (list): user IDs of the users whose ID verification attempt should be manually approved
@@ -148,5 +149,6 @@ class Command(BaseCommand):
 
         for verification in existing_id_verifications:
             verification.approve(service='idv_verifications command')
+            send_approval_email(verification)
 
         return list(failed_user_ids)

--- a/lms/djangoapps/verify_student/tests/test_api.py
+++ b/lms/djangoapps/verify_student/tests/test_api.py
@@ -1,0 +1,43 @@
+"""
+Tests of API module.
+"""
+from unittest.mock import patch
+
+import ddt
+from django.conf import settings
+from django.core import mail
+from django.test import TestCase
+
+from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.verify_student.api import send_approval_email
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
+
+
+@ddt.ddt
+class TestSendApprovalEmail(TestCase):
+    """
+    Test cases for the send_approval_email API method.
+    """
+    def setUp(self):
+        super().setUp()
+
+        self.user = UserFactory.create()
+        self.attempt = SoftwareSecurePhotoVerification(
+            status="submitted",
+            user=self.user
+        )
+        self.attempt.save()
+
+    def _assert_verification_approved_email(self, expiration_date):
+        """Check that a verification approved email was sent."""
+        assert len(mail.outbox) == 1
+        email = mail.outbox[0]
+        assert email.subject == 'Your édX ID verification was approved!'
+        assert 'Your édX ID verification photos have been approved' in email.body
+        assert expiration_date.strftime("%m/%d/%Y") in email.body
+
+    @ddt.data(True, False)
+    def test_send_approval(self, use_ace):
+        with patch.dict(settings.VERIFY_STUDENT, {'USE_DJANGO_MAIL': use_ace}):
+            send_approval_email(self.attempt)
+            self._assert_verification_approved_email(self.attempt.expiration_datetime)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description


This commit modifies the `approve_id_verifications` management command to send an IDV approval email to learners. This ensures that learners are informed of approvals to their IDV attempts when performed using the management command. This more closely mirrors the way IDV approvals work when using an IDV vendor.

## Supporting information

**Jira**: [COSMO-310](https://2u-internal.atlassian.net/browse/COSMO-310) (private)

## Testing instructions

1. Create an instance of the SoftwareSecurePhotoVerification model in the submitted state. A good way to do this is via the Verified Name feature in the Account MFE.
2. Create a text file with the user IDs of the users whose IDV attempts you want to approve; one ID per line.
3. Run `manage.py lms approve_id_verifications <path_to_file>`.

## Deadline

None.

## Other information

None.
