### PR TITLE
temp: Retirement refactor example

### DIFF
--- a/scripts/user_retirement/requirements/base.in
+++ b/scripts/user_retirement/requirements/base.in
@@ -10,4 +10,5 @@ jenkinsapi
 unicodecsv
 simplejson
 simple-salesforce
+stevedore
 google-api-python-client

--- a/scripts/user_retirement/setup.cfg
+++ b/scripts/user_retirement/setup.cfg
@@ -1,0 +1,12 @@
+[options]
+packages = utils.thirdparty_apis
+
+[options.entry_points]
+# `retirement_driver` is the namespace chosen by our plugin manager
+# this driver should register itself to `retirement_driver`
+retirement_driver =
+    AMPLITUDE = utils.thirdparty_apis.amplitude_api:AmplitudeApi
+    BRAZE = utils.thirdparty_apis.braze_api:BrazeApi
+    HUBSPOT = utils.thirdparty_apis.hubspot_api:HubspotApi
+    SALESFORCE = utils.thirdparty_apis.salesforce_api:SalesforceApi
+    SEGMENT = utils.thirdparty_apis.segment_api:SegmentApi

--- a/scripts/user_retirement/setup.py
+++ b/scripts/user_retirement/setup.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+
+setup()

--- a/scripts/user_retirement/utils/thirdparty_apis/amplitude_api.py
+++ b/scripts/user_retirement/utils/thirdparty_apis/amplitude_api.py
@@ -36,6 +36,26 @@ class AmplitudeApi:
         self.base_url = "https://amplitude.com/"
         self.delete_user_path = "api/2/deletions/users"
 
