### PR TITLE
fix: unhide discussion tab when enabling it (#677)

### DIFF
--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -354,6 +354,14 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
                     key not in LegacySettingsSerializer.Meta.fields_cohorts
                 )
             }
+        # Toggle discussion tab is_hidden. Before Palm, we would mark the discussion tab with the is_hidden property.
+        # Redwood and later, we disable discussions entirely by toggling the discussion configuration enabled property.
+        # This ensures pre-Palm courses import with discussions tab appropriately shown/hidden.
+        for tab in course.tabs:
+            if tab.tab_id == 'discussion' and tab.is_hidden == validated_data.get('enabled'):
+                tab.is_hidden = not validated_data.get('enabled')
+                save = True
+                break
         if save:
             modulestore().update_item(course, self.context['user_id'])
         return instance

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -387,6 +387,26 @@ class DataTest(AuthorizedApiTest, DataTestMixin):
         assert data['plugin_configuration'] == {'key': 'value'}
         assert data['lti_configuration'] == DEFAULT_LTI_CONFIGURATION
 
+    @ddt.data(
+        True,
+        False,
+    )
+    def test_enabled_configuration(self, enabled):
+        """
+        Test that setting the "enabled" property for Discussions shows the Discussions tab.
+        """
+        payload = {
+            "provider_type": Provider.PIAZZA,
+            "enabled": enabled,
+        }
+        self._post(payload)
+
+        data = self.get()
+        for tab in self.store.get_course(self.course.id).tabs:
+            if tab.tab_id == "discussion":
+                assert data["enabled"] == (not tab.is_hidden)
+                break
+
     def test_change_plugin_configuration(self):
         """
         Tests custom config values persist that when changing discussion


### PR DESCRIPTION
## Description

Update the `is_hidden` property in the modulestore to store the visibility of the discussions tab properly.

## Supporting information

- https://github.com/open-craft/edx-platform/pull/677

## Testing instructions

1. Create a course in a Palm devstack/sandbox.
2. Set the discussion tab to hidden.
3. Export the course.
4. Import the course in a Redwood devstack/sandbox.
5. Create a Course Update
6. Verify the discussion tab disappears in the LMS.
7. Apply this change to the devstack/sandbox.
8. Enable the discussions in Studio Pages & Resources.
9. Create a Course Update.
10. Verify the discussion tab does not disappear this time.

## Deadline

None