### PR TITLE
feat: implicitCount added to content search index

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -41,6 +41,7 @@ class Fields:
     # For details on the format of the hierarchical tag data.
     # We currently have a hard-coded limit of 4 levels of tags in the search index (level0..level3).
     tags = "tags"
+    tags_count = "implicit_count"
     tags_taxonomy = "taxonomy"  # subfield of tags, i.e. tags.taxonomy
     tags_level0 = "level0"  # subfield of tags, i.e. tags.level0
     tags_level1 = "level1"
@@ -183,9 +184,14 @@ def _tags_for_content_object(object_id: UsageKey | LearningContextKey) -> dict:
         # Clear out tags in the index when unselecting all tags for the block, otherwise
         # it would remain the last value if a cleared Fields.tags field is not included
         return {Fields.tags: {}}
+    tags_count = tagging_api.get_object_tag_counts(str(object_id), count_implicit=True)
+    tag_count = 0
+    if str(object_id) in tags_count:
+        tag_count = tags_count[str(object_id)]
     result = {
         Fields.tags_taxonomy: [],
         Fields.tags_level0: [],
+        Fields.tags_count: tag_count,
         # ... other levels added as needed
     }
     for obj_tag in all_tags:

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -209,6 +209,7 @@ class TestSearchApi(ModuleStoreTestCase):
         doc_sequential_with_tags1 = {
             "id": self.doc_sequential["id"],
             "tags": {
+                'implicit_count': 2,
                 'taxonomy': ['A'],
                 'level0': ['A > one', 'A > two']
             }
@@ -216,6 +217,7 @@ class TestSearchApi(ModuleStoreTestCase):
         doc_sequential_with_tags2 = {
             "id": self.doc_sequential["id"],
             "tags": {
+                'implicit_count': 4,
                 'taxonomy': ['A', 'B'],
                 'level0': ['A > one', 'A > two', 'B > four', 'B > three']
             }
@@ -263,6 +265,7 @@ class TestSearchApi(ModuleStoreTestCase):
         doc_problem_with_tags1 = {
             "id": self.doc_problem["id"],
             "tags": {
+                'implicit_count': 2,
                 'taxonomy': ['A'],
                 'level0': ['A > one', 'A > two']
             }
@@ -270,6 +273,7 @@ class TestSearchApi(ModuleStoreTestCase):
         doc_problem_with_tags2 = {
             "id": self.doc_problem["id"],
             "tags": {
+                'implicit_count': 4,
                 'taxonomy': ['A', 'B'],
                 'level0': ['A > one', 'A > two', 'B > four', 'B > three']
             }

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -120,6 +120,7 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             # and https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/js/
             # For details on why the hierarchical tag data is in this format.
             "tags": {
+                "implicit_count": 1,
                 "taxonomy": ["Difficulty"],
                 "level0": ["Difficulty > Easy"],
             },
@@ -162,6 +163,7 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 ),
             },
             "tags": {
+                "implicit_count": 6,
                 "taxonomy": ["Difficulty", "Subject"],
                 "level0": ["Difficulty > Normal", "Subject > Hypertext", "Subject > Linguistics"],
                 "level1": ["Subject > Hypertext > Jump Links", "Subject > Linguistics > Asian Languages"],


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds `implicit_count` to content search index.

## Supporting information

- This is used to show tag count in library components card: https://github.com/openedx/frontend-app-course-authoring/issues/1037
- Internal ticket: [FAL-3757](https://tasks.opencraft.com/browse/FAL-3757)

## Testing instructions

- Run [taxonomy-sample-data](https://github.com/open-craft/taxonomy-sample-data) script.
- Make sure you have meilisearch setup locally, follow the setup instructions here https://github.com/open-craft/tutor-contrib-meilisearch.
- Run tutor dev run cms bash and `./manage.py cms reindex_studio --experimental`.
- Access `http://meilisearch.local.edly.io:7700/` and check if the created documents have the `tags.implicit_count` field


