### PR TITLE
refactor: remove unused builtinblock webpack entry points

### DIFF
--- a/webpack.builtinblocks.config.js
+++ b/webpack.builtinblocks.config.js
@@ -1,17 +1,5 @@
 module.exports = {
     entry: {
-        AboutBlockDisplay: [
-            './xmodule/js/src/xmodule.js',
-            './xmodule/js/src/html/display.js',
-            './xmodule/js/src/javascript_loader.js',
-            './xmodule/js/src/collapsible.js',
-            './xmodule/js/src/html/imageModal.js',
-            './xmodule/js/common_static/js/vendor/draggabilly.js'
-        ],
-        AboutBlockEditor: [
-            './xmodule/js/src/xmodule.js',
-            './xmodule/js/src/html/edit.js'
-        ],
         AnnotatableBlockDisplay: [
             './xmodule/js/src/xmodule.js',
             './xmodule/js/src/html/display.js',
@@ -32,18 +20,6 @@ module.exports = {
         ConditionalBlockEditor: [
             './xmodule/js/src/xmodule.js',
             './xmodule/js/src/sequence/edit.js'
-        ],
-        CourseInfoBlockDisplay: [
-            './xmodule/js/src/xmodule.js',
-            './xmodule/js/src/html/display.js',
-            './xmodule/js/src/javascript_loader.js',
-            './xmodule/js/src/collapsible.js',
-            './xmodule/js/src/html/imageModal.js',
-            './xmodule/js/common_static/js/vendor/draggabilly.js'
-        ],
-        CourseInfoBlockEditor: [
-            './xmodule/js/src/xmodule.js',
-            './xmodule/js/src/html/edit.js'
         ],
         CustomTagBlockDisplay: './xmodule/js/src/xmodule.js',
         CustomTagBlockEditor: [
@@ -103,18 +79,6 @@ module.exports = {
         SplitTestBlockEditor: [
             './xmodule/js/src/xmodule.js',
             './xmodule/js/src/sequence/edit.js'
-        ],
-        StaticTabBlockDisplay: [
-            './xmodule/js/src/xmodule.js',
-            './xmodule/js/src/html/display.js',
-            './xmodule/js/src/javascript_loader.js',
-            './xmodule/js/src/collapsible.js',
-            './xmodule/js/src/html/imageModal.js',
-            './xmodule/js/common_static/js/vendor/draggabilly.js'
-        ],
-        StaticTabBlockEditor: [
-            './xmodule/js/src/xmodule.js',
-            './xmodule/js/src/html/edit.js'
         ],
         VideoBlockDisplay: [
             './xmodule/js/src/xmodule.js',


### PR DESCRIPTION
@openedx/axim-aximprovements , this PR just fixes a small mistake I made when working on simplifying built-in XBlocks in the past. I came across it while doing research on the XBlock JS decoupling, and I felt it would be good to fix the mistake so it does not cause confusion going forward.

Would one of you folks be able to review it? 

##  Description

Most blocks built into edx-platform have a pair of webpack entry points, like this:

* {BlockName}Display    # js for student+author+public views
* {BlockName}Editor     # js for studio view

Prior to a past build refactoring [1], these entry points were defined in an auto-genered webpack config file. In order to simplify the js build process, this config generation step was removed and the new file webpack.builtinblocks.config.js was checked directly into edx-platform.

However, during that refactoring, three paris of pointless entry points were introduced:

* AboutBlockDisplay, AboutBlockEditor
* CourseInfoBlockDisplay, CourseInfoBlockEditor
* StaticTabBlockDisplay, StaticTabBlockEditor

They are pointless because those three XBlocks are just subclasses of HtmlBlock, and they use HtmlBlock's JS: HtmlBlockDisplay and HtmlBlockEditor. So, we delete them from webpack.builtinblocks.js, which will have no effect on anything but may help avoid dev confusion in the future.

[1] https://github.com/openedx/edx-platform/issues/32481

## Test instructions

I did not manually test, and I do not believe this needs manual testing.

You can confirm that these entry points are unused by searching for them in edx-platform. I do not see any references outside of webpack.builtinblocks.js.

## Merge considerations

No side effects, and no rush to merge

