### PR TITLE
revert: "fix: update course discussion config before course load"

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -58,7 +58,6 @@ from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadReq
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
-from openedx.core.djangoapps.discussions.tasks import update_discussions_settings_from_course
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
@@ -303,10 +302,6 @@ def course_handler(request, course_key_string=None):
             else:
                 return HttpResponseBadRequest()
         elif request.method == 'GET':  # assume html
-            # Update course discussion settings, sometimes the course discussion settings are not updated
-            # when the course is created, so we need to update them here.
-            course_key = CourseKey.from_string(course_key_string)
-            update_discussions_settings_from_course(course_key)
             if course_key_string is None:
                 return redirect(reverse('home'))
             else:

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -717,8 +717,8 @@ class TestCourseOutline(CourseTestCase):
         """
         Test to check number of queries made to mysql and mongo
         """
-        with self.assertNumQueries(32, table_ignorelist=WAFFLE_TABLES):
-            with check_mongo_calls(5):
+        with self.assertNumQueries(29, table_ignorelist=WAFFLE_TABLES):
+            with check_mongo_calls(3):
                 self.client.get_html(reverse_course_url('course_handler', self.course.id))
 
 


### PR DESCRIPTION
This reverts commit 5c0942481ce292a90f86259bd223d66e7ceffe9f.

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This change impacts Course Authors. PR #35219 causes 504 errors on large courses. For exploration is needed to determine why `update_discussions_settings_from_course` causes timeout errors. I am unable to reproduce the error on my local set-up, but based on the timing of the bug and merge of PR the two appear to be linked.

## Supporting information

JIRA Ticket: [TNL-11723 🔒 ](https://2u-internal.atlassian.net/browse/TNL-11723)
> The course team has reported being unable to access or edit any of their courses in Studio due to a scheduled maintenance notice
