### PR TITLE
build: upgrade edxapp docker image to python 3.11

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches:
       - master
+      - edxapp-docker-python311-upgrade
+
 jobs:
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     strategy:
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - master
-      - edxapp-docker-python311-upgrade
 
 jobs:
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     runs-on: ubuntu-latest
-  
+    if: github.event_name == 'push'
+
     strategy:
       matrix:
         variant:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,14 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     runs-on: ubuntu-latest
+  
+    strategy:
+      matrix:
+        variant:
+          - "lms_dev"
+          - "cms_dev"
+          - "cms"
+          - "lms"
 
     steps:
       - name: Checkout
@@ -32,4 +40,4 @@ jobs:
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        run: make docker_build
+        run: make docker_tag_build_push_${{matrix.variant}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,14 +12,6 @@ jobs:
   push:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        variant:
-          - "lms_dev"
-          - "cms_dev"
-          - "cms"
-          - "lms"
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,8 +28,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and push lms base docker image
+      - name: Build and push lms/cms base docker images
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        run: make docker_tag_build_push_${{matrix.variant}}
+        run: make docker_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM ubuntu:focal as minimal-system
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SERVICE_VARIANT
 ARG SERVICE_PORT
+ARG PYTHON_VERSION=3.11
 
 # Env vars: paver
 # We intentionally don't use paver in this Dockerfile, but Devstack may invoke paver commands
@@ -50,16 +51,13 @@ RUN echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8"
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
     apt-get -y install --no-install-recommends \
-        python3 \
-        python3-venv \
-        python3.8 \
-        python3.8-minimal \
-        # python3-dev: required for building mysqlclient python package version 2.2.0
-        python3-dev \
-        libpython3.8 \
-        libpython3.8-stdlib \
+        python$PYTHON_VERSION \
+        python$PYTHON_VERSION-pip \
+        python$PYTHON_VERSION-dev \
+        python$PYTHON_VERSION-venv \
+        libpython$PYTHON_VERSION \
+        libpython$PYTHON_VERSION-stdlib \
         libmysqlclient21 \
-        # libmysqlclient-dev: required for building mysqlclient python package version 2.2.0
         libmysqlclient-dev \
         pkg-config \
         libssl1.1 \
@@ -105,7 +103,7 @@ RUN apt-get update && \
 
 # Setup python virtual environment
 # It is already 'activated' because $VIRTUAL_ENV/bin was put on $PATH
-RUN python3.8 -m venv "${VIRTUAL_ENV}"
+RUN python$PYTHON_VERSION -m venv "${VIRTUAL_ENV}"
 
 # Install python requirements
 # Requires copying over requirements files, but not entire repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends \
         python3-pip \
         python3.11 \
+        # python3-dev: required for building mysqlclient python package
         python3.11-dev \
         python3.11-venv \
         libpython3.11 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update && \
         libpython3.11 \
         libpython3.11-stdlib \
         libmysqlclient21 \
+        # libmysqlclient-dev: required for building mysqlclient python package
         libmysqlclient-dev \
         pkg-config \
         libssl1.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,16 +46,21 @@ RUN useradd -m --shell /bin/false app
 RUN echo "locales locales/default_environment_locale select en_US.UTF-8" | debconf-set-selections
 RUN echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" | debconf-set-selections
 
+# Setting up ppa deadsnakes to get python 3.11
+RUN apt-get update && \
+  apt-get install -y software-properties-common && \
+  apt-add-repository -y ppa:deadsnakes/ppa
+
 # Install requirements that are absolutely necessary
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
     apt-get -y install --no-install-recommends \
+        python3-pip \
         python3.11 \
-        python3.11-pip \
         python3.11-dev \
         python3.11-venv \
-        libpython$PYTHON_VERSION \
-        libpython$PYTHON_VERSION-stdlib \
+        libpython3.11 \
+        libpython3.11-stdlib \
         libmysqlclient21 \
         libmysqlclient-dev \
         pkg-config \
@@ -102,7 +107,7 @@ RUN apt-get update && \
 
 # Setup python virtual environment
 # It is already 'activated' because $VIRTUAL_ENV/bin was put on $PATH
-RUN python$PYTHON_VERSION -m venv "${VIRTUAL_ENV}"
+RUN python3.11 -m venv "${VIRTUAL_ENV}"
 
 # Install python requirements
 # Requires copying over requirements files, but not entire repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ FROM ubuntu:focal as minimal-system
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SERVICE_VARIANT
 ARG SERVICE_PORT
-ARG PYTHON_VERSION=3.11
 
 # Env vars: paver
 # We intentionally don't use paver in this Dockerfile, but Devstack may invoke paver commands
@@ -51,10 +50,10 @@ RUN echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8"
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
     apt-get -y install --no-install-recommends \
-        python$PYTHON_VERSION \
-        python$PYTHON_VERSION-pip \
-        python$PYTHON_VERSION-dev \
-        python$PYTHON_VERSION-venv \
+        python3.11 \
+        python3.11-pip \
+        python3.11-dev \
+        python3.11-venv \
         libpython$PYTHON_VERSION \
         libpython$PYTHON_VERSION-stdlib \
         libmysqlclient21 \


### PR DESCRIPTION
### Description
- Updating docker-build workflow and Dockerfile to build images with Python 3.11 as default.
- Closes the issue https://github.com/openedx/edx-platform/issues/34984.

### Testing
- The Docker images have been tested to successfully being built with `Python 3.11` both locally and on the PR using the custom workflow settings. 
- The updated image has been successfully uploaded on the [Dockerhub](https://hub.docker.com/r/openedx/lms-dev/tags) as well.