### PR TITLE
Test  scorm xblock csp middleware

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1011,6 +1011,7 @@ these custom CSPs are set in the return value of a callback function passed via 
 """
 X_FRAME_OPTIONS = 'DENY'
 
+
 def _get_custom_csps():
     # pylint: disable=import-error
     from django.conf import settings

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1022,6 +1022,8 @@ def _get_custom_csps():
 
 GET_CUSTOM_CSPS = _get_custom_csps
 
+# GET_CUSTOM_CSPS = _get_custom_csps
+
 # Platform for Privacy Preferences header
 P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -92,13 +92,26 @@ LMS_ENROLLMENT_API_PATH = "/api/enrollment/v1/"
 # IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
 IDA_LOGOUT_URI_LIST = []
 
+################# Clickjacking protection ###################
+"""
+X-FRAME-OPTIONS headers are set by default to `DENY`.
+This means that the page cannot be displayed in a frame, regardless
+of the site attempting to do so. This is a security measure to prevent clickjacking attacks.
+
+In some cases, like for the SCORM xblock, we need to allow SAMEORIGIN as well
+as Microfrontend MFE URLs to render the content. For this, a Content-Security-Policy (CSP) is needed.
+To implement this only for endpoints where it is needed, we have a custom
+middleware that allows us to set a specific CSP for URLs matching a regex.
+This will override the default CSP which you can set via the `CSP_STATIC_ENFORCE` setting.
+
+Since this needs access to the MFE URLs set via config, which are not available when this file is executed,
+these custom CSPs are set in the return value of a callback function passed via the `GET_CUSTOM_CSPS` setting.
+"""
+
 # Clickjacking protection can be disabled by setting this to 'ALLOW' or adjusted by setting this to 'SAMEORIGIN'.
 # It is not advised to set this to 'ALLOW' without a Content Security Policy header.
 X_FRAME_OPTIONS = 'DENY'
 
-# You can override this header for certain URLs using regexes. However, do not set it to 'ALLOW' without having a
-# Content Security Policy in place.
-# SCORM xblocks require a more permissive cross-domain header to render than the default of 'DENY'
 def _get_custom_csps():
     from django.conf import settings
     learning_url = getattr(settings, 'LEARNING_MICROFRONTEND_URL', None)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -112,6 +112,7 @@ these custom CSPs are set in the return value of a callback function passed via 
 # It is not advised to set this to 'ALLOW' without a Content Security Policy header.
 X_FRAME_OPTIONS = 'DENY'
 
+
 def _get_custom_csps():
     from django.conf import settings
     learning_url = getattr(settings, 'LEARNING_MICROFRONTEND_URL', None)

--- a/openedx/core/lib/content_security_policy/README.rst
+++ b/openedx/core/lib/content_security_policy/README.rst
@@ -1,9 +1,39 @@
 Content-Security-Policy Middleware
-**************************
+**********************************
 
 .. The preferred way to prevent clickjacking is to use the Content Security Policy headers.
 .. This middleware adds the Content-Security-Policy headers to the response.
-.. It allows overriding the default Content-Security-Policy header for specific urls by
-.. setting the CUSTOM_CSPS environment variable.
+.. It allows overriding the default Content-Security-Policy header for specific urls.
 
-- Add the middleware ``'openedx.core.lib.content_security_policy.middleware.content_security_policy_middleware',`` near the beginning of your ``MIDDLEWARE`` list.
+- Add the middleware ``'openedx.core.lib.content_security_policy.middleware.content_security_policy_middleware',``
+  near the beginning of your ``MIDDLEWARE`` list.
+- To add a Content-Security-Policy header for all endpoints, set the ``CSP_STATIC_ENFORCE`` setting to
+  the desired value for the header; this excludes only the reporting options.
+- If desired, the ``CSP_STATIC_REPORT_ONLY``, ``CSP_STATIC_REPORTING_URI``, and ``CSP_STATIC_REPORTING_NAME``
+  settings can be added to enable reporting of violations.
+- If you want different CSP headers for specific URLs, define a function
+  like in the example ``_get_custom_csps`` below and then assign this function
+  to the ``GET_CUSTOM_CSPS`` setting.
+- This defines a callback function that will be executed by the middleware.
+  The function should return a list of value pairs like ``[['.*/example-regex', 'example-csp-header-string']]``,
+  where each pair contains a regex pattern
+  and a CSP header value to be applied to URLs that match the pattern.
+- If no ``CSP_STATIC_ENFORCE`` setting is defined, the middleware will only add the header for the URLs matching
+  the patterns specified in the ``GET_CUSTOM_CSPS`` function return.
+- If the ``CSP_STATIC_ENFORCE`` setting is defined as well, the custom CSP headers will take precedence
+  for the specified URLs.
+- The reason a callback function is used is that django configuration settings like ``LEARNING_MICROFRONTEND_URL``
+  are not available at the time the settings are loaded, so the function is called at runtime.
+
+Example for ``_get_custom_csps`` callback function:
+---------------------------------------------------
+
+```
+def _get_custom_csps():
+  from django.conf import settings
+  learning_url = getattr(settings, 'LEARNING_MICROFRONTEND_URL', None)
+  return [
+      ['.*/media/scorm/.*', f"frame-ancestors 'self' {learning_url}"],
+      ['.*/xblock/.*', f"frame-ancestors 'self' {learning_url}"]
+  ]
+```

--- a/openedx/core/lib/content_security_policy/middleware.py
+++ b/openedx/core/lib/content_security_policy/middleware.py
@@ -6,6 +6,7 @@ import re
 
 from django.conf import settings
 
+
 def _load_headers(override=None) -> dict:
     """
     Return a dict of headers to append to every response, based on settings.

