### PR TITLE
Update CORS allowed headers for compatibility w/ axios-cache-interceptor

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3687,6 +3687,9 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
 # because that decision might happen in a later config file. (The headers to
 # allow is an application logic, and not site policy.)
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+    'cache-control',
+    'expires',
+    'pragma',
     'use-jwt-cookie',
 )
 


### PR DESCRIPTION
## Summary

Fixes a CORS error seen by developers who run MFEs in dev mode on their host, alongside Tutor.

## Description

In https://github.com/openedx/frontend-app-course-authoring/pull/1209 , the version of `axios-cache-interceptor` used in the Course Authoring MFE was bumped from v0.28 to v1.6. The new setting [cache.cacheTakeover](https://axios-cache-interceptor.js.org/config/request-specifics#cache-cachetakeover) which defaults to true is adding three new headers to the "runtime config" request that happens when the MFE starts up, and this is causing an error for those of us who run the MFE outside of a container.

This exact issue and the suggested fix are described in the linked documentation for [cache.cacheTakeover](https://axios-cache-interceptor.js.org/config/request-specifics#cache-cachetakeover):

> `cache.cacheTakeover` (default `true`): you need to make sure Cache-Control, Pragma and Expires headers are included into your server’s Access-Control-Allow-Headers CORS configuration.

## Supporting information

[Discussed on Slack](https://openedx.slack.com/archives/C04BM6YC7A6/p1724956617320169)

## Alternatives

I could make the changes for both `cms` and `lms`; currently I only modified LMS.

I could make the changes in Tutor or only in dev mode; I put them in `lms/common`

## Testing instructions

1. Make sure course-authoring is bind-mounted so tutor doesn't run it:
    ```
    tutor mounts add /path/to/frontend-app-course-authoring
    ```
2. Start Tutor but not the MFE: `tutor dev start lms cms mfe` (we don't start `course-authoring`)
3. On your host, run `git pull` and `npm install` in the `frontend-app-course-authoring` folder.
4. On your host, start the MFE:
    ```
    APP_ID=course-authoring PUBLIC_PATH=/course-authoring/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' npm run start -- --host apps.local.overhang.io
    ```
    (or `apps.local.edly.io` if your Tutor instance is not as old as mine is)
5. Without this fix, you should see a CORE error when trying to access any part of course-authoring. With this fix, it should work.

## Deadline

None
