### PR TITLE
feat: removed styling from course update notification

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -960,4 +960,17 @@ class CourseUpdateNotificationTests(ModuleStoreTestCase):
         send_course_update_notification(self.course.id, content, self.user)
         assert Notification.objects.all().count() == 1
         notification = Notification.objects.first()
-        assert notification.content == "<p><strong><p>content</p></strong></p>"
+        assert notification.content == "<p><strong>content</strong></p>"
+
+    def test_if_content_is_plain_text(self):
+        """
+        Test that the course_update notification is sent.
+        """
+        user = UserFactory()
+        CourseEnrollment.enroll(user=user, course_key=self.course.id)
+        assert Notification.objects.all().count() == 0
+        content = "<p>content<p>Sub content</p><h1>heading</h1></p><img src='' />"
+        send_course_update_notification(self.course.id, content, self.user)
+        assert Notification.objects.all().count() == 1
+        notification = Notification.objects.first()
+        assert notification.content == "<p><strong>content Sub content heading</strong></p>"

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2244,22 +2244,9 @@ def clean_html_body(html_body):
     Get html body, remove tags and limit to 500 characters
     """
     html_body = BeautifulSoup(Truncator(html_body).chars(500, html=True), 'html.parser')
-
-    tags_to_remove = [
-        "a", "link",  # Link Tags
-        "img", "picture", "source",  # Image Tags
-        "video", "track",  # Video Tags
-        "audio",  # Audio Tags
-        "embed", "object", "iframe",  # Embedded Content
-        "script"
-    ]
-
-    # Remove the specified tags while keeping their content
-    for tag in tags_to_remove:
-        for match in html_body.find_all(tag):
-            match.unwrap()
-
-    return str(html_body)
+    text_content = html_body.get_text(separator=" ").strip()
+    text_content = text_content.replace('\n', '').replace('\r', '')
+    return text_content
 
 
 def send_course_update_notification(course_key, content, user):


### PR DESCRIPTION
Removed all styling from course update notification content. 
- Tray notification will be plain text
- Email notification will also be plain text 

Ticket: [INF-1622](https://2u-internal.atlassian.net/browse/INF-1622)

### Screenshots
#### Course update
<img width="898" alt="Screenshot 2024-10-21 at 12 02 18 PM" src="https://github.com/user-attachments/assets/a578dac0-fdfd-4ba8-a73d-fea93c84014b">

#### Tray notification
<img width="550" alt="Screenshot 2024-10-21 at 12 23 18 PM" src="https://github.com/user-attachments/assets/34a91bd2-4c45-4a95-abf2-01b9f57d8c2f">

