### PR TITLE
feat: allow blocks lower than units to be bookmarked

### DIFF
--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -62,7 +62,7 @@ from openedx.core.djangolib.markup import HTML
 <div class="vert-mod">
 % for idx, item in enumerate(items):
   % if item['content']:
-    <div class="vert vert-${idx}" data-id="${item['id']}">
+    <div class="vert vert-${idx}" data-id="${item['id']}" id="${item['id']}">
         ${HTML(item['content'])}
     </div>
   %endif

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/models/bookmark.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/models/bookmark.js
@@ -1,20 +1,37 @@
 (function(define) {
-    'use strict';
+  'use strict';
 
-    define(['backbone'], function(Backbone) {
-        return Backbone.Model.extend({
-            idAttribute: 'id',
-            defaults: {
-                course_id: '',
-                usage_id: '',
-                display_name: '',
-                path: [],
-                created: ''
-            },
+  define(['backbone'], function(Backbone) {
+    return Backbone.Model.extend({
+      idAttribute: 'id',
+      defaults: {
+        course_id: '',
+        usage_id: '',
+        display_name: '',
+        path: [],
+        created: ''
+      },
 
-            blockUrl: function() {
-                return '/courses/' + this.get('course_id') + '/jump_to/' + this.get('usage_id');
-            }
-        });
+      blockUrl: function() {
+        var path = this.get('path');
+        var url = '/courses/' + this.get('course_id') + '/jump_to/' + this.get('usage_id');
+        var params = new URLSearchParams();
+        var usage_id = this.get('usage_id');
+        // Confirm that current usage_id does not correspond to current unit
+        // path contains an array of parent blocks to the bookmarked block.
+        // Units only have two parents i.e. section and subsections.
+        // Below condition is only satisfied if a block lower than unit is bookmarked.
+        if (path.length > 2 && usage_id !== path[path.length - 1]) {
+          params.append('jumpToId', usage_id);
+        }
+        if (params.size > 0) {
+          // Pass nested block details via query parameters for it to be passed to learning mfe
+          // The learning mfe should pass it back to unit xblock via iframe url params.
+          // This would allow us to scroll to the child xblock.
+          url = url + '?' + params.toString();
+        }
+        return url;
+      }
     });
+  });
 }(define || RequireJS.define));

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmark_button.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmark_button.js
@@ -20,6 +20,12 @@
                     this.bookmarkId = options.bookmarkId;
                     this.bookmarked = options.bookmarked;
                     this.usageId = options.usageId;
+                    if (options.bookmarkedText) {
+                        this.bookmarkedText = options.bookmarkedText;
+                    }
+                    if (options.bookmarkText) {
+                        this.bookmarkText = options.bookmarkText;
+                    }
                     this.setBookmarkState(this.bookmarked);
                 },
 

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmarks_list.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmarks_list.js
@@ -78,9 +78,7 @@
                         component_type: componentType,
                         component_usage_id: componentUsageId
                     }
-                ).always(function() {
-                    window.location.href = event.currentTarget.pathname;
-                });
+                );
             },
 
             /**


### PR DESCRIPTION
## Description

Adds support to jump/scroll to blocks lower than units if bookmarked. It also fixes an issue with bookmark visit url function where it was not passing query params.

## Supporting information

* https://github.com/open-craft/multi-problem-xblock/pull/1 demonstrates use of bookmarking lower level blocks. It allows users to bookmark a block inside a multi-problem block which itself is a child of unit level block. Along with changes in https://github.com/openedx/frontend-app-learning/pull/1427, it scrolls to correct block in the unit.
* `Private-ref`: [BB-8950](https://tasks.opencraft.com/browse/BB-8950)

## Testing instructions

* Follow instructions in https://github.com/open-craft/multi-problem-xblock/pull/1 to setup multi-problem-xblock.
* Checkout PR: in frontend-app-learning
* Test bookmark button in multi-problem block.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.