### PR TITLE
fix: don't wrap HTML data with newlines when serializing for LC

### DIFF
--- a/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
+++ b/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
@@ -159,7 +159,7 @@ class ClipboardTestCase(ModuleStoreTestCase):
             <html url_name="toyhtml" display_name="Text"><![CDATA[
             <a href='/static/handouts/sample_handout.txt'>Sample</a>
             ]]></html>
-        """).lstrip()
+        """).replace("\n", "") + "\n"  # No newlines, expect one trailing newline.
 
         # Now if we GET the clipboard again, the GET response should exactly equal the last POST response:
         assert client.get(CLIPBOARD_ENDPOINT).json() == response_data

--- a/openedx/core/lib/xblock_serializer/block_serializer.py
+++ b/openedx/core/lib/xblock_serializer/block_serializer.py
@@ -133,7 +133,7 @@ class XBlockSerializer:
 
         # Escape any CDATA special chars
         escaped_block_data = block.data.replace("]]>", "]]&gt;")
-        olx_node.text = etree.CDATA("\n" + escaped_block_data + "\n")
+        olx_node.text = etree.CDATA(escaped_block_data)
         return olx_node
 
 


### PR DESCRIPTION
## Description

When serializing to OLX, the Learning Core runtime wraps HTML content in CDATA to avoid having to escape every individual `<`, `>`, and `&`. The runtime would also wrap the content in newlines, so `...` would become `<![CDATA[\n...\n]]>`.

The problem is that every time you serialize an HTML block to OLX, it adds another pair of newlines. These newlines aren't visible to the end users, but they do make it so that importing and exporting content never reached a stable, aka "canonical" form. It also makes unit testing difficult, because the value of `html_block.data` becomes a moving target.

We do not believe these newlines are necessary, so we have removed them from the `CDATA` block, and added a unit test to ensure that HTML blocks having a canonical serialization.

Closes: https://github.com/openedx/edx-platform/issues/35525

## Testing

Not needed

## Deadline

Soon, as this is affects the unit tests in:

*  https://github.com/openedx/edx-platform/pull/34925