### PR TITLE
feat: add endpoint to get draft version of a library component asset

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
@@ -219,8 +219,8 @@ class LibrariesEmbedViewTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestM
         # show up.
         html = self._embed_block(block_id, version='published')
         # This is the pattern we're looking for:
-        #   <img src="https://localhost:18010/library_assets/b5864c63-e1da-4d48-8c8a-cc718e2f9ad3/static/deer.jpg"/>
-        assert re.search(r'/library_assets/[0-9a-f-]*/static/deer.jpg', html)
+        #   <img src="https://localhost:18010/library_assets/component_versions/b5864c63-e1da-4d48-8c8a-cc718e2f9ad3/static/deer.jpg"/>
+        assert re.search(r'/library_assets/component_versions/[0-9a-f-]*/static/deer.jpg', html)
 
         # Now grab the draft version (4), which is going to once again not have
         # the asset (because we deleted it).

--- a/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
@@ -219,7 +219,7 @@ class LibrariesEmbedViewTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestM
         # show up.
         html = self._embed_block(block_id, version='published')
         # This is the pattern we're looking for:
-        #   <img src="https://localhost:18010/library_assets/component_versions/b5864c63-e1da-4d48-8c8a-cc718e2f9ad3/static/deer.jpg"/>
+        #   <img src="https://localhost:18010/library_assets/component_versions/.../static/deer.jpg"/>
         assert re.search(r'/library_assets/component_versions/[0-9a-f-]*/static/deer.jpg', html)
 
         # Now grab the draft version (4), which is going to once again not have

--- a/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_embed_block.py
@@ -219,7 +219,7 @@ class LibrariesEmbedViewTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestM
         # show up.
         html = self._embed_block(block_id, version='published')
         # This is the pattern we're looking for:
-        #   <img src="https://localhost:18010/library_assets/component_versions/.../static/deer.jpg"/>
+        #   <img src="https://{host}/library_assets/component_versions/.../static/deer.jpg"/>
         assert re.search(r'/library_assets/component_versions/[0-9a-f-]*/static/deer.jpg', html)
 
         # Now grab the draft version (4), which is going to once again not have

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -129,14 +129,14 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
 
     def test_good_responses(self):
         get_response = self.client.get(
-            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+            f"/library_assets/component_versions/{self.draft_component_version.uuid}/static/test.svg"
         )
         assert get_response.status_code == 200
         content = b''.join(chunk for chunk in get_response.streaming_content)
         assert content == SVG_DATA
 
         good_head_response = self.client.head(
-            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+            f"/library_assets/component_versions/{self.draft_component_version.uuid}/static/test.svg"
         )
         assert good_head_response.headers == get_response.headers
 
@@ -145,20 +145,20 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
         # Non-existent version...
         wrong_version_uuid = UUID('11111111-1111-1111-1111-111111111111')
         response = self.client.get(
-            f"/library_assets/{wrong_version_uuid}/static/test.svg"
+            f"/library_assets/component_versions/{wrong_version_uuid}/static/test.svg"
         )
         assert response.status_code == 404
 
         # Non-existent file...
         response = self.client.get(
-            f"/library_assets/{self.draft_component_version.uuid}/static/missing.svg"
+            f"/library_assets/component_versions/{self.draft_component_version.uuid}/static/missing.svg"
         )
         assert response.status_code == 404
 
         # File-like ComponenVersionContent entry that isn't an actually
         # downloadable file...
         response = self.client.get(
-            f"/library_assets/{self.draft_component_version.uuid}/block.xml"
+            f"/library_assets/component_versions/{self.draft_component_version.uuid}/block.xml"
         )
         assert response.status_code == 404
 
@@ -166,7 +166,7 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
         """Anonymous users shouldn't get access to library assets."""
         self.client.logout()
         response = self.client.get(
-            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+            f"/library_assets/component_versions/{self.draft_component_version.uuid}/static/test.svg"
         )
         assert response.status_code == 403
 
