### PR TITLE
Revert out updates and pins many of the jobs to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python-version:
           - "3.11"
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-22.04"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version:
           - "3.11"
         # 'pinned' is used to install the latest patch version of Django
@@ -126,7 +126,7 @@ jobs:
     if: always()
     needs:
       - check_migrations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         # uses: re-actors/alls-green@v1.2.1

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +75,7 @@ jobs:
     if: always()
     needs:
       - run-pylint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         # uses: re-actors/alls-green@v1.2.1

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version:
           - "3.11"
         node-version: [20]

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version:
           - "3.11"
         node-version: [18, 20]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   run-tests:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:
@@ -164,7 +164,7 @@ jobs:
           overwrite: true
 
   collect-and-verify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -229,7 +229,7 @@ jobs:
   # https://github.com/orgs/community/discussions/33579
   success:
     name: Unit tests successful
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: always()
     needs: [run-tests]
     steps:
@@ -240,7 +240,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
   compile-warnings-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [run-tests]
     steps:
       - uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
           overwrite: true
 
   merge-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [compile-warnings-report]
     steps:
       - name: Merge Pytest Warnings JSON Artifacts
@@ -288,7 +288,7 @@ jobs:
   # Combine and upload coverage reports.
   coverage:
     if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [run-tests]
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           if [[ "${{ matrix.mongo-version }}" != "4.4" ]]; then
             wget -qO - https://www.mongodb.org/static/pgp/server-${{ matrix.mongo-version }}.asc | sudo apt-key add -
-            echo "deb https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/${{ matrix.mongo-version }} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${{ matrix.mongo-version }}.list
+            echo "deb https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/${{ matrix.mongo-version }} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${{ matrix.mongo-version }}.list
             sudo apt-get update && sudo apt-get install -y mongodb-org="${{ matrix.mongo-version }}.*"
           fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@edx/brand-edx.org": "^2.0.7",
         "@edx/edx-bootstrap": "1.0.4",
         "@edx/edx-proctoring": "^4.18.1",
-        "@edx/frontend-component-cookie-policy-banner": "2.6.0",
+        "@edx/frontend-component-cookie-policy-banner": "2.2.0",
         "@edx/paragon": "2.6.4",
         "@edx/studio-frontend": "^2.1.0",
         "babel-loader": "^9.1.3",
@@ -1883,25 +1883,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.7.tgz",
-      "integrity": "sha512-gMmIEhg35sXk9Te5qbGp3W9YKrvLt3HV658/d3odWrHSqT0JeG5OzsJWFHRLiOohRyjRsJc/x03DhJm3i8VJxg==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.30.2",
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
-    },
     "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -2125,16 +2106,14 @@
       }
     },
     "node_modules/@edx/frontend-component-cookie-policy-banner": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-cookie-policy-banner/-/frontend-component-cookie-policy-banner-2.6.0.tgz",
-      "integrity": "sha512-Em/7v41BtVJsHWyaxGOgefif3YOe2Bw8rDZO6Rci40Mcx035Q7L0IlyG3Sxz+GKQIoSOJDYf+EfODS5i01AJOg==",
-      "license": "AGPL-3.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-cookie-policy-banner/-/frontend-component-cookie-policy-banner-2.2.0.tgz",
+      "integrity": "sha512-Ye5tL8dU1v77Vtva9QkrgNG0I50sR317OK51/aQwHn50Aoq45FML29dbP8E5dy36QSqvF99bNFA4rptLigiTGQ==",
       "dependencies": {
         "@edx/brand-edx.org": "2.0.3",
-        "@openedx/paragon": "^21.13.1",
+        "@edx/paragon": "^12.0.5",
         "babel-preset-minify": "^0.5.0",
         "classnames": "^2.3.1",
-        "identity-obj-proxy": "^3.0.0",
         "prop-types": "^15.6.1",
         "type-fest": "^2.14.0",
         "universal-cookie": "^4.0.0"
@@ -2147,83 +2126,36 @@
     "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/@edx/brand-edx.org": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.0.3.tgz",
-      "integrity": "sha512-QRmq2su1Xy+9GhY3NRZ+WdjtYWHmgfuKbVCW2skxgfgW9Q6kea8L6LrgigfrZtW+kQq/KdX2tVJcYBkB9xALtQ==",
-      "license": "UNLICENSED"
+      "integrity": "sha512-QRmq2su1Xy+9GhY3NRZ+WdjtYWHmgfuKbVCW2skxgfgW9Q6kea8L6LrgigfrZtW+kQq/KdX2tVJcYBkB9xALtQ=="
     },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/@openedx/paragon": {
-      "version": "21.13.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-21.13.1.tgz",
-      "integrity": "sha512-sLL+Z3ZWIRM6x+OrKZV0S7/SQpEcSeRcDm7E3FzhsnAWudsJCTELvSW+84uy/8dwV7mJhttsBPqQEtNafbCyYA==",
-      "license": "Apache-2.0",
-      "workspaces": [
-        "example",
-        "component-generator",
-        "www",
-        "icons",
-        "dependent-usage-analyzer"
-      ],
+    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/@edx/paragon": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-12.8.0.tgz",
+      "integrity": "sha512-gJVnozu4V1e2PCI0lFICvnrs2yi0ZzcaO5gJB9OjB1Pzf5GXpkKNWLtdTwjgp4fvzL9w4sqvyB30apbQzWW8yw==",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.1.1",
-        "@fortawesome/react-fontawesome": "^0.1.18",
-        "@popperjs/core": "^2.11.4",
-        "bootstrap": "^4.6.2",
-        "chalk": "^4.1.2",
-        "child_process": "^1.0.2",
-        "classnames": "^2.3.1",
+        "@fortawesome/fontawesome-svg-core": "^1.2.30",
+        "@fortawesome/free-solid-svg-icons": "^5.14.0",
+        "@fortawesome/react-fontawesome": "^0.1.11",
+        "airbnb-prop-types": "^2.12.0",
+        "bootstrap": "^4.4.1",
+        "classnames": "^2.2.6",
         "email-prop-type": "^3.0.0",
-        "file-selector": "^0.6.0",
         "font-awesome": "^4.7.0",
