### PR TITLE
fix: Keep sync component count in collection card [FC-0062]

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -80,6 +80,7 @@ class Fields:
     published = "published"
     published_display_name = "display_name"
     published_description = "description"
+    published_num_children = "num_children"
 
     # Note: new fields or values can be added at any time, but if they need to be indexed for filtering or keyword
     # search, the index configuration will need to be changed, which is only done as part of the 'reindex_studio'
@@ -485,6 +486,15 @@ def searchable_doc_for_collection(
     if collection:
         assert collection.key == collection_key
 
+        draft_num_children = authoring_api.filter_publishable_entities(
+            collection.entities,
+            has_draft=True,
+        ).count()
+        published_num_children = authoring_api.filter_publishable_entities(
+            collection.entities,
+            has_published=True,
+        ).count()
+
         doc.update({
             Fields.context_key: str(library_key),
             Fields.org: str(library_key.org),
@@ -495,7 +505,10 @@ def searchable_doc_for_collection(
             Fields.description: collection.description,
             Fields.created: collection.created.timestamp(),
             Fields.modified: collection.modified.timestamp(),
-            Fields.num_children: collection.entities.count(),
+            Fields.num_children: draft_num_children,
+            Fields.published: {
+                Fields.published_num_children: published_num_children,
+            },
             Fields.access_id: _meili_access_id_from_context_key(library_key),
             Fields.breadcrumbs: [{"display_name": collection.learning_package.title}],
         })

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -198,6 +198,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": created_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
 
@@ -472,6 +475,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": created_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_collection2_created = {
@@ -487,6 +493,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": created_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_collection2_updated = {
@@ -502,6 +511,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": updated_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_collection1_updated = {
@@ -517,6 +529,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": updated_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_problem_with_collection1 = {

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -443,5 +443,37 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             'tags': {
                 'taxonomy': ['Difficulty'],
                 'level0': ['Difficulty > Normal']
+            },
+            "published": {
+                "num_children": 0
+            }
+        }
+
+    def test_collection_with_published_library(self):
+        library_api.publish_changes(self.library.key)
+
+        doc = searchable_doc_for_collection(self.library.key, self.collection.key)
+        doc.update(searchable_doc_tags_for_collection(self.library.key, self.collection.key))
+
+        assert doc == {
+            "id": "lib-collectionedx2012_falltoy_collection-d1d907a4",
+            "block_id": self.collection.key,
+            "usage_key": self.collection_usage_key,
+            "type": "collection",
+            "org": "edX",
+            "display_name": "Toy Collection",
+            "description": "my toy collection description",
+            "num_children": 1,
+            "context_key": "lib:edX:2012_Fall",
+            "access_id": self.library_access_id,
+            "breadcrumbs": [{"display_name": "some content_library"}],
+            "created": 1680674828.0,
+            "modified": 1680674828.0,
+            'tags': {
+                'taxonomy': ['Difficulty'],
+                'level0': ['Difficulty > Normal']
+            },
+            "published": {
+                "num_children": 1
             }
         }

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -83,6 +83,7 @@ from openedx_events.content_authoring.data import (
     ContentLibraryData,
     LibraryBlockData,
     LibraryCollectionData,
+    ContentObjectChangedData,
 )
 from openedx_events.content_authoring.signals import (
     CONTENT_LIBRARY_CREATED,
@@ -92,6 +93,7 @@ from openedx_events.content_authoring.signals import (
     LIBRARY_BLOCK_DELETED,
     LIBRARY_BLOCK_UPDATED,
     LIBRARY_COLLECTION_UPDATED,
+    CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
 )
 from openedx_learning.api import authoring as authoring_api
 from openedx_learning.api.authoring_models import (
@@ -684,7 +686,11 @@ def _get_library_component_tags_count(library_key) -> dict:
     return get_object_tag_counts(library_key_pattern, count_implicit=True)
 
 
-def get_library_components(library_key, text_search=None, block_types=None) -> QuerySet[Component]:
+def get_library_components(
+    library_key,
+    text_search=None,
+    block_types=None,
+) -> QuerySet[Component]:
     """
     Get the library components and filter.
 
@@ -700,6 +706,7 @@ def get_library_components(library_key, text_search=None, block_types=None) -> Q
         type_names=block_types,
         draft_title=text_search,
     )
+
     return components
 
 
@@ -1093,14 +1100,30 @@ def delete_library_block(usage_key, remove_from_parent=True):
     Delete the specified block from this library (soft delete).
     """
     component = get_component_from_usage_key(usage_key)
+    library_key = usage_key.context_key
+    affected_collections = authoring_api.get_entity_collections(component.learning_package_id, component.key)
+
     authoring_api.soft_delete_draft(component.pk)
 
     LIBRARY_BLOCK_DELETED.send_event(
         library_block=LibraryBlockData(
-            library_key=usage_key.context_key,
+            library_key=library_key,
             usage_key=usage_key
         )
     )
+
+    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
+    # collection indexing asynchronously.
+    #
+    # To delete the component on collections
+    for collection in affected_collections:
+        LIBRARY_COLLECTION_UPDATED.send_event(
+            library_collection=LibraryCollectionData(
+                library_key=library_key,
+                collection_key=collection.key,
+                background=True,
+            )
+        )
 
 
 def get_library_block_static_asset_files(usage_key) -> list[LibraryXBlockStaticFile]:
@@ -1317,6 +1340,39 @@ def revert_changes(library_key):
             update_blocks=True
         )
     )
+
+    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
+    # collection indexing asynchronously.
+    #
+    # This is to update component counts in all library collections,
+    # because there may be components that have been discarded in the revert.
+    for collection in authoring_api.get_collections(learning_package.id):
+        LIBRARY_COLLECTION_UPDATED.send_event(
+            library_collection=LibraryCollectionData(
+                library_key=library_key,
+                collection_key=collection.key,
+                background=True,
+            )
+        )
+
+    # Reindex components that are in collections
+    #
+    # Use case: When a component that was within a collection has been deleted
+    # and the changes are reverted, the component should appear in the
+    # collection again.
+    components_in_collections = authoring_api.get_components(
+        learning_package.id, draft=True, namespace='xblock.v1',
+    ).filter(publishable_entity__collections__isnull=False)
+
+    for component in components_in_collections:
+        usage_key = library_component_usage_key(library_key, component)
+
+        CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
+            content_object=ContentObjectChangedData(
+                object_id=str(usage_key),
+                changes=["collections"],
+            ),
+        )
 
 
 def create_library_collection(

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -139,7 +139,7 @@ optimizely-sdk<5.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.17.0
+openedx-learning==0.18.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -827,7 +827,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.17.0
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1381,7 +1381,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.17.0
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -990,7 +990,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.17.0
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1041,7 +1041,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.17.0
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fix: 
- https://github.com/openedx/modular-learning/issues/234
- https://github.com/openedx/edx-platform/issues/35776

Fixed component counter synchronization in these cases:

1. When deleting a component inside a collection.
2. With the library published, when adding a new component in a collection and reverting library changes.
3. With the library published, when deleting a component inside a collection and reverting library changes.

Also adds a `published > num_counts` field in collections in the search index.

## Supporting information

Related github issues: 
- https://github.com/openedx/modular-learning/issues/234
- https://github.com/openedx/edx-platform/issues/35776
Internal link: https://tasks.opencraft.com/browse/FAL-3921
Depends on: https://github.com/openedx/openedx-learning/pull/257

## Testing instructions

- Run `make requirements` on lms and cms shell.

1. When deleting a component inside a collection

- Go the library home of a library
- Go to the collection list page.
- Create a component in a collection or use a collection with components.
- Delete a component on the collection home page.
- Return to the collection list page and verify the component count in the collection card

2. With the library published, when adding a new component in a collection and reverting library changes.

- Go the library home of a **published** library
- Go to the collection list page.
- Create a component in a collection on the collection home page.
- Return to the collection list page and verify the component count in the collection card.
- Discarg library changes
- Return to the collection list page and verify the component count in the collection card.

3. With the library published, when deleting a component inside a collection and reverting library changes.

- Go the library home of a **published** library
- Go to the collection list page.
- Create a component in a collection (and publish) or use a collection with components published.
- Delete a component on the collection home page
- Return to the collection list page and verify the component count in the collection card.
- Discarg library changes
- Return to the collection list page and verify the component count in the collection card.

To test the new  `published > num_counts` field, you can follow the testing instructions in: https://github.com/openedx/frontend-app-authoring/pull/1481
