### PR TITLE
feat!: Replace sass with vanilla css in custom tag block

### DIFF
--- a/xmodule/assets/CustomTagBlockEditor.scss
+++ b/xmodule/assets/CustomTagBlockEditor.scss
@@ -1,3 +1,0 @@
-.xmodule_edit.xmodule_CustomTagBlock {
-  @import "codemirror/codemirror.scss";
-}

--- a/xmodule/assets/codemirror/_codemirror.scss
+++ b/xmodule/assets/codemirror/_codemirror.scss
@@ -1,5 +1,0 @@
-.CodeMirror {
-  background: #fff;
-  font-size: 13px;
-  color: #3c3c3c;
-}

--- a/xmodule/static/css-builtin-blocks/CustomTagBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/CustomTagBlockEditor.css
@@ -1,0 +1,5 @@
+.xmodule_edit.xmodule_CustomTagBlock .CodeMirror {
+    background: #fff;
+    font-size: 13px;
+    color: #3c3c3c;
+}

--- a/xmodule/template_block.py
+++ b/xmodule/template_block.py
@@ -9,7 +9,7 @@ from lxml import etree
 from web_fragments.fragment import Fragment
 from xmodule.editing_block import EditingMixin
 from xmodule.raw_block import RawMixin
-from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_sass_to_fragment
+from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_css_to_fragment
 from xmodule.x_module import (
     ResourceTemplates,
     shim_xmodule_js,
@@ -69,7 +69,7 @@ class CustomTagBlock(CustomTagTemplateBlock):  # pylint: disable=abstract-method
         fragment = Fragment(
             self.runtime.service(self, 'mako').render_cms_template(self.mako_template, self.get_context())
         )
-        add_sass_to_fragment(fragment, 'CustomTagBlockEditor.scss')
+        add_css_to_fragment(fragment, 'CustomTagBlockEditor.css')
         add_webpack_js_to_fragment(fragment, 'CustomTagBlockEditor')
         shim_xmodule_js(fragment, 'XMLEditingDescriptor')
         return fragment


### PR DESCRIPTION
feat!: Replace sass with vanilla css in custom tag block

Parent story: https://github.com/openedx/edx-platform/issues/35300


### Tasks:

- [x] Convert Sass variable into css variables
- [x] Compile the css file of the block following given steps.
    - [x] Change [this line](https://github.com/openedx/edx-platform/blob/master/scripts/compile_sass.py#L209C1-L209C93) to the following to avoid adding comments in the compiled css files 
         ```python
              source_comments: int = SASS_COMMENTS_NONE
         ```
    - [x] Compile the sass to uncompressed CSS using following command 
        ```shell
              npm run compile-sass-dev
         ```
    - [x] Copy the compiled XBlock linked CSS (lms/static/css/*Display.css and lms/static/css/*Editor.css) into `xmodule/static/css-builtin-blocks`.
    - [x] Format the CSS files using the editor.
    - [x] Add those CSS files to version control.
- [x] Replace add_sass_to_fragment to add_css_to_fragment in blocks `.py` file


- [x] Remove all .scss files linked to the block under xmodule/assets. 
    - Make sure to remove the .scss file in a separate alone commit so reviewer could review scss changes and they stay in history.
    - Don't remove the scss file if its linked to some other block.

### Testing Notes:
- [x] Run ```npm run build``` to run webpack and compile sass files.
- [x] Run ```./manage.py lms collectstatic``` in lms shell to re-collect static files.
- [x] Run ```./manage.py cms collectstatic``` in cms shell to re-collect static files.
- [ ] Verify the block's compiled css and the css global variables in the LMS
- [ ] Verify the block's compiled css and the css global variables in the Studio
- [ ] Test the XBlock rendering and User Experience in LMS
- [ ] Test the XBlock rendering and User Experience in Studio

## Testing Known Issues:
When I try to add any block from following entry pionts in editor, it throws error.

```json
[
    "book",
    "customtag",
    "image",
    "custom_tag_template",
    "discuss",
    "slides",
    "videodev"
]
```

<img width="1330" alt="Screenshot 2024-11-08 at 5 42 19 PM" src="https://github.com/user-attachments/assets/0f212900-b510-40b2-9d86-0553f88a976c">

```shell
2024-11-06 22:09:43 Traceback (most recent call last):
2024-11-06 22:09:43   File "/openedx/edx-platform/cms/djangoapps/contentstore/views/preview.py", line 351, in get_preview_fragment
2024-11-06 22:09:43     fragment = block.render(preview_view, context)
2024-11-06 22:09:43                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/venv/lib/python3.11/site-packages/xblock/core.py", line 818, in render
2024-11-06 22:09:43     return self.runtime.render(self, view, context)
2024-11-06 22:09:43            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/edx-platform/xmodule/x_module.py", line 994, in render
2024-11-06 22:09:43     return super().render(block, view_name, context=context)
2024-11-06 22:09:43            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/venv/lib/python3.11/site-packages/xblock/runtime.py", line 823, in render
2024-11-06 22:09:43     frag = view_fn(context)
2024-11-06 22:09:43            ^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/edx-platform/xmodule/vertical_block.py", line 224, in author_view
2024-11-06 22:09:43     self.render_children(context, fragment, can_reorder=True, can_add=True)
2024-11-06 22:09:43   File "/openedx/edx-platform/xmodule/studio_editable.py", line 30, in render_children
2024-11-06 22:09:43     rendered_child = child.render(StudioEditableBlock.get_preview_view_name(child), context)
2024-11-06 22:09:43                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/venv/lib/python3.11/site-packages/xblock/core.py", line 818, in render
2024-11-06 22:09:43     return self.runtime.render(self, view, context)
2024-11-06 22:09:43            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/edx-platform/xmodule/x_module.py", line 994, in render
2024-11-06 22:09:43     return super().render(block, view_name, context=context)
2024-11-06 22:09:43            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/venv/lib/python3.11/site-packages/xblock/runtime.py", line 823, in render
2024-11-06 22:09:43     frag = view_fn(context)
2024-11-06 22:09:43            ^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/edx-platform/xmodule/template_block.py", line 114, in student_view
2024-11-06 22:09:43     fragment.add_content(self.rendered_html)
2024-11-06 22:09:43                          ^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/edx-platform/xmodule/template_block.py", line 107, in rendered_html
2024-11-06 22:09:43     return self.render_template(self.runtime, self.data)
2024-11-06 22:09:43            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/edx-platform/xmodule/template_block.py", line 81, in render_template
2024-11-06 22:09:43     xmltree = etree.fromstring(xml_data)
2024-11-06 22:09:43               ^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "/openedx/edx-platform/openedx/core/lib/safe_lxml/xmlparser.py", line 128, in fromstring
2024-11-06 22:09:43     rootelement = _etree.fromstring(text, parser, base_url=base_url)
2024-11-06 22:09:43                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-06 22:09:43   File "src/lxml/etree.pyx", line 3264, in lxml.etree.fromstring
2024-11-06 22:09:43   File "src/lxml/parser.pxi", line 1916, in lxml.etree._parseMemoryDocument
2024-11-06 22:09:43   File "src/lxml/parser.pxi", line 1796, in lxml.etree._parseDoc
2024-11-06 22:09:43   File "src/lxml/parser.pxi", line 1085, in lxml.etree._BaseParser._parseUnicodeDoc
2024-11-06 22:09:43   File "src/lxml/parser.pxi", line 618, in lxml.etree._ParserContext._handleParseResultDoc
2024-11-06 22:09:43   File "src/lxml/parser.pxi", line 728, in lxml.etree._handleParseResult
2024-11-06 22:09:43   File "src/lxml/parser.pxi", line 657, in lxml.etree._raiseParseError
2024-11-06 22:09:43   File "<string>", line 1
2024-11-06 22:09:43 lxml.etree.XMLSyntaxError: Document is empty, line 1, column 1
2024-11-06 22:09:43 [06/Nov/2024 17:09:43] "GET /xblock/block-v1:edx+3+3+type@vertical+block@44306a226476427cb4ad0d9057fc3795/container_preview?_=1730912983221 HTTP/1.1" 200 631
```

