### PR TITLE
feat: added truncate and alert in notification

### DIFF
--- a/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
@@ -33,7 +33,7 @@
                         </td>
                         <td class="notification-content" width="100%" align="left" valign="top" style=" padding: 1rem 1rem 1rem 0.5rem">
                             <p style="font-size: 0.875rem; font-weight:400; line-height:24px; color:#454545; margin: 0;">
-                                {{ notification.content | safe }}
+                                {{ notification.content | truncatechars_html:600 | safe }}
                             </p>
                             <p style="height: 0.5rem; margin: 0"></p>
                             <p style="color:#707070; margin: 0">

--- a/openedx/core/djangoapps/notifications/templates/notifications/email_digest_preference_update.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/email_digest_preference_update.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>{{ _("Email Digest Preferences Updated") }}</title>
+    </head>
+    <body>
+        <script>
+            alert('{{ _("You have successfully unsubscribed from email digest for learning activity") }}');
+            window.location.replace("{{ notification_preferences_url }}");
+        </script>
+    </body>
+</html>

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -5,8 +5,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.db.models import Count
-from django.http import HttpResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.utils.translation import gettext as _
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
@@ -442,4 +441,7 @@ def preference_update_from_encrypted_username_view(request, username, patch):
     username and patch must be string
     """
     update_user_preferences_from_patch(username, patch)
-    return HttpResponse("<!DOCTYPE html><html><body>Success</body></html>", status=status.HTTP_200_OK)
+    context = {
+        "notification_preferences_url": f"{settings.ACCOUNT_MICROFRONTEND_URL}/notifications"
+    }
+    return render(request, "notifications/email_digest_preference_update.html", context=context)


### PR DESCRIPTION
This PR has following changes
- Truncate email notification content to 600 characters
- One click unsubscribe link will show alert that preferences has been updated and will redirect user to notification preferences.

Tickets: [INF-1461](https://2u-internal.atlassian.net/browse/INF-1461) [INF-1491](https://2u-internal.atlassian.net/browse/INF-1491)