### PR TITLE
feat: Add override option to upgrade CTA utils and add course_run_key identifier

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -126,9 +126,9 @@ class ChooseModeView(View):
             if ecommerce_service.is_enabled(request.user):
                 professional_mode = modes.get(CourseMode.NO_ID_PROFESSIONAL_MODE) or modes.get(CourseMode.PROFESSIONAL)
                 if purchase_workflow == "single" and professional_mode.sku:
-                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.sku)
+                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.sku, course_run_key=course_id)
                 if purchase_workflow == "bulk" and professional_mode.bulk_sku:
-                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.bulk_sku)
+                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.bulk_sku, course_run_key=course_id)
             return redirect(redirect_url)
         course = modulestore().get_course(course_key)
 
@@ -237,7 +237,7 @@ class ChooseModeView(View):
 
             if verified_mode.sku:
                 context["use_ecommerce_payment_flow"] = ecommerce_service.is_enabled(request.user)
-                context["ecommerce_payment_page"] = ecommerce_service.get_add_to_basket_url()
+                context["ecommerce_payment_page"] = ecommerce_service.payment_page_url()
                 context["sku"] = verified_mode.sku
                 context["bulk_sku"] = verified_mode.bulk_sku
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -126,9 +126,13 @@ class ChooseModeView(View):
             if ecommerce_service.is_enabled(request.user):
                 professional_mode = modes.get(CourseMode.NO_ID_PROFESSIONAL_MODE) or modes.get(CourseMode.PROFESSIONAL)
                 if purchase_workflow == "single" and professional_mode.sku:
-                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.sku, course_run_keys=course_id)
+                    redirect_url = ecommerce_service.get_checkout_page_url(
+                        professional_mode.sku, course_run_keys=course_id
+                    )
                 if purchase_workflow == "bulk" and professional_mode.bulk_sku:
-                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.bulk_sku, course_run_keys=course_id)
+                    redirect_url = ecommerce_service.get_checkout_page_url(
+                        professional_mode.bulk_sku, course_run_keys=course_id
+                    )
             return redirect(redirect_url)
         course = modulestore().get_course(course_key)
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -126,9 +126,9 @@ class ChooseModeView(View):
             if ecommerce_service.is_enabled(request.user):
                 professional_mode = modes.get(CourseMode.NO_ID_PROFESSIONAL_MODE) or modes.get(CourseMode.PROFESSIONAL)
                 if purchase_workflow == "single" and professional_mode.sku:
-                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.sku, course_run_key=course_id)
+                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.sku, course_run_keys=course_id)
                 if purchase_workflow == "bulk" and professional_mode.bulk_sku:
-                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.bulk_sku, course_run_key=course_id)
+                    redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.bulk_sku, course_run_keys=course_id)
             return redirect(redirect_url)
         course = modulestore().get_course(course_key)
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -127,11 +127,11 @@ class ChooseModeView(View):
                 professional_mode = modes.get(CourseMode.NO_ID_PROFESSIONAL_MODE) or modes.get(CourseMode.PROFESSIONAL)
                 if purchase_workflow == "single" and professional_mode.sku:
                     redirect_url = ecommerce_service.get_checkout_page_url(
-                        professional_mode.sku, course_run_keys=course_id
+                        professional_mode.sku, course_run_keys=[course_id]
                     )
                 if purchase_workflow == "bulk" and professional_mode.bulk_sku:
                     redirect_url = ecommerce_service.get_checkout_page_url(
-                        professional_mode.bulk_sku, course_run_keys=course_id
+                        professional_mode.bulk_sku, course_run_keys=[course_id]
                     )
             return redirect(redirect_url)
         course = modulestore().get_course(course_key)
@@ -241,7 +241,7 @@ class ChooseModeView(View):
 
             if verified_mode.sku:
                 context["use_ecommerce_payment_flow"] = ecommerce_service.is_enabled(request.user)
