### PR TITLE
feat: added custom setting attribute for gradebook freeze timedelta

### DIFF
--- a/lms/djangoapps/grades/grade_utils.py
+++ b/lms/djangoapps/grades/grade_utils.py
@@ -23,7 +23,7 @@ def are_grades_frozen(course_key):
     if ENFORCE_FREEZE_GRADE_AFTER_COURSE_END.is_enabled(course_key):
         course = CourseOverview.get_from_id(course_key)
         if course.end:
-            freeze_grade_date = course.end + timedelta(settings.GRADEBOOK_FREEZE_TIMEDELTA)
+            freeze_grade_date = course.end + timedelta(settings.GRADEBOOK_FREEZE_DAYS)
             now = timezone.now()
             return now > freeze_grade_date
     return False

--- a/lms/djangoapps/grades/grade_utils.py
+++ b/lms/djangoapps/grades/grade_utils.py
@@ -7,6 +7,7 @@ import logging
 from datetime import timedelta
 
 from django.utils import timezone
+from django.conf import settings
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
@@ -22,7 +23,7 @@ def are_grades_frozen(course_key):
     if ENFORCE_FREEZE_GRADE_AFTER_COURSE_END.is_enabled(course_key):
         course = CourseOverview.get_from_id(course_key)
         if course.end:
-            freeze_grade_date = course.end + timedelta(30)
+            freeze_grade_date = course.end + timedelta(settings.GRADEBOOK_FREEZE_TIMEDELTA)
             now = timezone.now()
             return now > freeze_grade_date
     return False

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1101,8 +1101,10 @@ DEFAULT_GROUPS = []
 # If this is true, random scores will be generated for the purpose of debugging the profile graphs
 GENERATE_PROFILE_SCORES = False
 
-# Sets the number of days after which the gradebook will freeze following the course's end.
-GRADEBOOK_FREEZE_TIMEDELTA = 30
+# .. setting_name: GRADEBOOK_FREEZE_DAYS
+# .. setting_default: 30
+# .. setting_description: Sets the number of days after which the gradebook will freeze following the course's end.
+GRADEBOOK_FREEZE_DAYS = 30
 
 # Used with XQueue
 XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1103,7 +1103,7 @@ GENERATE_PROFILE_SCORES = False
 
 # Sets the number of days after which the gradebook will freeze following the course's end.
 GRADEBOOK_FREEZE_TIMEDELTA = 30
- 
+
 # Used with XQueue
 XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds
 XQUEUE_INTERFACE = {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1102,7 +1102,7 @@ DEFAULT_GROUPS = []
 GENERATE_PROFILE_SCORES = False
 
 # Sets the number of days after which the gradebook will freeze following the course's end.
-GRADEBOOK_FREEZE_TIMEDELTA = 30 
+GRADEBOOK_FREEZE_TIMEDELTA = 30
  
 # Used with XQueue
 XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1101,6 +1101,9 @@ DEFAULT_GROUPS = []
 # If this is true, random scores will be generated for the purpose of debugging the profile graphs
 GENERATE_PROFILE_SCORES = False
 
+# Sets the number of days after which the gradebook will freeze following the course's end.
+GRADEBOOK_FREEZE_TIMEDELTA = 30 
+ 
 # Used with XQueue
 XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds
 XQUEUE_INTERFACE = {


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds a custom attribute in settings for controlling the gradebook freeze time after course end. Currently the value has been hard coded to 30 in `lms/djangoapps/grades/grade_utils.py`

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner" & "Course Author"

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions
- Create a new course in studio.
- From settings dropdown, select `Schedule and Details`.
- Set the start date and end date to yesterday's date.
- Save the changes and return back to course outline.
- Create a section, subsection and a problem unit and publish it.
- From settings dropdown, select `Grading`.
- Set `Grace Period on Deadline` to `48:00`(2 days, during which the submit button remains enabled)
- Return back to course outline and in the subsection's settings, set the grading to `Homework`
- Set `GRADEBOOK_FREEZE_DAYS = 0` in your `private.py` file
- Go to the unit and click on `View Live Version`.
- Submit the problem with the correct answer.
- Click on the progress tab to open the gradebook page. The gradebook should not be updated.

## Deadline

"None"
