### PR TITLE
fix: pin urllib3 in user retirement scripts

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2099,7 +2099,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/testing.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.23.0
+tox==4.23.1
     # via -r requirements/edx/testing.txt
 tqdm==4.66.5
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1556,7 +1556,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.23.0
+tox==4.23.1
     # via -r requirements/edx/testing.in
 tqdm==4.66.5
     # via

--- a/scripts/user_retirement/requirements/base.in
+++ b/scripts/user_retirement/requirements/base.in
@@ -11,3 +11,7 @@ unicodecsv
 simplejson
 simple-salesforce
 google-api-python-client
+
+# urllib3 is needed for the user_retirement scripts 
+# constraint will be investigated and removed in a separate issue
+urllib3<2.0.0

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -158,8 +158,9 @@ unicodecsv==0.14.1
     # via -r scripts/user_retirement/requirements/base.in
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==2.2.3
+urllib3==1.26.20
     # via
+    #   -r scripts/user_retirement/requirements/base.in
     #   botocore
     #   requests
 zeep==4.3.1

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -266,7 +266,7 @@ uritemplate==4.1.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-urllib3==2.2.3
+urllib3==1.26.20
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   botocore


### PR DESCRIPTION
## Description
- Upgrading `urllib3` constraint caused issues in `user_retirement` scripts pipeline so pinning package version in the scripts requirements for now.
- A separate ticket will be created to investigate and remove this constraint.