### PR TITLE
API functions for the new generic VerificationAttempt model in the verify_student app

### DIFF
--- a/lms/djangoapps/verify_student/api.py
+++ b/lms/djangoapps/verify_student/api.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.utils.translation import gettext as _
 
 from lms.djangoapps.verify_student.emails import send_verification_approved_email
+from lms.djangoapps.verify_student.models import VerificationAttempt
 from lms.djangoapps.verify_student.tasks import send_verification_status_email
 
 
@@ -33,3 +34,42 @@ def send_approval_email(attempt):
     else:
         email_context = {'user': attempt.user, 'expiration_datetime': expiration_datetime.strftime("%m/%d/%Y")}
         send_verification_approved_email(context=email_context)
+
+
+def create_verification_attempt(user, name, status, expiration_datetime=None):
+    """
+    Create a verification attempt.
+
+    Args:
+        user (User): the user (usually a learner) performing the verfication attempt
+        name (string): the name of the user
+        status (string): the initial status of the verification attempt
+        expiration_datetime (datetime, optional): When the verification attempt expires. Defaults to None.
+
+    Returns:
+        VerificationAttempt (VerificationAttempt): The created VerificationAttempt instance
+    """
+    verification_attempt = VerificationAttempt.objects.create(
+        user=user,
+        name=name,
+        status=status,
+        expiration_datetime=expiration_datetime,
+    )
+
+    return verification_attempt.id
+
+
+def update_verification_status(attempt_id, status):
+    """
+    Update the VerificationAttempt status.
+
+    Arguments:
+        * id (str): the verification attempt id
+        * status (str): the new status
+
+    Returns:
+        * None
+    """
+    attempt = VerificationAttempt.objects.get(id=attempt_id)
+    attempt.status = status
+    attempt.save()

--- a/lms/djangoapps/verify_student/api.py
+++ b/lms/djangoapps/verify_student/api.py
@@ -74,8 +74,10 @@ def update_verification_attempt(attempt_id, name=None, status=None, expiration_d
     This method is intended to be used by IDV implementation plugins to update VerificationAttempt instances.
 
     Arguments:
-        * id (str): the verification attempt id of the attempt to update
-        * status (str): the new status
+        * attempt_id (int): the verification attempt id of the attempt to update
+        * name (string, optional): the new name being ID verified
+        * status (string, optional): the new status of the verification attempt
+        * expiration_datetime (datetime, optional): The new expiration date and time
 
     Returns:
         * None

--- a/lms/djangoapps/verify_student/api.py
+++ b/lms/djangoapps/verify_student/api.py
@@ -64,7 +64,6 @@ def create_verification_attempt(user, name, status, expiration_datetime=None):
         expiration_datetime=expiration_datetime,
     )
 
-
     return verification_attempt.id
 
 

--- a/lms/djangoapps/verify_student/exceptions.py
+++ b/lms/djangoapps/verify_student/exceptions.py
@@ -5,3 +5,6 @@ Exceptions for the verify student app
 
 class WindowExpiredException(Exception):
     pass
+
+class VerificationAttemptInvalidStatus(Exception):
+    pass

--- a/lms/djangoapps/verify_student/exceptions.py
+++ b/lms/djangoapps/verify_student/exceptions.py
@@ -6,5 +6,6 @@ Exceptions for the verify student app
 class WindowExpiredException(Exception):
     pass
 
+
 class VerificationAttemptInvalidStatus(Exception):
     pass

--- a/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
@@ -8,7 +8,7 @@ import os
 import time
 from pprint import pformat
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user, unused-import
 from django.core.management.base import BaseCommand, CommandError
 
 from lms.djangoapps.verify_student.api import send_approval_email

