### PR TITLE
feat: add studio_access attribute to metadata

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/serializers.py
@@ -43,6 +43,7 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     """
     celebrations = serializers.DictField()
     course_access = serializers.DictField()
+    studio_access = serializers.BooleanField()
     course_id = serializers.CharField()
     is_enrolled = serializers.BooleanField()
     is_self_paced = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -20,7 +20,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.course_goals.models import UserActivity
 from lms.djangoapps.course_home_api.course_metadata.serializers import CourseHomeMetadataSerializer
-from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access, has_cms_access
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
 from lms.djangoapps.courseware.courses import check_course_access
 from lms.djangoapps.courseware.masquerade import setup_masquerade
@@ -124,6 +124,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
         data = {
             'course_id': course.id,
             'username': username,
+            'studio_access': has_cms_access(request.user, course_key),
             'is_staff': has_access(request.user, 'staff', course_key).has_access,
             'original_user_is_staff': original_user_is_staff,
             'number': course.display_number_with_default,

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -97,6 +97,7 @@ def has_ccx_coach_role(user, course_key):
                                             "user is a coach on CCX, you must provide key to CCX")
     return False
 
+
 def has_cms_access(user, course_key):
     """
     Check if user has access to the CMS. When requesting from the LMS, a user with the
@@ -113,8 +114,8 @@ def has_cms_access(user, course_key):
     """
     has_course_author_access = auth.has_course_author_access(user, course_key)
     is_limited_staff = auth.user_has_role(
-            user, CourseLimitedStaffRole(course_key)
-        ) and not GlobalStaff().has_user(user)
+        user, CourseLimitedStaffRole(course_key)
+    ) and not GlobalStaff().has_user(user)
 
     if is_limited_staff and has_course_author_access:
         return False

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -119,9 +119,8 @@ def has_cms_access(user, course_key):
 
     if is_limited_staff and has_course_author_access:
         return False
-    if has_course_author_access:
-        return True
-    return False
+
+    return has_course_author_access
 
 
 @function_trace('has_access')
@@ -439,7 +438,6 @@ def _has_access_course(user, action, courselike):
         )
 
     checkers = {
-        # 'cms': lambda: auth.has_course_author_access(user, courselike.id),
         'load': can_load,
         'load_mobile': lambda: can_load() and _can_load_course_on_mobile(user, courselike),
         'enroll': can_enroll,

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -330,7 +330,6 @@ def _has_access_course(user, action, courselike):
 
     Valid actions:
 
-    'cms' -- can load and has access to cms view of course
     'load' -- load the courseware, see inside the course
     'load_forum' -- can load and contribute to the forums (one access level for now)
     'load_mobile' -- can load from a mobile context


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds `studio_access` attribute to a courses metadata for LMS requests. This field is used when determining is the "View in Studio" button is showed in the Instructors Toolbar. Currently the button appears for all staff members regardless of their studio permissions. However, the "Limited Staff" role does not have access to Studio, but is shown the Studio button and sees a 403 error when trying to load the Studio page. This change impacts Authors.

## Supporting information

JIRA Ticket: [AU-2055 🔒](https://2u-internal.atlassian.net/browse/AU-2055)

> Expected behavior
>
> The Studio button should not be visible since this role doesn’t have permission to view content in Studio.
> 
> Studio will not load because this role doesn’t grant access to it. 
> 
> Actual behavior
> The Studio button is visible even though this role doesn’t have permission to view content in Studio.
> 
> Studio does not load. Instead, an error message displays:
> 
>  > 403 Forbidden

## Testing instructions

Using `frontend-app-learing/KristinAoki/fix-studio-button-limited-staff` branch

1. Go to Instructor > Membership > “Course Team Management”.
2. Select “Limited Staff” from the dropdown. 
3. Add a test account of yours to this role.
4. Save your changes.
5. As this test account, sign in.. 
6. Go to the course you added yourself to. 
7. See the Banner bar that contains the masquerade (“View this course as:”) toolbar.
8. Confirm that the Studio button is not present.
9. Log back into instructor account
10. Confirm that the Studio button is present.

## Deadline

None

## Other information

openedx/frontend-app-learning PR [#1452](https://github.com/openedx/frontend-app-learning/pull/1452) is dependent on this change
