### PR TITLE
build: Downgrade xblock due to behavior regression.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -136,3 +136,7 @@ django-storages<1.14.4
 # We are pinning this until after all the smaller migrations get handled and then we can migrate this all at once.
 # Ticket to unpin: https://github.com/edx/edx-arch-experiments/issues/760
 social-auth-app-django<=5.4.1
+
+# Xblock==5.0.0 changed how entrypoints were loaded, breaking a workaround for overriding blocks.
+# See ticket: https://github.com/openedx/XBlock/issues/777
+xblock[django]==4.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1258,8 +1258,9 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/paver.txt
-xblock[django]==5.0.0
+xblock[django]==4.0.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   acid-xblock
     #   crowdsourcehinter-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2231,8 +2231,9 @@ wrapt==1.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-xblock[django]==5.0.0
+xblock[django]==4.0.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   acid-xblock

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1549,8 +1549,9 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/base.txt
-xblock[django]==5.0.0
+xblock[django]==4.0.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   crowdsourcehinter-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1646,8 +1646,9 @@ wrapt==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   astroid
-xblock[django]==5.0.0
+xblock[django]==4.0.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   crowdsourcehinter-xblock


### PR DESCRIPTION
Xblock used to allow overrides of the built-in xblocks. The latest version introduced a regression. See https://github.com/openedx/XBlock/issues/777 for more information

