### PR TITLE
feat: [FC-0044] expose editor for advanced xblocks and move modal in CMS

### DIFF
--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -73,10 +73,8 @@ log = logging.getLogger(__name__)
 CREATE_IF_NOT_FOUND = ["course_info"]
 
 # Useful constants for defining predicates
-def NEVER(x):
-    return False
-def ALWAYS(x):
-    return True
+NEVER = lambda x: False
+ALWAYS = lambda x: True
 
 
 # Disable atomic requests so transactions made during the request commit immediately instead of waiting for the end of
@@ -309,7 +307,9 @@ def xblock_view_handler(request, usage_key_string, view_name):
 @login_required
 def xblock_actions_view(request, usage_key_string, action_name):
     """
-    The handler for rendered edit xblock view.
+    Return rendered xblock action view.
+    The action name should be provided as an argument.
+    Valid options for action names are edit and move.
     """
     usage_key = usage_key_with_run(usage_key_string)
     if not has_studio_read_access(request.user, usage_key.course_key):

--- a/cms/static/js/views/modals/base_modal.js
+++ b/cms/static/js/views/modals/base_modal.js
@@ -119,6 +119,10 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview'],
                     event.preventDefault();
                     event.stopPropagation(); // Make sure parent modals don't see the click
                 }
+                window.parent.postMessage({
+                    method: 'close_edit_modal',
+                    msg: 'Sends a message when the modal window is closed'
+                }, '*');
                 this.hide();
             },
 

--- a/cms/static/js/views/modals/base_modal.js
+++ b/cms/static/js/views/modals/base_modal.js
@@ -120,7 +120,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview'],
                     event.stopPropagation(); // Make sure parent modals don't see the click
                 }
                 window.parent.postMessage({
-                    method: 'close_edit_modal',
+                    method: 'close_modal',
                     msg: 'Sends a message when the modal window is closed'
                 }, '*');
                 this.hide();

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -209,8 +209,8 @@ function($, _, Backbone, gettext, BaseModal, ViewUtils, XBlockViewUtils, XBlockE
             Backbone.trigger('xblock:editorModalHidden');
 
             window.parent.postMessage({
-              method: 'close_edit_modal',
-              msg: 'Sends a message when the modal window is closed'
+              method: 'close_modal',
+              msg: 'Sends a message when the edit modal window is closed'
             }, '*');
 
             BaseModal.prototype.hide.call(this);

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -208,6 +208,11 @@ function($, _, Backbone, gettext, BaseModal, ViewUtils, XBlockViewUtils, XBlockE
             // Notify child views to stop listening events
             Backbone.trigger('xblock:editorModalHidden');
 
+            window.parent.postMessage({
+              method: 'close_edit_modal',
+              msg: 'Sends a message when the modal window is closed'
+            }, '*');
+
             BaseModal.prototype.hide.call(this);
 
             // Notify the runtime that the modal has been hidden

--- a/cms/static/js/views/modals/move_xblock_modal.js
+++ b/cms/static/js/views/modals/move_xblock_modal.js
@@ -185,6 +185,10 @@ function($, Backbone, _, gettext, BaseView, XBlockViewUtils, MoveXBlockUtils, Ht
                     targetParentLocator: this.targetParentXBlockInfo.id
                 }
             );
+            window.parent.postMessage({
+                method: 'close_edit_modal',
+                msg: 'Sends a message when the modal window is closed'
+            }, '*');
         }
     });
 

--- a/cms/static/js/views/modals/move_xblock_modal.js
+++ b/cms/static/js/views/modals/move_xblock_modal.js
@@ -185,10 +185,6 @@ function($, Backbone, _, gettext, BaseView, XBlockViewUtils, MoveXBlockUtils, Ht
                     targetParentLocator: this.targetParentXBlockInfo.id
                 }
             );
-            window.parent.postMessage({
-                method: 'close_edit_modal',
-                msg: 'Sends a message when the modal window is closed'
-            }, '*');
         }
     });
 

