### PR TITLE
feat: add register intent prop for login segment call

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -354,13 +354,15 @@ def _track_user_login(user, request):
             'MailChimp': False
         }
     )
+    register_intent = request.POST.get('register_intent') == 'true'
     segment.track(
         user.id,
         "edx.bi.user.account.authenticated",
         {
             'category': "conversion",
             'label': request.POST.get('course_id'),
-            'provider': None
+            'provider': None,
+            'register_intent': register_intent,
         },
     )
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -1041,6 +1041,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
     USERNAME = "bob"
     EMAIL = "bob@example.com"
     PASSWORD = "password"
+    REGISTER_INTENT = 'true'
 
     @classmethod
     def setUpClass(cls):
@@ -1117,6 +1118,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
         data = {
             "email": self.EMAIL,
             "password": self.PASSWORD,
+            "register_intent": self.REGISTER_INTENT,
         }
         if include_analytics:
             track_label = "edX/DemoX/Fall"
@@ -1145,7 +1147,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
         mock_segment.track.assert_called_once_with(
             expected_user_id,
             'edx.bi.user.account.authenticated',
-            {'category': 'conversion', 'provider': None, 'label': track_label}
+            {'category': 'conversion', 'provider': None, 'label': track_label, 'register_intent': True}
         )
 
     def test_login_with_username(self):


### PR DESCRIPTION
## Description

Add register intent property on login successful in segment call. The reason for adding this is to know how many users have landed on register page and then move to login page to get login. 

## Supporting information
[Jira VAN-1929](https://2u-internal.atlassian.net/browse/VAN-1929)

## Testing instructions

Unit test has been updated

