### PR TITLE
chore: bump edx-enterprise to 4.23.3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,7 +20,7 @@ celery>=5.2.2,<6.0.0
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==4.22.6
+edx-enterprise==4.23.3
 
 # Stay on LTS version, remove once this is added to common constraint
 Django<5.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -465,7 +465,7 @@ edx-drf-extensions==10.3.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.22.6
+edx-enterprise==4.23.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -740,7 +740,7 @@ edx-drf-extensions==10.3.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.22.6
+edx-enterprise==4.23.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -545,7 +545,7 @@ edx-drf-extensions==10.3.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.22.6
+edx-enterprise==4.23.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -569,7 +569,7 @@ edx-drf-extensions==10.3.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.22.6
+edx-enterprise==4.23.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
[ENT-8661](https://2u-internal.atlassian.net/browse/ENT-8661)
https://github.com/openedx/edx-enterprise/releases/tag/4.23.3

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
