### PR TITLE
chore: upgrade edx-search to 4.1.1

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -32,3 +32,7 @@ elasticsearch<7.14.0
 # This can be unpinned once https://github.com/openedx/edx-platform/issues/34586
 # has been resolved and edx-platform is running with pymongo>=4.4.0
 
+
+# Cause: https://github.com/openedx/edx-lint/issues/458
+# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
+pip<24.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -513,7 +513,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via -r requirements/edx/kernel.in
 edx-sga==0.25.0
     # via -r requirements/edx/bundled.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -806,7 +806,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -594,7 +594,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -620,7 +620,7 @@ edx-rest-api-client==6.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==4.1.0
+edx-search==4.1.1
     # via -r requirements/edx/base.txt
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,6 +9,8 @@ wheel==0.44.0
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
-    # via -r requirements/pip.in
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in
 setuptools==75.2.0
     # via -r requirements/pip.in


### PR DESCRIPTION
This is to benefit from the latest changes concerning meilisearch index creation: https://github.com/openedx/edx-search/pull/166

This is a backport of: https://github.com/openedx/edx-platform/pull/35755