### PR TITLE
test: re-enable content libraries runtime tests [FC-0062] (#35783)

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -2,12 +2,12 @@
 Test the Learning-Core-based XBlock runtime and content libraries together.
 """
 import json
-from gettext import GNUTranslations
-from django.test import TestCase
 
 from completion.test_utils import CompletionWaffleTestMixin
 from django.db import connections, transaction
+from django.test import TestCase, override_settings
 from django.utils.text import slugify
+import django.utils.translation
 from organizations.models import Organization
 from rest_framework.test import APIClient
 from xblock.core import XBlock
@@ -141,18 +141,17 @@ class ContentLibraryOlxTests(ContentLibraryContentTestMixin, TestCase):
         assert olx_3 == olx_2 == canonical_olx
 
 
-class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin):
+class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin, TestCase):
     """
     Basic tests of the Learning-Core-based XBlock runtime using XBlocks in a
     content library.
     """
-
     def test_dndv2_sets_translator(self):
         dnd_block_key = library_api.create_library_block(self.library.key, "drag-and-drop-v2", "dnd1").usage_key
         library_api.publish_changes(self.library.key)
         dnd_block = xblock_api.load_block(dnd_block_key, self.student_a)
         i18n_service = dnd_block.runtime.service(dnd_block, 'i18n')
-        assert isinstance(i18n_service.translator, GNUTranslations)
+        assert i18n_service.translator is django.utils.translation
 
     def test_has_score(self):
         """
@@ -170,8 +169,7 @@ class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin):
         """
         Test the XBlock metadata API
         """
-        unit_block_key = library_api.create_library_block(self.library.key, "unit", "metadata-u1").usage_key
-        problem_key = library_api.create_library_block_child(unit_block_key, "problem", "metadata-p1").usage_key
+        problem_key = library_api.create_library_block(self.library.key, "problem", "metadata-p1").usage_key
         new_olx = """
         <problem display_name="New Multi Choice Question" max_attempts="5">
             <multiplechoiceresponse>
@@ -192,14 +190,6 @@ class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin):
         # Now view the problem as Alice:
         client = APIClient()
         client.login(username=self.student_a.username, password='edx')
-
-        # Check the metadata API for the unit:
-        metadata_view_result = client.get(
-            URL_BLOCK_METADATA_URL.format(block_key=unit_block_key),
-            {"include": "children,editable_children"},
-        )
-        assert metadata_view_result.data['children'] == [str(problem_key)]
-        assert metadata_view_result.data['editable_children'] == [str(problem_key)]
 
         # Check the metadata API for the problem:
         metadata_view_result = client.get(
@@ -227,8 +217,7 @@ class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin):
         client.login(username=self.staff_user.username, password='edx')
 
         # create/save a block using the library APIs first
-        unit_block_key = library_api.create_library_block(self.library.key, "unit", "fields-u1").usage_key
-        block_key = library_api.create_library_block_child(unit_block_key, "html", "fields-p1").usage_key
+        block_key = library_api.create_library_block(self.library.key, "html", "fields-p1").usage_key
         new_olx = """
         <html display_name="New Text Block">
             <p>This is some <strong>HTML</strong>.</p>
@@ -251,14 +240,24 @@ class ContentLibraryRuntimeTests(ContentLibraryContentTestMixin):
             }
         }, format='json')
         block_saved = xblock_api.load_block(block_key, self.staff_user)
-        assert block_saved.data == '\n<p>test</p>\n'
+        assert block_saved.data == '<p>test</p>'
         assert block_saved.display_name == 'New Display Name'
 
 
+# EphemeralKeyValueStore requires a working cache, and the default test cache is a dummy cache.
+@override_settings(
+    XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE='default',
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'edx_loc_mem_cache',
+        },
+    },
+)
 # We can remove the line below to enable this in Studio once we implement a session-backed
 # field data store which we can use for both studio users and anonymous users
 @skip_unless_lms
-class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin):
+class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin, TestCase):
     """
     Test that the Blockstore-based XBlock runtime can store and retrieve student
     state for XBlocks when learners access blocks directly in a library context,
@@ -561,7 +560,7 @@ class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin):
 
 
 @skip_unless_lms  # No completion tracking in Studio
-class ContentLibraryXBlockCompletionTest(ContentLibraryContentTestMixin, CompletionWaffleTestMixin):
+class ContentLibraryXBlockCompletionTest(ContentLibraryContentTestMixin, CompletionWaffleTestMixin, TestCase):
     """
     Test that the Blockstore-based XBlocks can track their completion status
     using the completion library.


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Backports https://github.com/openedx/edx-platform/pull/35783 to sumac so that the sumac branch can also guard against breaking changes that may be made to the content libraries runtime.

Only affects developers. 

## Supporting information

Port of: https://github.com/openedx/edx-platform/pull/35783
Private-ref: [FAL-3927](https://tasks.opencraft.com/browse/FAL-3927)

## Testing instructions

See https://github.com/openedx/edx-platform/pull/35783