### PR TITLE
fix: jump_to url not working for tutor

### DIFF
--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -12,7 +12,7 @@ from django.http import HttpRequest
 from django.http.request import QueryDict
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from six.moves.urllib.parse import urlencode, urlparse, urlunparse
+from six.moves.urllib.parse import urlencode, urlparse
 
 from lms.djangoapps.courseware.toggles import courseware_mfe_is_active
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
@@ -190,7 +190,7 @@ def make_learning_mfe_courseware_url(
             mfe_link += f'/{unit_key}'
 
     if get_params:
-        mfe_link += get_params.urlencode()
+        mfe_link += f'?{get_params.urlencode()}'
 
     return mfe_link
 

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -171,9 +171,8 @@ def make_learning_mfe_courseware_url(
     strings. They're only ever used to concatenate a URL string.
     `params` is an optional QueryDict object (e.g. request.GET)
     """
-    mfe_link = f'/course/{course_key}'
+    mfe_link = f'{settings.LEARNING_MICROFRONTEND_URL}/course/{course_key}'
     get_params = params.copy() if params else None
-    query_string = ''
 
     if preview:
         if len(get_params.keys()) > 1:
@@ -182,7 +181,7 @@ def make_learning_mfe_courseware_url(
             get_params = None
 
         if (unit_key or sequence_key):
-            mfe_link = f'/preview/course/{course_key}'
+            mfe_link = f'{settings.LEARNING_MICROFRONTEND_URL}/preview/course/{course_key}'
 
     if sequence_key:
         mfe_link += f'/{sequence_key}'
@@ -191,13 +190,9 @@ def make_learning_mfe_courseware_url(
             mfe_link += f'/{unit_key}'
 
     if get_params:
-        query_string = get_params.urlencode()
+        mfe_link += get_params.urlencode()
 
-    url_parts = list(urlparse(settings.LEARNING_MICROFRONTEND_URL))
-    url_parts[2] = mfe_link
-    url_parts[4] = query_string
-
-    return urlunparse(url_parts)
+    return mfe_link
 
 
 def get_learning_mfe_home_url(


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR fixes `jump_to` not working in Tutor. This bug was introduced in #35747 via the url builder assuming that `settings.LEARNING_MICROFRONTEND_URL` is always the base url. See [comment](https://github.com/openedx/edx-platform/pull/35747#discussion_r1832950520) in original PR This change impacts learners and course authors.