### PR TITLE
Added a check to initialize legacy proctoring dashboard only if it's being used

### DIFF
--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -50,6 +50,12 @@ such that the value can be defined later than this assignment (file load order).
 
     $activeSection = null;
 
+    var usesProctoringLegacyView = function () {
+        // If the element #proctoring-mfe-view is present, then uses the new MFE
+        // and the legagy views should not be initialized.
+        return !document.getElementById('proctoring-mfe-view');
+    }
+
     SafeWaiter = (function() {
         function safeWaiter() {
             this.after_handlers = [];
@@ -200,7 +206,7 @@ such that the value can be defined later than this assignment (file load order).
             }
         ];
         // eslint-disable-next-line no-void
-        if (edx.instructor_dashboard.proctoring !== void 0) {
+        if (usesProctoringLegacyView() && edx.instructor_dashboard.proctoring !== void 0) {
             sectionsToInitialize = sectionsToInitialize.concat([
                 {
                     constructor: edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView,

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -52,7 +52,7 @@ such that the value can be defined later than this assignment (file load order).
 
     var usesProctoringLegacyView = function () {
         // If the element #proctoring-mfe-view is present, then uses the new MFE
-        // and the legagy views should not be initialized.
+        // and the legacy views should not be initialized.
         return !document.getElementById('proctoring-mfe-view');
     }
 


### PR DESCRIPTION
## Description

The new https://github.com/openedx/frontend-lib-special-exams should take care of the proctoring dashboard. The old views are still being loaded in the background. This can be seen since the old Backbone views extracted the `course_id` from an element `student-proctored-exam-container` that's not being rendered any more, this makes the old view take `undefined` as the `course_id` and some endpoints are being called with this value in them.

When the new proctoring MFE is being used, a [div with `id="proctoring-mfe-view"` is rendered](https://github.com/openedx/edx-platform/blob/0196def99d95b084e41d4b29232f3a0004aedbb3/lms/templates/instructor/instructor_dashboard_2/special_exams.html#L9). I'm checking for its presence in the DOM to detect if it's being used, and if so, initialization on the legacy views is skipped.

Useful information to include:

- Which edX user roles will this change impact? "Instructor"

## Testing instructions
- Visit the exams testing course (or any course with an LTI-based proctoring provider): [Course | edX](https://courses.stage.edx.org/courses/course-v1:edx+EXAMTEST101+3T2023/).
- Open the developer tools to the network tab.
- Click the “Instructor” tab at the top.
- Observe there are no requests with `undefined` in their path in the developer tools network tab (or returning `404` code whatsoever).

## Deadline

- None
