### PR TITLE
feat: Add waffle flag for First Purchase Discount override

### DIFF
--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -32,12 +32,12 @@ from common.djangoapps.track import segment
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to enable the First Purchase Discount to be overriden from
-#   EDXWELCOME/BIENVENIDOAEDX 15% discount to a new code with 30% discount.
+#   EDXWELCOME/BIENVENIDOAEDX 15% discount to a new code.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2024-07-18
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REV-4097
-# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+# .. toggle_warning: This feature toggle does not have a target removal date.
 FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG = WaffleFlag('discounts.enable_first_purchase_discount_override', __name__)
 
 # .. toggle_name: discounts.enable_discounting

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -33,7 +33,7 @@ from common.djangoapps.track import segment
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to enable the First Purchase Discount to be overriden from
 #   EDXWELCOME/BIENVENIDOAEDX 15% discount to a new code.
-# .. toggle_use_cases: temporary
+# .. toggle_use_cases: opt_in
 # .. toggle_creation_date: 2024-07-18
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REV-4097

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -28,6 +28,18 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.track import segment
 
 
+# .. toggle_name: discounts.enable_first_purchase_discount_override
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable the First Purchase Discount to be overriden from
+#   EDXWELCOME/BIENVENIDOAEDX 15% discount to a new code with 30% discount.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-07-18
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: REV-4097
+# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG = WaffleFlag('discounts.enable_first_purchase_discount_override', __name__)
+
 # .. toggle_name: discounts.enable_discounting
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False


### PR DESCRIPTION
[REV-4097](https://2u-internal.atlassian.net/browse/REV-4097).

The OC New Registrant Promo Update involves overriding the First Purchase Discount from `EDXWELCOME/BIENVENIDOAEDX` at 15% discount to a new code with 30% discount.

This is where the learning MFE gets the metadata for a course and user to decide whether to display the FPD code or not in the Upgrade Notification in Course Home and Courseware experience.

We want to be able to easily rollback from one coupon code to the other if necessary, which is why we are using a waffle flag.