### PR TITLE
feat:  removing the job runners in advance of removing the code

### DIFF
--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -137,8 +137,6 @@ def handle_course_cert_date_change(sender, course_key, **kwargs):  # pylint: dis
     LOGGER.info(f"Handling COURSE_CERT_DATE_CHANGE for course {course_key}")
     # import here, because signal is registered at startup, but items in tasks are not yet loaded
     from openedx.core.djangoapps.programs.tasks import update_certificate_available_date_on_course_update
-    from openedx.core.djangoapps.programs.tasks import update_certificate_visible_date_on_course_update
-    update_certificate_visible_date_on_course_update.delay(str(course_key))
     update_certificate_available_date_on_course_update.delay(str(course_key))
 
 
@@ -163,6 +161,4 @@ def handle_course_pacing_change(sender, updated_course_overview, **kwargs):  # p
     LOGGER.info(f"Handling COURSE_PACING_CHANGED for course {course_id}")
     # import here, because signal is registered at startup, but items in tasks are not yet loaded
     from openedx.core.djangoapps.programs.tasks import update_certificate_available_date_on_course_update
-    from openedx.core.djangoapps.programs.tasks import update_certificate_visible_date_on_course_update
     update_certificate_available_date_on_course_update.delay(course_id)
-    update_certificate_visible_date_on_course_update.delay(course_id)

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -294,7 +294,7 @@ class CourseCertAvailableDateChangedReceiverTest(TestCase):
 
         handle_course_cert_date_change(**self.signal_kwargs)
         assert mock_is_learner_issuance_enabled.call_count == 1
-        assert mock_visible_date_task.call_count == 1
+        assert mock_visible_date_task.call_count == 0
         assert mock_cad_task.call_count == 1
 
 
@@ -355,5 +355,5 @@ class CoursePacingChangedReceiverTest(TestCase):
 
         handle_course_pacing_change(**self.signal_kwargs)
         assert mock_is_creds_enabled.call_count == 1
-        assert mock_visible_date_task.call_count == 1
+        assert mock_visible_date_task.call_count == 0
         assert mock_cad_task.call_count == 1

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -238,8 +238,8 @@ class CertRevokedReceiverTest(TestCase):
 
 
 @skip_unless_lms
-@mock.patch('openedx.core.djangoapps.programs.tasks.update_certificate_visible_date_on_course_update.delay')
 @mock.patch('openedx.core.djangoapps.programs.tasks.update_certificate_available_date_on_course_update.delay')
+@mock.patch('openedx.core.djangoapps.programs.tasks.update_certificate_visible_date_on_course_update.delay')
 @mock.patch(
     'openedx.core.djangoapps.credentials.models.CredentialsApiConfig.is_learner_issuance_enabled',
     new_callable=mock.PropertyMock,


### PR DESCRIPTION
## Description

@justinhynes  pointed out that the task queues  might be populated with the to-be-removed task during a blue-green deployment, and it makes sense to remove the  job that queues up  the tasks slated for removal _before_ removing the code for those tasks.

FIXES: APER-3535
