### PR TITLE
fix: content search last_published date [FC-0059]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -206,7 +206,9 @@ class LibraryXBlockMetadata:
         """
         Construct a LibraryXBlockMetadata from a Component object.
         """
-        last_publish_log = authoring_api.get_last_publish(component.pk)
+        ref = ContentLibrary.objects.get_by_key(library_key)
+        learning_package = ref.learning_package
+        last_publish_log = authoring_api.get_last_publish(learning_package.id, key=component.publishable_entity.key)
 
         return cls(
             usage_key=LibraryUsageLocatorV2(

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -206,9 +206,7 @@ class LibraryXBlockMetadata:
         """
         Construct a LibraryXBlockMetadata from a Component object.
         """
-        ref = ContentLibrary.objects.get_by_key(library_key)
-        learning_package = ref.learning_package
-        last_publish_log = authoring_api.get_last_publish(learning_package.id, key=component.publishable_entity.key)
+        last_publish_log = component.versioning.last_publish_log
 
         return cls(
             usage_key=LibraryUsageLocatorV2(

--- a/openedx/core/djangoapps/content_tagging/tests/test_objecttag_export_helpers.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_objecttag_export_helpers.py
@@ -441,7 +441,7 @@ class TestContentTagChildrenExport(TaggedCourseMixin):  # type: ignore[misc]
         """
         Test if we can export a library
         """
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(8):
             tagged_library = build_object_tree_with_objecttags(self.library.key, self.all_library_object_tags)
 
         assert tagged_library == self.expected_library_tagged_xblock

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -87,8 +87,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-# FIXME: bump version when merged and tagged https://github.com/openedx/openedx-learning/pull/204
-git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity#egg=openedx_learning
+openedx-learning==0.10.1
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -87,7 +87,8 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.10.0
+# FIXME: bump version when merged and tagged https://github.com/openedx/openedx-learning/pull/204
+git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity#egg=openedx_learning
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -763,7 +763,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
+openedx-learning==0.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -763,7 +763,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.10.0
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1303,7 +1303,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
+openedx-learning==0.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1303,7 +1303,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.10.0
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -891,7 +891,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
+openedx-learning==0.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -891,7 +891,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.10.0
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -970,7 +970,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
+openedx-learning==0.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -970,7 +970,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.10.0
+openedx-learning @ git+https://github.com/openedx/openedx-learning.git@jill/get_last_publish_log_for_entity
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

https://github.com/openedx/edx-platform/pull/35103 mis-used the "last published" log to determine the component published date. https://github.com/openedx/openedx-learning/pull/204 resolves this issue by providing a new property `component.versions.last_publish_log`, from which we can get the `published_at` datetime.

- Which edX user roles will this change impact? Content libraries v2 aren't production ready yet, so no users should be affected. 

## Supporting information

Depends on https://github.com/openedx/openedx-learning/pull/204

Private-ref: [FAL-3758](https://tasks.opencraft.com/browse/FAL-3758)

## Testing instructions

0. Run this branch at the frontend: https://github.com/openedx/frontend-app-course-authoring/pull/1147
1. Install the branches for this PR + https://github.com/openedx/openedx-learning/pull/204 into your CMS.
2. Ensure your search index has been updated (from previous PR changes): `python manage.py cms reindex_studio --experimental`
3. Create a v2 content library in the Course Authoring MFE.
4. Add components A.
5. Publish the content library.
6. From the shell, publish the library:
   ```
   from openedx.core.djangoapps.content_libraries import api, models
   library = models.ContentLibrary.objects.get(org=`<your library org>`, slug='<your library slug>')
   api.publish_changes(library.library_key)
   ```
7. Add a component B, and re-publish the library.
8. Add a component C, but do not publish.
9. View your library's "Components" tab, and sort by "Recently Published". Should see components B and A (in that order), and C should be omitted.

Or you can just reindex studio content to apply this change to existing components:

```
python manage.py cms reindex_studio --experimental
```

## Deadline

None