### PR TITLE
fix: disable submit button for archived courses

### DIFF
--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -808,9 +808,8 @@ class ProblemBlock(
         """
         Return the date submissions should be closed from.
         """
-        course_end_date = self.course_end_date
 
-        due_date = self.due or course_end_date
+        due_date = self.due or self.course_end_date
 
         if self.graceperiod is not None and due_date:
             return due_date + self.graceperiod

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -1442,7 +1442,7 @@ class ProblemBlock(
                 closed_date = (
                     course.end + self.graceperiod if self.graceperiod is not None else course.end
                 )
-                if datetime.datetime.now(utc) > closed_date:
+                if closed_date and datetime.datetime.now(utc) > closed_date:
                     return True
         except AttributeError:
             pass

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -1419,12 +1419,13 @@ class ProblemBlock(
         return self.get_demand_hint(hint_index)
 
     def course_is_archived(self):
+        """ Is the course archived? """
         from xmodule.modulestore.django import modulestore
-        course = modulestore().get_course(self.course_id)
         try:
+            course = modulestore().get_course(self.course_id)
             if course.has_ended():
                 return True
-        except:
+        except (AssertionError, AttributeError):
             pass
         return False
 

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -797,10 +797,14 @@ class ProblemBlock(
 
     @property
     def course_end_date(self):
+        """
+        Return the end date of the problem's course
+        """
+
         try:
             course_block_key = self.runtime.course_entry.structure['root']
             return self.runtime.course_entry.structure['blocks'][course_block_key].fields['end']
-        except:
+        except (AttributeError, KeyError):
             return None
 
     @property

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -1433,6 +1433,10 @@ class ProblemBlock(
         """
         Is the student still allowed to submit answers?
         """
+        from xmodule.modulestore.django import modulestore
+        course = modulestore().get_course(self.course_id)
+        if course.has_ended():
+            return True
         if self.used_all_attempts():
             return True
         if self.is_past_due():

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -806,7 +806,7 @@ class ProblemBlock(
         """
         try:
             course_end_date = self.get_course_end_date()
-        except AttributeError:
+        except (AttributeError, KeyError):
             course_end_date = None
 
         due_date = self.due or course_end_date

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -795,19 +795,20 @@ class ProblemBlock(
                 }
                 yield (user_state.username, report)
 
-    def get_course_end_date(self):
-        course_block_key = self.runtime.course_entry.structure['root']
-        return self.runtime.course_entry.structure['blocks'][course_block_key].fields['end']
+    @property
+    def course_end_date(self):
+        try:
+            course_block_key = self.runtime.course_entry.structure['root']
+            return self.runtime.course_entry.structure['blocks'][course_block_key].fields['end']
+        except:
+            return None
 
     @property
     def close_date(self):
         """
         Return the date submissions should be closed from.
         """
-        try:
-            course_end_date = self.get_course_end_date()
-        except (AttributeError, KeyError):
-            course_end_date = None
+        course_end_date = self.course_end_date
 
         due_date = self.due or course_end_date
 

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -50,7 +50,6 @@ from common.djangoapps.xblock_django.constants import (
     ATTR_KEY_USER_IS_STAFF,
     ATTR_KEY_USER_ID,
 )
-from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangolib.markup import HTML, Text
 from .capa.xqueue_interface import XQueueService
 
@@ -1443,7 +1442,6 @@ class ProblemBlock(
         """
         Is the student still allowed to submit answers?
         """
-
         if self.used_all_attempts():
             return True
         if self.is_past_due():

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -1418,6 +1418,16 @@ class ProblemBlock(
         hint_index = int(data['hint_index'])
         return self.get_demand_hint(hint_index)
 
+    def course_is_archived(self):
+        from xmodule.modulestore.django import modulestore
+        course = modulestore().get_course(self.course_id)
+        try:
+            if course.has_ended():
+                return True
+        except:
+            pass
+        return False
+
     def used_all_attempts(self):
         """ All attempts have been used """
         return self.max_attempts is not None and self.attempts >= self.max_attempts
@@ -1433,9 +1443,7 @@ class ProblemBlock(
         """
         Is the student still allowed to submit answers?
         """
-        from xmodule.modulestore.django import modulestore
-        course = modulestore().get_course(self.course_id)
-        if course.has_ended():
+        if self.course_is_archived():
             return True
         if self.used_all_attempts():
             return True

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -4005,7 +4005,8 @@ class ProblemBlockReportGenerationTest(unittest.TestCase):
             ))
             assert 'Python Error: No Answer Retrieved' in list(report_data[0][1].values())
 
-class ProblemBlockModuleStoreTest(ModuleStoreTestCase): # lint-amnesty, pylint: disable=missing-class-docstring
+
+class ProblemBlockModuleStoreTest(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
     def test_closed_for_archive(self):
         test_user = ModuleStoreEnum.UserID.test
         test_course = CourseFactory.create(

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -655,7 +655,7 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
                                    due=self.yesterday_str)
         assert block.closed()
 
-    @patch.object(ProblemBlock,'course_end_date', new_callable=PropertyMock)
+    @patch.object(ProblemBlock, 'course_end_date', new_callable=PropertyMock)
     def test_closed_for_archive(self, mock_course_end_date):
 
         # Utility to create a datetime object in the past

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -36,9 +36,6 @@ from xmodule.capa.correctmap import CorrectMap
 from xmodule.capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
 from xmodule.capa.xqueue_interface import XQueueInterface
 from xmodule.capa_block import ComplexEncoder, ProblemBlock
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.tests import DATA_DIR
 
 from ..capa_block import RANDOMIZATION, SHOWANSWER
@@ -660,11 +657,12 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
 
     @patch('xmodule.capa_block.ProblemBlock.get_course_end_date')
     def test_closed_for_archive(self, mock_get_course_end_date):
-        # Utility to create a datetime string in the past
+
+        # Utility to create a datetime object in the past
         def past_datetime(days):
             return (datetime.datetime.now(UTC) - datetime.timedelta(days=days))
 
-        # Utility to create a datetime string in the future
+        # Utility to create a datetime object in the future
         def future_datetime(days):
             return (datetime.datetime.now(UTC) + datetime.timedelta(days=days))
 

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -655,8 +655,8 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
                                    due=self.yesterday_str)
         assert block.closed()
 
-    @patch('xmodule.capa_block.ProblemBlock.get_course_end_date')
-    def test_closed_for_archive(self, mock_get_course_end_date):
+    @patch.object(ProblemBlock,'course_end_date', new_callable=PropertyMock)
+    def test_closed_for_archive(self, mock_course_end_date):
 
         # Utility to create a datetime object in the past
         def past_datetime(days):
@@ -669,20 +669,20 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
         block = CapaFactory.create(max_attempts="1", attempts="0")
 
         # For active courses without graceperiod
-        mock_get_course_end_date.return_value = future_datetime(10)
+        mock_course_end_date.return_value = future_datetime(10)
         assert not block.closed()
 
         # For archive courses without graceperiod
-        mock_get_course_end_date.return_value = past_datetime(10)
+        mock_course_end_date.return_value = past_datetime(10)
         assert block.closed()
 
         # For active courses with graceperiod
-        mock_get_course_end_date.return_value = future_datetime(10)
+        mock_course_end_date.return_value = future_datetime(10)
         block.graceperiod = datetime.timedelta(days=2)
         assert not block.closed()
 
         # For archive courses with graceperiod
-        mock_get_course_end_date.return_value = past_datetime(2)
+        mock_course_end_date.return_value = past_datetime(2)
         block.graceperiod = datetime.timedelta(days=3)
         assert not block.closed()
 

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -667,7 +667,7 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
             return (datetime.datetime.now(UTC) + datetime.timedelta(days=days))
 
         block = CapaFactory.create(max_attempts="1", attempts="0")
-        
+
         # For active courses without graceperiod
         mock_get_course_end_date.return_value = future_datetime(10)
         assert not block.closed()

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -4005,7 +4005,7 @@ class ProblemBlockReportGenerationTest(unittest.TestCase):
             ))
             assert 'Python Error: No Answer Retrieved' in list(report_data[0][1].values())
 
-class ProblemBlockModuleStoreTest(ModuleStoreTestCase):        
+class ProblemBlockModuleStoreTest(ModuleStoreTestCase): # lint-amnesty, pylint: disable=missing-class-docstring
     def test_closed_for_archive(self):
         test_user = ModuleStoreEnum.UserID.test
         test_course = CourseFactory.create(
@@ -4025,7 +4025,7 @@ class ProblemBlockModuleStoreTest(ModuleStoreTestCase):
         )
 
         course = self.store.get_course(problem.course_id)
-        
+
         # For active courses without grace period
         course.end = datetime.datetime.now(UTC) + datetime.timedelta(days=1)
         self.update_course(course, test_user)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR disables the submission button for problems in the archived courses.

Current behaviour:
The learner can submit the problem in the archived courses which don't have a due date. The grade is recorded in the gradebook that should be closed. 

After the PR merges:
The submit button will be disabled and the learner cannot submit the problem.

Useful information to include:

- Which edX user roles will this change impact? "Learner"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
Before
<img width="1179" alt="Screenshot 2024-06-05 at 3 17 16 PM" src="https://github.com/openedx/edx-platform/assets/88967643/0e9618f9-b200-4926-ae18-a1632569402d">

After
<img width="1179" alt="Screenshot 2024-06-05 at 3 14 50 PM" src="https://github.com/openedx/edx-platform/assets/88967643/3f9caa05-72eb-47b7-9225-65fdc606da57">

- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/mitodl/hq/issues/4415

## Testing instructions

- Create a new course in studio.
- From settings dropdown, select `Schedule and Details`.
- Make the course `self-paced` and add the start date and end date to some past dates.
- Save the changes and return back to course outline.
- Create a section, subsection and a problem unit and publish it.
- In the subsection's settings, set the grading to `Homework`
- Go to the unit and click on `View Live Version`.
- Validate that the submit button is disabled.
## Deadline

None

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
