### PR TITLE
feat: override refund

### DIFF
--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -288,7 +288,7 @@ def refund_seat(course_enrollment, change_mode=False):
             user=enrollee,
         )
         if change_mode:
-            _auto_enroll(course_enrollment)
+            auto_enroll(course_enrollment)
     else:
         log.info('No refund opened for user [%s], course [%s]', enrollee.id, course_key_str)
 
@@ -355,7 +355,7 @@ def _refund_in_commerce_coordinator(course_enrollment, change_mode):
         log.info('Refund successfully sent to Commerce Coordinator for user [%s], course [%s].',
                  course_enrollment.user_id, course_key_str)
         if change_mode:
-            _auto_enroll(course_enrollment)
+            auto_enroll(course_enrollment)
         return True
     else:
         # Refund was not meant to be sent to Commerce Coordinator
@@ -364,7 +364,7 @@ def _refund_in_commerce_coordinator(course_enrollment, change_mode):
         return False
 
 
-def _auto_enroll(course_enrollment):
+def auto_enroll(course_enrollment):
     """
     Helper method to update an enrollment to a default course mode.
 

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -238,6 +238,7 @@ def refund_entitlement(course_entitlement):
         return False
 
 
+@pluggable_override('OVERRIDE_REFUND_SEAT')
 def refund_seat(course_enrollment, change_mode=False):
     """
     Attempt to initiate a refund for any orders associated with the seat being unenrolled,


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description
This PR allows a plugin app to override the `refund_seat` method for a customized implementation without affecting the open source code.

## Other Information:
To utilize this functionality, developers must define the path to the alternative implementations in the settings file using the override flags.

Override flags being introduced in this PR:
- `OVERRIDE_REFUND_SEAT`

Override implementation needs to be housed somewhere else outside of edx-platform which can be a pluggable app installed independently in edx-platform requirements