### PR TITLE
build: Remove newrelic from dependencies; note system deps in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,8 @@ Language Packages:
   - ``pip install -r requirements/edx/base.txt`` (production)
   - ``pip install -r requirements/edx/dev.txt`` (development)
 
+  Some Python packages have system dependencies. For example, installing these packages on Debian or Ubuntu will require first running ``sudo apt install python3-dev default-libmysqlclient-dev build-essential pkg-config`` to satisfy the requirements of the ``mysqlclient`` Python package.
+
 Build Steps
 -----------
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -770,9 +770,7 @@ multidict==6.1.0
 mysqlclient==2.2.4
     # via -r requirements/edx/kernel.in
 newrelic==10.2.0
-    # via
-    #   -r requirements/edx/bundled.in
-    #   edx-django-utils
+    # via edx-django-utils
 nh3==0.2.18
     # via -r requirements/edx/kernel.in
 nltk==3.9.1

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -34,7 +34,6 @@ algoliasearch                       # Algolia’s API client for indexed searchi
 django-ses                          # Django email backend for Amazon’s Simple Email Service
 edx-braze-client                    # a customer engagement platform used for edx.org
 mailsnake                           # MailChimp API; used for two management commands in the "mailing" djangoapp
-newrelic                            # New Relic agent for performance monitoring
 optimizely-sdk                      # Optimizely provides A/B testing and other features, used by edx.org
 
 


### PR DESCRIPTION
We don't need a dependency on `newrelic` in edx-platform, since it's already brought in via edx-django-utils, which is where telemetry dependencies belong anyhow.

Ran `make compile-requirements` to apply changes to lockfiles.

(Additional context: We may end up DEPRing the direct dependencies in edx-django-utils as well and requiring deployers to install newrelic separately. In any case, there aren't any places in openedx code that is installed into the LMS or CMS that import newrelic directly.)

Also, update README to note system package dependencies that are required for installing edx-platform deps. I had to reinstall my laptop and ran into this again and wanted to actually document it this time.
