### PR TITLE
feat: fetched notifications based on time not date

### DIFF
--- a/openedx/core/djangoapps/notifications/email/tasks.py
+++ b/openedx/core/djangoapps/notifications/email/tasks.py
@@ -70,10 +70,12 @@ def get_user_preferences_for_courses(course_ids, user):
     return new_preferences
 
 
-def send_digest_email_to_user(user, cadence_type, course_language='en', courses_data=None):
+def send_digest_email_to_user(user, cadence_type, start_date, end_date, course_language='en', courses_data=None):
     """
     Send [cadence_type] email to user.
     Cadence Type can be EmailCadence.DAILY or EmailCadence.WEEKLY
+    start_date: Datetime object
+    end_date: Datetime object
     """
     if cadence_type not in [EmailCadence.DAILY, EmailCadence.WEEKLY]:
         raise ValueError('Invalid cadence_type')
@@ -81,7 +83,6 @@ def send_digest_email_to_user(user, cadence_type, course_language='en', courses_
     if not is_email_notification_flag_enabled(user):
         logger.info(f'<Email Cadence> Flag disabled for {user.username} ==Temp Log==')
         return
-    start_date, end_date = get_start_end_date(cadence_type)
     notifications = Notification.objects.filter(user=user, email=True,
                                                 created__gte=start_date, created__lte=end_date)
     if not notifications:
@@ -115,6 +116,7 @@ def send_digest_email_to_all_users(cadence_type):
     logger.info(f'<Email Cadence> Sending cadence email of type {cadence_type}')
     users = get_audience_for_cadence_email(cadence_type)
     courses_data = {}
+    start_date, end_date = get_start_end_date(cadence_type)
     logger.info(f'<Email Cadence> Email Cadence Audience {len(users)}')
     for user in users:
-        send_digest_email_to_user(user, cadence_type, courses_data=courses_data)
+        send_digest_email_to_user(user, cadence_type, start_date, end_date, courses_data=courses_data)

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -171,13 +171,10 @@ def get_start_end_date(cadence_type):
     """
     if cadence_type not in [EmailCadence.DAILY, EmailCadence.WEEKLY]:
         raise ValueError('Invalid cadence_type')
-    date_today = datetime.datetime.now()
-    yesterday = date_today - datetime.timedelta(days=1)
-    end_date = datetime.datetime.combine(yesterday, datetime.time.max)
-    start_date = end_date
+    end_date = datetime.datetime.now()
+    start_date = end_date - datetime.timedelta(days=1, minutes=15)
     if cadence_type == EmailCadence.WEEKLY:
-        start_date = end_date - datetime.timedelta(days=6)
-    start_date = datetime.datetime.combine(start_date, datetime.time.min)
+        start_date = start_date - datetime.timedelta(days=6)
     return utc.localize(start_date), utc.localize(end_date)
 
 


### PR DESCRIPTION
Notifications will be fetched based on time instead of date. 
For Weekly: Last 7 days
For Daily: Last 24 hours

15 minutes buffer time has been added for both cadence types. 

Ticket: [INF-1495](https://2u-internal.atlassian.net/browse/INF-1495)