### PR TITLE
fix: renamed DatabaseNotReadyError for better code clarity

### DIFF
--- a/lms/djangoapps/grades/exceptions.py
+++ b/lms/djangoapps/grades/exceptions.py
@@ -3,9 +3,9 @@ Custom exceptions raised by grades.
 """
 
 
-class DatabaseNotReadyError(IOError):
+class ScoreNotFoundError(IOError):
     """
-    Subclass of IOError to indicate the database has not yet committed
-    the data we're trying to find.
+    Subclass of IOError to indicate the staff has not yet graded the problem or
+    the database has not yet committed the data we're trying to find.
     """
     pass  # lint-amnesty, pylint: disable=unnecessary-pass

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -33,7 +33,7 @@ from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disa
 from .config.waffle import DISABLE_REGRADE_ON_POLICY_CHANGE
 from .constants import ScoreDatabaseTableEnum
 from .course_grade_factory import CourseGradeFactory
-from .exceptions import DatabaseNotReadyError
+from .exceptions import ScoreNotFoundError
 from .grade_utils import are_grades_frozen
 from .signals.signals import SUBSECTION_SCORE_CHANGED
 from .subsection_grade_factory import SubsectionGradeFactory
@@ -45,7 +45,7 @@ COURSE_GRADE_TIMEOUT_SECONDS = 1200
 KNOWN_RETRY_ERRORS = (  # Errors we expect occasionally, should be resolved on retry
     DatabaseError,
     ValidationError,
-    DatabaseNotReadyError,
+    ScoreNotFoundError,
     UsageKeyNotInBlockStructure,
 )
 RECALCULATE_GRADE_DELAY_SECONDS = 2  # to prevent excessive _has_db_updated failures. See TNL-6424.
@@ -239,7 +239,7 @@ def _recalculate_subsection_grade(self, **kwargs):
         has_database_updated = _has_db_updated_with_new_score(self, scored_block_usage_key, **kwargs)
 
         if not has_database_updated:
-            raise DatabaseNotReadyError
+            raise ScoreNotFoundError
 
         _update_subsection_grades(
             course_key,


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

At MIT, we received an issue regarding the `DatabaseNotReadyError` occurring in `edx-sga` problem blocks that have not yet been graded by staff, when running the `recalculate_subsection_grades` management command. The same error occurs for ungraded `ORA problems` that have a submission but are not yet graded. The error message was unclear, so in this PR, it has been renamed to `ScoreNotFoundError` for better clarity. The `DatabaseNotReadyError` is used in only one instance across the entire edX organization ([reference](https://github.com/search?q=org%3Aopenedx+DatabaseNotReadyError&type=code)).


Useful information to include:

- Which edX user roles will this change impact? Operator and Developer
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/mitodl/edx-sga/issues/342

## Testing instructions

- Create an ORA unit in Studio ([steps](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/open_response_assessments/CreateORAAssignment.html#step-1-add-the-component)).
- Click on the `View Live Version` button.
- Submit your response but leave the problem ungraded.
- Open the LMS shell and run `./manage.py lms recalculate_subsection_grades --modified_start="2024-08-25 16:43" --modified_end="2024-08-27 16:43"`. Adjust the datetime accordingly.
- The error raised should be `ScoreNotFoundError`.


## Deadline

"None"

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
