### PR TITLE
[sumac] fix: allow non-Elasticsearch search engines when reindexing courses [FC-0062]

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -256,7 +256,8 @@ class SearchIndexerBase(metaclass=ABCMeta):
                 # Now index the content
                 for item in structure.get_children():
                     prepare_item_index(item, groups_usage_info=groups_usage_info)
-                searcher.index(items_index, request_timeout=timeout)
+                if items_index:
+                    searcher.index(items_index, request_timeout=timeout)
                 cls.remove_deleted_items(searcher, structure_key, indexed_items)
         except Exception as err:  # pylint: disable=broad-except
             # broad exception so that index operation does not prevent the rest of the application from working

--- a/cms/djangoapps/contentstore/management/commands/reindex_course.py
+++ b/cms/djangoapps/contentstore/management/commands/reindex_course.py
@@ -97,14 +97,16 @@ class Command(BaseCommand):
                         logging.exception('Search Engine error - %s', exc)
                         return
 
-                    index_exists = searcher._es.indices.exists(index=index_name)  # pylint: disable=protected-access
+                    # Legacy Elasticsearch engine
+                    if hasattr(searcher, '_es'):  # pylint: disable=protected-access
+                        index_exists = searcher._es.indices.exists(index=index_name)  # pylint: disable=protected-access
 
-                    index_mapping = searcher._es.indices.get_mapping(  # pylint: disable=protected-access
-                        index=index_name,
-                    ) if index_exists else {}
+                        index_mapping = searcher._es.indices.get_mapping(  # pylint: disable=protected-access
+                            index=index_name,
+                        ) if index_exists else {}
 
-                    if index_exists and index_mapping:
-                        return
+                        if index_exists and index_mapping:
+                            return
 
             # if reindexing is done during devstack setup step, don't prompt the user
             if setup_option or query_yes_no(self.CONFIRMATION_PROMPT, default="no"):

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -504,6 +504,11 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
         """ Test for removing course from CourseAboutSearchIndexer """
         self._test_delete_course_from_search_index_after_course_deletion(self.store)
 
+    def test_empty_course(self):
+        empty_course = CourseFactory.create(modulestore=self.store, start=datetime(2015, 3, 1, tzinfo=UTC))
+        added_to_index = CoursewareSearchIndexer.do_course_reindex(self.store, empty_course.id)
+        assert added_to_index == 0
+
 
 @patch('django.conf.settings.SEARCH_ENGINE', 'search.tests.utils.ForceRefreshElasticSearchEngine')
 @ddt.ddt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR only fixes the `reindex_course` management command so it can be used when indexing courses on Meilisearch.

## Supporting information

Relates to: https://github.com/overhangio/tutor/pull/1141
Part of: https://github.com/openedx/modular-learning/issues/236
Private-ref: [FAL-3903](https://tasks.opencraft.com/browse/FAL-3903)

## Testing instructions

See https://github.com/openedx/edx-platform/pull/35743

## Deadline

ASAP