--- a/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
@@ -8,7 +8,6 @@ import os
 import time
 from pprint import pformat
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user, unused-import
 from django.core.management.base import BaseCommand, CommandError
 
 from lms.djangoapps.verify_student.api import send_approval_email

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1203,10 +1203,10 @@ class VerificationAttempt(TimeStampedModel):
     name = models.CharField(blank=True, max_length=255)
 
     STATUS_CHOICES = [
-        VerificationAttemptStatus.created,
-        VerificationAttemptStatus.pending,
-        VerificationAttemptStatus.approved,
-        VerificationAttemptStatus.denied,
+        VerificationAttemptStatus.CREATED,
+        VerificationAttemptStatus.PENDING,
+        VerificationAttemptStatus.APPROVED,
+        VerificationAttemptStatus.DENIED,
     ]
     status = models.CharField(max_length=64, choices=[(status, status) for status in STATUS_CHOICES])
 

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1213,4 +1213,5 @@ class VerificationAttempt(TimeStampedModel):
     expiration_datetime = models.DateTimeField(
         null=True,
         blank=True,
+        db_index=True,
     )

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1213,5 +1213,4 @@ class VerificationAttempt(TimeStampedModel):
     expiration_datetime = models.DateTimeField(
         null=True,
         blank=True,
-        db_index=True,
     )

--- a/lms/djangoapps/verify_student/statuses.py
+++ b/lms/djangoapps/verify_student/statuses.py
@@ -1,21 +1,22 @@
 """
 Status enums for verify_student.
 """
+from enum import StrEnum, auto
 
 
-class VerificationAttemptStatus:
+class VerificationAttemptStatus(StrEnum):
     """This class describes valid statuses for a verification attempt to be in."""
 
     # This is the initial state of a verification attempt, before a learner has started IDV.
-    created = "created"
+    CREATED = auto()
 
     # A verification attempt is pending when it has been started but has not yet been completed.
-    pending = "pending"
+    PENDING = auto()
 
     # A verification attempt is approved when it has been approved by some mechanism (e.g. automatic review, manual
     # review, etc).
-    approved = "approved"
+    APPROVED = auto()
 
     # A verification attempt is denied when it has been denied by some mechanism (e.g. automatic review, manual review,
     # etc).
-    denied = "denied"
+    DENIED = auto()

--- a/lms/djangoapps/verify_student/tests/test_api.py
+++ b/lms/djangoapps/verify_student/tests/test_api.py
@@ -31,8 +31,8 @@ class TestSendApprovalEmail(TestCase):
 
         self.user = UserFactory.create()
         self.attempt = SoftwareSecurePhotoVerification(
-            status="submitted",
-            user=self.user
+            status = "submitted",
+            user = self.user
         )
         self.attempt.save()
 
@@ -62,10 +62,10 @@ class CreateVerificationAttempt(TestCase):
 
         self.user = UserFactory.create()
         self.attempt = VerificationAttempt(
-            user=self.user,
-            name='Tester McTest',
-            status=VerificationAttemptStatus.created,
-            expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
+            user = self.user,
+            name = 'Tester McTest',
+            status = VerificationAttemptStatus.created,
+            expiration_datetime = datetime(2024, 12, 31, tzinfo = timezone.utc)
         )
         self.attempt.save()
 
@@ -73,31 +73,31 @@ class CreateVerificationAttempt(TestCase):
         expected_id = 2
         self.assertEqual(
             create_verification_attempt(
-                user=self.user,
-                name='Tester McTest',
-                status=VerificationAttemptStatus.created,
-                expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
+                user = self.user,
+                name = 'Tester McTest',
+                status = VerificationAttemptStatus.created,
+                expiration_datetime = datetime(2024, 12, 31, tzinfo = timezone.utc)
             ),
             expected_id
         )
-        verification_attempt = VerificationAttempt.objects.get(id=expected_id)
+        verification_attempt = VerificationAttempt.objects.get(id = expected_id)
 
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
         self.assertEqual(verification_attempt.status, VerificationAttemptStatus.created)
-        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo=timezone.utc))
+        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo = timezone.utc))
 
     def test_create_verification_attempt_no_expiration_datetime(self):
         expected_id = 2
         self.assertEqual(
             create_verification_attempt(
-                user=self.user,
-                name='Tester McTest',
-                status=VerificationAttemptStatus.created,
+                user = self.user,
+                name = 'Tester McTest',
+                status = VerificationAttemptStatus.created,
             ),
             expected_id
         )
