### PR TITLE
fix: remove incorrect key type when filtering inaccessible blocks

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -501,7 +501,7 @@ class CourseNavigationBlocksView(RetrieveAPIView):
             for section_data in course_sections:
                 section_data['children'] = self.get_accessible_sequences(
                     user_course_outline,
-                    section_data.get('children', ['completion'])
+                    section_data.get('children', [])
                 )
                 accessible_sequence_ids = {str(usage_key) for usage_key in user_course_outline.accessible_sequences}
                 for sequence_data in section_data['children']:


### PR DESCRIPTION
## Description

Returning the list with a 'completion' string was added in 9bc0f85. However, the `get_accessible_sequences` method expects a list of dicts with an 'id' key. When it gets the `['completion']`, it fails with the following traceback:
```python
Internal Server Error: /api/course_home/v1/navigation/course-v1:OpenedX+DemoX+DemoCourse
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/lms/djangoapps/course_home_api/outline/views.py", line 478, in get
    course_blocks = self.filter_inaccessible_blocks(course_blocks, course_key)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/lms/djangoapps/course_home_api/outline/views.py", line 502, in filter_inaccessible_blocks
    section_data['children'] = self.get_accessible_sequences(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/lms/djangoapps/course_home_api/outline/views.py", line 589, in get_accessible_sequences
    return [
           ^
  File "/openedx/edx-platform/lms/djangoapps/course_home_api/outline/views.py", line 591, in <listcomp>
    if seq_data['id'] in available_sequence_ids or seq_data['type'] != 'sequential'
       ~~~~~~~~^^^^^^
TypeError: string indices must be integers, not 'str'
```

## Testing instructions
1. Check that no tests are broken after this change.

## Steps to reproduce this error
1. Create the `courseware.disable_navigation_sidebar_blocks_caching`  waffle flag and set it to `Yes`.
2. Create a new empty section in an existing course.
3. Visit the `http://local.edly.io:8000/api/course_home/v1/navigation/course-v1:OpenedX+DemoX+DemoCourse` endpoint (it should return HTTP 500) and check the LMS logs.

_Private-ref: [BB-8469](https://tasks.opencraft.com/browse/BB-8469) (temporary)_