### PR TITLE
fix: fixed course update notification UI in notification tray

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -974,3 +974,18 @@ class CourseUpdateNotificationTests(ModuleStoreTestCase):
         assert Notification.objects.all().count() == 1
         notification = Notification.objects.first()
         assert notification.content == "<p><strong>content Sub content heading</strong></p>"
+
+    def test_if_html_unescapes(self):
+        """
+        Tests if html unescapes when creating content of course update notification
+        """
+        user = UserFactory()
+        CourseEnrollment.enroll(user=user, course_key=self.course.id)
+        assert Notification.objects.all().count() == 0
+        content = "<p>&lt;p&gt; &amp;nbsp;&lt;/p&gt;<br />"\
+                  "&lt;p&gt;abcd&lt;/p&gt;<br />"\
+                  "&lt;p&gt;&amp;nbsp;&lt;/p&gt;<br /></p>"
+        send_course_update_notification(self.course.id, content, self.user)
+        assert Notification.objects.all().count() == 1
+        notification = Notification.objects.first()
+        assert notification.content == "<p><strong>abcd</strong></p>"

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -3,6 +3,7 @@ Common utility functions useful throughout the contentstore
 """
 from __future__ import annotations
 import configparser
+import html
 import logging
 import re
 from collections import defaultdict
@@ -2258,6 +2259,7 @@ def clean_html_body(html_body):
     """
     Get html body, remove tags and limit to 500 characters
     """
+    html_body = html.unescape(html_body).strip()
     html_body = BeautifulSoup(Truncator(html_body).chars(500, html=True), 'html.parser')
     text_content = html_body.get_text(separator=" ").strip()
     text_content = text_content.replace('\n', '').replace('\r', '')


### PR DESCRIPTION
Fixed edge case UI of course update notification when course update is created using course authoring

Ticket: [INF-1667](https://2u-internal.atlassian.net/browse/INF-1667)

Screenshots
Before
<img width="550" alt="Screenshot 2024-10-24 at 1 00 16 PM" src="https://github.com/user-attachments/assets/415b82c7-eb25-4274-ab49-263980901cd0">

After
<img width="551" alt="Screenshot 2024-10-24 at 1 00 05 PM" src="https://github.com/user-attachments/assets/7c1b5e57-0373-452b-b48c-07613f04f457">