@@ -182,20 +182,20 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
         )
         self.client.login(username="student", password="student-pass")
         get_response = self.client.get(
-            f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
+            f"/library_assets/component_versions/{self.draft_component_version.uuid}/static/test.svg"
         )
         assert get_response.status_code == 403
 
     def test_draft_version(self):
         """Get draft version of asset"""
         get_response = self.client.get(
-            f"/library_assets/{self.usage_key}/static/test.svg"
+            f"/library_assets/component_versions/{self.usage_key}/static/test.svg"
         )
         assert get_response.status_code == 200
         content = b''.join(chunk for chunk in get_response.streaming_content)
         assert content == SVG_DATA
 
         good_head_response = self.client.head(
-            f"/library_assets/{self.usage_key}/static/test.svg"
+            f"/library_assets/blocks/{self.usage_key}/static/test.svg"
         )
         assert good_head_response.headers == get_response.headers

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -205,7 +205,7 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
         get_response = self.client.get(
             f"/library_assets/blocks/{self.usage_key}@/static/test.svg"
         )
-        assert get_response.status_code == 400
+        assert get_response.status_code == 404
 
         get_response = self.client.get(
             f"/library_assets/blocks/{self.usage_key}/static/test2.svg"

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -189,7 +189,7 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
     def test_draft_version(self):
         """Get draft version of asset"""
         get_response = self.client.get(
-            f"/library_assets/component_versions/{self.usage_key}/static/test.svg"
+            f"/library_assets/blocks/{self.usage_key}/static/test.svg"
         )
         assert get_response.status_code == 200
         content = b''.join(chunk for chunk in get_response.streaming_content)
@@ -199,3 +199,15 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
             f"/library_assets/blocks/{self.usage_key}/static/test.svg"
         )
         assert good_head_response.headers == get_response.headers
+
+    def test_draft_version_404(self):
+        """Get draft version of asset"""
+        get_response = self.client.get(
+            f"/library_assets/blocks/{self.usage_key}@/static/test.svg"
+        )
+        assert get_response.status_code == 404
+
+        get_response = self.client.get(
+            f"/library_assets/blocks/{self.usage_key}/static/test2.svg"
+        )
+        assert get_response.status_code == 404

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -123,6 +123,7 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
         block = self._add_block_to_library(library["id"], "html", "html1")
         self._set_library_block_asset(block["id"], "static/test.svg", SVG_DATA)
         usage_key = UsageKey.from_string(block["id"])
+        self.usage_key = usage_key
         self.component = get_component_from_usage_key(usage_key)
         self.draft_component_version = self.component.versioning.draft
 
@@ -184,3 +185,17 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
             f"/library_assets/{self.draft_component_version.uuid}/static/test.svg"
         )
         assert get_response.status_code == 403
+
+    def test_draft_version(self):
+        """Get draft version of asset"""
+        get_response = self.client.get(
+            f"/library_assets/{self.usage_key}/static/test.svg"
+        )
+        assert get_response.status_code == 200
+        content = b''.join(chunk for chunk in get_response.streaming_content)
+        assert content == SVG_DATA
+
+        good_head_response = self.client.head(
+            f"/library_assets/{self.usage_key}/static/test.svg"
+        )
+        assert good_head_response.headers == get_response.headers

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -205,7 +205,7 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
         get_response = self.client.get(
             f"/library_assets/blocks/{self.usage_key}@/static/test.svg"
         )
-        assert get_response.status_code == 404
+        assert get_response.status_code == 400
 
         get_response = self.client.get(
             f"/library_assets/blocks/{self.usage_key}/static/test2.svg"

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -83,7 +83,7 @@ urlpatterns = [
             name='library-assets',
         ),
         path(
-            'blocks/<str:usage_key_str>/<path:asset_path>',
+            'blocks/<usage_v2:usage_key>/<path:asset_path>',
             views.component_draft_asset,
             name='library-draft-assets',
         ),

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -78,12 +78,12 @@ urlpatterns = [
     ])),
     path('library_assets/', include([
         path(
-            '<uuid:component_version_uuid>/<path:asset_path>',
+            'component_versions/<uuid:component_version_uuid>/<path:asset_path>',
             views.component_version_asset,
             name='library-assets',
         ),
         path(
-            '<str:usage_key_str>/<path:asset_path>',
+            'blocks/<str:usage_key_str>/<path:asset_path>',
             views.component_draft_asset,
             name='library-draft-assets',
         ),

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -76,9 +76,17 @@ urlpatterns = [
             path('pub/jwks/', views.LtiToolJwksView.as_view(), name='lti-pub-jwks'),
         ])),
     ])),
