### PR TITLE
fix: do not open mfe editors automatically on block paste

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -558,6 +558,7 @@ def _create_block(request):
             "locator": str(created_xblock.location),
             "courseKey": str(created_xblock.location.course_key),
             "static_file_notices": asdict(notices),
+            "upstreamRef": str(created_xblock.upstream),
         })
 
     category = request.json["category"]


### PR DESCRIPTION
Cherry pick of https://github.com/openedx/edx-platform/pull/35728

## Description

Fix for: https://github.com/openedx/frontend-app-authoring/issues/1436

## Testing instructions

* Disable `contentstore.new_studio_mfe.use_new_unit_page` waffle flag to open legacy unit page.
* Enable `new_core_editors.use_new_problem_editor`, `new_core_editors.use_new_video_editor` & `new_core_editors.use_new_text_editor` waffle flags to use new mfe editors.
* Copy any text, video or problem block and paste it, without the changes in this PR, it will automatically open mfe editor on paste.
* Checkout this PR and try pasting again, it should directly paste the component without opening the editor.