### PR TITLE
fix: error when saving changes to a v2 library block [FC-0059]

### DIFF
--- a/openedx/core/djangoapps/xblock/rest_api/views.py
+++ b/openedx/core/djangoapps/xblock/rest_api/views.py
@@ -257,7 +257,7 @@ class BlockFieldsView(APIView):
 
         # Signal that we've modified this block
         context_impl = get_learning_context_impl(usage_key)
-        context_impl.send_updated_event(usage_key)
+        context_impl.send_block_updated_event(usage_key)
 
         return Response({
             "id": str(block.location),


### PR DESCRIPTION
## Description

I tried saving changes to a component in a v2 content library and got an error that `send_updated_event` was not defined.

## Supporting information

This fixes a change introduced in #35103.

## Testing instructions

Use the (deprecated) library authoring MFE to make a change to an XBlock that's in a content library. Or ask me about using my WIP editor in the course authoring MFE.

## Deadline

ASAP

## Other information

n/a