### PR TITLE
fix: Fixes auto_advance feature for video XBlock

### DIFF
--- a/xmodule/js/src/video/08_video_auto_advance_control.js
+++ b/xmodule/js/src/video/08_video_auto_advance_control.js
@@ -119,8 +119,16 @@
                 },
 
                 autoAdvance: function() {
+                    // We are posting a message to the MFE and then let the eventlistener
+                    // in the MFE handle the action taken.
                     if (this.state.auto_advance) {
-                        $('.sequence-nav-button.button-next').first().click();
+                         if (window !== window.parent) {
+                            window.parent.postMessage({
+                              type: 'plugin.autoAdvance',
+                              payload: {}
+                            }, document.referrer
+                          );
+                         }
                     }
                 }
             };


### PR DESCRIPTION
## Description

The PR fixes the auto-advance feature for video XBlock, the feature was broken when we started using learning MFE.

## Supporting information

We are passing a message from the iframe to the parent, the message has a type `plugin.autoAdvance`, which helps the MFE to trigger the next sequence button.

## Testing instructions

TBD

## Deadline

~~"None" if there's no rush, or provide a specific date or event (and reason) if there is one.~~

## Other information