### PR TITLE
fix: suppress errors+warnings when video is used in a content library [FC-0062]

### DIFF
--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -649,6 +649,9 @@ def _get_item(request, data):
     Returns the item.
     """
     usage_key = UsageKey.from_string(data.get('locator'))
+    if not usage_key.context_key.is_course:
+        # TODO: implement transcript support for learning core / content libraries.
+        raise TranscriptsRequestValidationException(_('Transcripts are not yet supported in content libraries.'))
     # This is placed before has_course_author_access() to validate the location,
     # because has_course_author_access() raises  r if location is invalid.
     item = modulestore().get_item(usage_key)

--- a/xmodule/video_block/transcripts_utils.py
+++ b/xmodule/video_block/transcripts_utils.py
@@ -1074,7 +1074,7 @@ def get_transcript_from_learning_core(video_block, language, output_format, tran
     """
     # TODO: Update to use Learning Core data models once static assets support
     # has been added.
-    raise NotImplementedError("Transcripts not supported.")
+    raise NotFoundError("No transcript - transcripts not supported yet by learning core components.")
 
 
 def get_transcript(video, lang=None, output_format=Transcript.SRT, youtube_id=None):

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -482,7 +482,7 @@ class VideoBlock(
             'hide_downloads': is_public_view or is_embed,
             'id': self.location.html_id(),
             'block_id': str(self.location),
-            'course_id': str(self.location.course_key),
+            'course_id': str(self.context_key),
             'video_id': str(self.edx_video_id),
             'user_id': self.get_user_id(),
             'is_embed': is_embed,
@@ -510,8 +510,10 @@ class VideoBlock(
         """
         Return course video sharing options override or None
         """
+        if not self.context_key.is_course:
+            return False  # Only courses support this feature at all (not libraries)
         try:
-            course = get_course_by_id(self.course_id)
+            course = get_course_by_id(self.context_key)
             return getattr(course, 'video_sharing_options', None)
 
         # In case the course / modulestore does something weird
@@ -523,11 +525,13 @@ class VideoBlock(
         """
         Is public sharing enabled for this video?
         """
+        if not self.context_key.is_course:
+            return False  # Only courses support this feature at all (not libraries)
         try:
             # Video share feature must be enabled for sharing settings to take effect
-            feature_enabled = PUBLIC_VIDEO_SHARE.is_enabled(self.location.course_key)
+            feature_enabled = PUBLIC_VIDEO_SHARE.is_enabled(self.context_key)
         except Exception as err:  # pylint: disable=broad-except
-            log.exception(f"Error retrieving course for course ID: {self.location.course_key}")
+            log.exception(f"Error retrieving course for course ID: {self.context_key}")
             return False
         if not feature_enabled:
             return False
@@ -552,11 +556,13 @@ class VideoBlock(
         """
         Is transcript feedback enabled for this video?
         """
+        if not self.context_key.is_course:
+            return False  # Only courses support this feature at all (not libraries)
         try:
             # Video transcript feedback must be enabled in order to show the widget
-            feature_enabled = TRANSCRIPT_FEEDBACK.is_enabled(self.location.course_key)
+            feature_enabled = TRANSCRIPT_FEEDBACK.is_enabled(self.context_key)
         except Exception as err:  # pylint: disable=broad-except
-            log.exception(f"Error retrieving course for course ID: {self.location.course_key}")
+            log.exception(f"Error retrieving course for course ID: {self.context_key}")
             return False
         return feature_enabled
 


### PR DESCRIPTION
## Description

When editing a video component in a (v2) content library, there are currently a bunch of errors and warnings that will be logged to the CMS stdout, due to unsupported functionality. This PR tweaks the handling of the errors and warnings so that they result in 404/400 errors rather than 500 errors. It also fixes some deprecation warnings about using `context_key` instead of `location.course_key`.

## Supporting information

Part of https://github.com/openedx/frontend-app-course-authoring/issues/1092

Private ref: [FAL-3827](https://tasks.opencraft.com/browse/FAL-3827)

## Testing instructions

Watch the CMS console while opening a video component in a content library in the visual editor. Repeat after checking out this PR branch.
