### PR TITLE
[sumac] fix: remove the "Legacy Library" button if libraries v1 are disabled [FC-0062]

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -26,7 +26,12 @@ from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.xblock_django.api import authorable_xblocks, disabled_xblocks
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
 from cms.djangoapps.contentstore.helpers import is_unit
-from cms.djangoapps.contentstore.toggles import libraries_v2_enabled, use_new_problem_editor, use_new_unit_page
+from cms.djangoapps.contentstore.toggles import (
+    libraries_v1_enabled,
+    libraries_v2_enabled,
+    use_new_problem_editor,
+    use_new_unit_page,
+)
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import load_services_for_studio
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
@@ -488,6 +493,8 @@ def _filter_disabled_blocks(all_blocks):
     Filter out disabled xblocks from the provided list of xblock names.
     """
     disabled_block_names = [block.name for block in disabled_xblocks()]
+    if not libraries_v1_enabled():
+        disabled_block_names.append('library')
     if not libraries_v2_enabled():
         disabled_block_names.append('library_v2')
         disabled_block_names.append('itembank')


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Backports https://github.com/openedx/edx-platform/pull/35736 to sumac.

Removes the "Legacy Library" button from the legacy Studio "new block" button array if Libraries v1 are disabled, either via waffle flag or via the ENABLE_CONTENT_LIBRARIES feature flag.

## Supporting information

Addresses: https://github.com/openedx/modular-learning/issues/237
Private-ref: [FAL-3855](https://tasks.opencraft.com/browse/FAL-3855)

## Testing instructions

See https://github.com/openedx/edx-platform/pull/35736

## Deadline

ASAP