### PR TITLE
temp: build: compile python requirements with 3.8, not 3.11

### DIFF
--- a/.github/workflows/compile-python-requirements.yml
+++ b/.github/workflows/compile-python-requirements.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.8"
 
       - name: Run make compile-requirements
         env:

--- a/.github/workflows/upgrade-one-python-dependency.yml
+++ b/.github/workflows/upgrade-one-python-dependency.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.8"
 
       - name: Update any pinned dependencies
         env:


### PR DESCRIPTION
We haven't quite dropped Py3.8 support yet, so we can't use these workflows if
they're compiling with 3.11:

* upgrade-one-python-dependency (upgrading a single, targeted dep)
* compile-python-requirements (recompiling all deps without upgrading)

So, we "downgrade" those workflows to use 3.8, for now. We should revert this
commit when we drop 3.8 support.

Note: The upgrade-python-requirements.yml workflow is still using 3.8, so this
commit will update the other workflows to match that one.