### PR TITLE
temp: Log enterpriseDashboard on learner home InitializeView

### DIFF
--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -480,6 +480,10 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
         # Gather info for enterprise dashboard
         enterprise_customer = get_enterprise_customer(user, self.request, is_masquerade)
 
+        # TEMP log for learner dashboard enterpriseDashboard incident
+        logger.info(
+            f'Temp: enterprise customer: {enterprise_customer}'
+        )
         # Get site-wide social sharing config
         social_share_settings = get_social_share_settings()
 


### PR DESCRIPTION
Looking into the incident where the learner home dashboard (menu dropdown) does not load with an error on `entepriseDashboard` seen in `frontend-app-learner-dashboard`.

This log does not contain PII and is already logged in [enterprise_customer_from_session_or_learner_data](https://github.com/openedx/edx-platform/blob/dbc1b23d4d4db47cb6e2ac07dba53024b5ba9e5e/openedx/features/enterprise_support/api.py#L873)

**EDIT:** closing this PR as the root cause was found in `frontend-component-header-edx`.