### PR TITLE
Server-side Library asset support (asset view and api get/add/delete)

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -333,3 +333,13 @@ COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = {
     "SECRET": "***",
     "URL": "***",
 }
+
+############## openedx-learning (Learning Core) config ##############
+OPENEDX_LEARNING = {
+    'MEDIA': {
+        'BACKEND': 'django.core.files.storage.InMemoryStorage',
+        'OPTIONS': {
+            'location': MEDIA_ROOT + "_private"
+        }
+    }
+}

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -661,13 +661,13 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             self._get_library_block_olx(block3_key, expect_response=403)
             self._get_library_block_fields(block3_key, expect_response=403)
             self._get_library_block_assets(block3_key, expect_response=403)
-            self._get_library_block_asset(block3_key, file_name="whatever.png", expect_response=403)
+            self._get_library_block_asset(block3_key, file_name="static/whatever.png", expect_response=403)
             # Nor can they preview the block:
             self._render_block_view(block3_key, view_name="student_view", expect_response=403)
         # But if we grant allow_public_read, then they can:
         with self.as_user(admin):
             self._update_library(lib_id, allow_public_read=True)
-            # self._set_library_block_asset(block3_key, "whatever.png", b"data")
+            self._set_library_block_asset(block3_key, "static/whatever.png", b"data")
         with self.as_user(random_user):
             self._get_library_block_olx(block3_key)
             self._render_block_view(block3_key, view_name="student_view")
@@ -680,7 +680,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             with self.as_user(user):
                 self._set_library_block_olx(block3_key, "<problem/>", expect_response=403)
                 self._set_library_block_fields(block3_key, {"data": "<problem />", "metadata": {}}, expect_response=403)
-                # self._set_library_block_asset(block3_key, "test.txt", b"data", expect_response=403)
+                self._set_library_block_asset(block3_key, "static/test.txt", b"data", expect_response=403)
                 self._delete_library_block(block3_key, expect_response=403)
                 self._commit_library_changes(lib_id, expect_response=403)
                 self._revert_library_changes(lib_id, expect_response=403)
@@ -690,9 +690,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             olx = self._get_library_block_olx(block3_key)
             self._set_library_block_olx(block3_key, olx)
             self._set_library_block_fields(block3_key, {"data": olx, "metadata": {}})
-            # self._get_library_block_assets(block3_key)
-            # self._set_library_block_asset(block3_key, "test.txt", b"data")
-            # self._get_library_block_asset(block3_key, file_name="test.txt")
+            self._get_library_block_assets(block3_key)
+            self._set_library_block_asset(block3_key, "static/test.txt", b"data")
+            self._get_library_block_asset(block3_key, file_name="static/test.txt")
             self._delete_library_block(block3_key)
             self._commit_library_changes(lib_id)
             self._revert_library_changes(lib_id)  # This is a no-op after the commit, but should still have 200 response
@@ -915,7 +915,6 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             event_receiver.call_args.kwargs
         )
 
-    @skip("We still need to re-implement static asset handling.")
     def test_library_block_add_asset_update_event(self):
         """
         Check that LIBRARY_BLOCK_CREATED event is sent when a static asset is
@@ -934,7 +933,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
 
         block = self._add_block_to_library(lib_id, "unit", "u1")
         block_id = block["id"]
-        self._set_library_block_asset(block_id, "test.txt", b"data")
+        self._set_library_block_asset(block_id, "static/test.txt", b"data")
 
         usage_key = LibraryUsageLocatorV2(
             lib_key=library_key,
@@ -955,7 +954,6 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             event_receiver.call_args.kwargs
         )
 
-    @skip("We still need to re-implement static asset handling.")
     def test_library_block_del_asset_update_event(self):
         """
         Check that LIBRARY_BLOCK_CREATED event is sent when a static asset is
@@ -974,9 +972,9 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
 
         block = self._add_block_to_library(lib_id, "unit", "u1")
         block_id = block["id"]
-        self._set_library_block_asset(block_id, "test.txt", b"data")
+        self._set_library_block_asset(block_id, "static/test.txt", b"data")
 