-        verification_attempt = VerificationAttempt.objects.get(id=expected_id)
+        verification_attempt = VerificationAttempt.objects.get(id = expected_id)
 
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
@@ -114,12 +114,12 @@ class UpdateVerificationAttemptStatus(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.user= UserFactory.create()
-        self.attempt= VerificationAttempt(
-            user=self.user,
-            name='Tester McTest',
-            status=VerificationAttemptStatus.created,
-            expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
+        self.user = UserFactory.create()
+        self.attempt = VerificationAttempt(
+            user = self.user,
+            name = 'Tester McTest',
+            status = VerificationAttemptStatus.created,
+            expiration_datetime = datetime(2024, 12, 31, tzinfo = timezone.utc)
         )
         self.attempt.save()
 
@@ -129,14 +129,14 @@ class UpdateVerificationAttemptStatus(TestCase):
         VerificationAttemptStatus.denied,
     )
     def test_update_verification_attempt_status(self, to_status):
-        update_verification_attempt_status(attempt_id=self.attempt.id, status=to_status)
+        update_verification_attempt_status(attempt_id = self.attempt.id, status = to_status)
 
-        verification_attempt = VerificationAttempt.objects.get(id=self.attempt.id)
+        verification_attempt = VerificationAttempt.objects.get(id = self.attempt.id)
 
         # These are fields whose values should not change as a result of this update.
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
-        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo=timezone.utc))
+        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo = timezone.utc))
 
         # This field's value should change as a result of this update.
         self.assertEqual(verification_attempt.status, to_status)
@@ -153,14 +153,14 @@ class UpdateVerificationAttemptStatus(TestCase):
         self.assertRaises(
             VerificationAttemptInvalidStatus,
             update_verification_attempt_status,
-            attempt_id=self.attempt.id,
-            status=to_status,
+            attempt_id = self.attempt.id,
+            status = to_status,
         )
 
     def test_update_verification_attempt_status_not_found(self):
         self.assertRaises(
             VerificationAttempt.DoesNotExist,
             update_verification_attempt_status,
-            attempt_id=999999,
-            status=VerificationAttemptStatus.approved,
+            attempt_id = 999999,
+            status = VerificationAttemptStatus.approved,
         )

--- a/lms/djangoapps/verify_student/tests/test_api.py
+++ b/lms/djangoapps/verify_student/tests/test_api.py
@@ -64,7 +64,7 @@ class CreateVerificationAttempt(TestCase):
         self.attempt = VerificationAttempt(
             user=self.user,
             name='Tester McTest',
-            status=VerificationAttemptStatus.created,
+            status=VerificationAttemptStatus.CREATED,
             expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
         )
         self.attempt.save()
@@ -75,7 +75,7 @@ class CreateVerificationAttempt(TestCase):
             create_verification_attempt(
                 user=self.user,
                 name='Tester McTest',
-                status=VerificationAttemptStatus.created,
+                status=VerificationAttemptStatus.CREATED,
                 expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
             ),
             expected_id
@@ -84,7 +84,7 @@ class CreateVerificationAttempt(TestCase):
 
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
-        self.assertEqual(verification_attempt.status, VerificationAttemptStatus.created)
+        self.assertEqual(verification_attempt.status, VerificationAttemptStatus.CREATED)
         self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo=timezone.utc))
 
     def test_create_verification_attempt_no_expiration_datetime(self):
@@ -93,7 +93,7 @@ class CreateVerificationAttempt(TestCase):
             create_verification_attempt(
                 user=self.user,
                 name='Tester McTest',
-                status=VerificationAttemptStatus.created,
+                status=VerificationAttemptStatus.CREATED,
             ),
             expected_id
         )
@@ -101,7 +101,7 @@ class CreateVerificationAttempt(TestCase):
 
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
-        self.assertEqual(verification_attempt.status, VerificationAttemptStatus.created)
+        self.assertEqual(verification_attempt.status, VerificationAttemptStatus.CREATED)
         self.assertEqual(verification_attempt.expiration_datetime, None)
 
 
