### PR TITLE
fix: remove learner_downloadable field references

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1014,7 +1014,6 @@ def import_staged_content_from_user_clipboard(library_key: LibraryLocatorV2, use
                 component_version.pk,
                 content.id,
                 key=filename,
-                learner_downloadable=True,
             )
 
     # Emit library block created event
@@ -1084,7 +1083,6 @@ def _create_component_for_block(content_lib, usage_key, user_id=None):
             component_version.pk,
             content.id,
             key="block.xml",
-            learner_downloadable=False
         )
 
         return component_version

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -1199,7 +1199,6 @@ def get_component_version_asset(request, component_version_uuid, asset_path):
         component_version_uuid,
         asset_path,
         public=False,
-        learner_downloadable_only=False,
     )
 
     # If there was any error, we return that response because it will have the

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -139,7 +139,7 @@ optimizely-sdk<5.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.16.3
+openedx-learning==0.17.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -827,7 +827,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.3
+openedx-learning==0.17.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1381,7 +1381,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.3
+openedx-learning==0.17.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -990,7 +990,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.3
+openedx-learning==0.17.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1041,7 +1041,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.3
+openedx-learning==0.17.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

See https://github.com/openedx/openedx-learning/pull/256 for more information

## Supporting information

None

## Testing instructions

None

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.
