### PR TITLE
feat: course about page markup and styles improvements

### DIFF
--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -156,7 +156,10 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         assert resp.status_code == 200
         pre_requisite_courses = get_prerequisite_courses_display(course)
         pre_requisite_course_about_url = reverse('about_course', args=[str(pre_requisite_courses[0]['key'])])
-        assert '<span class="important-dates-item-text pre-requisite"><a href="{}">{}</a></span>'.format(pre_requisite_course_about_url, pre_requisite_courses[0]['display']) in resp.content.decode(resp.charset).strip('\n')  # pylint: disable=line-too-long
+        assert (
+            f'You must successfully complete <a href="{pre_requisite_course_about_url}">'
+            f'{pre_requisite_courses[0]["display"]}</a> before you begin this course.'
+        ) in resp.content.decode(resp.charset).strip('\n')
 
     @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
     def test_about_page_unfulfilled_prereqs(self):
@@ -190,7 +193,10 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         assert resp.status_code == 200
         pre_requisite_courses = get_prerequisite_courses_display(course)
         pre_requisite_course_about_url = reverse('about_course', args=[str(pre_requisite_courses[0]['key'])])
-        assert '<span class="important-dates-item-text pre-requisite"><a href="{}">{}</a></span>'.format(pre_requisite_course_about_url, pre_requisite_courses[0]['display']) in resp.content.decode(resp.charset).strip('\n')  # pylint: disable=line-too-long
+        assert (
+            f'You must successfully complete <a href="{pre_requisite_course_about_url}">'
+            f'{pre_requisite_courses[0]["display"]}</a> before you begin this course.'
+        ) in resp.content.decode(resp.charset).strip('\n')
 
         url = reverse('about_course', args=[str(pre_requisite_course.id)])
         resp = self.client.get(url)

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -44,12 +44,22 @@
       > div.table {
         display: table;
         width: 100%;
+
+        @include media-breakpoint-down(sm) {
+          display: flex;
+          flex-direction: column;
+        }
       }
 
       .intro {
         box-sizing: border-box;
 
         @include clearfix();
+
+        @include media-breakpoint-down(sm) {
+            width: auto;
+            order: 2;
+        }
 
         display: table-cell;
         vertical-align: middle;
@@ -127,6 +137,10 @@
           a.add-to-cart {
             @include button(shiny, $button-color);
 
+            @include media-breakpoint-down(md) {
+              width: 100%;
+            }
+
             box-sizing: border-box;
             border-radius: 3px;
             display: block;
@@ -189,6 +203,11 @@
             @include float(left);
             @include margin(1px, flex-gutter(8), 0, 0);
             @include transition(none);
+            @include media-breakpoint-down(md) {
+              width: 100%;
+              margin-right: 0;
+              margin-bottom: 10px;
+            }
 
             width: flex-grid(5, 8);
           }
@@ -212,6 +231,11 @@
         position: relative;
         width: flex-grid(4);
         z-index: 2;
+
+        @include media-breakpoint-down(sm) {
+          width: auto;
+          order: 1;
+        }
 
         .hero {
           border: 1px solid $border-color-3;

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -217,7 +217,6 @@ from openedx.core.lib.courses import course_image_url
           <li class="prerequisite-course important-dates-item">
             <span class="icon fa fa-list-ul" aria-hidden="true"></span>
             <p class="important-dates-item-title">${_("Prerequisites")}</p>
-            ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
             <p class="tip">
             ${Text(_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.")).format(
               link_start=HTML('<a href="{}">').format(prc_target),

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -62,11 +62,10 @@ from openedx.core.lib.courses import course_image_url
       <div class="table">
       <section class="intro">
         <div class="heading-group">
-          <h1>
-            ${course.display_name_with_default}
-          </h1>
-          <br />
+          <h1>${course.display_name_with_default}</h1>
           <span>${course.display_org_with_default}</span>
+          <br />
+          <p>${get_course_about_section(request, course, 'short_description')}</p>
         </div>
 
         <div class="main-cta">
@@ -219,7 +218,6 @@ from openedx.core.lib.courses import course_image_url
             <span class="icon fa fa-list-ul" aria-hidden="true"></span>
             <p class="important-dates-item-title">${_("Prerequisites")}</p>
             ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
-            <span class="important-dates-item-text pre-requisite"><a href="${prc_target}">${pre_requisite_courses[0]['display']}</a></span>
             <p class="tip">
             ${Text(_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.")).format(
               link_start=HTML('<a href="{}">').format(prc_target),
@@ -231,7 +229,11 @@ from openedx.core.lib.courses import course_image_url
           % endif
 
           % if get_course_about_section(request, course, "prerequisites"):
-            <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
+            <li class="important-dates-item">
+              <span class="icon fa fa-book" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Requirements")}</p>
+              <span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span>
+            </li>
           % endif
         </ol>
         </%block>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -63,7 +63,6 @@ from openedx.core.lib.courses import course_image_url
       <section class="intro">
         <div class="heading-group">
           <h1>${course.display_name_with_default}</h1>
-          <span>${course.display_org_with_default}</span>
           <br />
           <p>${get_course_about_section(request, course, 'short_description')}</p>
         </div>
@@ -159,7 +158,16 @@ from openedx.core.lib.courses import course_image_url
 
         <%block name="course_about_important_dates">
         <ol class="important-dates">
-          <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default}</span></li>
+          <li class="important-dates-item">
+              <span class="icon fa fa-building" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Organization")}</p>
+              <span class="important-dates-item-text course-org">${course.display_org_with_default}</span>
+          </li>
+          <li class="important-dates-item">
+              <span class="icon fa fa-info-circle" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Course Number")}</p>
+              <span class="important-dates-item-text course-number">${course.display_number_with_default}</span>
+          </li>
           % if not course.start_date_is_still_default:
               <%
                   course_start_date = course.advertised_start or course.start
@@ -217,6 +225,8 @@ from openedx.core.lib.courses import course_image_url
           <li class="prerequisite-course important-dates-item">
             <span class="icon fa fa-list-ul" aria-hidden="true"></span>
             <p class="important-dates-item-title">${_("Prerequisites")}</p>
+            ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
+            <span class="important-dates-item-text pre-requisite"><a href="${prc_target}">${pre_requisite_courses[0]['display']}</a></span>
             <p class="tip">
             ${Text(_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.")).format(
               link_start=HTML('<a href="{}">').format(prc_target),

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -62,6 +62,7 @@ from openedx.core.lib.courses import course_image_url
       <div class="table">
       <section class="intro">
         <div class="heading-group">
+          <p><small>${course.display_org_with_default}</small></p>
           <h1>${course.display_name_with_default}</h1>
           <br />
           <p>${get_course_about_section(request, course, 'short_description')}</p>
@@ -158,11 +159,6 @@ from openedx.core.lib.courses import course_image_url
 
         <%block name="course_about_important_dates">
         <ol class="important-dates">
-          <li class="important-dates-item">
-              <span class="icon fa fa-building" aria-hidden="true"></span>
-              <p class="important-dates-item-title">${_("Organization")}</p>
-              <span class="important-dates-item-text course-org">${course.display_org_with_default}</span>
-          </li>
           <li class="important-dates-item">
               <span class="icon fa fa-info-circle" aria-hidden="true"></span>
               <p class="important-dates-item-title">${_("Course Number")}</p>


### PR DESCRIPTION
#### Similar PR is opened to the open-release/palm branch:
- quince https://github.com/openedx/edx-platform/pull/33791
- master https://github.com/openedx/edx-platform/pull/33712

#### Description
There are some fixes for the course about page:

- display a course short description in course about heading-group (if necessary)
- removing duplicated pre-requisite info in right sidebar
- code formatting for the block `% if get_course_about_section(request, course, "prerequisites"):`
 
Fixes were also made to the `_course_about.scss` styles, to fix responsive layout of the course about header element.

#### Before fixes:
![image](https://github.com/openedx/edx-platform/assets/17108583/efa725a0-3462-4bda-bd21-d2527dbc8516)

#### After fixes:
![image](https://github.com/openedx/edx-platform/assets/17108583/bd5f907b-8bd8-455e-904c-e4a6c0b1560f)