### PR TITLE
backport fix: disable submit button for archived courses (#34920) to quince

### DIFF
--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -734,11 +734,24 @@ class ProblemBlock(
                 yield (user_state.username, report)
 
     @property
+    def course_end_date(self):
+        """
+        Return the end date of the problem's course
+        """
+
+        try:
+            course_block_key = self.runtime.course_entry.structure['root']
+            return self.runtime.course_entry.structure['blocks'][course_block_key].fields['end']
+        except (AttributeError, KeyError):
+            return None
+
+    @property
     def close_date(self):
         """
         Return the date submissions should be closed from.
         """
-        due_date = self.due
+
+        due_date = self.due or self.course_end_date
 
         if self.graceperiod is not None and due_date:
             return due_date + self.graceperiod

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -10,7 +10,7 @@ import os
 import random
 import textwrap
 import unittest
-from unittest.mock import DEFAULT, Mock, patch
+from unittest.mock import DEFAULT, Mock, patch, PropertyMock
 
 import pytest
 import ddt

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -648,6 +648,37 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
                                    due=self.yesterday_str)
         assert block.closed()
 
+    @patch.object(ProblemBlock, 'course_end_date', new_callable=PropertyMock)
+    def test_closed_for_archive(self, mock_course_end_date):
+
+        # Utility to create a datetime object in the past
+        def past_datetime(days):
+            return (datetime.datetime.now(UTC) - datetime.timedelta(days=days))
+
+        # Utility to create a datetime object in the future
+        def future_datetime(days):
+            return (datetime.datetime.now(UTC) + datetime.timedelta(days=days))
+
+        block = CapaFactory.create(max_attempts="1", attempts="0")
+
+        # For active courses without graceperiod
+        mock_course_end_date.return_value = future_datetime(10)
+        assert not block.closed()
+
+        # For archive courses without graceperiod
+        mock_course_end_date.return_value = past_datetime(10)
+        assert block.closed()
+
+        # For active courses with graceperiod
+        mock_course_end_date.return_value = future_datetime(10)
+        block.graceperiod = datetime.timedelta(days=2)
+        assert not block.closed()
+
+        # For archive courses with graceperiod
+        mock_course_end_date.return_value = past_datetime(2)
+        block.graceperiod = datetime.timedelta(days=3)
+        assert not block.closed()
+
     def test_parse_get_params(self):
 
         # Valid GET param dict


### PR DESCRIPTION
* fix: disable submit button for archived courses

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR backports https://github.com/openedx/edx-platform/commit/3b8973ad011444fc37464f0c6905f583138c9a8b to quince. This disables the submission button for problems in the archived courses.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
Before
<img width="1179" alt="Screenshot 2024-06-05 at 3 17 16 PM" src="https://github.com/openedx/edx-platform/assets/88967643/0e9618f9-b200-4926-ae18-a1632569402d">

After
<img width="1179" alt="Screenshot 2024-06-05 at 3 14 50 PM" src="https://github.com/openedx/edx-platform/assets/88967643/3f9caa05-72eb-47b7-9225-65fdc606da57">

- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/mitodl/hq/issues/4415

## Testing instructions

## Testing instructions

- Create a new course in studio.
- From settings dropdown, select `Schedule and Details`.
- Make the course `self-paced` and add the start date and end date to some past dates.
- Save the changes and return back to course outline.
- Create a section, subsection and a problem unit and publish it.
- In the subsection's settings, set the grading to `Homework`
- Go to the unit and click on `View Live Version`.
- Validate that the submit button is disabled.

## Deadline

None

