### PR TITLE
fix: bump MAX_BLOCKS_PER_CONTENT_LIBRARY default to 100,000

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2734,7 +2734,7 @@ PASSWORD_RESET_IP_RATE = '1/m'
 PASSWORD_RESET_EMAIL_RATE = '2/h'
 
 ######################## Setting for content libraries ########################
-MAX_BLOCKS_PER_CONTENT_LIBRARY = 1000
+MAX_BLOCKS_PER_CONTENT_LIBRARY = 100_000
 
 ################# Student Verification #################
 VERIFY_STUDENT = {


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Increases the `MAX_BLOCKS_PER_CONTENT_LIBRARY ` setting from 1,000 to 100,000 , which is a more reasonable limit based on Meilisearch performance and content author usage.

Content Authors using Libraries v2 are affected by this change.

## Supporting information

Relates to: https://github.com/openedx/frontend-app-authoring/issues/1456
Private-ref: [FAL-3873](https://tasks.opencraft.com/browse/FAL-3873)

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/1468

## Deadline

ASAP -- will port to Sumac