### PR TITLE
feat: Add override on percentage config to the First Purchase Discount

### DIFF
--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -184,11 +184,11 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert welcome_message_html == (None if welcome_message_is_dismissed else '<p>Welcome</p>')
 
     @ddt.data(
-        (False, 'EDXWELCOME'),
-        (True, 'NOTEDXWELCOME'),
+        (False, 'EDXWELCOME', 15),
+        (True, 'NOTEDXWELCOME', 30),
     )
     @ddt.unpack
-    def test_offer(self, is_fpd_override_waffle_flag_on, fpd_code):
+    def test_offer(self, is_fpd_override_waffle_flag_on, fpd_code, fpd_percentage):
         """
         Test that the offer data contains the correct code for the first purchase discount,
         which can be overriden via a waffle flag from the default EDXWELCOME.
@@ -199,12 +199,16 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert response.data['offer'] is None
 
         with override_settings(FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE='NOTEDXWELCOME'):
-            with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
-                with override_waffle_flag(FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG, active=is_fpd_override_waffle_flag_on):
-                    response = self.client.get(self.url)
+            with override_settings(FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE=fpd_percentage):
+                with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
+                    with override_waffle_flag(
+                        FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG, active=is_fpd_override_waffle_flag_on
+                    ):
+                        response = self.client.get(self.url)
 
-                    # Just a quick spot check that the dictionary looks like what we expect
-                    assert response.data['offer']['code'] == fpd_code
+                        # Just a quick spot check that the dictionary looks like what we expect
+                        assert response.data['offer']['code'] == fpd_code
+                        assert response.data['offer']['percentage'] == fpd_percentage
 
     def test_access_expiration(self):
         enrollment = CourseEnrollment.enroll(self.user, self.course.id, CourseMode.VERIFIED)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4295,6 +4295,10 @@ SOCIAL_PLATFORMS = {
     }
 }
 
+# Enable First Purchase Discount offer override
+FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
+FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE = 15
+
 # E-Commerce API Configuration
 ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:8002'
 ECOMMERCE_API_URL = 'http://localhost:8002/api/v2'

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -239,10 +239,6 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and (
 ########################## Authn MFE Context API #######################
 ENABLE_DYNAMIC_REGISTRATION_FIELDS = True
 
-########################## Discount/Coupons #######################
-FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
-FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE = ''
-
 ############## ECOMMERCE API CONFIGURATION SETTINGS ###############
 ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:18130'
 ECOMMERCE_API_URL = 'http://edx.devstack.ecommerce:18130/api/v2'

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -241,6 +241,7 @@ ENABLE_DYNAMIC_REGISTRATION_FIELDS = True
 
 ########################## Discount/Coupons #######################
 FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
+FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE = ''
 
 ############## ECOMMERCE API CONFIGURATION SETTINGS ###############
 ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:18130'

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -92,10 +92,6 @@ WIKI_ENABLED = True
 # Enable a parental consent age limit for testing
 PARENTAL_CONSENT_AGE_LIMIT = 13
 
-# Enable First Purchase Discount offer override
-FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
-FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE = ''
-
 # Local Directories
 TEST_ROOT = path("test_root")
 # Want static files in the same dir for running on jenkins.

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -94,6 +94,7 @@ PARENTAL_CONSENT_AGE_LIMIT = 13
 
 # Enable First Purchase Discount offer override
 FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
+FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE = ''
 
 # Local Directories
 TEST_ROOT = path("test_root")

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 
 import pytz
 from crum import get_current_request, impersonate
+from django.conf import settings
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from edx_toggles.toggles import WaffleFlag
@@ -227,6 +228,13 @@ def discount_percentage(course):
     """
     Get the configured discount amount.
     """
+    if FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG.is_enabled():
+        return getattr(
+            settings,
+            'FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE',
+            15
+        )
+
     configured_percentage = DiscountPercentageConfig.current(course_key=course.id).percentage
     if configured_percentage:
         return configured_percentage

--- a/openedx/features/discounts/tests/test_utils.py
+++ b/openedx/features/discounts/tests/test_utils.py
@@ -90,9 +90,11 @@ class TestOfferData(TestCase):
 
     def test_override(self):
         with override_settings(FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE='NOTEDXWELCOME'):
-            with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
-                with override_waffle_flag(FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG, active=True):
-                    assert utils.generate_offer_data(self.user, self.overview)['code'] == 'NOTEDXWELCOME'
+            with override_settings(FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE=30):
+                with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
+                    with override_waffle_flag(FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG, active=True):
+                        assert utils.generate_offer_data(self.user, self.overview)['code'] == 'NOTEDXWELCOME'
+                        assert utils.generate_offer_data(self.user, self.overview)['percentage'] == 30
 
     def test_anonymous(self):
         assert utils.generate_offer_data(AnonymousUser(), self.overview) is None


### PR DESCRIPTION
[REV-4098](https://2u-internal.atlassian.net/browse/REV-4098).

There is a previously added `DiscountPercentageConfig` that would allow us to change the percentage displayed for the First Purchase Discount via Django Admin. However, this is controlled in [app-permissions](https://github.com/edx/app-permissions/commit/f0ae77f8349e0a95ea976831e30ef55ec079974b), which as been broken for several weeks, and none of the current Purchase squad members have the ability to see this config (it's also not added in the discounts_admin group). 

Adding an override via waffle flag for the displayed percentage instead.