-        self._delete_library_block_asset(block_id, 'text.txt')
+        self._delete_library_block_asset(block_id, 'static/text.txt')
 
         usage_key = LibraryUsageLocatorV2(
             lib_key=library_key,

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -1,11 +1,16 @@
 """
 Tests for static asset files in Learning-Core-based Content Libraries
 """
-from unittest import skip
+from uuid import UUID
 
+from opaque_keys.edx.keys import UsageKey
+
+from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content_libraries.tests.base import (
     ContentLibrariesRestApiTest,
 )
+from openedx.core.djangoapps.xblock.api import get_component_from_usage_key
+from openedx.core.djangolib.testing.utils import skip_unless_cms
 
 # Binary data representing an SVG image file
 SVG_DATA = """<svg xmlns="http://www.w3.org/2000/svg" height="30" width="100">
@@ -23,15 +28,10 @@ I'm Anant Agarwal, I'm the president of edX,
 """
 
 
-@skip("Assets are being reimplemented in Learning Core. Disable until that's ready.")
+@skip_unless_cms
 class ContentLibrariesStaticAssetsTest(ContentLibrariesRestApiTest):
     """
     Tests for static asset files in Learning-Core-based Content Libraries
-
-    WARNING: every test should have a unique library slug, because even though
-    the django/mysql database gets reset for each test case, the lookup between
-    library slug and bundle UUID does not because it's assumed to be immutable
-    and cached forever.
     """
 
     def test_asset_filenames(self):
@@ -79,7 +79,7 @@ class ContentLibrariesStaticAssetsTest(ContentLibrariesRestApiTest):
             />
         """)
         # Upload the transcript file
-        self._set_library_block_asset(block_id, "3_yD_cEKoCk-en.srt", TRANSCRIPT_DATA)
+        self._set_library_block_asset(block_id, "static/3_yD_cEKoCk-en.srt", TRANSCRIPT_DATA)
 
         transcript_handler_url = self._get_block_handler_url(block_id, "transcript")
 
@@ -108,3 +108,79 @@ class ContentLibrariesStaticAssetsTest(ContentLibrariesRestApiTest):
         self._commit_library_changes(library["id"])
         check_sjson()
         check_download()
+
+
+@skip_unless_cms
+class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
+    """
+    Tests for the view that actually delivers the Library asset in Studio.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        library = self._create_library(slug="asset-lib2", title="Static Assets Test Library")
+        block = self._add_block_to_library(library["id"], "html", "html1")
+        self._set_library_block_asset(block["id"], "static/test.svg", SVG_DATA)
+        usage_key = UsageKey.from_string(block["id"])
+        self.component = get_component_from_usage_key(usage_key)
+        self.draft_component_version = self.component.versioning.draft
+
+    def test_good_responses(self):
+        get_response = self.client.get(
+            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+        )
+        assert get_response.status_code == 200
+        content = b''.join(chunk for chunk in get_response.streaming_content)
+        assert content == SVG_DATA
+
+        good_head_response = self.client.head(
+            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+        )
+        assert good_head_response.headers == get_response.headers
+
+    def test_missing(self):
+        """Test asset requests that should 404."""
+        # Non-existent version...
+        wrong_version_uuid = UUID('11111111-1111-1111-1111-111111111111')
+        response = self.client.get(
+            f"/library_assets/{wrong_version_uuid}/static/test.svg"
+        )
+        assert response.status_code == 404
+
+        # Non-existent file...
+        response = self.client.get(
+            f"/library_assets/{self.draft_component_version.uuid}/static/missing.svg"
+        )
+        assert response.status_code == 404
+
+        # File-like ComponenVersionContent entry that isn't an actually
+        # downloadable file...
+        response = self.client.get(
+            f"/library_assets/{self.draft_component_version.uuid}/block.xml"
+        )
+        assert response.status_code == 404
+
+    def test_anonymous_user(self):
+        """Anonymous users shouldn't get access to library assets."""
+        self.client.logout()
+        response = self.client.get(
+            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+        )
+        assert response.status_code == 403
+
+    def test_unauthorized_user(self):
+        """User who is not a Content Library staff should not have access."""
+        self.client.logout()
+        student = UserFactory.create(
+            username="student",
+            email="student@example.com",
+            password="student-pass",
+            is_staff=False,
+            is_superuser=False,
+        )
+        self.client.login(username="student", password="student-pass")
+        get_response = self.client.get(
+            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+        )
+        assert get_response.status_code == 403

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -75,4 +75,9 @@ urlpatterns = [
             path('pub/jwks/', views.LtiToolJwksView.as_view(), name='lti-pub-jwks'),
         ])),
     ])),
