### PR TITLE
Revert "fix(deps): update dependency moment-timezone to v0.5.45"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "js-cookie": "3.0.1",
         "jwt-decode": "^3.1.2",
         "moment": "2.29.4",
-        "moment-timezone": "0.5.45",
+        "moment-timezone": "0.5.37",
         "node-gyp": "10.0.1",
         "picturefill": "3.0.3",
         "popper.js": "1.12.9",
@@ -7777,6 +7777,18 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/edx-ui-toolkit/node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
       "engines": {
         "node": "*"
       }
@@ -16666,12 +16678,11 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.45",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
-      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
-      "license": "MIT",
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
+      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
       "dependencies": {
-        "moment": "^2.29.4"
+        "moment": ">= 2.9.0"
       },
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-cookie": "3.0.1",
     "jwt-decode": "^3.1.2",
     "moment": "2.29.4",
-    "moment-timezone": "0.5.45",
+    "moment-timezone": "0.5.37",
     "node-gyp": "10.0.1",
     "picturefill": "3.0.3",
     "popper.js": "1.12.9",


### PR DESCRIPTION
We were seeing issues with the programs dashboard rendering with this change.

```
TypeError: M.tz is not a function
    at z (ProgramDetailsFactory.a06d132fdc0f8f0cfdd4.1c20f1b1fd86.js:2:320138)
```

We believe it's related to this line of code: https://github.com/openedx/edx-platform/blob/8b4adaf4bd72acb0ea4641dea1b47f2efa28003b/lms/static/js/learner_dashboard/models/program_subscription_model.js#L23

Reverts openedx/edx-platform#34924