### PR TITLE
feat: Add collection tags to index [FC-0062]

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -608,6 +608,17 @@ def upsert_block_collections_index_docs(usage_key: UsageKey):
     _update_index_docs([doc])
 
 
+def upsert_collection_tags_index_docs(collection_usage_key: LibraryLocatorV2):
+    """
+    Updates the tags data in documents for the given library collection
+    """
+    collection = lib_api.get_library_collection_from_usage_key(collection_usage_key)
+
+    doc = {Fields.id: collection.id}
+    doc.update(collection_usage_key.library_key, collection)
+    _update_index_docs([doc])
+
+
 def _get_user_orgs(request: Request) -> list[str]:
     """
     Get the org.short_names for the organizations that the requesting user has OrgStaffRole or OrgInstructorRole.

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -18,7 +18,7 @@ from meilisearch import Client as MeilisearchClient
 from meilisearch.errors import MeilisearchError
 from meilisearch.models.task import TaskInfo
 from opaque_keys.edx.keys import UsageKey
-from opaque_keys.edx.locator import LibraryLocatorV2
+from opaque_keys.edx.locator import LibraryLocatorV2, LibraryCollectionLocator
 from openedx_learning.api import authoring as authoring_api
 from common.djangoapps.student.roles import GlobalStaff
 from rest_framework.request import Request
@@ -608,14 +608,14 @@ def upsert_block_collections_index_docs(usage_key: UsageKey):
     _update_index_docs([doc])
 
 
-def upsert_collection_tags_index_docs(collection_usage_key: LibraryLocatorV2):
+def upsert_collection_tags_index_docs(collection_usage_key: LibraryCollectionLocator):
     """
     Updates the tags data in documents for the given library collection
     """
     collection = lib_api.get_library_collection_from_usage_key(collection_usage_key)
 
     doc = {Fields.id: collection.id}
-    doc.update(collection_usage_key.library_key, collection)
+    doc.update(searchable_doc_tags_for_collection(collection_usage_key.library_key, collection))
     _update_index_docs([doc])
 
 

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -10,6 +10,7 @@ from django.utils.text import slugify
 from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys.edx.keys import LearningContextKey, UsageKey
 from openedx_learning.api import authoring as authoring_api
+from opaque_keys.edx.locator import LibraryLocatorV2
 
 from openedx.core.djangoapps.content.search.models import SearchAccess
 from openedx.core.djangoapps.content_libraries import api as lib_api
@@ -335,6 +336,28 @@ def searchable_doc_collections(usage_key: UsageKey) -> dict:
         Fields.id: meili_id_from_opaque_key(usage_key),
     }
     doc.update(_collections_for_content_object(usage_key))
+
+    return doc
+
+
+def searchable_doc_tags_for_collection(
+    library_key: LibraryLocatorV2,
+    collection,
+) -> dict:
+    """
+    Generate a dictionary document suitable for ingestion into a search engine
+    like Meilisearch or Elasticsearch, with the tags data for the given library collection.
+    """
+    doc = {
+        Fields.id: collection.id,
+    }
+
+    collection_usage_key = lib_api.get_library_collection_usage_key(
+        library_key,
+        collection.key,
+    )
+
+    doc.update(_tags_for_content_object(collection_usage_key))
 
     return doc
 

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -405,6 +405,7 @@ def searchable_doc_for_collection(collection) -> dict:
         doc.update({
             Fields.context_key: str(context_key),
             Fields.org: org,
+            Fields.usage_key: str(lib_api.get_library_collection_usage_key(context_key, collection.key)),
         })
     except LearningPackage.contentlibrary.RelatedObjectDoesNotExist:
         log.warning(f"Related library not found for {collection}")

--- a/openedx/core/djangoapps/content/search/handlers.py
+++ b/openedx/core/djangoapps/content/search/handlers.py
@@ -195,9 +195,10 @@ def content_object_associations_changed_handler(**kwargs) -> None:
 
     try:
         # Check if valid if course or library block
-        usage_key = UsageKey.from_string(str(content_object.object_id))        
+        usage_key = UsageKey.from_string(str(content_object.object_id))
     except InvalidKeyError:
         try:
+            # Check if valid if library collection
             usage_key = LibraryCollectionLocator.from_string(str(content_object.object_id))
         except InvalidKeyError:
             log.error("Received invalid content object id")

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -221,6 +221,9 @@ class TestSearchApi(ModuleStoreTestCase):
         doc_problem2 = copy.deepcopy(self.doc_problem2)
         doc_problem2["tags"] = {}
         doc_problem2["collections"] = {}
+        doc_collection = copy.deepcopy(self.collection_dict)
+        doc_collection["tags"] = {}
+        doc_collection["collections"] = {}
 
         api.rebuild_index()
         assert mock_meilisearch.return_value.index.return_value.add_documents.call_count == 3
@@ -228,7 +231,7 @@ class TestSearchApi(ModuleStoreTestCase):
             [
                 call([doc_sequential, doc_vertical]),
                 call([doc_problem1, doc_problem2]),
-                call([self.collection_dict]),
+                call([doc_collection]),
             ],
             any_order=True,
         )

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -223,7 +223,6 @@ class TestSearchApi(ModuleStoreTestCase):
         doc_problem2["collections"] = {}
         doc_collection = copy.deepcopy(self.collection_dict)
         doc_collection["tags"] = {}
-        doc_collection["collections"] = {}
 
         api.rebuild_index()
         assert mock_meilisearch.return_value.index.return_value.add_documents.call_count == 3

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -201,7 +201,6 @@ class TestSearchApi(ModuleStoreTestCase):
             "access_id": lib_access.id,
             "breadcrumbs": [{"display_name": "Library"}],
         }
-        
 
     @override_settings(MEILISEARCH_ENABLED=False)
     def test_reindex_meilisearch_disabled(self, mock_meilisearch):

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -19,6 +19,7 @@ try:
     from ..documents import (
         searchable_doc_for_course_block,
         searchable_doc_tags,
+        searchable_doc_tags_for_collection,
         searchable_doc_collections,
         searchable_doc_for_collection,
         searchable_doc_for_library_block,
@@ -27,6 +28,7 @@ try:
 except RuntimeError:
     searchable_doc_for_course_block = lambda x: x
     searchable_doc_tags = lambda x: x
+    searchable_doc_tags_for_collection = lambda x: x
     searchable_doc_for_collection = lambda x: x
     searchable_doc_for_library_block = lambda x: x
     SearchAccess = {}
@@ -76,6 +78,7 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 created_by=None,
                 description="my toy collection description"
             )
+            cls.collection_usage_key = "lib-collection:edX:2012_Fall:TOY_COLLECTION"
             cls.library_block = library_api.create_library_block(
                 cls.library.key,
                 "html",
@@ -109,6 +112,7 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
         tagging_api.tag_object(str(cls.html_block_key), cls.subject_tags, tags=["Chinese", "Jump Links"])
         tagging_api.tag_object(str(cls.html_block_key), cls.difficulty_tags, tags=["Normal"])
         tagging_api.tag_object(str(cls.library_block.usage_key), cls.difficulty_tags, tags=["Normal"])
+        tagging_api.tag_object(cls.collection_usage_key, cls.difficulty_tags, tags=["Normal"])
 
     @property
     def toy_course_access_id(self):
@@ -295,10 +299,16 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
         }
 
     def test_collection_with_library(self):
-        doc = searchable_doc_for_collection(self.collection)
+        doc = {}
+        doc.update(searchable_doc_for_collection(self.collection))
+        doc.update(searchable_doc_tags_for_collection(self.library.key ,self.collection))
+
+        print(doc)
+
         assert doc == {
             "id": self.collection.id,
             "block_id": self.collection.key,
+            "usage_key": self.collection_usage_key,
             "type": "collection",
             "org": "edX",
             "display_name": "Toy Collection",
@@ -309,6 +319,10 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "breadcrumbs": [{"display_name": "some content_library"}],
             "created": 1680674828.0,
             "modified": 1680674828.0,
+            'tags': {
+                'taxonomy': ['Difficulty'],
+                'level0': ['Difficulty > Normal']
+            }
         }
 
     def test_collection_with_no_library(self):

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -299,11 +299,8 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
         }
 
     def test_collection_with_library(self):
-        doc = {}
-        doc.update(searchable_doc_for_collection(self.collection))
+        doc = searchable_doc_for_collection(self.collection)
         doc.update(searchable_doc_tags_for_collection(self.library.key, self.collection))
-
-        print(doc)
 
         assert doc == {
             "id": self.collection.id,

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -301,7 +301,7 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
     def test_collection_with_library(self):
         doc = {}
         doc.update(searchable_doc_for_collection(self.collection))
-        doc.update(searchable_doc_tags_for_collection(self.library.key ,self.collection))
+        doc.update(searchable_doc_tags_for_collection(self.library.key, self.collection))
 
         print(doc)
 

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1292,7 +1292,7 @@ def get_library_collection_from_usage_key(
     collection_key = collection_usage_key.collection_id
     content_library = ContentLibrary.objects.get_by_key(library_key)  # type: ignore[attr-defined]
     try:
-        return authoring_api.get(
+        return authoring_api.get_collection(
             content_library.learning_package_id,
             collection_key,
         )

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -73,7 +73,8 @@ from opaque_keys.edx.keys import BlockTypeKey, UsageKey, UsageKeyV2
 from opaque_keys.edx.locator import (
     LibraryLocatorV2,
     LibraryUsageLocatorV2,
-    LibraryLocator as LibraryLocatorV1
+    LibraryLocator as LibraryLocatorV1,
+    LibraryCollectionLocator,
 )
 from opaque_keys import InvalidKeyError
 from openedx_events.content_authoring.data import (
@@ -1260,6 +1261,24 @@ def update_library_collection_components(
         )
 
     return collection
+
+
+def get_library_collection_usage_key(
+    library_key: LibraryLocatorV2,
+    collection_key: str,
+    # As an optimization, callers may pass in a pre-fetched ContentLibrary instance
+    content_library: ContentLibrary | None = None,
+) -> LibraryCollectionLocator:
+    """
+    Returns the LibraryCollectionLocator associated to a collection
+    """
+    if not content_library:
+        content_library = ContentLibrary.objects.get_by_key(library_key)  # type: ignore[attr-defined]
+    assert content_library
+    assert content_library.learning_package_id
+    assert content_library.library_key == library_key
+
+    return LibraryCollectionLocator(library_key, collection_key)
 
 
 # V1/V2 Compatibility Helpers

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1281,6 +1281,25 @@ def get_library_collection_usage_key(
     return LibraryCollectionLocator(library_key, collection_key)
 
 
+def get_library_collection_from_usage_key(
+    collection_usage_key: LibraryCollectionLocator,
+) -> Collection:
+    """
+    Return a Collection ussing the LibraryCollectionLocator
+    """
+
+    library_key = collection_usage_key.library_key
+    collection_key = collection_usage_key.collection_id
+    content_library = ContentLibrary.objects.get_by_key(library_key)  # type: ignore[attr-defined]
+    try:
+        return authoring_api.get(
+            content_library.learning_package_id,
+            collection_key,
+        )
+    except Collection.DoesNotExist as exc:
+        raise ContentLibraryCollectionNotFound from exc
+
+
 # V1/V2 Compatibility Helpers
 # (Should be removed as part of
 #  https://github.com/openedx/edx-platform/issues/32457)

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1285,7 +1285,7 @@ def get_library_collection_from_usage_key(
     collection_usage_key: LibraryCollectionLocator,
 ) -> Collection:
     """
