### PR TITLE
feat: add block_id field to filterable attributes of meilisearch

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -315,6 +315,8 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None) -> None:
         client.index(temp_index_name).update_distinct_attribute(Fields.usage_key)
         # Mark which attributes can be used for filtering/faceted search:
         client.index(temp_index_name).update_filterable_attributes([
+            # Get specific block/collection using combination of block_id and context_key
+            Fields.block_id,
             Fields.block_type,
             Fields.context_key,
             Fields.org,


### PR DESCRIPTION
Adds block_id field to filterable attributes of meilisearch allowing us to fetch a single block/collection from index under a library (`context_key`).

## Supporting information

* https://github.com/openedx/frontend-app-authoring/pull/1281

## Testing instructions

Follow instructions in https://github.com/openedx/frontend-app-authoring/pull/1281

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
