### PR TITLE
fix: also filter for show_dashboard for instructor

### DIFF
--- a/cms/djangoapps/contentstore/proctoring.py
+++ b/cms/djangoapps/contentstore/proctoring.py
@@ -39,10 +39,6 @@ def register_special_exams(course_key):
         # if feature is not enabled then do a quick exit
         return
 
-
-    ### TODO: Go through this and figure out what calls "get_backend_provider" in edx-proctoring
-    ### And ideally surround those parts with an "if lti_external" filter
-
     course = modulestore().get_course(course_key)
     if course is None:
         raise ItemNotFoundError("Course {} does not exist", str(course_key))  # lint-amnesty, pylint: disable=raising-format-tuple
@@ -89,17 +85,14 @@ def register_special_exams(course_key):
             'is_practice_exam': timed_exam.is_practice_exam or timed_exam.is_onboarding_exam,
             'is_active': True,
             'hide_after_due': timed_exam.hide_after_due,
-            # TODO: See if this matters for the noisy log
             'backend': course.proctoring_provider,
         }
 
         try:
-            # TODO: See if this matters for the noisy log
             exam = get_exam_by_content_id(str(course_key), str(timed_exam.location))
             # update case, make sure everything is synced
             exam_metadata['exam_id'] = exam['id']
 
-            # TODO: See if this matters for the noisy log
             exam_id = update_exam(**exam_metadata)
             msg = 'Updated timed exam {exam_id}'.format(exam_id=exam['id'])
             log.info(msg)
@@ -107,7 +100,6 @@ def register_special_exams(course_key):
         except ProctoredExamNotFoundException:
             exam_metadata['course_id'] = str(course_key)
             exam_metadata['content_id'] = str(timed_exam.location)
-            # TODO: See if this matters for the noisy log
             exam_id = create_exam(**exam_metadata)
             msg = f'Created new timed exam {exam_id}'
             log.info(msg)
@@ -121,25 +113,21 @@ def register_special_exams(course_key):
         # only create/update exam policy for the proctored exams
         if timed_exam.is_proctored_exam and not timed_exam.is_practice_exam and not timed_exam.is_onboarding_exam:
             try:
-                # TODO: See if this matters for the noisy log
                 update_review_policy(**exam_review_policy_metadata)
             except ProctoredExamReviewPolicyNotFoundException:
                 if timed_exam.exam_review_rules:  # won't save an empty rule.
-                    # TODO: See if this matters for the noisy log
                     create_exam_review_policy(**exam_review_policy_metadata)
                     msg = f'Created new exam review policy with exam_id {exam_id}'
                     log.info(msg)
         else:
             try:
                 # remove any associated review policy
-                # TODO: See if this matters for the noisy log
                 remove_review_policy(exam_id=exam_id)
             except ProctoredExamReviewPolicyNotFoundException:
                 pass
 
     # then see which exams we have in edx-proctoring that are not in
     # our current list. That means the the user has disabled it
-    # TODO: See if this matters for the noisy log
     exams = get_all_exams_for_course(course_key)
 
     for exam in exams:
@@ -155,7 +143,6 @@ def register_special_exams(course_key):
                 # the exam as inactive (we don't delete!)
                 msg = 'Disabling timed exam {exam_id}'.format(exam_id=exam['id'])
                 log.info(msg)