@@ -118,15 +118,15 @@ class UpdateVerificationAttempt(TestCase):
         self.attempt = VerificationAttempt(
             user=self.user,
             name='Tester McTest',
-            status=VerificationAttemptStatus.created,
+            status=VerificationAttemptStatus.CREATED,
             expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
         )
         self.attempt.save()
 
     @ddt.data(
-        ('Tester McTest', VerificationAttemptStatus.pending, datetime(2024, 12, 31, tzinfo=timezone.utc)),
-        ('Tester McTest2', VerificationAttemptStatus.approved, datetime(2025, 12, 31, tzinfo=timezone.utc)),
-        ('Tester McTest3', VerificationAttemptStatus.denied, datetime(2026, 12, 31, tzinfo=timezone.utc)),
+        ('Tester McTest', VerificationAttemptStatus.PENDING, datetime(2024, 12, 31, tzinfo=timezone.utc)),
+        ('Tester McTest2', VerificationAttemptStatus.APPROVED, datetime(2025, 12, 31, tzinfo=timezone.utc)),
+        ('Tester McTest3', VerificationAttemptStatus.DENIED, datetime(2026, 12, 31, tzinfo=timezone.utc)),
     )
     @ddt.unpack
     def test_update_verification_attempt(self, name, status, expiration_datetime):
@@ -155,18 +155,18 @@ class UpdateVerificationAttempt(TestCase):
 
         verification_attempt = VerificationAttempt.objects.get(id=self.attempt.id)
 
-        # Values should not change as a result of the values passed in being None.
+        # Values should not change as a result of the values passed in being None, except for expiration_datetime.
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, self.attempt.name)
         self.assertEqual(verification_attempt.status, self.attempt.status)
-        self.assertEqual(verification_attempt.expiration_datetime, self.attempt.expiration_datetime)
+        self.assertEqual(verification_attempt.expiration_datetime, None)
 
     def test_update_verification_attempt_not_found(self):
         self.assertRaises(
             VerificationAttempt.DoesNotExist,
             update_verification_attempt,
             attempt_id=999999,
-            status=VerificationAttemptStatus.approved,
+            status=VerificationAttemptStatus.APPROVED,
         )
 
     @ddt.data(

--- a/lms/djangoapps/verify_student/tests/test_api.py
+++ b/lms/djangoapps/verify_student/tests/test_api.py
@@ -31,8 +31,8 @@ class TestSendApprovalEmail(TestCase):
 
         self.user = UserFactory.create()
         self.attempt = SoftwareSecurePhotoVerification(
-            status = "submitted",
-            user = self.user
+            status="submitted",
+            user=self.user
         )
         self.attempt.save()
 
@@ -62,10 +62,10 @@ class CreateVerificationAttempt(TestCase):
 
         self.user = UserFactory.create()
         self.attempt = VerificationAttempt(
-            user = self.user,
-            name = 'Tester McTest',
-            status = VerificationAttemptStatus.created,
-            expiration_datetime = datetime(2024, 12, 31, tzinfo = timezone.utc)
+            user=self.user,
+            name='Tester McTest',
+            status=VerificationAttemptStatus.created,
+            expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
         )
         self.attempt.save()
 
@@ -73,31 +73,31 @@ class CreateVerificationAttempt(TestCase):
         expected_id = 2
         self.assertEqual(
             create_verification_attempt(
-                user = self.user,
-                name = 'Tester McTest',
-                status = VerificationAttemptStatus.created,
-                expiration_datetime = datetime(2024, 12, 31, tzinfo = timezone.utc)
+                user=self.user,
+                name='Tester McTest',
+                status=VerificationAttemptStatus.created,
+                expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
             ),
             expected_id
         )
-        verification_attempt = VerificationAttempt.objects.get(id = expected_id)
+        verification_attempt = VerificationAttempt.objects.get(id=expected_id)
 
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
         self.assertEqual(verification_attempt.status, VerificationAttemptStatus.created)
-        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo = timezone.utc))
+        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo=timezone.utc))
 
     def test_create_verification_attempt_no_expiration_datetime(self):
         expected_id = 2
         self.assertEqual(
             create_verification_attempt(
-                user = self.user,
-                name = 'Tester McTest',
-                status = VerificationAttemptStatus.created,
+                user=self.user,
+                name='Tester McTest',
+                status=VerificationAttemptStatus.created,
             ),
             expected_id
         )
