### PR TITLE
feat: save author pronoun separately for notification to prevent info loss

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -118,9 +118,10 @@ class DiscussionNotificationSender:
             self.parent_response and
             self.creator.id != int(self.thread.user_id)
         ):
+            author_name = f"{self.parent_response.username}'s"
             # use your if author of response is same as author of post.
             # use 'their' if comment author is also response author.
-            author_name = (
+            author_pronoun = (
                 # Translators: Replier commented on "your" response to your post
                 _("your")
                 if self._response_and_thread_has_same_creator()
@@ -129,10 +130,12 @@ class DiscussionNotificationSender:
                     _("their")
                     if self._response_and_comment_has_same_creator()
                     else f"{self.parent_response.username}'s"
+
                 )
             )
             context = {
                 "author_name": str(author_name),
+                "author_pronoun": str(author_pronoun),
             }
             self._send_notification([self.thread.user_id], "new_comment", extra_context=context)
 

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -192,10 +192,22 @@ class DiscussionNotificationSender:
         if not self.parent_id:
             self._send_notification(users, "response_on_followed_post")
         else:
+            author_name = f"{self.parent_response.username}'s"
+            # use 'their' if comment author is also response author.
+            author_pronoun = (
+                    # Translators: Replier commented on "their" response in a post you're following
+                    _("their")
+                    if self._response_and_comment_has_same_creator()
+                    else f"{self.parent_response.username}'s"
+            )
             self._send_notification(
                 users,
                 "comment_on_followed_post",
-                extra_context={"author_name": self.parent_response.username}
+                extra_context=
+                {
+                    "author_name": str(author_name),
+                    "author_pronoun": str(author_pronoun),
+                }
             )
 
     def _create_cohort_course_audience(self):

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -195,16 +195,15 @@ class DiscussionNotificationSender:
             author_name = f"{self.parent_response.username}'s"
             # use 'their' if comment author is also response author.
             author_pronoun = (
-                    # Translators: Replier commented on "their" response in a post you're following
-                    _("their")
-                    if self._response_and_comment_has_same_creator()
-                    else f"{self.parent_response.username}'s"
+                # Translators: Replier commented on "their" response in a post you're following
+                _("their")
+                if self._response_and_comment_has_same_creator()
+                else f"{self.parent_response.username}'s"
             )
             self._send_notification(
                 users,
                 "comment_on_followed_post",
-                extra_context=
-                {
+                extra_context={
                     "author_name": str(author_name),
                     "author_pronoun": str(author_pronoun),
                 }

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -338,6 +338,7 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'replier_name': self.user_3.username,
             'post_title': self.thread.title,
             'author_name': 'dummy\'s',
+            'author_pronoun': 'dummy\'s',
             'course_name': self.course.display_name,
             'sender_id': self.user_3.id
         }
@@ -399,7 +400,8 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
         expected_context = {
             'replier_name': self.user_3.username,
             'post_title': self.thread.title,
-            'author_name': 'your',
+            'author_name': 'dummy\'s',
+            'author_pronoun': 'your',
             'course_name': self.course.display_name,
             'sender_id': self.user_3.id,
         }
@@ -441,7 +443,8 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'sender_id': self.user_2.id,
         }
         if parent_id:
-            expected_context['author_name'] = 'dummy'
+            expected_context['author_name'] = 'dummy\'s'
+            expected_context['author_pronoun'] = 'dummy\'s'
         self.assertDictEqual(args.context, expected_context)
         self.assertEqual(
             args.content_url,
@@ -531,7 +534,8 @@ class TestSendCommentNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCas
         send_response_notifications(thread.id, str(self.course.id), self.user_2.id, parent_id=response.id)
         handler.assert_called_once()
         context = handler.call_args[1]['notification_data'].context
-        self.assertEqual(context['author_name'], 'their')
+        self.assertEqual(context['author_name'], 'dummy\'s')
+        self.assertEqual(context['author_pronoun'], 'their')
 
 
 @override_waffle_flag(ENABLE_NOTIFICATIONS, active=True)

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -109,8 +109,9 @@ COURSE_NOTIFICATION_TYPES = {
         'is_core': True,
         'info': '',
         'non_editable': [],
-        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on {author_name}\'s response in '
-                              'a post you’re following <{strong}>{post_title}</{strong}></{p}>'),
+        'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on <{strong}>{author_name}'
+                              '</{strong}> response in a post you’re following <{strong}>{post_title}'
+                              '</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',
             'author_name': 'author name',
@@ -491,6 +492,13 @@ def get_new_comment_notification_content(notification_type, context):
         Returns notification content for the new_comment notification.
     """
     return get_notification_content_with_author_pronoun(notification_type,context)
+
+
+def get_comment_on_followed_post_notification_content(notification_type, context):
+    """
+        Returns notification content for the comment_on_followed_post notification.
+    """
+    return get_notification_content_with_author_pronoun(notification_type, context)
 
 
 def get_notification_content_with_author_pronoun(notification_type, context):

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -491,7 +491,7 @@ def get_new_comment_notification_content(notification_type, context):
     """
         Returns notification content for the new_comment notification.
     """
-    return get_notification_content_with_author_pronoun(notification_type,context)
+    return get_notification_content_with_author_pronoun(notification_type, context)
 
 
 def get_comment_on_followed_post_notification_content(notification_type, context):

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -457,6 +457,16 @@ class NotificationAppManager:
         return course_notification_preference_config
 
 
+def get_notification_type_content_function(notification_type):
+    """
+        Returns the content function for the given notification if it exists.
+    """
+    try:
+        return globals()[f"get_{notification_type}_notification_content"]
+    except KeyError:
+        return None
+
+
 def get_notification_content(notification_type, context):
     """
     Returns notification content for the given notification type with provided context.
@@ -465,11 +475,37 @@ def get_notification_content(notification_type, context):
         'strong': 'strong',
         'p': 'p',
     }
+    content_function = get_notification_type_content_function(notification_type)
     notification_type = NotificationTypeManager().notification_types.get(notification_type, None)
     if notification_type:
+        if content_function:
+            return content_function(notification_type, context)
         notification_type_content_template = notification_type.get('content_template', None)
         if notification_type_content_template:
             return notification_type_content_template.format(**context, **html_tags_context)
+    return ''
+
+
+def get_new_comment_notification_content(notification_type, context):
+    """
+        Returns notification content for the new_comment notification.
+    """
+    return get_notification_content_with_author_pronoun(notification_type,context)
+
+
+def get_notification_content_with_author_pronoun(notification_type, context):
+    """
+        Helper function to get notification content with author's pronoun.
+    """
+    html_tags_context = {
+        'strong': 'strong',
+        'p': 'p',
+    }
+    notification_type_content_template = notification_type.get('content_template', None)
+    if 'author_pronoun' in context:
+        context['author_name'] = context['author_pronoun']
+    if notification_type_content_template:
+        return notification_type_content_template.format(**context, **html_tags_context)
     return ''
 
 

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -7,6 +7,7 @@ from .email_notifications import EmailCadence
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from .utils import find_app_in_normalized_apps, find_pref_in_normalized_prefs
 from ..django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA
+from .notification_content import get_notification_type_content_function
 
 FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE = 'filter_audit_expired_users_with_no_role'
 
@@ -458,16 +459,6 @@ class NotificationAppManager:
         return course_notification_preference_config
 
 