+    path(
+        'library_assets/<uuid:component_version_uuid>/<path:asset_path>',
+        views.component_version_asset,
+        name='library-assets',
+    ),
 ]

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -1212,7 +1212,7 @@ def component_version_asset(request, component_version_uuid, asset_path):
 
     # Otherwise it's going to be a GET response. We don't support response
     # offsets or anything fancy, because we don't expect to run this view at
-    # scale.
+    # LMS-scale.
     return StreamingHttpResponse(
         content.read_file().chunks(),
         headers=redirect_response.headers,

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -71,14 +71,16 @@ import logging
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login
 from django.contrib.auth.models import Group
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.transaction import atomic, non_atomic_requests
-from django.http import Http404, HttpResponseBadRequest, JsonResponse
+from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_safe
 from django.views.generic.base import TemplateResponseMixin, View
 from pylti1p3.contrib.django import DjangoCacheDataStorage, DjangoDbToolConf, DjangoMessageLaunch, DjangoOIDCLogin
 from pylti1p3.exception import LtiException, OIDCException
@@ -86,6 +88,7 @@ from pylti1p3.exception import LtiException, OIDCException
 import edx_api_doc_tools as apidocs
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
+from openedx_learning.api import authoring
 from organizations.api import ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 from organizations.models import Organization
@@ -792,7 +795,7 @@ class LibraryBlockAssetView(APIView):
             raise ValidationError("File too big")
         file_content = file_wrapper.read()
         try:
-            result = api.add_library_block_static_asset_file(usage_key, file_path, file_content)
+            result = api.add_library_block_static_asset_file(usage_key, file_path, file_content, request.user)
         except ValueError:
             raise ValidationError("Invalid file path")  # lint-amnesty, pylint: disable=raise-missing-from
         return Response(LibraryXBlockStaticFileSerializer(result).data)
@@ -807,7 +810,7 @@ class LibraryBlockAssetView(APIView):
             usage_key.lib_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
         )
         try:
-            api.delete_library_block_static_asset_file(usage_key, file_path)
+            api.delete_library_block_static_asset_file(usage_key, file_path, request.user)
         except ValueError:
             raise ValidationError("Invalid file path")  # lint-amnesty, pylint: disable=raise-missing-from
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -1143,3 +1146,74 @@ class LtiToolJwksView(LtiToolView):
         Return the JWKS.
         """
         return JsonResponse(self.lti_tool_config.get_jwks(), safe=False)
+
+
+@require_safe
+def component_version_asset(request, component_version_uuid, asset_path):
+    """
+    Serves static assets associated with particular Component versions.
+
+    Important notes:
+    * This is meant for Studio/authoring use ONLY. It requires read access to
+      the content library.
+    * It uses the UUID because that's easier to parse than the key field (which
+      could be part of an OpaqueKey, but could also be almost anything else).
+    * This is not very performant, and we still want to use the X-Accel-Redirect
+      method for serving LMS traffic in the longer term (and probably Studio
+      eventually).
+    """
+    try:
+        component_version = authoring.get_component_version_by_uuid(
+            component_version_uuid
+        )
+    except ObjectDoesNotExist as exc:
+        raise Http404() from exc
+
+    # Permissions check...
+    learning_package = component_version.component.learning_package
+    library_key = LibraryLocatorV2.from_string(learning_package.key)
+    api.require_permission_for_library_key(
+        library_key, request.user, permissions.CAN_VIEW_THIS_CONTENT_LIBRARY,
+    )
+
+    # We already have logic for getting the correct content and generating the
+    # proper headers in Learning Core, but the response generated here is an
+    # X-Accel-Redirect and lacks the actual content. We eventually want to use
+    # this response in conjunction with a media reverse proxy (Caddy or Nginx),
+    # but in the short term we're just going to remove the redirect and stream
+    # the content directly.
+    redirect_response = authoring.get_redirect_response_for_component_asset(
+        component_version_uuid,
+        asset_path,
+        public=False,
+        learner_downloadable_only=False,
+    )
+
+    # If there was any error, we return that response because it will have the
+    # correct headers set and won't have any X-Accel-Redirect header set.
+    if redirect_response.status_code != 200:
+        return redirect_response
+
+    # If we got here, we know that the asset exists and it's okay to download.
+    cv_content = component_version.componentversioncontent_set.get(key=asset_path)
+    content = cv_content.content
+
+    # Delete the re-direct part of the response headers. We'll copy the rest.
+    headers = redirect_response.headers
+    headers.pop('X-Accel-Redirect')
+
+    # We need to set the content size header manually because this is a
+    # streaming response. It's not included in the redirect headers because it's
+    # not needed there (the reverse-proxy would have direct access to the file).
+    headers['Content-Length'] = content.size
+
+    if request.method == "HEAD":
+        return HttpResponse(headers=headers)
+
+    # Otherwise it's going to be a GET response. We don't support response
+    # offsets or anything fancy, because we don't expect to run this view at
+    # scale.
+    return StreamingHttpResponse(
+        content.read_file().chunks(),
+        headers=redirect_response.headers,
+    )

--- a/xmodule/video_block/transcripts_utils.py
+++ b/xmodule/video_block/transcripts_utils.py
@@ -1042,29 +1042,29 @@ def get_transcript_from_contentstore(video, language, output_format, transcripts
 
 def get_transcript_from_learning_core(video_block, language, output_format, transcripts_info):
     """
