### PR TITLE
fix: Don't add x-is-pointer-node attribute to Capa problem XML on paste [FC-0062]

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -7,6 +7,7 @@ import pathlib
 import urllib
 from lxml import etree
 from mimetypes import guess_type
+import re
 
 from attrs import frozen, Factory
 from django.conf import settings
@@ -446,6 +447,10 @@ def _import_xml_node_to_parent(
         node_without_children = etree.Element(node.tag, **node.attrib)
         temp_xblock = xblock_class.parse_xml(node_without_children, runtime, keys)
         child_nodes = list(node)
+
+    if issubclass(xblock_class, XmlMixin) and "x-is-pointer-node" in getattr(temp_xblock, "data", ""):
+        # Undo the "pointer node" hack if needed (e.g. for capa problems)
+        temp_xblock.data = re.sub(r'([^>]+) x-is-pointer-node="no"', r'\1', temp_xblock.data, count=1)
 
     # Restore the original id_generator
     runtime.id_generator = original_id_generator

--- a/xmodule/xml_block.py
+++ b/xmodule/xml_block.py
@@ -123,7 +123,11 @@ class XmlMixin:
                          # places in the platform rely on it.
                          'course', 'org', 'url_name', 'filename',
                          # Used for storing xml attributes between import and export, for roundtrips
-                         'xml_attributes')
+                         'xml_attributes',
+                         # Used by _import_xml_node_to_parent in cms/djangoapps/contentstore/helpers.py to prevent
+                         # XmlMixin from treating some XML nodes as "pointer nodes".
+                         "x-is-pointer-node",
+                         )
 
     # This is a categories to fields map that contains the block category specific fields which should not be
     # cleaned and/or override while adding xml to node.


### PR DESCRIPTION
## Description

When a `problem` component is pasted from a library into a course, we use a hack that adds a "temporary" `x-is-pointer-node` attribute to the XML to prevent `XmlMixin` from looking for more XML data in a place that doesn't exist (the filesystem). However, this somehow causes the temporary `x-is-pointer-node` attribute to end up in the capa problem's `data` (string) attribute, and authors would see that if they use the advanced editor mode.

This PR fixes that by explicitly removing the attribute in cases where it persists.

## Supporting information

Relates to https://github.com/openedx/frontend-app-authoring/issues/1377 - this was one of the contributing causes.

## Testing instructions

Paste a capa problem component from a library into a course, then open its advanced editor and verify that it doesn't have this attribute in its OLX.

## Deadline

Not urgent.

Private ref: [FAL-3873](https://tasks.opencraft.com/browse/FAL-3873)
