### PR TITLE
fix: hide new library button for ineligible users split studio view (#35316)

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1534,6 +1534,7 @@ def get_library_context(request, request_is_json=False):
     )
     from cms.djangoapps.contentstore.views.library import (
         LIBRARIES_ENABLED,
+        user_can_view_create_library_button,
     )
 
     libraries = _accessible_libraries_iter(request.user) if LIBRARIES_ENABLED else []
@@ -1547,7 +1548,7 @@ def get_library_context(request, request_is_json=False):
             'in_process_course_actions': [],
             'courses': [],
             'libraries_enabled': LIBRARIES_ENABLED,
-            'show_new_library_button': LIBRARIES_ENABLED and request.user.is_active,
+            'show_new_library_button': user_can_view_create_library_button(request.user) and request.user.is_active,
             'user': request.user,
             'request_course_creator_url': reverse('request_course_creator'),
             'course_creator_status': _get_course_creator_status(request.user),


### PR DESCRIPTION
## Description

(cherry picked from commit 79fb1cc4042c52d4cf7b24adde07380b1c672c1b)

Cherry Pick of #35316

This PR does the following:

1. The New Library button is now only shown to eligible users in the split studio view, instead of all active users.
2. Common code between [user_can_view_create_library_button()](https://github.com/openedx/edx-platform/blob/3d7cc1c616bd2e6f1112922578e108b34063fd52/cms/djangoapps/contentstore/views/library.py#L72) and [user_can_create_library()](https://github.com/openedx/edx-platform/blob/3d7cc1c616bd2e6f1112922578e108b34063fd52/cms/djangoapps/contentstore/views/library.py#L96C5-L96C28) functions are refactored out to a new fuction.

## Testing instructions

Check #35316 

## Other information

Private Ref: [BB-9077](https://tasks.opencraft.com/browse/BB-9077)
