### PR TITLE
chore: upgrade edx-search to 4.1.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -513,7 +513,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via -r requirements/edx/kernel.in
 edx-sga==0.25.0
     # via -r requirements/edx/bundled.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -806,7 +806,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -594,7 +594,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -620,7 +620,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This is to benefit from the latest changes concerning meilisearch index creation: https://github.com/openedx/edx-search/pull/166

## Testing instructions

On a brand new instance, running tutor with the with the [regisb/meilisearch](https://github.com/overhangio/tutor/pull/1141) branch, running the following command should always succeed flawlessly:

    ./manage.py lms shell -c "import search.meilisearch; search.meilisearch.create_indexes()"

## Deadline

ASAP, because I'd like to backport this in open-release/sumac.master as well.
