### PR TITLE
feat: Add First Purchase Discount override 

### DIFF
--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -11,6 +11,7 @@ import ddt  # lint-amnesty, pylint: disable=wrong-import-order
 import json  # lint-amnesty, pylint: disable=wrong-import-order
 from completion.models import BlockCompletion
 from django.conf import settings  # lint-amnesty, pylint: disable=wrong-import-order
+from django.test import override_settings
 from django.urls import reverse  # lint-amnesty, pylint: disable=wrong-import-order
 from edx_toggles.toggles.testutils import override_waffle_flag  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -33,7 +34,10 @@ from openedx.features.course_experience import (
     DISPLAY_COURSE_SOCK_FLAG,
     ENABLE_COURSE_GOALS
 )
-from openedx.features.discounts.applicability import DISCOUNT_APPLICABILITY_FLAG
+from openedx.features.discounts.applicability import (
+    DISCOUNT_APPLICABILITY_FLAG,
+    FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG
+)
 from xmodule.course_block import COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -179,17 +183,28 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         welcome_message_html = self.client.get(self.url).data['welcome_message_html']
         assert welcome_message_html == (None if welcome_message_is_dismissed else '<p>Welcome</p>')
 
-    def test_offer(self):
+    @ddt.data(
+        (False, 'EDXWELCOME'),
+        (True, 'NOTEDXWELCOME'),
+    )
+    @ddt.unpack
+    def test_offer(self, is_fpd_override_waffle_flag_on, fpd_code):
+        """
+        Test that the offer data contains the correct code for the first purchase discount,
+        which can be overriden via a waffle flag from the default EDXWELCOME.
+        """
         CourseEnrollment.enroll(self.user, self.course.id)
 
         response = self.client.get(self.url)
         assert response.data['offer'] is None
 
-        with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
-            response = self.client.get(self.url)
+        with override_settings(FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE='NOTEDXWELCOME'):
+            with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
+                with override_waffle_flag(FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG, active=is_fpd_override_waffle_flag_on):
+                    response = self.client.get(self.url)
 
-            # Just a quick spot check that the dictionary looks like what we expect
-            assert response.data['offer']['code'] == 'EDXWELCOME'
+                    # Just a quick spot check that the dictionary looks like what we expect
+                    assert response.data['offer']['code'] == fpd_code
 
     def test_access_expiration(self):
         enrollment = CourseEnrollment.enroll(self.user, self.course.id, CourseMode.VERIFIED)

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -239,6 +239,9 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and (
 ########################## Authn MFE Context API #######################
 ENABLE_DYNAMIC_REGISTRATION_FIELDS = True
 
+########################## Discount/Coupons #######################
+FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
+
 ############## ECOMMERCE API CONFIGURATION SETTINGS ###############
 ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:18130'
 ECOMMERCE_API_URL = 'http://edx.devstack.ecommerce:18130/api/v2'

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -92,7 +92,7 @@ WIKI_ENABLED = True
 # Enable a parental consent age limit for testing
 PARENTAL_CONSENT_AGE_LIMIT = 13
 
-# Enable Fist Purchase Discount offer override
+# Enable First Purchase Discount offer override
 FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
 
 # Local Directories

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -92,6 +92,9 @@ WIKI_ENABLED = True
 # Enable a parental consent age limit for testing
 PARENTAL_CONSENT_AGE_LIMIT = 13
 
+# Enable Fist Purchase Discount offer override
+FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
+
 # Local Directories
 TEST_ROOT = path("test_root")
 # Want static files in the same dir for running on jenkins.

--- a/openedx/features/discounts/tests/test_utils.py
+++ b/openedx/features/discounts/tests/test_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, Mock
 
 import ddt
 from django.contrib.auth.models import AnonymousUser
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils.translation import override as override_lang
 from edx_toggles.toggles.testutils import override_waffle_flag
 
@@ -14,7 +14,11 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from openedx.features.discounts.applicability import DISCOUNT_APPLICABILITY_FLAG, get_discount_expiration_date
+from openedx.features.discounts.applicability import (
+    DISCOUNT_APPLICABILITY_FLAG,
+    FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG,
+    get_discount_expiration_date
+)
 
 from .. import utils
 
@@ -83,6 +87,12 @@ class TestOfferData(TestCase):
     def test_spanish_code(self):
         with override_lang('es-419'):
             assert utils.generate_offer_data(self.user, self.overview)['code'] == 'BIENVENIDOAEDX'
+
+    def test_override(self):
+        with override_settings(FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE='NOTEDXWELCOME'):
+            with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
+                with override_waffle_flag(FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG, active=True):
+                    assert utils.generate_offer_data(self.user, self.overview)['code'] == 'NOTEDXWELCOME'
 
     def test_anonymous(self):
         assert utils.generate_offer_data(AnonymousUser(), self.overview) is None


### PR DESCRIPTION
[REV-4098](https://2u-internal.atlassian.net/browse/REV-4098).

Adding the logic to modify the `offer` data in Course Home API to be able to be overriden if the waffle flag is enabled to another First Purchase Discount code.

This offer data is used by Learning MFE to display the upgrade notification message with a discount code.