### PR TITLE
feat: add can_access_advanced_settings to studio home [BB-9081]

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/home.py
@@ -51,6 +51,7 @@ class CourseHomeSerializer(serializers.Serializer):
         allow_empty=True
     )
     archived_courses = CourseCommonSerializer(required=False, many=True)
+    can_access_advanced_settings = serializers.BooleanField()
     can_create_organizations = serializers.BooleanField()
     course_creator_status = serializers.CharField()
     courses = CourseCommonSerializer(required=False, many=True)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/home.py
@@ -52,6 +52,7 @@ class HomePageView(APIView):
             "allow_unicode_course_id": false,
             "allowed_organizations": [],
             "archived_courses": [],
+            "can_access_advanced_settings": true,
             "can_create_organizations": true,
             "course_creator_status": "granted",
             "courses": [],

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
@@ -44,6 +44,7 @@ class HomePageViewTest(CourseTestCase):
             "allow_unicode_course_id": False,
             "allowed_organizations": [],
             "archived_courses": [],
+            "can_access_advanced_settings": True,
             "can_create_organizations": True,
             "course_creator_status": "granted",
             "courses": [],

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1715,6 +1715,7 @@ def get_home_context(request, no_course=False):
         'allowed_organizations': get_allowed_organizations(user),
         'allowed_organizations_for_libraries': get_allowed_organizations_for_libraries(user),
         'can_create_organizations': user_can_create_organizations(user),
+        'can_access_advanced_settings': auth.has_studio_advanced_settings_access(user),
     }
 
     return home_context


### PR DESCRIPTION
## Description

Adds `can_access_advanced_settings` flag to the `HomePageView` view's response. Currently this flag is used to control visibility of the "Advanced Settings" drop-down menu item here: 

## Testing instructions

1. Set `DISABLE_ADVANCED_SETTINGS` feature flag to `True`.
2. Create a test user and give it a "Staff" course team role (not Django staff!)
3. As this test user, verify that the response of http://studio.local.edly.io:8001/api/contentstore/v1/home contains `can_access_advanced_settings: false`.
4. For Django staff and superuser `can_access_advanced_settings` should be `true`.
