### PR TITLE
fix: update autogenerated username functionality

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_utils.py
@@ -45,6 +45,8 @@ class TestGenerateUsername(TestCase):
         ({}, None),
         ({'first_name': '', 'last_name': ''}, None),
         ({'name': ''}, None),
+        ({'name': '='}, None),
+        ({'name': '@'}, None),
         ({'first_name': '阿提亚', 'last_name': '阿提亚'}, "AT"),
         ({'first_name': 'أحمد', 'last_name': 'محمد'}, "HM"),
         ({'name': 'أحمد محمد'}, "HM"),

--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -128,16 +128,25 @@ def _get_username_prefix(data):
     - str: Name initials or None.
     """
     username_regex_partial = settings.USERNAME_REGEX_PARTIAL
+    valid_username_regex = r'^[A-Za-z0-9_\-]+$'
     full_name = ''
-    if data.get('first_name', '').strip() and data.get('last_name', '').strip():
-        full_name = f"{unidecode(data.get('first_name', ''))} {unidecode(data.get('last_name', ''))}"
-    elif data.get('name', '').strip():
-        full_name = unidecode(data['name'])
+    try:
+        if data.get('first_name', '').strip() and data.get('last_name', '').strip():
+            full_name = f"{unidecode(data.get('first_name', ''))} {unidecode(data.get('last_name', ''))}"
+        elif data.get('name', '').strip():
+            full_name = unidecode(data['name'])
 
-    if full_name.strip():
-        full_name = re.findall(username_regex_partial, full_name)[0]
-        name_initials = "".join([name_part[0] for name_part in full_name.split()[:2]])
-        return name_initials.upper() if name_initials else None
+        if full_name.strip():
+            matched_name = re.findall(username_regex_partial, full_name)
+            if matched_name:
+                full_name = " ".join(matched_name)
+                name_initials = "".join([name_part[0] for name_part in full_name.split()[:2]])
+                if re.match(valid_username_regex, name_initials):
+                    return name_initials.upper() if name_initials else None
+
+    except Exception as e:  # pylint: disable=broad-except
+        logging.info(f"Error in _get_username_prefix: {e}")
+        return None
 
     return None
 


### PR DESCRIPTION

## Description


"When entering special characters like '=', '@', or any other, it raised a server error when the autogenerated username was enabled. I have fixed it in the backend, and now users are allowed to create accounts with special characters."
Useful information to include:

### JIRA:
[https://2u-internal.atlassian.net/browse/VAN-1988](https://2u-internal.atlassian.net/browse/VAN-1988)

#### How Has This Been Tested?

Updated unit tests

#### Video :

https://github.com/openedx/edx-platform/assets/7627421/abdeded3-f029-481d-8ed5-2fcf015d3726

