### PR TITLE
feat: use jammy repositories to install mongo for testing and unpin lxml and xmlsec.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           if [[ "${{ matrix.mongo-version }}" != "4.4" ]]; then
             wget -qO - https://www.mongodb.org/static/pgp/server-${{ matrix.mongo-version }}.asc | sudo apt-key add -
-            echo "deb https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/${{ matrix.mongo-version }} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${{ matrix.mongo-version }}.list
+            echo "deb https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/${{ matrix.mongo-version }} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${{ matrix.mongo-version }}.list
             sudo apt-get update && sudo apt-get install -y mongodb-org="${{ matrix.mongo-version }}.*"
           fi
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -84,13 +84,6 @@ django-storages<1.14.4
 # for them.
 edx-enterprise==4.27.2
 
-# Date: 2024-05-09
-# This has to be constrained as well because newer versions of edx-i18n-tools need the
-# newer version of lxml but that requirement was not made expilict in the 1.6.0 version
-# of the package.  This can be un-pinned when we're upgrading lxml.
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35274
-edx-i18n-tools<1.6.0
-
 # Date: 2024-07-26
 # To override the constraint of edx-lint
 # This can be removed once https://github.com/openedx/edx-platform/issues/34586 is resolved
@@ -104,13 +97,6 @@ event-tracking==3.0.0
 # away from legacy LMS/CMS frontends:
 # https://github.com/openedx/edx-platform/issues/31616
 libsass==0.10.0
-
-# Date: 2024-04-30
-# lxml>=5.0 introduced breaking changes related to system dependencies
-# lxml==5.2.1 introduced new extra so we'll nee to rename lxml --> lxml[html-clean]
-# This constraint can be removed once we upgrade to Python 3.11
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35272
-lxml<5.0
 
 # Date: 2018-12-14
 # markdown>=3.4.0 has failures due to internal refactorings which causes the tests to fail
@@ -187,8 +173,3 @@ social-auth-app-django<=5.4.1
 # which require urllib3<2 for now.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/32222
 urllib3<2.0.0
-
-# Date: 2024-04-24
-# xmlsec==1.3.14 breaking tests or all builds, can be removed once a fix is available
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35264
-xmlsec<1.3.14

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -26,12 +26,11 @@ joblib==1.4.2
     # via nltk
 kiwisolver==1.4.7
     # via matplotlib
-lxml==4.9.4
+lxml==5.3.0
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/base.in
     #   openedx-calc
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via
     #   chem
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,11 +6,11 @@
 #
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via -r requirements/edx/github.in
-acid-xblock==0.3.1
+acid-xblock==0.4.1
     # via -r requirements/edx/kernel.in
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.6
+aiohttp==3.10.9
     # via
     #   geoip2
     #   openai
@@ -70,13 +70,13 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.35.27
+boto3==1.35.37
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.27
+botocore==1.35.37
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -87,7 +87,7 @@ cachecontrol==0.14.0
     # via firebase-admin
 cachetools==5.5.0
     # via google-auth
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==4.0.1
     # via meilisearch
 celery==5.4.0
     # via
@@ -328,7 +328,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
-django-ses==4.1.1
+django-ses==4.2.0
     # via -r requirements/edx/bundled.in
 django-simple-history==3.4.0
     # via
@@ -387,7 +387,7 @@ djangorestframework==3.14.0
     #   super-csv
 djangorestframework-xml==2.0.0
     # via edx-enterprise
-dnspython==2.6.1
+dnspython==2.7.0
     # via
     #   -r requirements/edx/paver.txt
     #   pymongo
@@ -429,7 +429,7 @@ edx-celeryutils==1.3.0
     #   super-csv
 edx-codejail==3.4.1
     # via -r requirements/edx/kernel.in
-edx-completion==4.7.1
+edx-completion==4.7.2
     # via -r requirements/edx/kernel.in
 edx-django-release-util==1.4.0
     # via