-    path(
-        'library_assets/<uuid:component_version_uuid>/<path:asset_path>',
-        views.component_version_asset,
-        name='library-assets',
+    path('library_assets/', include([
+        path(
+            '<uuid:component_version_uuid>/<path:asset_path>',
+            views.component_version_asset,
+            name='library-assets',
+        ),
+        path(
+            '<str:usage_key_str>/<path:asset_path>',
+            views.component_draft_asset,
+            name='library-draft-assets',
+        ),
+    ])
     ),
 ]

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -87,7 +87,7 @@ from pylti1p3.exception import LtiException, OIDCException
 
 import edx_api_doc_tools as apidocs
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2, UsageKeyV2
+from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
 from openedx_learning.api import authoring
 from organizations.api import ensure_organization
 from organizations.exceptions import InvalidOrganizationException

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -1248,10 +1248,7 @@ def component_draft_asset(request, usage_key_str, asset_path):
     """
     try:
         key = UsageKeyV2.from_string(usage_key_str)
-        learning_package = authoring.get_learning_package_by_key(key.lib_key)
-        component = api.get_component_from_usage_key(key)
-        publishable_entity = authoring.get_publishable_entity_by_key(learning_package.id, component.key)
-        component_version_uuid = authoring.get_draft_version(publishable_entity.id).uuid
+        component_version_uuid = api.get_component_from_usage_key(key).versioning.draft.uuid
     except InvalidKeyError as exc:
         return HttpResponseBadRequest()
     except ObjectDoesNotExist as exc:

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -1253,7 +1253,7 @@ def component_draft_asset(request, usage_key_str, asset_path):
         publishable_entity = authoring.get_publishable_entity_by_key(learning_package.id, component.key)
         component_version_uuid = authoring.get_draft_version(publishable_entity.id).uuid
     except InvalidKeyError as exc:
-        raise Http404() from exc
+        return HttpResponseBadRequest()
     except ObjectDoesNotExist as exc:
         raise Http404() from exc
 

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -1237,3 +1237,18 @@ def component_version_asset(request, component_version_uuid, asset_path):
         content.read_file().chunks(),
         headers=redirect_response.headers,
     )
+
+
+@require_safe
+def component_draft_asset(request, usage_key_str, asset_path):
+    """
+    Serves the draft version of static assets associated with a Library Component.
+
+    See `component_version_asset` for more details
+    """
+    key = LibraryUsageLocatorV2.from_string(usage_key_str)
+    learning_package = authoring.get_learning_package_by_key(key.lib_key)
+    component = api.get_component_from_usage_key(key)
+    publishable_entity = authoring.get_publishable_entity_by_key(learning_package.id, component.key)
+    component_version_uuid = authoring.get_draft_version(publishable_entity.id).uuid
+    return component_version_asset(request, component_version_uuid, asset_path)

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -1240,17 +1240,14 @@ def component_version_asset(request, component_version_uuid, asset_path):
 
 
 @require_safe
-def component_draft_asset(request, usage_key_str, asset_path):
+def component_draft_asset(request, usage_key, asset_path):
     """
     Serves the draft version of static assets associated with a Library Component.
 
     See `component_version_asset` for more details
     """
     try:
-        key = UsageKeyV2.from_string(usage_key_str)
-        component_version_uuid = api.get_component_from_usage_key(key).versioning.draft.uuid
-    except InvalidKeyError as exc:
-        return HttpResponseBadRequest()
+        component_version_uuid = api.get_component_from_usage_key(usage_key).versioning.draft.uuid
     except ObjectDoesNotExist as exc:
         raise Http404() from exc
 

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -377,7 +377,7 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
         then this method will be called with asset_path="test.png" and should
         return a URL like:
 
-          http://studio.local.openedx.io:8001/library_assets/cd31871e-a342-4c3f-ba2f-a661bf630996/static/test.png
+          http://studio.local.openedx.io:8001/library_assets/component_versions/cd31871e-a342-4c3f-ba2f-a661bf630996/static/test.png
 
         If the asset file is not recognized, return None
 


### PR DESCRIPTION
## Description

Creates a new to get the draft version of a library component asset via its `usage_key` and asset path.

## Supporting information

Needed for https://github.com/openedx/frontend-app-authoring/pull/1403

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
