### PR TITLE
style: constrain exam iframe to avoid scroll problems

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -7,7 +7,7 @@ import pytz
 <div class="proctoring-wrapper">
   % if section_data.get('mfe_view_url'):
   <div id="proctoring-mfe-view">
-    <iframe width="100%" height="1280" frameborder="0" src="${ section_data['mfe_view_url'] }"></iframe>
+    <iframe width="100%" style="height: 55vh;" frameborder="0" src="${ section_data['mfe_view_url'] }"></iframe>
   </div>
   % else:
     % if section_data.get('escalation_email'):


### PR DESCRIPTION
## Description

This makes the iframe for the exams dashboard content much smaller. This was set large originally to avoid scrolling inside the frame and rely on scrolling this page. However, we found once [ModalDialog](https://paragon-openedx.netlify.app/components/modal/modal-dialog/) components were added it posed a problem to content falling below the fold. The modal overlay will prevent scrolling outside the iframe making it hard to access that content.

This change should guarantee the frame fits in view until we're narrow enough to fall into mobile breakpoints in the exams dashboard app where this issue isn't a problem.

