### PR TITLE
fix: Remove the unused edx-custom-a11y-rules package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,6 @@
         "@edx/mockprock": "github:openedx/mockprock#3ad18c6888e6521e9bf7a4df0db6f8579b928235",
         "@edx/stylelint-config-edx": "2.3.3",
         "babel-jest": "26.0.0",
-        "edx-custom-a11y-rules": "1.0.6",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.8",
         "eslint-import-resolver-webpack": "0.8.4",
@@ -8474,12 +8473,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
-    },
-    "node_modules/edx-custom-a11y-rules": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/edx-custom-a11y-rules/-/edx-custom-a11y-rules-1.0.6.tgz",
-      "integrity": "sha512-syMILFpMPFDfTdoSgU1ctcM0OMg2wKFFcF1uyTmLUpvIoUewQbj6zNr3gBs61s51JZZRXN3N5S+FyUMkMsgELw==",
       "dev": true
     },
     "node_modules/edx-proctoring-proctortrack": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@edx/mockprock": "github:openedx/mockprock#3ad18c6888e6521e9bf7a4df0db6f8579b928235",
     "@edx/stylelint-config-edx": "2.3.3",
     "babel-jest": "26.0.0",
-    "edx-custom-a11y-rules": "1.0.6",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.8",
     "eslint-import-resolver-webpack": "0.8.4",


### PR DESCRIPTION
This package was only used by bok-choy which was archived a while ago.
We just missed the fact that this package was also a node dependency.

See https://github.com/openedx/public-engineering/issues/13 for more
details.
