### PR TITLE
feat: replaced button and heading tags in email digest content

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -399,4 +399,18 @@ def clean_thread_html_body(html_body):
         for match in html_body.find_all(tag):
             match.unwrap()
 
+    # Replace tags that are not allowed in email
+    tags_to_update = [
+        {"source": "button", "target": "span"},
+        {"source": "h1", "target": "h4"},
+        {"source": "h2", "target": "h4"},
+        {"source": "h3", "target": "h4"},
+    ]
+    for tag_dict in tags_to_update:
+        for source_tag in html_body.find_all(tag_dict['source']):
+            target_tag = html_body.new_tag(tag_dict['target'], **source_tag.attrs)
+            if source_tag.string:
+                target_tag.string = source_tag.string
+            source_tag.replace_with(target_tag)
+
     return str(html_body)

--- a/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
@@ -168,3 +168,29 @@ class TestCleanThreadHtmlBody(unittest.TestCase):
 
         result = clean_thread_html_body(html_body)
         self.assertEqual(result.strip(), expected_output)
+
+    def test_button_tag_replace(self):
+        """
+        Tests that the clean_thread_html_body function replaces the button tag with span tag
+        """
+        # Tests for button replacement tag with text
+        html_body = '<button class="abc">Button</button>'
+        expected_output = '<span class="abc">Button</span>'
+        result = clean_thread_html_body(html_body)
+        self.assertEqual(result, expected_output)
+
+        # Tests button tag replacement without text
+        html_body = '<button class="abc"></button>'
+        expected_output = '<span class="abc"></span>'
+        result = clean_thread_html_body(html_body)
+        self.assertEqual(result, expected_output)
+
+    def test_heading_tag_replace(self):
+        """
+        Tests that the clean_thread_html_body function replaces the h1, h2 and h3 tags with h4 tag
+        """
+        for tag in ['h1', 'h2', 'h3']:
+            html_body = f'<{tag}>Heading</{tag}>'
+            expected_output = '<h4>Heading</h4>'
+            result = clean_thread_html_body(html_body)
+            self.assertEqual(result, expected_output)


### PR DESCRIPTION
Replaced tags in email digest content
- `button` tag with `span` tag
- `h1`, `h2` and `h3` tags with `h4` tag

Ticket: [INF-1574](https://2u-internal.atlassian.net/browse/INF-1574)


Before
<img width="555" alt="before" src="https://github.com/user-attachments/assets/7c90d3c7-dded-4a89-bc66-3d1794af4698">

After
<img width="553" alt="after" src="https://github.com/user-attachments/assets/4190e3eb-529b-476c-85ce-d0f5d22c6243">


