### PR TITLE
feat: added channel field in ace sent event

### DIFF
--- a/lms/djangoapps/bulk_email/signals.py
+++ b/lms/djangoapps/bulk_email/signals.py
@@ -44,10 +44,15 @@ def ace_email_sent_handler(sender, **kwargs):
     course_id = message.context.get('course_id')
     if not course_id:
         course_id = course_email.course_id if course_email else None
+    try:
+        channel = sender.__class__.__name__
+    except AttributeError:
+        channel = 'Other'
     tracker.emit(
-        'edx.bulk_email.sent',
+        'edx.ace.message_sent',
         {
             'message_type': message.name,
+            'channel': channel,
             'course_id': course_id,
             'user_id': user_id,
         }


### PR DESCRIPTION
PR contains
- Changed ace event from `edx.bulk_email.sent` to `edx.ace.message_sent`
- Added `channel` field in the above mentioned event

Channel value is the name of Channel class. 

Ticket: [INF-1526](https://2u-internal.atlassian.net/browse/INF-1526)