-def get_notification_type_content_function(notification_type):
-    """
-        Returns the content function for the given notification if it exists.
-    """
-    try:
-        return globals()[f"get_{notification_type}_notification_content"]
-    except KeyError:
-        return None
-
-
 def get_notification_content(notification_type, context):
     """
     Returns notification content for the given notification type with provided context.
@@ -484,36 +475,6 @@ def get_notification_content(notification_type, context):
         notification_type_content_template = notification_type.get('content_template', None)
         if notification_type_content_template:
             return notification_type_content_template.format(**context, **html_tags_context)
-    return ''
-
-
-def get_new_comment_notification_content(notification_type, context):
-    """
-        Returns notification content for the new_comment notification.
-    """
-    return get_notification_content_with_author_pronoun(notification_type, context)
-
-
-def get_comment_on_followed_post_notification_content(notification_type, context):
-    """
-        Returns notification content for the comment_on_followed_post notification.
-    """
-    return get_notification_content_with_author_pronoun(notification_type, context)
-
-
-def get_notification_content_with_author_pronoun(notification_type, context):
-    """
-        Helper function to get notification content with author's pronoun.
-    """
-    html_tags_context = {
-        'strong': 'strong',
-        'p': 'p',
-    }
-    notification_type_content_template = notification_type.get('content_template', None)
-    if 'author_pronoun' in context:
-        context['author_name'] = context['author_pronoun']
-    if notification_type_content_template:
-        return notification_type_content_template.format(**context, **html_tags_context)
     return ''
 
 

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -119,7 +119,7 @@ class Notification(TimeStampedModel):
         """
         Returns the content for the notification.
         """
-        return get_notification_content(self.notification_type, self.content_context.copy())
+        return get_notification_content(self.notification_type, self.content_context)
 
 
 class CourseNotificationPreference(TimeStampedModel):

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -119,7 +119,7 @@ class Notification(TimeStampedModel):
         """
         Returns the content for the notification.
         """
-        return get_notification_content(self.notification_type, self.content_context)
+        return get_notification_content(self.notification_type, self.content_context.copy())
 
 
 class CourseNotificationPreference(TimeStampedModel):

--- a/openedx/core/djangoapps/notifications/notification_content.py
+++ b/openedx/core/djangoapps/notifications/notification_content.py
@@ -1,0 +1,31 @@
+
+def get_notification_type_content_function(notification_type):
+    """
+        Returns the content function for the given notification if it exists.
+    """
+    try:
+        return globals()[f"get_{notification_type}_notification_content"]
+    except KeyError:
+        return None
+
+
+def get_notification_content_with_author_pronoun(notification_type, context):
+    """
+        Helper function to get notification content with author's pronoun.
+    """
+    html_tags_context = {
+        'strong': 'strong',
+        'p': 'p',
+    }
+    notification_type_content_template = notification_type.get('content_template', None)
+    if 'author_pronoun' in context:
+        context['author_name'] = context['author_pronoun']
+    if notification_type_content_template:
+        return notification_type_content_template.format(**context, **html_tags_context)
+    return ''
+
+
+# Returns notification content for the new_comment notification.
+get_new_comment_notification_content = get_notification_content_with_author_pronoun
+# Returns notification content for the comment_on_followed_post notification.
+get_comment_on_followed_post_notification_content = get_notification_content_with_author_pronoun

--- a/openedx/core/djangoapps/notifications/notification_content.py
+++ b/openedx/core/djangoapps/notifications/notification_content.py
@@ -1,3 +1,7 @@
+"""
+Helper functions for overriding notification content for given notification type.
+"""
+
 
 def get_notification_type_content_function(notification_type):
     """


### PR DESCRIPTION
### Ticket: [INF-1485](https://2u-internal.atlassian.net/browse/INF-1485)

For discussion notifications, the username is replaced with a pronoun in context, which results in information loss. To prevent this issue the username and the user pronoun will now be stored separately. 

Changes: 
1. For the `new_comment` notification the pronoun that was previously being saved in `author_name` will be stored separately in `author_pronoun`.
2. For the `comment_on_followed_post` notification a pronoun will be calculated according to the user and will be stored in `author_pronoun`.