### PR TITLE
fix: delete flaky TestGetCourseUserPartitions tests

### DIFF
--- a/xmodule/partitions/tests/test_partitions.py
+++ b/xmodule/partitions/tests/test_partitions.py
@@ -552,32 +552,6 @@ class TestGetCourseUserPartitions(PartitionServiceBaseClass):
         """
         FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = enable
 
-    def test_enrollment_track_partition_not_added_if_conflict(self):
-        """
-        Test that the dynamic enrollment track scheme is NOT added if a UserPartition exists with that ID.
-        """
-        self.user_partition = UserPartition(
-            ENROLLMENT_TRACK_PARTITION_ID,
-            self.TEST_NAME,
-            self.TEST_DESCRIPTION,
-            self.TEST_GROUPS,
-            self.non_random_scheme,
-            self.TEST_PARAMETERS,
-        )
-        self.course.user_partitions = [self.user_partition]
-        all_partitions = get_all_partitions_for_course(self.course)
-        assert 1 == len(all_partitions)
-        assert self.TEST_SCHEME_NAME == all_partitions[0].scheme.name
-
-    def test_enrollment_track_partition_not_added_if_disabled(self):
-        """
-        Test that the dynamic enrollment track scheme is NOT added if the settings FEATURE flag is disabled.
-        """
-        TestGetCourseUserPartitions._enable_enrollment_track_partition(False)
-        all_partitions = get_all_partitions_for_course(self.course)
-        assert 1 == len(all_partitions)
-        assert self.TEST_SCHEME_NAME == all_partitions[0].scheme.name
-
     def test_filter_inactive_user_partitions(self):
         """
         Tests supplying the `active_only` parameter.

--- a/xmodule/partitions/tests/test_partitions.py
+++ b/xmodule/partitions/tests/test_partitions.py
@@ -14,7 +14,6 @@ from stevedore.extension import Extension, ExtensionManager
 
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from xmodule.partitions.partitions import (
-    ENROLLMENT_TRACK_PARTITION_ID,
     USER_PARTITION_SCHEME_NAMESPACE,
     Group,
     NoSuchUserPartitionGroupError,


### PR DESCRIPTION
The following TestGetCourseUserPartitions tests were deleted:
- test_enrollment_track_partition_not_added_if_conflict
- test_enrollment_track_partition_not_added_if_disabled

For details, see:
https://github.com/openedx/edx-platform/issues/35028

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
