### PR TITLE
[FC-0059] feat: Add `order` query param to lib v2 API

### DIFF
--- a/openedx/core/djangoapps/content_libraries/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/serializers.py
@@ -115,6 +115,7 @@ class BaseFilterSerializer(serializers.Serializer):
     """
     text_search = serializers.CharField(default=None, required=False)
     org = serializers.CharField(default=None, required=False)
+    order = serializers.CharField(default=None, required=False)
 
 
 class ContentLibraryFilterSerializer(BaseFilterSerializer):

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -89,6 +89,13 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
         """
         assert big_dict.items() >= subset_dict.items()
 
+    def assertOrderEqual(self, libraries_list, expected_order):
+        """
+        Assert that the provided list of libraries match the order of expected
+        list by comparing the slugs.
+        """
+        assert [lib["slug"] for lib in libraries_list] == expected_order
+
     # API helpers
 
     def _api(self, method, url, data, expect_response):

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -230,6 +230,27 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                                          'text_search': 'library-title-4'})) == 1
         assert len(self._list_libraries({'type': VIDEO})) == 3
 
+        self.assertOrderEqual(
+            self._list_libraries({'order': 'title'}),
+            ["test-lib-filter-1", "test-lib-filter-2", "l3", "l4", "l5"],
+        )
+        self.assertOrderEqual(
+            self._list_libraries({'order': '-title'}),
+            ["l5", "l4", "l3", "test-lib-filter-2", "test-lib-filter-1"],
+        )
+        self.assertOrderEqual(
+            self._list_libraries({'order': 'created'}),
+            ["test-lib-filter-1", "test-lib-filter-2", "l3", "l4", "l5"],
+        )
+        self.assertOrderEqual(
+            self._list_libraries({'order': '-created'}),
+            ["l5", "l4", "l3", "test-lib-filter-2", "test-lib-filter-1"],
+        )
+        # An invalid order doesn't apply any specific ordering to the result, so just
+        # check if successfully returned libraries
+        assert len(self._list_libraries({'order': 'invalid'})) == 5
+        assert len(self._list_libraries({'order': '-invalid'})) == 5
+
     # General Content Library XBlock tests:
 
     def test_library_blocks(self):

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -196,6 +196,11 @@ class LibraryRootView(GenericAPIView):
                 str,
                 description="The string used to filter libraries by searching in title, id, org, or description",
             ),
+            apidocs.query_parameter(
+                'order',
+                str,
+                description="The order in which the libraries are sorted",
+            ),
         ],
     )
     def get(self, request):
@@ -207,12 +212,14 @@ class LibraryRootView(GenericAPIView):
         org = serializer.validated_data['org']
         library_type = serializer.validated_data['type']
         text_search = serializer.validated_data['text_search']
+        order = serializer.validated_data['order']
 
         queryset = api.get_libraries_for_user(
             request.user,
             org=org,
             library_type=library_type,
             text_search=text_search,
+            order=order,
         )
         paginated_qs = self.paginate_queryset(queryset)
         result = api.get_metadata(paginated_qs)

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -199,7 +199,9 @@ class LibraryRootView(GenericAPIView):
             apidocs.query_parameter(
                 'order',
                 str,
-                description="The order in which the libraries are sorted",
+                description=(
+                    "Name of the content library field to sort the results by. Prefix with a '-' to sort descending."
+                ),
             ),
         ],
     )


### PR DESCRIPTION
## Description

This PR adds the `order` query param to the `/api/libraries/v2/` endpoint to specify the ordering of the queried content libraries.

## Supporting information

Related Tickets:
- https://github.com/openedx/frontend-app-course-authoring/issues/1035
- Needed for https://github.com/openedx/frontend-app-course-authoring/pull/1117

## Testing instructions

Check that the tests cover the functionality and follow the testing instructions in https://github.com/openedx/frontend-app-course-authoring/pull/1117

---
Private-ref: [FAL-3752](https://tasks.opencraft.com/browse/FAL-3752)