### PR TITLE
test: cancel old unit tests when a new PR commit is pushed

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - master
 
+concurrency:
+  # We only need to be running tests for the latest commit on each PR
+  # (however, we fully test every commit on master, even as new ones land).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   run-tests:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})


### PR DESCRIPTION
Based on: 
* https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-and-the-default-behavior
* https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only

If this works well, we can add to other workflows and other repos.