### PR TITLE
fix: add missing end field

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -104,10 +104,9 @@ class TestCourseListing(ModuleStoreTestCase):
         dest_course_key = CourseKey.from_string(data['destination_course_key'])
 
         self.assertEqual(dest_course_key.run, 'copy')
-        source_course = self.store.get_course(self.source_course_key)
         dest_course = self.store.get_course(dest_course_key)
         self.assertEqual(dest_course.start, CourseFields.start.default)
-        self.assertEqual(dest_course.end, source_course.end)
+        self.assertEqual(dest_course.end, None)
         self.assertEqual(dest_course.enrollment_start, None)
         self.assertEqual(dest_course.enrollment_end, None)
         course_orgs = get_course_organizations(dest_course_key)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -878,6 +878,7 @@ def _create_or_rerun_course(request):
         display_name = request.json.get('display_name')
         # force the start date for reruns and allow us to override start via the client
         start = request.json.get('start', CourseFields.start.default)
+        end = request.json.get('end', CourseFields.end.default)
         run = request.json.get('run')
         has_course_creator_role = is_content_creator(request.user, org)
 
@@ -892,7 +893,7 @@ def _create_or_rerun_course(request):
                     status=400
                 )
 
-        fields = {'start': start}
+        fields = {'start': start, 'end': end}
         if display_name is not None:
             fields['display_name'] = display_name
 
@@ -1040,6 +1041,7 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     add_instructor(destination_course_key, user, user)
 
     # Mark the action as initiated
+    print(fields)
     CourseRerunState.objects.initiated(source_course_key, destination_course_key, user, fields['display_name'])
 
     # Clear the fields that must be reset for the rerun

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1041,7 +1041,6 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     add_instructor(destination_course_key, user, user)
 
     # Mark the action as initiated
-    print(fields)
     CourseRerunState.objects.initiated(source_course_key, destination_course_key, user, fields['display_name'])
 
     # Clear the fields that must be reset for the rerun


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Previously course reruns done in Studio would update the start date to the default start date or the start date provided via the api, but did not update the end date. As a result the end date would be copied from the original run of the course. If the course author did not change it before the re-run, it could end up messing up the start/end dates for a course and list a course as archived instead of active. This change updates the end date for a course rerun the same way it is done for the start date. Now when a course is re-ran it will default to no end date (the behavior as a new course) or have the end date provided via the api. This change impacts Course Authors.

## Supporting information

JIRA Ticket: [TNL-11477](https://2u-internal.atlassian.net/browse/TNL-11477)

## Testing instructions

1. Open a course in Studio
2. Navigate to the Schedule and details page
3. Update the start date to be today
4. Update the end date to be tomorrow
5. Click "Save"
6. Navigate back to Studio home
7. Find the course that was just edited
8. Click "Re-run course"
9. Fill out the form and create re-run
10. Navigate to the Schedule and details page
11. Check the end date, should be empty

## Deadline

None