--- a/openedx/core/lib/content_security_policy/middleware.py
+++ b/openedx/core/lib/content_security_policy/middleware.py
@@ -129,6 +129,7 @@ def content_security_policy_middleware(get_response):
     csp_headers = _load_headers()
     get_csp_override = getattr(settings, 'GET_CUSTOM_CSPS', None)
     url_specific_csps = get_csp_override() if get_csp_override else None
+    # import pdb; pdb.set_trace()
     if not csp_headers and not url_specific_csps:
         raise MiddlewareNotUsed()  # tell Django to skip this middleware
 

--- a/openedx/core/lib/content_security_policy/tests/test_content_security_policy_middleware.py
+++ b/openedx/core/lib/content_security_policy/tests/test_content_security_policy_middleware.py
@@ -1,0 +1,158 @@
+"""
+Tests for Content-Security-Policy middleware.
+"""
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+import ddt
+import pytest
+from django.core.exceptions import MiddlewareNotUsed
+from django.test import override_settings
+
+import edx_django_utils.security.csp.middleware as csp
+
+
+@ddt.ddt
+class TestLoadHeaders(TestCase):
+    """Test loading of headers from settings."""
+
+    @ddt.unpack
+    @ddt.data(
+        # Empty settings
+        [{}, {}],
+        # The reporting URL and endpoint names alone don't do anything
+        [{"CSP_STATIC_REPORTING_URI": "http://localhost"}, {}],
+        [{"CSP_STATIC_REPORTING_NAME": "default"}, {}],
+        [
+            {
+                "CSP_STATIC_REPORTING_URI": "http://localhost",
+                "CSP_STATIC_REPORTING_NAME": "default"
+            },
+            {},
+        ],
+        # Just the enforcement header
+        [
+            {"CSP_STATIC_ENFORCE": "default-src https:"},
+            {'Content-Security-Policy': "default-src https:"},
+        ],
+        # Just the reporting header
+        [
+            {"CSP_STATIC_REPORT_ONLY": "default-src 'none'"},
+            {'Content-Security-Policy-Report-Only': "default-src 'none'"},
+        ],
+        # Reporting URL is automatically appended to headers
+        [
+            {
+                "CSP_STATIC_ENFORCE": "default-src https:",
+                "CSP_STATIC_REPORT_ONLY": "default-src 'none'",
+                "CSP_STATIC_REPORTING_URI": "http://localhost",
+            },
+            {
+                'Content-Security-Policy': "default-src https:; report-uri http://localhost",
+                'Content-Security-Policy-Report-Only': "default-src 'none'; report-uri http://localhost",
+            },
+        ],
+        # ...and when an endpoint name is supplied,
+        # Reporting-Endpoints is added and a report-to directive is
+        # included.
+        [
+            {
+                "CSP_STATIC_ENFORCE": "default-src https:",
+                "CSP_STATIC_REPORT_ONLY": "default-src 'none'",
+                "CSP_STATIC_REPORTING_URI": "http://localhost",
+                "CSP_STATIC_REPORTING_NAME": "default",
+            },
+            {
+                'Reporting-Endpoints': 'default="http://localhost"',
+                'Content-Security-Policy': "default-src https:; report-uri http://localhost; report-to default",
+                'Content-Security-Policy-Report-Only': (
+                    "default-src 'none'; report-uri http://localhost; report-to default"
+                ),
+            },
+        ],
+        # Adding a reporting endpoint name without a URL doesn't change anything.
+        [
+            {
+                "CSP_STATIC_REPORT_ONLY": "default-src 'none'",
+                "CSP_STATIC_REPORTING_NAME": "default",
+            },
+            {'Content-Security-Policy-Report-Only': "default-src 'none'"},
+        ],
+        # Any newlines and trailing semicolon are stripped.
+        [
+            {
+                "CSP_STATIC_REPORT_ONLY": "default-src 'self';   \n \t  frame-src 'none';  \n ",
+                "CSP_STATIC_REPORTING_URI": "http://localhost",
+            },
+            {
+                'Content-Security-Policy-Report-Only': (
+                    "default-src 'self'; frame-src 'none'; "
+                    "report-uri http://localhost"
+                ),
+            },
+        ],
+    )
+    def test_load_headers(self, settings, headers):
+        with override_settings(**settings):
+            assert csp._load_headers() == headers  # pylint: disable=protected-access
+
+
+@ddt.ddt
+class TestHeaderManipulation(TestCase):
+    """Test _append_headers"""
+
+    @ddt.unpack
+    @ddt.data(
+        [{}, {}, {}],
+        [
+            {'existing': 'aaa', 'multi': '111'},
+            {'multi': '222', 'new': 'xxx'},
+            {'existing': 'aaa', 'multi': '111, 222', 'new': 'xxx'},
+        ],
+    )
+    def test_append_headers(self, response_headers, more_headers, expected):
+        csp._append_headers(response_headers, more_headers)  # pylint: disable=protected-access
+        assert response_headers == expected
+
+
+@ddt.ddt
+class TestCSPMiddleware(TestCase):
+    """Test the actual middleware."""
+
+    def setUp(self):
+        super().setUp()
+        self.fake_response = Mock()
+        self.fake_response.headers = {'Existing': 'something'}
+
+    def test_make_middleware_unused(self):
+        with pytest.raises(MiddlewareNotUsed):
+            csp.content_security_policy_middleware(lambda _: self.fake_response)
+
+    @override_settings(CSP_STATIC_ENFORCE="default-src: https:")
+    def test_make_middleware_configured(self):
+        handler = csp.content_security_policy_middleware(lambda _: self.fake_response)
+
+        assert handler(Mock()) is self.fake_response
+
+        # Headers have been mutated in place (if flag enabled)
+        assert self.fake_response.headers == {
+            'Existing': 'something',
+            'Content-Security-Policy': 'default-src: https:',
+        }
+
+########### New Test Cases #############
+
+'''
+- If GET_CUSTOM_CSPS and CSP_STATIC_ENFORCE are not set, the middleware should raise MiddlewareNotUsed.
+- If GET_CUSTOM_CSPS is set, but returns None, the middleware should raise MiddlewareNotUsed.
+- If GET_CUSTOM_CSPS is set, but returns an empty list, the middleware should raise MiddlewareNotUsed.
+- If GET_CUSTOM_CSPS or CSP_STATIC_ENFORCE are set, the middleware should not raise MiddlewareNotUsed.
+- If GET_CUSTOM_CSPS and CSP_STATIC_ENFORCE are set, GET_CUSTOM_CSPS should take precedence.
+- Test that when GET_CUSTOM_CSPS is set and the current path matches one of the
+regexes in the list, the value of the custom CSP is used.
+- Test that when GET_CUSTOM_CSPS and CSP_STATIC_ENFORCE are set and the current path does not match any of the
+regexes in the list, the value of the default CSP is used.
+- Test that when GET_CUSTOM_CSPS is set and the current path does not match any of the
+regexes in the list, the middleware does not append any headers.
+'''

--- a/openedx/core/lib/content_security_policy/tests/test_content_security_policy_middleware.py
+++ b/openedx/core/lib/content_security_policy/tests/test_content_security_policy_middleware.py
@@ -13,6 +13,7 @@ import openedx.core.lib.content_security_policy.middleware as csp
 
 MiddlewareNotUsed = csp.MiddlewareNotUsed
 
+
 @ddt.ddt
 class TestLoadHeaders(TestCase):
     """Test loading of headers from settings."""


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
