### PR TITLE
fix: searching tag refinement was sometimes not working

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -327,11 +327,20 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
         ])
         # Mark which attributes are used for keyword search, in order of importance:
         client.index(temp_index_name).update_searchable_attributes([
+            # Keyword search does _not_ search the course name, course ID, breadcrumbs, block type, or other fields.
             Fields.display_name,
             Fields.block_id,
             Fields.content,
             Fields.tags,
-            # Keyword search does _not_ search the course name, course ID, breadcrumbs, block type, or other fields.
+            # If we don't list the following sub-fields _explicitly_, they're only sometimes searchable - that is, they
+            # are searchable only if at least one document in the index has a value. If we didn't list them here and,
+            # say, there were no tags.level3 tags in the index, the client would get an error if trying to search for
+            # these sub-fields: "Attribute `tags.level3` is not searchable."
+            Fields.tags + "." + Fields.tags_taxonomy,
+            Fields.tags + "." + Fields.tags_level0,
+            Fields.tags + "." + Fields.tags_level1,
+            Fields.tags + "." + Fields.tags_level2,
+            Fields.tags + "." + Fields.tags_level3,
         ])
 
         ############## Libraries ##############


### PR DESCRIPTION
## Description

Fixes https://github.com/openedx/modular-learning/issues/224

It turns out that if no documents on the instance contain any "level 3" tags, then the search which tries to filter the tags using a keyword search (and explicitly includes the `tags.level3` field) would fail. The fix is simple, to always explicitly add `tags.levelX` as "searchable fields", rather than assuming they'll be implicitly searchable because the parent `tags` field is included.

## Supporting information



## Testing instructions

To reproduce the bug, before checking out this branch, go to this line: 

https://github.com/openedx/edx-platform/blob/7f7cade1310db6b50b2e32914b9d8f4d431d69f4/openedx/core/djangoapps/content/search/documents.py#L205

and change `4` to `3`. This simulates "no documents have level 3 tags". Then run `python manage.py cms reindex_studio --experimental`.

Then open the search UI in course authoring and enter a keyword into the tags filter. It should have no effect.

Then checkout this branch, run the reindex command again, and see that the fix worked.

## Deadline

We want to get this backported to Redwood ASAP.

Private Ref: MNG-4283
