### PR TITLE
build: Build assets requirements before development.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ REQ_FILES = \
 	requirements/edx/base \
 	requirements/edx/doc \
 	requirements/edx/testing \
-	requirements/edx/development \
 	requirements/edx/assets \
+	requirements/edx/development \
 	requirements/edx/semgrep \
 	scripts/xblock/requirements \
 	scripts/user_retirement/requirements/base \


### PR DESCRIPTION
The development.txt file requires assets.txt so build assets first so we
don't get conflicts when running make upgrade.
