### PR TITLE
feat: in-context discussion for units can be disabled by default

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -566,6 +566,14 @@ FEATURES = {
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2024-04-10
     'BADGES_ENABLED': False,
+
+    # .. toggle_name: FEATURES['IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Set to False to disable in-context discussion for units by default.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-09-02
+    'IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT': True,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from functools import reduce
 
 import pytz
+from django.conf import settings
 from lxml import etree
 from openedx_filters.learning.filters import VerticalBlockChildRenderStarted, VerticalBlockRenderCompleted
 from web_fragments.fragment import Fragment
@@ -43,7 +44,7 @@ class VerticalFields:
     discussion_enabled = Boolean(
         display_name=_("Enable in-context discussions for the Unit"),
         help=_("Add discussion for the Unit."),
-        default=True,
+        default=settings.FEATURES.get('IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT', True),
         scope=Scope.settings,
     )
 


### PR DESCRIPTION
## Description

Currently for all new units which are added to a course, the in-context discussions is enabled by default, which the course instructor can disable individually.

This PR, adds to the ability to keep the in-context discussions disabled by default. That way all new units which are added will have the discussions sidebar disabled and can be individually enabled by the course instructors.

## Testing instructions

1. Checkout this branch in your local dev environment
2. Create a new course and add a unit there.
3. Check that the in-context discussions sidebar is enabled for that unit by default. Go to the LMS and verify that the same.
4. Now set `IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT` feature flag to False
5. Create a new unit again and this time check that the in-context discussion is disabled by default for that unit. Go to the LMS and verify the same.


## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Private Ref : [BB-9112](https://tasks.opencraft.com/browse/BB-9112)