### PR TITLE
feat: added automatic hiding functionality for the survey report banner when clicking on the dismiss button

### DIFF
--- a/openedx/features/survey_report/static/survey_report/js/admin_banner.js
+++ b/openedx/features/survey_report/static/survey_report/js/admin_banner.js
@@ -4,8 +4,26 @@ $(document).ready(function(){
       // If you want to do something after the slide-up, do it here.
       // For example, you can hide the entire div:
       // $(this).hide();
+      var userId = document.getElementById('userIdSurvey').value;
+      // Store the dismissal time in milliseconds
+      var dismissalTime = new Date().getTime();
+      // Calculate the expiration time (1 month in milliseconds)
+      var expirationTime = dismissalTime + (30 * 24 * 60 * 60 * 1000); // 30 days
+      // Store the dismissal time in the browser's local storage
+      localStorage.setItem('bannerDismissalTime_' + userId, dismissalTime);
+      localStorage.setItem('bannerExpirationTime_' + userId, expirationTime);
     });
   });
+
+    // Check if the banner should be shown or hidden on page load
+  var userId = document.getElementById('userIdSurvey').value;
+  var bannerDismissalTime = localStorage.getItem('bannerDismissalTime_' + userId);
+  var bannerExpirationTime = localStorage.getItem('bannerExpirationTime_' + userId);
+  var currentTime = new Date().getTime();
+  if (bannerDismissalTime && bannerExpirationTime && currentTime < bannerExpirationTime) {
+    // Banner was dismissed and it's still within the expiration period, so hide it
+    $('#originalContent').hide();
+  }
   // When the form is submitted
   $("#survey_report_form").submit(function(event){
     event.preventDefault();  // Prevent the form from submitting traditionally

--- a/openedx/features/survey_report/static/survey_report/js/admin_banner.js
+++ b/openedx/features/survey_report/static/survey_report/js/admin_banner.js
@@ -1,37 +1,51 @@
 $(document).ready(function(){
+    // Function to get user ID
+  function getUserId() {
+    return $('#userIdSurvey').val();
+  }
+
+  // Function to get current time in milliseconds
+  function getCurrentTime() {
+    return new Date().getTime();
+  }
+
+  // Function to set dismissal time and expiration time in local storage
+  function setDismissalAndExpirationTime(userId, dismissalTime) {
+    let expirationTime = dismissalTime + (30 * 24 * 60 * 60 * 1000); // 30 days
+    localStorage.setItem('bannerDismissalTime_' + userId, dismissalTime);
+    localStorage.setItem('bannerExpirationTime_' + userId, expirationTime);
+  }
+
+  // Function to check if banner should be shown or hidden
+  function checkBannerVisibility() {
+    let userId = getUserId();
+    let bannerDismissalTime = localStorage.getItem('bannerDismissalTime_' + userId);
+    let bannerExpirationTime = localStorage.getItem('bannerExpirationTime_' + userId);
+    let currentTime = getCurrentTime();
+
+    if (bannerDismissalTime && bannerExpirationTime && currentTime > bannerExpirationTime) {
+      // Banner was dismissed and it's not within the expiration period, so show it
+      $('#originalContent').show();
+    } else if (bannerDismissalTime && bannerExpirationTime && currentTime < bannerExpirationTime) {
+      // Banner was dismissed and it's within the expiration period, so hide it
+      $('#originalContent').hide();
+    } else {
+      // Banner has not been dismissed ever so we need to show it.
+      $('#originalContent').show();
+    }
+  }
+
+  // Click event for dismiss button
   $('#dismissButton').click(function() {
     $('#originalContent').slideUp('slow', function() {
-      // If you want to do something after the slide-up, do it here.
-      // For example, you can hide the entire div:
-      // $(this).hide();
-      let userId = document.getElementById('userIdSurvey').value;
-      // Store the dismissal time in milliseconds
-      let dismissalTime = new Date().getTime();
-      // Calculate the expiration time (1 month in milliseconds)
-      let expirationTime = dismissalTime + (30 * 24 * 60 * 60 * 1000); // 30 days
-      // Store the dismissal time in the browser's local storage
-      localStorage.setItem('bannerDismissalTime_' + userId, dismissalTime);
-      localStorage.setItem('bannerExpirationTime_' + userId, expirationTime);
+      let userId = getUserId();
+      let dismissalTime = getCurrentTime();
+      setDismissalAndExpirationTime(userId, dismissalTime);
     });
   });
 
-    // Check if the banner should be shown or hidden on page load
-  let userId = document.getElementById('userIdSurvey').value;
-  let bannerDismissalTime = localStorage.getItem('bannerDismissalTime_' + userId);
-  let bannerExpirationTime = localStorage.getItem('bannerExpirationTime_' + userId);
-  let currentTime = new Date().getTime();
-  if (bannerDismissalTime && bannerExpirationTime && currentTime > bannerExpirationTime) {
-    // Banner was dismissed and it's not within the expiration period, so show it
-    $('#originalContent').show();
-  }
-  else if (bannerDismissalTime && bannerExpirationTime && currentTime < bannerExpirationTime) {
-    // Banner was dismissed and it's within the expiration period, so hide it
-    $('#originalContent').hide();
-  }
-  else{
-    // Banner has not been dimissed ever
-        $('#originalContent').show();
-  }
+  // Check banner visibility on page load
+  checkBannerVisibility();
   // When the form is submitted
   $("#survey_report_form").submit(function(event){
     event.preventDefault();  // Prevent the form from submitting traditionally

--- a/openedx/features/survey_report/static/survey_report/js/admin_banner.js
+++ b/openedx/features/survey_report/static/survey_report/js/admin_banner.js
@@ -4,11 +4,11 @@ $(document).ready(function(){
       // If you want to do something after the slide-up, do it here.
       // For example, you can hide the entire div:
       // $(this).hide();
-      var userId = document.getElementById('userIdSurvey').value;
+      let userId = document.getElementById('userIdSurvey').value;
       // Store the dismissal time in milliseconds
-      var dismissalTime = new Date().getTime();
+      let dismissalTime = new Date().getTime();
       // Calculate the expiration time (1 month in milliseconds)
-      var expirationTime = dismissalTime + (30 * 24 * 60 * 60 * 1000); // 30 days
+      let expirationTime = dismissalTime + (30 * 24 * 60 * 60 * 1000); // 30 days
       // Store the dismissal time in the browser's local storage
       localStorage.setItem('bannerDismissalTime_' + userId, dismissalTime);
       localStorage.setItem('bannerExpirationTime_' + userId, expirationTime);
@@ -16,13 +16,21 @@ $(document).ready(function(){
   });
 
     // Check if the banner should be shown or hidden on page load
-  var userId = document.getElementById('userIdSurvey').value;
-  var bannerDismissalTime = localStorage.getItem('bannerDismissalTime_' + userId);
-  var bannerExpirationTime = localStorage.getItem('bannerExpirationTime_' + userId);
-  var currentTime = new Date().getTime();
-  if (bannerDismissalTime && bannerExpirationTime && currentTime < bannerExpirationTime) {
-    // Banner was dismissed and it's still within the expiration period, so hide it
+  let userId = document.getElementById('userIdSurvey').value;
+  let bannerDismissalTime = localStorage.getItem('bannerDismissalTime_' + userId);
+  let bannerExpirationTime = localStorage.getItem('bannerExpirationTime_' + userId);
+  let currentTime = new Date().getTime();
+  if (bannerDismissalTime && bannerExpirationTime && currentTime > bannerExpirationTime) {
+    // Banner was dismissed and it's not within the expiration period, so show it
+    $('#originalContent').show();
+  }
+  else if (bannerDismissalTime && bannerExpirationTime && currentTime < bannerExpirationTime) {
+    // Banner was dismissed and it's within the expiration period, so hide it
     $('#originalContent').hide();
+  }
+  else{
+    // Banner has not been dimissed ever
+        $('#originalContent').show();
   }
   // When the form is submitted
   $("#survey_report_form").submit(function(event){

--- a/openedx/features/survey_report/templates/survey_report/admin_banner.html
+++ b/openedx/features/survey_report/templates/survey_report/admin_banner.html
@@ -15,6 +15,7 @@
    <button id="dismissButton" type="button" style="background-color:var(--close-button-bg); color: var(--button-fg); border: none; border-radius: 4px; padding: 10px 20px; margin-right: 10px; cursor: pointer;">Dismiss</button>
     <form id='survey_report_form' method="POST" action="/survey_report/generate_report" style="margin: 0; padding: 0;">
         {% csrf_token %}
+        <input type="hidden" id="userIdSurvey" value="{{ user.id }}">
         <button type="submit" style="background-color: #377D4D; color: var(--button-fg); border: none; border-radius: 4px; padding: 10px 20px; cursor: pointer;">Send Report</button>
     </form>
 </div>

--- a/openedx/features/survey_report/templates/survey_report/admin_banner.html
+++ b/openedx/features/survey_report/templates/survey_report/admin_banner.html
@@ -1,7 +1,7 @@
 {% block survey_report_banner %}
 {% load static %}
 {% if show_survey_report_banner %}
-<div id="originalContent" style="border: 3px solid #06405d; margin-bottom: 50px; rgb(0 0 0 / 18%) 0px 3px 5px;">
+<div id="originalContent" style="border: 3px solid #06405d; margin-bottom: 50px; rgb(0 0 0 / 18%) 0px 3px 5px; display: none;">
   <div  style="background-color: #06405d;padding: 17px 37px;">
     <h1 style="margin: 0; color: #FFFF; font-weight: 600;">Join the Open edX Data Sharing Initiative and shape the future of learning</h1>
 </div>


### PR DESCRIPTION

## Description

This PR adds a basic functionality to automatically hide the survey report banner when the dismiss button is clicked for one month depending on the user that clicked on the button. This could be changed in the future if requested. We use the localStorage to check when the Dismiss button was clicked so we can hide the banner from the admin site.


## Testing instructions

1. Create 2 admin users and check the admin site separetly.
2. With the first admin click on the Dismiss button and if you refresh the page, you should see how the banner dissapears after a short delay
3. The second admin should see the banner appear normally
4. Afterwards, if you click on the button with the second admin, the banner should hide automatically as well
5. Is important to note that this dismiss variable is located in the local storage and you can clear it in your browser if necesarry if you want to do further testing