@@ -438,7 +438,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/kernel.in
-edx-django-utils==5.16.0
+edx-django-utils==6.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   django-config-models
@@ -475,9 +475,8 @@ edx-event-bus-kafka==5.8.1
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/kernel.in
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.6.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
     #   ora2
 edx-milestones==0.6.0
@@ -517,7 +516,7 @@ edx-search==4.0.0
     # via -r requirements/edx/kernel.in
 edx-sga==0.25.0
     # via -r requirements/edx/bundled.in
-edx-submissions==3.8.0
+edx-submissions==3.8.1
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
@@ -584,14 +583,14 @@ geoip2==4.8.0
     # via -r requirements/edx/kernel.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
-google-api-core[grpc]==2.20.0
+google-api-core[grpc]==2.21.0
     # via
     #   firebase-admin
     #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.147.0
+google-api-python-client==2.149.0
     # via firebase-admin
 google-auth==2.35.0
     # via
@@ -621,11 +620,11 @@ googleapis-common-protos==1.65.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.66.1
+grpcio==1.66.2
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.1
+grpcio-status==1.66.2
     # via google-api-core
 gunicorn==23.0.0
     # via -r requirements/edx/kernel.in
@@ -639,7 +638,7 @@ httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-icalendar==5.0.13
+icalendar==6.0.0
     # via -r requirements/edx/kernel.in
 idna==3.10
     # via
@@ -658,7 +657,7 @@ interchange==2021.0.4
     # via py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/kernel.in
-isodate==0.6.1
+isodate==0.7.2
     # via python3-saml
 jinja2==3.1.4
     # via code-annotations
@@ -683,7 +682,7 @@ jsonschema==4.23.0
     # via
     #   drf-spectacular
     #   optimizely-sdk
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 jwcrypto==1.5.6
     # via
@@ -708,19 +707,21 @@ loremipsum==1.0.5
     # via ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/kernel.in
-lxml==4.9.4
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via lxml
 mailsnake==1.6.4
     # via -r requirements/edx/bundled.in
 mako==1.3.5
@@ -737,7 +738,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via
     #   -r requirements/edx/paver.txt
     #   chem
@@ -769,7 +770,7 @@ multidict==6.1.0
     #   yarl
 mysqlclient==2.2.4
     # via -r requirements/edx/kernel.in
-newrelic==9.13.0
+newrelic==10.0.0
     # via
     #   -r requirements/edx/bundled.in
     #   edx-django-utils
@@ -820,7 +821,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.10.0
+openedx-filters==1.11.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
@@ -829,7 +830,7 @@ openedx-learning==0.13.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
-openedx-mongodbproxy==0.2.1
+openedx-mongodbproxy==0.2.2
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via
@@ -881,6 +882,8 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.48
     # via click-repl
+propcache==0.2.0
+    # via yarl
 proto-plus==1.24.0
     # via
     #   google-api-core
@@ -911,7 +914,7 @@ pycountry==24.6.1
     # via -r requirements/edx/kernel.in
 pycparser==2.22
     # via cffi
-pycryptodomex==3.20.0
+pycryptodomex==3.21.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
@@ -1017,7 +1020,6 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1039,7 +1041,7 @@ random2==1.0.2
     # via -r requirements/edx/kernel.in
 recommender-xblock==2.2.1
     # via -r requirements/edx/bundled.in
-redis==5.0.8
+redis==5.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   walrus
@@ -1092,7 +1094,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
@@ -1131,7 +1133,6 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
-    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pansi
@@ -1208,6 +1209,7 @@ typing-extensions==4.12.2
 tzdata==2024.2
     # via
     #   celery
+    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -1237,7 +1239,7 @@ voluptuous==0.15.2
     # via ora2
 walrus==0.9.4
     # via edx-event-bus-redis
-watchdog==5.0.2
+watchdog==5.0.3
     # via -r requirements/edx/paver.txt
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -1285,13 +1287,11 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   python3-saml
+xmlsec==1.3.14
+    # via python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/kernel.in
-yarl==1.12.1
+yarl==1.14.0
     # via aiohttp
 zipp==3.20.2
     # via importlib-metadata

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,13 +6,13 @@
 #
 chardet==5.2.0
     # via diff-cover
