### PR TITLE
Revert "feat: update preview url to direct to mfe"

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
@@ -117,7 +117,7 @@ class HomePageCoursesViewTest(CourseTestCase):
             "courses": [{
                 "course_key": course_id,
                 "display_name": self.course.display_name,
-                "lms_link": f'{settings.LMS_ROOT_URL}/courses/{course_id}/jump_to/{self.course.location}',
+                "lms_link": f'//{settings.LMS_BASE}/courses/{course_id}/jump_to/{self.course.location}',
                 "number": self.course.number,
                 "org": self.course.org,
                 "rerun_link": f'/course_rerun/{course_id}',
@@ -144,7 +144,7 @@ class HomePageCoursesViewTest(CourseTestCase):
                 OrderedDict([
                     ("course_key", course_id),
                     ("display_name", self.course.display_name),
-                    ("lms_link", f'{settings.LMS_ROOT_URL}/courses/{course_id}/jump_to/{self.course.location}'),
+                    ("lms_link", f'//{settings.LMS_BASE}/courses/{course_id}/jump_to/{self.course.location}'),
                     ("number", self.course.number),
                     ("org", self.course.org),
                     ("rerun_link", f'/course_rerun/{course_id}'),

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -62,7 +62,7 @@ class HomePageCoursesViewV2Test(CourseTestCase):
                 OrderedDict([
                     ("course_key", course_id),
                     ("display_name", self.course.display_name),
-                    ("lms_link", f'{settings.LMS_ROOT_URL}/courses/{course_id}/jump_to/{self.course.location}'),
+                    ("lms_link", f'//{settings.LMS_BASE}/courses/{course_id}/jump_to/{self.course.location}'),
                     ("cms_link", f'//{settings.CMS_BASE}{reverse_course_url("course_handler", self.course.id)}'),
                     ("number", self.course.number),
                     ("org", self.course.org),
@@ -76,7 +76,7 @@ class HomePageCoursesViewV2Test(CourseTestCase):
                     ("display_name", self.archived_course.display_name),
                     (
                         "lms_link",
-                        f'{settings.LMS_ROOT_URL}/courses/{archived_course_id}/jump_to/{self.archived_course.location}'
+                        f'//{settings.LMS_BASE}/courses/{archived_course_id}/jump_to/{self.archived_course.location}'
                     ),
                     (
                         "cms_link",
@@ -139,7 +139,7 @@ class HomePageCoursesViewV2Test(CourseTestCase):
         self.assertEqual(response.data["results"]["courses"], [OrderedDict([
             ("course_key", str(self.course.id)),
             ("display_name", self.course.display_name),
-            ("lms_link", f'{settings.LMS_ROOT_URL}/courses/{str(self.course.id)}/jump_to/{self.course.location}'),
+            ("lms_link", f'//{settings.LMS_BASE}/courses/{str(self.course.id)}/jump_to/{self.course.location}'),
             ("cms_link", f'//{settings.CMS_BASE}{reverse_course_url("course_handler", self.course.id)}'),
             ("number", self.course.number),
             ("org", self.course.org),
@@ -164,11 +164,7 @@ class HomePageCoursesViewV2Test(CourseTestCase):
             ("display_name", self.archived_course.display_name),
             (
                 "lms_link",
-                '{url_root}/courses/{course_id}/jump_to/{location}'.format(
-                    url_root=settings.LMS_ROOT_URL,
-                    course_id=str(self.archived_course.id),
-                    location=self.archived_course.location
-                ),
+                f'//{settings.LMS_BASE}/courses/{str(self.archived_course.id)}/jump_to/{self.archived_course.location}',
             ),
             ("cms_link", f'//{settings.CMS_BASE}{reverse_course_url("course_handler", self.archived_course.id)}'),
             ("number", self.archived_course.number),
@@ -194,11 +190,7 @@ class HomePageCoursesViewV2Test(CourseTestCase):
             ("display_name", self.archived_course.display_name),
             (
                 "lms_link",
-                '{url_root}/courses/{course_id}/jump_to/{location}'.format(
-                    url_root=settings.LMS_ROOT_URL,
-                    course_id=str(self.archived_course.id),
-                    location=self.archived_course.location
-                ),
+                f'//{settings.LMS_BASE}/courses/{str(self.archived_course.id)}/jump_to/{self.archived_course.location}',
             ),
             ("cms_link", f'//{settings.CMS_BASE}{reverse_course_url("course_handler", self.archived_course.id)}'),
             ("number", self.archived_course.number),

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -9,7 +9,7 @@ import re
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from urllib.parse import quote_plus, urlencode, urlunparse, urlparse
+from urllib.parse import quote_plus
 from uuid import uuid4
 
 from bs4 import BeautifulSoup
@@ -193,30 +193,31 @@ def get_lms_link_for_item(location, preview=False):
     """
     assert isinstance(location, UsageKey)
 
-    # checks LMS_ROOT_URL value in site configuration for the given course_org_filter(org)
-    # if not found returns settings.LMS_ROOT_URL
+    # checks LMS_BASE value in site configuration for the given course_org_filter(org)
+    # if not found returns settings.LMS_BASE
     lms_base = SiteConfiguration.get_value_for_org(
         location.org,
-        "LMS_ROOT_URL",
-        settings.LMS_ROOT_URL
+        "LMS_BASE",
+        settings.LMS_BASE
     )
-    query_string = ''
 
     if lms_base is None:
         return None
 
     if preview:
-        params = {'preview': '1'}
-        query_string = urlencode(params)
+        # checks PREVIEW_LMS_BASE value in site configuration for the given course_org_filter(org)
+        # if not found returns settings.FEATURES.get('PREVIEW_LMS_BASE')
+        lms_base = SiteConfiguration.get_value_for_org(
+            location.org,
+            "PREVIEW_LMS_BASE",
+            settings.FEATURES.get('PREVIEW_LMS_BASE')
+        )
 
-    url_parts = list(urlparse(lms_base))
-    url_parts[2] = '/courses/{course_key}/jump_to/{location}'.format(
+    return "//{lms_base}/courses/{course_key}/jump_to/{location}".format(
+        lms_base=lms_base,
         course_key=str(location.course_key),
         location=str(location),
     )
-    url_parts[4] = query_string
-
-    return urlunparse(url_parts)
 
 
 def get_lms_link_for_certificate_web_view(course_key, mode):

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -27,7 +27,6 @@ from web_fragments.fragment import Fragment
 from xmodule.course_block import COURSE_VISIBILITY_PUBLIC
 from xmodule.modulestore.django import modulestore
 from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
-from xmodule.util.xmodule_django import get_current_request_hostname
 
 from common.djangoapps.edxmako.shortcuts import render_to_response, render_to_string
 from common.djangoapps.student.models import CourseEnrollment
@@ -189,13 +188,11 @@ class CoursewareIndex(View):
                 unit_key = None
         except InvalidKeyError:
             unit_key = None
-        is_preview = settings.FEATURES.get('PREVIEW_LMS_BASE') == get_current_request_hostname()
         url = make_learning_mfe_courseware_url(
             self.course_key,
             self.section.location if self.section else None,
             unit_key,
             params=self.request.GET,
-            preview=is_preview,
         )
         return url
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -51,7 +51,6 @@ from xmodule.course_block import (
     COURSE_VISIBILITY_PUBLIC_OUTLINE,
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
 )
-from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
 from xmodule.tabs import CourseTabList
@@ -440,12 +439,10 @@ def jump_to(request, course_id, location):
     except InvalidKeyError as exc:
         raise Http404("Invalid course_key or usage_key") from exc
 
-    staff_access = has_access(request.user, 'staff', course_key)
     try:
         redirect_url = get_courseware_url(
             usage_key=usage_key,
             request=request,
-            is_staff=staff_access,
         )
     except (ItemNotFoundError, NoPathToItem):
         # We used to 404 here, but that's ultimately a bad experience. There are real world use cases where a user
@@ -455,7 +452,6 @@ def jump_to(request, course_id, location):
         redirect_url = get_courseware_url(
             usage_key=course_location_from_key(course_key),
             request=request,
-            is_staff=staff_access,
         )
 
     return redirect(redirect_url)
@@ -1569,150 +1565,142 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
             f"Rendering of the xblock view '{nh3.clean(requested_view)}' is not supported."
         )
 
-    staff_access = bool(has_access(request.user, 'staff', course_key))
-    is_preview = request.GET.get('preview') == '1'
+    staff_access = has_access(request.user, 'staff', course_key)
 
-    store = modulestore()
-    branchType = ModuleStoreEnum.Branch.draft_preferred if is_preview else ModuleStoreEnum.Branch.published_only
+    with modulestore().bulk_operations(course_key):
+        # verify the user has access to the course, including enrollment check
+        try:
+            course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=check_if_enrolled)
+        except CourseAccessRedirect:
+            raise Http404("Course not found.")  # lint-amnesty, pylint: disable=raise-missing-from
 
-    if is_preview and not staff_access:
-        return HttpResponseBadRequest("You do not have access to preview this xblock")
+        # with course access now verified:
+        # assume masquerading role, if applicable.
+        # (if we did this *before* the course access check, then course staff
+        #  masquerading as learners would often be denied access, since course
+        #  staff are generally not enrolled, and viewing a course generally
+        #  requires enrollment.)
+        _course_masquerade, request.user = setup_masquerade(
+            request,
+            course_key,
+            staff_access,
+        )
 
-    with store.bulk_operations(course_key):
-        with store.branch_setting(branchType, course_key):
-            # verify the user has access to the course, including enrollment check
-            try:
-                course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=check_if_enrolled)
-            except CourseAccessRedirect:
-                raise Http404("Course not found.")  # lint-amnesty, pylint: disable=raise-missing-from
+        # Record user activity for tracking progress towards a user's course goals (for mobile app)
+        UserActivity.record_user_activity(
+            request.user, usage_key.course_key, request=request, only_if_mobile_app=True
+        )
 
-            # with course access now verified:
-            # assume masquerading role, if applicable.
-            # (if we did this *before* the course access check, then course staff
-            #  masquerading as learners would often be denied access, since course
-            #  staff are generally not enrolled, and viewing a course generally
-            #  requires enrollment.)
-            _course_masquerade, request.user = setup_masquerade(
-                request,
-                course_key,
-                staff_access,
-            )
+        # get the block, which verifies whether the user has access to the block.
+        recheck_access = request.GET.get('recheck_access') == '1'
+        block, _ = get_block_by_usage_id(
+            request,
+            str(course_key),
+            str(usage_key),
+            disable_staff_debug_info=disable_staff_debug_info,
+            course=course,
+            will_recheck_access=recheck_access,
+        )
 
-            # Record user activity for tracking progress towards a user's course goals (for mobile app)
-            UserActivity.record_user_activity(
-                request.user, usage_key.course_key, request=request, only_if_mobile_app=True
-            )
+        student_view_context = request.GET.dict()
+        student_view_context['show_bookmark_button'] = request.GET.get('show_bookmark_button', '0') == '1'
+        student_view_context['show_title'] = request.GET.get('show_title', '1') == '1'
 
-            # get the block, which verifies whether the user has access to the block.
-            recheck_access = request.GET.get('recheck_access') == '1'
-            block, _ = get_block_by_usage_id(
-                request,
-                str(course_key),
-                str(usage_key),
-                disable_staff_debug_info=disable_staff_debug_info,
-                course=course,
-                will_recheck_access=recheck_access,
-            )
+        is_learning_mfe = is_request_from_learning_mfe(request)
+        # Right now, we only care about this in regards to the Learning MFE because it results
+        # in a bad UX if we display blocks with access errors (repeated upgrade messaging).
+        # If other use cases appear, consider removing the is_learning_mfe check or switching this
+        # to be its own query parameter that can toggle the behavior.
+        student_view_context['hide_access_error_blocks'] = is_learning_mfe and recheck_access
+        is_mobile_app = is_request_from_mobile_app(request)
+        student_view_context['is_mobile_app'] = is_mobile_app
 
-            student_view_context = request.GET.dict()
-            student_view_context['show_bookmark_button'] = request.GET.get('show_bookmark_button', '0') == '1'
-            student_view_context['show_title'] = request.GET.get('show_title', '1') == '1'
+        enable_completion_on_view_service = False
+        completion_service = block.runtime.service(block, 'completion')
+        if completion_service and completion_service.completion_tracking_enabled():
+            if completion_service.blocks_to_mark_complete_on_view({block}):
+                enable_completion_on_view_service = True
+                student_view_context['wrap_xblock_data'] = {
+                    'mark-completed-on-view-after-delay': completion_service.get_complete_on_view_delay_ms()
+                }
 
-            is_learning_mfe = is_request_from_learning_mfe(request)
-            # Right now, we only care about this in regards to the Learning MFE because it results
-            # in a bad UX if we display blocks with access errors (repeated upgrade messaging).
-            # If other use cases appear, consider removing the is_learning_mfe check or switching this
-            # to be its own query parameter that can toggle the behavior.
-            student_view_context['hide_access_error_blocks'] = is_learning_mfe and recheck_access
-            is_mobile_app = is_request_from_mobile_app(request)
-            student_view_context['is_mobile_app'] = is_mobile_app
+        missed_deadlines, missed_gated_content = dates_banner_should_display(course_key, request.user)
 
-            enable_completion_on_view_service = False
-            completion_service = block.runtime.service(block, 'completion')
-            if completion_service and completion_service.completion_tracking_enabled():
-                if completion_service.blocks_to_mark_complete_on_view({block}):
-                    enable_completion_on_view_service = True
-                    student_view_context['wrap_xblock_data'] = {
-                        'mark-completed-on-view-after-delay': completion_service.get_complete_on_view_delay_ms()
-                    }
-
-            missed_deadlines, missed_gated_content = dates_banner_should_display(course_key, request.user)
-
-            # Some content gating happens only at the Sequence level (e.g. "has this
-            # timed exam started?").
-            ancestor_sequence_block = enclosing_sequence_for_gating_checks(block)
-            if ancestor_sequence_block:
-                context = {'specific_masquerade': is_masquerading_as_specific_student(request.user, course_key)}
-                # If the SequenceModule feels that gating is necessary, redirect
-                # there so we can have some kind of error message at any rate.
-                if ancestor_sequence_block.descendants_are_gated(context):
-                    return redirect(
-                        reverse(
-                            'render_xblock',
-                            kwargs={'usage_key_string': str(ancestor_sequence_block.location)}
-                        )
+        # Some content gating happens only at the Sequence level (e.g. "has this
+        # timed exam started?").
+        ancestor_sequence_block = enclosing_sequence_for_gating_checks(block)
+        if ancestor_sequence_block:
+            context = {'specific_masquerade': is_masquerading_as_specific_student(request.user, course_key)}
+            # If the SequenceModule feels that gating is necessary, redirect
+            # there so we can have some kind of error message at any rate.
+            if ancestor_sequence_block.descendants_are_gated(context):
+                return redirect(
+                    reverse(
+                        'render_xblock',
+                        kwargs={'usage_key_string': str(ancestor_sequence_block.location)}
                     )
-
-            # For courses using an LTI provider managed by edx-exams:
-            # Access to exam content is determined by edx-exams and passed to the LMS using a
-            # JWT url param. There is no longer a need for exam gating or logic inside the
-            # sequence block or its render call. descendants_are_gated shoule not return true
-            # for these timed exams. Instead, sequences are assumed gated by default and we look for
-            # an access token on the request to allow rendering to continue.
-            if course.proctoring_provider == 'lti_external':
-                seq_block = ancestor_sequence_block if ancestor_sequence_block else block
-                if getattr(seq_block, 'is_time_limited', None):
-                    if not _check_sequence_exam_access(request, seq_block.location):
-                        return HttpResponseForbidden("Access to exam content is restricted")
-
-            context = {
-                'course': course,
-                'block': block,
-                'disable_accordion': True,
-                'allow_iframing': True,
-                'disable_header': True,
-                'disable_footer': True,
-                'disable_window_wrap': True,
-                'enable_completion_on_view_service': enable_completion_on_view_service,
-                'edx_notes_enabled': is_feature_enabled(course, request.user),
-                'staff_access': staff_access,
-                'xqa_server': settings.FEATURES.get('XQA_SERVER', 'http://your_xqa_server.com'),
-                'missed_deadlines': missed_deadlines,
-                'missed_gated_content': missed_gated_content,
-                'has_ended': course.has_ended(),
-                'web_app_course_url': get_learning_mfe_home_url(course_key=course.id, url_fragment='home'),
-                'on_courseware_page': True,
-                'verified_upgrade_link': verified_upgrade_deadline_link(request.user, course=course),
-                'is_learning_mfe': is_learning_mfe,
-                'is_mobile_app': is_mobile_app,
-                'render_course_wide_assets': True,
-            }
-
-            try:
-                # .. filter_implemented_name: RenderXBlockStarted
-                # .. filter_type: org.openedx.learning.xblock.render.started.v1
-                context, student_view_context = RenderXBlockStarted.run_filter(
-                    context=context, student_view_context=student_view_context
                 )
-            except RenderXBlockStarted.PreventXBlockBlockRender as exc:
-                log.info("Halted rendering block %s. Reason: %s", usage_key_string, exc.message)
-                return render_500(request)
-            except RenderXBlockStarted.RenderCustomResponse as exc:
-                log.info("Rendering custom exception for block %s. Reason: %s", usage_key_string, exc.message)
-                context.update({
-                    'fragment': Fragment(exc.response)
-                })
-                return render_to_response('courseware/courseware-chromeless.html', context, request=request)
 
-            fragment = block.render(requested_view, context=student_view_context)
-            optimization_flags = get_optimization_flags_for_content(block, fragment)
+        # For courses using an LTI provider managed by edx-exams:
+        # Access to exam content is determined by edx-exams and passed to the LMS using a
+        # JWT url param. There is no longer a need for exam gating or logic inside the
+        # sequence block or its render call. descendants_are_gated shoule not return true
+        # for these timed exams. Instead, sequences are assumed gated by default and we look for
+        # an access token on the request to allow rendering to continue.
+        if course.proctoring_provider == 'lti_external':
+            seq_block = ancestor_sequence_block if ancestor_sequence_block else block
+            if getattr(seq_block, 'is_time_limited', None):
+                if not _check_sequence_exam_access(request, seq_block.location):
+                    return HttpResponseForbidden("Access to exam content is restricted")
 
+        context = {
+            'course': course,
+            'block': block,
+            'disable_accordion': True,
+            'allow_iframing': True,
+            'disable_header': True,
+            'disable_footer': True,
+            'disable_window_wrap': True,
+            'enable_completion_on_view_service': enable_completion_on_view_service,
+            'edx_notes_enabled': is_feature_enabled(course, request.user),
+            'staff_access': staff_access,
+            'xqa_server': settings.FEATURES.get('XQA_SERVER', 'http://your_xqa_server.com'),
+            'missed_deadlines': missed_deadlines,
+            'missed_gated_content': missed_gated_content,
+            'has_ended': course.has_ended(),
+            'web_app_course_url': get_learning_mfe_home_url(course_key=course.id, url_fragment='home'),
+            'on_courseware_page': True,
+            'verified_upgrade_link': verified_upgrade_deadline_link(request.user, course=course),
+            'is_learning_mfe': is_learning_mfe,
+            'is_mobile_app': is_mobile_app,
+            'render_course_wide_assets': True,
+        }
+
+        try:
+            # .. filter_implemented_name: RenderXBlockStarted
+            # .. filter_type: org.openedx.learning.xblock.render.started.v1
+            context, student_view_context = RenderXBlockStarted.run_filter(
+                context=context, student_view_context=student_view_context
+            )
+        except RenderXBlockStarted.PreventXBlockBlockRender as exc:
+            log.info("Halted rendering block %s. Reason: %s", usage_key_string, exc.message)
+            return render_500(request)
+        except RenderXBlockStarted.RenderCustomResponse as exc:
+            log.info("Rendering custom exception for block %s. Reason: %s", usage_key_string, exc.message)
             context.update({
-                'fragment': fragment,
-                **optimization_flags,
+                'fragment': Fragment(exc.response)
             })
-
             return render_to_response('courseware/courseware-chromeless.html', context, request=request)
+
+        fragment = block.render(requested_view, context=student_view_context)
+        optimization_flags = get_optimization_flags_for_content(block, fragment)
+
+        context.update({
+            'fragment': fragment,
+            **optimization_flags,
+        })
+
+        return render_to_response('courseware/courseware-chromeless.html', context, request=request)
 
 
 def get_optimization_flags_for_content(block, fragment):

--- a/xmodule/modulestore/search.py
+++ b/xmodule/modulestore/search.py
@@ -12,7 +12,7 @@ from .exceptions import ItemNotFoundError, NoPathToItem
 LOGGER = getLogger(__name__)
 
 
-def path_to_location(modulestore, usage_key, request=None, full_path=False, branch_type=None):
+def path_to_location(modulestore, usage_key, request=None, full_path=False):
     '''
     Try to find a course_id/chapter/section[/position] path to location in
     modulestore.  The courseware insists that the first level in the course is
@@ -82,47 +82,46 @@ def path_to_location(modulestore, usage_key, request=None, full_path=False, bran
             queue.append((parent, newpath))
 
     with modulestore.bulk_operations(usage_key.course_key):
-        with modulestore.branch_setting(branch_type, usage_key.course_key):
-            if not modulestore.has_item(usage_key):
-                raise ItemNotFoundError(usage_key)
+        if not modulestore.has_item(usage_key):
+            raise ItemNotFoundError(usage_key)
 
-            path = find_path_to_course()
-            if path is None:
-                raise NoPathToItem(usage_key)
+        path = find_path_to_course()
+        if path is None:
+            raise NoPathToItem(usage_key)
 
-            if full_path:
-                return path
+        if full_path:
+            return path
 
-            n = len(path)
-            course_id = path[0].course_key
-            # pull out the location names
-            chapter = path[1].block_id if n > 1 else None
-            section = path[2].block_id if n > 2 else None
-            vertical = path[3].block_id if n > 3 else None
-            # Figure out the position
-            position = None
+        n = len(path)
+        course_id = path[0].course_key
+        # pull out the location names
+        chapter = path[1].block_id if n > 1 else None
+        section = path[2].block_id if n > 2 else None
+        vertical = path[3].block_id if n > 3 else None
+        # Figure out the position
+        position = None
 
-            # This block of code will find the position of a block within a nested tree
-            # of blocks. If a problem is on tab 2 of a sequence that's on tab 3 of a
-            # sequence, the resulting position is 3_2. However, no positional blocks
-            # (e.g. sequential) currently deal with this form of representing nested
-            # positions. This needs to happen before jumping to a block nested in more
-            # than one positional block will work.
+        # This block of code will find the position of a block within a nested tree
+        # of blocks. If a problem is on tab 2 of a sequence that's on tab 3 of a
+        # sequence, the resulting position is 3_2. However, no positional blocks
+        # (e.g. sequential) currently deal with this form of representing nested
+        # positions. This needs to happen before jumping to a block nested in more
+        # than one positional block will work.
 
-            if n > 3:
-                position_list = []
-                for path_index in range(2, n - 1):
-                    category = path[path_index].block_type
-                    if category == 'sequential':
-                        section_desc = modulestore.get_item(path[path_index])
-                        # this calls get_children rather than just children b/c old mongo includes private children
-                        # in children but not in get_children
-                        child_locs = get_child_locations(section_desc, request, course_id)
-                        # positions are 1-indexed, and should be strings to be consistent with
-                        # url parsing.
-                        if path[path_index + 1] in child_locs:
-                            position_list.append(str(child_locs.index(path[path_index + 1]) + 1))
-                position = "_".join(position_list)
+        if n > 3:
+            position_list = []
+            for path_index in range(2, n - 1):
+                category = path[path_index].block_type
+                if category == 'sequential':
+                    section_desc = modulestore.get_item(path[path_index])
+                    # this calls get_children rather than just children b/c old mongo includes private children
+                    # in children but not in get_children
+                    child_locs = get_child_locations(section_desc, request, course_id)
+                    # positions are 1-indexed, and should be strings to be consistent with
+                    # url parsing.
+                    if path[path_index + 1] in child_locs:
+                        position_list.append(str(child_locs.index(path[path_index + 1]) + 1))
+            position = "_".join(position_list)
 
     return (course_id, chapter, section, vertical, position, path[-1])
 

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -1752,7 +1752,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
             for location, expected in should_work:
                 # each iteration has different find count, pop this iter's find count
                 with check_mongo_calls(num_finds.pop(0), num_sends), self.assertNumQueries(num_mysql.pop(0)):
-                    path = path_to_location(self.store, location, branch_type=ModuleStoreEnum.Branch.published_only)
+                    path = path_to_location(self.store, location)
                     assert path == expected
 
         not_found = (

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -179,6 +179,7 @@ class VideoBlock(
                 track_url = self.track
             elif sub or other_lang:
                 track_url = self.runtime.handler_url(self, 'transcript', 'download').rstrip('/?')
+
         transcript_language = self.get_default_transcript_language(transcripts, dest_lang)
         native_languages = {lang: label for lang, label in settings.LANGUAGES if len(lang) == 2}
         languages = {


### PR DESCRIPTION
Reverts openedx/edx-platform#35687

The xblocks are not loading in the learning mfe when using the preview redirect. The xblocks are not receiving valid usage keys. This revert is to prevent course authors from being redirected. At the moment, I do not think that the bug is in these changes, but instead the front end changes.