### PR TITLE
fix: allow courses to render with invalid proctoring provider

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -217,7 +217,10 @@ class CourseMetadata:
             try:
                 val = model['value']
                 if hasattr(block, key) and getattr(block, key) != val:
-                    key_values[key] = block.fields[key].from_json(val)
+                    if key == 'proctoring_provider':
+                        key_values[key] = block.fields[key].from_json(val, validate_providers=True)
+                    else:
+                        key_values[key] = block.fields[key].from_json(val)
             except (TypeError, ValueError) as err:
                 raise ValueError(_("Incorrect format for field '{name}'. {detailed_message}").format(  # lint-amnesty, pylint: disable=raise-missing-from
                     name=model['display_name'], detailed_message=str(err)))
@@ -253,7 +256,10 @@ class CourseMetadata:
             try:
                 val = model['value']
                 if hasattr(block, key) and getattr(block, key) != val:
-                    key_values[key] = block.fields[key].from_json(val)
+                    if key == 'proctoring_provider':
+                        key_values[key] = block.fields[key].from_json(val, validate_providers=True)
+                    else:
+                        key_values[key] = block.fields[key].from_json(val)
             except (TypeError, ValueError, ValidationError) as err:
                 did_validate = False
                 errors.append({'key': key, 'message': str(err), 'model': model})

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -228,7 +228,7 @@ class ProctoringProvider(String):
     and default that pulls from edx platform settings.
     """
 
-    def from_json(self, value):
+    def from_json(self, value, validate_providers=False):
         """
         Return ProctoringProvider as full featured Python type. Perform validation on the provider
         and include any inherited values from the platform default.
@@ -237,7 +237,8 @@ class ProctoringProvider(String):
         if settings.FEATURES.get('ENABLE_PROCTORED_EXAMS'):
             # Only validate the provider value if ProctoredExams are enabled on the environment
             # Otherwise, the passed in provider does not matter. We should always return default
-            self._validate_proctoring_provider(value)
+            if validate_providers:
+                self._validate_proctoring_provider(value)
             value = self._get_proctoring_value(value)
             return value
         else:

--- a/xmodule/tests/test_course_block.py
+++ b/xmodule/tests/test_course_block.py
@@ -542,13 +542,26 @@ class ProctoringProviderTestCase(unittest.TestCase):
         with override_settings(FEATURES=FEATURES_WITH_PROCTORED_EXAMS):
             if proctored_exams_setting_enabled:
                 with pytest.raises(InvalidProctoringProvider) as context_manager:
-                    self.proctoring_provider.from_json(provider)
+                    self.proctoring_provider.from_json(provider, validate_providers=True)
                 expected_error = f'The selected proctoring provider, {provider}, is not a valid provider. ' \
                     f'Please select from one of {allowed_proctoring_providers}.'
                 assert str(context_manager.value) == expected_error
             else:
-                provider_value = self.proctoring_provider.from_json(provider)
+                provider_value = self.proctoring_provider.from_json(provider, validate_providers=True)
                 assert provider_value == self.proctoring_provider.default
+
+    def test_from_json_validate_providers(self):
+        """
+        Test that an invalid provider is ignored if validate providers is set to false
+        """
+        provider = 'invalid-provider'
+
+        FEATURES_WITH_PROCTORED_EXAMS = settings.FEATURES.copy()
+        FEATURES_WITH_PROCTORED_EXAMS['ENABLE_PROCTORED_EXAMS'] = True
+
+        with override_settings(FEATURES=FEATURES_WITH_PROCTORED_EXAMS):
+            provider_value = self.proctoring_provider.from_json(provider, validate_providers=False)
+            assert provider_value == provider
 
     def test_from_json_adds_platform_default_for_missing_provider(self):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

If a course is configured to use a proctoring provider that is no longer supported by the platform (i.e. the proctoring provider has been removed from the `PROCTORING_BACKENDS` Django setting), the course becomes inaccessible via both the LMS and CMS, and there is no way for a course team to update their course to use a valid proctoring provider. 

In order to maintain access to a course in this state, validation on the proctoring provider should only occur when the proctoring provider setting is being updated, not when it is being read from the database. Course teams will still be unable to configure an invalid proctoring provider when updating their course, but they will now be able to choose a new provider should their current proctoring provider selection no longer be supported. 

## Supporting information

https://2u-internal.atlassian.net/browse/COSMO-449
