### PR TITLE
feat: add verify_uuid to response of CertificatesListView

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -82,6 +82,7 @@ def _format_certificate_for_user(username, cert):
                 if cert.status == CertificateStatuses.downloadable
                 else None
             ),
+            "uuid": cert.verify_uuid,
         }
 
     return None

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -173,17 +173,22 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
     def assert_success_response_for_student(self, response, download_url='www.google.com'):
         """ This method is required by AuthAndScopesTestMixin. """
-        assert response.data ==\
-               [{'username': self.student.username,
-                 'course_id': str(self.course.id),
-                 'course_display_name': self.course.display_name,
-                 'course_organization': self.course.org,
-                 'certificate_type': CourseMode.VERIFIED,
-                 'created_date': self.now,
-                 'modified_date': self.now,
-                 'status': CertificateStatuses.downloadable,
-                 'is_passing': True,
-                 'download_url': download_url, 'grade': '0.88'}]
+        assert response.data == [
+            {
+                'username': self.student.username,
+                'course_id': str(self.course.id),
+                'course_display_name': self.course.display_name,
+                'course_organization': self.course.org,
+                'certificate_type': CourseMode.VERIFIED,
+                'created_date': self.now,
+                'modified_date': self.now,
+                'status': CertificateStatuses.downloadable,
+                'is_passing': True,
+                'download_url': download_url,
+                'grade': '0.88',
+                'uuid': str(self.cert.verify_uuid)
+            }
+        ]
 
     @patch('edx_rest_framework_extensions.permissions.log')
     @ddt.data(*list(AuthType))
@@ -212,6 +217,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
         assert resp.status_code == status.HTTP_200_OK
         assert len(resp.data) == 1
+        assert 'uuid' in resp.data[0]
 
     def test_owner_can_access_its_certs(self):
         """
@@ -227,6 +233,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
         resp = self.get_response(AuthType.session, requesting_user=self.student)
         assert resp.status_code == status.HTTP_200_OK
+        assert 'uuid' in resp.data[0]
 
         # verifies that other than owner cert list api is not accessible
         resp = self.get_response(AuthType.session, requesting_user=self.other_student)
@@ -246,12 +253,15 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
         resp = self.get_response(AuthType.session, requesting_user=self.student)
         assert resp.status_code == status.HTTP_200_OK
+        assert 'uuid' in resp.data[0]
 
         resp = self.get_response(AuthType.session, requesting_user=self.other_student)
         assert resp.status_code == status.HTTP_200_OK
+        assert 'uuid' in resp.data[0]
 
         resp = self.get_response(AuthType.session, requesting_user=self.global_staff)
         assert resp.status_code == status.HTTP_200_OK
+        assert 'uuid' in resp.data[0]
 
     @ddt.data(*list(AuthType))
     def test_another_user_with_certs_shared_custom(self, auth_type):
@@ -276,6 +286,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
         assert resp.status_code == status.HTTP_200_OK
         assert len(resp.data) == 1
+        assert 'uuid' in resp.data[0]
 
     @patch('edx_rest_framework_extensions.permissions.log')
     @ddt.data(*JWT_AUTH_TYPES)
@@ -290,6 +301,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         else:
             assert resp.status_code == status.HTTP_200_OK
             assert len(resp.data) == 1
+            assert 'uuid' in resp.data[0]
 
     @patch('edx_rest_framework_extensions.permissions.log')
     @ddt.data(*JWT_AUTH_TYPES)
@@ -422,3 +434,4 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         assert response.status_code == status.HTTP_200_OK
         self.assertContains(response, cert_for_deleted_course.download_url)
         self.assertContains(response, expected_course_name)
+        assert 'uuid' in response.data[0]

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -244,6 +244,7 @@ class CertificatesListView(APIView):
                     'is_passing': user_cert.get('is_passing'),
                     'download_url': user_cert.get('download_url'),
                     'grade': user_cert.get('grade'),
+                    'uuid': user_cert.get('uuid'),
                 })
         return Response(user_certs)
 


### PR DESCRIPTION
Ticket:[ INF-1570](https://2u-internal.atlassian.net/browse/INF-1570)

Added the value of the certificate's  `verify_uuid` to the response of the `CertificatesListView`.

Frontend PR: [Link](https://github.com/openedx/frontend-app-profile/pull/1114)