### PR TITLE
fix: DiscussionsConfigurations admin error

### DIFF
--- a/openedx/core/djangoapps/discussions/admin.py
+++ b/openedx/core/djangoapps/discussions/admin.py
@@ -3,6 +3,7 @@ Customize the django admin experience
 """
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
+from django.contrib.admin.utils import quote
 from simple_history.admin import SimpleHistoryAdmin
 
 from openedx.core.djangoapps.config_model_utils.admin import StackedConfigModelAdmin
@@ -25,6 +26,9 @@ class DiscussionsConfigurationAdmin(SimpleHistoryAdmin):
         'enabled',
         'provider_type',
     )
+
+    def change_view(self, request, object_id=None, form_url="", extra_context=None):
+        return super().change_view(request, quote(object_id), form_url, extra_context)
 
 
 class AllowListFilter(SimpleListFilter):

--- a/openedx/core/djangoapps/discussions/tests/test_admin.py
+++ b/openedx/core/djangoapps/discussions/tests/test_admin.py
@@ -1,0 +1,32 @@
+"""
+Tests for DiscussionsConfiguration admin view
+"""
+from django.test import TestCase
+from django.urls import reverse
+
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
+
+
+class DiscussionsConfigurationAdminTest(TestCase):
+    """
+    Tests for discussion config admin
+    """
+    def setUp(self):
+        super().setUp()
+        self.superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=self.superuser.username, password="Password1234")
+
+    def test_change_view(self):
+        """
+        Test that the DiscussionAdmin's change_view processes the context_key correctly and returns a successful
+        response.
+        """
+        discussion_config = DiscussionsConfiguration.objects.create(
+            context_key='course-v1:test+test+06_25_2024',
+            provider_type=Provider.OPEN_EDX,
+        )
+        url = reverse('admin:discussions_discussionsconfiguration_change', args=[discussion_config.context_key])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'course-v1:test+test+06_25_2024')


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- Create a course with a Course Run having _25 in it. (for example, "06_25_2024")
- In the django admin, go to http://localhost:18010/admin/discussions/discussionsconfiguration and select the configuration object for the course you created.
- You will get an invalid key error, because the context_key in [DiscussionsConfiguration](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/discussions/models.py#L406) is set to primary key and django pass this context_key to the [unquote fn](https://github.com/django/django/blob/main/django/contrib/admin/utils.py#L97) which converts "_25" to "%"

Useful information to include:

- Which edX user roles will this change impact? "Developer" and "Operator".
- Screenshots
   - Before
    <img width="1310" alt="Screenshot 2024-07-08 at 8 03 52 PM" src="https://github.com/openedx/edx-platform/assets/88967643/77711586-17e4-4d50-9a72-ecff874442c2">

   - After 
   <img width="1310" alt="Screenshot 2024-07-08 at 8 02 04 PM" src="https://github.com/openedx/edx-platform/assets/88967643/c2c487db-f1d4-4420-8093-2d852ba3d907">

## Supporting information

https://github.com/mitodl/hq/issues/4705

## Testing instructions

- Checkout to this branch and follow the steps in description
- Validate that the DiscussionsConfiguration loads perfectly on admin

## Deadline

None

