### PR TITLE
fix: make course update email pref false

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2255,7 +2255,7 @@ def send_course_update_notification(course_key, content, user):
             "course_update_content": text_content if len(text_content.strip()) < 10 else "Click here to view",
             **extra_context,
         },
-        notification_type="course_update",
+        notification_type="course_updates",
         content_url=f"{settings.LMS_ROOT_URL}/courses/{str(course_key)}/course/updates",
         app_name="updates",
         audience_filters={},

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -169,13 +169,13 @@ COURSE_NOTIFICATION_TYPES = {
         'email_template': '',
         'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE]
     },
-    'course_update': {
+    'course_updates': {
         'notification_app': 'updates',
-        'name': 'course_update',
+        'name': 'course_updates',
         'is_core': False,
         'info': '',
         'web': True,
-        'email': True,
+        'email': False,
         'push': True,
         'email_cadence': EmailCadence.DAILY,
         'non_editable': [],

--- a/openedx/core/djangoapps/notifications/email/tests/test_utils.py
+++ b/openedx/core/djangoapps/notifications/email/tests/test_utils.py
@@ -70,7 +70,7 @@ class TestUtilFunctions(ModuleStoreTestCase):
         """
         Notification.objects.all().delete()
         create_notification(self.user, self.course.id, app_name='discussion', notification_type='new_comment')
-        create_notification(self.user, self.course.id, app_name='updates', notification_type='course_update')
+        create_notification(self.user, self.course.id, app_name='updates', notification_type='course_updates')
         app_dict = create_app_notifications_dict(Notification.objects.all())
         assert len(app_dict.keys()) == 2
         for key in ['discussion', 'updates']:
@@ -130,7 +130,7 @@ class TestContextFunctions(ModuleStoreTestCase):
         discussion_notification = create_notification(self.user, self.course.id, app_name='discussion',
                                                       notification_type='new_comment')
         update_notification = create_notification(self.user, self.course.id, app_name='updates',
-                                                  notification_type='course_update')
+                                                  notification_type='course_updates')
         app_dict = create_app_notifications_dict(Notification.objects.all())
         end_date = datetime.datetime(2024, 3, 24, 12, 0)
         params = {

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -23,7 +23,7 @@ NOTIFICATION_CHANNELS = ['web', 'push', 'email']
 ADDITIONAL_NOTIFICATION_CHANNEL_SETTINGS = ['email_cadence']
 
 # Update this version when there is a change to any course specific notification type or app.
-COURSE_NOTIFICATION_CONFIG_VERSION = 10
+COURSE_NOTIFICATION_CONFIG_VERSION = 11
 
 
 def get_course_notification_preference_config():

--- a/openedx/core/djangoapps/notifications/tests/test_tasks.py
+++ b/openedx/core/djangoapps/notifications/tests/test_tasks.py
@@ -390,7 +390,7 @@ class TestDeleteNotificationTask(ModuleStoreTestCase):
         """
         assert not Notification.objects.all()
         create_notification(self.user, self.course_1.id, app_name='discussion', notification_type='new_comment')
-        create_notification(self.user, self.course_1.id, app_name='updates', notification_type='course_update')
+        create_notification(self.user, self.course_1.id, app_name='updates', notification_type='course_updates')
         delete_notifications({'app_name': 'discussion'})
         assert not Notification.objects.filter(app_name='discussion')
         assert Notification.objects.filter(app_name='updates')

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -275,9 +275,9 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                     'enabled': True,
                     'core_notification_types': [],
                     'notification_types': {
-                        'course_update': {
+                        'course_updates': {
                             'web': True,
-                            'email': True,
+                            'email': False,
                             'push': True,
                             'email_cadence': 'Daily',
                             'info': ''


### PR DESCRIPTION
## Description 

Updated email preference for course update email notification to false .


## Ticket 
https://2u-internal.atlassian.net/browse/INF-1476