### PR TITLE
feat: Add default setting DEFAULT_CERTIFICATES_DISPLAY_BEHAVIOR

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -61,7 +61,7 @@ from lms.envs.common import (
     PROFILE_IMAGE_HASH_SEED, PROFILE_IMAGE_MIN_BYTES, PROFILE_IMAGE_MAX_BYTES, PROFILE_IMAGE_SIZES_MAP,
     # The following setting is included as it is used to check whether to
     # display credit eligibility table on the CMS or not.
-    COURSE_MODE_DEFAULTS, DEFAULT_COURSE_ABOUT_IMAGE_URL,
+    COURSE_MODE_DEFAULTS, DEFAULT_COURSE_ABOUT_IMAGE_URL, DEFAULT_CERTIFICATES_DISPLAY_BEHAVIOR,
 
     # User-uploaded content
     MEDIA_ROOT,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -72,6 +72,7 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
 from openedx.core.lib.derived import derived, derived_collection_entry
 from openedx.core.release import doc_version
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
+from xmodule.data import CertificatesDisplayBehaviors
 
 ################################### FEATURES ###################################
 # .. setting_name: PLATFORM_NAME
@@ -1547,6 +1548,11 @@ USAGE_ID_PATTERN = r'(?P<usage_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|
 USERNAME_REGEX_PARTIAL = r'[\w .@_+-]+'
 USERNAME_PATTERN = fr'(?P<username>{USERNAME_REGEX_PARTIAL})'
 
+# .. setting_name: DEFAULT_CERTIFICATES_DISPLAY_BEHAVIOR
+# .. setting_default: CertificatesDisplayBehaviors.END.value
+# .. setting_description: Default value for the `certificates_display_behavior` course field.
+#      Together with certificate_available_date it will determine when a user can see their certificate for the course.
+DEFAULT_CERTIFICATES_DISPLAY_BEHAVIOR = CertificatesDisplayBehaviors.END.value
 
 ############################## EVENT TRACKING #################################
 LMS_SEGMENT_KEY = None

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -22,7 +22,6 @@ from openedx.core.lib.license import LicenseMixin
 from openedx.core.lib.teams_config import TeamsConfig  # lint-amnesty, pylint: disable=unused-import
 from xmodule import course_metadata_utils
 from xmodule.course_metadata_utils import DEFAULT_GRADING_POLICY, DEFAULT_START_DATE
-from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.graders import grader_from_conf
 from xmodule.seq_block import SequenceBlock
 from xmodule.tabs import CourseTabList, InvalidTabsException
@@ -589,7 +588,7 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
             "user can see their certificate for the course"
         ),
         scope=Scope.settings,
-        default=CertificatesDisplayBehaviors.END.value,
+        default=settings.DEFAULT_CERTIFICATES_DISPLAY_BEHAVIOR
     )
     course_image = String(
         display_name=_("Course About Page Image"),


### PR DESCRIPTION
## Description

Adding a default setting will allow more flexible control over certificate creation behavior at the global level.
This way we can set any of the available values ​​by default:
- `END`
- `END_WITH_DATE`
- `EARLY_NO_INFO`

<img width="1111" alt="screen_setting_cert_beh" src="https://github.com/user-attachments/assets/12a89bdc-99b9-4d56-8335-1998dfb46fae">
