### PR TITLE
fix(AU-2128): Let 'en' be selected as transcript by default when youtube video

### DIFF
--- a/xmodule/video_block/transcripts_utils.py
+++ b/xmodule/video_block/transcripts_utils.py
@@ -866,8 +866,11 @@ class VideoTranscriptsMixin:
         """
         sub, other_lang = transcripts["sub"], transcripts["transcripts"]
 
-        if dest_lang and dest_lang in other_lang.keys():
-            transcript_language = dest_lang
+        if dest_lang:
+            if dest_lang in other_lang.keys():
+                transcript_language = dest_lang
+            elif dest_lang == 'en' and (not other_lang or (other_lang and sub)):
+                transcript_language = 'en'
         elif self.transcript_language in other_lang:
             transcript_language = self.transcript_language
         elif sub:


### PR DESCRIPTION
[AU-2128](https://2u-internal.atlassian.net/browse/AU-2128)

## Description

Let english transcript be selected by default in video player despite transcript not available in `transcripts["transcripts"]` but available in `transcripts["sub"]`.

Current Behavior
https://www.loom.com/share/a4e31efd83d8418f9577f3e43c9a5721?sid=34060663-e8dc-456a-a49d-ea163b650c4d

New Behavior
https://www.loom.com/share/c7cf07c1440942c893e7287496b83b7b?sid=bec454c3-7685-4dca-9970-daf341d64c43

## Testing instructions

## Deadline

## Other information