### PR TITLE
test: run content_libraries runtime tests

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -141,7 +141,7 @@ class ContentLibraryOlxTests(ContentLibraryContentTestMixin, TestCase):
         assert olx_3 == olx_2 == canonical_olx
 
 
-class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin):
+class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin, TestCase):
     """
     Basic tests of the Learning-Core-based XBlock runtime using XBlocks in a
     content library.
@@ -258,7 +258,7 @@ class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin):
 # We can remove the line below to enable this in Studio once we implement a session-backed
 # field data store which we can use for both studio users and anonymous users
 @skip_unless_lms
-class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin):
+class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin, TestCase):
     """
     Test that the Blockstore-based XBlock runtime can store and retrieve student
     state for XBlocks when learners access blocks directly in a library context,
@@ -561,7 +561,7 @@ class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin):
 
 
 @skip_unless_lms  # No completion tracking in Studio
-class ContentLibraryXBlockCompletionTest(ContentLibraryContentTestMixin, CompletionWaffleTestMixin):
+class ContentLibraryXBlockCompletionTest(ContentLibraryContentTestMixin, CompletionWaffleTestMixin, TestCase):
     """
     Test that the Blockstore-based XBlocks can track their completion status
     using the completion library.


### PR DESCRIPTION
## Description

Somewhere in the series of refactorings that this app has undergone, it seems that we removed TestCase from the inheritance tree of the tests in openedx/core/djangoapps/content_libraries/tests/test_runtime.py, effectively skipping the test cases.

This PR turns them back into tests. TODO: Fix the test failures.

## Testing instructions

Check the logs of `openedx-1-with-lms` and `openedx-2-with-cms` to confirm that test_runtime is executing.

## Deadline

Sooner better than later

## Other information

This could have been avoided if we had:

* https://github.com/openedx/edx-platform/issues/32659