### PR TITLE
fix: remove duplicate (unclosed) tag

### DIFF
--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -33,7 +33,6 @@ ${HTML(fragment.foot_html())}
       lang=${course.language}
     % endif
     >
-    <section class="container">
       <div class="static_tab_wrapper">
         ${HTML(fragment.body_html())}
       </div>


### PR DESCRIPTION
## Description

This PR removes some bad (duplicated) markup in the static tab file. The current behavior leads to an unclosed HTML tag, which can be confirmed by viewing the document source.

---
See original, abandoned PR here: https://github.com/openedx/edx-platform/pull/35301

See a 2nd abandoned PR here: https://github.com/openedx/edx-platform/pull/35382

@kdmccormick
