### PR TITLE
fix: Delete translations more conservatively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ pull_xblock_translations:  ## pull xblock translations via atlas
 
 clean_translations: ## Remove existing translations to prepare for a fresh pull
 	# Removes core edx-platform translations but keeps config files and Esperanto (eo) test translations
-	find conf/locale -mindepth 1 -maxdepth 1 -type d -a ! -name eo -exec rm -rf {} +
+	find conf/locale/ -type f \! -path '*/eo/*' \( -name '*.mo' -o -name '*.po' \) -delete
 	# Removes the xblocks/plugins and js-compiled translations
 	rm -rf conf/plugins-locale cms/static/js/i18n/ lms/static/js/i18n/ cms/static/js/xblock.v1-i18n/ lms/static/js/xblock.v1-i18n/
 


### PR DESCRIPTION
This was deleting `conf/locale/en/LC_MESSAGES/.gitignore` which was introduced in https://github.com/openedx/edx-platform/pull/34628 such that `make pull_translations` (which depends on `clean_translations`) was leaving the git working directory dirty.

Deleting just the mo/po files will avoid this. I'm not sure if this is the best approach, or if there are other things we can do to avoid the complications with the en/LC_MESSAGES dir, but this shouldn't hurt.

Relates to https://github.com/edx/edx-arch-experiments/issues/732