-    Return a Collection ussing the LibraryCollectionLocator
+    Return a Collection using the LibraryCollectionLocator
     """
 
     library_key = collection_usage_key.library_key


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds tags of library collections into meilisearch index.

## Supporting information

- Github issue: https://github.com/openedx/modular-learning/issues/228#issuecomment-2311656593
- Internal ticket: [FAL-3817](https://tasks.opencraft.com/browse/FAL-3817)

## Testing instructions

- Run the script to get sample taxonomies: https://github.com/open-craft/taxonomy-sample-data
- Run this snippet to create a collection and add a tag - reindexing should happen automatically.

```python
from openedx.core.djangoapps.content_libraries import api
from openedx.core.djangoapps.content_tagging import api as tagging_api
from opaque_keys.edx.locator import LibraryLocatorV2, LibraryCollectionLocator
from openedx_tagging.core.tagging.models import Taxonomy

lib_key_str = "lib:<your lib key>"
library_key = LibraryLocatorV2.from_string(lib_key_str)
taxonomy = Taxonomy.objects.get(name='MultiOrgTaxonomy')
tags = ['multi org taxonomy tag 0']
collection_key = "FAL-3817"

api.create_library_collection(library_key, collection_key, title="Collection FAL-3817")
collection_usage_key = api.get_library_collection_usage_key(library_key, collection_key)
tagging_api.tag_object(str(collection_usage_key), taxonomy, tags)
```

- Go to http://meilisearch.local.edly.io:7700/
- Search `FAL-3817` and verify that the tags are indexed
- Run `tutor dev run cms ./manage.py cms reindex_studio --experimental`
- Go to http://meilisearch.local.edly.io:7700/
- Search `FAL-3817` and verify that the tags are indexed