### PR TITLE
feat: [FC-0070] add message events to the unit page container

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -128,6 +128,14 @@ function($, _, Backbone, gettext, BasePage,
 
             }
 
+            if (this.options.isIframeEmbed) {
+                window.addEventListener('message', (event) => {
+                  if (event.data && event.data.type === 'refreshXBlock') {
+                      this.render();
+                  }
+               });
+            }
+
             this.listenTo(Backbone, 'move:onXBlockMoved', this.onXBlockMoved);
         },
 
@@ -625,26 +633,40 @@ function($, _, Backbone, gettext, BasePage,
         },
 
         showMoveXBlockModal: function(event) {
+            var xblockElement = this.findXBlockElement(event.target),
+                parentXBlockElement = xblockElement.parents('.studio-xblock-wrapper'),
+                sourceXBlockInfo = XBlockUtils.findXBlockInfo(xblockElement, this.model),
+                sourceParentXBlockInfo = XBlockUtils.findXBlockInfo(parentXBlockElement, this.model),
+                modal = new MoveXBlockModal({
+                    sourceXBlockInfo: sourceXBlockInfo,
+                    sourceParentXBlockInfo: sourceParentXBlockInfo,
+                    XBlockURLRoot: this.getURLRoot(),
+                    outlineURL: this.options.outlineURL
+                });
+
             try {
                 if (this.options.isIframeEmbed) {
                     window.parent.postMessage(
                         {
                             type: 'showMoveXBlockModal',
-                            payload: {}
+                            payload: {
+                                sourceXBlockInfo: {
+                                  id: sourceXBlockInfo.attributes.id,
+                                  displayName: sourceXBlockInfo.attributes.display_name,
+                                },
+                                sourceParentXBlockInfo: {
+                                  id: sourceParentXBlockInfo.attributes.id,
+                                  category: sourceParentXBlockInfo.attributes.category,
+                                  hasChildren: sourceParentXBlockInfo.attributes.has_children,
+                                },
+                            },
                         }, document.referrer
                     );
+                    return true;
                 }
             } catch (e) {
                 console.error(e);
             }
-            var xblockElement = this.findXBlockElement(event.target),
-                parentXBlockElement = xblockElement.parents('.studio-xblock-wrapper'),
-                modal = new MoveXBlockModal({
-                    sourceXBlockInfo: XBlockUtils.findXBlockInfo(xblockElement, this.model),
-                    sourceParentXBlockInfo: XBlockUtils.findXBlockInfo(parentXBlockElement, this.model),
-                    XBlockURLRoot: this.getURLRoot(),
-                    outlineURL: this.options.outlineURL
-                });
 
             event.preventDefault();
             modal.show();


### PR DESCRIPTION
🚨 **Dependencies:**
- 🔗 [frontend-app-authoring](https://github.com/openedx/frontend-app-authoring/pull/1375) [MERGED]
- 🔗 [edx-platform](https://github.com/openedx/edx-platform/pull/35587) [MERGED]

## Description
This feature introduces two main functionalities to improve XBlock interactions within iframes:
- Add an event listener to the window object that listens for messages of type refreshXBlock. Upon receiving such a message, the render() method is called to refresh the current XBlock.
- When the isIframeEmbed option is enabled, the XBlock sends a postMessage to the parent window. This message contains information about the source XBlock and its parent, triggering a modal display in the parent context.

https://github.com/user-attachments/assets/f985a88e-0480-4f43-a1bf-95417667303a

## Related Pull Requests
- https://github.com/openedx/frontend-app-authoring/pull/1422 - move modal implementation in MFE Authoring

## Testing instructions
- сreate a new course.
- create several units.
- open the course unit page.
- add some xBlocks to the unit.
- move xBlock to another unit: click three dots icon (xBlock action menu) -> select "Move" -> select new location.