### PR TITLE
feat: index library collections in meilisearch [FC-0062]

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -449,7 +449,6 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
                 except (TypeError, KeyError, MeilisearchError) as err:
                     status_cb(f"Error indexing collection batch {p}: {err}")
 
-
     status_cb(f"Done! {num_blocks_done} blocks indexed across {num_contexts_done} courses, collections and libraries.")
 
 

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -423,13 +423,14 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
 
         ############## Collections ##############
         status_cb("Indexing collections...")
-        # To reduce memory usage on large instances, split up the Collections into pages of 1,00 collections:
+        # To reduce memory usage on large instances, split up the Collections into pages of 100 collections:
         paginator = Paginator(authoring_api.get_collections(), 100)
         for p in paginator.page_range:
             docs = []
             for collection in paginator.page(p).object_list:
                 status_cb(
-                    f"{num_contexts_done + 1}/{num_contexts}. Now indexing collection {collection.name} ({collection.id})"
+                    f"{num_contexts_done + 1}/{num_contexts}. "
+                    f"Now indexing collection {collection.name} ({collection.id})"
                 )
                 try:
                     doc = searchable_doc_for_collection(collection)
@@ -444,10 +445,9 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
                     # Add docs in batch of 100 at once (usually faster than adding one at a time):
                     _wait_for_meili_task(client.index(temp_index_name).add_documents(docs))
                 except (TypeError, KeyError, MeilisearchError) as err:
-                    status_cb(f"Error indexing collection {collection}: {err}")
+                    status_cb(f"Error indexing collection batch {p}: {err}")
 
                 num_contexts_done += len(docs)
-
 
     status_cb(f"Done! {num_blocks_done} blocks indexed across {num_contexts_done} courses, collections and libraries.")
 

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -424,13 +424,13 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
         ############## Collections ##############
         status_cb("Indexing collections...")
         # To reduce memory usage on large instances, split up the Collections into pages of 100 collections:
-        paginator = Paginator(authoring_api.get_collections(), 100)
+        paginator = Paginator(authoring_api.get_collections(enabled=True), 100)
         for p in paginator.page_range:
             docs = []
             for collection in paginator.page(p).object_list:
                 status_cb(
                     f"{num_contexts_done + 1}/{num_contexts}. "
-                    f"Now indexing collection {collection.name} ({collection.id})"
+                    f"Now indexing collection {collection.title} ({collection.id})"
                 )
                 try:
                     doc = searchable_doc_for_collection(collection)

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -435,10 +435,12 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
                 try:
                     doc = searchable_doc_for_collection(collection)
                     # Uncomment below line once collections are tagged.
-                    # doc.update(searchable_doc_tags(metadata.usage_key))
+                    # doc.update(searchable_doc_tags(collection.id))
                     docs.append(doc)
                 except Exception as err:  # pylint: disable=broad-except
                     status_cb(f"Error indexing collection {collection}: {err}")
+                finally:
+                    num_contexts_done += 1
 
             if docs:
                 try:
@@ -447,7 +449,6 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
                 except (TypeError, KeyError, MeilisearchError) as err:
                     status_cb(f"Error indexing collection batch {p}: {err}")
 
-                num_contexts_done += len(docs)
 
     status_cb(f"Done! {num_blocks_done} blocks indexed across {num_contexts_done} courses, collections and libraries.")
 

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -288,10 +288,14 @@ def searchable_doc_for_collection(collection) -> dict:
     doc = {
         Fields.id: collection.id,
         Fields.type: DocType.collection,
-        Fields.display_name: collection.name,
+        Fields.display_name: collection.title,
         Fields.description: collection.description,
         Fields.created: collection.created.timestamp(),
         Fields.modified: collection.modified.timestamp(),
+        # Add related learning_package.key as context_key by default.
+        # If related contentlibrary is found, it will override this value below.
+        # Mostly contentlibrary.library_key == learning_package.key
+        Fields.context_key: collection.learning_package.key,
     }
     # Just in case learning_package is not related to a library
     if hasattr(collection.learning_package, 'contentlibrary'):
@@ -300,8 +304,8 @@ def searchable_doc_for_collection(collection) -> dict:
         doc.update({
             Fields.context_key: str(context_key),
             Fields.org: org,
-            Fields.access_id: _meili_access_id_from_context_key(context_key),
         })
