### PR TITLE
feat: update management command to manually create verified names

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
@@ -10,9 +10,11 @@ from pprint import pformat
 
 from django.core.management.base import BaseCommand, CommandError
 
+from common.djangoapps.student.models_api import get_name, get_pending_name_change
 from lms.djangoapps.verify_student.api import send_approval_email
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from lms.djangoapps.verify_student.utils import earliest_allowed_verification_date
+from openedx.features.name_affirmation_api.utils import get_name_affirmation_service
 
 
 log = logging.getLogger(__name__)
@@ -149,5 +151,37 @@ class Command(BaseCommand):
         for verification in existing_id_verifications:
             verification.approve(service='idv_verifications command')
             send_approval_email(verification)
+            self._update_verified_name(verification)
 
         return list(failed_user_ids)
+
+    def _update_verified_name(self, verification):
+        """
+        This method manually creates a verified name given a SoftwareSecurePhotoVerification object.
+        """
+
+        name_affirmation_service = get_name_affirmation_service()
+
+        if name_affirmation_service:
+            from edx_name_affirmation.exceptions import VerifiedNameDoesNotExist  # pylint: disable=import-error
+
+            pending_name_change = get_pending_name_change(verification.user)
+            if pending_name_change:
+                full_name = pending_name_change.new_name
+            else:
+                full_name = get_name(verification.user.id)
+
+            try:
+                name_affirmation_service.update_verified_name_status(
+                    verification.user,
+                    'approved',
+                    verification_attempt_id=verification.id
+                )
+            except VerifiedNameDoesNotExist:
+                name_affirmation_service.create_verified_name(
+                    verification.user,
+                    verification.name,
+                    full_name,
+                    verification_attempt_id=verification.id,
+                    status='approved',
+                )

--- a/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/approve_id_verifications.py
@@ -151,11 +151,11 @@ class Command(BaseCommand):
         for verification in existing_id_verifications:
             verification.approve(service='idv_verifications command')
             send_approval_email(verification)
-            self._update_verified_name(verification)
+            self._approve_verified_name_for_software_secure_verification(verification)
 
         return list(failed_user_ids)
 
-    def _update_verified_name(self, verification):
+    def _approve_verified_name_for_software_secure_verification(self, verification):
         """
         This method manually creates a verified name given a SoftwareSecurePhotoVerification object.
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

The SSPV verification model is no longer hooked up to send events to the name affirmation models. However, we still need the ability to create verified names based on approved SSPV verification attempts. 

This PR updates the `approve_id_verifications` management command to manually create or update verified name records instead of relying on django signals.


