### PR TITLE
feat: show error on courses with unknown proctoring providers

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
@@ -277,18 +277,14 @@ class ProctoringExamSettingsPostTests(
 
         # response is correct
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        self.assertDictEqual(
-            response.data,
+        self.assertIn(
             {
-                "detail": [
-                    {
-                        "proctoring_provider": (
-                            "The selected proctoring provider, notvalidprovider, is not a valid provider. "
-                            "Please select from one of ['test_proctoring_provider']."
-                        )
-                    }
-                ]
+                "proctoring_provider": (
+                    "The selected proctoring provider, notvalidprovider, is not a valid provider. "
+                    "Please select from one of ['test_proctoring_provider']."
+                )
             },
+            response.data['detail'],
         )
 
         # course settings have been updated
@@ -408,18 +404,14 @@ class ProctoringExamSettingsPostTests(
 
         # response is correct
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        self.assertDictEqual(
-            response.data,
+        self.assertIn(
             {
-                "detail": [
-                    {
-                        "proctoring_provider": (
-                            "The selected proctoring provider, lti_external, is not a valid provider. "
-                            "Please select from one of ['null']."
-                        )
-                    }
-                ]
+                "proctoring_provider": (
+                    "The selected proctoring provider, lti_external, is not a valid provider. "
+                    "Please select from one of ['null']."
+                )
             },
+            response.data['detail'],
         )
 
         # course settings have been updated

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -490,17 +490,30 @@ class CourseMetadata:
             enable_proctoring = block.enable_proctored_exams
 
         if enable_proctoring:
+
+            if proctoring_provider_model:
+                proctoring_provider = proctoring_provider_model.get('value')
+            else:
+                proctoring_provider = block.proctoring_provider
+
+            # If the proctoring provider stored in the course block no longer
+            # matches the available providers for this instance, show an error
+            if proctoring_provider not in available_providers:
+                message = (
+                    f'The proctoring provider configured for this course, \'{proctoring_provider}\', is not valid.'
+                )
+                errors.append({
+                    'key': 'proctoring_provider',
+                    'message': message,
+                    'model': proctoring_provider_model
+                })
+
             # Require a valid escalation email if Proctortrack is chosen as the proctoring provider
             escalation_email_model = settings_dict.get('proctoring_escalation_email')
             if escalation_email_model:
                 escalation_email = escalation_email_model.get('value')
             else:
                 escalation_email = block.proctoring_escalation_email
-
-            if proctoring_provider_model:
-                proctoring_provider = proctoring_provider_model.get('value')
-            else:
-                proctoring_provider = block.proctoring_provider
 
             missing_escalation_email_msg = 'Provider \'{provider}\' requires an exam escalation contact.'
             if proctoring_provider_model and proctoring_provider == 'proctortrack':


### PR DESCRIPTION
## Description

If the available PROCTORING_BACKENDS on an instance ever changes there may be courses with old values stored in the course block that no longer exist. This error message is shown when loading a course in this state to prompt course teams to resolve the error.

Depends on https://github.com/openedx/edx-platform/pull/35430


![Screenshot 2024-09-06 at 1 44 45 PM](https://github.com/user-attachments/assets/bc76f8fc-c381-4c1a-87b3-ac9e882b237d)

