### PR TITLE
feat: filter by current site organizations

### DIFF
--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -40,6 +40,7 @@ from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.views.index import save_positions_recursively_up
 from lms.djangoapps.mobile_api.models import MobileConfig
 from lms.djangoapps.mobile_api.utils import API_V1, API_V05, API_V2, API_V3, API_V4
+from openedx.core.djangoapps.site_configuration.helpers import get_current_site_orgs
 from openedx.features.course_duration_limits.access import check_course_expired
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -350,6 +351,11 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
         """
         Check course org matches request org param or no param provided
         """
+        current_orgs = get_current_site_orgs()
+
+        if current_orgs and course_org not in current_orgs:
+            return False
+
         return check_org is None or (check_org.lower() == course_org.lower())
 
     def get_serializer_context(self):


### PR DESCRIPTION
## Description

This change filters out course enrollments whose organization is no available for the current site when the  site configuration is enabled 

I am proposing this change because when an instance contains multiple sites, each of which has access to only specific organizations, there is an issue where the API returns all courses a user is enrolled in, even if the current site does not have access to certain organizations. Although the API offers a query parameter to filter by organization, this parameter only supports one organization at a time, whereas a site may have access to multiple organizations.

## Testing instructions

1. Enable site configuration 
2. set the course_org_filter value
3. Go to `/api/mobile/v4/users/<username>/course_enrollments/ ` and check that the result doesn't contain any invalid organization

