### PR TITLE
fix: allow courses to render with invalid proctoring provider

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3776,6 +3776,42 @@ class TestSpecialExamXBlockInfo(ItemTest):
         assert xblock_info["was_exam_ever_linked_with_external"] is False
         assert mock_get_exam_by_content_id.call_count == 1
 
+    @patch_get_exam_configuration_dashboard_url
+    @patch_does_backend_support_onboarding
+    @patch_get_exam_by_content_id_success
+    def test_special_exam_xblock_info_get_dashboard_error(
+        self,
+        mock_get_exam_by_content_id,
+        _mock_does_backend_support_onboarding,
+        mock_get_exam_configuration_dashboard_url,
+    ):
+        sequential = BlockFactory.create(
+            parent_location=self.chapter.location,
+            category="sequential",
+            display_name="Test Lesson 1",
+            user_id=self.user.id,
+            is_proctored_enabled=True,
+            is_time_limited=True,
+            default_time_limit_minutes=100,
+            is_onboarding_exam=False,
+        )
+        sequential = modulestore().get_item(sequential.location)
+        mock_get_exam_configuration_dashboard_url.side_effect = Exception("proctoring error")
+        xblock_info = create_xblock_info(
+            sequential,
+            include_child_info=True,
+            include_children_predicate=ALWAYS,
+        )
+
+        # no errors should be raised and proctoring_exam_configuration_link is None
+        assert xblock_info["is_proctored_exam"] is True
+        assert xblock_info["was_exam_ever_linked_with_external"] is True
+        assert xblock_info["is_time_limited"] is True
+        assert xblock_info["default_time_limit_minutes"] == 100
+        assert xblock_info["proctoring_exam_configuration_link"] == None
+        assert xblock_info["supports_onboarding"] is True
+        assert xblock_info["is_onboarding_exam"] is False
+
 
 class TestLibraryXBlockInfo(ModuleStoreTestCase):
     """

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3808,7 +3808,7 @@ class TestSpecialExamXBlockInfo(ItemTest):
         assert xblock_info["was_exam_ever_linked_with_external"] is True
         assert xblock_info["is_time_limited"] is True
         assert xblock_info["default_time_limit_minutes"] == 100
-        assert xblock_info["proctoring_exam_configuration_link"] == None
+        assert xblock_info["proctoring_exam_configuration_link"] is None
         assert xblock_info["supports_onboarding"] is True
         assert xblock_info["is_onboarding_exam"] is False
 

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1162,11 +1162,16 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
 
                 # only call get_exam_configuration_dashboard_url if not using an LTI proctoring provider
                 if xblock.is_proctored_exam and (course.proctoring_provider != 'lti_external'):
-                    proctoring_exam_configuration_link = (
-                        get_exam_configuration_dashboard_url(
-                            course.id, xblock_info["id"]
+                    try:
+                        proctoring_exam_configuration_link = (
+                            get_exam_configuration_dashboard_url(
+                                course.id, xblock_info["id"]
+                            )
                         )
-                    )
+                    except Exception as e:
+                        log.error(
+                            f"Error while getting proctoring exam configuration link: {e}"
+                        )
 
                 if course.proctoring_provider == "proctortrack":
                     show_review_rules = SHOW_REVIEW_RULES_FLAG.is_enabled(

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1168,7 +1168,7 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                                 course.id, xblock_info["id"]
                             )
                         )
-                    except Exception as e:
+                    except Exception as e:  # pylint: disable=broad-except
                         log.error(
                             f"Error while getting proctoring exam configuration link: {e}"
                         )


### PR DESCRIPTION
## Description

This function call should not fail if the proctoring dashboard url is unable to be retrieved since this field is not critical to xblock render. The bug was found while altering proctoring provider support. This function may throw an exception if courses have a no longer supported proctoring provider stored in their course block.

Unsupported proctoring provider configuration is handled elsewhere, if we hit it here we should log the error and move on rather than throwing up a 500.