--- a/cms/static/js/views/utils/move_xblock_utils.js
+++ b/cms/static/js/views/utils/move_xblock_utils.js
@@ -26,8 +26,25 @@ function($, _, Backbone, Feedback, AlertView, XBlockViewUtils, MoveXBlockUtils, 
             .done(function(response) {
             // hide modal
                 Backbone.trigger('move:hideMoveModal');
-                // hide xblock element
-                data.sourceXBlockElement.hide();
+                if (data.sourceXBlockElement) {
+                   // hide xblock element
+                  data.sourceXBlockElement.hide();
+                }
+
+                window.parent.postMessage({
+                  method: 'move_xblock',
+                  msg: 'Sends a message when the xblock is moved',
+                  params: {
+                    sourceDisplayName: data.sourceDisplayName,
+                    sourceLocator: data.sourceLocator,
+                    targetParentLocator: data.targetParentLocator,
+                  }
+                }, '*');
+                window.parent.postMessage({
+                  method: 'close_modal',
+                  msg: 'Sends a message when the modal window is closed'
+                }, '*');
+
                 showMovedNotification(
                     StringUtils.interpolate(
                         gettext('Success! "{displayName}" has been moved.'),
@@ -36,7 +53,7 @@ function($, _, Backbone, Feedback, AlertView, XBlockViewUtils, MoveXBlockUtils, 
                         }
                     ),
                     {
-                        sourceXBlockElement: data.sourceXBlockElement,
+                        sourceXBlockElement: data.sourceXBlockElement ? data.sourceXBlockElement : null,
                         sourceDisplayName: data.sourceDisplayName,
                         sourceLocator: data.sourceLocator,
                         sourceParentLocator: data.sourceParentLocator,
@@ -78,7 +95,7 @@ function($, _, Backbone, Feedback, AlertView, XBlockViewUtils, MoveXBlockUtils, 
                         click: function() {
                             undoMoveXBlock(
                                 {
-                                    sourceXBlockElement: data.sourceXBlockElement,
+                                    sourceXBlockElement: data.sourceXBlockElement ? data.sourceXBlockElement : null,
                                     sourceDisplayName: data.sourceDisplayName,
                                     sourceLocator: data.sourceLocator,
                                     sourceParentLocator: data.sourceParentLocator,

--- a/cms/templates/container_editor.html
+++ b/cms/templates/container_editor.html
@@ -1,0 +1,317 @@
+## coding=utf-8
+## mako
+
+## Pages currently use v1 styling by default. Once the Pattern Library
+## rollout has been completed, this default can be switched to v2.
+<%! main_css = "style-main-v1" %>
+
+## Standard imports
+<%namespace name='static' file='static_content.html'/>
+<%!
+from django.utils.translation import gettext as _
+from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
+from lms.djangoapps.branding import api as branding_api
+from openedx.core.djangoapps.util.user_messages import PageLevelMessages
+from openedx.core.djangolib.js_utils import (
+    dump_js_escaped_json, js_escaped_string
+)
+from openedx.core.djangolib.markup import HTML
+from openedx.core.release import RELEASE_LINE
+%>
+<%def name="online_help_token()">
+<%
+    return "container"
+%>
+</%def>
+<%!
+from django.urls import reverse
+from django.utils.translation import gettext as _
+from cms.djangoapps.contentstore.helpers import xblock_studio_url, xblock_type_display_name
+from openedx.core.djangolib.js_utils import (
+    dump_js_escaped_json, js_escaped_string
+)
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<%page expression_filter="h"/>
+<!doctype html>
+<!--[if lte IE 9]><html class="ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
+<!--[if !IE]><<!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
+    <head dir="${static.dir_rtl()}">
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta name="openedx-release-line" content="${RELEASE_LINE}" />
+        <title>
+            <%block name="title">
+                ${xblock.display_name_with_default} ${xblock_type_display_name(xblock)}
+            </%block> |
+            % if context_course:
+                <% ctx_loc = context_course.location %>
+                ${context_course.display_name_with_default} |
+            % elif context_library:
+                ${context_library.display_name_with_default} |
+            % endif
+                ${settings.STUDIO_NAME}
+        </title>
+
+        <%
+          jsi18n_path = "js/i18n/{language}/djangojs.js".format(language=LANGUAGE_CODE)
+        %>
+
+        % if getattr(settings, 'CAPTURE_CONSOLE_LOG', False):
+            <script type="text/javascript">
+                const oldOnError = window.onerror;
+                window.localStorage.setItem('console_log_capture', JSON.stringify([]));
+
+                window.onerror = function (message, url, lineno, colno, error) {
+                    if (oldOnError) {
+                        oldOnError.apply(this, arguments);
+                    }
+
+                    const messages = JSON.parse(window.localStorage.getItem('console_log_capture'));
+                    messages.push([message, url, lineno, colno, (error || {}).stack]);
+                    window.localStorage.setItem('console_log_capture', JSON.stringify(messages));
+                }
+            </script>
+        % endif
+
+        <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+        % if settings.DEBUG:
+            ## Provides a fallback for gettext functions in development environment
+            <script type="text/javascript" src="${static.url('js/src/gettext_fallback.js')}"></script>
+        % endif
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <meta name="path_prefix" content="${EDX_ROOT_URL}">
+        <%block name="header_meta"></%block>
+        <% favicon_url = branding_api.get_favicon_url() %>
+        <link rel="icon" type="image/x-icon" href="${favicon_url}"/>
+        <%static:css group='style-vendor'/>
+        <%static:css group='style-vendor-tinymce-content'/>
+        <%static:css group='style-vendor-tinymce-skin'/>
+        <style>
+            html body {
+                background: transparent;
+            }
+        </style>
+
+        % if uses_bootstrap:
+            <link rel="stylesheet" href="${static.url(self.attr.main_css)}" type="text/css" media="all" />
+        % else:
+            <%static:css group='${self.attr.main_css}'/>
+        % endif
+
+        <%include file="widgets/segment-io.html" />
+        <%block name="header_extras">
+
+        % for template_name in templates:
+        <script type="text/template" id="${template_name}-tpl">
+            <%static:include path="js/${template_name}.underscore" />
+        </script>
+        % endfor
+        <script type="text/template" id="image-modal-tpl">
+            <%static:include path="common/templates/image-modal.underscore" />
+        </script>
+        <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
+        % if not settings.STUDIO_FRONTEND_CONTAINER_URL:
+            <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/common.min.css')}" />
+            <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/editImageModal.min.css')}" />
+        % endif
+
+        </%block>
+        <!-- Hotjar Tracking Code for studio -->
+        <script>
+            (function(h, o, t, j, a, r){
+                h.hj = h.hj || function() { (h.hj.q = h.hj.q || []).push(arguments) };
+                h._hjSettings={ hjid: Number('${settings.HOTJAR_ID |n, js_escaped_string}'), hjsv: 6 };
+                a = o.getElementsByTagName('head')[0];
+                r = o.createElement('script');
+                r.async = 1;
+                r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                a.appendChild(r);
+            })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+        </script>
+    </head>
+
+    <body class="${static.dir_rtl()} <%block name='bodyclass'></%block> lang_${LANGUAGE_CODE} view-container">
+        <%block name="view_notes"></%block>
+        <a class="nav-skip" href="#main">${_("Skip to main content")}</a>
+        <%static:js group='base_vendor'/>
+        <%static:webpack entry="commons"/>
+        <script type="text/javascript">
+            window.baseUrl = '${settings.STATIC_URL | n, js_escaped_string}';
+            require.config({ baseUrl: window.baseUrl });
+        </script>
+        <script type="text/javascript" src="${static.url("cms/js/require-config.js")}"></script>
+        <!-- view -->
+        <div class="wrapper wrapper-view" dir="${static.dir_rtl()}">
+        <%
+            banner_messages = list(PageLevelMessages.user_messages(request))
+        %>
+        <main id="main" aria-label="Content" tabindex="-1">
+            <div id="content">
+                <%block name="content">
+                    <script type="text/javascript">
+                        window.STUDIO_FRONTEND_IN_CONTEXT_IMAGE_SELECTION = true;
+                    </script>
+
+                    <div style="display:none" class="wrapper-mast wrapper">
+                        <header class="mast has-actions has-navigation has-subtitle">
+                            <nav class="nav-actions" aria-label="${_('Page Actions')}">
+                                <ul>
+                                    <li class="action-item action-edit nav-item">
+                                        <a href="#"  class="button button-edit action-button edit-button">
+                                            <span class="icon fa fa-pencil" aria-hidden="true"></span>
+                                            <span class="action-button-text">${_("Edit")}</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </header>
+                    </div>
+
+                    <script type="text/javascript">
+                        $(document).ready(() => {
+                            // Serves to initialize the rendering of a xblock edit modal window.
+                            setTimeout(() => $('.button-edit').trigger('click'), 300);
+
+                            /**
+                             * Callback function for the MutationObserver to handle mutations
+                             * and send information when the modal window close logic is triggered.
+                             *
+                             * @callback mutationCallback
+                             * @param {MutationRecord[]} mutations - The list of mutations detected by the observer.
+                             */
+                            const xblockEditModalObserver = new MutationObserver((mutations) => {
+                                const modalClassName = 'wrapper-modal-window-edit-xblock';
+
+                                // When a modal window is opened while the template is rendering,
+                                // an element with class modalClassName is rendered,
+                                // the MutationObserver defines this process in removedNodes.
+                                const modalElementMutationRecords = mutations
+                                    .filter(({ removedNodes }) => {
+                                        const filteredModalClassName = Array.from(removedNodes).filter((node) =>
+                                            node.className && node.className.includes(modalClassName));
+
+                                        return filteredModalClassName.length > 0;
+                                    });
+
+                                // If the element was present and deleted, close the modal window.
+                                if (modalElementMutationRecords.length > 0 && !$('.' + modalClassName).length) {
+                                    window.parent.postMessage({
+                                        method: 'close_edit_modal',
+                                        msg: 'Sends a message when the modal window is closed'
+                                    }, '*');
+                                }
+                            });
+
+                            xblockEditModalObserver.observe(document, {
+                                childList: true,
+                                subtree: true,
+                                attributes: true,
+                                attributeFilter: ['class']
+                            });
+                        });
+                    </script>
+                </%block>
+            </div>
+        </main>
+    </div>
+
+    <%block name="modal_placeholder"></%block>
+    <%block name="jsextra"></%block>
+
+    % if context_course:
+        <%static:webpack entry="js/factories/context_course"/>
+        <script type="text/javascript">
+            window.course = new ContextCourse({
+                id: '${context_course.id | n, js_escaped_string}',
+                name: '${context_course.display_name_with_default | n, js_escaped_string}',
+                url_name: '${context_course.location.block_id | n, js_escaped_string}',
+                org: '${context_course.location.org | n, js_escaped_string}',
+                num: '${context_course.location.course | n, js_escaped_string}',
+                display_course_number: '${context_course.display_coursenumber | n, js_escaped_string}',
+                revision: '${context_course.location.branch | n, js_escaped_string}',
+                self_paced: ${ context_course.self_paced | n, dump_js_escaped_json },
+                is_custom_relative_dates_active: ${CUSTOM_RELATIVE_DATES.is_enabled(context_course.id) | n, dump_js_escaped_json},
+                start: ${context_course.start | n, dump_js_escaped_json},
+                discussions_settings: ${context_course.discussions_settings | n, dump_js_escaped_json}
+            });
+        </script>
+    % endif
+
+    % if user.is_authenticated:
+        <%static:webpack entry='js/sock'/>
+    % endif
+
+    <%block name='page_bundle'>
+        <script type="text/javascript">
+            require(['js/factories/base'], function () {
+                <%block name='requirejs'></%block>
+            });
+        </script>
+        <%static:webpack entry="js/factories/container">
+            ContainerFactory(
+                ${component_templates | n, dump_js_escaped_json},
+                ${xblock_info | n, dump_js_escaped_json},
+                '${action | n, js_escaped_string}',
+                {
+                    isUnitPage: ${is_unit_page | n, dump_js_escaped_json},
+                    canEdit: true,
+                    outlineURL: '${outline_url | n, js_escaped_string}',
+                    clipboardData: ${user_clipboard | n, dump_js_escaped_json},
+                }
+            );
+
+            require(['js/models/xblock_info', 'js/views/xblock', 'js/views/utils/xblock_utils', 'common/js/components/utils/view_utils', 'gettext'], function (XBlockInfo, XBlockView, XBlockUtils, ViewUtils, gettext) {
+                var model = new XBlockInfo({ id: '${subsection.location|n, decode.utf8}' });
+                var xblockView = new XBlockView({
+                    model: model,
+                    el: $('#sequence-nav'),
+                    view: 'author_view?position=${position|n, decode.utf8}&next_url=${next_url|n, decode.utf8}&prev_url=${prev_url|n, decode.utf8}',
+                    clipboardData: ${user_clipboard | n, dump_js_escaped_json},
+                });
+
+                xblockView.xblockReady = function() {
+                    var toggleCaretButton = function(clipboardData) {
+                        if (clipboardData && clipboardData.content && clipboardData.source_usage_key.includes('vertical')) {
+                            $('.dropdown-toggle-button').show();
+                        } else {
+                            $('.dropdown-toggle-button').hide();
+                            $('.dropdown-options').hide();
+                        }
+                    };
+                    this.clipboardBroadcastChannel = new BroadcastChannel('studio_clipboard_channel');
+                    this.clipboardBroadcastChannel.onmessage = (event) => toggleCaretButton(event.data);
+                    toggleCaretButton(this.options.clipboardData);
+
+                    $('#new-unit-button').on('click', function(event) {
+                        event.preventDefault();
+                        XBlockUtils.addXBlock($(this)).done(function(locator) {
+                            ViewUtils.redirect('/container/' + locator + '?action=new');
+                        });
+                    });
+
+                    $('.custom-dropdown .dropdown-toggle-button').on('click', function(event) {
+                        event.stopPropagation(); // Prevent the event from closing immediately when we open it
+                        $(this).next('.dropdown-options').slideToggle('fast'); // This toggles the dropdown visibility
+                        var isExpanded = $(this).attr('aria-expanded') === 'true';
+                        $(this).attr('aria-expanded', !isExpanded);
+                    });
+
+                    $('.seq_paste_unit').on('click', function(event) {
+                        event.preventDefault();
+                        $('.dropdown-options').hide();
+                        XBlockUtils.pasteXBlock($(this)).done(function(data) {
+                            ViewUtils.redirect('/container/' + data.locator + '?action=new');
+                        });
+                    });
+                };
+
+                xblockView.render();
+            });
+        </%static:webpack>
+    </%block>
+
+    <div class="modal-cover"></div>
+  </body>
+</html>

--- a/cms/templates/container_editor.html
+++ b/cms/templates/container_editor.html
@@ -192,20 +192,28 @@ from openedx.core.djangolib.markup import HTML, Text
             require(['js/models/xblock_info', 'js/views/xblock', 'js/views/utils/xblock_utils',
 'common/js/components/utils/view_utils', 'gettext', 'js/views/modals/edit_xblock', 'js/views/modals/move_xblock_modal'],
 function (XBlockInfo, XBlockView, XBlockUtils, ViewUtils, gettext, EditXBlockModal, MoveXBlockModal) {
-            if ('${action_name|n, decode.utf8}' === 'move') {
-                 var parentModel = new XBlockInfo({ id: '${unit.location|n, decode.utf8}', category: 'vertical' });
-                 var moveModal = new MoveXBlockModal({
-                         sourceXBlockInfo: new XBlockInfo(${xblock_info | n, dump_js_escaped_json}),
-                         sourceParentXBlockInfo: parentModel,
-                         XBlockURLRoot: "/xblock",
-                         outlineURL: '${outline_url | n, js_escaped_string}',
-                     });
-                moveModal.show();
-            } else if ('${action_name|n, decode.utf8}' === 'edit') {
-             var editModal = new EditXBlockModal();
+                function showMoveModal(unitLocation, xblockInfo, outlineUrl) {
+                    var parentModel = new XBlockInfo({ id: unitLocation, category: 'vertical' });
+                    var moveModal = new MoveXBlockModal({
+                        sourceXBlockInfo: new XBlockInfo(xblockInfo),
+                        sourceParentXBlockInfo: parentModel,
+                        XBlockURLRoot: '/xblock',
+                        outlineURL: outlineUrl,
+                    });
+                    moveModal.show();
+                }
 
-             editModal.edit([], new XBlockInfo(${xblock_info | n, dump_js_escaped_json}), {});
-            }
+                function showEditModal(xblockInfo) {
+                    var editModal = new EditXBlockModal();
+                    editModal.edit([], new XBlockInfo(xblockInfo), {});
+                }
+
+                var actionName = '${action_name|n, decode.utf8}';
+                if (actionName === 'move') {
+                    showMoveModal('${unit.location|n, decode.utf8}', ${xblock_info | n, dump_js_escaped_json}, '${outline_url | n, js_escaped_string}');
+                } else if (actionName === 'edit') {
+                    showEditModal(${xblock_info | n, dump_js_escaped_json});
+                }
             });
         </%static:webpack>
     </%block>

--- a/cms/templates/container_editor.html
+++ b/cms/templates/container_editor.html
@@ -150,68 +150,6 @@ from openedx.core.djangolib.markup import HTML, Text
         <main id="main" aria-label="Content" tabindex="-1">
             <div id="content">
                 <%block name="content">
-                    <script type="text/javascript">
-                        window.STUDIO_FRONTEND_IN_CONTEXT_IMAGE_SELECTION = true;
-                    </script>
-
-                    <div style="display:none" class="wrapper-mast wrapper">
-                        <header class="mast has-actions has-navigation has-subtitle">
-                            <nav class="nav-actions" aria-label="${_('Page Actions')}">
-                                <ul>
-                                    <li class="action-item action-edit nav-item">
-                                        <a href="#"  class="button button-edit action-button edit-button">
-                                            <span class="icon fa fa-pencil" aria-hidden="true"></span>
-                                            <span class="action-button-text">${_("Edit")}</span>
-                                        </a>
-                                    </li>
-                                </ul>
-                            </nav>
-                        </header>
-                    </div>
-
-                    <script type="text/javascript">
-                        $(document).ready(() => {
-                            // Serves to initialize the rendering of a xblock edit modal window.
-                            setTimeout(() => $('.button-edit').trigger('click'), 300);
-
-                            /**
-                             * Callback function for the MutationObserver to handle mutations
-                             * and send information when the modal window close logic is triggered.
-                             *
-                             * @callback mutationCallback
-                             * @param {MutationRecord[]} mutations - The list of mutations detected by the observer.
-                             */
-                            const xblockEditModalObserver = new MutationObserver((mutations) => {
-                                const modalClassName = 'wrapper-modal-window-edit-xblock';
-
-                                // When a modal window is opened while the template is rendering,
-                                // an element with class modalClassName is rendered,
-                                // the MutationObserver defines this process in removedNodes.
-                                const modalElementMutationRecords = mutations
-                                    .filter(({ removedNodes }) => {
-                                        const filteredModalClassName = Array.from(removedNodes).filter((node) =>
-                                            node.className && node.className.includes(modalClassName));
-
-                                        return filteredModalClassName.length > 0;
-                                    });
-
-                                // If the element was present and deleted, close the modal window.
-                                if (modalElementMutationRecords.length > 0 && !$('.' + modalClassName).length) {
-                                    window.parent.postMessage({
-                                        method: 'close_edit_modal',
-                                        msg: 'Sends a message when the modal window is closed'
-                                    }, '*');
-                                }
-                            });
-
-                            xblockEditModalObserver.observe(document, {
-                                childList: true,
-                                subtree: true,
-                                attributes: true,
-                                attributeFilter: ['class']
-                            });
-                        });
-                    </script>
                 </%block>
             </div>
         </main>
@@ -250,64 +188,24 @@ from openedx.core.djangolib.markup import HTML, Text
             });
         </script>
         <%static:webpack entry="js/factories/container">
-            ContainerFactory(
-                ${component_templates | n, dump_js_escaped_json},
-                ${xblock_info | n, dump_js_escaped_json},
-                '${action | n, js_escaped_string}',
-                {
-                    isUnitPage: ${is_unit_page | n, dump_js_escaped_json},
-                    canEdit: true,
-                    outlineURL: '${outline_url | n, js_escaped_string}',
-                    clipboardData: ${user_clipboard | n, dump_js_escaped_json},
-                }
-            );
 
-            require(['js/models/xblock_info', 'js/views/xblock', 'js/views/utils/xblock_utils', 'common/js/components/utils/view_utils', 'gettext'], function (XBlockInfo, XBlockView, XBlockUtils, ViewUtils, gettext) {
-                var model = new XBlockInfo({ id: '${subsection.location|n, decode.utf8}' });
-                var xblockView = new XBlockView({
-                    model: model,
-                    el: $('#sequence-nav'),
-                    view: 'author_view?position=${position|n, decode.utf8}&next_url=${next_url|n, decode.utf8}&prev_url=${prev_url|n, decode.utf8}',
-                    clipboardData: ${user_clipboard | n, dump_js_escaped_json},
-                });
+            require(['js/models/xblock_info', 'js/views/xblock', 'js/views/utils/xblock_utils',
+'common/js/components/utils/view_utils', 'gettext', 'js/views/modals/edit_xblock', 'js/views/modals/move_xblock_modal'],
+function (XBlockInfo, XBlockView, XBlockUtils, ViewUtils, gettext, EditXBlockModal, MoveXBlockModal) {
+            if ('${action_name|n, decode.utf8}' === 'move') {
+                 var parentModel = new XBlockInfo({ id: '${unit.location|n, decode.utf8}', category: 'vertical' });
+                 var moveModal = new MoveXBlockModal({
+                         sourceXBlockInfo: new XBlockInfo(${xblock_info | n, dump_js_escaped_json}),
+                         sourceParentXBlockInfo: parentModel,
+                         XBlockURLRoot: "/xblock",
+                         outlineURL: '${outline_url | n, js_escaped_string}',
+                     });
+                moveModal.show();
+            } else if ('${action_name|n, decode.utf8}' === 'edit') {
+             var editModal = new EditXBlockModal();
 
-                xblockView.xblockReady = function() {
-                    var toggleCaretButton = function(clipboardData) {
-                        if (clipboardData && clipboardData.content && clipboardData.source_usage_key.includes('vertical')) {
-                            $('.dropdown-toggle-button').show();
-                        } else {
-                            $('.dropdown-toggle-button').hide();
-                            $('.dropdown-options').hide();
-                        }
-                    };
-                    this.clipboardBroadcastChannel = new BroadcastChannel('studio_clipboard_channel');
-                    this.clipboardBroadcastChannel.onmessage = (event) => toggleCaretButton(event.data);
-                    toggleCaretButton(this.options.clipboardData);
-
-                    $('#new-unit-button').on('click', function(event) {
-                        event.preventDefault();
-                        XBlockUtils.addXBlock($(this)).done(function(locator) {
-                            ViewUtils.redirect('/container/' + locator + '?action=new');
-                        });
-                    });
-
-                    $('.custom-dropdown .dropdown-toggle-button').on('click', function(event) {
-                        event.stopPropagation(); // Prevent the event from closing immediately when we open it
-                        $(this).next('.dropdown-options').slideToggle('fast'); // This toggles the dropdown visibility
-                        var isExpanded = $(this).attr('aria-expanded') === 'true';
-                        $(this).attr('aria-expanded', !isExpanded);
-                    });
-
-                    $('.seq_paste_unit').on('click', function(event) {
-                        event.preventDefault();
-                        $('.dropdown-options').hide();
-                        XBlockUtils.pasteXBlock($(this)).done(function(data) {
-                            ViewUtils.redirect('/container/' + data.locator + '?action=new');
-                        });
-                    });
-                };
-
-                xblockView.render();
+             editModal.edit([], new XBlockInfo(${xblock_info | n, dump_js_escaped_json}), {});
+            }
             });
         </%static:webpack>
     </%block>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -18,6 +18,7 @@ import openedx.core.djangoapps.debug.views
 import openedx.core.djangoapps.lang_pref.views
 from cms.djangoapps.contentstore import toggles
 from cms.djangoapps.contentstore import views as contentstore_views
+from cms.djangoapps.contentstore.views.block import edit_view_xblock
 from cms.djangoapps.contentstore.views.organization import OrganizationListView
 from openedx.core.apidocs import api_info
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
@@ -145,6 +146,8 @@ urlpatterns = oauth2_urlpatterns + [
             name='xblock_outline_handler'),
     re_path(fr'^xblock/container/{settings.USAGE_KEY_PATTERN}$', contentstore_views.xblock_container_handler,
             name='xblock_container_handler'),
+    re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/editor$', edit_view_xblock,
+            name='xblock_editor_handler'),
     re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/(?P<view_name>[^/]+)$', contentstore_views.xblock_view_handler,
             name='xblock_view_handler'),
     re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}?$', contentstore_views.xblock_handler,

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -18,7 +18,7 @@ import openedx.core.djangoapps.debug.views
 import openedx.core.djangoapps.lang_pref.views
 from cms.djangoapps.contentstore import toggles
 from cms.djangoapps.contentstore import views as contentstore_views
-from cms.djangoapps.contentstore.views.block import edit_view_xblock
+from cms.djangoapps.contentstore.views.block import xblock_actions_view
 from cms.djangoapps.contentstore.views.organization import OrganizationListView
 from openedx.core.apidocs import api_info
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
@@ -146,8 +146,8 @@ urlpatterns = oauth2_urlpatterns + [
             name='xblock_outline_handler'),
     re_path(fr'^xblock/container/{settings.USAGE_KEY_PATTERN}$', contentstore_views.xblock_container_handler,
             name='xblock_container_handler'),
-    re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/editor$', edit_view_xblock,
-            name='xblock_editor_handler'),
+    re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/actions/(?P<action_name>[^/]+)$$', xblock_actions_view,
+            name='xblock_actions_handler'),
     re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/(?P<view_name>[^/]+)$', contentstore_views.xblock_view_handler,
             name='xblock_view_handler'),
     re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}?$', contentstore_views.xblock_handler,

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -146,7 +146,7 @@ urlpatterns = oauth2_urlpatterns + [
             name='xblock_outline_handler'),
     re_path(fr'^xblock/container/{settings.USAGE_KEY_PATTERN}$', contentstore_views.xblock_container_handler,
             name='xblock_container_handler'),
-    re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/actions/(?P<action_name>[^/]+)$$', xblock_actions_view,
+    re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/actions/(?P<action_name>[^/]+)$', xblock_actions_view,
             name='xblock_actions_handler'),
     re_path(fr'^xblock/{settings.USAGE_KEY_PATTERN}/(?P<view_name>[^/]+)$', contentstore_views.xblock_view_handler,
             name='xblock_view_handler'),


### PR DESCRIPTION
## Description

In this PR a new view is added to CMS to render xblock modal views such as editor for advanced problem types and move xBlock modal. It's intended to use this view to render mentioned earlier interfaces in the course-authoring MFE. The course-authoring implementation can be found in this PR - https://github.com/openedx/frontend-app-course-authoring/pull/985.
This particular decision was made because the functionality to edit and move modals depends on the BackboneJS implementation, and can't be recreated in the React.js within the current solution.

According to discussions in https://github.com/openedx/edx-platform/pull/34161#issuecomment-2112522240 and https://github.com/openedx/frontend-app-course-authoring/pull/964#pullrequestreview-2033590615 the final decision for rendering xblock previews will also affect rendering of the edit modal for advanced xBlock. Therefore, it was decided to postpone the merge of the current implementation, and revise it after the decision for xBlocks previews is made.

## Supporting information

Issue: https://github.com/openedx/platform-roadmap/issues/321

## Testing instructions

- Start CMS service
- Copy xBlock locator for advanced problem
- Open to - {CMS_BASE}/xblock/{xblock_locator}/actions/edit
- See edit modal for the xBlock

- Start CMS service
- Copy xBlock locator for advanced problem
- Open to - {CMS_BASE}/xblock/{xblock_locator}/actions/move
- See move modal for the xBlock

## Deadline

"None"

## Other information

This PR is a replacement for the github.com/openedx/edx-platform/pull/34656
