### PR TITLE
fix: update course discussion config before course load

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -58,6 +58,7 @@ from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadReq
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
+from openedx.core.djangoapps.discussions.tasks import update_discussions_settings_from_course
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
@@ -302,6 +303,10 @@ def course_handler(request, course_key_string=None):
             else:
                 return HttpResponseBadRequest()
         elif request.method == 'GET':  # assume html
+            # Update course discussion settings, sometimes the course discussion settings are not updated
+            # when the course is created, so we need to update them here.
+            course_key = CourseKey.from_string(course_key_string)
+            update_discussions_settings_from_course(course_key)
             if course_key_string is None:
                 return redirect(reverse('home'))
             else:

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -717,8 +717,8 @@ class TestCourseOutline(CourseTestCase):
         """
         Test to check number of queries made to mysql and mongo
         """
-        with self.assertNumQueries(29, table_ignorelist=WAFFLE_TABLES):
-            with check_mongo_calls(3):
+        with self.assertNumQueries(32, table_ignorelist=WAFFLE_TABLES):
+            with check_mongo_calls(5):
                 self.client.get_html(reverse_course_url('course_handler', self.course.id))
 
 


### PR DESCRIPTION
## Description
Ensure to update course discussions settings before course is loaded cms , sometimes newly created courses are not synced to real discussions settings which causes false information for the user.


## Ticket
https://2u-internal.atlassian.net/browse/INF-1469