### PR TITLE
fix: readthedocs python version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.12"
+    python: "3.11"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
This is related to https://github.com/openedx/edx-platform/issues/35807

We are downgrading the Python version to 3.11 for ReadTheDocs to address dependency issues.


Fixes: https://readthedocs.org/projects/edx-platform-docs/builds/26309672/