### PR TITLE
feat: Add Matamo integration for platform.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1627,6 +1627,10 @@ GOOGLE_ANALYTICS_LINKEDIN = 'GOOGLE_ANALYTICS_LINKEDIN_DUMMY'
 GOOGLE_ANALYTICS_TRACKING_ID = None
 GOOGLE_ANALYTICS_4_ID = None
 
+######################## MATAMO ANALYTICS ####################
+MATAMO_SITE_ID = None
+MATAMO_INSTANCE_URL = None
+
 ######################## BRANCH.IO ###########################
 BRANCH_IO_KEY = ''
 

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -177,6 +177,28 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
   </script>
 % endif
 
+
+<% matamo_site_id = static.get_value("MATAMO_SITE_ID", settings.MATAMO_SITE_ID) %>
+<% matamo_instance_url = static.get_value("MATAMO_INSTANCE_URL", settings.MATAMO_INSTANCE_URL) %>
+% if matamo_site_id and matamo_instance_url:
+    <script type="text/javascript">
+        var _paq = (window._paq = window._paq || []);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function () {
+        var u = '${matamo_instance_url | n, js_escaped_string}';
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId','${matamo_site_id | n, js_escaped_string}']);
+        var d = document,
+            g = d.createElement('script'),
+            s = d.getElementsByTagName('script')[0];
+        g.async = true;
+        g.src = u + 'matomo.js';
+        s.parentNode.insertBefore(g, s);
+        })();
+    </script>
+% endif
+
 <% branch_key = static.get_value("BRANCH_IO_KEY", settings.BRANCH_IO_KEY) %>
 % if branch_key and not is_from_mobile_app:
     <script type="text/javascript">


### PR DESCRIPTION
## Description

These changes help to add  Matamo analytics to the platform, this helps to add the matamo analytics to the launch page. 

Useful information to include:

The platform already supports Google Analytics this PR pushes to support Matamo as a tool to capture analytics.

## Testing instructions

1. Configure Tutor to run on this branch.
2. Once that is done we need to add the value of 

```
MATAMO_SITE_ID = 3
MATAMO_INSTANCE_URL = https://analytics.dummy.com
```
3. We need to add this in `(tutor config printroot)/env/apps/openedx/settings/lms/development.py`
4. Restart LMS and CMS: tutor dev restart lms cms
5. Hard reload http://local.edly.io:8000/
6. Now in the network tab in the browser console should have a request being made to the URL.
