### PR TITLE
fix: Delete tags_count from LibraryXBlockMetadata [FC-0062]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -218,7 +218,6 @@ class LibraryXBlockMetadata:
     last_draft_created_by = attr.ib("")
     published_by = attr.ib("")
     has_unpublished_changes = attr.ib(False)
-    tags_count = attr.ib(0)
     created = attr.ib(default=None, type=datetime)
 
     @classmethod


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This deletes `tags_count` from the library block metadata. Currently not used and confusing to have in code

- Which edX user roles will this change impact?  "Course Author",

## Supporting information

- Github Issue: https://github.com/openedx/frontend-app-authoring/issues/1286
- Internal ticket: [FAL-3847](https://tasks.opencraft.com/browse/FAL-3847)

## Testing instructions

- Read the code
- Test the API, you can follow the testing instructions of this https://github.com/openedx/frontend-app-authoring/pull/1299, and verify that all is OK.

## Deadline

ASAP
