### PR TITLE
fix: unskip the migration sync test

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -121,9 +121,6 @@ class MigrationTests(TestCase):
     Tests for migrations.
     """
 
-    @unittest.skip(
-        "Temporary skip for ENT-9003 while the career_engagement_network_message column is renamed."
-    )
     @override_settings(MIGRATION_MODULES={})
     def test_migrations_are_in_sync(self):
         """


### PR DESCRIPTION
I had to skip the migrations-in-sync test as part of: https://github.com/openedx/edx-platform/pull/34996
This change unskips that test.
