### PR TITLE
fix: image aspect ratio on component preview [FC-0062]

### DIFF
--- a/xmodule/static/css-builtin-blocks/HtmlBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/HtmlBlockDisplay.css
@@ -222,6 +222,7 @@
 .xmodule_display.xmodule_HtmlBlock img,
 .xmodule_display.xmodule_StaticTabBlock img {
     max-width: 100%;
+    height: auto;
 }
 
 .xmodule_display.xmodule_AboutBlock pre,


### PR DESCRIPTION
## Description

This PR fixes a bug wherein an image is rendered with the wrong aspect ratio if included in a Text component with explicit `width` and `height`.

## More Information
- Related to:
  - https://github.com/openedx/frontend-app-authoring/issues/1465

## Testing instructions
1. Before checking out this branch, create a new Text block with the following OFX:
```html
<html display_name="Text46">
  <p>Hi!</p>
  <p><img src="https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg" width="1313" height="590" /></p>
</html>
```
2. Check the component preview on the sidebar, and it should look distorted aspect ratio
3. Checkout this branch
4. Run `tutor dev exec cms openedx-assets build --env=dev` to rebuild the `css`
5. Reload the page, and the image should look with the correct aspect ratio

___
Private ref: [FAL-3926](https://tasks.opencraft.com/browse/FAL-3926)