### PR TITLE
fix: removed extra space and colon from ORA notification content

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -197,7 +197,7 @@ COURSE_NOTIFICATION_TYPES = {
         'push': False,
         'email_cadence': EmailCadence.DAILY,
         'non_editable': [],
-        'content_template': _('<{p}>You have a new open response submission awaiting for review for : '
+        'content_template': _('<{p}>You have a new open response submission awaiting for review for '
                               '<{strong}>{ora_name}</{strong}></{p}>'),
         'content_context': {
             'ora_name': 'Name of ORA in course',


### PR DESCRIPTION
Ticket: [INF-1462](https://2u-internal.atlassian.net/browse/INF-1462)

Extra colon and space were removed from the ORA notification content.

### Before:
<img width="556" alt="image-20240709-072858" src="https://github.com/user-attachments/assets/e80c2296-7fd0-4638-9f75-829c74273b5a">

### After:
<img width="550" alt="Screenshot 2024-07-31 at 11 48 04 AM" src="https://github.com/user-attachments/assets/ea101697-70fc-40e3-9dbf-61b82feaa230">
