### PR TITLE
chore: Bump the version of enmerkar-underscore

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -549,7 +549,7 @@ elasticsearch==7.13.4
     #   edx-search
 enmerkar==0.7.1
     # via enmerkar-underscore
-enmerkar-underscore==2.3.0
+enmerkar-underscore==2.3.1
     # via -r requirements/edx/kernel.in
 event-tracking==3.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -861,7 +861,7 @@ enmerkar==0.7.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   enmerkar-underscore
-enmerkar-underscore==2.3.0
+enmerkar-underscore==2.3.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -635,7 +635,7 @@ enmerkar==0.7.1
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar-underscore
-enmerkar-underscore==2.3.0
+enmerkar-underscore==2.3.1
     # via -r requirements/edx/base.txt
 event-tracking==3.0.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -661,7 +661,7 @@ enmerkar==0.7.1
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar-underscore
-enmerkar-underscore==2.3.0
+enmerkar-underscore==2.3.1
     # via -r requirements/edx/base.txt
 event-tracking==3.0.0
     # via


### PR DESCRIPTION
We need to correctly pull in the vendored markey files.

This should resolve the edx-platform translations issue noted in https://github.com/openedx/openedx-translations/issues/7066
