### PR TITLE
fix: added course_id in email sent event

### DIFF
--- a/lms/djangoapps/bulk_email/signals.py
+++ b/lms/djangoapps/bulk_email/signals.py
@@ -41,7 +41,9 @@ def ace_email_sent_handler(sender, **kwargs):
     except user_model.DoesNotExist:
         user_id = None
     course_email = message.context.get('course_email', None)
-    course_id = course_email.course_id if course_email else None
+    course_id = message.context.get('course_id')
+    if not course_id:
+        course_id = course_email.course_id if course_email else None
     tracker.emit(
         'edx.bulk_email.sent',
         {

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -75,6 +75,7 @@ def send_ace_message(goal):
         'email': user.email,
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
         'course_name': course_name,
+        'course_id': str(goal.course_key),
         'days_per_week': goal.days_per_week,
         'course_url': course_home_url,
         'goals_unsubscribe_url': goals_unsubscribe_url,

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -526,6 +526,7 @@ class CourseNextSectionUpdate(PrefixedDebugLoggerMixin, RecipientResolver):
                 'week_num': week_num,
                 'week_highlights': week_highlights,
                 # This is used by the bulk email optout policy
+                'course_id': str(course.id),
                 'course_ids': [str(course.id)],
                 'unsubscribe_url': unsubscribe_url,
             })

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -293,6 +293,7 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
             'contact_email': 'info@example.com',
             'contact_mailing_address': '123 Sesame Street',
             'course_ids': [str(self.course.id)],
+            'course_id': str(self.course.id),
             'course_name': self.course.display_name,
             'course_url': f'http://learning-mfe/course/{self.course.id}/home',
             'dashboard_url': '/dashboard',


### PR DESCRIPTION
Add course id in following email event
- goal reminder
- course update

Ticket Link: [INF-1529](https://2u-internal.atlassian.net/browse/INF-1529) 