### PR TITLE
fix: added font styles for email digest browser compatibility

### DIFF
--- a/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/digest_content.html
@@ -1,5 +1,5 @@
 {% for notification_app in email_content %}
-    <h3 style="font-size: 1.375rem; font-weight:700; line-height:28px; margin: 0.75rem 0 0;">
+    <h3 style="font-size: 22px; font-weight:700; line-height:28px; margin: 0.75rem 0 0;">
         {{ notification_app.title }}
     </h3>
     {% if notification_app.help_text %}
@@ -29,7 +29,7 @@
                             />
                         </td>
                         <td class="notification-content" width="100%" align="left" valign="top" style="padding: 1rem 1rem 1rem 0.5rem;">
-                            <blockquote style="font-size: 0.875rem; font-weight:400; line-height:24px; color:#454545; margin: 0 0 0.5rem 0;">
+                            <blockquote style="font-size: 14px; font-weight:400; line-height:24px; color:#454545; margin: 0 0 0.5rem 0;">
                                 <style> strong {color: #00262B; font-weight:500} </style>
                                 {{ notification.email_content | truncatechars_html:600 | safe }}
                             </blockquote>

--- a/openedx/core/djangoapps/notifications/templates/notifications/digest_footer.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/digest_footer.html
@@ -1,4 +1,4 @@
-<table cellpadding="0" cellspacing="0" style="color:black; font-weight:400; font-size:0.75rem;line-height:20px" width="100%">
+<table cellpadding="0" cellspacing="0" style="color:black; font-weight:400; font-size:12px;line-height:20px" width="100%">
     <tbody>
         <tr>
             <td>

--- a/openedx/core/djangoapps/notifications/templates/notifications/digest_header.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/digest_header.html
@@ -19,7 +19,7 @@
         </tr>
         <tr style="height: 20px"></tr>
         <tr align="center">
-            <td style="font-family: Inter; font-size: 32px; font-style: normal; font-weight: 700; line-height: 36px">
+            <td style="font-family: Inter, Arial, Verdana, sans-serif; font-size: 32px; font-style: normal; font-weight: 700; line-height: 36px">
                 {{ digest_frequency }} email digest
             </td>
         </tr>
@@ -28,7 +28,7 @@
             <td
                 style="
                     color: #bfc9ca;
-                    font-family: Inter;
+                    font-family: Inter, Arial, Verdana, sans-serif;
                     font-size: 14px;
                     font-style: normal;
                     font-weight: 400;
@@ -54,7 +54,7 @@
                                                 </td>
                                             </tr>
                                             <tr align="center">
-                                                <td style="font-weight: 600; font-size: 0.875rem; line-height: 20px; padding: 0">
+                                                <td style="font-weight: 600; font-size: 14px; line-height: 20px; padding: 0">
                                                     {{update.title}}
                                                 </td>
                                             </tr>

--- a/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
+++ b/openedx/core/djangoapps/notifications/templates/notifications/edx_ace/email_digest/email/body.html
@@ -3,7 +3,7 @@
 </head>
 
 <div style="margin:0; padding:0; min-width: 100%; background-color:#C9C9C9; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-smooth: never;">
-    <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:1.5; max-width:600px; font-family:Inter">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:1.5; max-width:600px; font-family:Inter, Arial, Verdana, sans-serif">
         <tbody style="background-color:#f5f5f5">
             <tr>
                 <td>


### PR DESCRIPTION
Updated email digest font css for compatibility across email providers:
1. Added fallback sans-serif fonts to match the primary Inter font where it is not available
2. Updated all font sizes to px for consistency within a template and across browsers