### PR TITLE
fix: gate use of proctoring api if provider is LTI based

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3674,14 +3674,15 @@ class TestSpecialExamXBlockInfo(ItemTest):
     @patch_does_backend_support_onboarding
     @patch_get_exam_by_content_id_success
     @ddt.data(
-        ("lti_external", False),
-        ("other_proctoring_backend", True),
+        ("lti_external", False, None),
+        ("other_proctoring_backend", True, "test_url"),
     )
     @ddt.unpack
-    def test_support_onboarding_is_correct_depending_on_lti_external(
+    def test_proctoring_values_correct_depending_on_lti_external(
         self,
         external_id,
-        expected_value,
+        expected_supports_onboarding_value,
+        expected_proctoring_link,
         mock_get_exam_by_content_id,
         mock_does_backend_support_onboarding,
         _mock_get_exam_configuration_dashboard_url,
@@ -3691,8 +3692,9 @@ class TestSpecialExamXBlockInfo(ItemTest):
             category="sequential",
             display_name="Test Lesson 1",
             user_id=self.user.id,
-            is_proctored_enabled=False,
-            is_time_limited=False,
+            is_proctored_enabled=True,
+            is_time_limited=True,
+            default_time_limit_minutes=100,
             is_onboarding_exam=False,
         )
 
@@ -3709,7 +3711,8 @@ class TestSpecialExamXBlockInfo(ItemTest):
             include_children_predicate=ALWAYS,
             course=self.course,
         )
-        assert xblock_info["supports_onboarding"] is expected_value
+        assert xblock_info["supports_onboarding"] is expected_supports_onboarding_value
+        assert xblock_info["proctoring_exam_configuration_link"] == expected_proctoring_link
 
     @patch_get_exam_configuration_dashboard_url
     @patch_does_backend_support_onboarding

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1159,7 +1159,9 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                     supports_onboarding = False
 
                 proctoring_exam_configuration_link = None
-                if xblock.is_proctored_exam:
+
+                # only call get_exam_configuration_dashboard_url if not using an LTI proctoring provider
+                if xblock.is_proctored_exam and (course.proctoring_provider != 'lti_external'):
                     proctoring_exam_configuration_link = (
                         get_exam_configuration_dashboard_url(
                             course.id, xblock_info["id"]


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

When creating a re-run of a course that has `lti_external` as the proctoring provider, the publishing of the course succeeds. However, when you go to view the course in studio, you will see a “Studio Server Error” message. This PR fixes the root cause of the error, which is an edx-proctoring API call that shouldn't be made in the case that the course is using an LTI based proctoring provider.
