### PR TITLE
fix: connect verify_student handlers to app

### DIFF
--- a/lms/djangoapps/verify_student/apps.py
+++ b/lms/djangoapps/verify_student/apps.py
@@ -17,5 +17,5 @@ class VerifyStudentConfig(AppConfig):
         """
         Connect signal handlers.
         """
-        from lms.djangoapps.verify_student.signals import signals  # pylint: disable=unused-import
+        from lms.djangoapps.verify_student.signals import handlers, signals  # pylint: disable=unused-import
         from lms.djangoapps.verify_student import tasks    # pylint: disable=unused-import


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

The signal handlers were refactored as part of https://github.com/openedx/edx-platform/pull/35468, but never re-imported to the `apps.py` file. This means that the handlers have not been connected since that PR has been merged. This PR reconnects the handlers to the app.