-coverage==7.6.1
+coverage==7.6.2
     # via -r requirements/edx/coverage.in
 diff-cover==9.2.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.4
     # via diff-cover
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via jinja2
 pluggy==1.5.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -12,16 +12,16 @@ accessible-pygments==0.0.5
     # via
     #   -r requirements/edx/doc.txt
     #   pydata-sphinx-theme
-acid-xblock==0.3.1
+acid-xblock==0.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
-aiohttp==3.10.6
+aiohttp==3.10.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -140,14 +140,14 @@ boto==2.49.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.35.27
+boto3==1.35.37
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.27
+botocore==1.35.37
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -157,7 +157,7 @@ bridgekeeper==0.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-build==1.2.2
+build==1.2.2.post1
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   pip-tools
@@ -172,7 +172,7 @@ cachetools==5.5.0
     #   -r requirements/edx/testing.txt
     #   google-auth
     #   tox
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==4.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -278,7 +278,7 @@ colorama==0.4.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -325,11 +325,11 @@ defusedxml==0.7.1
     #   social-auth-core
 diff-cover==9.2.0
     # via -r requirements/edx/testing.txt
-dill==0.3.8
+dill==0.3.9
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-distlib==0.3.8
+distlib==0.3.9
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
@@ -544,7 +544,7 @@ django-sekizai==4.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-django-wiki
-django-ses==4.1.1
+django-ses==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -627,7 +627,7 @@ djangorestframework-xml==2.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-dnspython==2.6.1
+dnspython==2.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -696,7 +696,7 @@ edx-codejail==3.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-completion==4.7.1
+edx-completion==4.7.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -710,7 +710,7 @@ edx-django-sites-extensions==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-utils==5.16.0
+edx-django-utils==6.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -754,9 +754,8 @@ edx-event-bus-redis==0.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.6.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -814,7 +813,7 @@ edx-sga==0.25.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-submissions==3.8.0
+edx-submissions==3.8.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -879,7 +878,7 @@ execnet==2.1.1
     #   pytest-xdist
 factory-boy==3.3.1
     # via -r requirements/edx/testing.txt
-faker==30.0.0
+faker==30.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -943,7 +942,7 @@ glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-google-api-core[grpc]==2.20.0
+google-api-core[grpc]==2.21.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -952,7 +951,7 @@ google-api-core[grpc]==2.20.0
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.147.0
+google-api-python-client==2.149.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1005,17 +1004,17 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.4.1
+grimp==3.5
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
-grpcio==1.66.1
+grpcio==1.66.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.1
+grpcio-status==1.66.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1045,7 +1044,7 @@ httplib2==0.22.0
     #   google-auth-httplib2
 httpretty==1.1.4
     # via -r requirements/edx/testing.txt
-icalendar==5.0.13
+icalendar==6.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1062,7 +1061,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-import-linter==2.0
+import-linter==2.1
     # via -r requirements/edx/testing.txt
 importlib-metadata==8.5.0
     # via
@@ -1087,7 +1086,7 @@ ipaddress==1.0.23
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-isodate==0.6.1
+isodate==0.7.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1136,7 +1135,7 @@ jsonschema==4.23.0
     #   drf-spectacular
     #   optimizely-sdk
     #   sphinxcontrib-openapi
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1183,14 +1182,14 @@ lti-consumer-xblock==9.11.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-lxml==4.9.4
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -1198,6 +1197,11 @@ lxml==4.9.4
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   lxml
 mailsnake==1.6.4
     # via
     #   -r requirements/edx/doc.txt
@@ -1218,7 +1222,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1290,7 +1294,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-newrelic==9.13.0
+newrelic==10.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1368,7 +1372,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.10.0
+openedx-filters==1.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1379,7 +1383,7 @@ openedx-learning==0.13.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-mongodbproxy==0.2.1
+openedx-mongodbproxy==0.2.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1407,7 +1411,7 @@ packaging==24.1
     #   snowflake-connector-python
     #   sphinx
     #   tox
