### PR TITLE
fix: adds content.search to docs apps

### DIFF
--- a/docs/docs_settings.py
+++ b/docs/docs_settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS.extend(
         "cms.djangoapps.course_creators",
         "cms.djangoapps.xblock_config.apps.XBlockConfig",
         "lms.djangoapps.lti_provider",
+        "openedx.core.djangoapps.content.search",
     ]
 )
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds `openedx.core.djangoapps.content.search` to the list of installed applications used by sphinx to generate the platform documentation. This app is included in the CMS django config, not the LMS, and so triggers an error without this change.

## Supporting information

Fixes this error reported by @feoh on [Slack #general](https://openedx.slack.com/archives/C02SNA1U4/p1730409791599779):

```
RuntimeError: Model class openedx.core.djangoapps.content.search.models.SearchAccess doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

Private-ref: [FAL-3123](https://tasks.opencraft.com/browse/FAL-3123)

## Testing instructions

1. Install the docs requirements to your virtualenv: `pip install -r requirements/edx/doc.txt`
2. Build the docs: `make docs`  (ok to cancel after the initial setup; this error happens early in the build)

## Deadline

ASAP -- need to port to Sumac

## Author Notes & Concerns

We should have caught this issue when it happened, but there's no docs validation currently in our CI. 

I can add a github workflow as part of this change, to do one or more of these steps. Let me know if I should? Also asked on [#wg-documentation](https://openedx.slack.com/archives/C1LM7G955/p1730769405819529).

1. Run `make docs` and just make sure it succeeds. This adds some time to the already long CI, but it's a quick thing to add.
2. Run `make docs` + verify that there are no changes to the built docs. This would be the next best thing to suggestion 1, and ensure that our docs are continually updated.
3. Add a new `make docs-lint` step to our existing list checks that uses e.g [sphinx-lint](https://pypi.org/project/sphinx-lint/) to quickly verify the docs config and syntax. Also not hard to do, but wouldn't increase the CI build time as much as doing a full docs build.