### PR TITLE
fix: fix broken proctoring settings link in studio

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -162,7 +162,7 @@ from django.urls import reverse
             % if mfe_proctored_exam_settings_url:
               <% url_encoded_course_id = quote(str(context_course.id).encode('utf-8'), safe='') %>
               ${Text(_("To update these settings go to the {link_start}Proctored Exam Settings page{link_end}.")).format(
-                link_start=HTML('<a href="${mfe_proctored_exam_settings_url}">').format(
+                link_start=HTML('<a href="{mfe_proctored_exam_settings_url}">').format(
                         mfe_proctored_exam_settings_url=mfe_proctored_exam_settings_url
                 ),
                 link_end=HTML("</a>")


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR fixes a bug in studio. When there is a proctoring error (see screenshot) there is a page alert that includes a link. This link is currently broken due to an html formatting issue. This change will impact the course author since the bug is in studio.

<img width="1403" alt="Screenshot 2024-09-24 at 9 27 40 AM" src="https://github.com/user-attachments/assets/ebc74d80-5135-491c-8cad-5b74919624e0">

## Testing instructions



## Deadline

This needs to be merged ASAP, by 9/27 to coincide with the removal of PSI as a proctoring provider. We  expect this page alert to appear for users with software secure as their proctoring provider so it would be important to have this link fixed by then.