-pact-python==2.2.1
+pact-python==2.2.2
     # via -r requirements/edx/testing.txt
 pansi==2020.7.3
     # via
@@ -1488,6 +1492,11 @@ prompt-toolkit==3.0.48
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   click-repl
+propcache==0.2.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   yarl
 proto-plus==1.24.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1542,7 +1551,7 @@ pycparser==2.22
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cffi
-pycryptodomex==3.20.0
+pycryptodomex==3.21.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1666,7 +1675,7 @@ pyproject-api==1.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   build
@@ -1767,7 +1776,6 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1799,7 +1807,7 @@ recommender-xblock==2.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-redis==5.0.8
+redis==5.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1869,7 +1877,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1926,7 +1934,6 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
-    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pact-python
@@ -1986,7 +1993,7 @@ soupsieve==2.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==8.0.2
+sphinx==8.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   pydata-sphinx-theme
@@ -2087,7 +2094,7 @@ tinycss2==1.2.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   bleach
-tomli==2.0.1
+tomli==2.0.2
     # via django-stubs
 tomlkit==0.13.2
     # via
@@ -2095,7 +2102,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/testing.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.20.0
+tox==4.21.2
     # via -r requirements/edx/testing.txt
 tqdm==4.66.5
     # via
@@ -2103,7 +2110,7 @@ tqdm==4.66.5
     #   -r requirements/edx/testing.txt
     #   nltk
     #   openai
-types-pytz==2024.2.0.20240913
+types-pytz==2024.2.0.20241003
     # via django-stubs
 types-pyyaml==6.0.12.20240917
     # via
@@ -2122,6 +2129,7 @@ typing-extensions==4.12.2
     #   django-stubs-ext
     #   djangorestframework-stubs
     #   edx-opaque-keys
+    #   faker
     #   fastapi
     #   grimp
     #   import-linter
@@ -2137,6 +2145,7 @@ tzdata==2024.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   celery
+    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -2165,7 +2174,7 @@ user-util==1.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-uvicorn==0.30.6
+uvicorn==0.31.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -2176,7 +2185,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.5
+virtualenv==20.26.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -2185,14 +2194,14 @@ voluptuous==0.15.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-vulture==2.12
+vulture==2.13
     # via -r requirements/edx/development.in
 walrus==0.9.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-redis
-watchdog==5.0.2
+watchdog==5.0.3
     # via
     #   -r requirements/edx/development.in
     #   -r requirements/edx/doc.txt
@@ -2266,9 +2275,8 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
+xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml
@@ -2276,7 +2284,7 @@ xss-utils==0.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-yarl==1.12.1
+yarl==1.14.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -8,13 +8,13 @@
     # via -r requirements/edx/base.txt
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-acid-xblock==0.3.1
+acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.3
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.10.6
+aiohttp==3.10.9
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -102,13 +102,13 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.35.27
+boto3==1.35.37
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.27
+botocore==1.35.37
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -123,7 +123,7 @@ cachetools==5.5.0
     # via
     #   -r requirements/edx/base.txt
     #   google-auth
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
@@ -398,7 +398,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.1.1
+django-ses==4.2.0
     # via -r requirements/edx/base.txt
 django-simple-history==3.4.0
     # via
@@ -459,7 +459,7 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-dnspython==2.6.1
+dnspython==2.7.0
     # via
     #   -r requirements/edx/base.txt
     #   pymongo
@@ -509,7 +509,7 @@ edx-celeryutils==1.3.0
     #   super-csv
 edx-codejail==3.4.1
     # via -r requirements/edx/base.txt
-edx-completion==4.7.1
+edx-completion==4.7.2
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.4.0
     # via
@@ -518,7 +518,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/base.txt
-edx-django-utils==5.16.0
+edx-django-utils==6.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -555,9 +555,8 @@ edx-event-bus-kafka==5.8.1
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.6.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   ora2
 edx-milestones==0.6.0
