### PR TITLE
build: Run regular requirement updates with 3.11

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -19,6 +19,7 @@ jobs:
       team_reviewers: "arbi-bom"
       email_address: arbi-bom@edx.org
       send_success_notification: false
+      python_version: "3.11"
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
       requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
We've already moved onto 3.11 for this repo so run the regular
requiremnet update PRs with Python 3.11
