### PR TITLE
feat: set links for CourseAuthoring discussion alert

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
@@ -1,6 +1,7 @@
 """
 Unit tests for course index outline.
 """
+from django.conf import settings
 from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
@@ -62,7 +63,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
                 "advance_settings_url": f"/settings/advanced/{self.course.id}"
             },
             "discussions_incontext_feedback_url": "",
-            "discussions_incontext_learnmore_url": "",
+            "discussions_incontext_learnmore_url": settings.DISCUSSIONS_INCONTEXT_LEARNMORE_URL,
             "is_custom_relative_dates_active": True,
             "initial_state": None,
             "initial_user_clipboard": {
@@ -103,7 +104,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
                 "advance_settings_url": f"/settings/advanced/{self.course.id}"
             },
             "discussions_incontext_feedback_url": "",
-            "discussions_incontext_learnmore_url": "",
+            "discussions_incontext_learnmore_url": settings.DISCUSSIONS_INCONTEXT_LEARNMORE_URL,
             "is_custom_relative_dates_active": False,
             "initial_state": {
                 "expanded_locators": [

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2814,8 +2814,14 @@ EDX_BRAZE_API_SERVER = None
 
 BRAZE_COURSE_ENROLLMENT_CANVAS_ID = ''
 
+######################## Discussion Forum settings ########################
+
+# Feedback link in upgraded discussion notification alert
 DISCUSSIONS_INCONTEXT_FEEDBACK_URL = ''
-DISCUSSIONS_INCONTEXT_LEARNMORE_URL = ''
+
+# Learn More link in upgraded discussion notification alert
+# pylint: disable=line-too-long
+DISCUSSIONS_INCONTEXT_LEARNMORE_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/manage_discussions/discussions.html"
 
 #### django-simple-history##
 # disable indexing on date field its coming django-simple-history.


### PR DESCRIPTION
# Description

There is an [alert](https://github.com/open-craft/frontend-app-course-authoring/blob/04bdc64391ab092b85ebb2f7de6bf10a09fda1ea/src/course-outline/page-alerts/PageAlerts.jsx#L104) in CourseAuthoring MFE to inform about the usage of an upgraded version of discussion. This PR sets the links used in that alert instead of defaulting to the having clickable empty links.

# Testing instructions
Please refer to the related MFE PR https://github.com/openedx/frontend-app-course-authoring/pull/1245 

# ref
BB-9079