### PR TITLE
fix: update content reported notification

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1458,6 +1458,8 @@ class CreateSubCommentUnicodeTestCase(
 @disable_signal(views, 'comment_created')
 @disable_signal(views, 'comment_voted')
 @disable_signal(views, 'comment_deleted')
+@disable_signal(views, 'comment_flagged')
+@disable_signal(views, 'thread_flagged')
 class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):
     # Most of the test points use the same ddt data.
     # args: user, commentable_id, status_code

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -314,7 +314,7 @@ class DiscussionNotificationSender:
         content_type = thread_types[self.thread.type][getattr(self.thread, 'depth', 0)]
 
         context = {
-            'username': self.creator.username,
+            'username': self.thread.username,
             'content_type': content_type,
             'content': thread_body
         }

--- a/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
@@ -44,7 +44,7 @@ class TestDiscussionNotificationSender(unittest.TestCase):
 
         self.assertEqual(notification_type, "content_reported")
         self.assertEqual(context, {
-            'username': 'test_user',
+            'username': self.thread.username,
             'content_type': expected_content_type,
             'content': 'Thread body'
         })


### PR DESCRIPTION
Ticket: [INF-1513](https://2u-internal.atlassian.net/browse/INF-1513)

Previously, the reported content notification was as follows: 
{reporter}’s content has been reported …

Updated it to make it as follows: 
{author}’s content has been reported …