@@ -598,7 +597,7 @@ edx-search==4.0.0
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.8.0
+edx-submissions==3.8.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -683,7 +682,7 @@ gitpython==3.1.43
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.20.0
+google-api-core[grpc]==2.21.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -691,7 +690,7 @@ google-api-core[grpc]==2.20.0
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.147.0
+google-api-python-client==2.149.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -735,12 +734,12 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.66.1
+grpcio==1.66.2
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.1
+grpcio-status==1.66.2
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -757,7 +756,7 @@ httplib2==0.22.0
     #   -r requirements/edx/base.txt
     #   google-api-python-client
     #   google-auth-httplib2
-icalendar==5.0.13
+icalendar==6.0.0
     # via -r requirements/edx/base.txt
 idna==3.10
     # via
@@ -781,7 +780,7 @@ interchange==2021.0.4
     #   py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
-isodate==0.6.1
+isodate==0.7.2
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
@@ -818,7 +817,7 @@ jsonschema==4.23.0
     #   drf-spectacular
     #   optimizely-sdk
     #   sphinxcontrib-openapi
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -850,19 +849,23 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/base.txt
-lxml==4.9.4
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
 mako==1.3.5
@@ -879,7 +882,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -923,7 +926,7 @@ multidict==6.1.0
     #   yarl
 mysqlclient==2.2.4
     # via -r requirements/edx/base.txt
-newrelic==9.13.0
+newrelic==10.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -979,7 +982,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.10.0
+openedx-filters==1.11.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
@@ -988,7 +991,7 @@ openedx-learning==0.13.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-openedx-mongodbproxy==0.2.1
+openedx-mongodbproxy==0.2.2
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via
@@ -1057,6 +1060,10 @@ prompt-toolkit==3.0.48
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
+propcache==0.2.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   yarl
 proto-plus==1.24.0
     # via
     #   -r requirements/edx/base.txt
@@ -1094,7 +1101,7 @@ pycparser==2.22
     # via
     #   -r requirements/edx/base.txt
     #   cffi
-pycryptodomex==3.20.0
+pycryptodomex==3.21.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
@@ -1222,7 +1229,6 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1245,7 +1251,7 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==2.2.1
     # via -r requirements/edx/base.txt
-redis==5.0.8
+redis==5.1.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
@@ -1305,7 +1311,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1350,7 +1356,6 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
-    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pansi
@@ -1394,7 +1399,7 @@ soupsieve==2.6
     # via
     #   -r requirements/edx/base.txt
     #   beautifulsoup4
-sphinx==8.0.2
+sphinx==8.1.0
     # via
     #   -r requirements/edx/doc.in
     #   pydata-sphinx-theme
@@ -1489,6 +1494,7 @@ tzdata==2024.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
+    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -1524,7 +1530,7 @@ walrus==0.9.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
-watchdog==5.0.2
+watchdog==5.0.3
     # via -r requirements/edx/base.txt
 wcwidth==0.2.13
     # via
@@ -1576,14 +1582,13 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
+xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/base.txt
-yarl==1.12.1
+yarl==1.14.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests
-dnspython==2.6.1
+dnspython==2.7.0
     # via pymongo
 edx-opaque-keys==2.11.0
     # via -r requirements/edx/paver.in
@@ -22,7 +22,7 @@ libsass==0.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.in
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via -r requirements/edx/paver.in
 mock==5.1.0
     # via -r requirements/edx/paver.in
@@ -61,7 +61,7 @@ urllib3==1.26.20
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests
-watchdog==5.0.2
+watchdog==5.0.3
     # via -r requirements/edx/paver.in
 wrapt==1.16.0
     # via -r requirements/edx/paver.in

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -15,7 +15,7 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-bracex==2.5
+bracex==2.5.post1
     # via wcmatch
 certifi==2024.8.30
     # via requests
