### PR TITLE
feat: update account verification email context

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -62,6 +62,7 @@ from openedx.core.djangoapps.user_authn.toggles import (
 )
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.features.discounts.applicability import FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG
 from openedx.features.enterprise_support.utils import is_enterprise_learner
 from common.djangoapps.student.email_helpers import generate_activation_email_context
 from common.djangoapps.student.helpers import DISABLE_UNENROLL_CERT_STATES, cert_info
@@ -206,12 +207,13 @@ def compose_activation_email(
     message_context = generate_activation_email_context(user, user_registration)
     message_context.update({
         'confirm_activation_link': _get_activation_confirmation_link(message_context['key'], redirect_url),
+        'is_enterprise_learner': is_enterprise_learner(user),
+        'is_first_purchase_discount_overridden': FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG.is_enabled(),
         'route_enabled': route_enabled,
         'routed_user': user.username,
         'routed_user_email': user.email,
         'routed_profile_name': profile_name,
         'registration_flow': registration_flow,
-        'is_enterprise_learner': is_enterprise_learner(user),
         'show_auto_generated_username': show_auto_generated_username(user.username),
     })
 

--- a/openedx/core/djangoapps/user_authn/tests/test_tasks.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_tasks.py
@@ -19,6 +19,7 @@ class SendActivationEmailTestCase(TestCase):
     """
     Test for send activation email to user
     """
+
     def setUp(self):
         """ Setup components used by each test."""
         super().setUp()
@@ -44,6 +45,7 @@ class SendActivationEmailTestCase(TestCase):
         assert self.msg.context['routed_profile_name'] == ''
         assert self.msg.context['registration_flow'] is False
         assert self.msg.context['is_enterprise_learner'] is False
+        assert self.msg.context['is_first_purchase_discount_overridden'] is False
 
     @mock.patch('time.sleep', mock.Mock(return_value=None))
     @mock.patch('openedx.core.djangoapps.user_authn.tasks.log')

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -31,7 +31,7 @@ from common.djangoapps.track import segment
 # .. toggle_name: discounts.enable_first_purchase_discount_override
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Waffle flag to enable the First Purchase Discount to be overriden from
+# .. toggle_description: Waffle flag to enable the First Purchase Discount to be overridden from
 #   EDXWELCOME/BIENVENIDOAEDX 15% discount to a new code.
 # .. toggle_use_cases: opt_in
 # .. toggle_creation_date: 2024-07-18


### PR DESCRIPTION
[INF-1468](https://2u-internal.atlassian.net/browse/INF-1468)

## Description
- Updated account activation/verification email context. 
- Add the `is_first_purchase_discount_overridden` flag in the email context.
- Waffle flag to override the First Purchase Discount from EDXWELCOME/BIENVENIDOAEDX 15% discount to a new code.
- Here is the PR for the template update [edx-theme-820](https://github.com/edx/edx-themes/pull/820)

## Testing instructions
Tested locally
