### PR TITLE
fix: video page api error

### DIFF
--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -690,7 +690,10 @@ def _get_index_videos(course, pagination_conf=None):
         for attr in attrs:
             if attr == 'courses':
                 current_course = [c for c in video['courses'] if course_id in c]
-                (__, values['course_video_image_url']), = list(current_course[0].items())
+                if current_course:
+                    values['course_video_image_url'] = current_course[0][course_id]
+                else:
+                    values['course_video_image_url'] = None
             elif attr == 'encoded_videos':
                 values['download_link'] = ''
                 values['file_size'] = 0


### PR DESCRIPTION
## Description

When there is corruption in course video data, we can run into the following error:
```
File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/video_storage_handlers.py", line 693, in _get_values
    (__, values['course_video_image_url']), = list(current_course[0].items())
IndexError: list index out of range
```

This causes the api to not return course video data even if one url is missing (and subsequently causes the course video page to not load at all).

This PR ensures that the IndexError is not triggered so the api call can at least return as much information as it can.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11628

## Testing instructions

Test on stage by accessing https://course-authoring.stage.edx.org/course/course-v1:edx+gc_6+2024_T1/videos/.
It should not show an error.
