### PR TITLE
feat: return publishing information on get component endpoint [FC-0062]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -219,7 +219,7 @@ class LibraryXBlockMetadata:
     display_name = attr.ib("")
     last_published = attr.ib(default=None, type=datetime)
     last_draft_created = attr.ib(default=None, type=datetime)
-    last_draft_created_by = attr.ib(default=None, type=datetime)
+    last_draft_created_by = attr.ib("")
     published_by = attr.ib("")
     has_unpublished_changes = attr.ib(False)
     tags_count = attr.ib(0)

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -236,11 +236,9 @@ class LibraryXBlockMetadata:
         if last_publish_log and last_publish_log.published_by:
             published_by = last_publish_log.published_by.username
 
-        last_draft_log = authoring_api.get_entities_with_unpublished_changes(component.pk) \
-            .order_by('-created').first()
-        last_draft_created = last_draft_log.created if last_draft_log else None
-        last_draft_created_by = \
-            last_draft_log.created_by.username if last_draft_log and last_draft_log.created_by else None
+        draft = component.versioning.draft
+        last_draft_created = draft.created if draft else None
+        last_draft_created_by = draft.publishable_entity_version.created_by if draft else None
 
         return cls(
             usage_key=LibraryUsageLocatorV2(

--- a/openedx/core/djangoapps/content_libraries/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/serializers.py
@@ -148,7 +148,12 @@ class LibraryXBlockMetadataSerializer(serializers.Serializer):
 
     block_type = serializers.CharField(source="usage_key.block_type")
     display_name = serializers.CharField(read_only=True)
+    last_published = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
+    published_by = serializers.CharField(read_only=True)
+    last_draft_created = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
+    last_draft_created_by = serializers.CharField(read_only=True)
     has_unpublished_changes = serializers.BooleanField(read_only=True)
+    created = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
 
     # When creating a new XBlock in a library, the slug becomes the ID part of
     # the definition key and usage key:

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -5,9 +5,11 @@ from unittest.mock import Mock, patch
 from unittest import skip
 
 import ddt
+from datetime import datetime, timezone
 from uuid import uuid4
 from django.contrib.auth.models import Group
 from django.test.client import Client
+from freezegun import freeze_time
 from organizations.models import Organization
 from rest_framework.test import APITestCase
 
@@ -287,10 +289,14 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         assert self._get_library(lib_id)['has_unpublished_changes'] is True
 
         # Publish the changes:
-        self._commit_library_changes(lib_id)
+        updated_date = datetime(2024, 6, 7, 8, 9, 10, tzinfo=timezone.utc)
+        with freeze_time(updated_date):
+            self._commit_library_changes(lib_id)
         assert self._get_library(lib_id)['has_unpublished_changes'] is False
         # And now the block information should also show that block has no unpublished changes:
         block_data["has_unpublished_changes"] = False
+        block_data["last_published"] = updated_date.isoformat().replace('+00:00', 'Z')
+        block_data["published_by"] = "Bob"
         self.assertDictContainsEntries(self._get_library_block(block_id), block_data)
         assert self._get_library_blocks(lib_id)['results'] == [block_data]
 
@@ -372,10 +378,14 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         assert self._get_library(lib_id)['has_unpublished_changes'] is True
 
         # Publish the changes:
-        self._commit_library_changes(lib_id)
+        updated_date = datetime(2024, 6, 7, 8, 9, 10, tzinfo=timezone.utc)
+        with freeze_time(updated_date):
+            self._commit_library_changes(lib_id)
         assert self._get_library(lib_id)['has_unpublished_changes'] is False
         # And now the block information should also show that block has no unpublished changes:
         block_data["has_unpublished_changes"] = False
+        block_data["last_published"] = updated_date.isoformat().replace('+00:00', 'Z')
+        block_data["published_by"] = "Bob"
         self.assertDictContainsEntries(self._get_library_block(block_id), block_data)
         assert self._get_library_blocks(lib_id)['results'] == [block_data]
 

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -272,12 +272,18 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         assert self._get_library_blocks(lib_id)['results'] == []
 
         # Add a 'problem' XBlock to the library:
-        block_data = self._add_block_to_library(lib_id, "problem", "ࠒröblæm1")
+        create_date = datetime(2024, 6, 6, 6, 6, 6, tzinfo=timezone.utc)
+        with freeze_time(create_date):
+            block_data = self._add_block_to_library(lib_id, "problem", "ࠒröblæm1")
         self.assertDictContainsEntries(block_data, {
             "id": "lb:CL-TEST:téstlꜟط:problem:ࠒröblæm1",
             "display_name": "Blank Problem",
             "block_type": "problem",
             "has_unpublished_changes": True,
+            "last_published": None,
+            "published_by": None,
+            "last_draft_created": create_date.isoformat().replace('+00:00', 'Z'),
+            "last_draft_created_by": "Bob",
         })
         block_id = block_data["id"]
         # Confirm that the result contains a definition key, but don't check its value,
@@ -289,13 +295,13 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         assert self._get_library(lib_id)['has_unpublished_changes'] is True
 
         # Publish the changes:
-        updated_date = datetime(2024, 6, 7, 8, 9, 10, tzinfo=timezone.utc)
-        with freeze_time(updated_date):
+        publish_date = datetime(2024, 7, 7, 7, 7, 7, tzinfo=timezone.utc)
+        with freeze_time(publish_date):
             self._commit_library_changes(lib_id)
         assert self._get_library(lib_id)['has_unpublished_changes'] is False
         # And now the block information should also show that block has no unpublished changes:
         block_data["has_unpublished_changes"] = False
-        block_data["last_published"] = updated_date.isoformat().replace('+00:00', 'Z')
+        block_data["last_published"] = publish_date.isoformat().replace('+00:00', 'Z')
         block_data["published_by"] = "Bob"
         self.assertDictContainsEntries(self._get_library_block(block_id), block_data)
         assert self._get_library_blocks(lib_id)['results'] == [block_data]
@@ -317,13 +323,16 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             </multiplechoiceresponse>
         </problem>
         """.strip()
-        self._set_library_block_olx(block_id, new_olx)
+        update_date = datetime(2024, 8, 8, 8, 8, 8, tzinfo=timezone.utc)
+        with freeze_time(update_date):
+            self._set_library_block_olx(block_id, new_olx)
         # now reading it back, we should get that exact OLX (no change to whitespace etc.):
         assert self._get_library_block_olx(block_id) == new_olx
         # And the display name and "unpublished changes" status of the block should be updated:
         self.assertDictContainsEntries(self._get_library_block(block_id), {
             "display_name": "New Multi Choice Question",
             "has_unpublished_changes": True,
+            "last_draft_created": update_date.isoformat().replace('+00:00', 'Z')
         })
 
         # Now view the XBlock's student_view (including draft changes):
@@ -364,12 +373,18 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         assert self._get_library_blocks(lib_id)['results'] == []
 
         # Add a 'html' XBlock to the library:
-        block_data = self._add_block_to_library(lib_id, "html", "html1")
+        create_date = datetime(2024, 6, 6, 6, 6, 6, tzinfo=timezone.utc)
+        with freeze_time(create_date):
+            block_data = self._add_block_to_library(lib_id, "html", "html1")
         self.assertDictContainsEntries(block_data, {
             "id": "lb:CL-TEST:testlib2:html:html1",
             "display_name": "Text",
             "block_type": "html",
             "has_unpublished_changes": True,
+            "last_published": None,
+            "published_by": None,
+            "last_draft_created": create_date.isoformat().replace('+00:00', 'Z'),
+            "last_draft_created_by": "Bob",
         })
         block_id = block_data["id"]
 
@@ -378,13 +393,13 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         assert self._get_library(lib_id)['has_unpublished_changes'] is True
 
         # Publish the changes:
-        updated_date = datetime(2024, 6, 7, 8, 9, 10, tzinfo=timezone.utc)
-        with freeze_time(updated_date):
+        publish_date = datetime(2024, 7, 7, 7, 7, 7, tzinfo=timezone.utc)
+        with freeze_time(publish_date):
             self._commit_library_changes(lib_id)
         assert self._get_library(lib_id)['has_unpublished_changes'] is False
         # And now the block information should also show that block has no unpublished changes:
         block_data["has_unpublished_changes"] = False
-        block_data["last_published"] = updated_date.isoformat().replace('+00:00', 'Z')
+        block_data["last_published"] = publish_date.isoformat().replace('+00:00', 'Z')
         block_data["published_by"] = "Bob"
         self.assertDictContainsEntries(self._get_library_block(block_id), block_data)
         assert self._get_library_blocks(lib_id)['results'] == [block_data]
@@ -393,13 +408,17 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         orig_olx = self._get_library_block_olx(block_id)
         assert '<html' in orig_olx
         new_olx = "<html><b>Hello world!</b></html>"
-        self._set_library_block_olx(block_id, new_olx)
+
+        update_date = datetime(2024, 8, 8, 8, 8, 8, tzinfo=timezone.utc)
+        with freeze_time(update_date):
+            self._set_library_block_olx(block_id, new_olx)
         # now reading it back, we should get that exact OLX (no change to whitespace etc.):
         assert self._get_library_block_olx(block_id) == new_olx
         # And the display name and "unpublished changes" status of the block should be updated:
         self.assertDictContainsEntries(self._get_library_block(block_id), {
             "display_name": "Text",
             "has_unpublished_changes": True,
+            "last_draft_created": update_date.isoformat().replace('+00:00', 'Z')
         })
 
         # Now view the XBlock's studio view (including draft changes):
@@ -1029,6 +1048,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             # the the block in the clipboard
             self.assertDictContainsEntries(self._get_library_block(paste_data["id"]), {
                 **block_data,
+                "last_draft_created_by": None,
                 "id": f"lb:CL-TEST:test_lib_paste_clipboard:problem:{pasted_block_id}",
             })
 

--- a/openedx/core/djangoapps/content_tagging/tests/test_objecttag_export_helpers.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_objecttag_export_helpers.py
@@ -4,14 +4,15 @@ Test the objecttag_export_helpers module
 import time
 from unittest.mock import patch
 
+from openedx_tagging.core.tagging.models import ObjectTag
+from organizations.models import Organization
+
 from openedx.core.djangoapps.content_libraries import api as library_api
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 from .. import api
 from ..helpers.objecttag_export_helpers import TaggedContent, build_object_tree_with_objecttags, iterate_with_level
-from openedx_tagging.core.tagging.models import ObjectTag
-from organizations.models import Organization
 
 
 class TestGetAllObjectTagsMixin:
@@ -441,7 +442,7 @@ class TestContentTagChildrenExport(TaggedCourseMixin):  # type: ignore[misc]
         """
         Test if we can export a library
         """
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(8):
             tagged_library = build_object_tree_with_objecttags(self.library.key, self.all_library_object_tags)
 
         assert tagged_library == self.expected_library_tagged_xblock

--- a/openedx/core/djangoapps/content_tagging/tests/test_objecttag_export_helpers.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_objecttag_export_helpers.py
@@ -441,7 +441,7 @@ class TestContentTagChildrenExport(TaggedCourseMixin):  # type: ignore[misc]
         """
         Test if we can export a library
         """
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(11):
             tagged_library = build_object_tree_with_objecttags(self.library.key, self.all_library_object_tags)
 
         assert tagged_library == self.expected_library_tagged_xblock

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -93,7 +93,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-openedx-learning==0.11.4
+# openedx-learning==0.11.5
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -93,7 +93,7 @@ libsass==0.10.0
 click==8.1.6
 
 # pinning this version to avoid updates while the library is being developed
-# openedx-learning==0.11.5
+openedx-learning==0.11.5
 
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
 openai<=0.28.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -825,7 +825,9 @@ openedx-filters==1.9.0
     #   lti-consumer-xblock
     #   ora2
 openedx-learning==0.11.5
-    # via -r requirements/edx/kernel.in
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/kernel.in
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -824,7 +824,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
+openedx-learning==0.11.5
     # via -r requirements/edx/kernel.in
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -824,10 +824,8 @@ openedx-filters==1.9.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.4
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/kernel.in
+openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
+    # via -r requirements/edx/kernel.in
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1373,9 +1373,8 @@ openedx-filters==1.9.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.4
+openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 openedx-mongodbproxy==0.2.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1375,6 +1375,7 @@ openedx-filters==1.9.0
     #   ora2
 openedx-learning==0.11.5
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 openedx-mongodbproxy==0.2.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1373,7 +1373,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
+openedx-learning==0.11.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -984,7 +984,9 @@ openedx-filters==1.9.0
     #   lti-consumer-xblock
     #   ora2
 openedx-learning==0.11.5
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -983,10 +983,8 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.4
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
+    # via -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -983,7 +983,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
+openedx-learning==0.11.5
     # via -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -120,8 +120,6 @@ openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-learning                    # Open edX Learning core (experimental)
-# openedx-learning                    # Open edX Learning core (experimental)
-openedx-learning@git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
 openedx-mongodbproxy
 openedx-django-wiki
 path

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -120,6 +120,8 @@ openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-learning                    # Open edX Learning core (experimental)
+# openedx-learning                    # Open edX Learning core (experimental)
+openedx-learning@git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
 openedx-mongodbproxy
 openedx-django-wiki
 path

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1034,7 +1034,7 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
+openedx-learning==0.11.5
     # via -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1035,7 +1035,9 @@ openedx-filters==1.9.0
     #   lti-consumer-xblock
     #   ora2
 openedx-learning==0.11.5
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1034,10 +1034,8 @@ openedx-filters==1.9.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.11.4
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+openedx-learning @ git+https://github.com/open-craft/openedx-learning/@rpenido/fal-3802-component-sidebar-manage-tab
+    # via -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1


### PR DESCRIPTION
## Description

This PR adds the following fields to the `LibraryXBlockMetadata` object, to be used in the component sidebar:
- `last_draft_created`
- `last_draft_created_by`
- `published_by`
- `created`

## More information

Part of:
 - https://github.com/openedx/frontend-app-course-authoring/issues/1190

## Testing Instructions

Check https://github.com/openedx/frontend-app-course-authoring/pull/1275
___
Private ref: [FAL-3802](https://tasks.opencraft.com/browse/FAL-3802)