### PR TITLE
fix: course outline now working for MFE

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -75,8 +75,12 @@ def course_detail(request, username, course_key):
     user = get_effective_user(request.user, username)
     overview = get_course_overview_with_access(
         user,
-        get_permission_for_course_about(),
-        course_key,
+        action=(
+            "load"
+            if CourseEnrollment.is_enrolled(request.user, course_key)
+            else get_permission_for_course_about()
+        ),
+        course_key=course_key,
     )
     overview.effective_user = user
     return overview


### PR DESCRIPTION
## Description


 This changes fixes the case when:

 1. The course visbility in studio advance settings is set to 'none'.
 2. The `COURSE_ABOUT_VISIBILITY_PERMISSION` is set `see_about_page`.

 The fix is done by assuming that whenever a learner is accsing
 course content and they are **enrolled**, then we use 'load'
 action for them see (course detail/course outline), as oppiste
 to the default which would use `COURSE_ABOUT_VISIBILITY_PERMISSION`
 no matter if learner enrolled or not enrolled.

 Note this change dosn't affect the logic of `course-id/about` page
 at all, since that view doesn't use this view.



## Supporting information

Note setting  `COURSE_ABOUT_VISIBILITY_PERMISSION` to `see_exists` (default devstack) might make it work for MFE but then the course visbility setting would not work as what everyone expect it to work. i.e if you set course visbility to none, course about page will still be visible. 



## Testing instructions

 - Make sure the platform  COURSE_ABOUT_VISIBILITY_PERMISSION is set `see_about_page`. (default in tutor but not in devstack )
- Create a course and set visibility to none 
- Try to access course outline page/course home page as student in MFE.  (It shouldn't work unless you add this change)

