### PR TITLE
feat: update XBlock to 5.1.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -136,7 +136,3 @@ django-storages<1.14.4
 # We are pinning this until after all the smaller migrations get handled and then we can migrate this all at once.
 # Ticket to unpin: https://github.com/edx/edx-arch-experiments/issues/760
 social-auth-app-django<=5.4.1
-
-# Xblock==5.0.0 changed how entrypoints were loaded, breaking a workaround for overriding blocks.
-# See ticket: https://github.com/openedx/XBlock/issues/777
-xblock[django]==4.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1256,7 +1256,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/paver.txt
-xblock[django]==4.0.1
+xblock[django]==5.1.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1258,7 +1258,6 @@ wrapt==1.16.0
     # via -r requirements/edx/paver.txt
 xblock[django]==5.1.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   acid-xblock
     #   crowdsourcehinter-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2232,7 +2232,6 @@ wrapt==1.16.0
     #   astroid
 xblock[django]==5.1.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   acid-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2230,7 +2230,7 @@ wrapt==1.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-xblock[django]==4.0.1
+xblock[django]==5.1.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1547,7 +1547,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/base.txt
-xblock[django]==4.0.1
+xblock[django]==5.1.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1549,7 +1549,6 @@ wrapt==1.16.0
     # via -r requirements/edx/base.txt
 xblock[django]==5.1.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   crowdsourcehinter-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1646,7 +1646,6 @@ wrapt==1.16.0
     #   astroid
 xblock[django]==5.1.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   crowdsourcehinter-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1644,7 +1644,7 @@ wrapt==1.16.0
     # via
     #   -r requirements/edx/base.txt
     #   astroid
-xblock[django]==4.0.1
+xblock[django]==5.1.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Unpins XBlock version to 5.1.0 which adds native ability to override an XBlock implementation.

## Supporting information

This is a fix-forward for #35244 which caused a 2U-specific plugin to break that had relied on the now-deprecated `pkg_resources` library which allowed a hacky way to override an XBlock through runtime `entry_points` tweaking.

## Testing instructions

Loading a course should now work, even with our 2U-specific plugin installed.

## Deadline

⚠️ Should not be deployed until:
- [x] Existing 2U plugin is updated for `pkg_resources` deprecation
