### PR TITLE
feat: configuration to block unsupported types while pasting in library [FC-0062]

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2724,6 +2724,7 @@ PASSWORD_RESET_EMAIL_RATE = '2/h'
 
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = 1000
+LIBRARY_UNSUPPORTED_BLOCKS = ['openassessment', 'lti', 'library_content']
 
 ################# Student Verification #################
 VERIFY_STUDENT = {

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -572,6 +572,7 @@ SYSTEM_WIDE_ROLE_CLASSES = ENV_TOKENS.get('SYSTEM_WIDE_ROLE_CLASSES') or SYSTEM_
 
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
+LIBRARY_UNSUPPORTED_BLOCKS = ENV_TOKENS.get('LIBRARY_UNSUPPORTED_BLOCKS', LIBRARY_UNSUPPORTED_BLOCKS)
 
 ########################## Derive Any Derived Settings  #######################
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5202,6 +5202,7 @@ SUPPORT_HOW_TO_UNENROLL_LINK = ''
 
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = 1000
+LIBRARY_UNSUPPORTED_BLOCKS = ['openassessment', 'lti', 'library_content']
 
 ######################## Setting for django-countries ########################
 # django-countries provides an option to make the desired countries come up in

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -993,6 +993,7 @@ DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
+LIBRARY_UNSUPPORTED_BLOCKS = ENV_TOKENS.get('LIBRARY_UNSUPPORTED_BLOCKS', LIBRARY_UNSUPPORTED_BLOCKS)
 
 ########################## Derive Any Derived Settings  #######################
 

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -816,11 +816,7 @@ def validate_can_add_block_to_library(
                 )
             )
     if block_type in settings.LIBRARY_UNSUPPORTED_BLOCKS:
-        raise IncompatibleTypesError(
-            _('Libraries do not support this type: "{block_type}" of content yet.').format(
-                block_type=block_type
-            )
-        )
+        raise IncompatibleTypesError(_('Libraries do not support this type of content yet.'))
 
     # If adding a component would take us over our max, return an error.
     component_count = authoring_api.get_all_drafts(content_library.learning_package.id).count()

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -815,6 +815,12 @@ def validate_can_add_block_to_library(
                     block_type=block_type, library_type=content_library.type,
                 )
             )
+    if block_type in settings.LIBRARY_UNSUPPORTED_BLOCKS:
+        raise IncompatibleTypesError(
+            _('Libraries do not support this type: "{block_type}" of content yet.').format(
+                block_type=block_type
+            )
+        )
 
     # If adding a component would take us over our max, return an error.
     component_count = authoring_api.get_all_drafts(content_library.learning_package.id).count()


### PR DESCRIPTION
## Description

Adds setting to stop authors from pasting unsupported block types in libraries

- Which edX user roles will this change impact?: "Course Author"

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/1311
* https://github.com/openedx/frontend-app-authoring/pull/1378
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-3860

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/1378 for test instructions.

## Deadline

ASAP
