### PR TITLE
fix: hide new library button for ineligible users in split studio view

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/home.py
@@ -75,7 +75,7 @@ class HomePageView(APIView):
         ```
         """
 
-        home_context = get_home_context(request, no_course=True, hide_library_button_for_mfe=False)
+        home_context = get_home_context(request, True)
         home_context.update({
             'allow_to_create_new_org': settings.FEATURES.get('ENABLE_CREATOR_GROUP', True) and request.user.is_staff,
             'studio_name': settings.STUDIO_NAME,

--- a/cms/djangoapps/contentstore/rest_api/v1/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/home.py
@@ -75,7 +75,7 @@ class HomePageView(APIView):
         ```
         """
 
-        home_context = get_home_context(request, True)
+        home_context = get_home_context(request, no_course=True, hide_library_button_for_mfe=False)
         home_context.update({
             'allow_to_create_new_org': settings.FEATURES.get('ENABLE_CREATOR_GROUP', True) and request.user.is_staff,
             'studio_name': settings.STUDIO_NAME,

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1534,6 +1534,7 @@ def get_library_context(request, request_is_json=False):
     )
     from cms.djangoapps.contentstore.views.library import (
         LIBRARIES_ENABLED,
+        user_can_view_create_library_button,
     )
 
     libraries = _accessible_libraries_iter(request.user) if LIBRARIES_ENABLED else []
@@ -1547,7 +1548,7 @@ def get_library_context(request, request_is_json=False):
             'in_process_course_actions': [],
             'courses': [],
             'libraries_enabled': LIBRARIES_ENABLED,
-            'show_new_library_button': LIBRARIES_ENABLED and request.user.is_active,
+            'show_new_library_button': user_can_view_create_library_button(request.user) and request.user.is_active,
             'user': request.user,
             'request_course_creator_url': reverse('request_course_creator'),
             'course_creator_status': _get_course_creator_status(request.user),

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1651,7 +1651,7 @@ def get_course_context_v2(request):
     return courses_iter, in_process_course_actions
 
 
-def get_home_context(request, no_course=False):
+def get_home_context(request, no_course=False, hide_library_button_for_mfe=True):
     """
     Utils is used to get context of course home.
     It is used for both DRF and django views.
@@ -1688,6 +1688,11 @@ def get_home_context(request, no_course=False):
     if not split_library_view_on_dashboard() and LIBRARIES_ENABLED and not no_course:
         libraries = get_library_context(request, True)['libraries']
 
+    show_new_library_button = user_can_view_create_library_button(user)
+
+    if hide_library_button_for_mfe:
+        show_new_library_button = show_new_library_button and not should_redirect_to_library_authoring_mfe()
+
     home_context = {
         'courses': active_courses,
         'split_studio_home': split_library_view_on_dashboard(),
@@ -1699,8 +1704,7 @@ def get_home_context(request, no_course=False):
         'library_authoring_mfe_url': LIBRARY_AUTHORING_MICROFRONTEND_URL,
         'taxonomy_list_mfe_url': get_taxonomy_list_url(),
         'libraries': libraries,
-        'show_new_library_button': user_can_view_create_library_button(user)
-        and not should_redirect_to_library_authoring_mfe(),
+        'show_new_library_button': show_new_library_button,
         'user': user,
         'request_course_creator_url': reverse('request_course_creator'),
         'course_creator_status': _get_course_creator_status(user),

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1652,7 +1652,7 @@ def get_course_context_v2(request):
     return courses_iter, in_process_course_actions
 
 
-def get_home_context(request, no_course=False, hide_library_button_for_mfe=True):
+def get_home_context(request, no_course=False):
     """
     Utils is used to get context of course home.
     It is used for both DRF and django views.
@@ -1689,11 +1689,6 @@ def get_home_context(request, no_course=False, hide_library_button_for_mfe=True)
     if not split_library_view_on_dashboard() and LIBRARIES_ENABLED and not no_course:
         libraries = get_library_context(request, True)['libraries']
 
-    show_new_library_button = user_can_view_create_library_button(user)
-
-    if hide_library_button_for_mfe:
-        show_new_library_button = show_new_library_button and not should_redirect_to_library_authoring_mfe()
-
     home_context = {
         'courses': active_courses,
         'split_studio_home': split_library_view_on_dashboard(),
@@ -1705,7 +1700,8 @@ def get_home_context(request, no_course=False, hide_library_button_for_mfe=True)
         'library_authoring_mfe_url': LIBRARY_AUTHORING_MICROFRONTEND_URL,
         'taxonomy_list_mfe_url': get_taxonomy_list_url(),
         'libraries': libraries,
-        'show_new_library_button': show_new_library_button,
+        'show_new_library_button': user_can_view_create_library_button(user)
+        and not should_redirect_to_library_authoring_mfe(),
         'user': user,
         'request_course_creator_url': reverse('request_course_creator'),
         'course_creator_status': _get_course_creator_status(user),


### PR DESCRIPTION
## Description

The [user_can_view_create_library_button()](https://github.com/openedx/edx-platform/blob/3d7cc1c616bd2e6f1112922578e108b34063fd52/cms/djangoapps/contentstore/views/library.py#L72-L93) function is used to check if the a studio user should be shown the `New Library` button in Studio.

Currently this works fine in the legacy studio UI, but in the split studio view, users who don't have access to create a library are still shown the `New Library` button. This creates a confusing user experience since, if such an user tries to create a library, they get an error down the UI flow.

This PR fixes this issue.

As such, this PR does the following:
1. The `New Library` button is now only shown to eligible users in the split studio view, instead of all active users.
2. Common code between [user_can_view_create_library_button()](https://github.com/openedx/edx-platform/blob/3d7cc1c616bd2e6f1112922578e108b34063fd52/cms/djangoapps/contentstore/views/library.py#L72) and [user_can_create_library()](https://github.com/openedx/edx-platform/blob/3d7cc1c616bd2e6f1112922578e108b34063fd52/cms/djangoapps/contentstore/views/library.py#L96C5-L96C28) functions are refactored out to a new fuction.

## Supporting information

This PR is a companion to openedx/frontend-app-course-authoring#1216

## Testing instructions

1. Setup this PR branch in a local or sandbox environment.
2. Login to studio through a user account without any staff access
3. Access the split studio view ( <Studio_URL>/home_library )
4. Ensure `New Library` button is missing there.

## Other information

Private Ref: [BB-9077](https://tasks.opencraft.com/browse/BB-9077)
