### PR TITLE
fix: add query param to sso redirection during tpa pipeline

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -577,7 +577,7 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
 
     def dispatch_to_register():
         """Redirects to the registration page."""
-        return redirect(AUTH_DISPATCH_URLS[AUTH_ENTRY_REGISTER])
+        return redirect(AUTH_DISPATCH_URLS[AUTH_ENTRY_REGISTER] + '?pipeline_redirect=true')
 
     def should_force_account_creation():
         """ For some third party providers, we auto-create user accounts """

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -230,7 +230,7 @@ class HelperMixin:
     def assert_redirect_to_register_looks_correct(self, response):
         """Asserts a response would redirect to /register."""
         assert 302 == response.status_code
-        assert '/register' == response.get('Location')
+        assert '/register?pipeline_redirect=true' == response.get('Location')
 
     def assert_register_response_before_pipeline_looks_correct(self, response):
         """Asserts a GET of /register not in the pipeline looks correct."""
@@ -400,7 +400,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
 
         self.request_factory = test.RequestFactory()
         self.login_page_url = reverse('signin_user')
-        self.register_page_url = reverse('register_user')
+        self.register_page_url = reverse('register_user') + '?pipeline_redirect=true'
         patcher = testutil.patch_mako_templates()
         patcher.start()
         self.addCleanup(patcher.stop)

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -311,7 +311,7 @@ class EnsureUserInformationTestCase(TestCase):
         )
 
     @ddt.data(
-        (True, '/register'),
+        (True, '/register?pipeline_redirect=true'),
         (False, '/login')
     )
     @ddt.unpack
@@ -341,10 +341,10 @@ class EnsureUserInformationTestCase(TestCase):
                 assert response.url == expected_redirect_url
 
     @ddt.data(
-        ('non_existing_user_email@example.com', '/register', True),
+        ('non_existing_user_email@example.com', '/register?pipeline_redirect=true', True),
         ('email@example.com', '/login', True),
-        (None, '/register', True),
-        ('non_existing_user_email@example.com', '/register', False),
+        (None, '/register?pipeline_redirect=true', True),
+        ('non_existing_user_email@example.com', '/register?pipeline_redirect=true', False),
         ('email@example.com', '/login', False),
         (None, '/login', False),
     )


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

In the authentication micro frontend (MFE), we need to identify whether the user has been redirected from the pipeline to the authentication MFE or from any other flow. This distinction is crucial to ensure that auto-registration only occurs for users redirected directly from the pipeline.

Other scenarios where a user can access the authentication MFE include:

- Clicking on Login/Register buttons from different MFEs
- Directly navigating to the authentication URL
- Attempting to access any authenticated domain without being logged in.

