### PR TITLE
DeprecationWarning: .text & .listdir are deprecated , Resolved 

### DIFF
--- a/common/djangoapps/xblock_django/tests/test_commands.py
+++ b/common/djangoapps/xblock_django/tests/test_commands.py
@@ -64,7 +64,7 @@ def test_compile_xblock_translations(tmp_translations_dir):
                     'msgfmt', '--check-format', '-o', str(po_file.with_suffix('.mo')), str(po_file),
                 ], 'Compiles the .po files'
 
-            js_file_text = get_javascript_i18n_file_path('done', 'tr').text()
+            js_file_text = get_javascript_i18n_file_path('done', 'tr').read_text()
             assert 'Merhaba' in js_file_text, 'Ensures the JavaScript catalog is compiled'
             assert 'TestingDoneXBlockI18n' in js_file_text, 'Ensures the namespace is used'
             assert 'gettext' in js_file_text, 'Ensures the gettext function is defined'

--- a/common/djangoapps/xblock_django/translation.py
+++ b/common/djangoapps/xblock_django/translation.py
@@ -101,7 +101,7 @@ def compile_xblock_js_messages():
         xblock_conf_locale_dir = xmodule_api.get_python_locale_root() / xblock_module
         i18n_js_namespace = xblock_class.get_i18n_js_namespace()
 
-        for locale_dir in xblock_conf_locale_dir.listdir():
+        for locale_dir in xblock_conf_locale_dir.iterdir():
             locale_code = str(locale_dir.basename())
             locale_messages_dir = locale_dir / 'LC_MESSAGES'
             js_translations_domain = None


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