-    Get video transcript from Learning Core.
+    Get video transcript from Learning Core (used for Content Libraries)
 
     Limitation: This is only going to grab from the Draft version.
 
-    HISTORIC INFORMATION FROM WHEN THIS FUNCTION WAS `get_transcript_from_blockstore`:
+    Learning Core models a VideoBlock's data in a more generic thing it calls a
+    Component. Each Component has its own virtual space for file-like data. The
+    OLX for the VideoBlock itself is stored at the root of that space, as
+    ``block.xml``. Static assets that are meant to be user-downloadable are
+    placed in a `static/` directory for that Component, and this is where we
+    expect to store transcript files.
 
-      Blockstore expects video transcripts to be placed into the 'static/'
-      subfolder of the XBlock's folder in a Blockstore bundle. For example, if the
-      video XBlock's definition is in the standard location of
-          video/video1/definition.xml
-      Then the .srt files should be placed at e.g.
-          video/video1/static/video1-en.srt
-      This is the same place where other public static files are placed for other
-      XBlocks, such as image files used by HTML blocks.
+    So if there is a ``video1-en.srt`` file for a particular VideoBlock, we
+    expect that to be stored as ``static/video1-en.srt`` in the Component. Any
+    other downloadable files would be here as well, such as thumbnails.
 
-      Video XBlocks in Blockstore must set the 'transcripts' XBlock field to a
-      JSON dictionary listing the filename of the transcript for each language:
-          <video
-              youtube_id_1_0="3_yD_cEKoCk"
-              transcripts='{"en": "3_yD_cEKoCk-en.srt"}'
-              display_name="Welcome Video with Transcript"
-              download_track="true"
-          />
+    Video XBlocks in Blockstore must set the 'transcripts' XBlock field to a
+    JSON dictionary listing the filename of the transcript for each language:
+        <video
+            youtube_id_1_0="3_yD_cEKoCk"
+            transcripts='{"en": "3_yD_cEKoCk-en.srt"}'
+            display_name="Welcome Video with Transcript"
+            download_track="true"
+        />
 
       This method is tested in openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
 
@@ -1077,7 +1077,7 @@ def get_transcript_from_learning_core(video_block, language, output_format, tran
     Returns:
         tuple containing content, filename, mimetype
     """
-    usage_key = video_block.scope_ids.usage_id
+    usage_key = video_block.usage_key
 
     # Validate that the format is something we even support...
     if output_format not in (Transcript.SRT, Transcript.SJSON, Transcript.TXT):


### PR DESCRIPTION
## Description

Creates a new view to display static assets associated with library content
backed by Learning Core data models. Also re-implements parts of the content
libraries API module that had initially been implemented for Blockstore, and
then remained as stubs after the switchover to openedx-learning backed models.

Content Libraries API calls that are re-implemented in this PR:

* `get_library_block_static_asset_files`
* `add_library_block_static_asset_file`
* `delete_library_block_static_asset_file`

This overlaps https://github.com/openedx/edx-platform/pull/35557 , but does _not_ include:

* changes to the file metadata API to facilitate UI changes in Studio's Files and Uploads
* copy-paste functionality

Those will follow in separate PRs.