### PR TITLE
fix: update bulk email created event data

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -472,7 +472,7 @@ def _send_course_email(entry_id, email_id, to_list, global_email_context, subtas
         'edx.bulk_email.created',
         {
             'course_id': str(course_email.course_id),
-            'to_list': to_list,
+            'to_list': [user_obj.get('email', '') for user_obj in to_list],
             'total_recipients': total_recipients,
         }
     )


### PR DESCRIPTION
Fixed `edx.bulk_email.created` event. Replaced user object list with email list

Ticket: [INF-1530](https://2u-internal.atlassian.net/browse/INF-1530) 