### PR TITLE
fix: Delete flaky test `test_get_user_group_id_for_partition`

### DIFF
--- a/xmodule/partitions/tests/test_partitions.py
+++ b/xmodule/partitions/tests/test_partitions.py
@@ -462,21 +462,6 @@ class TestPartitionService(PartitionServiceBaseClass):
     Test getting a user's group out of a partition
     """
 
-    def test_get_user_group_id_for_partition(self):
-        # assign the first group to be returned
-        user_partition_id = self.user_partition.id
-        groups = self.user_partition.groups
-        self.user_partition.scheme.current_group = groups[0]
-
-        # get a group assigned to the user
-        group1_id = self.partition_service.get_user_group_id_for_partition(self.user, user_partition_id)
-        assert group1_id == groups[0].id
-
-        # switch to the second group and verify that it is returned for the user
-        self.user_partition.scheme.current_group = groups[1]
-        group2_id = self.partition_service.get_user_group_id_for_partition(self.user, user_partition_id)
-        assert group2_id == groups[1].id
-
     def test_caching(self):
         username = "psvc_cache_user"
         user_partition_id = self.user_partition.id


### PR DESCRIPTION
This test failed on 2024-08-06 and 2024-09-24 but passed on re-run.

Deleted according to flaky test process:
https://openedx.atlassian.net/wiki/spaces/AC/pages/4306337795/Flaky+Test+Process

Flaky test ticket: https://2u-internal.atlassian.net/browse/CR-7071