-                context["ecommerce_payment_page"] = ecommerce_service.payment_page_url()
+                context["ecommerce_payment_page"] = ecommerce_service.get_add_to_basket_url()
                 context["sku"] = verified_mode.sku
                 context["bulk_sku"] = verified_mode.bulk_sku
 

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -160,7 +160,7 @@ class EcommerceService:
         verified_mode = CourseMode.verified_mode_for_course(course_key)
         if verified_mode:
             if self.is_enabled(user):
-                return self.get_checkout_page_url(verified_mode.sku, course_run_keys=course_run_key)
+                return self.get_checkout_page_url(verified_mode.sku, course_run_keys=[course_run_key])
             else:
                 return reverse('dashboard')
         return None

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -23,10 +23,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.theming import helpers as theming_helpers
 
 from .models import CommerceConfiguration
-from .waffle import (  # lint-amnesty, pylint: disable=invalid-django-waffle-import
-    should_redirect_to_commerce_coordinator_checkout,
-    should_redirect_to_commerce_coordinator_refunds,
-)
+from .waffle import should_redirect_to_commerce_coordinator_refunds
 from edx_django_utils.plugins import pluggable_override
 
 log = logging.getLogger(__name__)
@@ -111,6 +108,7 @@ class EcommerceService:
         return self.get_absolute_ecommerce_url(self.config.basket_checkout_page)
 
 
+    @pluggable_override('OVERRIDE_GET_CHECKOUT_PAGE_URL')
     def get_checkout_page_url(self, *skus, **kwargs):
         """ Construct the URL to the ecommerce checkout page and include products.
 
@@ -127,8 +125,7 @@ class EcommerceService:
         """
         program_uuid = kwargs.get('program_uuid')
         enterprise_catalog_uuid = kwargs.get('catalog')
-        course_run_key = kwargs.get('course_run_key')
-        query_params = {'sku': skus, 'course_run_key': course_run_key}
+        query_params = {'sku': skus}
         if enterprise_catalog_uuid:
             query_params.update({'catalog': enterprise_catalog_uuid})
 
@@ -152,7 +149,7 @@ class EcommerceService:
         verified_mode = CourseMode.verified_mode_for_course(course_key)
         if verified_mode:
             if self.is_enabled(user):
-                return self.get_checkout_page_url(verified_mode.sku, course_run_key=course_run_key)
+                return self.get_checkout_page_url(verified_mode.sku, course_run_keys=course_run_key)
             else:
                 return reverse('dashboard')
         return None

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -126,6 +126,7 @@ class EcommerceService:
         Args:
             skus (list): List of SKUs associated with products to be added to basket
             program_uuid (string): The UUID of the program, if applicable
+            course_run_keys (list): The course run keys of the products to be added to basket.
 
         Returns:
             Absolute path to the ecommerce checkout page showing basket that contains specified products.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -825,9 +825,13 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
                 single_paid_mode = modes.get(CourseMode.PROFESSIONAL)
 
             if single_paid_mode and single_paid_mode.sku:
-                ecommerce_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.sku, course_run_keys=course_id)
+                ecommerce_checkout_link = ecomm_service.get_checkout_page_url(
+                    single_paid_mode.sku, course_run_keys=course_id
+                )
             if single_paid_mode and single_paid_mode.bulk_sku:
-                ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.bulk_sku, course_run_keys=course_id)
+                ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(
+                    single_paid_mode.bulk_sku, course_run_keys=course_id
+                )
 
         registration_price, course_price = get_course_prices(course)  # lint-amnesty, pylint: disable=unused-variable
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -825,9 +825,9 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
                 single_paid_mode = modes.get(CourseMode.PROFESSIONAL)
 
             if single_paid_mode and single_paid_mode.sku:
-                ecommerce_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.sku, course_run_key=course_id)
+                ecommerce_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.sku, course_run_keys=course_id)
             if single_paid_mode and single_paid_mode.bulk_sku:
