### PR TITLE
feat: added additional content in endorsed notification

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -286,13 +286,19 @@ class DiscussionNotificationSender:
         response on his thread has been endorsed
         """
         if self.creator.id != int(self.thread.user_id):
-            self._send_notification([self.thread.user_id], "response_endorsed_on_thread")
+            context = {
+                "email_content": clean_thread_html_body(self.comment.body)
+            }
+            self._send_notification([self.thread.user_id], "response_endorsed_on_thread", extra_context=context)
 
     def send_response_endorsed_notification(self):
         """
         Sends a notification to the author of the response
         """
-        self._send_notification([self.creator.id], "response_endorsed")
+        context = {
+            "email_content": clean_thread_html_body(self.comment.body)
+        }
+        self._send_notification([self.creator.id], "response_endorsed", extra_context=context)
 
     def send_new_thread_created_notification(self):
         """

--- a/lms/djangoapps/discussion/rest_api/tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tasks.py
@@ -64,7 +64,7 @@ def send_response_endorsed_notifications(thread_id, response_id, course_key_str,
     creator = User.objects.get(id=response.user_id)
     endorser = User.objects.get(id=endorsed_by)
     course = get_course_with_access(creator, 'load', course_key, check_if_enrolled=True)
-    notification_sender = DiscussionNotificationSender(thread, course, creator)
+    notification_sender = DiscussionNotificationSender(thread, course, creator, comment_id=response_id)
     # skip sending notification to author of thread if they are the same as the author of the response
     if response.user_id != thread.user_id:
         # sends notification to author of thread

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -663,6 +663,7 @@ class TestResponseEndorsedNotifications(DiscussionAPIViewTestMixin, ModuleStoreT
             'post_title': 'test thread',
             'course_name': self.course.display_name,
             'sender_id': int(self.user_2.id),
+            'email_content': 'dummy'
         }
         self.assertDictEqual(notification_data.context, expected_context)
         self.assertEqual(notification_data.content_url, _get_mfe_url(self.course.id, thread.id))
@@ -680,6 +681,7 @@ class TestResponseEndorsedNotifications(DiscussionAPIViewTestMixin, ModuleStoreT
             'post_title': 'test thread',
             'course_name': self.course.display_name,
             'sender_id': int(response.user_id),
+            'email_content': 'dummy'
         }
         self.assertDictEqual(notification_data.context, expected_context)
         self.assertEqual(notification_data.content_url, _get_mfe_url(self.course.id, thread.id))


### PR DESCRIPTION
Added additional content in two notification types
- response_endorsed
- response_endorsed_on_thread

Ticket Link: [INF-1536](https://2u-internal.atlassian.net/browse/INF-1536)