### PR TITLE
fix: Drop the click constraint.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,9 +17,6 @@
 celery>=5.2.2,<6.0.0
 
 
-# required for celery>=5.2.0;<5.3.0
-click>=8.0,<9.0
-
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.


### PR DESCRIPTION
Celery is already at version 5.4.0 and so it's unclear why this
dependency is here anymore.  THe latest version of click is less than
9.0.0
