### PR TITLE
fix: Respect the authsource kwarg for MongoDB connections

### DIFF
--- a/xmodule/mongo_utils.py
+++ b/xmodule/mongo_utils.py
@@ -34,7 +34,7 @@ def connect_to_mongodb(
     # Convert the lowercased authsource parameter to the camel-cased authSource expected by MongoClient.
     auth_source = db
     if auth_source_key := {'authSource', 'authsource'}.intersection(set(kwargs.keys())):
-        auth_source = kwargs.pop(auth_source_key)
+        auth_source = kwargs.pop(auth_source_key.pop()) or db
 
     # sanitize a kwarg which may be present and is no longer expected
     # AED 2020-03-02 TODO: Remove this when 'auth_source' will no longer exist in kwargs

--- a/xmodule/mongo_utils.py
+++ b/xmodule/mongo_utils.py
@@ -30,8 +30,11 @@ def connect_to_mongodb(
     handles AutoReconnect errors by retrying read operations, since these exceptions
     typically indicate a temporary step-down condition for MongoDB.
     """
-    # If the MongoDB server uses a separate authentication database that should be specified here
-    auth_source = kwargs.get('authsource', '') or None
+    # If the MongoDB server uses a separate authentication database that should be specified here.
+    # Convert the lowercased authsource parameter to the camel-cased authSource expected by MongoClient.
+    auth_source = db
+    if auth_source_key := {'authSource', 'authsource'}.intersection(set(kwargs.keys())):
+        auth_source = kwargs.pop(auth_source_key)
 
     # sanitize a kwarg which may be present and is no longer expected
     # AED 2020-03-02 TODO: Remove this when 'auth_source' will no longer exist in kwargs
@@ -63,7 +66,7 @@ def connect_to_mongodb(
     }
 
     if user is not None and password is not None and not db.startswith('test_'):
-        connection_params.update({'username': user, 'password': password, 'authSource': db})
+        connection_params.update({'username': user, 'password': password, 'authSource': auth_source})
 
     mongo_conn = pymongo.MongoClient(**connection_params)
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

The changes for upgrading to PyMongo 4.4 introduced an authentication bug in Mongo connections. The `authSource` parameter was being hard-coded to use the database being connected to. In Mongo the `admin` db is typically the source of authentication, so unless the user was explicitly created in the target db then any attempts to connect would result in authentication failures.

This restores the behavior of allowing for the lowercased `authsource` kwarg to be used for the `authSource` connection parameter, while otherwise respecting the operator's configuration parameters.

## Supporting information

This addresses an error introduced by https://github.com/openedx/edx-platform/pull/35179

## Testing instructions

To test this change requires a MongoDB instance that is using a modulestore database name that is different than `admin` and does not contain the user that is authenticating (which is a fairly common scenario). Specifying either `authsource` or `authSource` in the configuration should allow the connection to be made without error.

## Deadline

ASAP, as the master branch is broken for typical MongoDB installations.