### PR TITLE
build: Pin MyPY due to internal error

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -123,6 +123,11 @@ markdown<3.4.0
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35270
 moto<5.0
 
+# Date: 2024-10-16
+# MyPY 1.12.0 fails on all PRs with the following error:
+# openedx/core/djangoapps/content_libraries/api.py:732: error: INTERNAL ERROR
+mypy<1.12.0
+
 # Date: 2024-07-16
 # We need to upgrade the version of elasticsearch to atleast 7.15 before we can upgrade to Numpy 2.0.0
 # Otherwise we see a failure while running the following command:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -126,6 +126,7 @@ moto<5.0
 # Date: 2024-10-16
 # MyPY 1.12.0 fails on all PRs with the following error:
 # openedx/core/djangoapps/content_libraries/api.py:732: error: INTERNAL ERROR
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35667
 mypy<1.12.0
 
 # Date: 2024-07-16

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1279,8 +1279,9 @@ multidict==6.1.0
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.12.0
+mypy==1.11.2
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
     #   django-stubs
     #   djangorestframework-stubs


### PR DESCRIPTION
Currently all PRs are failing on an INTERNAL ERROR in MyPY that seems to have been introduced in 1.12.0. This pins edx-platform to <1.12.0 until we can find out more information and hopefully get an upstream fix.

Unpin issue: https://github.com/openedx/edx-platform/issues/35667
Related (cause?): https://github.com/openedx/edx-platform/issues/35275
