### PR TITLE
fix: update email_content when grouping notifications

### DIFF
--- a/openedx/core/djangoapps/notifications/grouping_notifications.py
+++ b/openedx/core/djangoapps/notifications/grouping_notifications.py
@@ -80,6 +80,7 @@ class NewCommentGrouper(BaseNotificationGrouper):
             context['grouped'] = True
         context['replier_name_list'].append(new_notification.content_context['replier_name'])
         context['grouped_count'] += 1
+        context['email_content'] = new_notification.content_context.get('email_content', '')
         return context
 
 

--- a/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
+++ b/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
@@ -88,6 +88,19 @@ class TestNewCommentGrouper(unittest.TestCase):
         self.assertEqual(len(updated_context['replier_name_list']), 3)
         self.assertEqual(updated_context['grouped_count'], 3)
 
+    def test_group_email_content(self):
+        """
+        Tests email_content in content_context when grouping notification
+        """
+        self.old_notification.content_context['email_content'] = 'old content'
+        self.new_notification.content_context = {
+            'email_content': 'new content',
+            'replier_name': 'user_2',
+        }
+        content_context = NewCommentGrouper().group(self.new_notification, self.old_notification)
+        self.assertIn('email_content', content_context)
+        self.assertEqual(content_context['email_content'], 'new content')
+
 
 class TestGroupUserNotifications(unittest.TestCase):
     """


### PR DESCRIPTION
Updated `email_content` to show latest content when grouping notifications

Ticket: [INF-1654](https://2u-internal.atlassian.net/browse/INF-1654)