@@ -42,7 +42,7 @@ idna==3.10
     # via requests
 jsonschema==4.23.0
     # via semgrep
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
@@ -60,7 +60,7 @@ referencing==0.35.1
     #   jsonschema-specifications
 requests==2.32.3
     # via semgrep
-rich==13.8.1
+rich==13.9.2
     # via semgrep
 rpds-py==0.20.0
     # via
@@ -72,7 +72,7 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 semgrep==1.52.0
     # via -r requirements/edx/semgrep.in
-tomli==2.0.1
+tomli==2.0.2
     # via semgrep
 typing-extensions==4.12.2
     # via semgrep

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,13 +6,13 @@
 #
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via -r requirements/edx/base.txt
-acid-xblock==0.3.1
+acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.3
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.10.6
+aiohttp==3.10.9
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -102,13 +102,13 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.35.27
+boto3==1.35.37
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.27
+botocore==1.35.37
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -124,7 +124,7 @@ cachetools==5.5.0
     #   -r requirements/edx/base.txt
     #   google-auth
     #   tox
-camel-converter[pydantic]==3.1.2
+camel-converter[pydantic]==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
@@ -209,7 +209,7 @@ codejail-includes==1.0.0
     # via -r requirements/edx/base.txt
 colorama==0.4.6
     # via tox
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -247,9 +247,9 @@ defusedxml==0.7.1
     #   social-auth-core
 diff-cover==9.2.0
     # via -r requirements/edx/coverage.txt
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 django==4.2.16
     # via
@@ -427,7 +427,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.1.1
+django-ses==4.2.0
     # via -r requirements/edx/base.txt
 django-simple-history==3.4.0
     # via
@@ -488,7 +488,7 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-dnspython==2.6.1
+dnspython==2.7.0
     # via
     #   -r requirements/edx/base.txt
     #   pymongo
@@ -533,7 +533,7 @@ edx-celeryutils==1.3.0
     #   super-csv
 edx-codejail==3.4.1
     # via -r requirements/edx/base.txt
-edx-completion==4.7.1
+edx-completion==4.7.2
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.4.0
     # via
@@ -542,7 +542,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/base.txt
-edx-django-utils==5.16.0
+edx-django-utils==6.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -579,9 +579,8 @@ edx-event-bus-kafka==5.8.1
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.6.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   ora2
 edx-lint==5.4.0
@@ -624,7 +623,7 @@ edx-search==4.0.0
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.8.0
+edx-submissions==3.8.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -674,7 +673,7 @@ execnet==2.1.1
     # via pytest-xdist
 factory-boy==3.3.1
     # via -r requirements/edx/testing.in
-faker==30.0.0
+faker==30.3.0
     # via factory-boy
 fastapi==0.115.0
     # via pact-python
@@ -717,7 +716,7 @@ geoip2==4.8.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.20.0
+google-api-core[grpc]==2.21.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -725,7 +724,7 @@ google-api-core[grpc]==2.20.0
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.147.0
+google-api-python-client==2.149.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -769,14 +768,14 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.4.1
+grimp==3.5
     # via import-linter
-grpcio==1.66.1
+grpcio==1.66.2
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.1
+grpcio-status==1.66.2
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -797,7 +796,7 @@ httplib2==0.22.0
     #   google-auth-httplib2
 httpretty==1.1.4
     # via -r requirements/edx/testing.in
-icalendar==5.0.13
+icalendar==6.0.0
     # via -r requirements/edx/base.txt
 idna==3.10
     # via
@@ -807,7 +806,7 @@ idna==3.10
     #   requests
     #   snowflake-connector-python
     #   yarl
-import-linter==2.0
+import-linter==2.1
     # via -r requirements/edx/testing.in
 importlib-metadata==8.5.0
     # via -r requirements/edx/base.txt
@@ -824,7 +823,7 @@ interchange==2021.0.4
     #   py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
-isodate==0.6.1
+isodate==0.7.2
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
@@ -865,7 +864,7 @@ jsonschema==4.23.0
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   optimizely-sdk
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -899,13 +898,13 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/base.txt
-lxml==4.9.4
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -913,6 +912,10 @@ lxml==4.9.4
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
 mako==1.3.5
