### PR TITLE
feat: allow disabling spaced out sections in self paced courses

### DIFF
--- a/openedx/core/djangoapps/course_date_signals/waffle.py
+++ b/openedx/core/djangoapps/course_date_signals/waffle.py
@@ -1,0 +1,32 @@
+"""
+This module contains various configuration settings via waffle switches for
+course date signals.
+"""
+
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+WAFFLE_FLAG_NAMESPACE = "course_date_signals"
+
+# .. toggle_name: course_date_signals.relative_dates_disable_suggested_schedule
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to disable suggested schedule for self paced courses.
+#   When suggested schedule is enabled, graded content in self paced courses
+#   will be assigned a suggested relative due date. Suggested relative due dates
+#   are calculated by getting an average time needed per section, by getting an
+#   estimated duration of a course and dividing it by a number of sections,
+#   and then multiplying it by an index of a section that is currently being
+#   assigned a due date. E.g. if a course is estimated to be 4 weeks, has 4
+#   sections, and each one is marked as graded, the first section's relative due
+#   date is going to be one week from the date of the enrollment, the second -
+#   two weeks, etc.
+#   The estimated course duration is fetched from the Course Discovery service,
+#   and is clamped between 4 and 18 weeks. If Course Discovery is not available
+#   or value is not set for a course that is being requested, the estimated time
+#   would be set to 4 weeks.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-09-02
+# .. toggle_target_removal_date: None
+DISABLE_SPACED_OUT_SECTIONS = CourseWaffleFlag(
+    f"{WAFFLE_FLAG_NAMESPACE}.relative_dates_disable_suggested_schedule", __name__
+)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

In self paced courses, if relative due dates are enabled via `SelfPacedRelativeDatesConfig`, all graded content would be assigned relative due dates which are evenly spaced out over an estimated duration of a course (aka. Personal Learner Schedule or PLS). If `CUSTOM_RELATIVE_DATES` are enabled, custom set relative due dates would (sometimes) override the "spaced out" ones.

However, there are some usecases, when custom relative due dates are desired, without the PLS. For this usecase we are adding a `DISABLE_SPACED_OUT_SECTIONS` CourseWaffleFlag. None of the existing behaviour is changed unwillingly. When the flag is enabled, the relative due dates will only be applied to the subsections that have custom relative due dates set, or when a similar setting is set in Advanced Settings of a course.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

* Load demo course
* Enable `SelfPacedRelativeDatesConfig` in admin panel
* Enable `CUSTOM_RELATIVE_DATES` waffle flag
* Republish the course? Basically, trigger the due dates recalculations (e.g. updating relative due date in advanced settings)
* Check that all subsections have relative due date (for some reason not all due dates are displayed when set this way, the way I was checking is by attaching a debugger and checking the output of the extract_dates_from_course)
* Enable the new flag
* Trigger relative due dates recalculations
* Check that only subsections with custom relative due dates have due dates

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.

_Private-ref:_ [BB-8968](https://tasks.opencraft.com/browse/BB-8968)