### PR TITLE
Test PR: deprecate WordCloudXBlock and extract it to xblocks-contrib repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ XBLOCKS = [
     "video = xmodule.video_block:VideoBlock",
     "videoalpha = xmodule.video_block:VideoBlock",
     "videodev = xmodule.template_block:TranslateCustomTagBlock",
-    "word_cloud = xmodule.word_cloud_block:WordCloudBlock",
+    "word_cloud_deprecated = xmodule.word_cloud_block:WordCloudBlock",
     "wrapper = xmodule.wrapper_block:WrapperBlock",
 ]
 XBLOCKS_ASIDES = [

--- a/xmodule/assets/word_cloud/src/js/word_cloud_main.js
+++ b/xmodule/assets/word_cloud/src/js/word_cloud_main.js
@@ -37,7 +37,7 @@ function generateUniqueId(wordCloudId, counter) {
 export default class WordCloudMain {
     constructor(el) {
         // eslint-disable-next-line no-undef
-        this.wordCloudEl = $(el).find('.word_cloud');
+        this.wordCloudEl = $(el).find('.word_cloud_deprecated');
 
         // Get the URL to which we will post the users words.
         this.ajax_url = this.wordCloudEl.data('ajax-url');

--- a/xmodule/word_cloud_block.py
+++ b/xmodule/word_cloud_block.py
@@ -257,7 +257,7 @@ class WordCloudBlock(  # pylint: disable=abstract-method
             'ajax_url': self.ajax_url,
             'display_name': self.display_name,
             'instructions': self.instructions,
-            'element_class': self.location.block_type,
+            'element_class': 'word_cloud_deprecated',
             'element_id': self.location.html_id(),
             'num_inputs': self.num_inputs,
             'submitted': self.submitted,


### PR DESCRIPTION
refactor: deprecate WordCloudXBlock and extract it to xblocks-contrib repo

This a test PR to test this [PR](https://github.com/openedx/xblocks-contrib/pull/4) exist in xblock-contrib

Ticket: https://github.com/openedx/edx-platform/issues/34840
Relevant PR: https://github.com/openedx/xblocks-contrib/pull/4

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
