### PR TITLE
chore: removed style from email digest content

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -392,7 +392,8 @@ def clean_thread_html_body(html_body):
         "video", "track",  # Video Tags
         "audio",  # Audio Tags
         "embed", "object", "iframe",  # Embedded Content
-        "script"
+        "script",
+        "b", "strong", "i", "em", "u", "s", "strike", "del", "ins", "mark", "sub", "sup",  # Text Formatting
     ]
 
     # Remove the specified tags while keeping their content
@@ -403,9 +404,10 @@ def clean_thread_html_body(html_body):
     # Replace tags that are not allowed in email
     tags_to_update = [
         {"source": "button", "target": "span"},
-        {"source": "h1", "target": "h4"},
-        {"source": "h2", "target": "h4"},
-        {"source": "h3", "target": "h4"},
+        *[
+            {"source": tag, "target": "p"}
+            for tag in ["div", "section", "article", "h1", "h2", "h3", "h4", "h5", "h6"]
+        ],
     ]
     for tag_dict in tags_to_update:
         for source_tag in html_body.find_all(tag_dict['source']):
@@ -414,4 +416,7 @@ def clean_thread_html_body(html_body):
                 target_tag.string = source_tag.string
             source_tag.replace_with(target_tag)
 
+    for tag in html_body.find_all(True):
+        tag.attrs = {}
+        tag['style'] = 'margin: 0'
     return str(html_body)

--- a/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_discussions_notifications.py
@@ -104,14 +104,14 @@ class TestCleanThreadHtmlBody(unittest.TestCase):
         <p>This is a <a href="#">link</a> to a page.</p>
         <p>Here is an image: <img src="image.jpg" alt="image"></p>
         <p>Embedded video: <iframe src="video.mp4"></iframe></p>
-        <p>Script test: <script>alert('hello');</script></p>
+        <p>Script test: <script>alert("hello");</script></p>
         <p>Some other content that should remain.</p>
         """
-        expected_output = ("<p>This is a link to a page.</p>"
-                           "<p>Here is an image: </p>"
-                           "<p>Embedded video: </p>"
-                           "<p>Script test: alert('hello');</p>"
-                           "<p>Some other content that should remain.</p>")
+        expected_output = ('<p style="margin: 0">This is a link to a page.</p>'
+                           '<p style="margin: 0">Here is an image: </p>'
+                           '<p style="margin: 0">Embedded video: </p>'
+                           '<p style="margin: 0">Script test: alert("hello");</p>'
+                           '<p style="margin: 0">Some other content that should remain.</p>')
 
         result = clean_thread_html_body(html_body)
 
@@ -132,19 +132,16 @@ class TestCleanThreadHtmlBody(unittest.TestCase):
         """
         Test that the clean_thread_html_body function truncates the HTML body to 500 characters
         """
-        html_body = """
-        <p>This is a long text that should be truncated to 500 characters.</p>
-        """ * 20  # Repeat to exceed 500 characters
-
-        result = clean_thread_html_body(html_body)
-        self.assertGreaterEqual(500, len(result))
+        html_body = "This is a long text that should be truncated to 500 characters." * 20
+        result = clean_thread_html_body(f"<p>{html_body}</p>")
+        self.assertGreaterEqual(525, len(result))    # 500 characters + 25 characters for the HTML tags
 
     def test_no_tags_to_remove(self):
         """
         Test that the clean_thread_html_body function does not remove any tags if there are no unwanted tags
         """
         html_body = "<p>This paragraph has no tags to remove.</p>"
-        expected_output = "<p>This paragraph has no tags to remove.</p>"
+        expected_output = '<p style="margin: 0">This paragraph has no tags to remove.</p>'
 
         result = clean_thread_html_body(html_body)
         self.assertEqual(result, expected_output)
@@ -169,28 +166,33 @@ class TestCleanThreadHtmlBody(unittest.TestCase):
         result = clean_thread_html_body(html_body)
         self.assertEqual(result.strip(), expected_output)
 
+    def test_tag_replace(self):
+        """
+        Tests if the clean_thread_html_body function replaces tags
+        """
+        for tag in ["div", "section", "article", "h1", "h2", "h3", "h4", "h5", "h6"]:
+            html_body = f'<{tag}>Text</{tag}>'
+            result = clean_thread_html_body(html_body)
+            self.assertEqual(result, '<p style="margin: 0">Text</p>')
+
     def test_button_tag_replace(self):
         """
         Tests that the clean_thread_html_body function replaces the button tag with span tag
         """
         # Tests for button replacement tag with text
         html_body = '<button class="abc">Button</button>'
-        expected_output = '<span class="abc">Button</span>'
+        expected_output = '<span style="margin: 0">Button</span>'
         result = clean_thread_html_body(html_body)
         self.assertEqual(result, expected_output)
 
         # Tests button tag replacement without text
         html_body = '<button class="abc"></button>'
-        expected_output = '<span class="abc"></span>'
+        expected_output = '<span style="margin: 0"></span>'
         result = clean_thread_html_body(html_body)
         self.assertEqual(result, expected_output)
 
-    def test_heading_tag_replace(self):
-        """
-        Tests that the clean_thread_html_body function replaces the h1, h2 and h3 tags with h4 tag
-        """
-        for tag in ['h1', 'h2', 'h3']:
-            html_body = f'<{tag}>Heading</{tag}>'
-            expected_output = '<h4>Heading</h4>'
-            result = clean_thread_html_body(html_body)
-            self.assertEqual(result, expected_output)
+    def test_attributes_removal_from_tag(self):
+        # Tests for removal of attributes from tags
+        html_body = '<p class="abc" style="color:red" aria-disabled=true>Paragraph</p>'
+        result = clean_thread_html_body(html_body)
+        self.assertEqual(result, '<p style="margin: 0">Paragraph</p>')


### PR DESCRIPTION
Removed styling from email digest additional content

Ticket: [INF-1618](https://2u-internal.atlassian.net/browse/INF-1618)


## Screenshots:

### Original Content
<img width="886" alt="Screenshot 2024-10-04 at 8 34 38 AM" src="https://github.com/user-attachments/assets/3649db15-3e14-4894-9b93-a528702e5630">

### Content in email
<img width="560" alt="Screenshot 2024-10-04 at 9 19 21 AM" src="https://github.com/user-attachments/assets/c44f8bcf-d413-40b4-ad93-a14d4e294542">

