### PR TITLE
[FC-0059] feat: allow copy library v2 xblock

### DIFF
--- a/openedx/core/djangoapps/content_staging/views.py
+++ b/openedx/core/djangoapps/content_staging/views.py
@@ -104,7 +104,7 @@ class ClipboardEndpoint(APIView):
 
             elif isinstance(course_key, LibraryLocatorV2):
                 lib_api.require_permission_for_library_key(
-                    usage_key,
+                    course_key,
                     request.user,
                     lib_api.permissions.CAN_VIEW_THIS_CONTENT_LIBRARY
                 )


### PR DESCRIPTION
## Description
This PR changes the content stage Rest API to allow copying XBlocks from Libraries V2.

## Testing instructions
Follow the instructions from https://github.com/openedx/frontend-app-course-authoring/pull/1197

---
Private ref: [FAL-3769](https://tasks.opencraft.com/browse/FAL-3769)