### PR TITLE
Confirmation modal to preview and accept v2 library updates [FC-0062]

### DIFF
--- a/cms/lib/xblock/upstream_sync.py
+++ b/cms/lib/xblock/upstream_sync.py
@@ -165,11 +165,7 @@ class UpstreamLink:
         return cls(
             upstream_ref=downstream.upstream,
             version_synced=downstream.upstream_version,
-            version_available=(lib_meta.draft_version_num if lib_meta else None),
-            # TODO: Previous line is wrong. It should use the published version instead, but the
-            # LearningCoreXBlockRuntime APIs do not yet support published content yet.
-            # Will be fixed in a follow-up task: https://github.com/openedx/edx-platform/issues/35582
-            # version_available=(lib_meta.published_version_num if lib_meta else None),
+            version_available=(lib_meta.published_version_num if lib_meta else None),
             version_declined=downstream.upstream_version_declined,
             error_message=None,
         )
@@ -213,9 +209,14 @@ def _load_upstream_link_and_block(downstream: XBlock, user: User) -> tuple[Upstr
     """
     link = UpstreamLink.get_for_block(downstream)  # can raise UpstreamLinkException
     # We import load_block here b/c UpstreamSyncMixin is used by cms/envs, which loads before the djangoapps are ready.
-    from openedx.core.djangoapps.xblock.api import load_block  # pylint: disable=wrong-import-order
+    from openedx.core.djangoapps.xblock.api import load_block, CheckPerm, LatestVersion  # pylint: disable=wrong-import-order
     try:
-        lib_block: XBlock = load_block(LibraryUsageLocatorV2.from_string(downstream.upstream), user)
+        lib_block: XBlock = load_block(
+            LibraryUsageLocatorV2.from_string(downstream.upstream),
+            user,
+            check_permission=CheckPerm.CAN_READ_AS_AUTHOR,
+            version=LatestVersion.PUBLISHED,
+        )
     except (NotFound, PermissionDenied) as exc:
         raise BadUpstream(_("Linked library item could not be loaded: {}").format(downstream.upstream)) from exc
     return link, lib_block

--- a/cms/static/js/views/modals/preview_v2_library_changes.js
+++ b/cms/static/js/views/modals/preview_v2_library_changes.js
@@ -1,0 +1,98 @@
+/**
+ * The PreviewLibraryChangesModal is a Backbone view that shows an iframe in a
+ * modal window. The iframe embeds a view from the Authoring MFE that allows
+ * authors to preview the new version of a library-sourced XBlock, and decide
+ * whether to accept ("sync") or reject ("ignore") the changes.
+ */
+define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal',
+    'js/views/utils/xblock_utils'],
+function($, _, gettext, BaseModal, XBlockViewUtils) {
+    'use strict';
+
+    var PreviewLibraryChangesModal = BaseModal.extend({
+        events: _.extend({}, BaseModal.prototype.events, {
+            'click .action-accept': 'acceptChanges',
+            'click .action-ignore': 'ignoreChanges',
+        }),
+
+        options: $.extend({}, BaseModal.prototype.options, {
+            modalName: 'preview-lib-changes',
+            modalSize: 'med',
+            view: 'studio_view',
+            viewSpecificClasses: 'modal-lib-preview confirm',
+            // Translators: "title" is the name of the current component being edited.
+            titleFormat: gettext('Preview changes to: {title}'),
+            addPrimaryActionButton: false,
+        }),
+
+        initialize: function() {
+            BaseModal.prototype.initialize.call(this);
+            // this.template = this.loadTemplate('edit-xblock-modal');
+            // this.editorModeButtonTemplate = this.loadTemplate('editor-mode-button');
+        },
+
+        /**
+         * Adds the action buttons to the modal.
+         */
+        addActionButtons: function() {
+            this.addActionButton('accept', gettext('Accept changes'), true);
+            this.addActionButton('ignore', gettext('Ignore changes'));
+            this.addActionButton('cancel', gettext('Cancel'));
+        },
+
+        /**
+         * Show an edit modal for the specified xblock
+         * @param xblockElement The element that contains the xblock to be edited.
+         * @param rootXBlockInfo An XBlockInfo model that describes the root xblock on the page.
+         * @param refreshFunction A function to refresh the block after it has been updated
+         */
+        showPreviewFor: function(xblockElement, rootXBlockInfo, refreshFunction) {
+            this.xblockElement = xblockElement;
+            this.xblockInfo = XBlockViewUtils.findXBlockInfo(xblockElement, rootXBlockInfo);
+            this.courseAuthoringMfeUrl = rootXBlockInfo.attributes.course_authoring_url;
+            const headerElement = xblockElement.find('.xblock-header-primary');
+            this.upstreamBlockId = headerElement.data('upstream-ref');
+            this.upstreamBlockVersionSynced = headerElement.data('version-synced');
+            // this.options.modalType = this.xblockInfo.get('category');
+            this.refreshFunction = refreshFunction;
+
+            this.render();
+            this.show();
+        },
+
+        getContentHtml: function() {
+            return `
+                <iframe src="${this.courseAuthoringMfeUrl}/legacy/preview-changes/${this.upstreamBlockId}?old=${this.upstreamBlockVersionSynced}">
+            `;
+        },
+
+        getTitle: function() {
+            var displayName = this.xblockInfo.get('display_name');
+            if (!displayName) {
+                if (this.xblockInfo.isVertical()) {
+                    displayName = gettext('Unit');
+                } else {
+                    displayName = gettext('Component');
+                }
+            }
+            return edx.StringUtils.interpolate(
+                this.options.titleFormat, {
+                    title: displayName
+                }
+            );
+        },
+
+        acceptChanges: function(event) {
+            event.preventDefault();
+        },
+
+        ignoreChanges: function(event) {
+            event.preventDefault();
+            if (confirm(gettext('Are you sure you want to ignore these changes?'))) {
+                // TODO
+            }
+        },
+    });
+
+    return PreviewLibraryChangesModal;
+});

--- a/cms/static/js/views/modals/preview_v2_library_changes.js
+++ b/cms/static/js/views/modals/preview_v2_library_changes.js
@@ -27,8 +27,6 @@ function($, _, gettext, BaseModal, ViewUtils, XBlockViewUtils) {
 
         initialize: function() {
             BaseModal.prototype.initialize.call(this);
-            // this.template = this.loadTemplate('edit-xblock-modal');
-            // this.editorModeButtonTemplate = this.loadTemplate('editor-mode-button');
         },
 
         /**

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -8,14 +8,15 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
     'js/models/xblock_info', 'js/views/xblock_string_field_editor', 'js/views/xblock_access_editor',
     'js/views/pages/container_subviews', 'js/views/unit_outline', 'js/views/utils/xblock_utils',
     'common/js/components/views/feedback_notification', 'common/js/components/views/feedback_prompt',
-    'js/views/utils/tagging_drawer_utils', 'js/utils/module',
+    'js/views/utils/tagging_drawer_utils', 'js/utils/module', 'js/views/modals/preview_v2_library_changes'
 ],
 function($, _, Backbone, gettext, BasePage,
     ViewUtils, ContainerView, XBlockView,
     AddXBlockComponent, EditXBlockModal, MoveXBlockModal,
     XBlockInfo, XBlockStringFieldEditor, XBlockAccessEditor,
     ContainerSubviews, UnitOutlineView, XBlockUtils,
-    NotificationView, PromptView, TaggingDrawerUtils, ModuleUtils) {
+    NotificationView, PromptView, TaggingDrawerUtils, ModuleUtils,
+    PreviewLibraryChangesModal) {
     'use strict';
 
     var XBlockContainerPage = BasePage.extend({
@@ -28,6 +29,7 @@ function($, _, Backbone, gettext, BasePage,
             'click .copy-button': 'copyXBlock',
             'click .move-button': 'showMoveXBlockModal',
             'click .delete-button': 'deleteXBlock',
+            'click .library-sync-button': 'showXBlockLibraryChangesPreview',
             'click .show-actions-menu-button': 'showXBlockActionsMenu',
             'click .new-component-button': 'scrollToNewComponentButtons',
             'click .save-button': 'saveSelectedLibraryComponents',
@@ -393,6 +395,18 @@ function($, _, Backbone, gettext, BasePage,
                 refresh: function() {
                     self.refreshXBlock(xblockElement, false);
                 }
+            });
+        },
+
+        showXBlockLibraryChangesPreview: function(event, options) {
+            event.preventDefault();
+
+            var xblockElement = this.findXBlockElement(event.target),
+                self = this,
+                modal = new PreviewLibraryChangesModal(options);
+
+            modal.showPreviewFor(xblockElement, this.model, function() {
+                self.refreshXBlock(xblockElement, false);
             });
         },
 

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -571,6 +571,7 @@
     & > iframe {
       width: 100%;
       min-height: 350px;
+      background: url('#{$static-path}/images/spinner.gif') center center no-repeat;
     }
   }
 }

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -562,6 +562,19 @@
   }
 }
 
+// Modal for previewing changes to a library-sourced block
+// cms/static/js/views/modals/preview_v2_library_changes.js
+.modal-lib-preview {
+  .modal-content {
+    padding: 0 !important;
+
+    & > iframe {
+      width: 100%;
+      min-height: 350px;
+    }
+  }
+}
+
 .ltiLaunchFrame{
     width:100%;
     height:100%

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -89,6 +89,10 @@ upstream_info = UpstreamLink.try_get_for_block(xblock)
     authoring_MFE_base_url = ${get_editor_page_base_url(xblock.location.course_key)}
     data-block-type = ${xblock.scope_ids.block_type}
     data-usage-id = ${xblock.scope_ids.usage_id}
+    % if upstream_info.upstream_ref:
+        data-upstream-ref = ${upstream_info.upstream_ref}
+        data-version-synced = ${upstream_info.version_synced}
+    %endif
     >
         <div class="header-details">
             % if show_inline:
@@ -137,7 +141,6 @@ upstream_info = UpstreamLink.try_get_for_block(xblock)
                                 <button
                                     class="btn-default library-sync-button action-button"
                                     data-tooltip="${_("Update available - click to sync")}"
-                                    onclick="$.post('/api/contentstore/v2/downstreams/${xblock.usage_key}/sync').done(() => { location.reload(); })"
                                 >
                                     <span class="icon fa fa-refresh" aria-hidden="true"></span>
                                     <span>${_("Update available")}</span>


### PR DESCRIPTION
## Description

Part of https://github.com/openedx/frontend-app-authoring/issues/1341 . Used when an author has copied library content into their course and there is a newer "upstream" version available. Implements a new modal dialog that allows authors to compare the new version to the old and then accept or ignore the update.

Video:

https://github.com/user-attachments/assets/ca2741f0-5971-4440-8f6d-7d9c175b060f

## Supporting information

Part of https://github.com/openedx/frontend-app-authoring/issues/1341

Builds on https://github.com/openedx/edx-platform/pull/34925

Depends on https://github.com/openedx/frontend-app-authoring/pull/1393

## Testing instructions

1. Check out this branch and run `tutor dev exec lms openedx-assets build --env=dev` to rebuild your static assets
2. Check out https://github.com/openedx/frontend-app-authoring/pull/1393 in the authoring MFE
3. Find a component, e.g. a text component, publish it, copy it, paste it into a course.
4. Edit that component in the library and publish it. You should now see the "Update available" button in the course. Click it.
5. Test the Accept and Ignore functionality. Make edits in the library as needed to facilitate testing. Confirm that only the published version will be shown as an update, and pulled in when the update is accepted.

## Deadline

Before Sumac cut.

## Notes

I'm not sure if there's a reasonable way to write useful/meaningful tests for this type of Backbone legacy UI code. I have updated the backend tests and will of course write tests for the parts in the MFE and the eventual equivalent we build therein.