### PR TITLE
chore: use the PEP 508 format without editable VCS requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via -r requirements/edx/github.in
 acid-xblock==0.4.1
     # via -r requirements/edx/kernel.in
 aiohappyeyeballs==2.4.4
@@ -509,6 +507,8 @@ edx-proctoring==5.1.2
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack @ git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2
+    # via -r requirements/edx/github.in
 edx-rbac==1.10.0
     # via edx-enterprise
 edx-rest-api-client==6.0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
 accessible-pygments==0.0.5
     # via
     #   -r requirements/edx/doc.txt
@@ -802,6 +798,10 @@ edx-proctoring==5.1.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack @ git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
 edx-rbac==1.10.0
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via -r requirements/edx/base.txt
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 acid-xblock==0.4.1
@@ -593,6 +591,8 @@ edx-proctoring==5.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack @ git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2
+    # via -r requirements/edx/base.txt
 edx-rbac==1.10.0
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -89,4 +89,4 @@
 
 # django42 support PR merged but new release is pending.
 # https://github.com/openedx/edx-platform/issues/33431
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
+edx_proctoring_proctortrack @ git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via -r requirements/edx/base.txt
 acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
 aiohappyeyeballs==2.4.4
@@ -617,6 +615,8 @@ edx-proctoring==5.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack
+edx-proctoring-proctortrack @ git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2
+    # via -r requirements/edx/base.txt
 edx-rbac==1.10.0
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION

## Description

This change makes it possible to use [uv](https://github.com/astral-sh/uv) as a pip replacement in order to perform a faster installation of requirements.

`edx_proctoring_proctortrack` already publishes to PyPI (although the release with Django 4.2 support has not been published), so we don't need to install the package as editable because the MANIFEST.in file already includes all the necessary extra files.

There was also the[ possibility of removing the package](https://github.com/openedx/edx-platform/issues/33431) altogether, maybe we can make that push for the Sumak release?