### PR TITLE
[sumac] fix: hide library_v2 and itembank in legacy library page

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -279,7 +279,14 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
     component_types = COMPONENT_TYPES[:]
 
     # Libraries do not support discussions, drag-and-drop, and openassessment and other libraries
-    component_not_supported_by_library = ['discussion', 'library', 'openassessment', 'drag-and-drop-v2']
+    component_not_supported_by_library = [
+        'discussion',
+        'library',
+        'openassessment',
+        'drag-and-drop-v2',
+        'library_v2',
+        'itembank',
+    ]
     if library:
         component_types = [component for component in component_types
                            if component not in set(component_not_supported_by_library)]

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -403,6 +403,8 @@ class UnitTestLibraries(CourseTestCase):
         self.assertNotIn('advanced', templates)
         self.assertNotIn('openassessment', templates)
         self.assertNotIn('library', templates)
+        self.assertNotIn('library_v2', templates)
+        self.assertNotIn('itembank', templates)
 
     def test_advanced_problem_types(self):
         """


### PR DESCRIPTION
Hide options to add library_v2 and itembank blocks in legacy library page.

(cherry picked from commit 0f7eb29a150aa884fc2493bab7602428bdf39a11)


Backport of https://github.com/openedx/edx-platform/pull/35772