### PR TITLE
feat: handled edit modals from advanced xblocks

### DIFF
--- a/cms/static/js/views/container.js
+++ b/cms/static/js/views/container.js
@@ -70,6 +70,16 @@ function($, _, XBlockView, ModuleUtils, gettext, StringUtils, NotificationView) 
                     newParent = undefined;
                 },
                 update: function(event, ui) {
+                    try {
+                        window.parent.postMessage(
+                            {
+                                type: 'refreshPositions',
+                                payload: {}
+                            }, document.referrer
+                        );
+                    } catch (e) {
+                        console.error(e);
+                    }
                     // When dragging from one ol to another, this method
                     // will be called twice (once for each list). ui.sender will
                     // be null if the change is related to the list the element

--- a/cms/static/js/views/modals/base_modal.js
+++ b/cms/static/js/views/modals/base_modal.js
@@ -100,6 +100,17 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview'],
                 this.render();
                 this.resize();
                 $(window).resize(_.bind(this.resize, this));
+                // console.log('this.resize ==================>', this.resize);
+                try {
+                    window.parent.postMessage(
+                        {
+                            type: 'showXBlockEditorModal',
+                            payload: {}
+                        }, document.referrer
+                    );
+                } catch (e) {
+                    console.error(e);
+                }
 
                 // child may want to have its own focus management
                 if (focusModalWindow) {
@@ -112,6 +123,17 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview'],
                 // Completely remove the modal from the DOM
                 this.undelegateEvents();
                 this.$el.html('');
+
+                try {
+                    window.parent.postMessage(
+                        {
+                            type: 'hideXBlockEditorModal',
+                            payload: {}
+                        }, document.referrer
+                    );
+                } catch (e) {
+                    console.error(e);
+                }
             },
 
             cancel: function(event) {
@@ -175,24 +197,37 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview'],
             },
 
             resize: function() {
-                var top, left, modalWindow, modalWidth, modalHeight,
-                    availableWidth, availableHeight, maxWidth, maxHeight;
+                // var top, left, modalWindow, modalWidth, modalHeight,
+                //     availableWidth, availableHeight, maxWidth, maxHeight;
+                var left, maxWidth, modalWidth;
 
-                modalWindow = this.$el.find(this.options.modalWindowClass);
+                var modalWindow = this.$el.find(this.options.modalWindowClass);
                 availableWidth = $(window).width();
-                availableHeight = $(window).height();
+                // availableHeight = $(window).height();
                 maxWidth = availableWidth * 0.98;
-                maxHeight = availableHeight * 0.98;
+                // maxHeight = availableHeight * 0.98;
                 modalWidth = Math.min(modalWindow.outerWidth(), maxWidth);
-                modalHeight = Math.min(modalWindow.outerHeight(), maxHeight);
+                // modalHeight = Math.min(modalWindow.outerHeight(), maxHeight);
 
                 left = (availableWidth - modalWidth) / 2;
-                top = (availableHeight - modalHeight) / 2;
+                // top = (availableHeight - modalHeight) / 2;
 
-                modalWindow.css({
-                    top: top + $(window).scrollTop(),
-                    left: left + $(window).scrollLeft()
+                window.addEventListener('message', (event) => {
+                    if (event.data && event.data.type === 'controlEditModalPosition') {
+                        console.log('============ controlEditModalPosition ============', {
+                            top: event.data.payload.height,
+                            left: left + $(window).scrollLeft()
+                        });
+                        modalWindow.css({
+                            top: `${event.data.payload.height}px`,
+                            left: left + $(window).scrollLeft()
+                        });
+                    }
                 });
+                // modalWindow.css({
+                //     top: 0,
+                //     // left: left + $(window).scrollLeft()
+                // });
             }
         });
 

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -126,6 +126,12 @@ function($, _, Backbone, gettext, BasePage,
 
             }
 
+            window.addEventListener('message', (event) => {
+                if (event.data && event.data.type === 'refreshXBlock') {
+                    this.render();
+                }
+            });
+
             this.listenTo(Backbone, 'move:onXBlockMoved', this.onXBlockMoved);
         },
 