-                ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.bulk_sku, course_run_key=course_id)
+                ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.bulk_sku, course_run_keys=course_id)
 
         registration_price, course_price = get_course_prices(course)  # lint-amnesty, pylint: disable=unused-variable
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -826,11 +826,11 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
 
             if single_paid_mode and single_paid_mode.sku:
                 ecommerce_checkout_link = ecomm_service.get_checkout_page_url(
-                    single_paid_mode.sku, course_run_keys=course_id
+                    single_paid_mode.sku, course_run_keys=[course_id]
                 )
             if single_paid_mode and single_paid_mode.bulk_sku:
                 ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(
-                    single_paid_mode.bulk_sku, course_run_keys=course_id
+                    single_paid_mode.bulk_sku, course_run_keys=[course_id]
                 )
 
         registration_price, course_price = get_course_prices(course)  # lint-amnesty, pylint: disable=unused-variable

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -825,9 +825,9 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
                 single_paid_mode = modes.get(CourseMode.PROFESSIONAL)
 
             if single_paid_mode and single_paid_mode.sku:
-                ecommerce_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.sku)
+                ecommerce_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.sku, course_run_key=course_id)
             if single_paid_mode and single_paid_mode.bulk_sku:
-                ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.bulk_sku)
+                ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(single_paid_mode.bulk_sku, course_run_key=course_id)
 
         registration_price, course_price = get_course_prices(course)  # lint-amnesty, pylint: disable=unused-variable
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -504,7 +504,7 @@ class PayAndVerifyView(View):
                 url = ecommerce_service.get_checkout_page_url(
                     sku,
                     catalog=self.request.GET.get('catalog'),
-                    course_run_keys=str(course_key)
+                    course_run_keys=[str(course_key)]
                 )
 
         # Redirect if necessary, otherwise implicitly return None

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -504,7 +504,7 @@ class PayAndVerifyView(View):
                 url = ecommerce_service.get_checkout_page_url(
                     sku,
                     catalog=self.request.GET.get('catalog'),
-                    course_run_key = str(course_key)
+                    course_run_keys = str(course_key)
                 )
 
         # Redirect if necessary, otherwise implicitly return None

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -504,7 +504,7 @@ class PayAndVerifyView(View):
                 url = ecommerce_service.get_checkout_page_url(
                     sku,
                     catalog=self.request.GET.get('catalog'),
-                    course_run_keys = str(course_key)
+                    course_run_keys=str(course_key)
                 )
 
         # Redirect if necessary, otherwise implicitly return None

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -503,7 +503,8 @@ class PayAndVerifyView(View):
             if ecommerce_service.is_enabled(user):
                 url = ecommerce_service.get_checkout_page_url(
                     sku,
-                    catalog=self.request.GET.get('catalog')
+                    catalog=self.request.GET.get('catalog'),
+                    course_run_key = str(course_key)
                 )
 
         # Redirect if necessary, otherwise implicitly return None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5544,3 +5544,6 @@ SURVEY_REPORT_CHECK_THRESHOLD = 6
 # .. setting_default: empty dictionary
 # .. setting_description: Dictionary with additional information that you want to share in the report.
 SURVEY_REPORT_EXTRA_DATA = {}
+
+
+OVERRIDE_GET_ABSOLUTE_ECOMMERCE_URL = 'edx_ecommerce_extension.overrides.get_absolute_ecommerce_url'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5544,6 +5544,3 @@ SURVEY_REPORT_CHECK_THRESHOLD = 6
 # .. setting_default: empty dictionary
 # .. setting_description: Dictionary with additional information that you want to share in the report.
 SURVEY_REPORT_EXTRA_DATA = {}
-
-
-OVERRIDE_GET_ABSOLUTE_ECOMMERCE_URL = 'edx_ecommerce_extension.overrides.get_absolute_ecommerce_url'

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -631,7 +631,9 @@ class ProgramDataExtender:
             ecommerce = EcommerceService()
             sku = getattr(required_mode, "sku", None)
             if ecommerce.is_enabled(self.user) and sku:
-                run_mode["upgrade_url"] = ecommerce.get_checkout_page_url(required_mode.sku)
+                run_mode["upgrade_url"] = ecommerce.get_checkout_page_url(
+                    required_mode.sku, course_run_keys=self.course_run_key
+                )
             else:
                 run_mode["upgrade_url"] = None
         else:

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -632,7 +632,7 @@ class ProgramDataExtender:
             sku = getattr(required_mode, "sku", None)
             if ecommerce.is_enabled(self.user) and sku:
                 run_mode["upgrade_url"] = ecommerce.get_checkout_page_url(
-                    required_mode.sku, course_run_keys=self.course_run_key
+                    required_mode.sku, course_run_keys=[self.course_run_key]
                 )
             else:
                 run_mode["upgrade_url"] = None