@@ -929,7 +932,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
@@ -974,7 +977,7 @@ multidict==6.1.0
     #   yarl
 mysqlclient==2.2.4
     # via -r requirements/edx/base.txt
-newrelic==9.13.0
+newrelic==10.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1030,7 +1033,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.10.0
+openedx-filters==1.11.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
@@ -1039,7 +1042,7 @@ openedx-learning==0.13.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-openedx-mongodbproxy==0.2.1
+openedx-mongodbproxy==0.2.2
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via
@@ -1057,7 +1060,7 @@ packaging==24.1
     #   pytest
     #   snowflake-connector-python
     #   tox
-pact-python==2.2.1
+pact-python==2.2.2
     # via -r requirements/edx/testing.in
 pansi==2020.7.3
     # via
@@ -1119,6 +1122,10 @@ prompt-toolkit==3.0.48
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
+propcache==0.2.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   yarl
 proto-plus==1.24.0
     # via
     #   -r requirements/edx/base.txt
@@ -1164,7 +1171,7 @@ pycparser==2.22
     # via
     #   -r requirements/edx/base.txt
     #   cffi
-pycryptodomex==3.20.0
+pycryptodomex==3.21.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
@@ -1340,7 +1347,6 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1362,7 +1368,7 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==2.2.1
     # via -r requirements/edx/base.txt
-redis==5.0.8
+redis==5.1.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
@@ -1422,7 +1428,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1470,7 +1476,6 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
-    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pact-python
@@ -1554,7 +1559,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.20.0
+tox==4.21.2
     # via -r requirements/edx/testing.in
 tqdm==4.66.5
     # via
@@ -1566,6 +1571,7 @@ typing-extensions==4.12.2
     #   -r requirements/edx/base.txt
     #   django-countries
     #   edx-opaque-keys
+    #   faker
     #   fastapi
     #   grimp
     #   import-linter
@@ -1578,6 +1584,7 @@ tzdata==2024.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
+    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -1601,7 +1608,7 @@ urllib3==1.26.20
     #   requests
 user-util==1.1.0
     # via -r requirements/edx/base.txt
-uvicorn==0.30.6
+uvicorn==0.31.1
     # via pact-python
 vine==5.1.0
     # via
@@ -1609,7 +1616,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.5
+virtualenv==20.26.6
     # via tox
 voluptuous==0.15.2
     # via
@@ -1619,7 +1626,7 @@ walrus==0.9.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
-watchdog==5.0.2
+watchdog==5.0.3
     # via -r requirements/edx/base.txt
 wcwidth==0.2.13
     # via
@@ -1673,14 +1680,13 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
+xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/base.txt
-yarl==1.12.1
+yarl==1.14.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
 click==8.1.6
     # via
@@ -14,7 +14,7 @@ packaging==24.1
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools

--- a/scripts/structures_pruning/requirements/base.txt
+++ b/scripts/structures_pruning/requirements/base.txt
@@ -11,7 +11,7 @@ click==8.1.6
     #   click-log
 click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.in
-dnspython==2.6.1
+dnspython==2.7.0
     # via pymongo
 edx-opaque-keys==2.11.0
     # via -r scripts/structures_pruning/requirements/base.in

--- a/scripts/structures_pruning/requirements/testing.txt
+++ b/scripts/structures_pruning/requirements/testing.txt
@@ -12,7 +12,7 @@ click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.txt
 ddt==1.7.2
     # via -r scripts/structures_pruning/requirements/testing.in
-dnspython==2.6.1
+dnspython==2.7.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   pymongo

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -10,9 +10,9 @@ attrs==24.2.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-boto3==1.35.27
+boto3==1.35.37
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.35.27
+botocore==1.35.37
     # via
     #   boto3
     #   s3transfer
@@ -46,13 +46,13 @@ django-crum==0.7.9
     # via edx-django-utils
 django-waffle==4.1.0
     # via edx-django-utils