@@ -380,11 +386,14 @@ function($, _, Backbone, gettext, BasePage,
         editXBlock: function(event, options) {
             event.preventDefault();
             try {
-                if (this.options.isIframeEmbed) {
-                    window.parent.postMessage(
+                if (this.options.isIframeEmbed && event.currentTarget.className === 'access-button') {
+                    return window.parent.postMessage(
                         {
-                            type: 'editXBlock',
-                            payload: {}
+                            type: 'manageXBlockAccess',
+                            payload: {
+                                id: this.findXBlockElement(event.target).data('locator'),
+                                targetElementClassName: event.currentTarget.className,
+                            }
                         }, document.referrer
                     );
                 }
@@ -404,7 +413,23 @@ function($, _, Backbone, gettext, BasePage,
                         || (useNewVideoEditor === 'True' && blockType === 'video')
                         || (useNewProblemEditor === 'True' && blockType === 'problem')
                 ) {
-                    var destinationUrl = primaryHeader.attr('authoring_MFE_base_url') + '/' + blockType + '/' + encodeURI(primaryHeader.attr('data-usage-id'));
+                    var pathToNewXBlockEditor = `/${blockType}/${encodeURI(primaryHeader.attr('data-usage-id'))}`;
+                    var destinationUrl = `${primaryHeader.attr('authoring_MFE_base_url')}${pathToNewXBlockEditor}`;
+
+                    try {
+                        if (this.options.isIframeEmbed) {
+                            return window.parent.postMessage(
+                                {
+                                    type: 'newXBlockEditor',
+                                    payload: {
+                                        url: pathToNewXBlockEditor,
+                                    }
+                                }, document.referrer
+                            );
+                        }
+                    } catch (e) {
+                        console.error(e);
+                    }
                     window.location.href = destinationUrl;
                     return;
                 }
@@ -497,10 +522,12 @@ function($, _, Backbone, gettext, BasePage,
             event.preventDefault();
             try {
                 if (this.options.isIframeEmbed) {
-                    window.parent.postMessage(
+                    return window.parent.postMessage(
                         {
                             type: 'copyXBlock',
-                            payload: {}
+                            payload: {
+                                id: this.findXBlockElement(event.target).data('locator')
+                            }
                         }, document.referrer
                     );
                 }
@@ -554,10 +581,12 @@ function($, _, Backbone, gettext, BasePage,
             event.preventDefault();
             try {
                 if (this.options.isIframeEmbed) {
-                    window.parent.postMessage(
+                    return window.parent.postMessage(
                         {
                             type: 'duplicateXBlock',
-                            payload: {}
+                            payload: {
+                                id: this.findXBlockElement(event.target).data('locator')
+                            }
                         }, document.referrer
                     );
                 }
@@ -597,10 +626,12 @@ function($, _, Backbone, gettext, BasePage,
             event.preventDefault();
             try {
                 if (this.options.isIframeEmbed) {
-                    window.parent.postMessage(
+                    return window.parent.postMessage(
                         {
                             type: 'deleteXBlock',
-                            payload: {}
+                            payload: {
+                                id: this.findXBlockElement(event.target).data('locator')
+                            }
                         }, document.referrer
                     );
                 }

--- a/cms/static/sass/course-unit-mfe-iframe-bundle.scss
+++ b/cms/static/sass/course-unit-mfe-iframe-bundle.scss
@@ -52,6 +52,7 @@
       &:hover {
         background-color: $primary;
         border-color: $transparent;
+        color: $white;
       }
 
       &:focus {
@@ -648,4 +649,8 @@ select {
 
 .wrapper-comp-setting.metadata-list-enum .action.setting-clear.active {
   margin-top: 0;
+}
+
+.wrapper-xblock .xblock-header-primary .header-actions .wrapper-nav-sub {
+  z-index: 15;
 }


### PR DESCRIPTION
## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
