### PR TITLE
fix: adds content.search to docs apps (Sumac backport)

### DIFF
--- a/docs/docs_settings.py
+++ b/docs/docs_settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS.extend([
     'cms.djangoapps.course_creators',
     'cms.djangoapps.xblock_config.apps.XBlockConfig',
     'lms.djangoapps.lti_provider',
+    'openedx.core.djangoapps.content.search',
 ])
 
 


### PR DESCRIPTION

- **fix: adds content.search to docs apps**

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds `openedx.core.djangoapps.content.search` to the list of installed applications used by sphinx to generate the platform documentation. This app is included in the CMS django config, not the LMS, and so triggers an error without this change.


## Supporting information

This is a backport from master to fix the docs build.

See https://github.com/openedx/edx-platform/pull/35766

cc @pomegranited
