### PR TITLE
fix: set xblock_iframe background to transparent [FC-0062]

### DIFF
--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -156,7 +156,7 @@
 <!-- The default stylesheet will set the body min-height to 100% (a common strategy to allow for background
   images to fill the viewport), but this has the undesireable side-effect of causing an infinite loop via the onResize
   event listeners below, in certain situations.  Resetting it to the default "auto" skirts the problem.-->
-<body style="min-height: auto">
+<body style="min-height: auto; background-color: transparent;">
   <!-- fragment body -->
   {{ fragment.body_html | safe }}
   <!-- fragment foot -->


### PR DESCRIPTION
## Description

This PR sets the background of the xblock_iframe wrapper to transparent, to fix the component preview in the course authoring mfe.

 Before:
![image](https://github.com/user-attachments/assets/de999a73-8826-4477-9a3b-582105ca941e)

After:
![image](https://github.com/user-attachments/assets/a25c8e1a-8cec-45ef-9079-4a620996b85d)

## Testing instructions

- Checkout this branch
- Open the Library Authoring Page and check the background of the component in the sidebar.

___
Private-ref: [FAL-3859](https://tasks.opencraft.com/browse/FAL-3859)