### PR TITLE
fix: hide library_v2 and itembank in legacy library page

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -279,7 +279,14 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
     component_types = COMPONENT_TYPES[:]
 
     # Libraries do not support discussions, drag-and-drop, and openassessment and other libraries
-    component_not_supported_by_library = ['discussion', 'library', 'openassessment', 'drag-and-drop-v2']
+    component_not_supported_by_library = [
+        'discussion',
+        'library',
+        'openassessment',
+        'drag-and-drop-v2',
+        'library_v2',
+        'itembank',
+    ]
     if library:
         component_types = [component for component in component_types
                            if component not in set(component_not_supported_by_library)]

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -403,6 +403,8 @@ class UnitTestLibraries(CourseTestCase):
         self.assertNotIn('advanced', templates)
         self.assertNotIn('openassessment', templates)
         self.assertNotIn('library', templates)
+        self.assertNotIn('library_v2', templates)
+        self.assertNotIn('itembank', templates)
 
     def test_advanced_problem_types(self):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Hide options to add library_v2 and itembank blocks in legacy library page.

Fix for: https://github.com/openedx/modular-learning/issues/238

## Supporting information

* `Private-ref`: [FAL-3934](https://tasks.opencraft.com/browse/FAL-3934)

## Testing instructions

* Verify that new library content and Problem bank options are not available in any legacy library page.