### PR TITLE
feat: add has_course_author_access to CourseHomeMetadataView response [BB-9082]

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -73,11 +73,17 @@ def user_has_role(user, role):
     return False
 
 
-def get_user_permissions(user, course_key, org=None):
+def get_user_permissions(user, course_key, org=None, service_variant=None):
     """
     Get the bitmask of permissions that this user has in the given course context.
     Can also set course_key=None and pass in an org to get the user's
     permissions for that organization as a whole.
+
+    :param user: a user
+    :param course_key: a CourseKey or None
+    :param org: an organization name or None
+    :param service_variant: the variant of the service (lms or cms). Permissions may differ between the two,
+        see the HACK comment in the function for more details.
     """
     if org is None:
         org = course_key.org
@@ -103,7 +109,7 @@ def get_user_permissions(user, course_key, org=None):
     #  the LMS and Studio permissions will be separated as a part of this project. Once this is done (and this code is
     #  not removed during its implementation), we can replace the Limited Staff permissions with more granular ones.
     if course_key and user_has_role(user, CourseLimitedStaffRole(course_key)):
-        if settings.SERVICE_VARIANT == 'lms':
+        if (service_variant or settings.SERVICE_VARIANT) == 'lms':
             return STUDIO_EDIT_CONTENT
         else:
             return STUDIO_NO_PERMISSIONS
@@ -119,7 +125,7 @@ def get_user_permissions(user, course_key, org=None):
     return STUDIO_NO_PERMISSIONS
 
 
-def has_studio_write_access(user, course_key):
+def has_studio_write_access(user, course_key, service_variant=None):
     """
     Return True if user has studio write access to the given course.
     Note that the CMS permissions model is with respect to courses.
@@ -131,15 +137,17 @@ def has_studio_write_access(user, course_key):
 
     :param user:
     :param course_key: a CourseKey
+    :param service_variant: the variant of the service (lms or cms). Permissions may differ between the two,
+        see the comment in get_user_permissions for more details.
     """
-    return bool(STUDIO_EDIT_CONTENT & get_user_permissions(user, course_key))
+    return bool(STUDIO_EDIT_CONTENT & get_user_permissions(user, course_key, service_variant=service_variant))
 
 
-def has_course_author_access(user, course_key):
+def has_course_author_access(user, course_key, service_variant=None):
     """
     Old name for has_studio_write_access
     """
-    return has_studio_write_access(user, course_key)
+    return has_studio_write_access(user, course_key, service_variant=service_variant)
 
 
 def has_studio_advanced_settings_access(user):

--- a/lms/djangoapps/course_home_api/course_metadata/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/serializers.py
@@ -59,3 +59,4 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     can_view_certificate = serializers.BooleanField()
     course_modes = CourseModeSerrializer(many=True)
     is_new_discussion_sidebar_view_enabled = serializers.BooleanField()
+    has_course_author_access = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -16,6 +16,7 @@ from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiv
 from openedx.core.djangoapps.courseware_api.utils import get_celebrations_dict
 
 from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.course_goals.models import UserActivity
@@ -140,6 +141,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'can_view_certificate': certificates_viewable_for_course(course),
             'course_modes': course_modes,
             'is_new_discussion_sidebar_view_enabled': new_discussion_sidebar_view_is_enabled(course_key),
+            'has_course_author_access': has_course_author_access(request.user, course_key, 'cms'),
         }
         context = self.get_serializer_context()
         context['course'] = course

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -141,6 +141,11 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'can_view_certificate': certificates_viewable_for_course(course),
             'course_modes': course_modes,
             'is_new_discussion_sidebar_view_enabled': new_discussion_sidebar_view_is_enabled(course_key),
+            # We check the course author access in the context of CMS here because this field is used
+            # to determine whether the user can access the course authoring tools in the CMS.
+            # This is a temporary solution until the course author role is split into "Course Author" and
+            # "Course Editor" as described in the permission matrix here:
+            # https://github.com/openedx/platform-roadmap/issues/246
             'has_course_author_access': has_course_author_access(request.user, course_key, 'cms'),
         }
         context = self.get_serializer_context()


### PR DESCRIPTION
# Description

Adds `has_course_author_access` boolean to `CourseHomeMetadataView`. Currently it's used to control visibility of the "View as Staff" button here: https://github.com/openedx/frontend-app-learning/pull/1436

# Testing

Open any unit in `frontend-app-learning`, open `Network` tab in your browser console, and search for `meta` there. There will be a single request, and its JSON response should contain `has_course_author_access` key. It should be `False` for all users that don't have access to Studio, especially those having the "Limited Staff" course team role.