### PR TITLE
Revert "feat: DEPR USE-JWT-COOKIE header"

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2544,6 +2544,7 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
 # because that decision might happen in a later config file. (The headers to
 # allow is an application logic, and not site policy.)
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+    'use-jwt-cookie',
     'content-range',
     'content-disposition',
 )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3686,7 +3686,9 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
 # Set CORS_ALLOW_HEADERS regardless of whether we've enabled ENABLE_CORS_HEADERS
 # because that decision might happen in a later config file. (The headers to
 # allow is an application logic, and not site policy.)
-CORS_ALLOW_HEADERS = corsheaders_default_headers
+CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+    'use-jwt-cookie',
+)
 
 # Default cache expiration for the cross-domain proxy HTML page.
 # This is a static page that can be iframed into an external page

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -74,6 +74,9 @@ class CookieTests(TestCase):
             for key, val in response.cookies.items()
         }
 
+    def _set_use_jwt_cookie_header(self, request):
+        request.META['HTTP_USE_JWT_COOKIE'] = 'true'
+
     def _assert_recreate_jwt_from_cookies(self, response, can_recreate):
         """
         If can_recreate is True, verifies that a JWT can be properly recreated
@@ -130,6 +133,7 @@ class CookieTests(TestCase):
     @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
     def test_set_logged_in_jwt_cookies(self):
         setup_login_oauth_client()
+        self._set_use_jwt_cookie_header(self.request)
         response = cookies_api.set_logged_in_cookies(self.request, HttpResponse(), self.user)
         self._assert_cookies_present(response, cookies_api.ALL_LOGGED_IN_COOKIE_NAMES)
         self._assert_consistent_expires(response, num_of_unique_expires=2)
@@ -149,6 +153,7 @@ class CookieTests(TestCase):
     @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
     def test_refresh_jwt_cookies(self):
         setup_login_oauth_client()
+        self._set_use_jwt_cookie_header(self.request)
         response = cookies_api.get_response_with_refreshed_jwt_cookies(self.request, self.user)
         data = json.loads(response.content.decode('utf8').replace("'", '"'))
         assert data['success'] is True


### PR DESCRIPTION
Reverts openedx/edx-platform#35393

It turns out that you a frontend sending the `USE-JWT-COOKIE` header will break, rather than the header being ignored, when `CORS_ALLOW_HEADERS` is updated. All usage of the header must be stopped first. The DEPR has been updated with the new plan. See https://github.com/openedx/edx-drf-extensions/issues/371