-        verification_attempt = VerificationAttempt.objects.get(id = expected_id)
+        verification_attempt = VerificationAttempt.objects.get(id=expected_id)
 
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
@@ -116,10 +116,10 @@ class UpdateVerificationAttemptStatus(TestCase):
 
         self.user = UserFactory.create()
         self.attempt = VerificationAttempt(
-            user = self.user,
-            name = 'Tester McTest',
-            status = VerificationAttemptStatus.created,
-            expiration_datetime = datetime(2024, 12, 31, tzinfo = timezone.utc)
+            user=self.user,
+            name='Tester McTest',
+            status=VerificationAttemptStatus.created,
+            expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
         )
         self.attempt.save()
 
@@ -129,14 +129,14 @@ class UpdateVerificationAttemptStatus(TestCase):
         VerificationAttemptStatus.denied,
     )
     def test_update_verification_attempt_status(self, to_status):
-        update_verification_attempt_status(attempt_id = self.attempt.id, status = to_status)
+        update_verification_attempt_status(attempt_id=self.attempt.id, status=to_status)
 
-        verification_attempt = VerificationAttempt.objects.get(id = self.attempt.id)
+        verification_attempt = VerificationAttempt.objects.get(id=self.attempt.id)
 
         # These are fields whose values should not change as a result of this update.
         self.assertEqual(verification_attempt.user, self.user)
         self.assertEqual(verification_attempt.name, 'Tester McTest')
-        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo = timezone.utc))
+        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo=timezone.utc))
 
         # This field's value should change as a result of this update.
         self.assertEqual(verification_attempt.status, to_status)
@@ -153,14 +153,14 @@ class UpdateVerificationAttemptStatus(TestCase):
         self.assertRaises(
             VerificationAttemptInvalidStatus,
             update_verification_attempt_status,
-            attempt_id = self.attempt.id,
-            status = to_status,
+            attempt_id=self.attempt.id,
+            status=to_status,
         )
 
     def test_update_verification_attempt_status_not_found(self):
         self.assertRaises(
             VerificationAttempt.DoesNotExist,
             update_verification_attempt_status,
-            attempt_id = 999999,
-            status = VerificationAttemptStatus.approved,
+            attempt_id=999999,
+            status=VerificationAttemptStatus.approved,
         )

