### PR TITLE
[sumac] fix: component asset api views (#35765)

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1110,8 +1110,8 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             self._get_library_block_asset(pasted_usage_key, "static/hello.txt")
 
             # Compare the two text files
-            src_data = self.client.get(f"/library_assets/blocks/{usage_key}/static/hello.txt").content
-            dest_data = self.client.get(f"/library_assets/blocks/{pasted_usage_key}/static/hello.txt").content
+            src_data = self.client.get(f"/library_assets/blocks/{usage_key}/static/hello.txt").getvalue()
+            dest_data = self.client.get(f"/library_assets/blocks/{pasted_usage_key}/static/hello.txt").getvalue()
             assert src_data == dest_data
 
             # Check that the new block was created after the paste and it's content matches

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -168,12 +168,12 @@ class ContentLibrariesComponentVersionAssetTest(ContentLibrariesRestApiTest):
         response = self.client.get(
             f"/library_assets/component_versions/{self.draft_component_version.uuid}/static/test.svg"
         )
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     def test_unauthorized_user(self):
         """User who is not a Content Library staff should not have access."""
         self.client.logout()
-        student = UserFactory.create(
+        UserFactory.create(
             username="student",
             email="student@example.com",
             password="student-pass",

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -79,12 +79,12 @@ urlpatterns = [
     path('library_assets/', include([
         path(
             'component_versions/<uuid:component_version_uuid>/<path:asset_path>',
-            views.component_version_asset,
+            views.LibraryComponentAssetView.as_view(),
             name='library-assets',
         ),
         path(
             'blocks/<usage_v2:usage_key>/<path:asset_path>',
-            views.component_draft_asset,
+            views.LibraryComponentDraftAssetView.as_view(),
             name='library-draft-assets',
         ),
     ])

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -80,7 +80,6 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_safe
 from django.views.generic.base import TemplateResponseMixin, View
 from pylti1p3.contrib.django import DjangoCacheDataStorage, DjangoDbToolConf, DjangoMessageLaunch, DjangoOIDCLogin
 from pylti1p3.exception import LtiException, OIDCException
@@ -1168,8 +1167,7 @@ class LtiToolJwksView(LtiToolView):
         return JsonResponse(self.lti_tool_config.get_jwks(), safe=False)
 
 
-@require_safe
-def component_version_asset(request, component_version_uuid, asset_path):
+def get_component_version_asset(request, component_version_uuid, asset_path):
     """
     Serves static assets associated with particular Component versions.
 
@@ -1239,16 +1237,34 @@ def component_version_asset(request, component_version_uuid, asset_path):
     )
 
 
-@require_safe
-def component_draft_asset(request, usage_key, asset_path):
+@view_auth_classes()
+class LibraryComponentAssetView(APIView):
+    """
+    Serves static assets associated with particular Component versions.
+    """
+    @convert_exceptions
+    def get(self, request, component_version_uuid, asset_path):
+        """
+        GET API for fetching static asset for given component_version_uuid.
+        """
+        return get_component_version_asset(request, component_version_uuid, asset_path)
+
+
+@view_auth_classes()
+class LibraryComponentDraftAssetView(APIView):
     """
     Serves the draft version of static assets associated with a Library Component.
 
-    See `component_version_asset` for more details
+    See `get_component_version_asset` for more details
     """
-    try:
-        component_version_uuid = api.get_component_from_usage_key(usage_key).versioning.draft.uuid
-    except ObjectDoesNotExist as exc:
-        raise Http404() from exc
+    @convert_exceptions
+    def get(self, request, usage_key, asset_path):
+        """
+        Fetches component_version_uuid for given usage_key and returns component asset.
+        """
+        try:
+            component_version_uuid = api.get_component_from_usage_key(usage_key).versioning.draft.uuid
+        except ObjectDoesNotExist as exc:
+            raise Http404() from exc
 
-    return component_version_asset(request, component_version_uuid, asset_path)
+        return get_component_version_asset(request, component_version_uuid, asset_path)


### PR DESCRIPTION
Uses drf view to authenticate user before allowing them to access library static assets.

(cherry picked from commit ca7da3754f061997b29fb23233a045becf1f2c23)

Backport of https://github.com/openedx/edx-platform/pull/35765