### PR TITLE
feat: use idv approved event

### DIFF
--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -583,7 +583,7 @@ class SetIDVerificationStatusTestCase(TestCase):
         """
         Verification signal is sent upon approval.
         """
-        with mock.patch('openedx.core.djangoapps.signals.signals.LEARNER_NOW_VERIFIED.send_robust') as mock_signal:
+        with mock.patch('openedx_events.learning.signals.IDV_ATTEMPT_APPROVED.send_event') as mock_signal:
             # Begin the pipeline.
             pipeline.set_id_verification_status(
                 auth_entry=pipeline.AUTH_ENTRY_LOGIN,

--- a/lms/djangoapps/certificates/docs/diagrams/certificate_generation.dsl
+++ b/lms/djangoapps/certificates/docs/diagrams/certificate_generation.dsl
@@ -31,7 +31,7 @@ workspace {
         }
 
         grades_app -> signal_handlers "Emits COURSE_GRADE_NOW_PASSED signal"
-        verify_student_app -> signal_handlers "Emits LEARNER_NOW_VERIFIED signal"
+        verify_student_app -> signal_handlers "Emits IDV_ATTEMPT_APPROVED signal"
         student_app -> signal_handlers "Emits ENROLLMENT_TRACK_UPDATED signal"
         allowlist -> signal_handlers "Emits APPEND_CERTIFICATE_ALLOWLIST signal"
         signal_handlers -> generation_handler "Invokes generate_allowlist_certificate()"

--- a/lms/djangoapps/verify_student/management/commands/tests/test_backfill_sso_verifications_for_old_account_links.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_backfill_sso_verifications_for_old_account_links.py
@@ -54,7 +54,7 @@ class TestBackfillSSOVerificationsCommand(TestCase):
         #self.assertNumQueries(100)
 
     def test_signal_called(self):
-        with patch('openedx.core.djangoapps.signals.signals.LEARNER_NOW_VERIFIED.send_robust') as mock_signal:
+        with patch('openedx_events.learning.signals.IDV_ATTEMPT_APPROVED.send_event') as mock_signal:
             call_command('backfill_sso_verifications_for_old_account_links', '--provider-slug', self.provider.provider_id)  # lint-amnesty, pylint: disable=line-too-long
         assert mock_signal.call_count == 1
 

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -42,8 +42,9 @@ from lms.djangoapps.verify_student.ssencrypt import (
     rsa_decrypt,
     rsa_encrypt
 )
-from openedx.core.djangoapps.signals.signals import LEARNER_NOW_VERIFIED
 from openedx.core.storage import get_storage
+from openedx_events.learning.signals import IDV_ATTEMPT_APPROVED
+from openedx_events.learning.data import UserData, VerificationAttemptData
 
 from .utils import auto_verify_for_testing_enabled, earliest_allowed_verification_date, submit_request_to_ss
 
@@ -248,13 +249,23 @@ class SSOVerification(IDVerificationAttempt):
             user_id=self.user, reviewer=approved_by
         ))
 
-        # Emit signal to find and generate eligible certificates
-        LEARNER_NOW_VERIFIED.send_robust(
-            sender=SSOVerification,
-            user=self.user
+        # Emit event to find and generate eligible certificates
+        verification_data = VerificationAttemptData(
+            attempt_id=self.id,
+            user=UserData(
+                pii=None,
+                id=self.user.id,
+                is_active=self.user.is_active,
+            ),
+            status=self.status,
+            name=self.name,
+            expiration_date=self.expiration_datetime,
+        )
+        IDV_ATTEMPT_APPROVED.send_event(
+            idv_attempt=verification_data,
         )
 
-        message = 'LEARNER_NOW_VERIFIED signal fired for {user} from SSOVerification'
+        message = 'IDV_ATTEMPT_APPROVED signal fired for {user} from SSOVerification'
         log.info(message.format(user=self.user.username))
 
 
@@ -451,13 +462,24 @@ class PhotoVerification(IDVerificationAttempt):
             days=settings.VERIFY_STUDENT["DAYS_GOOD_FOR"]
         )
         self.save()
-        # Emit signal to find and generate eligible certificates
-        LEARNER_NOW_VERIFIED.send_robust(
-            sender=PhotoVerification,
-            user=self.user
+
+        # Emit event to find and generate eligible certificates
+        verification_data = VerificationAttemptData(
+            attempt_id=self.id,
+            user=UserData(
+                pii=None,
+                id=self.user.id,
+                is_active=self.user.is_active,
+            ),
+            status=self.status,
+            name=self.name,
+            expiration_date=self.expiration_datetime,
+        )
+        IDV_ATTEMPT_APPROVED.send_event(
+            idv_attempt=verification_data,
         )
 
-        message = 'LEARNER_NOW_VERIFIED signal fired for {user} from PhotoVerification'
+        message = 'IDV_ATTEMPT_APPROVED signal fired for {user} from PhotoVerification'
         log.info(message.format(user=self.user.username))
 
     @status_before_must_be("ready", "must_retry")

--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -36,9 +36,5 @@ COURSE_GRADE_NOW_PASSED = Signal()
 # ]
 COURSE_GRADE_NOW_FAILED = Signal()
 
-# Signal that indicates that a user has become verified for certificate purposes
-# providing_args=['user']
-LEARNER_NOW_VERIFIED = Signal()
-
 # providing_args=['user']
 USER_ACCOUNT_ACTIVATED = Signal()  # Signal indicating email verification


### PR DESCRIPTION
#### Description
`IDV_ATTEMPT_APPROVED ` is a new openedx event introduced as part of https://github.com/openedx/platform-roadmap/issues/367. No changes in functionality here, this simply replaces the existing signal with an standardized event that can be emitted by a pluggable IDV implementation down the line.

JIRA: [COSMO-428](https://2u-internal.atlassian.net/browse/COSMO-428) (2U-internal)