### PR TITLE
chore: add gevent as bundle dependency

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -582,6 +582,8 @@ future==1.0.0
     # via pyjwkest
 geoip2==4.8.0
     # via -r requirements/edx/kernel.in
+gevent==24.2.1
+    # via -r requirements/edx/bundled.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
 google-api-core[grpc]==2.20.0
@@ -621,6 +623,8 @@ googleapis-common-protos==1.65.0
     # via
     #   google-api-core
     #   grpcio-status
+greenlet==3.1.1
+    # via gevent
 grpcio==1.66.1
     # via
     #   google-api-core
@@ -1294,6 +1298,10 @@ yarl==1.12.1
     # via aiohttp
 zipp==3.20.2
     # via importlib-metadata
+zope-event==5.0
+    # via gevent
+zope-interface==7.0.3
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -48,3 +48,4 @@ ora2>=4.5.0                         # Open Response Assessment XBlock
 xblock-poll                         # Xblock for polling users
 xblock-drag-and-drop-v2             # Drag and Drop XBlock
 xblock-google-drive                 # XBlock for google docs and calendar
+gevent

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -933,6 +933,10 @@ geoip2==4.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+gevent==24.2.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
 gitdb==4.0.11
     # via
     #   -r requirements/edx/doc.txt
@@ -1005,6 +1009,11 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
+greenlet==3.1.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   gevent
 grimp==3.4.1
     # via
     #   -r requirements/edx/testing.txt
@@ -2286,6 +2295,16 @@ zipp==3.20.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   importlib-metadata
+zope-event==5.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   gevent
+zope-interface==7.0.3
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -677,6 +677,8 @@ future==1.0.0
     #   pyjwkest
 geoip2==4.8.0
     # via -r requirements/edx/base.txt
+gevent==24.2.1
+    # via -r requirements/edx/base.txt
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
@@ -735,6 +737,10 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
+greenlet==3.1.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   gevent
 grpcio==1.66.1
     # via
     #   -r requirements/edx/base.txt
@@ -1590,6 +1596,14 @@ zipp==3.20.2
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata
+zope-event==5.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   gevent
+zope-interface==7.0.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -715,6 +715,8 @@ future==1.0.0
     #   pyjwkest
 geoip2==4.8.0
     # via -r requirements/edx/base.txt
+gevent==24.2.1
+    # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
 google-api-core[grpc]==2.20.0
@@ -769,6 +771,10 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
+greenlet==3.1.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   gevent
 grimp==3.4.1
     # via import-linter
 grpcio==1.66.1
@@ -1688,6 +1694,14 @@ zipp==3.20.2
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata
+zope-event==5.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   gevent
+zope-interface==7.0.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Description

Adds `gevent` as a bundle dependency to optimize celery for I/O bound tasks when running multiple queues.

By itself this change will not affect Celery, to work you need to change the `pool` option from `process` to `gevent` and increase the concurrency parameter. This parameter is currently not set by tutor and shouldn't reflect any change on their installations unless it's specifically changed.

For more information on the Celery's pool option: https://celery.school/celery-worker-pools

The technical details can be found here: https://github.com/overhangio/tutor/issues/1130

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

None

## Other information

See https://github.com/openedx/openedx-aspects/issues/116#issuecomment-2363754734 for more information