### PR TITLE
feat: add optional inclusion date arg to course reindex command

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/reindex_course.py
+++ b/cms/djangoapps/contentstore/management/commands/reindex_course.py
@@ -80,8 +80,9 @@ class Command(BaseCommand):
         readable_option = options['warning']
         index_all_courses_option = all_option or setup_option
 
-        if ((not course_ids and not (index_all_courses_option or active_option or inclusion_date_option)) or
-                (course_ids and (index_all_courses_option or active_option or inclusion_date_option))):
+        course_option_flag_option = index_all_courses_option or active_option or inclusion_date_option
+
+        if (not course_ids and not course_option_flag_option) or (course_ids and course_option_flag_option):
             raise CommandError((
                 "reindex_course requires one or more <course_id>s"
                 " OR the --all, --active, --setup, or --from_inclusion_date flags."

--- a/cms/djangoapps/contentstore/management/commands/reindex_course.py
+++ b/cms/djangoapps/contentstore/management/commands/reindex_course.py
@@ -4,9 +4,10 @@
 import logging
 from textwrap import dedent
 from time import time
-from datetime import date
+from datetime import date, datetime
 
 from django.core.management import BaseCommand, CommandError
+from django.conf import settings
 from elasticsearch import exceptions
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -42,6 +43,10 @@ class Command(BaseCommand):
         parser.add_argument('--active',
                             action='store_true',
                             help='Reindex active courses only')
+        parser.add_argument('--from_inclusion_date',
+                            action='store_true',
+                            help='Reindex courses with a start date greater than COURSEWARE_SEARCH_INCLUSION_DATE'
+                            )
         parser.add_argument('--setup',
                             action='store_true',
                             help='Reindex all courses on developers stack setup')
@@ -70,15 +75,16 @@ class Command(BaseCommand):
         course_ids = options['course_ids']
         all_option = options['all']
         active_option = options['active']
+        inclusion_date_option = options['from_inclusion_date']
         setup_option = options['setup']
         readable_option = options['warning']
         index_all_courses_option = all_option or setup_option
 
-        if ((not course_ids and not (index_all_courses_option or active_option)) or
-                (course_ids and (index_all_courses_option or active_option))):
+        if ((not course_ids and not (index_all_courses_option or active_option or inclusion_date_option)) or
+                (course_ids and (index_all_courses_option or active_option or inclusion_date_option))):
             raise CommandError((
                 "reindex_course requires one or more <course_id>s"
-                " OR the --all, --active or --setup flags."
+                " OR the --all, --active, --setup, or --from_inclusion_date flags."
             ))
 
         store = modulestore()
@@ -129,6 +135,20 @@ class Command(BaseCommand):
             course_keys = list(map(lambda course: course.id, active_courses))
 
             logging.warning(f'Selected {len(course_keys)} active courses over a total of {len(all_courses)}.')
+        elif inclusion_date_option:
+            # in case of --from_inclusion_date, we get the list of course keys from all courses
+            # that are stored in modulestore and filter out courses with a start date less than
+            # the settings defined COURSEWARE_SEARCH_INCLUSION_DATE
+            all_courses = modulestore().get_courses()
+
+            inclusion_date = datetime.strptime(
+                settings.FEATURES.get('COURSEWARE_SEARCH_INCLUSION_DATE', '2020-01-01'),
+                '%Y-%m-%d'
+            )
+
+            # We keep the courses that has a start date and the start date is greater than the inclusion date
+            active_courses = filter(lambda course: course.start and (course.start >= inclusion_date), all_courses)
+            course_keys = list(map(lambda course: course.id, active_courses))
 
         else:
             # in case course keys are provided as arguments


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR updates the `reindex_course` command to include an optional `from_inclusion_date` arg. If used, the command will reindex any course that has a start date that is greater than the setting defined `COURSEWARE_SEARCH_INCLUSION_DATE`.

[COSMO-308](https://2u-internal.atlassian.net/browse/COSMO-308)