-        "glob": "^8.0.3",
-        "inquirer": "^8.2.5",
-        "lodash.uniqby": "^4.7.0",
-        "mailto-link": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-bootstrap": "^1.6.5",
-        "react-colorful": "^5.6.1",
-        "react-dropzone": "^14.2.1",
-        "react-focus-on": "^3.5.4",
-        "react-imask": "^7.1.3",
-        "react-loading-skeleton": "^3.1.0",
-        "react-popper": "^2.2.5",
+        "mailto-link": "^1.0.0",
+        "prop-types": "^15.7.2",
+        "react-bootstrap": "^1.2.2",
+        "react-focus-on": "^3.5.0",
         "react-proptype-conditional-require": "^1.0.4",
-        "react-responsive": "^8.2.0",
-        "react-table": "^7.7.0",
-        "react-transition-group": "^4.4.2",
-        "tabbable": "^5.3.3",
-        "uncontrollable": "^7.2.1",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "paragon": "bin/paragon-scripts.js"
+        "react-responsive": "^6.1.1",
+        "react-table": "^7.6.1",
+        "react-transition-group": "^4.0.0",
+        "sanitize-html": "^1.20.0",
+        "tabbable": "^4.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0",
-        "react-intl": "^5.25.1 || ^6.4.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/attr-accept": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.4.tgz",
-      "integrity": "sha512-2pA6xFIbdTUDCAwjN8nQwI+842VwzbDUXO2IYlpPXQIORgKnavorcr4Ce3rwh+zsNg9zK7QPsdvDj3Lum4WX4w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+        "prop-types": "^15.7.2",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
       }
     },
     "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/bootstrap": {
@@ -2240,81 +2172,15 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-      "license": "MIT",
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
       }
     },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
     "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -2324,206 +2190,24 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-3.0.1.tgz",
       "integrity": "sha512-tONZGMEOOkadp5OBftuVXU8DsceWmINxYK+pqPFB4LT5ODjrPX/esel3WGqbV7d6in5/MnZE4n4QcqOr4gh7dg==",
-      "license": "MIT",
       "dependencies": {
         "email-validator": "^2.0.4"
       }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/inquirer": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.5.5",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/intl-messageformat": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.6.0.tgz",
-      "integrity": "sha512-AYKl/DY1nl75pJU8EK681JOVL40uQTNJe3yEMXKfydDFoz+5hNrM/PqjchueSMKGKCZKBVgeexqZwy3uC2B36Q==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.9",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/mailto-link": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mailto-link/-/mailto-link-2.0.0.tgz",
-      "integrity": "sha512-b5FErkZ4t6mpH1IFZSw7Mm2IQHXQ2R0/5Q4xd7Rv8dVkWvE54mFG/UW7HjfFazXFjXTNsM+dSX2tTeIDrV9K9A==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-ok": "~1.0.0",
-        "cast-array": "~1.0.1",
-        "object-filter": "~1.0.2",
-        "query-string": "~7.0.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "license": "ISC"
     },
     "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/query-string": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
-      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/react-dropzone": {
-      "version": "14.2.9",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.9.tgz",
-      "integrity": "sha512-jRZsMC7h48WONsOLHcmhyn3cRWJoIPQjPApvt/sJVfnYaB3Qltn025AoRTTJaj4WdmmgmLl6tUQg1s0wOhpodQ==",
-      "license": "MIT",
-      "dependencies": {
-        "attr-accept": "^2.2.2",
-        "file-selector": "^0.6.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8 || 18.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/react-intl": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.7.2.tgz",
-      "integrity": "sha512-v/lvAORTE70welhzqoIi1YI1yHvGE4/QX4W3JYNZoqRxH8ab8Q/Ed4Zem/ZVPZJN4byQ52U+2GESLy0zvY6IBw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "@formatjs/icu-messageformat-parser": "2.7.9",
-        "@formatjs/intl": "2.10.7",
-        "@formatjs/intl-displaynames": "6.6.9",
-        "@formatjs/intl-listformat": "7.5.8",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/react": "16 || 17 || 18",
-        "hoist-non-react-statics": "^3.3.2",
-        "intl-messageformat": "10.6.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.0 || 17 || 18",
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -2533,62 +2217,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@edx/frontend-component-cookie-policy-banner/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@edx/mockprock": {
@@ -3510,139 +3138,35 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.1.0.tgz",
-      "integrity": "sha512-SE2V2PE03K9U/YQZ3nxEOysRkQ/CfSwLHR789Uk9N0PTiWT6I+17UTDI97zYEwC1mbnjefqmtjbL8nunjPwGjw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/intl-localematcher": "0.5.4",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
-      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.9.tgz",
-      "integrity": "sha512-9Z5buDRMsTbplXknvRlDmnpWhZrayNVcVvkH0+SSz8Ll4XD/7Tcn8m1IjxM3iBJSwQbxwxb7/g0Fkx3d4j2osw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "@formatjs/icu-skeleton-parser": "1.8.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.3.tgz",
-      "integrity": "sha512-TsKAP013ayZFbWWR2KWy+f9QVZh0yDFTPK3yE4OqU2gnzafvmKTodRtJLVpfZmpXWJ5y7BWD1AsyT14mcbLzig==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.7.tgz",
-      "integrity": "sha512-26rNxo2nwQbbsVkV54ngml9XIA7bBzfQmELG6FFFF8eKzqzFrLKZzF8JBoBpPHgML4HKEUbGCQaBaARpKCN/sw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.9",
-        "@formatjs/intl-displaynames": "6.6.9",
-        "@formatjs/intl-listformat": "7.5.8",
-        "intl-messageformat": "10.6.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.6.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.9.tgz",
-      "integrity": "sha512-2hmS+YJwiXB1deNYXO2/pY7Zv4QUrZHghZxkcnWxBLEODk990h9cNbkjNg/u/RaDeCRkKVrZ3ERTdBcgkTvn2Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "@formatjs/intl-localematcher": "0.5.4",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.5.8.tgz",
-      "integrity": "sha512-WzMiw6nA2uP0ZqbbuPs7tQ+gmYRTbE20lwur4QcKp5K5cgPhkCzRAhovkDFLhrc885c3p7Wjigx8kyg0hypmZw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "@formatjs/intl-localematcher": "0.5.4",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
-      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl/node_modules/intl-messageformat": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.6.0.tgz",
-      "integrity": "sha512-AYKl/DY1nl75pJU8EK681JOVL40uQTNJe3yEMXKfydDFoz+5hNrM/PqjchueSMKGKCZKBVgeexqZwy3uC2B36Q==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.1.0",
-        "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.9",
-        "tslib": "^2.4.0"
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
-      "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
-      "license": "MIT",
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.6.0"
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
       },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