+    doc[Fields.access_id] = _meili_access_id_from_context_key(doc[Fields.context_key])
     # Add the breadcrumbs.
     doc[Fields.breadcrumbs] = [{"display_name": collection.learning_package.title}]
 

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -65,6 +65,7 @@ class DocType:
     """
     course_block = "course_block"
     library_block = "library_block"
+    collection = "collection"
 
 
 def meili_id_from_opaque_key(usage_key: UsageKey) -> str:
@@ -273,5 +274,27 @@ def searchable_doc_for_course_block(block) -> dict:
     }
 
     doc.update(_fields_from_block(block))
+
+    return doc
+
+
+def searchable_doc_for_collection(collection) -> dict:
+    """
+    Generate a dictionary document suitable for ingestion into a search engine
+    like Meilisearch or Elasticsearch, so that the given collection can be
+    found using faceted search.
+    """
+    # TODO: Add collection key once new collectionKey type is added to opaque_keys
+    doc = {
+        Fields.id: collection.id,
+        Fields.type: DocType.collection,
+        Fields.display_name: collection.name,
+        Fields.created: collection.created.timestamp(),
+        Fields.modified: collection.modified.timestamp(),
+        # Using learning_package.key as context key.
+        Fields.context_key: str(collection.learning_package.key),
+        # TODO: Get org value from collection_key.context_key.org
+        # Fields.org: str(collection.collection_key.context_key.org),
+    }
 
     return doc

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -307,7 +307,7 @@ def searchable_doc_for_collection(collection) -> dict:
             Fields.org: org,
         })
     except LearningPackage.contentlibrary.RelatedObjectDoesNotExist:
-        log.warning(f"Related library not found for collection: {collection.title} <{collection.id}>")
+        log.warning(f"Related library not found for {collection}")
     doc[Fields.access_id] = _meili_access_id_from_context_key(doc[Fields.context_key])
     # Add the breadcrumbs.
     doc[Fields.breadcrumbs] = [{"display_name": collection.learning_package.title}]

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -192,7 +192,8 @@ class TestSearchApi(ModuleStoreTestCase):
         with freeze_time(created_date):
             self.collection = authoring_api.create_collection(
                 learning_package_id=self.learning_package.id,
-                name="my_collection",
+                title="my_collection",
+                created_by=None,
                 description="my collection description"
             )
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -93,7 +93,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.11.1
+openedx-learning==0.11.2
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -823,7 +823,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -823,7 +823,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
+openedx-learning==0.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1372,7 +1372,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
+openedx-learning==0.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1372,7 +1372,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -982,7 +982,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
+openedx-learning==0.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -982,7 +982,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -119,8 +119,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
-# FIXME Remove this line after release of openedx-learning
-openedx-learning  @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api                   # Open edX Learning core (experimental)
+openedx-learning                    # Open edX Learning core (experimental)
 openedx-mongodbproxy
 openedx-django-wiki
 path

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -119,7 +119,8 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
-openedx-learning                    # Open edX Learning core (experimental)
+# FIXME Remove this line after release of openedx-learning
+openedx-learning  @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api                   # Open edX Learning core (experimental)
 openedx-mongodbproxy
 openedx-django-wiki
 path

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1033,7 +1033,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1033,7 +1033,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning@navin/update-collections-api
+openedx-learning==0.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Updates `rebuild_index` function to include collections for indexing in meilisearch.

## Supporting information

* `Private-ref`: [FAL-3786](https://tasks.opencraft.com/browse/FAL-3786)
* https://github.com/openedx/openedx-learning/pull/214
* https://github.com/openedx/modular-learning/issues/229

## Testing instructions

* Setup tutor with this PR and https://github.com/open-craft/tutor-contrib-meilisearch plugin
* Make sure to create few libraries
* Run below snippet to add some collections
```python
import random
from openedx_learning.api import authoring as authoring_api
from openedx_learning.api import authoring_models
learning_packages = authoring_models.LearningPackage.objects.all()
for i in range(20):
    learning_id = random.choice(learning_packages)
    authoring_api.create_collection(learning_id, f"collection_{i}", None, f'description_{i}')
```
* Run `tutor dev run cms ./manage.py cms reindex_studio --experimental`.
* Open http://meilisearch.local.edly.io:7700/ 
* Search for `collection` and verify the contents of collection documents.

## Deadline

None