### PR TITLE
fix: render library assets named xblock-...

### DIFF
--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -11,7 +11,7 @@ from opaque_keys.edx.locator import AssetLocator
 from xmodule.contentstore.content import StaticContent
 
 log = logging.getLogger(__name__)
-XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock'
+XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock/'
 
 
 def _url_replace_regex(prefix):

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -89,7 +89,11 @@ def test_process_url_no_match():
 def test_process_url_no_match_starts_with_xblock():
     def processor(original, prefix, quote, rest):  # pylint: disable=unused-argument, redefined-outer-name
         return quote + 'test' + prefix + rest + quote
-    assert process_static_urls('"/static/xblock-file.png"', processor, data_dir=DATA_DIRECTORY) == '"test/static/xblock-file.png"'
+    assert process_static_urls(
+        '"/static/xblock-file.png"',
+        processor,
+        data_dir=DATA_DIRECTORY
+    ) == '"test/static/xblock-file.png"'
 
 
 @patch('django.http.HttpRequest', autospec=True)

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -85,6 +85,7 @@ def test_process_url_no_match():
 
     assert process_static_urls(STATIC_SOURCE, processor) == '"test/static/file.png"'
 
+
 def test_process_url_no_match_starts_with_xblock():
     def processor(original, prefix, quote, rest):  # pylint: disable=unused-argument, redefined-outer-name
         return quote + 'test' + prefix + rest + quote

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -85,6 +85,11 @@ def test_process_url_no_match():
 
     assert process_static_urls(STATIC_SOURCE, processor) == '"test/static/file.png"'
 
+def test_process_url_no_match_starts_with_xblock():
+    def processor(original, prefix, quote, rest):  # pylint: disable=unused-argument, redefined-outer-name
+        return quote + 'test' + prefix + rest + quote
+    assert process_static_urls('"/static/xblock-file.png"', processor, data_dir=DATA_DIRECTORY) == '"test/static/xblock-file.png"'
+
 
 @patch('django.http.HttpRequest', autospec=True)
 def test_static_urls(mock_request):

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import datetime, timezone
+from urllib.parse import unquote
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.transaction import atomic
@@ -449,9 +450,20 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
                 .get(key=f"static/{asset_path}")
             )
         except ObjectDoesNotExist:
-            # This means we see a path that _looks_ like it should be a static
-            # asset for this Component, but that static asset doesn't really
-            # exist.
-            return None
+            try:
+                # Retry with unquoted path. We don't always unquote because it would not
+                # be backwards-compatible, but we need to try both.
+                asset_path = unquote(asset_path)
+                content = (
+                    component_version
+                    .componentversioncontent_set
+                    .filter(content__has_file=True)
+                    .get(key=f"static/{asset_path}")
+                )
+            except ObjectDoesNotExist:
+                # This means we see a path that _looks_ like it should be a static
+                # asset for this Component, but that static asset doesn't really
+                # exist.
+                return None
 
         return self._absolute_url_for_asset(component_version, asset_path)

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import datetime, timezone
-from urllib.parse import unquote
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.transaction import atomic
@@ -450,20 +449,9 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
                 .get(key=f"static/{asset_path}")
             )
         except ObjectDoesNotExist:
-            try:
-                # Retry with unquoted path. We don't always unquote because it would not
-                # be backwards-compatible, but we need to try both.
-                asset_path = unquote(asset_path)
-                content = (
-                    component_version
-                    .componentversioncontent_set
-                    .filter(content__has_file=True)
-                    .get(key=f"static/{asset_path}")
-                )
-            except ObjectDoesNotExist:
-                # This means we see a path that _looks_ like it should be a static
-                # asset for this Component, but that static asset doesn't really
-                # exist.
-                return None
+            # This means we see a path that _looks_ like it should be a static
+            # asset for this Component, but that static asset doesn't really
+            # exist.
+            return None
 
         return self._absolute_url_for_asset(component_version, asset_path)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Due to static url replacement logic being too open, if you name your static asset "xblock-*", the platform fails to render those images.

![image](https://github.com/user-attachments/assets/446a0bb5-16bd-4784-bfd7-a69c2d0b5b31)
 
This PR makes the matching more strict so it lets assets that start with "xblock" to be rendered correctly.

## Supporting information

Issue: https://github.com/openedx/edx-platform/issues/35853
Private-Ref: https://tasks.opencraft.com/browse/FAL-3966

## Testing instructions

(Make sure you are running the latest frontend-app-authoring changes, and if it still doesn't work try running provisioning)

1. create a text xblock
2. upload any image that starts with 'xblock'
3. assert that once you save, the image gets rendered correctly
![image](https://github.com/user-attachments/assets/548ba957-3573-4b72-a338-c7a0a4e27d27)
![image](https://github.com/user-attachments/assets/855a9001-9b06-461b-93b4-0e916359c9ae)



## Deadline

None
