### PR TITLE
build: add Documentation linting step to CI

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,41 @@
+name: Documentation linter
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  run_tests:
+    name: Quality Others
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        python-version:
+          - "3.11"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system requirements
+        run: sudo apt update && sudo apt install -y libxmlsec1-dev
+
+      - name: Install pip
+        run: python -m pip install -r requirements/pip.txt
+
+      - name: Install Required Python Dependencies
+        run: |
+          pip install -r requirements/edx/doc.txt
+
+      - name: Run lint check
+        run: |
+          make docs-lint

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ SWAGGER = docs/lms-openapi.yaml
 docs: swagger guides technical-docs ## build the documentation for this repository
 	$(MAKE) -C docs html
 
+docs-lint: swagger guides technical-docs ## build the documentation for this repository
+	$(MAKE) -C docs lint
+
 swagger: ## generate the swagger.yaml file
 	DJANGO_SETTINGS_MODULE=docs.docs_settings python manage.py lms generate_swagger --generator-class=edx_api_doc_tools.ApiSchemaGenerator -o $(SWAGGER)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXLINT    = sphinx-lint
 SOURCEDIR     = .
 BUILDDIR      = _build
 
@@ -11,7 +12,7 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help clean Makefile
+.PHONY: help clean lint Makefile
 
 clean:
 	rm -rf _build cms common lms openedx
@@ -20,6 +21,9 @@ clean:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+lint:
+	$(SPHINXLINT) "$(SOURCEDIR)"
 
 update_redirects:
 	# This updates redirects.txt, creating redirects for any files that have moved (relative to master).

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1484,6 +1484,7 @@ polib==1.2.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
+    #   sphinx-lint
 prompt-toolkit==3.0.48
     # via
     #   -r requirements/edx/doc.txt
@@ -1820,6 +1821,7 @@ regex==2024.9.11
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   nltk
+    #   sphinx-lint
 requests==2.32.3
     # via
     #   -r requirements/edx/doc.txt
@@ -2004,6 +2006,8 @@ sphinx==8.1.3
 sphinx-book-theme==1.1.3
     # via -r requirements/edx/doc.txt
 sphinx-design==0.6.1
+    # via -r requirements/edx/doc.txt
+sphinx-lint==1.0.0
     # via -r requirements/edx/doc.txt
 sphinx-mdinclude==0.6.2
     # via

--- a/requirements/edx/doc.in
+++ b/requirements/edx/doc.in
@@ -7,6 +7,7 @@ sphinx-book-theme         # Common theme for all Open edX projects
 gitpython                 # fetch git repo information
 Sphinx                    # Documentation builder
 sphinx-design             # provides various responsive web-components
+sphinx-lint               # documentation lint checker
 sphinxcontrib-openapi[markdown] # Be able to render openapi schema in a sphinx project
 sphinxext-rediraffe       # Quickly and easily redirect when we move pages around.
 sphinx-reredirects        # Redirect from a sphinx project out to other places on the web including other sphinx projects

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1054,6 +1054,7 @@ polib==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
+    #   sphinx-lint
 prompt-toolkit==3.0.48
     # via
     #   -r requirements/edx/base.txt
@@ -1262,6 +1263,7 @@ regex==2024.9.11
     # via
     #   -r requirements/edx/base.txt
     #   nltk
+    #   sphinx-lint
 requests==2.32.3
     # via
     #   -r requirements/edx/base.txt
@@ -1411,6 +1413,8 @@ sphinx==8.1.3
 sphinx-book-theme==1.1.3
     # via -r requirements/edx/doc.in
 sphinx-design==0.6.1
+    # via -r requirements/edx/doc.in
+sphinx-lint==1.0.0
     # via -r requirements/edx/doc.in
 sphinx-mdinclude==0.6.2
     # via sphinxcontrib-openapi


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

https://github.com/openedx/edx-platform/pull/32741 removed the documentation build step because it was taking > 40 minutes to run.

This PR adds a "documentation lint" step to the CI which uses [sphinx-lint](https://github.com/sphinx-contrib/sphinx-lint). This doesn't build the whole documentation tree, but should let PR creators know if they've made any code changes that break documentation.

This change affects Developers only.

## Supporting information

See https://github.com/openedx/edx-platform/pull/35766#issuecomment-2460239737 for more context.

## Testing instructions

1. Ensure the "Documentation linter" step added to the CI build is passing.

To verify that this added step helps us:

1. Revert the change made by https://github.com/openedx/edx-platform/pull/35766
2. In a python3.11 virtualenv, run: 
   ```
   pip install setuptools
   pip install -r requirements/edx/doc.txt
   ```
3. `make docs-lint` should fail with the error reported in the referenced PR.

## Deadline

None