### PR TITLE
feat!: removes deprecated v1 certificate behavior

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
@@ -31,4 +31,3 @@ class CourseSettingsSerializer(serializers.Serializer):
     show_min_grade_warning = serializers.BooleanField()
     sidebar_html_enabled = serializers.BooleanField()
     upgrade_deadline = serializers.DateTimeField(allow_null=True)
-    use_v2_cert_display_settings = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
@@ -95,7 +95,6 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
             "show_min_grade_warning": false,
             "sidebar_html_enabled": true,
             "upgrade_deadline": null,
-            "use_v2_cert_display_settings": false
             }
         ```
         """
@@ -112,7 +111,6 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
                 'course_display_name_with_default': course_block.display_name_with_default,
                 'platform_name': settings.PLATFORM_NAME,
                 'licensing_enabled': settings.FEATURES.get("LICENSING", False),
-                'use_v2_cert_display_settings': settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False),
             })
 
             serializer = CourseSettingsSerializer(settings_context)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
@@ -55,7 +55,6 @@ class CourseSettingsViewTest(CourseTestCase, PermissionAccessMixin):
             "show_min_grade_warning": False,
             "upgrade_deadline": None,
             "licensing_enabled": False,
-            "use_v2_cert_display_settings": False,
         }
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -468,17 +468,6 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/26106
     'ENABLE_HELP_LINK': True,
 
-    # .. toggle_name: FEATURES['ENABLE_V2_CERT_DISPLAY_SETTINGS']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: Whether to use the reimagined certificates_display_behavior and certificate_available_date
-    # .. settings. Will eventually become the default.
-    # .. toggle_use_cases: temporary
-    # .. toggle_creation_date: 2021-07-26
-    # .. toggle_target_removal_date: 2021-10-01
-    # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
-    'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
-
     # .. toggle_name: FEATURES['ENABLE_INTEGRITY_SIGNATURE']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -43,7 +43,6 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             ${show_min_grade_warning | n, dump_js_escaped_json},
             ${can_show_certificate_available_date_field(context_course) | n, dump_js_escaped_json},
             "${upgrade_deadline | n, js_escaped_string}",
-            ${settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS") | n, dump_js_escaped_json}
         );
     });
 </%block>
@@ -251,58 +250,45 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             </li>
           </ol>
 
-          <%
-            use_v2_cert_display_settings = settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False)
-          %>
           % if can_show_certificate_available_date_field(context_course):
           <ol class="list-input">
             <li class="field-group field-group-certificate-available" id="certificate-available">
               <div class="field date" id="field-certificates-display-behavior">
                 <label for="certificates-display-behavior">${_("Certificates Display Behavior")}</label>
-                % if use_v2_cert_display_settings:
-                  <select id="certificates-display-behavior">
-                    <option value="early_no_info">${_("Immediately upon passing")}</option>
-                    <option value="end">${_("End date of course")}</option>
-                    <option value="end_with_date">${_("A date after the course end date")}</option>
-                  </select>
-                % else:
-                  <input id="certificates-display-behavior" type="text">
-                % endif
+                <select id="certificates-display-behavior">
+                  <option value="early_no_info">${_("Immediately upon passing")}</option>
+                  <option value="end">${_("End date of course")}</option>
+                  <option value="end_with_date">${_("A date after the course end date")}</option>
+                </select>
                 <span class="tip tip-stacked">${_("Certificates are awarded at the end of a course run")}</span>
 
-                % if use_v2_cert_display_settings:
-                  <!-- Collapsible -->
-                  <div class="collapsible">
-                    <div id="certificate-display-behavior-collapsible-trigger" class="collapsible-trigger" role="button" tabindex="0" aria-expanded="false">
-                      <span>
-                        <span class="icon icon-inline fa fa-info-circle" aria-hidden="true"></span>
-                        ${_("Read more about this setting")}
-                      </span>
+                <!-- Collapsible -->
+                <div class="collapsible">
+                  <div id="certificate-display-behavior-collapsible-trigger" class="collapsible-trigger" role="button" tabindex="0" aria-expanded="false">
+                    <span>
+                      <span class="icon icon-inline fa fa-info-circle" aria-hidden="true"></span>
+                      ${_("Read more about this setting")}
+                    </span>
+                  </div>
+                  <div id="certificate-display-behavior-collapsible-content" class="collapsible-content collapsed">
+                    <p>${_("In all configurations of this setting, certificates are generated for learners as soon as they achieve the passing threshold in the course (which can occur before a final assignment based on course design)")}</p>
+                    <div>
+                      <div class="collapsible-description-heading">${_("Immediately upon passing")}</div>
+                      <div class="collapsible-description-description">${_("Learners can access their certificate as soon as they achieve a passing grade above the course grade threshold. Note: learners can achieve a passing grade before encountering all assignments in some course configurations.")}</div>
                     </div>
-                    <div id="certificate-display-behavior-collapsible-content" class="collapsible-content collapsed">
-                      <p>${_("In all configurations of this setting, certificates are generated for learners as soon as they achieve the passing threshold in the course (which can occur before a final assignment based on course design)")}</p>
-                      <div>
-                        <div class="collapsible-description-heading">${_("Immediately upon passing")}</div>
-                        <div class="collapsible-description-description">${_("Learners can access their certificate as soon as they achieve a passing grade above the course grade threshold. Note: learners can achieve a passing grade before encountering all assignments in some course configurations.")}</div>
-                      </div>
-                      <div>
-                        <div class="collapsible-description-heading">${_("On course end date")}</div>
-                        <div class="collapsible-description-description">${_("Learners with passing grades can access their certificate once the end date of the course has elapsed.")}</div>
-                      </div>
-                      <div>
-                        <div class="collapsible-description-heading">${_("A date after the course end date")}</div>
-                        <div class="collapsible-description-description">${_("Learners with passing grades can access their certificate after the date that you set has elapsed.")}</div>
-                      </div>
+                    <div>
+                      <div class="collapsible-description-heading">${_("On course end date")}</div>
+                      <div class="collapsible-description-description">${_("Learners with passing grades can access their certificate once the end date of the course has elapsed.")}</div>
+                    </div>
+                    <div>
+                      <div class="collapsible-description-heading">${_("A date after the course end date")}</div>
+                      <div class="collapsible-description-description">${_("Learners with passing grades can access their certificate after the date that you set has elapsed.")}</div>
                     </div>
                   </div>
-                % endif
+                </div>
               </div>
 
-              % if use_v2_cert_display_settings:
-                <div class="field date hidden" id="field-certificate-available-date" >
-              % else:
-                <div class="field date" id="field-certificate-available-date" >
-              % endif
+              <div class="field date hidden" id="field-certificate-available-date" >
                 <label for="certificate-available-date">${_("Certificates Available Date")}</label>
                 <input type="text" class="certificate-available-date date start datepicker" id="certificate-available-date" placeholder="MM/DD/YYYY" autocomplete="off" />
                 <span class="icon icon-inline fa fa-calendar-check-o datepicker-icon" aria-hidden="true"></span>

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -655,6 +655,7 @@ def _is_certificate_earned_but_not_available(course_overview, status):
         )
     )
 
+
 def process_survey_link(survey_link, user):
     """
     If {UNIQUE_ID} appears in the link, replace it with a unique id for the user.

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -646,22 +646,14 @@ def _is_certificate_earned_but_not_available(course_overview, status):
         (bool): True if the user earned the certificate but it's hidden due to display behavior, else False
 
     """
-    if settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS"):
-        return (
-            not certificates_viewable_for_course(course_overview)
-            and CertificateStatuses.is_passing_status(status)
-            and course_overview.certificates_display_behavior in (
-                CertificatesDisplayBehaviors.END_WITH_DATE,
-                CertificatesDisplayBehaviors.END
-            )
+    return (
+        not certificates_viewable_for_course(course_overview)
+        and CertificateStatuses.is_passing_status(status)
+        and course_overview.certificates_display_behavior in (
+            CertificatesDisplayBehaviors.END_WITH_DATE,
+            CertificatesDisplayBehaviors.END
         )
-    else:
-        return (
-            not certificates_viewable_for_course(course_overview) and
-            CertificateStatuses.is_passing_status(status) and
-            course_overview.certificate_available_date
-        )
-
+    )
 
 def process_survey_link(survey_link, user):
     """

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -10,7 +10,6 @@ certificates models or any other certificates modules.
 import logging
 from datetime import datetime
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -286,12 +286,9 @@ def certificate_downloadable_status(student, course_key):
 
     course_overview = get_course_overview_or_none(course_key)
 
-    if settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS"):
-        display_behavior_is_valid = (
-            course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
-        )
-    else:
-        display_behavior_is_valid = True
+    display_behavior_is_valid = (
+        course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
+    )
 
     if (
         not certificates_viewable_for_course(course_overview)
@@ -837,10 +834,7 @@ def can_show_certificate_message(course, student, course_grade, certificates_ena
 
 def _course_uses_available_date(course):
     """Returns if the course has an certificate_available_date set and that it should be used"""
-    if settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS"):
-        display_behavior_is_valid = course.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
-    else:
-        display_behavior_is_valid = True
+    display_behavior_is_valid = course.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
 
     return (
         can_show_certificate_available_date_field(course)

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -209,28 +209,6 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             "uuid": cert_status["uuid"],
         }
 
-    @ddt.data(
-        (False, timedelta(days=2), False, True),
-        (False, -timedelta(days=2), True, None),
-        (True, timedelta(days=2), True, None),
-    )
-    @ddt.unpack
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
-    @patch.dict(settings.FEATURES, {"ENABLE_V2_CERT_DISPLAY_SETTINGS": False})
-    def test_cert_api_return_v1(self, self_paced, cert_avail_delta, cert_downloadable_status, earned_but_not_available):
-        """
-        Test 'downloadable status'
-        """
-        cert_avail_date = datetime.now(pytz.UTC) + cert_avail_delta
-        self.course.self_paced = self_paced
-        self.course.certificate_available_date = cert_avail_date
-        self.course.save()
-
-        self._setup_course_certificate()
-
-        downloadable_status = certificate_downloadable_status(self.student, self.course.id)
-        assert downloadable_status["is_downloadable"] == cert_downloadable_status
-        assert downloadable_status.get("earned_but_not_available") == earned_but_not_available
 
     @ddt.data(
         (True, timedelta(days=2), CertificatesDisplayBehaviors.END_WITH_DATE, True, None),
@@ -243,8 +221,7 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
     )
     @ddt.unpack
     @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
-    @patch.dict(settings.FEATURES, {"ENABLE_V2_CERT_DISPLAY_SETTINGS": True})
-    def test_cert_api_return_v2(
+    def test_cert_api_return(
         self,
         self_paced,
         cert_avail_delta,

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -209,7 +209,6 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             "uuid": cert_status["uuid"],
         }
 
-
     @ddt.data(
         (True, timedelta(days=2), CertificatesDisplayBehaviors.END_WITH_DATE, True, None),
         (False, -timedelta(days=2), CertificatesDisplayBehaviors.EARLY_NO_INFO, True, None),

--- a/lms/djangoapps/certificates/tests/test_utils.py
+++ b/lms/djangoapps/certificates/tests/test_utils.py
@@ -80,40 +80,7 @@ class CertificateUtilityTests(TestCase):
         (CertificatesDisplayBehaviors.END, False, False, _LAST_MONTH, True, True),
     )
     @ddt.unpack
-    @patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=True)
-    def test_should_certificate_be_visible_v2(
-        self,
-        certificates_display_behavior,
-        certificates_show_before_end,
-        has_ended,
-        certificate_available_date,
-        self_paced,
-        expected_value
-    ):
-        """Test whether the certificate should be visible to user given multiple usecases"""
-        assert should_certificate_be_visible(
-            certificates_display_behavior,
-            certificates_show_before_end,
-            has_ended,
-            certificate_available_date,
-            self_paced
-        ) == expected_value
-
-    @ddt.data(
-        ('early_with_info', True, True, _LAST_MONTH, False, True),
-        ('early_no_info', False, False, _LAST_MONTH, False, True),
-        ('end', True, False, _LAST_MONTH, False, True),
-        ('end', False, True, _LAST_MONTH, False, True),
-        ('end', False, False, _NEXT_WEEK, False, False),
-        ('end', False, False, _LAST_WEEK, False, True),
-        ('end', False, False, None, False, False),
-        ('early_with_info', False, False, None, False, True),
-        ('end', False, False, _NEXT_WEEK, False, False),
-        ('end', False, False, _NEXT_WEEK, True, True),
-    )
-    @ddt.unpack
-    @patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=False)
-    def test_should_certificate_be_visible_v1(
+    def test_should_certificate_be_visible(
         self,
         certificates_display_behavior,
         certificates_show_before_end,

--- a/lms/djangoapps/certificates/tests/test_utils.py
+++ b/lms/djangoapps/certificates/tests/test_utils.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
 from django.test import TestCase
 from pytz import utc
 

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -153,30 +153,19 @@ def should_certificate_be_visible(
         certificate_available_date (datetime): the date the certificate is available on for the course.
         self_paced (bool): Whether the course is self-paced.
     """
-    if settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS"):
-        show_early = (
-            certificates_display_behavior == CertificatesDisplayBehaviors.EARLY_NO_INFO
-            or certificates_show_before_end
-        )
-        past_available_date = (
-            certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
-            and certificate_available_date
-            and certificate_available_date < datetime.now(utc)
-        )
-        ended_without_available_date = (
-            certificates_display_behavior == CertificatesDisplayBehaviors.END
-            and has_ended
-        )
-    else:
-        show_early = (
-            certificates_display_behavior in ('early_with_info', 'early_no_info')
-            or certificates_show_before_end
-        )
-        past_available_date = (
-            certificate_available_date
-            and certificate_available_date < datetime.now(utc)
-        )
-        ended_without_available_date = (certificate_available_date is None) and has_ended
+    show_early = (
+        certificates_display_behavior == CertificatesDisplayBehaviors.EARLY_NO_INFO
+        or certificates_show_before_end
+    )
+    past_available_date = (
+        certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
+        and certificate_available_date
+        and certificate_available_date < datetime.now(utc)
+    )
+    ended_without_available_date = (
+        certificates_display_behavior == CertificatesDisplayBehaviors.END
+        and has_ended
+    )
 
     return any((self_paced, show_early, past_available_date, ended_without_available_date))
 

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -353,28 +353,22 @@ def _get_user_certificate(request, user, course_key, course_overview, preview_mo
     if preview_mode:
         # certificate is being previewed from studio
         if request.user.has_perm(PREVIEW_CERTIFICATES, course_overview):
-            if not settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS"):
-                if course_overview.certificate_available_date and not course_overview.self_paced:
-                    modified_date = course_overview.certificate_available_date
-                else:
-                    modified_date = datetime.now().date()
+            if (
+                course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
+                and course_overview.certificate_available_date
+                and not course_overview.self_paced
+            ):
+                modified_date = course_overview.certificate_available_date
+            elif course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END:
+                modified_date = course_overview.end
             else:
-                if (
-                    course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
-                    and course_overview.certificate_available_date
-                    and not course_overview.self_paced
-                ):
-                    modified_date = course_overview.certificate_available_date
-                elif course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END:
-                    modified_date = course_overview.end
-                else:
-                    modified_date = datetime.now().date()
-            user_certificate = GeneratedCertificate(
-                mode=preview_mode,
-                verify_uuid=str(uuid4().hex),
-                modified_date=modified_date,
-                created_date=datetime.now().date(),
-            )
+                modified_date = datetime.now().date()
+        user_certificate = GeneratedCertificate(
+            mode=preview_mode,
+            verify_uuid=str(uuid4().hex),
+            modified_date=modified_date,
+            created_date=datetime.now().date(),
+        )
     elif certificates_viewable_for_course(course_overview):
         # certificate is being viewed by learner or public
         try:

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -301,21 +301,18 @@ class CertificateSerializer(serializers.Serializer):
         course_overview = enrollment.course_overview
         available_date = course_overview.certificate_available_date
 
-        if settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False):
-            if (
-                course_overview.certificates_display_behavior
-                == CertificatesDisplayBehaviors.END_WITH_DATE
-                and course_overview.certificate_available_date
-            ):
-                available_date = course_overview.certificate_available_date
-            elif (
-                course_overview.certificates_display_behavior
-                == CertificatesDisplayBehaviors.END
-                and course_overview.end
-            ):
-                available_date = course_overview.end
-        else:
+        if (
+            course_overview.certificates_display_behavior
+            == CertificatesDisplayBehaviors.END_WITH_DATE
+            and course_overview.certificate_available_date
+        ):
             available_date = course_overview.certificate_available_date
+        elif (
+            course_overview.certificates_display_behavior
+            == CertificatesDisplayBehaviors.END
+            and course_overview.end
+        ):
+            available_date = course_overview.end
 
         return serializers.DateTimeField().to_representation(available_date)
 

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -299,7 +299,7 @@ class CertificateSerializer(serializers.Serializer):
     def get_availableDate(self, enrollment):
         """Available date changes based off of Certificate display behavior"""
         course_overview = enrollment.course_overview
-        available_date = course_overview.certificate_available_date
+        available_date = None
 
         if (
             course_overview.certificates_display_behavior

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -544,23 +544,6 @@ class TestCertificateSerializer(LearnerDashboardBaseTest):
             },
         )
 
-    @mock.patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=False)
-    def test_available_date_old_format(self):
-        # Given new cert display settings are not enabled
-        input_data = self.create_test_enrollment(course_mode=CourseMode.VERIFIED)
-        input_data.course.certificate_available_date = random_date()
-        input_context = self.create_test_context(input_data.course)
-
-        # When I get certificate info
-        output_data = CertificateSerializer(input_data, context=input_context).data
-
-        # Then the available date is defaulted to the certificate available date
-        expected_available_date = datetime_to_django_format(
-            input_data.course.certificate_available_date
-        )
-        self.assertEqual(output_data["availableDate"], expected_available_date)
-
-    @mock.patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=True)
     def test_available_date_course_end(self):
         # Given new cert display settings are enabled
         input_data = self.create_test_enrollment(course_mode=CourseMode.VERIFIED)
@@ -578,7 +561,6 @@ class TestCertificateSerializer(LearnerDashboardBaseTest):
         expected_available_date = datetime_to_django_format(input_data.course.end)
         self.assertEqual(output_data["availableDate"], expected_available_date)
 
-    @mock.patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=True)
     def test_available_date_specific_end(self):
         # Given new cert display settings are enabled
         input_data = self.create_test_enrollment(course_mode=CourseMode.VERIFIED)

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -522,9 +522,12 @@ class TestCertificateSerializer(LearnerDashboardBaseTest):
         # ... with a certificate
         input_context = self.create_test_context(input_data.course)
 
-        # ... and some data preemptively gathered
+        # ... and some data preemptively gathered, including a certificate display behavior
         available_date = random_date()
         input_data.course.certificate_available_date = available_date
+        input_data.course.certificates_display_behavior = (
+            CertificatesDisplayBehaviors.END_WITH_DATE
+        )
         cert_url = input_context["cert_statuses"][input_data.course.id][
             "cert_web_view_url"
         ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -949,17 +949,6 @@ FEATURES = {
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/OSPR-5290'
     'ENABLE_BULK_USER_RETIREMENT': False,
 
-    # .. toggle_name: FEATURES['ENABLE_V2_CERT_DISPLAY_SETTINGS']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: Whether to use the reimagined certificates_display_behavior and certificate_available_date
-    # .. settings. Will eventually become the default.
-    # .. toggle_use_cases: temporary
-    # .. toggle_creation_date: 2021-07-26
-    # .. toggle_target_removal_date: 2021-10-01
-    # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
-    'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
-
     # .. toggle_name: FEATURES['ENABLE_INTEGRITY_SIGNATURE']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -44,14 +44,11 @@ else:
     <div class="message message-status ${status_css_class} is-shown">
       <p class="message-copy">
         <%
-          if settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False):
-            certificate_available_date_string = ""
-            if course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE and course_overview.certificate_available_date:
-              certificate_available_date_string = course_overview.certificate_available_date.strftime('%Y-%m-%dT%H:%M:%S%z')
-            elif course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END and course_overview.end:
-              certificate_available_date_string = course_overview.end.strftime('%Y-%m-%dT%H:%M:%S%z')
-          else:
+          certificate_available_date_string = ""
+          if course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE and course_overview.certificate_available_date:
             certificate_available_date_string = course_overview.certificate_available_date.strftime('%Y-%m-%dT%H:%M:%S%z')
+          elif course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END and course_overview.end:
+            certificate_available_date_string = course_overview.end.strftime('%Y-%m-%dT%H:%M:%S%z')
           container_string = _("Your grade and certificate will be ready after {date}.")
           format = 'shortDate'
         %>

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -371,10 +371,6 @@ class CourseDetails:
             tuple[str, str]: updated certificate_available_date, updated certificates_display_behavior
             None
         """
-        # If V2 is not enable, return original values
-        if not settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False):
-            return (certificate_available_date, certificates_display_behavior)
-
         # "early_no_info" will always show regardless of settings
         if certificates_display_behavior == CertificatesDisplayBehaviors.EARLY_NO_INFO:
             return (None, CertificatesDisplayBehaviors.EARLY_NO_INFO)

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -216,4 +216,3 @@ class CourseDetailsTestCase(ModuleStoreTestCase):
         assert CourseDetails.validate_certificate_settings(
             stored_date, stored_behavior
         ) == (expected_date, expected_behavior)
-

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -212,30 +212,8 @@ class CourseDetailsTestCase(ModuleStoreTestCase):
         ),
     )
     @ddt.unpack
-    @patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=True)
-    def test_validate_certificate_settings_v2(self, stored_date, stored_behavior, expected_date, expected_behavior):
+    def test_validate_certificate_settings(self, stored_date, stored_behavior, expected_date, expected_behavior):
         assert CourseDetails.validate_certificate_settings(
             stored_date, stored_behavior
         ) == (expected_date, expected_behavior)
 
-    @ddt.data(
-        (
-            EXAMPLE_CERTIFICATE_AVAILABLE_DATE,
-            CertificatesDisplayBehaviors.END_WITH_DATE,
-            EXAMPLE_CERTIFICATE_AVAILABLE_DATE,
-            CertificatesDisplayBehaviors.END_WITH_DATE
-        ),
-        (
-            None,
-            "invalid_option",
-            None,
-            "invalid_option"
-        ),
-    )
-    @ddt.unpack
-    @patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=False)
-    def test_validate_certificate_settings_v1(self, stored_date, stored_behavior, expected_date, expected_behavior):
-        """Test that method just returns passed in arguments if v2 is off"""
-        assert CourseDetails.validate_certificate_settings(
-            stored_date, stored_behavior
-        ) == (expected_date, expected_behavior)

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -8,7 +8,6 @@ from django.test import override_settings
 import pytest
 import ddt
 from pytz import UTC
-from unittest.mock import patch  # lint-amnesty, pylint: disable=wrong-import-order
 
 from django.conf import settings
 from xmodule.modulestore import ModuleStoreEnum

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -1115,9 +1115,6 @@ class CourseBlock(
         except InvalidTabsException as err:
             raise type(err)(f'{str(err)} For course: {str(self.id)}')  # lint-amnesty, pylint: disable=line-too-long
 
-        if not settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS"):
-            self.set_default_certificate_available_date()
-
     def set_grading_policy(self, course_policy):
         """
         The JSON object can have the keys GRADER and GRADE_CUTOFFS. If either is


### PR DESCRIPTION
## Description

this removes the long-deprecated v1  certificate behavior. This removes the old-style date selection behavior  (ie., not a choice between *Immediately upon passing*, *End date of course*, *A date after the course end date*), which is no longer reliably maintained or supported in Studio or Credentials.

There were no special concerns raised either for the deprecation ticket or for the [corresponding discussion](https://discuss.openedx.org/t/deprecation-removal-waffle-flag-enable-v2-cert-display-settings/13806)

FIXES: #35399

