### PR TITLE
feat: DEPR USE-JWT-COOKIE header

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2544,7 +2544,6 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
 # because that decision might happen in a later config file. (The headers to
 # allow is an application logic, and not site policy.)
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
-    'use-jwt-cookie',
     'content-range',
     'content-disposition',
 )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3686,9 +3686,7 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
 # Set CORS_ALLOW_HEADERS regardless of whether we've enabled ENABLE_CORS_HEADERS
 # because that decision might happen in a later config file. (The headers to
 # allow is an application logic, and not site policy.)
-CORS_ALLOW_HEADERS = corsheaders_default_headers + (
-    'use-jwt-cookie',
-)
+CORS_ALLOW_HEADERS = corsheaders_default_headers
 
 # Default cache expiration for the cross-domain proxy HTML page.
 # This is a static page that can be iframed into an external page

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -74,9 +74,6 @@ class CookieTests(TestCase):
             for key, val in response.cookies.items()
         }
 
-    def _set_use_jwt_cookie_header(self, request):
-        request.META['HTTP_USE_JWT_COOKIE'] = 'true'
-
     def _assert_recreate_jwt_from_cookies(self, response, can_recreate):
         """
         If can_recreate is True, verifies that a JWT can be properly recreated
@@ -133,7 +130,6 @@ class CookieTests(TestCase):
     @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
     def test_set_logged_in_jwt_cookies(self):
         setup_login_oauth_client()
-        self._set_use_jwt_cookie_header(self.request)
         response = cookies_api.set_logged_in_cookies(self.request, HttpResponse(), self.user)
         self._assert_cookies_present(response, cookies_api.ALL_LOGGED_IN_COOKIE_NAMES)
         self._assert_consistent_expires(response, num_of_unique_expires=2)
@@ -153,7 +149,6 @@ class CookieTests(TestCase):
     @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
     def test_refresh_jwt_cookies(self):
         setup_login_oauth_client()
-        self._set_use_jwt_cookie_header(self.request)
         response = cookies_api.get_response_with_refreshed_jwt_cookies(self.request, self.user)
         data = json.loads(response.content.decode('utf8').replace("'", '"'))
         assert data['success'] is True


### PR DESCRIPTION
This repo is no longer using USE-JWT-COOKIE header, since it has the required edx-drf-extensions>10.2.0, where it was fully removed.

This is final clean-up for this repo.

See "[DEPR]: USE-JWT-COOKIE header" for more details:
- https://github.com/openedx/edx-drf-extensions/issues/371

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