-                # TODO: See if this matters for the noisy log
                 update_exam(
                     exam_id=exam['id'],
                     is_proctored=False,

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3669,6 +3669,45 @@ class TestSpecialExamXBlockInfo(ItemTest):
     @patch_does_backend_support_onboarding
     @patch_get_exam_by_content_id_success
     @ddt.data(
+        ("lti_external", True),
+        ("other_proctoring_backend", False),
+    )
+    @ddt.unpack
+    def test_support_onboarding_is_correct_depending_on_lti_external(
+        self,
+        external_id,
+        expected_value,
+        mock_get_exam_by_content_id,
+        mock_does_backend_support_onboarding,
+        _mock_get_exam_configuration_dashboard_url,
+    ):
+        sequential = BlockFactory.create(
+            parent_location=self.chapter.location,
+            category="sequential",
+            display_name="Test Lesson 1",
+            user_id=self.user.id,
+            is_proctored_enabled=False,
+            is_time_limited=False,
+            is_onboarding_exam=False,
+        )
+        # set course.proctoring_provider to lti_external
+        self.course.proctoring_provider = external_id
+        print({self.course.proctoring_provider})
+        mock_get_exam_by_content_id.return_value = {"external_id": external_id}
+        # mock_does_backend_support_onboarding returns True
+        mock_does_backend_support_onboarding.return_value = True
+        sequential = modulestore().get_item(sequential.location)
+        xblock_info = create_xblock_info(
+            sequential,
+            include_child_info=True,
+            include_children_predicate=ALWAYS,
+        )
+        assert xblock_info["supports_onboarding"] is expected_value
+
+    @patch_get_exam_configuration_dashboard_url
+    @patch_does_backend_support_onboarding
+    @patch_get_exam_by_content_id_success
+    @ddt.data(
         ("test_external_id", True),
         (None, False),
     )

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3669,8 +3669,8 @@ class TestSpecialExamXBlockInfo(ItemTest):
     @patch_does_backend_support_onboarding
     @patch_get_exam_by_content_id_success
     @ddt.data(
-        ("lti_external", True),
-        ("other_proctoring_backend", False),
+        ("lti_external", False),
+        ("other_proctoring_backend", True),
     )
     @ddt.unpack
     def test_support_onboarding_is_correct_depending_on_lti_external(
@@ -3690,10 +3690,11 @@ class TestSpecialExamXBlockInfo(ItemTest):
             is_time_limited=False,
             is_onboarding_exam=False,
         )
+
         # set course.proctoring_provider to lti_external
         self.course.proctoring_provider = external_id
-        print({self.course.proctoring_provider})
         mock_get_exam_by_content_id.return_value = {"external_id": external_id}
+
         # mock_does_backend_support_onboarding returns True
         mock_does_backend_support_onboarding.return_value = True
         sequential = modulestore().get_item(sequential.location)
@@ -3701,6 +3702,7 @@ class TestSpecialExamXBlockInfo(ItemTest):
             sequential,
             include_child_info=True,
             include_children_predicate=ALWAYS,
+            course=self.course,
         )
         assert xblock_info["supports_onboarding"] is expected_value
 

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1146,7 +1146,8 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                     "online_proctoring_rules", ""
                 )
 
-                # Only call does_backend_support_onboarding if  not using an LTI proctoring provider
+                # Only call does_backend_support_onboarding if not using an LTI proctoring provider
+                print("course.proctoring_provider:",course.proctoring_provider)
                 if course.proctoring_provider != 'lti_external':
                     supports_onboarding = does_backend_support_onboarding(
                         course.proctoring_provider

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1147,7 +1147,6 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                 )
 
                 # Only call does_backend_support_onboarding if not using an LTI proctoring provider
-                print("course.proctoring_provider:",course.proctoring_provider)
                 if course.proctoring_provider != 'lti_external':
                     supports_onboarding = does_backend_support_onboarding(
                         course.proctoring_provider

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -310,7 +310,7 @@ def _section_special_exams(course, access):
         # Dashboard should always appear with LTI proctoring
         show_dashboard = True
     else:
-        # Only call does_backend_support_onboarding if  not using an LTI proctoring provider
+        # Only call does_backend_support_onboarding if not using an LTI proctoring provider
         show_onboarding = does_backend_support_onboarding(course.proctoring_provider)
         if proctoring_provider == 'proctortrack':
             escalation_email = course.proctoring_escalation_email

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -302,16 +302,20 @@ def _section_special_exams(course, access):
     proctoring_provider = course.proctoring_provider
     escalation_email = None
     mfe_view_url = None
+    show_dashboard = None
     if proctoring_provider == 'lti_external':
         mfe_view_url = f'{settings.EXAMS_DASHBOARD_MICROFRONTEND_URL}/course/{course_key}/exams/embed'
         # NOTE: LTI proctoring doesn't support onboarding. If that changes, this value should change to True.
         show_onboarding = False
+        # Dashboard should always appear with LTI proctoring
+        show_dashboard = True
     else:
         # Only call does_backend_support_onboarding if  not using an LTI proctoring provider
         show_onboarding = does_backend_support_onboarding(course.proctoring_provider)
         if proctoring_provider == 'proctortrack':
             escalation_email = course.proctoring_escalation_email
-    from edx_proctoring.api import is_backend_dashboard_available
+        from edx_proctoring.api import is_backend_dashboard_available
+        show_dashboard = is_backend_dashboard_available(course_key)
 
     section_data = {
         'section_key': 'special_exams',
@@ -319,7 +323,7 @@ def _section_special_exams(course, access):
         'access': access,
         'course_id': course_key,
         'escalation_email': escalation_email,
-        'show_dashboard': is_backend_dashboard_available(course_key),
+        'show_dashboard': show_dashboard,
         'show_onboarding': show_onboarding,
         'mfe_view_url': mfe_view_url,
     }


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/COSMO-193

## Description

This fix suppresses a noisy `NotImplementedError: No proctoring backend configured for 'lti_external'.  Available: ['null']` error that keeps going off when an LTI exam is published, which has made it hard to debug LTI proctoring.

This fix affects course authors and instructors.

## Deadline
None