--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -122,7 +122,7 @@ class ContentTypeGatingPartition(UserPartition):
         ecomm_service = EcommerceService()
         ecommerce_checkout = ecomm_service.is_enabled(user)
         if ecommerce_checkout and sku:
-            return ecomm_service.get_checkout_page_url(sku, course_run_key=course_run_key) or ''
+            return ecomm_service.get_checkout_page_url(sku, course_run_keys=course_run_key) or ''
 
     def _get_course_key_from_course_block(self, block):
         """

--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -122,7 +122,7 @@ class ContentTypeGatingPartition(UserPartition):
         ecomm_service = EcommerceService()
         ecommerce_checkout = ecomm_service.is_enabled(user)
         if ecommerce_checkout and sku:
-            return ecomm_service.get_checkout_page_url(sku, course_run_keys=course_run_key) or ''
+            return ecomm_service.get_checkout_page_url(sku, course_run_keys=[course_run_key]) or ''
 
     def _get_course_key_from_course_block(self, block):
         """

--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -91,7 +91,7 @@ class ContentTypeGatingPartition(UserPartition):
         if expiration_datetime and expiration_datetime < datetime.datetime.now(pytz.UTC):
             ecommerce_checkout_link = None
         else:
-            ecommerce_checkout_link = self._get_checkout_link(user, verified_mode.sku)
+            ecommerce_checkout_link = self._get_checkout_link(user, verified_mode.sku, str(course_key))
 
         request = crum.get_current_request()
 
@@ -118,11 +118,11 @@ class ContentTypeGatingPartition(UserPartition):
         else:
             return _("Graded assessments are available to Verified Track learners. Upgrade to Unlock.")
 
-    def _get_checkout_link(self, user, sku):
+    def _get_checkout_link(self, user, sku, course_run_key):
         ecomm_service = EcommerceService()
         ecommerce_checkout = ecomm_service.is_enabled(user)
         if ecommerce_checkout and sku:
-            return ecomm_service.get_checkout_page_url(sku) or ''
+            return ecomm_service.get_checkout_page_url(sku, course_run_key=course_run_key) or ''
 
     def _get_course_key_from_course_block(self, block):
         """

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -8,6 +8,7 @@ import pytz
 from django.conf import settings
 from django.utils.translation import get_language
 from django.utils.translation import gettext as _
+from edx_django_utils.plugins import pluggable_override
 
 from common.djangoapps.course_modes.models import format_course_price, get_course_prices
 from lms.djangoapps.experiments.models import ExperimentData
@@ -73,6 +74,7 @@ def _get_discount_prices(user, course, assume_discount=False):
         return format_course_price(base_price), None, None
 
 
+@pluggable_override("OVERRIDE_GENERATE_OFFER_DATA")
 def generate_offer_data(user, course):
     """
     Create a dictionary of information about the current discount offer.


### PR DESCRIPTION
## Description
This PR introduces override capabilities to the `EcommerceService` class utilities. Currently, upgrade CTA URLs across `edx-platform` depend on the `get_checkout_page_url` and `get_absolute_ecommerce_url` methods, both of which are closely tied to the Oscar-based `ecommerce` system. This tight coupling presents challenges when attempting to integrate alternative ecommerce systems. With this PR, alternative implementations for these methods can be provided by leveraging the [pluggable_override](https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/pluggable_override.py#L11) functionality from `edx_django_utils`.

## Other information

- Does this change depend on other changes elsewhere?
To utilize this functionality, developers must define the path to the alternative implementations in the settings file using the override flags.
Override flags being introduced in this PR:

1. `OVERRIDE_GET_CHECKOUT_PAGE_URL`
2. `OVERRIDE_GET_ABSOLUTE_ECOMMERCE_URL`

Override implementation needs to be housed somewhere else outside of `edx-platform` which can be a pluggable app installed independently in edx-platform requirements
