### PR TITLE
fix: fixed issue with iframe loading in Authoring mfe

### DIFF
--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -523,7 +523,7 @@ function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, MoveXBlockUtils, H
                 tagValueElement.className = 'tagging-label-value';
 
                 tagContentElement.appendChild(tagValueElement);
-                parentElement.appendChild(tagContentElement);
+                parentElement?.appendChild(tagContentElement);
 
                 if (tag.children.length > 0) {
                     var tagIconElement = document.createElement('span'),


### PR DESCRIPTION
## Description

On the Course unit page after merging the PR with [new iframe for xblocks](https://github.com/openedx/frontend-app-authoring/pull/1375), an issue with infinite loading of the iframe appeared if the unit/xblock has tags. This PR solves the problem with the error that appeared. Addition and processing of the tagging functionality is planned in future PRs.

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/6985a2b6-e3b3-4707-8af8-2a9bd5de8e03">

## Testing instructions

1. Switch the edx-platform to the branch of this PR
2. While on the master branch of authoring mfe, go to the Course unit page that has the added tags
3. The course xblocks should be rendered inside the iframe

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/f2957e5a-9975-4548-a5f9-5a957085469b">