### PR TITLE
feat: Allow specifying a version when loading a v2 XBlock

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -720,13 +720,15 @@ def get_library_block(usage_key) -> LibraryXBlockMetadata:
     return xblock_metadata
 
 
-def set_library_block_olx(usage_key, new_olx_str):
+def set_library_block_olx(usage_key, new_olx_str) -> int:
     """
     Replace the OLX source of the given XBlock.
 
     This is only meant for use by developers or API client applications, as
     very little validation is done and this can easily result in a broken XBlock
     that won't load.
+
+    Returns the version number of the newly created ComponentVersion.
     """
     # because this old pylint can't understand attr.ib() objects, pylint: disable=no-member
     assert isinstance(usage_key, LibraryUsageLocatorV2)
@@ -763,7 +765,7 @@ def set_library_block_olx(usage_key, new_olx_str):
             text=new_olx_str,
             created=now,
         )
-        authoring_api.create_next_version(
+        new_component_version = authoring_api.create_next_component_version(
             component.pk,
             title=new_title,
             content_to_replace={
@@ -778,6 +780,8 @@ def set_library_block_olx(usage_key, new_olx_str):
             usage_key=usage_key
         )
     )
+
+    return new_component_version.version_num
 
 
 def library_component_usage_key(

--- a/openedx/core/djangoapps/content_libraries/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/serializers.py
@@ -207,6 +207,7 @@ class LibraryXBlockOlxSerializer(serializers.Serializer):
     Serializer for representing an XBlock's OLX
     """
     olx = serializers.CharField()
+    version_num = serializers.IntegerField(read_only=True, required=False)
 
 
 class LibraryXBlockStaticFileSerializer(serializers.Serializer):

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -36,6 +36,7 @@ URL_LIB_LTI_JWKS = URL_LIB_LTI_PREFIX + 'pub/jwks/'
 URL_LIB_LTI_LAUNCH = URL_LIB_LTI_PREFIX + 'launch/'
 
 URL_BLOCK_RENDER_VIEW = '/api/xblock/v2/xblocks/{block_key}/view/{view_name}/'
+URL_BLOCK_EMBED_VIEW = '/xblocks/v2/{block_key}/embed/{view_name}/'  # Returns HTML not JSON so its URL is different
 URL_BLOCK_GET_HANDLER_URL = '/api/xblock/v2/xblocks/{block_key}/handler_url/{handler_name}/'
 URL_BLOCK_METADATA_URL = '/api/xblock/v2/xblocks/{block_key}/'
 URL_BLOCK_FIELDS_URL = '/api/xblock/v2/xblocks/{block_key}/fields/'
@@ -299,6 +300,24 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
         """
         url = URL_BLOCK_RENDER_VIEW.format(block_key=block_key, view_name=view_name)
         return self._api('get', url, None, expect_response)
+
+    def _embed_block(
+        self,
+        block_key,
+        *,
+        view_name="student_view",
+        version: str | int | None = None,
+        expect_response=200,
+    ) -> str:
+        """
+        Get an HTML response that displays the given XBlock. Returns HTML.
+        """
+        url = URL_BLOCK_EMBED_VIEW.format(block_key=block_key, view_name=view_name)
+        if version is not None:
+            url += f"?version={version}"
+        response = self.client.get(url)
+        assert response.status_code == expect_response, 'Unexpected response code {}:'.format(response.status_code)
+        return response.content.decode()
 
     def _get_block_handler_url(self, block_key, handler_name):
         """

--- a/openedx/core/djangoapps/content_libraries/tests/fields_test_block.py
+++ b/openedx/core/djangoapps/content_libraries/tests/fields_test_block.py
@@ -1,0 +1,60 @@
+"""
+Block for testing variously scoped XBlock fields.
+"""
+import json
+
+from webob import Response
+from web_fragments.fragment import Fragment
+from xblock.core import XBlock, Scope
+from xblock import fields
+
+
+class FieldsTestBlock(XBlock):
+    """
+    Block for testing variously scoped XBlock fields and XBlock handlers.
+
+    This has only authored fields. See also UserStateTestBlock which has user fields.
+    """
+    BLOCK_TYPE = "fields-test"
+    has_score = False
+
+    display_name = fields.String(scope=Scope.settings, name='User State Test Block')
+    setting_field = fields.String(scope=Scope.settings, name='A setting')
+    content_field = fields.String(scope=Scope.content, name='A setting')
+
+    @XBlock.json_handler
+    def update_fields(self, data, suffix=None):  # pylint: disable=unused-argument
+        """
+        Update the authored fields of this block
+        """
+        self.display_name = data["display_name"]
+        self.setting_field = data["setting_field"]
+        self.content_field = data["content_field"]
+        return {}
+
+    @XBlock.handler
+    def get_fields(self, request, suffix=None):  # pylint: disable=unused-argument
+        """
+        Get the various fields of this XBlock.
+        """
+        return Response(
+            json.dumps({
+                "display_name": self.display_name,
+                "setting_field": self.setting_field,
+                "content_field": self.content_field,
+            }),
+            content_type='application/json',
+            charset='UTF-8',
+        )
+
+    def student_view(self, _context):
+        """
+        Return the student view.
+        """
+        fragment = Fragment()
+        fragment.add_content(f'<h1>{self.display_name}</h1>\n')
+        fragment.add_content(f'<p>SF: {self.setting_field}</p>\n')
+        fragment.add_content(f'<p>CF: {self.content_field}</p>\n')
+        handler_url = self.runtime.handler_url(self, 'get_fields')
+        fragment.add_content(f'<p>handler URL: {handler_url}</p>\n')
+        return fragment

--- a/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
@@ -117,6 +117,9 @@ class LibrariesEmbedViewTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestM
         html = self._embed_block(block_id, version=2)
         check_fields('Field Test Block (Old, v2)', 'Old setting value 2.', 'Old content value 2.')
 
+        html = self._embed_block(block_id, version=4)
+        check_fields('Field Test Block (Draft, v4)', 'Draft setting value 4.', 'Draft content value 4.')
+
     @XBlock.register_temp_plugin(FieldsTestBlock, FieldsTestBlock.BLOCK_TYPE)
     def test_handlers_modifying_published_data(self):
         """

--- a/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
@@ -1,0 +1,125 @@
+"""
+Tests for the XBlock v2 runtime's "embed" view, using Content Libraries
+
+This view is used in the MFE to preview XBlocks that are in the library.
+"""
+import re
+
+import ddt
+from django.test.utils import override_settings
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from xblock.core import XBlock
+
+from openedx.core.djangoapps.content_libraries.tests.base import (
+    ContentLibrariesRestApiTest
+)
+from openedx.core.djangolib.testing.utils import skip_unless_cms
+from .fields_test_block import FieldsTestBlock
+
+
+@skip_unless_cms
+@ddt.ddt
+@override_settings(CORS_ORIGIN_WHITELIST=[])  # For some reason, this setting isn't defined in our test environment?
+class LibrariesEmbedViewTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMixin):
+    """
+    Tests for embed_view and interacting with draft/published/past versions of
+    Learning-Core-based XBlocks (in Content Libraries).
+
+    These tests use the REST API, which in turn relies on the Python API.
+    Some tests may use the python API directly if necessary to provide
+    coverage of any code paths not accessible via the REST API.
+
+    In general, these tests should
+    (1) Use public APIs only - don't directly create data using other methods,
+        which results in a less realistic test and ties the test suite too
+        closely to specific implementation details.
+        (Exception: users can be provisioned using a user factory)
+    (2) Assert that fields are present in responses, but don't assert that the
+        entire response has some specific shape. That way, things like adding
+        new fields to an API response, which are backwards compatible, won't
+        break any tests, but backwards-incompatible API changes will.
+
+    WARNING: every test should have a unique library slug, because even though
+    the django/mysql database gets reset for each test case, the lookup between
+    library slug and bundle UUID does not because it's assumed to be immutable
+    and cached forever.
+    """
+
+    @XBlock.register_temp_plugin(FieldsTestBlock, FieldsTestBlock.BLOCK_TYPE)
+    def test_embed_vew_versions(self):
+        """
+        Test that the embed_view renders a block and can render different versions of it.
+        """
+        # Create a library:
+        lib = self._create_library(slug="test-eb-1", title="Test Library", description="")
+        lib_id = lib["id"]
+        # Create an XBlock. This will be the empty version 1:
+        create_response = self._add_block_to_library(lib_id, FieldsTestBlock.BLOCK_TYPE, "block1")
+        block_id = create_response["id"]
+        # Create version 2 of the block by setting its OLX:
+        olx_response = self._set_library_block_olx(block_id, """
+            <fields-test
+                display_name="Field Test Block (Old, v2)"
+                setting_field="Old setting value 2."
+                content_field="Old content value 2."
+            />
+        """)
+        assert olx_response["version_num"] == 2
+        # Create version 3 of the block by setting its OLX again:
+        olx_response = self._set_library_block_olx(block_id, """
+            <fields-test
+                display_name="Field Test Block (Published, v3)"
+                setting_field="Published setting value 3."
+                content_field="Published content value 3."
+            />
+        """)
+        assert olx_response["version_num"] == 3
+        # Publish the library:
+        self._commit_library_changes(lib_id)
+
+        # Create the draft (version 4) of the block:
+        olx_response = self._set_library_block_olx(block_id, """
+            <fields-test
+                display_name="Field Test Block (Draft, v4)"
+                setting_field="Draft setting value 4."
+                content_field="Draft content value 4."
+            />
+        """)
+
+        # Now render the "embed block" view. This test only runs in CMS so it should default to the draft:
+        html = self._embed_block(block_id)
+
+        def check_fields(display_name, setting_value, content_value):
+            assert f'<h1>{display_name}</h1>' in html
+            assert f'<p>SF: {setting_value}</p>' in html
+            assert f'<p>CF: {content_value}</p>' in html
+            handler_url = re.search(r'<p>handler URL: ([^<]+)</p>', html).group(1)
+            assert handler_url.startswith('http')
+            handler_result = self.client.get(handler_url).json()
+            assert handler_result == {
+                "display_name": display_name,
+                "setting_field": setting_value,
+                "content_field": content_value,
+            }
+        check_fields('Field Test Block (Draft, v4)', 'Draft setting value 4.', 'Draft content value 4.')
+
+        # But if we request the published version, we get that:
+        html = self._embed_block(block_id, version="published")
+        check_fields('Field Test Block (Published, v3)', 'Published setting value 3.', 'Published content value 3.')
+
+        # And if we request a specific version, we get that:
+        html = self._embed_block(block_id, version=3)
+        check_fields('Field Test Block (Published, v3)', 'Published setting value 3.', 'Published content value 3.')
+
+        # And if we request a specific version, we get that:
+        html = self._embed_block(block_id, version=2)
+        check_fields('Field Test Block (Old, v2)', 'Old setting value 2.', 'Old content value 2.')
+
+    # TODO: if we requested any version other than "draft", the handlers should not allow _writing_ to authored field
+    # data. Writing to student state is OK.
+
+    # TODO: test that any static assets referenced in the student_view html are loaded as the correct version, and not
+    # always loaded as "latest draft".
+
+    # TODO: if we are ever able to run these tests in the LMS, test that the LMS only allows accessing the published
+    # version.

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -692,10 +692,10 @@ class LibraryBlockOlxView(APIView):
         serializer.is_valid(raise_exception=True)
         new_olx_str = serializer.validated_data["olx"]
         try:
-            api.set_library_block_olx(key, new_olx_str)
+            version_num = api.set_library_block_olx(key, new_olx_str)
         except ValueError as err:
             raise ValidationError(detail=str(err))  # lint-amnesty, pylint: disable=raise-missing-from
-        return Response(LibraryXBlockOlxSerializer({"olx": new_olx_str}).data)
+        return Response(LibraryXBlockOlxSerializer({"olx": new_olx_str, "version_num": version_num}).data)
 
 
 @method_decorator(non_atomic_requests, name="dispatch")

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -5,7 +5,7 @@ we keep here some extra classes for usage within edx-platform. These classes cov
 import logging
 
 from edx_toggles.toggles import WaffleFlag
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, LearningContextKey
 
 log = logging.getLogger(__name__)
 
@@ -107,12 +107,12 @@ class CourseWaffleFlag(WaffleFlag):
                 outside the context of any course.
         """
         if course_key:
-            assert isinstance(
-                course_key, CourseKey
-            ), "Provided course_key '{}' is not instance of CourseKey.".format(
-                course_key
-            )
-        is_enabled_for_course = self._get_course_override_value(course_key)
-        if is_enabled_for_course is not None:
-            return is_enabled_for_course
+            if isinstance(course_key, CourseKey):
+                is_enabled_for_course = self._get_course_override_value(course_key)
+                if is_enabled_for_course is not None:
+                    return is_enabled_for_course
+            else:
+                # In case this gets called with a content library key, that's fine - just ignore it and
+                # act like a normal waffle flag. We currently don't support library-specific overrides.
+                assert isinstance(course_key, LearningContextKey)
         return super().is_enabled()

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -99,7 +99,11 @@ class CourseWaffleFlag(WaffleFlag):
 
     def is_enabled(self, course_key=None):  # pylint: disable=arguments-differ
         """
-        Returns whether or not the flag is enabled within the context of a given course.
+        Returns whether or not the flag is enabled within the context of a given
+        course.
+
+        Can also be given the key of any other learning context (like a content
+        library), but it will act like a regular waffle flag in that case.
 
         Arguments:
             course_key (Optional[CourseKey]): The course to check for override before
@@ -114,5 +118,5 @@ class CourseWaffleFlag(WaffleFlag):
             else:
                 # In case this gets called with a content library key, that's fine - just ignore it and
                 # act like a normal waffle flag. We currently don't support library-specific overrides.
-                assert isinstance(course_key, LearningContextKey)
+                assert isinstance(course_key, LearningContextKey), "expected a course key or other learning context key"
         return super().is_enabled()

--- a/openedx/core/djangoapps/xblock/api.py
+++ b/openedx/core/djangoapps/xblock/api.py
@@ -17,7 +17,7 @@ from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from openedx_learning.api import authoring as authoring_api
-from openedx_learning.api.authoring_models import Component
+from openedx_learning.api.authoring_models import Component, ComponentVersion
 from opaque_keys.edx.keys import UsageKeyV2
 from opaque_keys.edx.locator import BundleDefinitionLocator, LibraryUsageLocatorV2
 from rest_framework.exceptions import NotFound
@@ -113,6 +113,9 @@ def load_block(
     except NoSuchUsage as exc:
         # Convert NoSuchUsage to NotFound so we do the right thing (404 not 500) by default.
         raise NotFound(f"The component '{usage_key}' does not exist.") from exc
+    except ComponentVersion.DoesNotExist as exc:
+        # Convert ComponentVersion.DoesNotExist to NotFound so we do the right thing (404 not 500) by default.
+        raise NotFound(f"The requested version of component '{usage_key}' does not exist.") from exc
 
 
 def get_block_metadata(block, includes=()):

--- a/openedx/core/djangoapps/xblock/api.py
+++ b/openedx/core/djangoapps/xblock/api.py
@@ -251,7 +251,7 @@ def render_block_view(block, view_name, user):  # pylint: disable=unused-argumen
 def get_handler_url(
     usage_key: UsageKeyV2,
     handler_name: str,
-    user: UserType,
+    user: UserType | None,
     *,
     version: int | LatestVersion = LatestVersion.AUTO,
 ):
@@ -281,9 +281,9 @@ def get_handler_url(
     """
     usage_key_str = str(usage_key)
     site_root_url = get_xblock_app_config().get_site_root_url()
-    if not user:  # lint-amnesty, pylint: disable=no-else-raise
+    if not user:
         raise TypeError("Cannot get handler URLs without specifying a specific user ID.")
-    elif user.is_authenticated:
+    if user.is_authenticated:
         user_id = user.id
     elif user.is_anonymous:
         user_id = get_xblock_id_for_anonymous_user(user)

--- a/openedx/core/djangoapps/xblock/apps.py
+++ b/openedx/core/djangoapps/xblock/apps.py
@@ -5,7 +5,7 @@ from django.apps import AppConfig, apps
 from django.conf import settings
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from .data import StudentDataMode
+from .data import StudentDataMode, AuthoredDataMode
 
 
 class XBlockAppConfig(AppConfig):
@@ -50,6 +50,7 @@ class LmsXBlockAppConfig(XBlockAppConfig):
         """
         return dict(
             student_data_mode=StudentDataMode.Persisted,
+            authored_data_mode=AuthoredDataMode.STRICTLY_PUBLISHED,
         )
 
     def get_site_root_url(self):
@@ -72,6 +73,7 @@ class StudioXBlockAppConfig(XBlockAppConfig):
         """
         return dict(
             student_data_mode=StudentDataMode.Ephemeral,
+            authored_data_mode=AuthoredDataMode.DEFAULT_DRAFT,
         )
 
     def get_site_root_url(self):

--- a/openedx/core/djangoapps/xblock/data.py
+++ b/openedx/core/djangoapps/xblock/data.py
@@ -11,3 +11,39 @@ class StudentDataMode(Enum):
     """
     Ephemeral = 'ephemeral'
     Persisted = 'persisted'
+
+
+class AuthoredDataMode(Enum):
+    """
+    Runtime configuration which determines whether published or draft versions of content is used by default.
+    """
+    # Published only: used by the LMS. ONLY the published version of an XBlock is ever loaded. Users/APIs cannot request
+    # the draft version nor a specific version.
+    STRICTLY_PUBLISHED = 'published'
+    # Default draft: used by Studio. By default the "lastest draft" version of an XBlock is used, but users/APIs can
+    # also request to see the published version or any specific (old) version.
+    DEFAULT_DRAFT = 'persisted'
+
+
+class CheckPerm(Enum):
+    """
+    Options for the default permission check done by load_block()
+    """
+    # can view the published block and call handlers etc. but not necessarily view its OLX source nor field data
+    CAN_LEARN = 1
+    # read-only studio view: can see the block (draft or published), see its OLX, see its field data, etc.
+    CAN_READ_AS_AUTHOR = 2
+    # can view everything and make changes to the block
+    CAN_EDIT = 3
+
+
+class LatestVersion(Enum):
+    """
+    Options for specifying which version of an XBlock you want to load, if not specifying a specific version.
+    """
+    # Get the latest draft
+    DRAFT = "draft"
+    # Get the latest published version
+    PUBLISHED = "published"
+    # Get the default (based on AuthoredDataMode, i.e. published for LMS APIs, draft for Studio APIs)
+    AUTO = "auto"

--- a/openedx/core/djangoapps/xblock/rest_api/urls.py
+++ b/openedx/core/djangoapps/xblock/rest_api/urls.py
@@ -32,6 +32,6 @@ urlpatterns = [
     path('xblocks/v2/<str:usage_key_str>/', include([
         # render one of this XBlock's views (e.g. student_view) for embedding in an iframe
         # NOTE: this endpoint is **unstable** and subject to changes after Sumac
-        re_path(r'^embed/(?P<view_name>[\w\-]+)/$', views.embed_block_view),
+        path('embed/<str:view_name>/', views.embed_block_view),
     ])),
 ]

--- a/openedx/core/djangoapps/xblock/rest_api/views.py
+++ b/openedx/core/djangoapps/xblock/rest_api/views.py
@@ -1,7 +1,6 @@
 """
 Views that implement a RESTful API for interacting with XBlocks.
 """
-import itertools
 import json
 
 from common.djangoapps.util.json_request import JsonResponse
@@ -58,7 +57,9 @@ def parse_version_request(version_str: str | None) -> LatestVersion | int:
     try:
         return int(version_str)
     except ValueError:
-        raise serializers.ValidationError("Invalid version specifier. Expected 'draft', 'published', or an integer.")
+        raise serializers.ValidationError(  # pylint: disable=raise-missing-from
+            "Invalid version specifier '{version_str}'. Expected 'draft', 'published', or an integer."
+        )
 
 
 @api_view(['GET'])

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -239,6 +239,13 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
         if not self.authored_data_store.has_changes(block):
             return  # No changes, so no action needed.
 
+        if block._runtime_requested_version != LatestVersion.DRAFT:
+            # Not sure if this is an important restriction but it seems like overwriting the latest version based on
+            # an old version is likely an accident, so for now we're not going to allow it.
+            raise ValidationError(
+                "Do not make changes to a component starting from the published or past versions. Use the latest draft."
+            )
+
         # Verify that the user has permission to write to authored data in this
         # learning context:
         if self.user is not None:

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -177,7 +177,7 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
 
         if version == LatestVersion.AUTO:
             if self.authored_data_mode == AuthoredDataMode.DEFAULT_DRAFT:
-                version = LatestVersion.DRAFT 
+                version = LatestVersion.DRAFT
             else:
                 version = LatestVersion.PUBLISHED
         if self.authored_data_mode == AuthoredDataMode.STRICTLY_PUBLISHED and version != LatestVersion.PUBLISHED:

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -218,7 +218,7 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
             block = block_class.parse_xml(xml_node, runtime=self, keys=keys)
 
         # Store the version request on the block so we can retrieve it when needed for generating handler URLs etc.
-        block._runtime_requested_version = version
+        block._runtime_requested_version = version  # pylint: disable=protected-access
 
         # Update field data with parsed values. We can't call .save() because it will call save_block(), below.
         block.force_save_fields(block._get_fields_to_save())  # pylint: disable=protected-access
@@ -239,7 +239,7 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
         if not self.authored_data_store.has_changes(block):
             return  # No changes, so no action needed.
 
-        if block._runtime_requested_version != LatestVersion.DRAFT:
+        if block._runtime_requested_version != LatestVersion.DRAFT:  # pylint: disable=protected-access
             # Not sure if this is an important restriction but it seems like overwriting the latest version based on
             # an old version is likely an accident, so for now we're not going to allow it.
             raise ValidationError(

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -38,7 +38,7 @@ from lms.djangoapps.grades.api import signals as grades_signals
 from openedx.core.types import User as UserType
 from openedx.core.djangoapps.enrollments.services import EnrollmentsService
 from openedx.core.djangoapps.xblock.apps import get_xblock_app_config
-from openedx.core.djangoapps.xblock.data import StudentDataMode
+from openedx.core.djangoapps.xblock.data import AuthoredDataMode, StudentDataMode
 from openedx.core.djangoapps.xblock.runtime.ephemeral_field_data import EphemeralKeyValueStore
 from openedx.core.djangoapps.xblock.runtime.mixin import LmsBlockMixin
 from openedx.core.djangoapps.xblock.utils import get_xblock_id_for_anonymous_user
@@ -101,6 +101,7 @@ class XBlockRuntime(RuntimeShim, Runtime):
         *,
         handler_url: Callable[[UsageKey, str, UserType | None], str],
         student_data_mode: StudentDataMode,
+        authored_data_mode: AuthoredDataMode,
         id_reader: Optional[IdReader] = None,
         authored_data_store: Optional[FieldData] = None,
     ):
@@ -115,6 +116,7 @@ class XBlockRuntime(RuntimeShim, Runtime):
             id_generator=MemoryIdManager(),  # We don't really use id_generator until we need to support asides
         )
         assert student_data_mode in (StudentDataMode.Ephemeral, StudentDataMode.Persisted)
+        self.authored_data_mode = authored_data_mode
         self.authored_data_store = authored_data_store
         self.children_data_store = None
         self.student_data_mode = student_data_mode


### PR DESCRIPTION
This updates the v2 XBlock python APIs so that they can load the latest draft version of an XBlock, or the latest published, or a specific version. Before this, they could only load the draft.

## Supporting information

Working toward https://github.com/openedx/frontend-app-authoring/issues/1341

Private ref: [FAL-3879](https://tasks.opencraft.com/browse/FAL-3879)

## Testing instructions

1. Create a block that says "this is the published version". Publish it, then edit it to say "This is the draft version".
2. Open that block's embed view in both the CMS and LMS. e.g.
    - http://studio.local.openedx.io:8001/xblocks/v2/lb:OpenCraftX:ALPHA:html:12345/embed/student_view/ - studio so will show draft
    - http://local.openedx.io:8000/xblocks/v2/lb:OpenCraftX:ALPHA:html:12345/embed/student_view/ - LMS so will show published
3. With the Studio endpoint you can also pass more specific query params:
    - http://studio.local.openedx.io:8001/xblocks/v2/lb:OpenCraftX:ALPHA:html:12345/embed/student_view/?version=published - studio can be requested to show the published version
    - http://studio.local.openedx.io:8001/xblocks/v2/lb:OpenCraftX:ALPHA:html:12345/embed/student_view/?version=2 - studio can show a specific past version
    - Those are all working examples for me, but you'll need to substitute the ID of a block on your system.

## Deadline

ASAP

## TODO (in future PRs)

This PR ensures that handlers are always executed using the same version of the block that called the handler, but it doesn't yet have the same support for loading static assets from the same version of the block (because we don't have static asset support merged yet).

It's kind of awkward having to publish the entire library at once, rather than publishing just one block that you're working on. But it seems like we don't have an API to publish a single component at a time yet.