### PR TITLE
build!: Switch to ubuntu-latest for builds

### DIFF
--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python-version:
           - "3.11"
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-latest"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/compile-python-requirements.yml
+++ b/.github/workflows/compile-python-requirements.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   recompile-python-dependencies:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out target branch

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         node-version: [18, 20]
         python-version:
           - "3.11"

--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-imports:
     name: Lint Python Imports
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out branch

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version:
           - "3.11"
         # 'pinned' is used to install the latest patch version of Django

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Setup mongodb user
         run: |
-          mongosh edxapp --eval '
+          docker exec ${{ job.services.mongo.id }} mongosh edxapp --eval '
             db.createUser(
               {
                 user: "edxapp",
@@ -67,7 +67,7 @@ jobs:
       - name: Verify mongo and mysql db credentials
         run: |
           mysql -h 127.0.0.1 -uedxapp001 -ppassword -e "select 1;" edxapp
-          mongosh --host 127.0.0.1 --username edxapp --password password --eval 'use edxapp; db.adminCommand("ping");' edxapp
+          docker exec ${{ job.services.mongo.id }} mongosh --host 127.0.0.1 --username edxapp --password password --eval 'use edxapp; db.adminCommand("ping");' edxapp
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish-ci-docker-image.yml
+++ b/.github/workflows/publish-ci-docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-pylint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version:
           - "3.11"
         node-version: [20]

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-latest"]
         python-version:
           - "3.11"
 

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version:
           - "3.11"
         node-version: [18, 20]

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -72,9 +72,6 @@ jobs:
         run: |
           pip install -r requirements/edx/assets.txt
 
-      - name: Initiate Mongo DB Service
-        run: sudo systemctl start mongod
-
       - name: Add node_modules bin to $Path
         run: echo $GITHUB_WORKSPACE/node_modules/.bin >> $GITHUB_PATH
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   run-tests:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
@@ -142,7 +142,7 @@ jobs:
           overwrite: true
 
   collect-and-verify:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -207,7 +207,7 @@ jobs:
   # https://github.com/orgs/community/discussions/33579
   success:
     name: Unit tests successful
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: always()
     needs: [run-tests]
     steps:
@@ -218,7 +218,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
   compile-warnings-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [run-tests]
     steps:
       - uses: actions/checkout@v4
@@ -246,7 +246,7 @@ jobs:
           overwrite: true
 
   merge-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [compile-warnings-report]
     steps:
       - name: Merge Pytest Warnings JSON Artifacts
@@ -266,7 +266,7 @@ jobs:
   # Combine and upload coverage reports.
   coverage:
     if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [run-tests]
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,29 @@ jobs:
 
       - name: install system requirements
         run: |
-          sudo apt-get update && sudo apt-get install libmysqlclient-dev libxmlsec1-dev lynx
+          sudo apt-get update && sudo apt-get install libmysqlclient-dev libxmlsec1-dev lynx openssl
+
+      # This is needed until the ENABLE_BLAKE2B_HASHING can be removed and we
+      # can stop using MD4 by default.
+      - name: enable md4 hashing in libssl
+        run: |
+          cat <<EOF | sudo tee /etc/ssl/openssl.cnf
+          # Use this in order to automatically load providers.
+          openssl_conf = openssl_init
+
+          [openssl_init]
+          providers = provider_sect
+
+          [provider_sect]
+          default = default_sect
+          legacy = legacy_sect
+
+          [default_sect]
+          activate = 1
+
+          [legacy_sect]
+          activate = 1
+          EOF
 
       - name: install mongo version
         run: |

--- a/.github/workflows/upgrade-one-python-dependency.yml
+++ b/.github/workflows/upgrade-one-python-dependency.yml
@@ -28,7 +28,7 @@ defaults:
 
 jobs:
   upgrade-one-python-dependency:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out target branch

--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   verify_dunder_init:
     name: Verify __init__.py Files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out branch


### PR DESCRIPTION
This code does not have any dependencies that are specific to any specific
version of ubuntu.  So instead of testing on a specific version and then needing
to do work to keep the versions up-to-date, we switch to the ubuntu-latest
target which should be sufficient for testing purposes.

This work is being done as a part of https://github.com/openedx/platform-roadmap/issues/377

closes https://github.com/openedx/edx-platform/issues/35314

Part of https://github.com/openedx/public-engineering/issues/278

⚠️ Operators Note ⚠️: In newer versions of ubuntu the MD4 hashing algorithm
is disabled by default. To enable it the openssl config needs to be
updated in a manner similar to what's being done here. Alternatively,
you can set the FEATURES['ENABLE_BLAKE2B_HASHING'] setting to True
which will switch to a newer hashing algorithm where MD4 was previously
used.

Because this hashing is being used as a part of [the edx-platform caching
mechanism](https://github.com/openedx/edx-platform/blob/master/lms/envs/common.py#L1173-L1262), this will effectively clear the cache for the items that use
this hash. The will impact any items where the cache key might have been
too big to store in memcache so it's hard to predict exactly which items
will be impacted.


**This build switches CI from Ubuntu 20.04 to 22.04.**

As a part of the review of this PR, we clarified that the edx-platform tests have never been testing with Codejail/Apparmor setup.  The testing of that subsystem has always happened in the `codejail` repository.  Making a note of that here for future readers in-case there is concern that this change would somehow break or not sufficiently test the codejail <-> apparmor integration.

This came from [the discussion here](https://discuss.openedx.org/t/depr-testing-on-ubuntu-20-04/13887/11).
