### PR TITLE
chore: pin lti-consumer-xblock library

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -129,3 +129,6 @@ path<16.12.0
 
 # Temporary to Support the python 3.11 Upgrade
 backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library
+
+# lti-consumer-xblock version 9.11.2 has a bug, pinning temporarily to 9.11.0 which is the last working version
+lti-consumer-xblock==9.11.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -665,8 +665,10 @@ libsass==0.10.0
     #   -r requirements/edx/paver.txt
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.11.2
-    # via -r requirements/edx/kernel.in
+lti-consumer-xblock==9.11.0
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/kernel.in
 lxml==4.9.4
     # via
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1145,8 +1145,9 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.11.2
+lti-consumer-xblock==9.11.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 lxml==4.9.4

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -783,8 +783,10 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.11.2
-    # via -r requirements/edx/base.txt
+lti-consumer-xblock==9.11.0
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 lxml==4.9.4
     # via
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -862,8 +862,10 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.11.2
-    # via -r requirements/edx/base.txt
+lti-consumer-xblock==9.11.0
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 lxml==4.9.4
     # via
     #   -c requirements/edx/../constraints.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

`lti-consumer-xblock` version 9.11.2 has a bug. Pinning to the last working version of the library, which is 9.11.0.
