### PR TITLE
build: Pin social-auth-app-django as a requirement.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -130,3 +130,9 @@ numpy<2.0.0
 # Two lines were added in 1.14.4 that make file_exists_in_storage function always return False,
 # as the default value of AWS_S3_FILE_OVERWRITE is True
 django-storages<1.14.4
+
+# social-auth-app-django 5.4.2 introduces a new migration that will not play nicely with large installations. This will touch
+# user tables, which are quite large, especially on instances like edx.org.
+# We are pinning this until after all the smaller migrations get handled and then we can migrate this all at once.
+# Ticket to unpin: https://github.com/edx/edx-arch-experiments/issues/760
+social-auth-app-django<=5.4.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1065,6 +1065,7 @@ snowflake-connector-python==3.11.0
     # via edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
 social-auth-core==4.5.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1884,6 +1884,7 @@ snowflake-connector-python==3.11.0
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1255,6 +1255,7 @@ snowflake-connector-python==3.11.0
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
 social-auth-core==4.5.4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1416,6 +1416,7 @@ snowflake-connector-python==3.11.0
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
 social-auth-core==4.5.4


### PR DESCRIPTION
There are a few migrations going into this library which cause operational headaches for operators.
We would like to pin until the migrations settle down and then we can unpin this again.