### PR TITLE
chore: Convert word cloud block sass variables to css variables

### DIFF
--- a/xmodule/assets/word_cloud/_display.scss
+++ b/xmodule/assets/word_cloud/_display.scss
@@ -4,7 +4,7 @@
 @import 'lms/theme/variables-v1';
 
 .input-cloud {
-  margin: ($baseline/4);
+  margin: calc((var(--baseline)/4));
 }
 
 .result_cloud_section {


### PR DESCRIPTION
Ticket: https://github.com/openedx/edx-platform/issues/35306

**Description:**
Convert word cloud block sass variables to css variables


**Other Relevant PR's:**
https://github.com/openedx/edx-platform/pull/35233
https://github.com/openedx/edx-platform/pull/35385

**How to test:**
- Add the word cloud block in a test course
- Open it in the LMS
- Make sure following property is accessible
`getComputedStyle(document.documentElement).getPropertyValue('--baseline')`

## Pending/Known Issue:
5px or appropriate value of margin should be reflected in the styling of word-cloud xblock unit frame but it's not.
I think the issue is `.xmodule_display.xmodule_WordCloudBlock` class doesn't exist referred in the generatd css file given below (css generated on the `master` branch for the testing)

```css
@import url("https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,700");
/* line 1, /openedx/edx-platform/xmodule/assets/WordCloudBlockDisplay.scss */
.xmodule_display.xmodule_WordCloudBlock {
  /* stylelint-disable-line */
  /* stylelint-disable-line */ }
  /* line 6, /openedx/edx-platform/xmodule/assets/word_cloud/_display.scss */
  .xmodule_display.xmodule_WordCloudBlock .input-cloud {
    margin: 5px; }
  /* line 10, /openedx/edx-platform/xmodule/assets/word_cloud/_display.scss */
  .xmodule_display.xmodule_WordCloudBlock .result_cloud_section {
    display: none;
    width: 0px;
    height: 0px; }
  /* line 16, /openedx/edx-platform/xmodule/assets/word_cloud/_display.scss */
  .xmodule_display.xmodule_WordCloudBlock .result_cloud_section.active {
    display: block;
    width: 100%;
    height: auto;
    margin-top: 1em; }
    /* line 22, /openedx/edx-platform/xmodule/assets/word_cloud/_display.scss */
    .xmodule_display.xmodule_WordCloudBlock .result_cloud_section.active h3 {
      font-size: 100%; }
  /* line 27, /openedx/edx-platform/xmodule/assets/word_cloud/_display.scss */
  .xmodule_display.xmodule_WordCloudBlock .your_words {
    font-size: 0.85em;
    display: block; }

```