### PR TITLE
chore: provide logo url from backend for batch enrollment email

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -34,6 +34,7 @@ from common.djangoapps.track.event_transaction_utils import (
     get_event_transaction_id,
     set_event_transaction_type
 )
+from lms.djangoapps.branding.api import get_logo_url_for_email
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.grades.api import constants as grades_constants
 from lms.djangoapps.grades.api import disconnect_submissions_signal_receiver
@@ -489,6 +490,7 @@ def get_email_params(course, auto_enroll, secure=True, course_key=None, display_
         'contact_mailing_address': contact_mailing_address,
         'platform_name': platform_name,
         'site_configuration_values': configuration_helpers.get_current_site_configuration_values(),
+        'logo_url': get_logo_url_for_email(),
     }
     return email_params
 

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -23,6 +23,7 @@ from xmodule.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFac
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, anonymous_id_for_user
 from common.djangoapps.student.roles import CourseCcxCoachRole
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
+from lms.djangoapps.branding.api import get_logo_url_for_email
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.models import StudentModule
@@ -940,6 +941,7 @@ class TestGetEmailParams(SharedModuleStoreTestCase):
         )
         cls.course_about_url = cls.course_url + 'about'
         cls.registration_url = f'https://{site}/register'
+        cls.logo_url = get_logo_url_for_email()
 
     def test_normal_params(self):
         # For a normal site, what do we expect to get for the URLs?
@@ -950,6 +952,7 @@ class TestGetEmailParams(SharedModuleStoreTestCase):
         assert result['course_about_url'] == self.course_about_url
         assert result['registration_url'] == self.registration_url
         assert result['course_url'] == self.course_url
+        assert result['logo_url'] == self.logo_url
 
     def test_marketing_params(self):
         # For a site with a marketing front end, what do we expect to get for the URLs?
@@ -962,6 +965,19 @@ class TestGetEmailParams(SharedModuleStoreTestCase):
         assert result['course_about_url'] is None
         assert result['registration_url'] == self.registration_url
         assert result['course_url'] == self.course_url
+        assert result['logo_url'] == self.logo_url
+
+    @patch('lms.djangoapps.instructor.enrollment.get_logo_url_for_email', return_value='https://www.logo.png')
+    def test_logo_url_params(self, mock_get_logo_url_for_email):
+        # Verify that the logo_url is correctly set in the email params
+        result = get_email_params(self.course, False)
+
+        assert result['auto_enroll'] is False
+        assert result['course_about_url'] == self.course_about_url
+        assert result['registration_url'] == self.registration_url
+        assert result['course_url'] == self.course_url
+        mock_get_logo_url_for_email.assert_called_once()
+        assert result['logo_url'] == 'https://www.logo.png'
 
 
 @ddt.ddt

--- a/themes/red-theme/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/themes/red-theme/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -63,7 +63,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="http://localhost:18000/static/red-theme/images/logo.png"
+                                    src="{{ logo_url }}"
                                     alt="{% filter force_escape %} {% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %} {% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">


### PR DESCRIPTION
## Ticket for internal tracking
https://github.com/mitodl/hq/issues/4923

## Description

For the past couple of years, edX has supported [a logo URL from the backend](https://github.com/openedx/edx-platform/pull/25994) for Bulk Email and edX ACE emails. But, this does not have similar support for emails using batch enrollment. Not sure if it is intentional or could have some other reasons but it causes the logo URL to be missed if it needs to be passed from the backend similar to Bulk Email and edX ACE emails. 

This pull request addresses the logo not appearing in batch enrollment emails when the logo URL is set in the backend and accessed in the template(or custom theme) similar to [how edX Bulk or ACE email use](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html#L82).

Useful information to include:

- No UI changes were made, so no screenshots are necessary.

## Supporting information

- [Related pull request in edX platform.](https://github.com/openedx/edx-platform/pull/25994)

## Testing instructions
- Ensure that `LOGO_URL_PNG_FOR_EMAIL` or any of the settings accessed in [this code](https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/branding/api.py#L648-L655) is set.
- Go to the Membership tab in the Instructor Dashboard with a user having staff access.
- Send a Batch Enrollment or Batch Beta Tester email.
- Verify that the logo appears correctly in the email.


## Other information

- This change is isolated to the email template logic and does not depend on other changes.
- No database migrations are involved.