+    @staticmethod
+    def get_instance(config):
+        """
+        This function is used to get instance of AmplitudeApi.
+
+        Returns:
+            AmplitudeApi: Returns instance of AmplitudeApi.
+
+        Args:
+            config (dict): Configuration dictionary.
+
+        Raises:
+            KeyError: If amplitude_api_key or amplitude_secret_key is not present in config.
+        """
+        amplitude_api_key = config.get('amplitude_api_key', None)
+        amplitude_secret_key = config.get('amplitude_secret_key', None)
+        if not amplitude_api_key or not amplitude_secret_key:
+            raise KeyError("amplitude_api_key or amplitude_secret_key is not present in config.")
+        return AmplitudeApi(amplitude_api_key, amplitude_secret_key)
+
     def auth(self):
         """
         Returns auth credentials for Amplitude authorization.

--- a/scripts/user_retirement/utils/thirdparty_apis/braze_api.py
+++ b/scripts/user_retirement/utils/thirdparty_apis/braze_api.py
@@ -30,6 +30,27 @@ class BrazeApi:
         # https://www.braze.com/docs/api/basics/#endpoints
         self.base_url = 'https://rest.{instance}.braze.com'.format(instance=braze_instance)
 
+    @staticmethod
+    def get_instance(config):
+        """
+        This function is used to get instance of BrazeApi.
+
+        Returns:
+            BrazeApi: Returns instance of BrazeApi.
+
+        Args:
+            config (dict): Configuration dictionary.
+
+        Raises:
+            KeyError: If braze_api_key or braze_instance is not present in config.
+        """
+        braze_api_key = config.get('braze_api_key', None)
+        braze_instance = config.get('braze_instance', None)
+        if not braze_api_key or not braze_instance:
+            raise KeyError("braze_api_key or braze_instance is not present in config.")
+
+        return BrazeApi(braze_api_key, braze_instance)
+
     def auth_headers(self):
         """Returns authorization headers suitable for passing to the requests library"""
         return {

--- a/scripts/user_retirement/utils/thirdparty_apis/hubspot_api.py
+++ b/scripts/user_retirement/utils/thirdparty_apis/hubspot_api.py
@@ -37,6 +37,30 @@ class HubspotAPI:
         self.from_address = from_address
         self.alert_email = alert_email
 
+    @staticmethod
+    def get_instance(config):
+        """
+        This function is used to get instance of HubspotAPI.
+
+        Returns:
+            HubspotAPI: Returns instance of HubspotAPI.
+
+        Args:
+            config (dict): Configuration dictionary.
+
+        Raises:
+            KeyError: If hubspot_api_key is not present in config.
+        """
+        hubspot_api_key = config.get('hubspot_api_key', None)
+        hubspot_aws_region = config.get('hubspot_aws_region', None)
+        hubspot_from_address = config.get('hubspot_from_address', None)
+        hubspot_alert_email = config.get('hubspot_alert_email', None)
+
+        if not hubspot_api_key or not hubspot_aws_region or not hubspot_from_address or not hubspot_alert_email:
+            raise KeyError("hubspot_api_key, hubspot_aws_region, hubspot_from_address, or hubspot_alert_email is not present in config.")
+
+        return HubspotAPI(hubspot_api_key, hubspot_aws_region, hubspot_from_address, hubspot_alert_email)
+
     @backoff.on_exception(
         backoff.expo,
         HubspotException,

--- a/scripts/user_retirement/utils/thirdparty_apis/salesforce_api.py
+++ b/scripts/user_retirement/utils/thirdparty_apis/salesforce_api.py
@@ -37,6 +37,31 @@ class SalesforceApi:
         if not self.assignee_id:
             raise Exception("Could not find Salesforce user with username " + assignee_username)
 
+    @staticmethod
+    def get_instance(config):
+        """
+        This function is used to get instance of SalesforceApi.
+
+        Returns:
+            SalesforceApi: Returns instance of SalesforceApi.
+
+        Args:
+            config (dict): Configuration dictionary.
+
+        Raises:
+            KeyError: If salesforce_username, salesforce_password, salesforce_security_token, salesforce_domain, or salesforce_assignee is not present in config.
+        """
+        salesforce_username = config.get('salesforce_username', None)
+        salesforce_password = config.get('salesforce_password', None)
+        salesforce_security_token = config.get('salesforce_security_token', None)
+        salesforce_domain = config.get('salesforce_domain', None)
+        salesforce_assignee = config.get('salesforce_assignee', None)
+
+        if not salesforce_username or not salesforce_password or not salesforce_security_token or not salesforce_domain or not salesforce_assignee:
+            raise KeyError("salesforce_username, salesforce_password, salesforce_security_token, salesforce_domain, or salesforce_assignee is not present in config.")
+
+        return SalesforceApi(salesforce_username, salesforce_password, salesforce_security_token, salesforce_domain, salesforce_assignee)
+
     @backoff.on_exception(
         backoff.expo,
         RequestsConnectionError,

--- a/scripts/user_retirement/utils/thirdparty_apis/segment_api.py
+++ b/scripts/user_retirement/utils/thirdparty_apis/segment_api.py
@@ -99,6 +99,29 @@ class SegmentApi:
         self.auth_token = auth_token
         self.workspace_slug = workspace_slug
 
+    @staticmethod
+    def get_instance(config):
+        """
+        This function is used to get instance of SegmentApi.
+
+        Returns:
+            SegmentApi: Returns instance of SegmentApi.
+
+        Args:
+            config (dict): Configuration dictionary.
+
+        Raises:
+            KeyError: If segment_base_url, segment_auth_token, and segment_workspace_slug are not present in config.
+        """
+        segment_base_url = config.get('segment_base_url', None)
+        segment_auth_token = config.get('segment_auth_token', None)
+        segment_workspace_slug = config.get('segment_workspace_slug', None)
+
+        if not segment_base_url or not segment_auth_token or not segment_workspace_slug:
+            raise KeyError("segment_base_url, segment_auth_token or segment_workspace_slug is not present in config.")
+
+        return SegmentApi(segment_base_url, segment_auth_token, segment_workspace_slug)
+
     @_retry_segment_api()
     def _call_segment_post(self, url, params):
         """


### PR DESCRIPTION
This commit shows an example of how we could use Stevedore drivers to handle retirement extension. The entrypoint name would become the "API" in our configuration, and each "API" extension class would provide a "get_instance" method which would take the retirement config dict and return a constructed instance of the API class, which would then be used a normal.

This code is not complete, simply a real world example of how we could abstract out the existing 3rd party APIs using this method.
