### PR TITLE
feat: add "beta" label to libraries v2 content + item bank buttons

### DIFF
--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -140,12 +140,13 @@
         position: relative;
         display: inline-block;
         width: ($baseline*6.25);
-        height: ($baseline*5);
+        height: ($baseline*7);
         margin-bottom: ($baseline/2);
         box-shadow: 0 1px 1px $shadow, 0 1px 0 rgba(255, 255, 255, 0.4) inset;
         border-radius: ($baseline/4);
         padding: 0;
         text-align: center;
+        vertical-align: top;
 
         @extend %btn-primary-green;
 
@@ -153,6 +154,21 @@
           box-sizing: border-box;
           display: block;
           color: $white;
+        }
+
+        .beta {
+          margin-top: 3px;
+          margin-bottom: -20px;
+          padding: 4px;
+          display: inline-block;
+
+          color: $uxpl-green-base;
+          background-color: theme-color("inverse");
+          border-color: theme-color("inverse");
+          border-radius: 3px;
+
+          font-size: 90%;
+          line-height: 90%;
         }
       }
     }

--- a/cms/templates/js/add-xblock-component-button.underscore
+++ b/cms/templates/js/add-xblock-component-button.underscore
@@ -6,4 +6,7 @@
   <span class="large-template-icon large-<%- type %>-icon"></span>
   <span class="sr"> <%- gettext("Add Component:") %></span>
   <span class="name"><%- display_name %></span>
+  <% if (type === 'library_v2' || type === 'itembank') { %>
+  <span class="beta"><%- gettext("Beta") %></span>
+  <% } %>
 </button>


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds a "beta" label to the new Libraries V2 components in legacy Studio.

This change affects Course Authors using legacy Studio to add blocks to units.

![image](https://github.com/user-attachments/assets/01fb1f77-21bc-4f58-bd5a-fa24ac8ade04)

## Supporting information

Relates to: https://github.com/openedx/frontend-app-authoring/issues/1415
Private-ref: [FAL-3907](https://tasks.opencraft.com/browse/FAL-3907)

## Testing instructions

1. Ensure meilisearch is enabled to enable Libraries V2 content.
1. Disable these waffle flags to use legacy Studio's unit page: 
   * `contentstore.new_studio_mfe.use_new_course_outline_page`
   * `contentstore.new_studio_mfe.use_new_unit_page`
1. Create/edit a Unit
2. Check that the "beta" label shows under the "Library Content" button.

## Deadline

ASAP -- before Sumac cuts

## Other information

1. The "Itembank" XBlock is being added by https://github.com/openedx/frontend-app-authoring/issues/1415 ; this will add the "beta" label to this block type too.
2. [Designs provided](https://github.com/openedx/frontend-app-authoring/issues/1415#issuecomment-2427358381) preferred a light green (#E7FEE7) background, but to avoid issues with custom themes, I decided to use built-in colors for background and text.