--- a/lms/djangoapps/verify_student/tests/test_api.py
+++ b/lms/djangoapps/verify_student/tests/test_api.py
@@ -3,14 +3,20 @@ Tests of API module.
 """
 from unittest.mock import patch
 
+from datetime import datetime, timezone
 import ddt
 from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.verify_student.api import send_approval_email
-from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.api import (
+    create_verification_attempt,
+    send_approval_email,
+    update_verification_status,
+)
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, VerificationAttempt
+from lms.djangoapps.verify_student.statuses import VerificationAttemptStatus
 
 
 @ddt.ddt
@@ -18,6 +24,7 @@ class TestSendApprovalEmail(TestCase):
     """
     Test cases for the send_approval_email API method.
     """
+
     def setUp(self):
         super().setUp()
 
@@ -41,3 +48,77 @@ class TestSendApprovalEmail(TestCase):
         with patch.dict(settings.VERIFY_STUDENT, {'USE_DJANGO_MAIL': use_ace}):
             send_approval_email(self.attempt)
             self._assert_verification_approved_email(self.attempt.expiration_datetime)
+
+
+@ddt.ddt
+class CreateVerificationAttempt(TestCase):
+    """
+    Test cases for the send_approval_email API method.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.user = UserFactory.create()
+        self.attempt = VerificationAttempt(
+            user=self.user,
+            name='Tester McTest',
+            status=VerificationAttemptStatus.created,
+            expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
+        )
+        self.attempt.save()
+
+    def test_create_verification_attempt(self):
+        expected_id = 2
+        self.assertEqual(
+            create_verification_attempt(
+                user=self.user,
+                name='Tester McTest',
+                status=VerificationAttemptStatus.created,
+                expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
+            ),
+            expected_id
+        )
+        verification_attempt = VerificationAttempt.objects.get(id=expected_id)
+
+        self.assertEqual(verification_attempt.user, self.user)
+        self.assertEqual(verification_attempt.name, 'Tester McTest')
+        self.assertEqual(verification_attempt.status, VerificationAttemptStatus.created)
+        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo=timezone.utc))
+
+
+@ddt.ddt
+class UpdateVerificationStatus(TestCase):
+    """
+    Test cases for the update_verification_status API method.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.user= UserFactory.create()
+        self.attempt= VerificationAttempt(
+            user=self.user,
+            name='Tester McTest',
+            status=VerificationAttemptStatus.created,
+            expiration_datetime=datetime(2024, 12, 31, tzinfo=timezone.utc)
+        )
+        self.attempt.save()
+
+    @ddt.data(
+        VerificationAttemptStatus.pending,
+        VerificationAttemptStatus.approved,
+        VerificationAttemptStatus.denied,
+    )
+    def test_update_verification_status(self, to_status):
+        update_verification_status(attempt_id=self.attempt.id, status=to_status)
+
+        verification_attempt = VerificationAttempt.objects.get(id=self.attempt.id)
+
+        # These are fields whose values should not change as a result of this update.
+        self.assertEqual(verification_attempt.user, self.user)
+        self.assertEqual(verification_attempt.name, 'Tester McTest')
+        self.assertEqual(verification_attempt.expiration_datetime, datetime(2024, 12, 31, tzinfo=timezone.utc))
+
+        # This field's value should change as a result of this update.
+        self.assertEqual(verification_attempt.status, to_status)

--- a/lms/djangoapps/verify_student/tests/test_api.py
+++ b/lms/djangoapps/verify_student/tests/test_api.py
@@ -169,8 +169,6 @@ class UpdateVerificationAttempt(TestCase):
             status=VerificationAttemptStatus.approved,
         )
 
-    # These are statuses used in edx-name-affirmation's VerifiedName model and persona-integration's unique
-    # VerificationAttempt model, and not by verify_student's VerificationAttempt model.
     @ddt.data(
         'completed',
         'failed',


### PR DESCRIPTION
## Description

This PR adds api functions which can be called by IDV plugins to create and update instances of the recently added generic VerificationAttempt model.

Context for this decision can be found in this excerpt from our internal spec doc:

```
We will introduce one new generic model - the VerificationAttempt model. The
purpose of this model is to store data about verification attempts on the
platform. 

The VerificationAttempt model will store information about each IDV attempt. It
will have the majority, if not all, the fields on the
[IDVerificationAttempt](https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/verify_student/models.py#L94) abstract base model. The biggest change is that the set of
available statuses will be created, pending, approved, and denied. 

Eventually, the vision is for all forms of IDV to be installed into the platform
as plugins. The plugins would write to the VerificationAttempt model so that the
platform has a record of the IDV information it needs. The rationale is that the
platform only cares whether the learner is ID verified and not how they are ID
verified.

This would replace the majority of filter hooks proposed in the original spec.
This is because doing database queries via filter hooks can cause unpredictable
performance problems. This has been a pain point for Open edX. Write now, read
later is a better pattern to follow.

Note that the IDVerificationURLRequested(url) filter hook is still a part of the
design to replace the IDV URL on the platform. Although we do not need to use it
to integrate Persona, it is necessary to enable additional implementations of
IDV via these changes.
```

Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
  - Learners will primarily be impacted due to our primary IDV vendor changing.
  - Course Authors will also be somewhat impacted, at the very least because they will need to be notified of the changed IDV process (which we've already made efforts to do).
  - Developers and Operators will also be somewhat impacted, as they'll also need to be notified of this change and how this impacts support as well as future development on IDV and IDV-related systems.


## Supporting information

Info from internal ticket:

introduce a Python API for the generic VerificationAttempt model in the [verify_student](https://github.com/openedx/edx-platform/tree/master/lms/djangoapps/verify_student) application. The purpose of this API is to allow plugins that implement different types of IDV to import these methods and effect changes in the [verify_student](https://github.com/openedx/edx-platform/tree/master/lms/djangoapps/verify_student) VerificationAttempt model.

Below is an idea for the function signatures.

```
id = create_verification_attempt(user, name, status, expiration_date=None)
update_verification_attempt(id, status)
```

Note that an id must be returned from create_verification_attempt so that the plugin can specify the id on any following update_verification calls.

## Deadline

None

## Other information

Other changes will be made in `openedx-events` and `edx-name-affirmation` to implement the downstream effects of calling these new API functions.