-      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
-      "license": "MIT",
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -4713,17 +4237,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/invariant": {
       "version": "2.2.37",
       "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.37.tgz",
@@ -5307,6 +4820,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -5321,6 +4835,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6609,26 +6124,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
@@ -6690,31 +6185,6 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/blob": {
@@ -6851,30 +6321,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-alloc": {
@@ -7217,12 +6663,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "license": "MIT"
-    },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -7260,12 +6700,6 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g==",
-      "license": "ISC"
     },
     "node_modules/chokidar": {
       "version": "1.7.0",
@@ -7606,18 +7040,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-width": {
@@ -7996,17 +7418,6 @@
       "dependencies": {
         "browserslist": "^4.23.3"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.38.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-      "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -8449,6 +7860,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8493,18 +7905,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -10585,32 +9985,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -10827,18 +10201,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/file-selector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -10902,15 +10264,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -11713,12 +11066,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/harmony-reflect": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
-      "license": "(Apache-2.0 OR MPL-1.1)"
-    },
     "node_modules/has": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
@@ -12144,38 +11491,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/identity-obj-proxy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
-      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
-      "license": "MIT",
-      "dependencies": {
-        "harmony-reflect": "^1.4.6"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -12183,18 +11498,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/imask": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/imask/-/imask-7.6.1.tgz",
-      "integrity": "sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.24.4"
-      },
-      "engines": {
-        "npm": ">=4.0.0"
       }
     },
     "node_modules/immediate": {
@@ -12843,15 +12146,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
@@ -13103,18 +12397,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
@@ -16875,12 +16157,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
-    "node_modules/lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-      "license": "MIT"
-    },
     "node_modules/log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -17324,6 +16600,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -18418,6 +17695,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -18480,140 +17758,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/ora/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/ora/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -18627,6 +17771,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20553,16 +19698,6 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-colorful": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
-      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
@@ -20603,12 +19738,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-element-proptypes/-/react-element-proptypes-1.0.0.tgz",
       "integrity": "sha512-unJTkc58D9n1xTXKA8swrwrbDQAsCF/13oT6fDYtBVHPvFxITFuI20HCMNbNzI7tTUzsYmJ3iqjskwfLJkOUFA=="
-    },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
     },
     "node_modules/react-focus-lock": {
       "version": "1.19.1",
@@ -20703,33 +19832,6 @@
         }
       }
     },
-    "node_modules/react-imask": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.6.1.tgz",
-      "integrity": "sha512-vLNfzcCz62Yzx/GRGh5tiCph9Gbh2cZu+Tz8OiO5it2eNuuhpA0DWhhSlOtVtSJ80+Bx+vFK5De8eQ9AmbkXzA==",
-      "license": "MIT",
-      "dependencies": {
-        "imask": "^7.6.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "npm": ">=4.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
-      }
-    },
-    "node_modules/react-imask/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/react-intl": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
@@ -20767,15 +19869,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
-    "node_modules/react-loading-skeleton": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz",
-      "integrity": "sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/react-overlays": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
@@ -20812,21 +19905,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-proptype-conditional-require": {
@@ -20902,21 +19980,19 @@
       }
     },
     "node_modules/react-responsive": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
-      "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
-      "license": "MIT",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
+      "integrity": "sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==",
       "dependencies": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1",
