### PR TITLE
fix: Fix matching of /c4x/ in course asset view urlpatterns

### DIFF
--- a/openedx/core/djangoapps/contentserver/test/test_views.py
+++ b/openedx/core/djangoapps/contentserver/test/test_views.py
@@ -1,0 +1,26 @@
+"""
+Tests for the view version of course asset serving.
+"""
+
+import ddt
+from django.test import TestCase
+from django.urls import resolve
+
+
+@ddt.ddt
+class UrlsTest(TestCase):
+    """
+    Tests for ensuring that the urlpatterns registered to the view are
+    appropriate for the URLs that the middleware historically handled.
+    """
+
+    @ddt.data(
+        '/c4x/edX/Open_DemoX/asset/images_course_image.jpg',
+        '/asset-v1:edX+DemoX.1+2T2019+type@asset+block/DemoX-poster.jpg',
+        '/assets/courseware/v1/0123456789abcdef0123456789abcdef/asset-v1:edX+FAKE101+2024+type@asset+block/HW1.png',
+    )
+    def test_sample_urls(self, sample_url):
+        """
+        Regression test -- c4x URL was previously incorrect in urls.py.
+        """
+        assert resolve(sample_url).view_name == 'openedx.core.djangoapps.contentserver.views.course_assets_view'

--- a/openedx/core/djangoapps/contentserver/urls.py
+++ b/openedx/core/djangoapps/contentserver/urls.py
@@ -2,7 +2,7 @@
 URL patterns for course asset serving.
 """
 
-from django.urls import path, re_path
+from django.urls import re_path
 
 from . import views
 
@@ -10,7 +10,7 @@ from . import views
 # components of the URLs. That's because the view itself is separately
 # parsing the paths, for historical reasons. See docstring on views.py.
 urlpatterns = [
-    path("c4x/", views.course_assets_view),
+    re_path("^c4x/", views.course_assets_view),
     re_path("^asset-v1:", views.course_assets_view),
     re_path("^assets/courseware/", views.course_assets_view),
 ]


### PR DESCRIPTION
This was failing to capture /c4x/ URLs when the `content_server.use_view` waffle flag was enabled, so we were returning 404s for those during our rollout test.

Part of https://github.com/openedx/edx-platform/issues/34702