### PR TITLE
fix: import font for notification digest email

### DIFF
--- a/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
@@ -28,8 +28,9 @@
                                 style="max-height: 28px; max-width: 28px; margin: 0.75rem 1rem 0.75rem 0"
                             />
                         </td>
-                        <td class="notification-content" width="100%" align="left" valign="top" style=" padding: 1rem 1rem 1rem 0.5rem">
+                        <td class="notification-content" width="100%" align="left" valign="top" style="padding: 1rem 1rem 1rem 0.5rem;">
                             <blockquote style="font-size: 0.875rem; font-weight:400; line-height:24px; color:#454545; margin: 0 0 0.5rem 0;">
+                                <style> strong {color: #00262B; font-weight:500} </style>
                                 {{ notification.email_content | truncatechars_html:600 | safe }}
                             </blockquote>
                             {% if notification.details %}
@@ -37,7 +38,7 @@
                                     {{ notification.details | safe }}
                                 </blockquote>
                             {% endif %}
-                            <blockquote style="color:#707070; margin: 0">
+                            <blockquote style="color:#707070; margin: 0; font-size: 14px; font-style: normal; font-weight: 400; line-height: 24px;">
                                 <span style="float: left">
                                     <span>{{ notification.course_name }}</span>
                                     <span style="padding: 0 0.375rem">{{ "&middot;"|safe }}</span>

--- a/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
@@ -1,3 +1,7 @@
+<head>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap'" rel="stylesheet" type="text/css">
+</head>
+
 <div style="margin:0; padding:0; min-width: 100%; background-color:#C9C9C9">
     <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:1.5; max-width:600px; font-family:Inter">
         <tbody style="background-color:#f5f5f5">

--- a/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
@@ -2,7 +2,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap'" rel="stylesheet" type="text/css">
 </head>
 
-<div style="margin:0; padding:0; min-width: 100%; background-color:#C9C9C9">
+<div style="margin:0; padding:0; min-width: 100%; background-color:#C9C9C9; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-smooth: never;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:1.5; max-width:600px; font-family:Inter">
         <tbody style="background-color:#f5f5f5">
             <tr>


### PR DESCRIPTION
Ticket: [INF-1616](https://2u-internal.atlassian.net/browse/INF-1616)

Imported the inter font for the notification email digest. 

#### Before font import:

<img width="300" src="https://github.com/user-attachments/assets/4c4bbc56-e9ac-4e35-ac5a-62b67a002591">

#### After:

<img width="300" src="https://github.com/user-attachments/assets/8c4cc8e8-06cc-4c2a-b392-96a09b22d87a">

