### PR TITLE
chore: add learner dash MFE to trusted origins in devstack settings

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -555,6 +555,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:1999',  # frontend-app-authn
     'http://localhost:18450',  # frontend-app-support-tools
     'http://localhost:1994',  # frontend-app-gradebook
+    'http://localhost:1996',  # frontend-app-learner-dashboard
 ]
 
 


### PR DESCRIPTION
## Description

Adds the Learner Dashboard MFE to the `CSRF_TRUSTED_ORIGINS` list in the devstack settings.

Without this, some API calls back to the monolith will fail (e.g. unenrolling from a course). 