### PR TITLE
feat(AU-2042): Show Google disclaimer on VideoBlock bottom section

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -175,7 +175,6 @@ from openedx.core.djangolib.js_utils import (
                 <a href="https://translate.google.com/" target="_blank">
                     <img
                         width="100"
-                        className="inline-image pl-1"
                         id="google-translate-logo"
                         src="https://learning.edx.org/d4ab1b25143ecad62d69d855b00e7313.png"
                         alt="Translated by Google logo"

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -170,6 +170,19 @@ from openedx.core.djangolib.js_utils import (
             </div>
         </div>
         % endif
+        <div class="google-disclaimer">
+            <span className="text-dark-300 x-small">Powered by
+                <a href="https://translate.google.com/" target="_blank">
+                    <img
+                        width="100"
+                        className="inline-image pl-1"
+                        id="google-translate-logo"
+                        src="https://learning.edx.org/d4ab1b25143ecad62d69d855b00e7313.png"
+                        alt="Translated by Google logo"
+                    >
+                </a>
+            </span>
+        </div>
     </div>
 </div>
 

--- a/xmodule/assets/video/_display.scss
+++ b/xmodule/assets/video/_display.scss
@@ -91,6 +91,7 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
 
   .wrapper-video-bottom-section {
     display: flex;
+    justify-content: space-between;
 
     .wrapper-download-video,
     .wrapper-download-transcripts,
@@ -175,6 +176,13 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
       box-shadow: none;
       background: transparent;
     }
+  }
+
+  .google-disclaimer {
+    display: none;
+    margin-top: $baseline;
+    @include padding-right($baseline);
+    vertical-align: top;
   }
 
   .video-wrapper {

--- a/xmodule/js/src/video/09_video_caption.js
+++ b/xmodule/js/src/video/09_video_caption.js
@@ -37,7 +37,8 @@
                 'previousLanguageMenuItem', 'nextLanguageMenuItem', 'handleCaptionToggle',
                 'showClosedCaptions', 'hideClosedCaptions', 'toggleClosedCaptions',
                 'updateCaptioningCookie', 'handleCaptioningCookie', 'handleTranscriptToggle',
-                'listenForDragDrop', 'setTranscriptVisibility', 'updateTranscriptCookie'
+                'listenForDragDrop', 'setTranscriptVisibility', 'updateTranscriptCookie',
+                'toggleGoogleDisclaimer'
             );
 
             this.state = state;
@@ -493,6 +494,31 @@
             },
 
             /**
+            * @desc Shows/Hides Google disclaimer based on captions being AI generated and
+            * if ClosedCaptions are being shown.
+            *
+            * @param {array} captions List of captions for the video.
+            *
+            * @returns {boolean}
+            */
+            toggleGoogleDisclaimer: function(captions) {
+                var self = this,
+                    state = this.state,
+                    aIGeneratedSpan = '<span id="captions-ai-generated"></span>',
+                    captionsAIGenerated = captions.some(caption => caption.includes(aIGeneratedSpan));
+
+                if (!self.hideCaptionsOnLoad && !state.captionsHidden) {
+                    if (captionsAIGenerated) {
+                        state.el.find('.google-disclaimer').show();
+                        self.shouldShowGoogleDisclaimer = true;
+                    } else {
+                        state.el.find('.google-disclaimer').hide();
+                        self.shouldShowGoogleDisclaimer = false;
+                    }
+                }
+            },
+
+            /**
             * @desc Fetch the caption file specified by the user. Upon successful
             *     receipt of the file, the captions will be rendered.
             * @param {boolean} [fetchWithYoutubeId] Fetch youtube captions if true.
@@ -546,6 +572,8 @@
                         results = self.getBoundedCaptions();
                         start = results.start;
                         captions = results.captions;
+
+                        self.toggleGoogleDisclaimer(captions);
 
                         if (self.loaded) {
                             if (self.rendered) {
@@ -1299,6 +1327,7 @@
             */
             hideCaptions: function(hideCaptions, triggerEvent) {
                 var transcriptControlEl = this.transcriptControlEl,
+                    self = this,
                     state = this.state,
                     text;
 
@@ -1309,6 +1338,8 @@
                     if (triggerEvent) {
                         this.state.el.trigger('transcript:hide');
                     }
+
+                    state.el.find('.google-disclaimer').hide();
 
                     transcriptControlEl
                         .removeClass('is-active')
@@ -1322,6 +1353,10 @@
                     if (triggerEvent) {
                         this.state.el.trigger('transcript:show');
                     }
+
+                    if (self.shouldShowGoogleDisclaimer) {
+                        state.el.find('.google-disclaimer').show();
+                      }
 
                     transcriptControlEl
                         .addClass('is-active')


### PR DESCRIPTION
[AU-2042](https://2u-internal.atlassian.net/browse/AU-2042)

## Description

- Add Google Disclaimer on VideoBlock bottom section (not shown by default).
- If video transcript selected was AI generated (based on a span we add to the transcript in [ai_translations PR](https://github.com/edx/ai-translations/pull/175)) then show the Google Disclaimer.
- If captions or transcripts are not shown in the right panel, then hide the Google Disclaimer.

## Supporting information

https://www.loom.com/share/e426d73e75334b538b2980bb97d05931?sid=748d97f2-cd13-41eb-a1e4-cdec7316f5a7

## Testing instructions

## Deadline

"None"

## Other information