### PR TITLE
docs: Fix links to extensions docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,11 +83,11 @@ try:
 except git.InvalidGitRepositoryError:
     edx_platform_version = "master"
 
-featuretoggles_source_path = edxplatform_source_path
+featuretoggles_source_path = str(edxplatform_source_path)
 featuretoggles_repo_url = edxplatform_repo_url
 featuretoggles_repo_version = edx_platform_version
 
-settings_source_path = edxplatform_source_path
+settings_source_path = str(edxplatform_source_path)
 settings_repo_url = edxplatform_repo_url
 settings_repo_version = edx_platform_version
 
@@ -108,7 +108,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -170,7 +170,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -274,7 +274,6 @@ if os.environ.get("READTHEDOCS", "") == "True":
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'https://docs.python.org/2.7': None,
     'django': ('https://docs.djangoproject.com/en/1.11/', 'https://docs.djangoproject.com/en/1.11/_objects/'),
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,8 @@ locations.
     how-tos/index
     references/index
     concepts/index
+    hooks/index
+    extensions/tinymce_plugins
 
 .. grid:: 1 2 2 2
    :gutter: 3
@@ -70,6 +72,18 @@ locations.
       * :doc:`concepts/frontend/javascript`
       +++
       .. button-ref:: concepts/index
+         :color: primary
+         :outline:
+         :expand:
+
+   .. grid-item-card:: Hooks and Extensions
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+
+      * :doc:`hooks/index`
+      * :doc:`extensions/tinymce_plugins`
+      +++
+      .. button-ref:: hooks/index
          :color: primary
          :outline:
          :expand:


### PR DESCRIPTION
The extensions docs did not get linked from the index previously. Add
them to the docs tree to make them easier to find.

![image](https://github.com/user-attachments/assets/70652e78-fa9c-40de-9ac6-f3d629f20dfd)
