### PR TITLE
fix: image aspect ratio on component preview [FC-0062] [sumac]

### DIFF
--- a/xmodule/assets/html/_display.scss
+++ b/xmodule/assets/html/_display.scss
@@ -118,6 +118,7 @@ a {
 
 img {
   max-width: 100%;
+  height: auto;
 }
 
 pre {


### PR DESCRIPTION
Backport of https://github.com/openedx/edx-platform/pull/35790

Note that these files where changed on `master` after this PR:
 - https://github.com/openedx/edx-platform/pull/35506
## Description

This PR fixes a bug wherein an image is rendered with the wrong aspect ratio if included in a Text component with explicit `width` and `height`.

## More Information
- Related to:
  - https://github.com/openedx/frontend-app-authoring/issues/1465

## Testing instructions
1. Before checking out this branch, create a new Text block with the following OFX:
```html
<html display_name="Text46">
  <p>Hi!</p>
  <p><img src="https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg" width="1313" height="590" /></p>
</html>
```
2. Check the component preview on the sidebar, and it should look distorted aspect ratio
3. Checkout this branch
4. Run `tutor dev exec cms openedx-assets build --env=dev` to rebuild the `css`
5. Reload the page, and the image should look with the correct aspect ratio

### Note

If you face the following error while running the sumac branch on an updated tutor stack, 
```
cms-1               | django.db.utils.OperationalError: (1054, "Unknown column 'content_libraries_contentlibrary.type' in 'where clause'")
```

you should need to rollback a single migration to fix it:
```
tutor dev exec cms python manage.py cms migrate content_libraries 0010_contentlibrary_learning_package_and_more
```

___
Private ref: [FAL-3926](https://tasks.opencraft.com/browse/FAL-3926)