### PR TITLE
fix: Remove trial logic using moment-timezone in B2C Subs Programs

### DIFF
--- a/lms/static/js/learner_dashboard/models/program_subscription_model.js
+++ b/lms/static/js/learner_dashboard/models/program_subscription_model.js
@@ -42,10 +42,7 @@ class ProgramSubscriptionModel extends Backbone.Model {
             data.current_period_end,
             userPreferences
         );
-        const [trialEndDate, trialEndTime] = ProgramSubscriptionModel.formatDate(
-            data.trial_end,
-            userPreferences
-        );
+        const [trialEndDate, trialEndTime] = ['', ''];
 
         super(
             {
@@ -69,7 +66,7 @@ class ProgramSubscriptionModel extends Backbone.Model {
         }
 
         const userTimezone = (
-            userPreferences.time_zone || moment.tz.guess() || 'UTC'
+            userPreferences.time_zone || moment?.tz?.guess?.() || 'UTC'
         );
         const userLanguage = userPreferences['pref-lang'] || 'en';
         const context = {
@@ -80,10 +77,7 @@ class ProgramSubscriptionModel extends Backbone.Model {
         };
 
         const localDate = DateUtils.localize(context);
-        const localTime = DateUtils.localizeTime(
-            DateUtils.stringToMoment(date),
-            userTimezone
-        ).format('HH:mm (z)');
+        const localTime = '';
 
         return [localDate, localTime];
     }

--- a/lms/static/js/learner_dashboard/models/program_subscription_model.js
+++ b/lms/static/js/learner_dashboard/models/program_subscription_model.js
@@ -19,10 +19,6 @@ class ProgramSubscriptionModel extends Backbone.Model {
         } = context;
 
         const priceInUSD = subscription_prices?.find(({ currency }) => currency === 'USD');
-        const trialMoment = DateUtils.localizeTime(
-            DateUtils.stringToMoment(data.trial_end),
-            'UTC'
-        );
 
         const subscriptionState = data.subscription_state?.toLowerCase() ?? '';
         const subscriptionPrice = StringUtils.interpolate(
@@ -38,10 +34,7 @@ class ProgramSubscriptionModel extends Backbone.Model {
                 ? urls.manage_subscription_url
                 : urls.buy_subscription_url;
 
-        const hasActiveTrial =
-            subscriptionState === 'active' && data.trial_end
-                ? trialMoment.isAfter(moment.utc())
-                : false;
+        const hasActiveTrial = false;
 
         const remainingDays = ProgramSubscriptionModel.getRemainingDays(
             data.trial_end,

--- a/lms/static/js/learner_dashboard/models/program_subscription_model.js
+++ b/lms/static/js/learner_dashboard/models/program_subscription_model.js
@@ -36,10 +36,7 @@ class ProgramSubscriptionModel extends Backbone.Model {
 
         const hasActiveTrial = false;
 
-        const remainingDays = ProgramSubscriptionModel.getRemainingDays(
-            data.trial_end,
-            userPreferences
-        );
+        const remainingDays = 0;
 
         const [currentPeriodEnd] = ProgramSubscriptionModel.formatDate(
             data.current_period_end,
@@ -89,30 +86,6 @@ class ProgramSubscriptionModel extends Backbone.Model {
         ).format('HH:mm (z)');
 
         return [localDate, localTime];
-    }
-
-    static getRemainingDays(trialEndDate, userPreferences) {
-        if (!trialEndDate) {
-            return 0;
-        }
-
-        const userTimezone = (
-            userPreferences.time_zone || moment.tz.guess() || 'UTC'
-        );
-        const trialEndTime = DateUtils.localizeTime(
-            DateUtils.stringToMoment(trialEndDate),
-            userTimezone
-        );
-        const currentTime = DateUtils.localizeTime(
-            moment.utc(),
-            userTimezone
-        );
-
-        return trialEndTime.diff(currentTime, 'days') < 1
-            ? // 0 if trial end time is less than 24 hrs
-              0
-            : // else return actual difference in days
-              trialEndTime.startOf('day').diff(currentTime.startOf('day'), 'days');
     }
 }
 


### PR DESCRIPTION
[REV-4067](https://2u-internal.atlassian.net/browse/REV-4067).

When `moment-timezone` was upgraded from v0.5.37 -> 0.5.45 by Renovate, it caused an issue in the ProgramDetails page, with console error `M.tz is not a function` in L23 `DateUtils.stringToMoment(data.trial_end)`.

Since then, `moment` has been updated by Renovate as well (previously there was dependency version conflicts with `moment` version from `edx-ui-toolkit` and the version in edx-platform.

Removing/setting to false or empty some trial related logic in the Program Subscription Model, some of which is only used when `hasActiveTrial` is true. 

This file still uses `DateUtils` from `edx-ui-toolkit` and `moment`, but I've added optional chaining to avoid calling `tz` if it doesn't exist.

If the issue still persists after the upgrade and is in `DateUtils`, this is outside of our scope and the appropriate team will be notified.