### PR TITLE
chore: Upgrade moment-timezone to v0.5.45

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,11 +31,8 @@
   ],
   // When adding an ignoreDep, please include a reason and a public link that we can use to follow up and ensure
   // that the ignoreDep is removed.
-  "ignoreDeps": [
-    // Latest moment-timezone version broke the legacy programs dashboard, which is deprecated and soon to be removed.
-    // https://github.com/openedx/edx-platform/pull/34928"
-    "moment-timezone",
-  ],
+  // This can be done as a comment within the ignoreDeps list.
+  "ignoreDeps": [],
   "timezone": "America/New_York",
   "prConcurrentLimit": 3,
   "enabledManagers": ["npm"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "js-cookie": "3.0.5",
         "jwt-decode": "^3.1.2",
         "moment": "2.30.1",
-        "moment-timezone": "0.5.37",
+        "moment-timezone": "0.5.45",
         "node-gyp": "10.0.1",
         "picturefill": "3.0.3",
         "popper.js": "1.12.9",
@@ -8540,18 +8540,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha512-YYp8cqz7/8eruZ15L1mzcPkvLYxipfdsWIDESvNdNmQP9o7TsDitRhNuV2xb7aFu2ofZngao1jiVrVZ842x4BQ=="
-    },
-    "node_modules/edx-ui-toolkit/node_modules/moment-timezone": {
-      "version": "0.5.45",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
-      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/edx-ui-toolkit/node_modules/requirejs": {
       "version": "2.1.22",
@@ -17448,11 +17436,11 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.37",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
-      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-cookie": "3.0.5",
     "jwt-decode": "^3.1.2",
     "moment": "2.30.1",
-    "moment-timezone": "0.5.37",
+    "moment-timezone": "0.5.45",
     "node-gyp": "10.0.1",
     "picturefill": "3.0.3",
     "popper.js": "1.12.9",


### PR DESCRIPTION
[REV-4067](https://2u-internal.atlassian.net/browse/REV-4067).

Once https://github.com/openedx/edx-platform/pull/34939 is merged, we want to upgrade `moment-timezone` again, which was previously done via Renovate in https://github.com/openedx/edx-platform/pull/34924 but caused an issue in production in the Program Details page.