### PR TITLE
fix: rephrasing and removing bugs from response endorsed notifications

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tasks.py
@@ -60,15 +60,16 @@ def send_response_endorsed_notifications(thread_id, response_id, course_key_str,
     if not ENABLE_NOTIFICATIONS.is_enabled(course_key):
         return
     thread = Thread(id=thread_id).retrieve()
-    creator = User.objects.get(id=endorsed_by)
-    course = get_course_with_access(creator, 'load', course_key, check_if_enrolled=True)
     response = Comment(id=response_id).retrieve()
+    creator = User.objects.get(id=response.user_id)
+    endorser = User.objects.get(id=endorsed_by)
+    course = get_course_with_access(creator, 'load', course_key, check_if_enrolled=True)
     notification_sender = DiscussionNotificationSender(thread, course, creator)
     # skip sending notification to author of thread if they are the same as the author of the response
     if response.user_id != thread.user_id:
         # sends notification to author of thread
         notification_sender.send_response_endorsed_on_thread_notification()
     # sends notification to author of response
-    if int(response.user_id) != creator.id:
+    if int(response.user_id) != endorser.id:
         notification_sender.creator = User.objects.get(id=response.user_id)
         notification_sender.send_response_endorsed_notification()

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -600,10 +600,10 @@ class TestResponseEndorsedNotifications(DiscussionAPIViewTestMixin, ModuleStoreT
         self.assertEqual(notification_data.notification_type, 'response_endorsed_on_thread')
 
         expected_context = {
-            'replier_name': self.user_3.username,
+            'replier_name': self.user_2.username,
             'post_title': 'test thread',
             'course_name': self.course.display_name,
-            'sender_id': int(self.user_3.id),
+            'sender_id': int(self.user_2.id),
         }
         self.assertDictEqual(notification_data.context, expected_context)
         self.assertEqual(notification_data.content_url, _get_mfe_url(self.course.id, thread.id))

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -146,11 +146,11 @@ COURSE_NOTIFICATION_TYPES = {
         'is_core': True,
         'info': '',
         'non_editable': [],
-        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> response has been endorsed in your post '
+        'content_template': _('<{p}><{strong}>{replier_name}\'s</{strong}> response has been endorsed in your post '
                               '<{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',
-            'replier_name': 'Endorsed by',
+            'replier_name': 'replier name',
         },
         'email_template': '',
         'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE]
@@ -161,7 +161,8 @@ COURSE_NOTIFICATION_TYPES = {
         'is_core': True,
         'info': '',
         'non_editable': [],
-        'content_template': _('<{p}><Your response has been endorsed <{strong}>{post_title}</{strong}></{p}>'),
+        'content_template': _('<{p}>Your response has been endorsed on the post <{strong}>{post_title}</{strong}></{'
+                              'p}>'),
         'content_context': {
             'post_title': 'Post title',
         },


### PR DESCRIPTION
Ticket: [INF-1460](https://2u-internal.atlassian.net/jira/software/c/projects/INF/boards/742?assignee=712020%3A2d2626ce-aad5-4db9-aa22-b89f1b1ea191&selectedIssue=INF-1460)

### Notification for when my response has been endorsed
### Before: 
<img width="1431" alt="image-20240709-062020" src="https://github.com/user-attachments/assets/52385c2d-e91f-4ad4-8ce0-ea1b97315f92">

### After: <img width="1427" alt="Screenshot 2024-07-18 at 12 10 45 PM" src="https://github.com/user-attachments/assets/ee410f30-238d-4d90-ba0a-b28ac14f8532">

### Notification for when someone’s response on my post has been endorsed
### Before: 
<img width="1439" alt="image-20240709-062509" src="https://github.com/user-attachments/assets/cf64e7d5-cfa9-468b-bc96-2b826aed95c0">

### After: 
<img width="1427" alt="Screenshot 2024-07-18 at 12 11 36 PM" src="https://github.com/user-attachments/assets/15657083-22fe-4984-92ab-66faa3c9bbce">


