### PR TITLE
feat: add verification attempt to django admin

### DIFF
--- a/lms/djangoapps/verify_student/admin.py
+++ b/lms/djangoapps/verify_student/admin.py
@@ -2,14 +2,14 @@
 Admin site configurations for verify_student.
 """
 
-
 from django.contrib import admin
 
 from lms.djangoapps.verify_student.models import (
     ManualVerification,
     SoftwareSecurePhotoVerification,
     SSOVerification,
-    SSPVerificationRetryConfig
+    SSPVerificationRetryConfig,
+    VerificationAttempt
 )
 
 
@@ -50,3 +50,13 @@ class SSPVerificationRetryAdmin(admin.ModelAdmin):
     Admin for the SSPVerificationRetryConfig table.
     """
     pass  # lint-amnesty, pylint: disable=unnecessary-pass
+
+
+@admin.register(VerificationAttempt)
+class VerificationAttemptAdmin(admin.ModelAdmin):
+    """
+    Admin for the VerificationAttempt table.
+    """
+    list_display = ('id', 'user', 'name', 'status', 'expiration_datetime',)
+    raw_id_fields = ('user',)
+    search_fields = ('user__username', 'name',)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds the VerificationAttempt model to Django admin so that admin can create, modify, and delete VerificationAttempts via Django admin.



## Testing instructions

- Go to Django admin (localhost:18000/admin)
- Create a VerificationAttempt
- Modify an existing VerificationAttempt
- Delete a VerificationAttempt

## Deadline

None

## Other Resources

https://github.com/openedx/platform-roadmap/issues/367
