### PR TITLE
feat: removed setting email cadence to Never when using one click unsubscribe

### DIFF
--- a/openedx/core/djangoapps/notifications/email/tests/test_utils.py
+++ b/openedx/core/djangoapps/notifications/email/tests/test_utils.py
@@ -16,7 +16,6 @@ from openedx.core.djangoapps.notifications.base_notification import (
     COURSE_NOTIFICATION_TYPES,
 )
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_EMAIL_NOTIFICATIONS
-from openedx.core.djangoapps.notifications.email_notifications import EmailCadence
 from openedx.core.djangoapps.notifications.models import CourseNotificationPreference, Notification
 from openedx.core.djangoapps.notifications.email.utils import (
     add_additional_attributes_to_notifications,
@@ -320,9 +319,7 @@ class TestUpdatePreferenceFromPatch(ModuleStoreTestCase):
                         if channel == param_channel:
                             assert type_prefs[channel] == new_value
                             if channel == 'email':
-                                cadence_value = EmailCadence.NEVER
-                                if new_value:
-                                    cadence_value = self.get_default_cadence_value(app_name, noti_type)
+                                cadence_value = self.get_default_cadence_value(app_name, noti_type)
                                 assert type_prefs['email_cadence'] == cadence_value
                         else:
                             default_app_json = self.default_json[app_name]
@@ -381,9 +378,7 @@ class TestUpdatePreferenceFromPatch(ModuleStoreTestCase):
                         if app_name == param_app_name:
                             assert type_prefs[channel] == new_value
                             if channel == 'email':
-                                cadence_value = EmailCadence.NEVER
-                                if new_value:
-                                    cadence_value = self.get_default_cadence_value(app_name, noti_type)
+                                cadence_value = self.get_default_cadence_value(app_name, noti_type)
                                 assert type_prefs['email_cadence'] == cadence_value
                         else:
                             default_app_json = self.default_json[app_name]
@@ -415,9 +410,7 @@ class TestUpdatePreferenceFromPatch(ModuleStoreTestCase):
                         if noti_type == param_notification_type:
                             assert type_prefs[channel] == new_value
                             if channel == 'email':
-                                cadence_value = EmailCadence.NEVER
-                                if new_value:
-                                    cadence_value = self.get_default_cadence_value(app_name, noti_type)
+                                cadence_value = self.get_default_cadence_value(app_name, noti_type)
                                 assert type_prefs['email_cadence'] == cadence_value
                         else:
                             default_app_json = self.default_json[app_name]

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -406,9 +406,7 @@ def update_user_preferences_from_patch(encrypted_username, encrypted_patch):
                         continue
                     if is_editable(app_name, noti_type, channel):
                         type_prefs[channel] = pref_value
-                        if channel == 'email':
-                            cadence_value = get_default_cadence_value(app_name, noti_type)\
-                                if pref_value else EmailCadence.NEVER
-                            type_prefs['email_cadence'] = cadence_value
+                        if channel == 'email' and pref_value and type_prefs.get('email_cadence') == EmailCadence.NEVER:
+                            type_prefs['email_cadence'] = get_default_cadence_value(app_name, noti_type)
         preference.save()
     notification_preference_unsubscribe_event(user)

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -27,7 +27,6 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_MODERATOR
 )
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
-from openedx.core.djangoapps.notifications.email_notifications import EmailCadence
 from openedx.core.djangoapps.notifications.models import (
     CourseNotificationPreference,
     Notification,
@@ -936,7 +935,6 @@ class UpdatePreferenceFromEncryptedDataView(ModuleStoreTestCase):
         for app_name, app_prefs in config.items():
             for type_prefs in app_prefs['notification_types'].values():
                 assert type_prefs['email'] is False
-                assert type_prefs['email_cadence'] == EmailCadence.NEVER
 
     def test_if_config_version_is_updated(self):
         """


### PR DESCRIPTION
Old Behavior:
When user uses one click link to unsubscribe, `email_cadence` type was set to `Never` and `email` was set to `False`

Behavior after changes are merged:
On clicking unsubscribe link, only `email` will be set to `False`

Ticket: [INF-1620](https://2u-internal.atlassian.net/browse/INF-1620)