### PR TITLE
When editing a v2 library xblock, update search index synchronously [FC-0062] 

### DIFF
--- a/openedx/core/djangoapps/content/search/handlers.py
+++ b/openedx/core/djangoapps/content/search/handlers.py
@@ -140,7 +140,9 @@ def library_block_deleted(**kwargs) -> None:
         log.error("Received null or incorrect data for event")
         return
 
-    delete_library_block_index_doc.delay(str(library_block_data.usage_key))
+    # Update content library index synchronously to make sure that search index is updated before
+    # the frontend invalidates/refetches results. This is only a single document update so is very fast.
+    delete_library_block_index_doc.apply(args=[str(library_block_data.usage_key)])
 
 
 @receiver(CONTENT_LIBRARY_UPDATED)

--- a/openedx/core/djangoapps/content/search/handlers.py
+++ b/openedx/core/djangoapps/content/search/handlers.py
@@ -124,7 +124,9 @@ def library_block_updated_handler(**kwargs) -> None:
         log.error("Received null or incorrect data for event")
         return
 
-    upsert_library_block_index_doc.delay(str(library_block_data.usage_key))
+    # Update content library index synchronously to make sure that search index is updated before
+    # the frontend invalidates/refetches results. This is only a single document update so is very fast.
+    upsert_library_block_index_doc.apply(args=[str(library_block_data.usage_key)])
 
 
 @receiver(LIBRARY_BLOCK_DELETED)


### PR DESCRIPTION
## Description

This improves the editing workflow for components (XBlocks) in content libraries, using the new frontend-authoring library v2 UI.

This fixes the issue described in [this comment](https://github.com/openedx/frontend-app-authoring/issues/1090#issuecomment-2349486198):

>  the search results don't update after you save changes. So when you edit a component, then click save, the card in the library view won't update right away. It will only update after you refresh the page or if you wait some time. Sorry I didn't catch this sooner - it only affects the sandbox, not our dev environments.

## Supporting information

Similar to other changes we've made to the API along the same lines.

## Testing instructions

1. Configure your devstack to not use EAGER mode
2. Create a Text component in a (v2) library
3. Edit it.
4. Ensure that search results are updated immediately to show the new title/description.

## Deadline

ASAP

## Other information

n/a