### PR TITLE
feat: update twitter brand icon in social share

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -85,17 +85,29 @@ from openedx.core.djangolib.js_utils import (
 
                                 <br />
                                 % for sharing_site_info in sharing_sites_info:
-                                <a
-                                    class="btn-link social-share-link"
-                                    data-source="${sharing_site_info['name']}"
-                                    href="${sharing_site_info['sharing_url']}"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    style="font-size: 1.5rem"
-                                >
-                                    <span class="icon fa ${sharing_site_info['fa_icon_name']}" aria-hidden="true"></span>
-                                    <span class="sr">${_("Share on {site}").format(site=sharing_site_info['name'])}</span>
-                                </a>
+                                    <a
+                                        class="btn-link social-share-link"
+                                        data-source="${sharing_site_info['name']}"
+                                        href="${sharing_site_info['sharing_url']}"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        style="font-size: 1.5rem"
+                                    >
+                                        <!--
+                                            Twitter now uses the X brand icon, but Font Awesome does not include fa-x-twitter until 6.0
+                                            Upgrading to 6.0 would require lots of leg work becuase all square icons have new name patterns
+                                            ex: fa-facebook-square is now fa-square-facebook
+                                        -->
+                                        % if (sharing_site_info['name'] == 'twitter'):
+                                            <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="14" width="12.25" viewBox="0 0 448 512">
+                                                <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+                                                <path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm297.1 84L257.3 234.6 379.4 396H283.8L209 298.1 123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5L313.6 116h47.5zM323.3 367.6L153.4 142.9H125.1L296.9 367.6h26.3z"/>
+                                            </svg>
+                                        % else:
+                                            <span class="icon fa ${sharing_site_info['fa_icon_name']}" aria-hidden="true"></span>
+                                        % endif
+                                        <span class="sr">${_("Share on {site}").format(site=sharing_site_info['name'])}</span>
+                                    </a>
                                 % endfor
                                 <br />
                                 <div style="background-color: #F2F0EF" class="public-video-url-container p-2">

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -83,7 +83,6 @@ from openedx.core.djangolib.js_utils import (
                                     <span style="color: black" class="icon fa fa-close" />
                                 </div>
 
-                                <br />
                                 % for sharing_site_info in sharing_sites_info:
                                     <a
                                         class="btn-link social-share-link"
@@ -93,23 +92,24 @@ from openedx.core.djangolib.js_utils import (
                                         rel="noopener noreferrer"
                                         style="font-size: 1.5rem"
                                     >
-                                        <!--
-                                            Twitter now uses the X brand icon, but Font Awesome does not include fa-x-twitter until 6.0
-                                            Upgrading to 6.0 would require lots of leg work becuase all square icons have new name patterns
-                                            ex: fa-facebook-square is now fa-square-facebook
-                                        -->
                                         % if (sharing_site_info['name'] == 'twitter'):
-                                            <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="14" width="12.25" viewBox="0 0 448 512">
-                                                <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
-                                                <path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm297.1 84L257.3 234.6 379.4 396H283.8L209 298.1 123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5L313.6 116h47.5zM323.3 367.6L153.4 142.9H125.1L296.9 367.6h26.3z"/>
-                                            </svg>
+                                            <!--
+                                                Twitter now uses the X brand icon, but Font Awesome does not include fa-x-twitter until 6.0
+                                                Upgrading to 6.0 would require lots of leg work becuase all square icons have new name patterns
+                                                ex: fa-facebook-square is now fa-square-facebook
+                                            -->
+                                            <span style="display: inline-block; vertical-align: middle; padding-left: 1px;">
+                                                <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="15" width="12.86" viewBox="0 0 448 512">
+                                                    <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+                                                    <path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm297.1 84L257.3 234.6 379.4 396H283.8L209 298.1 123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5L313.6 116h47.5zM323.3 367.6L153.4 142.9H125.1L296.9 367.6h26.3z"/>
+                                                </svg>
+                                            </span>
                                         % else:
                                             <span class="icon fa ${sharing_site_info['fa_icon_name']}" aria-hidden="true"></span>
                                         % endif
                                         <span class="sr">${_("Share on {site}").format(site=sharing_site_info['name'])}</span>
                                     </a>
                                 % endfor
-                                <br />
                                 <div style="background-color: #F2F0EF" class="public-video-url-container p-2">
                                     <a href=${public_video_url} class="d-inline-block align-middle" style="width: 200px">
                                         <div

--- a/xmodule/js/fixtures/video_all.html
+++ b/xmodule/js/fixtures/video_all.html
@@ -42,10 +42,12 @@
                   <span class="icon fa fa-share-alt" aria-hidden="true"></span>
                   Share on:
                   <a class="btn-link social-share-link" data-source="twitter" href="#">
-                    <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="14" width="12.25" viewBox="0 0 448 512">
-                      <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
-                      <path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm297.1 84L257.3 234.6 379.4 396H283.8L209 298.1 123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5L313.6 116h47.5zM323.3 367.6L153.4 142.9H125.1L296.9 367.6h26.3z"/>
-                    </svg>
+                    <span style="display: inline-block; vertical-align: middle; padding-left: 1px;">
+                      <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="15" width="12.86" viewBox="0 0 448 512">
+                          <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+                          <path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm297.1 84L257.3 234.6 379.4 396H283.8L209 298.1 123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5L313.6 116h47.5zM323.3 367.6L153.4 142.9H125.1L296.9 367.6h26.3z"/>
+                      </svg>
+                    </span>
                     <span class="sr">Share on twitter</span>
                   </a>
                   <a class="btn-link social-share-link" data-source="facebook" href="#">

--- a/xmodule/js/fixtures/video_all.html
+++ b/xmodule/js/fixtures/video_all.html
@@ -42,8 +42,11 @@
                   <span class="icon fa fa-share-alt" aria-hidden="true"></span>
                   Share on:
                   <a class="btn-link social-share-link" data-source="twitter" href="#">
-                      <span class="icon fa fa-linkedin-square" aria-hidden="true"></span>
-                      <span class="sr">Share on twitter</span>
+                    <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="14" width="12.25" viewBox="0 0 448 512">
+                      <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+                      <path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm297.1 84L257.3 234.6 379.4 396H283.8L209 298.1 123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5L313.6 116h47.5zM323.3 367.6L153.4 142.9H125.1L296.9 367.6h26.3z"/>
+                    </svg>
+                    <span class="sr">Share on twitter</span>
                   </a>
                   <a class="btn-link social-share-link" data-source="facebook" href="#">
                     <span class="icon fa fa-linkedin-square" aria-hidden="true"></span>


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR updates the twitter brand icon from the bird to the x in the social share popover. This change impacts the "Learner".

### Before
<img width="173" alt="Screenshot 2024-11-19 at 4 01 36 PM" src="https://github.com/user-attachments/assets/846e4d0b-21de-46ba-af21-1cdc7e4d9c00">

### After
<img width="173" alt="Screenshot 2024-11-20 at 4 10 04 PM" src="https://github.com/user-attachments/assets/78a9d742-ab6a-4484-9eaa-4abf36294a08">

## Supporting information

JIRA Ticket: [AU-1599 🔒](https://2u-internal.atlassian.net/browse/AU-1599)
> Replace video social share "twitter" icon with "X" icon

## Testing instructions

1. In Django Admin, enable `video_config.public_video_share`
2. Open a course
3. Enable video share for all videos in the course outline
4. Add a video block
5. Click on social share for the video
6. Confirm that the twitter bird icon is not visible
7. Confirm that the twitter x icon is visible

## Deadline

None
