### PR TITLE
chore: calc version bump

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -53,7 +53,7 @@ numpy==1.26.4
     #   matplotlib
     #   openedx-calc
     #   scipy
-openedx-calc==3.1.0
+openedx-calc==3.1.2
     # via -r requirements/edx-sandbox/base.in
 packaging==24.1
     # via matplotlib

--- a/requirements/edx-sandbox/releases/quince.txt
+++ b/requirements/edx-sandbox/releases/quince.txt
@@ -56,7 +56,7 @@ numpy==1.22.4
     #   matplotlib
     #   openedx-calc
     #   scipy
-openedx-calc==3.1.0
+openedx-calc==3.1.2
     # via -r requirements/edx-sandbox/base.in
 packaging==23.2
     # via matplotlib

--- a/requirements/edx-sandbox/releases/redwood.txt
+++ b/requirements/edx-sandbox/releases/redwood.txt
@@ -54,7 +54,7 @@ numpy==1.24.4
     #   matplotlib
     #   openedx-calc
     #   scipy
-openedx-calc==3.1.0
+openedx-calc==3.1.2
     # via -r requirements/edx-sandbox/base.in
 packaging==24.0
     # via matplotlib

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -801,7 +801,7 @@ openai==0.28.1
     #   edx-enterprise
 openedx-atlas==0.6.2
     # via -r requirements/edx/kernel.in
-openedx-calc==3.1.0
+openedx-calc==3.1.2
     # via -r requirements/edx/kernel.in
 openedx-django-pyfs==3.7.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1340,7 +1340,7 @@ openedx-atlas==0.6.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-calc==3.1.0
+openedx-calc==3.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -959,7 +959,7 @@ openai==0.28.1
     #   edx-enterprise
 openedx-atlas==0.6.2
     # via -r requirements/edx/base.txt
-openedx-calc==3.1.0
+openedx-calc==3.1.2
     # via -r requirements/edx/base.txt
 openedx-django-pyfs==3.7.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1010,7 +1010,7 @@ openai==0.28.1
     #   edx-enterprise
 openedx-atlas==0.6.2
     # via -r requirements/edx/base.txt
-openedx-calc==3.1.0
+openedx-calc==3.1.2
     # via -r requirements/edx/base.txt
 openedx-django-pyfs==3.7.0
     # via

--- a/xmodule/capa/tests/test_responsetypes.py
+++ b/xmodule/capa/tests/test_responsetypes.py
@@ -1538,6 +1538,20 @@ class NumericalResponseTest(ResponseTest):  # pylint: disable=missing-class-docs
             problem = self.build_problem(answer=given_answer)
             self.assert_multiple_grade(problem, correct_responses, incorrect_responses)
 
+    def test_percentage(self):
+        """
+        Test percentage
+        """
+        problem_setup = [
+            # [given_answer, [list of correct responses], [list of incorrect responses]]
+            ["1%", ["1%", "1.0%", "1.00%", "0.01"], [""]],
+            ["2.0%", ["2%", "2.0%", "2.00%", "0.02"], [""]],
+            ["4.00%", ["4%", "4.0%", "4.00%", "0.04"], [""]],
+        ]
+        for given_answer, correct_responses, incorrect_responses in problem_setup:
+            problem = self.build_problem(answer=given_answer)
+            self.assert_multiple_grade(problem, correct_responses, incorrect_responses)
+
     def test_grade_with_script(self):
         script_text = "computed_response = math.sqrt(4)"
         problem = self.build_problem(answer="$computed_response", script=script_text)


### PR DESCRIPTION
## Description

Numerical input problem blocks were not able to process integer percentage numbers correctly which impacted learners and authors.
For example, "1.0%" worked as an answer while "1%" did not.
This was due to an issue in `openedx-calc` that has been fixed. This PR bumps the versioning for `openedx-calc` as well as adds unit testing for percentage answers.

## Supporting information

openedx-calc code change:
https://github.com/openedx/openedx-calc/commit/ea0602fbb202280c3970009ff0df779617f9785f

## Testing instructions

Without this PR:
1. Create a problem block for numerical input.
2. Set the answer to 1%.
3. On the unit page, try answering the problem with an incorrect answer. You will see the error `There was a problem with the staff answer to this problem.`
5. On the unit page, try answering with '1%'. You will see the error `Could not interpret '1%' as a number.`

Repeat these steps with the PR. You should not see either of the 2 errors above.

## Deadline

None

## Other information

https://2u-internal.atlassian.net/browse/TNL-11586