### PR TITLE
fix: certificate display behavior not showing date-picker for end-with-date

### DIFF
--- a/cms/static/js/factories/settings.js
+++ b/cms/static/js/factories/settings.js
@@ -3,7 +3,7 @@ define([
 ], function($, CourseDetailsModel, MainView) {
     'use strict';
 
-    return function(detailsUrl, showMinGradeWarning, showCertificateAvailableDate, upgradeDeadline, useV2CertDisplaySettings) {
+    return function(detailsUrl, showMinGradeWarning, showCertificateAvailableDate, upgradeDeadline) {
         var model;
         // highlighting labels when fields are focused in
         $('form :input')
@@ -23,7 +23,6 @@ define([
         model = new CourseDetailsModel();
         model.urlRoot = detailsUrl;
         model.showCertificateAvailableDate = showCertificateAvailableDate;
-        model.useV2CertDisplaySettings = useV2CertDisplaySettings;
         model.set('upgrade_deadline', upgradeDeadline);
         model.fetch({
             // eslint-disable-next-line no-shadow
@@ -33,7 +32,6 @@ define([
                     model: model,
                     showMinGradeWarning: showMinGradeWarning
                 });
-                editor.useV2CertDisplaySettings = useV2CertDisplaySettings;
                 editor.render();
             },
             reset: true,

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -84,35 +84,33 @@ function(Backbone, _, gettext, ValidationHelpers, DateUtils, StringUtils) {
                 );
             }
 
-            if (this.useV2CertDisplaySettings) {
-                if (
-                    newattrs.certificates_display_behavior
-                        && !(Object.values(CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS).includes(newattrs.certificates_display_behavior))
-                ) {
-                    errors.certificates_display_behavior = StringUtils.interpolate(
-                        gettext(
-                            'The certificate display behavior must be one of: {behavior_options}'
-                        ),
-                        {
-                            behavior_options: Object.values(CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS).join(', ')
-                        }
-                    );
-                }
+            if (
+                newattrs.certificates_display_behavior
+                    && !(Object.values(CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS).includes(newattrs.certificates_display_behavior))
+            ) {
+                errors.certificates_display_behavior = StringUtils.interpolate(
+                    gettext(
+                        'The certificate display behavior must be one of: {behavior_options}'
+                    ),
+                    {
+                        behavior_options: Object.values(CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS).join(', ')
+                    }
+                );
+            }
 
-                // Throw error if there's a value for certificate_available_date
-                if (
-                    (newattrs.certificate_available_date && newattrs.certificates_display_behavior != CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS.END_WITH_DATE)
-                        || (!newattrs.certificate_available_date && newattrs.certificates_display_behavior == CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS.END_WITH_DATE)
-                ) {
-                    errors.certificates_display_behavior = StringUtils.interpolate(
-                        gettext(
-                            'The certificates display behavior must be {valid_option} if certificate available date is set.'
-                        ),
-                        {
-                            valid_option: CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS.END_WITH_DATE
-                        }
-                    );
-                }
+            // Throw error if there's a value for certificate_available_date
+            if (
+                (newattrs.certificate_available_date && newattrs.certificates_display_behavior != CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS.END_WITH_DATE)
+                    || (!newattrs.certificate_available_date && newattrs.certificates_display_behavior == CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS.END_WITH_DATE)
+            ) {
+                errors.certificates_display_behavior = StringUtils.interpolate(
+                    gettext(
+                        'The certificates display behavior must be {valid_option} if certificate available date is set.'
+                    ),
+                    {
+                        valid_option: CERTIFICATES_DISPLAY_BEHAVIOR_OPTIONS.END_WITH_DATE
+                    }
+                );
             }
 
             if (newattrs.intro_video && newattrs.intro_video !== this.get('intro_video')) {

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -388,9 +388,6 @@ function(ValidatingView, CodeMirror, _, $, ui, DateUtils, FileUploadModel,
                     Hides and clears the certificate available date field if a display behavior that doesn't use it is
                     chosen. Because we are clearing it, toggling back to "end_with_date" will require re-entering the date
                     */
-            if (!this.useV2CertDisplaySettings) {
-                return;
-            }
             // eslint-disable-next-line prefer-const
             let showDatepicker = this.model.get('certificates_display_behavior') == 'end_with_date';
             // eslint-disable-next-line prefer-const


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

https://github.com/openedx/edx-platform/pull/35562 has been merged recently removing `use_v2_cert_display_settings`. However, `useV2CertDisplaySettings` was left to be removed from the backbone JS files. This resulted in a bug of not showing the date-picker when Certificate Display Behaviour was set to `end-with-date`. This PR solves this issue and removes all the usage of `useV2CertDisplaySettings` from backbone JS files.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
Before:
<img width="670" alt="Screenshot 2024-10-18 at 11 53 42 PM" src="https://github.com/user-attachments/assets/63da58ca-4db5-4e36-80ee-971f253cc7a7">

After:
<img width="687" alt="Screenshot 2024-10-18 at 11 51 04 PM" src="https://github.com/user-attachments/assets/eab1283f-40a0-4fd5-9a9f-31d740cfaf6b">


## Supporting information

https://github.com/mitodl/hq/issues/5792

## Testing instructions

- Add `certificates.auto_certificate_generation` waffle switch in edx-platform
- In any instructor paced course, click the `Schedule and Details` in the settings tab.
- Select `A date after the course end date` from the `Certificates Display Behavior` options.
- A date picker s labelled as `Certificates Available Date` should be displayed next to `Certificates Display Behavior`
- Select a date and save. Reload the page, the settings should be saved.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