-        "shallow-equal": "^1.1.0"
+        "prop-types": "^15.6.1"
       },
       "engines": {
         "node": ">= 0.10"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "react": "^16.3.0"
       }
     },
     "node_modules/react-responsive/node_modules/prop-types": {
@@ -22193,15 +21269,6 @@
       "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
       "dev": true
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -23209,12 +22276,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -23273,7 +22334,8 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/simple-html-tokenizer": {
       "version": "0.1.1",
@@ -23774,15 +22836,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
       "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
       "dev": true
-    },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -24665,10 +23718,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
-      "license": "MIT"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
     },
     "node_modules/table": {
       "version": "6.8.2",
@@ -24933,7 +23985,8 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
     },
     "node_modules/through2": {
       "version": "3.0.2",
@@ -26048,15 +25101,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -26483,6 +25527,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -26543,6 +25588,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -26557,6 +25603,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -26567,7 +25614,8 @@
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@edx/brand-edx.org": "^2.0.7",
     "@edx/edx-bootstrap": "1.0.4",
     "@edx/edx-proctoring": "^4.18.1",
-    "@edx/frontend-component-cookie-policy-banner": "2.6.0",
+    "@edx/frontend-component-cookie-policy-banner": "2.2.0",
     "@edx/paragon": "2.6.4",
     "@edx/studio-frontend": "^2.1.0",
     "babel-loader": "^9.1.3",

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -84,6 +84,13 @@ django-storages<1.14.4
 # for them.
 edx-enterprise==4.27.2
 
+# Date: 2024-05-09
+# This has to be constrained as well because newer versions of edx-i18n-tools need the
+# newer version of lxml but that requirement was not made expilict in the 1.6.0 version
+# of the package.  This can be un-pinned when we're upgrading lxml.
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35274
+edx-i18n-tools<1.6.0
+
 # Date: 2024-07-26
 # To override the constraint of edx-lint
 # This can be removed once https://github.com/openedx/edx-platform/issues/34586 is resolved
@@ -97,6 +104,13 @@ event-tracking==3.0.0
 # away from legacy LMS/CMS frontends:
 # https://github.com/openedx/edx-platform/issues/31616
 libsass==0.10.0
+
+# Date: 2024-04-30
+# lxml>=5.0 introduced breaking changes related to system dependencies
+# lxml==5.2.1 introduced new extra so we'll nee to rename lxml --> lxml[html-clean]
+# This constraint can be removed once we upgrade to Python 3.11
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35272
+lxml<5.0
 
 # Date: 2018-12-14
 # markdown>=3.4.0 has failures due to internal refactorings which causes the tests to fail
@@ -173,3 +187,8 @@ social-auth-app-django<=5.4.1
 # which require urllib3<2 for now.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/32222
 urllib3<2.0.0
+
+# Date: 2024-04-24
+# xmlsec==1.3.14 breaking tests or all builds, can be removed once a fix is available
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35264
+xmlsec<1.3.14

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -26,11 +26,12 @@ joblib==1.4.2
     # via nltk
 kiwisolver==1.4.7
     # via matplotlib
-lxml==5.3.0
+lxml==4.9.4
     # via
+    #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/base.in
     #   openedx-calc
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via
     #   chem
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,11 +6,11 @@
 #
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via -r requirements/edx/github.in
-acid-xblock==0.4.1
+acid-xblock==0.3.1
     # via -r requirements/edx/kernel.in
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.0
     # via aiohttp
-aiohttp==3.10.9
+aiohttp==3.10.6
     # via
     #   geoip2
     #   openai
@@ -70,13 +70,13 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.35.37
+boto3==1.35.27
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.37
+botocore==1.35.27
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -87,7 +87,7 @@ cachecontrol==0.14.0
     # via firebase-admin
 cachetools==5.5.0
     # via google-auth
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==3.1.2
     # via meilisearch
 celery==5.4.0
     # via
@@ -328,7 +328,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
-django-ses==4.2.0
+django-ses==4.1.1
     # via -r requirements/edx/bundled.in
 django-simple-history==3.4.0
     # via
@@ -387,7 +387,7 @@ djangorestframework==3.14.0
     #   super-csv
 djangorestframework-xml==2.0.0
     # via edx-enterprise
-dnspython==2.7.0
+dnspython==2.6.1
     # via
     #   -r requirements/edx/paver.txt
     #   pymongo
@@ -429,7 +429,7 @@ edx-celeryutils==1.3.0
     #   super-csv
 edx-codejail==3.4.1
     # via -r requirements/edx/kernel.in
-edx-completion==4.7.2
+edx-completion==4.7.1
     # via -r requirements/edx/kernel.in
 edx-django-release-util==1.4.0
     # via
@@ -438,7 +438,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/kernel.in
-edx-django-utils==6.0.0
+edx-django-utils==5.16.0
     # via
     #   -r requirements/edx/kernel.in
     #   django-config-models
@@ -475,8 +475,9 @@ edx-event-bus-kafka==5.8.1
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/kernel.in
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
     #   ora2
 edx-milestones==0.6.0
@@ -516,7 +517,7 @@ edx-search==4.0.0
     # via -r requirements/edx/kernel.in
 edx-sga==0.25.0
     # via -r requirements/edx/bundled.in
-edx-submissions==3.8.1
+edx-submissions==3.8.0
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
@@ -583,14 +584,14 @@ geoip2==4.8.0
     # via -r requirements/edx/kernel.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
-google-api-core[grpc]==2.21.0
+google-api-core[grpc]==2.20.0
     # via
     #   firebase-admin
     #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.149.0
+google-api-python-client==2.147.0
     # via firebase-admin
 google-auth==2.35.0
     # via
@@ -620,11 +621,11 @@ googleapis-common-protos==1.65.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.66.2
+grpcio==1.66.1
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.2
+grpcio-status==1.66.1
     # via google-api-core
 gunicorn==23.0.0
     # via -r requirements/edx/kernel.in
@@ -638,7 +639,7 @@ httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-icalendar==6.0.0
+icalendar==5.0.13
     # via -r requirements/edx/kernel.in
 idna==3.10
     # via
@@ -657,7 +658,7 @@ interchange==2021.0.4
     # via py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/kernel.in
-isodate==0.7.2
+isodate==0.6.1
     # via python3-saml
 jinja2==3.1.4
     # via code-annotations
@@ -682,7 +683,7 @@ jsonschema==4.23.0
     # via
     #   drf-spectacular
     #   optimizely-sdk
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 jwcrypto==1.5.6
     # via
@@ -707,21 +708,19 @@ loremipsum==1.0.5
     # via ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/kernel.in
-lxml[html-clean]==5.3.0
+lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.3.1
-    # via lxml
 mailsnake==1.6.4
     # via -r requirements/edx/bundled.in
 mako==1.3.5
@@ -738,7 +737,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via
     #   -r requirements/edx/paver.txt
     #   chem
@@ -770,7 +769,7 @@ multidict==6.1.0
     #   yarl
 mysqlclient==2.2.4
     # via -r requirements/edx/kernel.in
-newrelic==10.0.0
+newrelic==9.13.0
     # via
     #   -r requirements/edx/bundled.in
     #   edx-django-utils
@@ -821,7 +820,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.10.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
@@ -830,7 +829,7 @@ openedx-learning==0.13.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
-openedx-mongodbproxy==0.2.2
+openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via
@@ -882,8 +881,6 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.48
     # via click-repl
-propcache==0.2.0
-    # via yarl
 proto-plus==1.24.0
     # via
     #   google-api-core
@@ -914,7 +911,7 @@ pycountry==24.6.1
     # via -r requirements/edx/kernel.in
 pycparser==2.22
     # via cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.20.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
@@ -1020,6 +1017,7 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
+    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1041,7 +1039,7 @@ random2==1.0.2
     # via -r requirements/edx/kernel.in
 recommender-xblock==2.2.1
     # via -r requirements/edx/bundled.in
-redis==5.1.1
+redis==5.0.8
     # via
     #   -r requirements/edx/kernel.in
     #   walrus
@@ -1094,7 +1092,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.3
+s3transfer==0.10.2
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
@@ -1133,6 +1131,7 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
+    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pansi
@@ -1209,7 +1208,6 @@ typing-extensions==4.12.2
 tzdata==2024.2
     # via
     #   celery
-    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -1239,7 +1237,7 @@ voluptuous==0.15.2
     # via ora2
 walrus==0.9.4
     # via edx-event-bus-redis
-watchdog==5.0.3
+watchdog==5.0.2
     # via -r requirements/edx/paver.txt
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -1287,11 +1285,13 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.14
-    # via python3-saml
+xmlsec==1.3.13
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/kernel.in
-yarl==1.14.0
+yarl==1.12.1
     # via aiohttp
 zipp==3.20.2
     # via importlib-metadata

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,13 +6,13 @@
 #
 chardet==5.2.0
     # via diff-cover
-coverage==7.6.2
+coverage==7.6.1
     # via -r requirements/edx/coverage.in
 diff-cover==9.2.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.4
     # via diff-cover
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via jinja2
 pluggy==1.5.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -12,16 +12,16 @@ accessible-pygments==0.0.5
     # via
     #   -r requirements/edx/doc.txt
     #   pydata-sphinx-theme
-acid-xblock==0.4.1
+acid-xblock==0.3.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
-aiohttp==3.10.9
+aiohttp==3.10.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -140,14 +140,14 @@ boto==2.49.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.35.37
+boto3==1.35.27
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.37
+botocore==1.35.27
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -157,7 +157,7 @@ bridgekeeper==0.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-build==1.2.2.post1
+build==1.2.2
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   pip-tools
@@ -172,7 +172,7 @@ cachetools==5.5.0
     #   -r requirements/edx/testing.txt
     #   google-auth
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==3.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -278,7 +278,7 @@ colorama==0.4.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-coverage[toml]==7.6.2
+coverage[toml]==7.6.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -325,11 +325,11 @@ defusedxml==0.7.1
     #   social-auth-core
 diff-cover==9.2.0
     # via -r requirements/edx/testing.txt
-dill==0.3.9
+dill==0.3.8
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-distlib==0.3.9
+distlib==0.3.8
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
@@ -544,7 +544,7 @@ django-sekizai==4.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-django-wiki
-django-ses==4.2.0
+django-ses==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -627,7 +627,7 @@ djangorestframework-xml==2.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-dnspython==2.7.0
+dnspython==2.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -696,7 +696,7 @@ edx-codejail==3.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-completion==4.7.2
+edx-completion==4.7.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -710,7 +710,7 @@ edx-django-sites-extensions==4.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-utils==6.0.0
+edx-django-utils==5.16.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -754,8 +754,9 @@ edx-event-bus-redis==0.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -813,7 +814,7 @@ edx-sga==0.25.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-submissions==3.8.1
+edx-submissions==3.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -878,7 +879,7 @@ execnet==2.1.1
     #   pytest-xdist
 factory-boy==3.3.1
     # via -r requirements/edx/testing.txt
-faker==30.3.0
+faker==30.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -942,7 +943,7 @@ glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-google-api-core[grpc]==2.21.0
+google-api-core[grpc]==2.20.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -951,7 +952,7 @@ google-api-core[grpc]==2.21.0
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.149.0
+google-api-python-client==2.147.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1004,17 +1005,17 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.5
+grimp==3.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
-grpcio==1.66.2
+grpcio==1.66.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.2
+grpcio-status==1.66.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1044,7 +1045,7 @@ httplib2==0.22.0
     #   google-auth-httplib2
 httpretty==1.1.4
     # via -r requirements/edx/testing.txt
-icalendar==6.0.0
+icalendar==5.0.13
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1061,7 +1062,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-import-linter==2.1
+import-linter==2.0
     # via -r requirements/edx/testing.txt
 importlib-metadata==8.5.0
     # via
@@ -1086,7 +1087,7 @@ ipaddress==1.0.23
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-isodate==0.7.2
+isodate==0.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1135,7 +1136,7 @@ jsonschema==4.23.0
     #   drf-spectacular
     #   optimizely-sdk
     #   sphinxcontrib-openapi
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1182,14 +1183,14 @@ lti-consumer-xblock==9.11.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-lxml[html-clean]==5.3.0
+lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -1197,11 +1198,6 @@ lxml[html-clean]==5.3.0
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.3.1
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   lxml
 mailsnake==1.6.4
     # via
     #   -r requirements/edx/doc.txt
@@ -1222,7 +1218,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1294,7 +1290,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-newrelic==10.0.0
+newrelic==9.13.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1372,7 +1368,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1383,7 +1379,7 @@ openedx-learning==0.13.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-mongodbproxy==0.2.2
+openedx-mongodbproxy==0.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1411,7 +1407,7 @@ packaging==24.1
     #   snowflake-connector-python
     #   sphinx
     #   tox
-pact-python==2.2.2
+pact-python==2.2.1
     # via -r requirements/edx/testing.txt
 pansi==2020.7.3
     # via
@@ -1492,11 +1488,6 @@ prompt-toolkit==3.0.48
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   click-repl
-propcache==0.2.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   yarl
 proto-plus==1.24.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1551,7 +1542,7 @@ pycparser==2.22
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.20.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1675,7 +1666,7 @@ pyproject-api==1.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-pyproject-hooks==1.2.0
+pyproject-hooks==1.1.0
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   build
@@ -1776,6 +1767,7 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
+    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1807,7 +1799,7 @@ recommender-xblock==2.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-redis==5.1.1
+redis==5.0.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1877,7 +1869,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.3
+s3transfer==0.10.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1934,6 +1926,7 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
+    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pact-python
@@ -1993,7 +1986,7 @@ soupsieve==2.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==8.1.0
+sphinx==8.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   pydata-sphinx-theme
@@ -2094,7 +2087,7 @@ tinycss2==1.2.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   bleach
-tomli==2.0.2
+tomli==2.0.1
     # via django-stubs
 tomlkit==0.13.2
     # via
@@ -2102,7 +2095,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/testing.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.21.2
+tox==4.20.0
     # via -r requirements/edx/testing.txt
 tqdm==4.66.5
     # via
@@ -2110,7 +2103,7 @@ tqdm==4.66.5
     #   -r requirements/edx/testing.txt
     #   nltk
     #   openai
-types-pytz==2024.2.0.20241003
+types-pytz==2024.2.0.20240913
     # via django-stubs
 types-pyyaml==6.0.12.20240917
     # via
@@ -2129,7 +2122,6 @@ typing-extensions==4.12.2
     #   django-stubs-ext
     #   djangorestframework-stubs
     #   edx-opaque-keys
-    #   faker
     #   fastapi
     #   grimp
     #   import-linter
@@ -2145,7 +2137,6 @@ tzdata==2024.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   celery
-    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -2174,7 +2165,7 @@ user-util==1.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-uvicorn==0.31.1
+uvicorn==0.30.6
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -2185,7 +2176,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.6
+virtualenv==20.26.5
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -2194,14 +2185,14 @@ voluptuous==0.15.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-vulture==2.13
+vulture==2.12
     # via -r requirements/edx/development.in
 walrus==0.9.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-redis
-watchdog==5.0.3
+watchdog==5.0.2
     # via
     #   -r requirements/edx/development.in
     #   -r requirements/edx/doc.txt
@@ -2275,8 +2266,9 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.14
+xmlsec==1.3.13
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml
@@ -2284,7 +2276,7 @@ xss-utils==0.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-yarl==1.14.0
+yarl==1.12.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -8,13 +8,13 @@
     # via -r requirements/edx/base.txt
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-acid-xblock==0.4.1
+acid-xblock==0.3.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.10.9
+aiohttp==3.10.6
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -102,13 +102,13 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.35.37
+boto3==1.35.27
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.37
+botocore==1.35.27
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -123,7 +123,7 @@ cachetools==5.5.0
     # via
     #   -r requirements/edx/base.txt
     #   google-auth
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==3.1.2
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
@@ -398,7 +398,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.2.0
+django-ses==4.1.1
     # via -r requirements/edx/base.txt
 django-simple-history==3.4.0
     # via
@@ -459,7 +459,7 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-dnspython==2.7.0
+dnspython==2.6.1
     # via
     #   -r requirements/edx/base.txt
     #   pymongo
@@ -509,7 +509,7 @@ edx-celeryutils==1.3.0
     #   super-csv
 edx-codejail==3.4.1
     # via -r requirements/edx/base.txt
-edx-completion==4.7.2
+edx-completion==4.7.1
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.4.0
     # via
@@ -518,7 +518,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/base.txt
-edx-django-utils==6.0.0
+edx-django-utils==5.16.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -555,8 +555,9 @@ edx-event-bus-kafka==5.8.1
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   ora2
 edx-milestones==0.6.0
@@ -597,7 +598,7 @@ edx-search==4.0.0
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.8.1
+edx-submissions==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -682,7 +683,7 @@ gitpython==3.1.43
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.21.0
+google-api-core[grpc]==2.20.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -690,7 +691,7 @@ google-api-core[grpc]==2.21.0
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.149.0
+google-api-python-client==2.147.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -734,12 +735,12 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.66.2
+grpcio==1.66.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.2
+grpcio-status==1.66.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -756,7 +757,7 @@ httplib2==0.22.0
     #   -r requirements/edx/base.txt
     #   google-api-python-client
     #   google-auth-httplib2
-icalendar==6.0.0
+icalendar==5.0.13
     # via -r requirements/edx/base.txt
 idna==3.10
     # via
@@ -780,7 +781,7 @@ interchange==2021.0.4
     #   py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
-isodate==0.7.2
+isodate==0.6.1
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
@@ -817,7 +818,7 @@ jsonschema==4.23.0
     #   drf-spectacular
     #   optimizely-sdk
     #   sphinxcontrib-openapi
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -849,23 +850,19 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/base.txt
-lxml[html-clean]==5.3.0
+lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.3.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
 mako==1.3.5
@@ -882,7 +879,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -926,7 +923,7 @@ multidict==6.1.0
     #   yarl
 mysqlclient==2.2.4
     # via -r requirements/edx/base.txt
-newrelic==10.0.0
+newrelic==9.13.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -982,7 +979,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
@@ -991,7 +988,7 @@ openedx-learning==0.13.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-openedx-mongodbproxy==0.2.2
+openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via
@@ -1060,10 +1057,6 @@ prompt-toolkit==3.0.48
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-propcache==0.2.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   yarl
 proto-plus==1.24.0
     # via
     #   -r requirements/edx/base.txt
@@ -1101,7 +1094,7 @@ pycparser==2.22
     # via
     #   -r requirements/edx/base.txt
     #   cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.20.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
@@ -1229,6 +1222,7 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
+    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1251,7 +1245,7 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==2.2.1
     # via -r requirements/edx/base.txt
-redis==5.1.1
+redis==5.0.8
     # via
     #   -r requirements/edx/base.txt
     #   walrus
@@ -1311,7 +1305,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.3
+s3transfer==0.10.2
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1356,6 +1350,7 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
+    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pansi
@@ -1399,7 +1394,7 @@ soupsieve==2.6
     # via
     #   -r requirements/edx/base.txt
     #   beautifulsoup4
-sphinx==8.1.0
+sphinx==8.0.2
     # via
     #   -r requirements/edx/doc.in
     #   pydata-sphinx-theme
@@ -1494,7 +1489,6 @@ tzdata==2024.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
-    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -1530,7 +1524,7 @@ walrus==0.9.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
-watchdog==5.0.3
+watchdog==5.0.2
     # via -r requirements/edx/base.txt
 wcwidth==0.2.13
     # via
@@ -1582,13 +1576,14 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.14
+xmlsec==1.3.13
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/base.txt
-yarl==1.14.0
+yarl==1.12.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests
-dnspython==2.7.0
+dnspython==2.6.1
     # via pymongo
 edx-opaque-keys==2.11.0
     # via -r requirements/edx/paver.in
@@ -22,7 +22,7 @@ libsass==0.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.in
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via -r requirements/edx/paver.in
 mock==5.1.0
     # via -r requirements/edx/paver.in
@@ -61,7 +61,7 @@ urllib3==1.26.20
     # via
     #   -c requirements/edx/../constraints.txt
     #   requests
-watchdog==5.0.3
+watchdog==5.0.2
     # via -r requirements/edx/paver.in
 wrapt==1.16.0
     # via -r requirements/edx/paver.in

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -15,7 +15,7 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-bracex==2.5.post1
+bracex==2.5
     # via wcmatch
 certifi==2024.8.30
     # via requests
@@ -42,7 +42,7 @@ idna==3.10
     # via requests
 jsonschema==4.23.0
     # via semgrep
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
@@ -60,7 +60,7 @@ referencing==0.35.1
     #   jsonschema-specifications
 requests==2.32.3
     # via semgrep
-rich==13.9.2
+rich==13.8.1
     # via semgrep
 rpds-py==0.20.0
     # via
@@ -72,7 +72,7 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 semgrep==1.52.0
     # via -r requirements/edx/semgrep.in
-tomli==2.0.2
+tomli==2.0.1
     # via semgrep
 typing-extensions==4.12.2
     # via semgrep

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,13 +6,13 @@
 #
 -e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
     # via -r requirements/edx/base.txt
-acid-xblock==0.4.1
+acid-xblock==0.3.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.10.9
+aiohttp==3.10.6
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -102,13 +102,13 @@ bleach[css]==6.1.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.35.37
+boto3==1.35.27
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.35.37
+botocore==1.35.27
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -124,7 +124,7 @@ cachetools==5.5.0
     #   -r requirements/edx/base.txt
     #   google-auth
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==3.1.2
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
@@ -209,7 +209,7 @@ codejail-includes==1.0.0
     # via -r requirements/edx/base.txt
 colorama==0.4.6
     # via tox
-coverage[toml]==7.6.2
+coverage[toml]==7.6.1
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -247,9 +247,9 @@ defusedxml==0.7.1
     #   social-auth-core
 diff-cover==9.2.0
     # via -r requirements/edx/coverage.txt
-dill==0.3.9
+dill==0.3.8
     # via pylint
-distlib==0.3.9
+distlib==0.3.8
     # via virtualenv
 django==4.2.16
     # via
@@ -427,7 +427,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.2.0
+django-ses==4.1.1
     # via -r requirements/edx/base.txt
 django-simple-history==3.4.0
     # via
@@ -488,7 +488,7 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-dnspython==2.7.0
+dnspython==2.6.1
     # via
     #   -r requirements/edx/base.txt
     #   pymongo
@@ -533,7 +533,7 @@ edx-celeryutils==1.3.0
     #   super-csv
 edx-codejail==3.4.1
     # via -r requirements/edx/base.txt
-edx-completion==4.7.2
+edx-completion==4.7.1
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.4.0
     # via
@@ -542,7 +542,7 @@ edx-django-release-util==1.4.0
     #   edxval
 edx-django-sites-extensions==4.2.0
     # via -r requirements/edx/base.txt
-edx-django-utils==6.0.0
+edx-django-utils==5.16.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -579,8 +579,9 @@ edx-event-bus-kafka==5.8.1
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.5.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.5.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   ora2
 edx-lint==5.4.0
@@ -623,7 +624,7 @@ edx-search==4.0.0
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.8.1
+edx-submissions==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -673,7 +674,7 @@ execnet==2.1.1
     # via pytest-xdist
 factory-boy==3.3.1
     # via -r requirements/edx/testing.in
-faker==30.3.0
+faker==30.0.0
     # via factory-boy
 fastapi==0.115.0
     # via pact-python
@@ -716,7 +717,7 @@ geoip2==4.8.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.21.0
+google-api-core[grpc]==2.20.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -724,7 +725,7 @@ google-api-core[grpc]==2.21.0
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.149.0
+google-api-python-client==2.147.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -768,14 +769,14 @@ googleapis-common-protos==1.65.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.5
+grimp==3.4.1
     # via import-linter
-grpcio==1.66.2
+grpcio==1.66.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.66.2
+grpcio-status==1.66.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -796,7 +797,7 @@ httplib2==0.22.0
     #   google-auth-httplib2
 httpretty==1.1.4
     # via -r requirements/edx/testing.in
-icalendar==6.0.0
+icalendar==5.0.13
     # via -r requirements/edx/base.txt
 idna==3.10
     # via
@@ -806,7 +807,7 @@ idna==3.10
     #   requests
     #   snowflake-connector-python
     #   yarl
-import-linter==2.1
+import-linter==2.0
     # via -r requirements/edx/testing.in
 importlib-metadata==8.5.0
     # via -r requirements/edx/base.txt
@@ -823,7 +824,7 @@ interchange==2021.0.4
     #   py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
-isodate==0.7.2
+isodate==0.6.1
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
@@ -864,7 +865,7 @@ jsonschema==4.23.0
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   optimizely-sdk
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -898,13 +899,13 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/base.txt
-lxml[html-clean]==5.3.0
+lxml==4.9.4
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
-    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -912,10 +913,6 @@ lxml[html-clean]==5.3.0
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.3.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
 mako==1.3.5
@@ -932,7 +929,7 @@ markdown==3.3.7
     #   openedx-django-wiki
     #   staff-graded-xblock
     #   xblock-poll
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
@@ -977,7 +974,7 @@ multidict==6.1.0
     #   yarl
 mysqlclient==2.2.4
     # via -r requirements/edx/base.txt
-newrelic==10.0.0
+newrelic==9.13.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1033,7 +1030,7 @@ openedx-events==9.14.1
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
@@ -1042,7 +1039,7 @@ openedx-learning==0.13.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-openedx-mongodbproxy==0.2.2
+openedx-mongodbproxy==0.2.1
     # via -r requirements/edx/base.txt
 optimizely-sdk==4.1.1
     # via
@@ -1060,7 +1057,7 @@ packaging==24.1
     #   pytest
     #   snowflake-connector-python
     #   tox
-pact-python==2.2.2
+pact-python==2.2.1
     # via -r requirements/edx/testing.in
 pansi==2020.7.3
     # via
@@ -1122,10 +1119,6 @@ prompt-toolkit==3.0.48
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-propcache==0.2.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   yarl
 proto-plus==1.24.0
     # via
     #   -r requirements/edx/base.txt
@@ -1171,7 +1164,7 @@ pycparser==2.22
     # via
     #   -r requirements/edx/base.txt
     #   cffi
-pycryptodomex==3.21.0
+pycryptodomex==3.20.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
@@ -1347,6 +1340,7 @@ pytz==2024.2
     #   edx-tincan-py35
     #   event-tracking
     #   fs
+    #   icalendar
     #   interchange
     #   olxcleaner
     #   ora2
@@ -1368,7 +1362,7 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==2.2.1
     # via -r requirements/edx/base.txt
-redis==5.1.1
+redis==5.0.8
     # via
     #   -r requirements/edx/base.txt
     #   walrus
@@ -1428,7 +1422,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.10.3
+s3transfer==0.10.2
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1476,6 +1470,7 @@ six==1.16.0
     #   fs-s3fs
     #   html5lib
     #   interchange
+    #   isodate
     #   libsass
     #   optimizely-sdk
     #   pact-python
@@ -1559,7 +1554,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.21.2
+tox==4.20.0
     # via -r requirements/edx/testing.in
 tqdm==4.66.5
     # via
@@ -1571,7 +1566,6 @@ typing-extensions==4.12.2
     #   -r requirements/edx/base.txt
     #   django-countries
     #   edx-opaque-keys
-    #   faker
     #   fastapi
     #   grimp
     #   import-linter
@@ -1584,7 +1578,6 @@ tzdata==2024.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
-    #   icalendar
     #   kombu
 unicodecsv==0.14.1
     # via
@@ -1608,7 +1601,7 @@ urllib3==1.26.20
     #   requests
 user-util==1.1.0
     # via -r requirements/edx/base.txt
-uvicorn==0.31.1
+uvicorn==0.30.6
     # via pact-python
 vine==5.1.0
     # via
@@ -1616,7 +1609,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.6
+virtualenv==20.26.5
     # via tox
 voluptuous==0.15.2
     # via
@@ -1626,7 +1619,7 @@ walrus==0.9.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
-watchdog==5.0.3
+watchdog==5.0.2
     # via -r requirements/edx/base.txt
 wcwidth==0.2.13
     # via
@@ -1680,13 +1673,14 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.14
+xmlsec==1.3.13
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/base.txt
-yarl==1.14.0
+yarl==1.12.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.2.2
     # via pip-tools
 click==8.1.6
     # via
@@ -14,7 +14,7 @@ packaging==24.1
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
-pyproject-hooks==1.2.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools

--- a/scripts/structures_pruning/requirements/base.txt
+++ b/scripts/structures_pruning/requirements/base.txt
@@ -11,7 +11,7 @@ click==8.1.6
     #   click-log
 click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.in
-dnspython==2.7.0
+dnspython==2.6.1
     # via pymongo
 edx-opaque-keys==2.11.0
     # via -r scripts/structures_pruning/requirements/base.in

--- a/scripts/structures_pruning/requirements/testing.txt
+++ b/scripts/structures_pruning/requirements/testing.txt
@@ -12,7 +12,7 @@ click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.txt
 ddt==1.7.2
     # via -r scripts/structures_pruning/requirements/testing.in
-dnspython==2.7.0
+dnspython==2.6.1
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   pymongo

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -10,9 +10,9 @@ attrs==24.2.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-boto3==1.35.37
+boto3==1.35.27
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.35.37
+botocore==1.35.27
     # via
     #   boto3
     #   s3transfer
@@ -46,13 +46,13 @@ django-crum==0.7.9
     # via edx-django-utils
 django-waffle==4.1.0
     # via edx-django-utils
-edx-django-utils==6.0.0
+edx-django-utils==5.16.0
     # via edx-rest-api-client
 edx-rest-api-client==6.0.0
     # via -r scripts/user_retirement/requirements/base.in
-google-api-core==2.21.0
+google-api-core==2.20.0
     # via google-api-python-client
-google-api-python-client==2.149.0
+google-api-python-client==2.147.0
     # via -r scripts/user_retirement/requirements/base.in
 google-auth==2.35.0
     # via
@@ -69,7 +69,7 @@ httplib2==0.22.0
     #   google-auth-httplib2
 idna==3.10
     # via requests
-isodate==0.7.2
+isodate==0.6.1
     # via zeep
 jenkinsapi==0.3.13
     # via -r scripts/user_retirement/requirements/base.in
@@ -77,11 +77,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lxml==5.3.0
-    # via zeep
+lxml==4.9.4
+    # via
+    #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
+    #   zeep
 more-itertools==10.5.0
     # via simple-salesforce
-newrelic==10.0.0
+newrelic==9.13.0
     # via edx-django-utils
 pbr==6.1.0
     # via stevedore
@@ -136,7 +138,7 @@ requests-toolbelt==1.0.0
     # via zeep
 rsa==4.9
     # via google-auth
-s3transfer==0.10.3
+s3transfer==0.10.2
     # via boto3
 simple-salesforce==1.12.6
     # via -r scripts/user_retirement/requirements/base.in
@@ -144,6 +146,7 @@ simplejson==3.19.3
     # via -r scripts/user_retirement/requirements/base.in
 six==1.16.0
     # via
+    #   isodate
     #   jenkinsapi
     #   python-dateutil
 sqlparse==0.5.1

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -14,11 +14,11 @@ attrs==24.2.0
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-boto3==1.35.37
+boto3==1.35.27
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.35.37
+botocore==1.35.27
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -66,17 +66,17 @@ django-waffle==4.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-edx-django-utils==6.0.0
+edx-django-utils==5.16.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
 edx-rest-api-client==6.0.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-api-core==2.21.0
+google-api-core==2.20.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.149.0
+google-api-python-client==2.147.0
     # via -r scripts/user_retirement/requirements/base.txt
 google-auth==2.35.0
     # via
@@ -103,7 +103,7 @@ idna==3.10
     #   requests
 iniconfig==2.0.0
     # via pytest
-isodate==0.7.2
+isodate==0.6.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
@@ -116,11 +116,11 @@ jmespath==1.0.1
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
     #   botocore
-lxml==5.3.0
+lxml==4.9.4
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-markupsafe==3.0.1
+markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
@@ -132,7 +132,7 @@ more-itertools==10.5.0
     #   simple-salesforce
 moto==4.2.14
     # via -r scripts/user_retirement/requirements/testing.in
-newrelic==10.0.0
+newrelic==9.13.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
@@ -235,7 +235,7 @@ rsa==4.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-s3transfer==0.10.3
+s3transfer==0.10.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -246,6 +246,7 @@ simplejson==3.19.3
 six==1.16.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
+    #   isodate
     #   jenkinsapi
     #   python-dateutil
 sqlparse==0.5.1
@@ -274,7 +275,7 @@ urllib3==1.26.20
     #   responses
 werkzeug==3.0.4
     # via moto
-xmltodict==0.14.1
+xmltodict==0.13.0
     # via moto
 zeep==4.2.1
     # via


### PR DESCRIPTION
Reverts openedx/edx-platform#35634 in its entirely.

This is breaking on deploy with the complaint: ```AssertionError: Internal issue: Candidate is not for this requirement lxml[html-clean,html-clean] vs lxml[html-clean]```

This PR also pins several jobs that install Python dependencies use Ubuntu 22.04 instead of ubuntu-latest. This is partially a revert/backout of https://github.com/openedx/edx-platform/pull/35450 . See https://github.com/openedx/edx-platform/pull/35635/commits/ff916691d7cb725b93b3f9f130a1debaee6be448 for the pinned jobs.