### PR TITLE
fix: remove broken management command (and celery task) logic

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
+++ b/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
@@ -1,10 +1,6 @@
 """
-A manangement command to populate the `certificate_available_date` field of the CourseCertificateConfiguration model in
-the Credentials IDA.
-
-This command is designed to be ran once to initially backpopulate data. Otherwise, anytime an existing course run
-adjusts its certificate available date or certificates display behavior settings, updates will automatically be queued
-and transmit to the Credentials IDA.
+A manangement command to populate or correct the `certificate_available_date` data of the
+CourseCertificateConfiguration model instances stored by the Credentials IDA.
 """
 from django.core.management.base import BaseCommand
 
@@ -13,8 +9,11 @@ from openedx.core.djangoapps.credentials.tasks.v1.tasks import backfill_date_for
 
 class Command(BaseCommand):
     """
-    A management command reponsible for populating the `certificate_available_date` field of
-    CourseCertificateConfiguration instances in the Credentials IDA.
+    Enqueue the `backfill_date_for_all_course_runs` Celery task, which will enqueue additional subtasks responsible for
+    sending certificate availability updates to the Credentials IDA.
+
+    Example usage:
+        $ ./manage.py lms update_credentials_available_date
     """
     def handle(self, *args, **options):
         backfill_date_for_all_course_runs.delay()


### PR DESCRIPTION
## Description

[APER-3385]

This PR fixes an existing management command that now has incorrect logic. We have recently done a lot of work to improve certificate-related date business logic to fix data inconsistencies between systems. Instead of maintaining separate and duplicated logic for sending date data to Credentials, instead we can use an existing (and tested) Celery task that will determine and send the correct date to the Credentials IDA.

Additionally, the original version of this management command skipped self-paced courses completely. This is no longer the case as we _know_ that there are self-paced courses that have been associated with a certificate available date because of bugs in the product. This management command will serve as a means to do a mass data fixup for data stored by the Credentials IDA.