### PR TITLE
feat!: hide courses in /courses based on catalog visibility

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -46,7 +46,11 @@ from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from token_utils.api import unpack_token_for
 from web_fragments.fragment import Fragment
-from xmodule.course_block import COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE
+from xmodule.course_block import (
+    COURSE_VISIBILITY_PUBLIC,
+    COURSE_VISIBILITY_PUBLIC_OUTLINE,
+    CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
+)
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
 from xmodule.tabs import CourseTabList
@@ -288,7 +292,10 @@ def courses(request):
     course_discovery_meanings = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
     set_default_filter = ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER.is_enabled()
     if not settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
-        courses_list = get_courses(request.user)
+        courses_list = get_courses(
+            request.user,
+            filter_={"catalog_visibility": CATALOG_VISIBILITY_CATALOG_AND_ABOUT},
+        )
 
         if configuration_helpers.get_value("ENABLE_COURSE_SORTING_BY_START_DATE",
                                            settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]):


### PR DESCRIPTION
## Description

Previously, courses were always displayed on the LMS /courses page, independently of their catalog visibility attribute. This meant that even with visibility="none" courses were being displayed. This was very counter-intuitive.

With this change, courses are displayed only when their visibility is set to "both".

This change is flagged as breaking because it has the potential to affect course catalogs in existing platforms.

## Supporting information

Close https://github.com/openedx/wg-build-test-release/issues/330

## Testing instructions

To test this change, go to http(s)://LMS/courses as an anonymous user. Pick a visible course and go to its "advanced settings" in the studio. Set "Course visibility in catalog" to "about" or "none". Then, clear the cache with the following command:

    ./manage.py lms shell -c "from django.core.cache import cache; cache.clear()"

Open the /courses page again: the course should no longer be visible.

## Deadline

This PR probably comes too late for redwood.3. Hopefully we can merge it in time for sumac.1. If the sumac branch is cut before this PR is merged, then we should backport this change to the sumac branch.