-edx-django-utils==5.16.0
+edx-django-utils==6.0.0
     # via edx-rest-api-client
 edx-rest-api-client==6.0.0
     # via -r scripts/user_retirement/requirements/base.in
-google-api-core==2.20.0
+google-api-core==2.21.0
     # via google-api-python-client
-google-api-python-client==2.147.0
+google-api-python-client==2.149.0
     # via -r scripts/user_retirement/requirements/base.in
 google-auth==2.35.0
     # via
@@ -69,7 +69,7 @@ httplib2==0.22.0
     #   google-auth-httplib2
 idna==3.10
     # via requests
-isodate==0.6.1
+isodate==0.7.2
     # via zeep
 jenkinsapi==0.3.13
     # via -r scripts/user_retirement/requirements/base.in
@@ -77,13 +77,11 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lxml==4.9.4
-    # via
-    #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
-    #   zeep
+lxml==5.3.0
+    # via zeep
 more-itertools==10.5.0
     # via simple-salesforce
-newrelic==9.13.0
+newrelic==10.0.0
     # via edx-django-utils
 pbr==6.1.0
     # via stevedore
@@ -138,7 +136,7 @@ requests-toolbelt==1.0.0
     # via zeep
 rsa==4.9
     # via google-auth
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via boto3
 simple-salesforce==1.12.6
     # via -r scripts/user_retirement/requirements/base.in
@@ -146,7 +144,6 @@ simplejson==3.19.3
     # via -r scripts/user_retirement/requirements/base.in
 six==1.16.0
     # via
-    #   isodate
     #   jenkinsapi
     #   python-dateutil
 sqlparse==0.5.1

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -14,11 +14,11 @@ attrs==24.2.0
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-boto3==1.35.27
+boto3==1.35.37
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.35.27
+botocore==1.35.37
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -66,17 +66,17 @@ django-waffle==4.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.16.0
+edx-django-utils==6.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
 edx-rest-api-client==6.0.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-api-core==2.20.0
+google-api-core==2.21.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.147.0
+google-api-python-client==2.149.0
     # via -r scripts/user_retirement/requirements/base.txt
 google-auth==2.35.0
     # via
@@ -103,7 +103,7 @@ idna==3.10
     #   requests
 iniconfig==2.0.0
     # via pytest
-isodate==0.6.1
+isodate==0.7.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
@@ -116,11 +116,11 @@ jmespath==1.0.1
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
     #   botocore
-lxml==4.9.4
+lxml==5.3.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-markupsafe==2.1.5
+markupsafe==3.0.1
     # via
     #   jinja2
     #   werkzeug
@@ -132,7 +132,7 @@ more-itertools==10.5.0
     #   simple-salesforce
 moto==4.2.14
     # via -r scripts/user_retirement/requirements/testing.in
-newrelic==9.13.0
+newrelic==10.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
@@ -235,7 +235,7 @@ rsa==4.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -246,7 +246,6 @@ simplejson==3.19.3
 six==1.16.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
-    #   isodate
     #   jenkinsapi
     #   python-dateutil
 sqlparse==0.5.1
@@ -275,7 +274,7 @@ urllib3==1.26.20
     #   responses
 werkzeug==3.0.4
     # via moto
-xmltodict==0.13.0
+xmltodict==0.14.1
     # via moto
 zeep==4.2.1
     # via


### PR DESCRIPTION
Unclear if there was a change in the focal repositories or if there was an issue with something else. The noble repositories 
don't support 7.0, so we're stuck here until we upgrade to 8.0.

This also unpins and updates lxml and xmlsec, which were being held back by the Python 3.11 upgrade.

I suspect something caused our runners to jump ahead suddenly in Ubuntu versions (which is weird, because https://github.com/openedx/edx-platform/pull/35450 was merged weeks ago) which wasn't compatible with our various versions of things and caused the test runners to start failing.

Addresses: https://github.com/openedx/edx-platform/issues/35264 https://github.com/openedx/edx-platform/issues/35272