### PR TITLE
fix: Financial Assistance Letter extend time to award and styling edits

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1984,7 +1984,7 @@ FINANCIAL_ASSISTANCE_HEADER = _(
     '(based on 12-month period from you first approval). \nTo apply for financial assistance: '
     '\n1. Enroll in the audit track for an eligible course that offers Verified Certificates. '
     '\n2. Complete this application. '
-    '\n3. Check your email, please allow 4-weeks for your application to be processed.'
+    '\n3. Check your email, please allow 4 weeks for your application to be processed.'
 )
 
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1977,13 +1977,14 @@ class PublicVideoXBlockEmbedView(BasePublicVideoXBlockView):
 # Translators: "percent_sign" is the symbol "%". "platform_name" is a
 # string identifying the name of this installation, such as "edX".
 FINANCIAL_ASSISTANCE_HEADER = _(
-    'We plan to use this information to evaluate your application for financial assistance and to further develop our'
-    ' financial assistance program. Please note that while \nassistance is available in most courses that offer'
-    ' verified certificates, a few courses and programs are not eligible. You must complete a separate application'
-    ' \nfor each course you take. You may be approved for financial assistance five (5) times each year'
-    ' (based on 12-month period from you first approval). \nTo apply for financial assistance: \n'
-    '1. Enroll in the audit track for an eligible course that offers Verified Certificates \n2. Complete this'
-    '  application \n3. Check your email, your application will be reviewed in 3-4 business days'
+    'We plan to use this information to evaluate your application for financial assistance and to further develop our '
+    'financial assistance program. \nPlease note that while assistance is available in most courses that offer '
+    'verified certificates, a few courses and programs are not eligible. You must complete a separate application '
+    'for each course you take. You may be approved for financial assistance five (5) times each year '
+    '(based on 12-month period from you first approval). \nTo apply for financial assistance: '
+    '\n1. Enroll in the audit track for an eligible course that offers Verified Certificates. '
+    '\n2. Complete this application. '
+    '\n3. Check your email, please allow 4-weeks for your application to be processed.'
 )
 
 

--- a/lms/static/sass/views/_financial-assistance.scss
+++ b/lms/static/sass/views/_financial-assistance.scss
@@ -32,7 +32,7 @@
 
   p {
     line-height: $base-line-height;
-    margin-top: 0;
+    margin-top: 1em;
     color: $gray-700;
     font-size: 1em;
   }

--- a/lms/templates/financial-assistance/financial-assistance.html
+++ b/lms/templates/financial-assistance/financial-assistance.html
@@ -36,7 +36,8 @@ from common.djangoapps.edxmako.shortcuts import marketing_link
       ## Translators: This string will not be used in Open edX installations.
       <p>${_("EdX is committed to making it possible for you to take high quality courses from leading institutions regardless of your financial situation, earn a Verified Certificate, and share your success with others.")}</p>
       ## Translators: This string will not be used in Open edX installations. Do not translate the name "Anant".
-      <p class="signature">${_("Sincerely, Anant")}</p>
+      <p class="signature">${_("Sincerely,")}</p>
+      <p class="signature">${_("Anant")}</p>
     </div>
   % endif
 


### PR DESCRIPTION
[REV-4066](https://2u-internal.atlassian.net/browse/REV-4066).

We need to extend the time to award a Financial Assistance coupon that is in the FA letter from 3-4 days to 4 weeks due to some FA staffing/functionality changes.
This PR also includes some styling tweaks for better readability.

**Before:**
<img width="1357" alt="Screenshot 2024-06-04 at 3 22 30 PM" src="https://github.com/openedx/edx-platform/assets/13632680/8d954a71-9de9-43f1-9910-16a068d72bb4">

**After:**
"4 weeks" i/o "4-weeks" below
<img width="1358" alt="Screenshot 2024-06-04 at 3 22 17 PM" src="https://github.com/openedx/edx-platform/assets/13632680/5448e566-9cf4-450a-814c-fcb5f5703440">
