### PR TITLE
feat: deprecate get_verification_details_by_id

### DIFF
--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -8,7 +8,6 @@ from itertools import chain
 from urllib.parse import quote
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
 from openedx_filters.learning.filters import IDVPageURLRequested
@@ -249,33 +248,3 @@ class IDVerificationService:
         # .. filter_implemented_name: IDVPageURLRequested
         # .. filter_type: org.openedx.learning.idv.page.url.requested.v1
         return IDVPageURLRequested.run_filter(location)
-
-    @classmethod
-    def get_verification_details_by_id(cls, attempt_id):
-        """
-        Returns a verification attempt object by attempt_id
-        If the verification object cannot be found, returns None
-
-        This method does not take into account verifications stored in the
-        VerificationAttempt model used for pluggable IDV implementations.
-
-        As part of the work to implement pluggable IDV, this method's use
-        will be deprecated: https://openedx.atlassian.net/browse/OSPR-1011
-        """
-        verification = None
-
-        # This does not look at the VerificationAttempt model since the provided id would become
-        # ambiguous between tables. The verification models in this list all inherit from the same
-        # base class and share the same id space.
-        verification_models = [
-            SoftwareSecurePhotoVerification,
-            SSOVerification,
-            ManualVerification,
-        ]
-        for ver_model in verification_models:
-            if not verification:
-                try:
-                    verification = ver_model.objects.get(id=attempt_id)
-                except ObjectDoesNotExist:
-                    pass
-        return verification

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -26,7 +26,6 @@ from .preferences.views import PreferencesDetailView, PreferencesView
 from .verification_api.views import (
     IDVerificationStatusView,
     IDVerificationStatusDetailsView,
-    IDVerificationSupportView,
 )
 
 ME = AccountViewSet.as_view({
@@ -146,11 +145,6 @@ urlpatterns = [
         fr'^v1/accounts/{settings.USERNAME_PATTERN}/verifications/$',
         IDVerificationStatusDetailsView.as_view(),
         name='verification_details'
-    ),
-    re_path(
-        r'^v1/accounts/verifications/(?P<attempt_id>[0-9]+)/$',
-        IDVerificationSupportView.as_view(),
-        name='verification_for_support'
     ),
     re_path(
         fr'^v1/accounts/{settings.USERNAME_PATTERN}/retirement_status/$',

--- a/openedx/core/djangoapps/user_api/verification_api/views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/views.py
@@ -3,7 +3,6 @@
 from django.contrib.auth import get_user_model
 from django.http import Http404
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from edx_rest_framework_extensions.permissions import IsStaff
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
@@ -61,21 +60,3 @@ class IDVerificationStatusDetailsView(ListAPIView):
             return sorted(verifications, key=lambda x: x.updated_at, reverse=True)
         except User.DoesNotExist:
             raise Http404  # lint-amnesty, pylint: disable=raise-missing-from
-
-
-class IDVerificationSupportView(APIView):
-    """ IDVerification endpoint for support-tool"""
-    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
-    permission_classes = (IsStaff,)
-
-    def get(self, request, **kwargs):
-        """
-        Get IDV attempt details by attempt_id. Only accessible by global staff.
-        """
-        attempt_id = kwargs.get('attempt_id')
-        verification_detail = IDVerificationService.get_verification_details_by_id(attempt_id)
-        if not verification_detail:
-            raise Http404
-        return Response(
-            IDVerificationDetailsSerializer(verification_detail).data
-        )


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR deprecates the [get_verification_details_by_id ](https://github.com/openedx/edx-platform/blob/5e3181ce61f4c18471221f5e1663f681b1bc1735/lms/djangoapps/verify_student/services.py#L241)method of the [IDVerificationService](https://github.com/openedx/edx-platform/blob/5e3181ce61f4c18471221f5e1663f681b1bc1735/lms/djangoapps/verify_student/services.py#L55) and the [IDVerificationSupportView](https://github.com/openedx/edx-platform/blob/5e3181ce61f4c18471221f5e1663f681b1bc1735/openedx/core/djangoapps/user_api/verification_api/views.py#L66).

This is the [DEPR ticket](https://github.com/openedx/edx-platform/issues/35452). The DEPR process is described [here](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html).

## Deadline

None
