### PR TITLE
feat: add LMS retirement listener for VerificationAttempts

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1214,3 +1214,13 @@ class VerificationAttempt(TimeStampedModel):
         null=True,
         blank=True,
     )
+
+    @classmethod
+    def retire_user(cls, user_id):
+        """
+        Retire user as part of GDPR pipeline
+
+        :param user_id: int
+        """
+        verification_attempts = cls.objects.filter(user_id=user_id)
+        verification_attempts.delete()

--- a/lms/djangoapps/verify_student/signals.py
+++ b/lms/djangoapps/verify_student/signals.py
@@ -10,9 +10,9 @@ from django.dispatch.dispatcher import receiver
 from xmodule.modulestore.django import SignalHandler, modulestore
 
 from common.djangoapps.student.models_api import get_name, get_pending_name_change
-from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_CRITICAL
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_CRITICAL, USER_RETIRE_LMS_MISC
 
-from .models import SoftwareSecurePhotoVerification, VerificationDeadline
+from .models import SoftwareSecurePhotoVerification, VerificationDeadline, VerificationAttempt
 
 log = logging.getLogger(__name__)
 
@@ -75,3 +75,9 @@ def send_idv_update(sender, instance, **kwargs):  # pylint: disable=unused-argum
         photo_id_name=instance.name,
         full_name=full_name
     )
+
+
+@receiver(USER_RETIRE_LMS_MISC)
+def _listen_for_lms_retire_verification_attempts(sender, **kwargs):  # pylint: disable=unused-argument
+    user = kwargs.get('user')
+    VerificationAttempt.retire_user(user.id)

--- a/lms/djangoapps/verify_student/tests/factories.py
+++ b/lms/djangoapps/verify_student/tests/factories.py
@@ -3,7 +3,7 @@ Factories related to student verification.
 """
 from factory.django import DjangoModelFactory
 
-from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, SSOVerification
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, SSOVerification, VerificationAttempt
 
 
 class SoftwareSecurePhotoVerificationFactory(DjangoModelFactory):
@@ -19,3 +19,8 @@ class SoftwareSecurePhotoVerificationFactory(DjangoModelFactory):
 class SSOVerificationFactory(DjangoModelFactory):
     class Meta():
         model = SSOVerification
+
+
+class VerificationAttemptFactory(DjangoModelFactory):
+    class Meta:
+        model = VerificationAttempt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Because the `VerificationAttempt` model contains PII, the data contained in that model should be removed upon user retirement. This PR adds an event listener for the `USER_RETIRE_LMS_MISC` signal, and deletes any `VerificationAttempt`s associated with the specified user upon receiving the event.

## Supporting information

[https://2u-internal.atlassian.net/browse/COSMO-464](https://2u-internal.atlassian.net/browse/COSMO-464)
[https://github.com/openedx/platform-roadmap/issues/367](https://github.com/openedx/platform-roadmap/issues/367
)
## Testing instructions

- Create a VerificationAttempt via the Django admin interface.
- Make a post request to `localhost:18000/api/user/v1/accounts/retire_misc/`, with a request body like `{ 'username': '<username for VerificationAttempt>'}`
- Assert that VerificationAttempt that was created for the user has been removed.
