### PR TITLE
refactor: deprecated course update notification waffle flag

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -53,16 +53,3 @@ REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(
 # .. toggle_warning: Flag course_experience.relative_dates should also be active for relative dates functionalities to work.
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-844
 CUSTOM_RELATIVE_DATES = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.custom_relative_dates', __name__)
-
-
-# .. toggle_name: studio.enable_course_update_notifications
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable course update notifications.
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 14-Feb-2024
-# .. toggle_target_removal_date: 14-Mar-2024
-ENABLE_COURSE_UPDATE_NOTIFICATIONS = CourseWaffleFlag(
-    f'{WAFFLE_NAMESPACE}.enable_course_update_notifications',
-    __name__
-)

--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -19,7 +19,7 @@ import re
 from django.http import HttpResponseBadRequest
 from django.utils.translation import gettext as _
 
-from cms.djangoapps.contentstore.config.waffle import ENABLE_COURSE_UPDATE_NOTIFICATIONS
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
 from cms.djangoapps.contentstore.utils import track_course_update_event, send_course_update_notification
 from openedx.core.lib.xblock_utils import get_course_update_items
 from xmodule.html_block import CourseInfoBlock  # lint-amnesty, pylint: disable=wrong-import-order
@@ -93,7 +93,7 @@ def update_course_updates(location, update, passed_id=None, user=None, request_m
         track_course_update_event(location.course_key, user, course_update_dict)
 
         # send course update notification
-        if ENABLE_COURSE_UPDATE_NOTIFICATIONS.is_enabled(location.course_key):
+        if ENABLE_NOTIFICATIONS.is_enabled(location.course_key):
             send_course_update_notification(
                 location.course_key, course_update_dict["content"], user,
             )

--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -19,7 +19,6 @@ import re
 from django.http import HttpResponseBadRequest
 from django.utils.translation import gettext as _
 
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
 from cms.djangoapps.contentstore.utils import track_course_update_event, send_course_update_notification
 from openedx.core.lib.xblock_utils import get_course_update_items
 from xmodule.html_block import CourseInfoBlock  # lint-amnesty, pylint: disable=wrong-import-order
@@ -93,10 +92,9 @@ def update_course_updates(location, update, passed_id=None, user=None, request_m
         track_course_update_event(location.course_key, user, course_update_dict)
 
         # send course update notification
-        if ENABLE_NOTIFICATIONS.is_enabled(location.course_key):
-            send_course_update_notification(
-                location.course_key, course_update_dict["content"], user,
-            )
+        send_course_update_notification(
+            location.course_key, course_update_dict["content"], user,
+        )
 
     # remove status key
     if "status" in course_update_dict:


### PR DESCRIPTION
### Ticket: [INF-1463](https://2u-internal.atlassian.net/jira/software/c/projects/INF/boards/742?selectedIssue=INF-1463)

Deprecated the `studio.enable_course_update_notifications` flag and used `notifications.enable_email_notifications` instead for sending course update notifications.
