### PR TITLE
[sumac] fix: keep library collection card component count in sync (#35734)

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -80,6 +80,7 @@ class Fields:
     published = "published"
     published_display_name = "display_name"
     published_description = "description"
+    published_num_children = "num_children"
 
     # Note: new fields or values can be added at any time, but if they need to be indexed for filtering or keyword
     # search, the index configuration will need to be changed, which is only done as part of the 'reindex_studio'
@@ -485,6 +486,15 @@ def searchable_doc_for_collection(
     if collection:
         assert collection.key == collection_key
 
+        draft_num_children = authoring_api.filter_publishable_entities(
+            collection.entities,
+            has_draft=True,
+        ).count()
+        published_num_children = authoring_api.filter_publishable_entities(
+            collection.entities,
+            has_published=True,
+        ).count()
+
         doc.update({
             Fields.context_key: str(library_key),
             Fields.org: str(library_key.org),
@@ -495,7 +505,10 @@ def searchable_doc_for_collection(
             Fields.description: collection.description,
             Fields.created: collection.created.timestamp(),
             Fields.modified: collection.modified.timestamp(),
-            Fields.num_children: collection.entities.count(),
+            Fields.num_children: draft_num_children,
+            Fields.published: {
+                Fields.published_num_children: published_num_children,
+            },
             Fields.access_id: _meili_access_id_from_context_key(library_key),
             Fields.breadcrumbs: [{"display_name": collection.learning_package.title}],
         })

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -199,6 +199,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": created_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
 
@@ -473,6 +476,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": created_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_collection2_created = {
@@ -488,6 +494,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": created_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_collection2_updated = {
@@ -503,6 +512,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": updated_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_collection1_updated = {
@@ -518,6 +530,9 @@ class TestSearchApi(ModuleStoreTestCase):
             "created": created_date.timestamp(),
             "modified": updated_date.timestamp(),
             "access_id": lib_access.id,
+            "published": {
+                "num_children": 0
+            },
             "breadcrumbs": [{"display_name": "Library"}],
         }
         doc_problem_with_collection1 = {

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -443,5 +443,37 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             'tags': {
                 'taxonomy': ['Difficulty'],
                 'level0': ['Difficulty > Normal']
+            },
+            "published": {
+                "num_children": 0
+            }
+        }
+
+    def test_collection_with_published_library(self):
+        library_api.publish_changes(self.library.key)
+
+        doc = searchable_doc_for_collection(self.library.key, self.collection.key)
+        doc.update(searchable_doc_tags_for_collection(self.library.key, self.collection.key))
+
+        assert doc == {
+            "id": "lib-collectionedx2012_falltoy_collection-d1d907a4",
+            "block_id": self.collection.key,
+            "usage_key": self.collection_usage_key,
+            "type": "collection",
+            "org": "edX",
+            "display_name": "Toy Collection",
+            "description": "my toy collection description",
+            "num_children": 1,
+            "context_key": "lib:edX:2012_Fall",
+            "access_id": self.library_access_id,
+            "breadcrumbs": [{"display_name": "some content_library"}],
+            "created": 1680674828.0,
+            "modified": 1680674828.0,
+            'tags': {
+                'taxonomy': ['Difficulty'],
+                'level0': ['Difficulty > Normal']
+            },
+            "published": {
+                "num_children": 1
             }
         }

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -82,6 +82,7 @@ from openedx_events.content_authoring.data import (
     ContentLibraryData,
     LibraryBlockData,
     LibraryCollectionData,
+    ContentObjectChangedData,
 )
 from openedx_events.content_authoring.signals import (
     CONTENT_LIBRARY_CREATED,
@@ -91,6 +92,7 @@ from openedx_events.content_authoring.signals import (
     LIBRARY_BLOCK_DELETED,
     LIBRARY_BLOCK_UPDATED,
     LIBRARY_COLLECTION_UPDATED,
+    CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
 )
 from openedx_learning.api import authoring as authoring_api
 from openedx_learning.api.authoring_models import (
@@ -698,7 +700,11 @@ def _get_library_component_tags_count(library_key) -> dict:
     return get_object_tag_counts(library_key_pattern, count_implicit=True)
 
 
-def get_library_components(library_key, text_search=None, block_types=None) -> QuerySet[Component]:
+def get_library_components(
+    library_key,
+    text_search=None,
+    block_types=None,
+) -> QuerySet[Component]:
     """
     Get the library components and filter.
 
@@ -714,6 +720,7 @@ def get_library_components(library_key, text_search=None, block_types=None) -> Q
         type_names=block_types,
         draft_title=text_search,
     )
+
     return components
 
 
@@ -1116,14 +1123,30 @@ def delete_library_block(usage_key, remove_from_parent=True):
     Delete the specified block from this library (soft delete).
     """
     component = get_component_from_usage_key(usage_key)
+    library_key = usage_key.context_key
+    affected_collections = authoring_api.get_entity_collections(component.learning_package_id, component.key)
+
     authoring_api.soft_delete_draft(component.pk)
 
     LIBRARY_BLOCK_DELETED.send_event(
         library_block=LibraryBlockData(
-            library_key=usage_key.context_key,
+            library_key=library_key,
             usage_key=usage_key
         )
     )
+
+    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
+    # collection indexing asynchronously.
+    #
+    # To delete the component on collections
+    for collection in affected_collections:
+        LIBRARY_COLLECTION_UPDATED.send_event(
+            library_collection=LibraryCollectionData(
+                library_key=library_key,
+                collection_key=collection.key,
+                background=True,
+            )
+        )
 
 
 def get_library_block_static_asset_files(usage_key) -> list[LibraryXBlockStaticFile]:
@@ -1358,6 +1381,39 @@ def revert_changes(library_key):
             update_blocks=True
         )
     )
+
+    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
+    # collection indexing asynchronously.
+    #
+    # This is to update component counts in all library collections,
+    # because there may be components that have been discarded in the revert.
+    for collection in authoring_api.get_collections(learning_package.id):
+        LIBRARY_COLLECTION_UPDATED.send_event(
+            library_collection=LibraryCollectionData(
+                library_key=library_key,
+                collection_key=collection.key,
+                background=True,
+            )
+        )
+
+    # Reindex components that are in collections
+    #
+    # Use case: When a component that was within a collection has been deleted
+    # and the changes are reverted, the component should appear in the
+    # collection again.
+    components_in_collections = authoring_api.get_components(
+        learning_package.id, draft=True, namespace='xblock.v1',
+    ).filter(publishable_entity__collections__isnull=False)
+
+    for component in components_in_collections:
+        usage_key = library_component_usage_key(library_key, component)
+
+        CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
+            content_object=ContentObjectChangedData(
+                object_id=str(usage_key),
+                changes=["collections"],
+            ),
+        )
 
 
 def create_library_collection(

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1042,7 +1042,6 @@ def import_staged_content_from_user_clipboard(library_key: LibraryLocatorV2, use
                 component_version.pk,
                 content.id,
                 key=filename,
-                learner_downloadable=True,
             )
 
     # Emit library block created event
@@ -1112,7 +1111,6 @@ def _create_component_for_block(content_lib, usage_key, user_id=None):
             component_version.pk,
             content.id,
             key="block.xml",
-            learner_downloadable=False
         )
 
         return component_version

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -1204,7 +1204,6 @@ def get_component_version_asset(request, component_version_uuid, asset_path):
         component_version_uuid,
         asset_path,
         public=False,
-        learner_downloadable_only=False,
     )
 
     # If there was any error, we return that response because it will have the

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -15,7 +15,6 @@
 # Note: Changes to this file will automatically be used by other repos, referencing
 #  this file from Github directly. It does not require packaging in edx-lint.
 
-
 # using LTS django version
 Django<5.0
 
@@ -25,13 +24,6 @@ Django<5.0
 elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-
-# Cause: https://github.com/openedx/event-tracking/pull/290
-# event-tracking 2.4.1 upgrades to pymongo 4.4.0 which is not supported on edx-platform.
-# We will pin event-tracking to do not break existing installations
-# This can be unpinned once https://github.com/openedx/edx-platform/issues/34586
-# has been resolved and edx-platform is running with pymongo>=4.4.0
-
 
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -146,7 +146,7 @@ optimizely-sdk<5.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.16.1
+openedx-learning==0.18.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -825,7 +825,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.1
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1376,7 +1376,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.1
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -986,7 +986,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.1
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1037,7 +1037,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-learning==0.16.1
+openedx-learning==0.18.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Fixed component counter synchronization and adds a published > num_counts field in collections in the search index.

Cherry-picked from these commits:
-  https://github.com/openedx/edx-platform/commit/d5850c812cd7e46acc701ace791e23f69c9fc74c
-  https://github.com/openedx/edx-platform/commit/d19707793bacb44c9493844844f21ba3ca499e0e

Backport of https://github.com/openedx/edx-platform/pull/35734