### PR TITLE
fix: Handle empty course_overviews in get_courses_order_by function

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -46,6 +46,31 @@ class HomePageCoursesViewV2Test(CourseTestCase):
             end=(datetime.now() - timedelta(days=365)).replace(tzinfo=pytz.UTC),
         )
 
+    def test_no_courses_non_staff_user(self):
+        """Get list of courses when there are no courses available.
+
+        Expected result:
+        - An empty list of courses available to the logged in user.
+        """
+        client, _ = self.create_non_staff_authed_user_client()
+        CourseOverviewFactory._meta.model.objects.all().delete()
+        response = client.get(self.api_v2_url, {"order": "display_name"})
+
+        expected_data = {
+            "courses": [],
+            "in_process_course_actions": [],
+        }
+        expected_response = OrderedDict([
+            ('count', 0),
+            ('num_pages', 1),
+            ('next', None),
+            ('previous', None),
+            ('results', expected_data),
+        ])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(expected_response, response.data)
+
     def test_home_page_response(self):
         """Get list of courses available to the logged in user.
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -621,7 +621,7 @@ def get_courses_order_by(order_query, course_overviews):
         order_query (str): any string used to order Course Overviews.
         course_overviews (Course Overview objects): queryset to be ordered.
     """
-    if not order_query:
+    if not (order_query and course_overviews):
         return course_overviews
     try:
         return course_overviews.order_by(order_query)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This pull request fixes an issue in the `get_courses_order_by` function where an empty list is passed as a course_overviews throws an error. Previously, the function attempted to call `order_by()` on an empty list, leading to unexpected crashes. This change ensures that the function explicitly checks if `course_overviews` is empty and returns an empty list in such cases.

**Changes Made**
- Added a condition to return an empty list if course_overviews is None or empty.
- Improved the robustness of the function to handle edge cases gracefully. 

```
2024-12-02 13:35:13,362 ERROR 378 [django.request] [user None] [ip None] log.py:241 - Internal Server Error: /api/contentstore/v2/home/courses
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/rest_api/v2/views/home.py", line 136, in get
    courses, in_process_course_actions = get_course_context_v2(request)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/utils.py", line 1666, in get_course_context_v2
    courses_iter, in_process_course_actions = get_courses_accessible_to_user(request, org)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/views/course.py", line 770, in get_courses_accessible_to_user
    courses, in_process_course_actions = _accessible_courses_list_from_groups(request)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/views/course.py", line 580, in _accessible_courses_list_from_groups
    courses_list = get_filtered_and_ordered_courses(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/views/course.py", line 485, in get_filtered_and_ordered_courses
    course_overviews = get_courses_order_by(order, course_overviews)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/views/course.py", line 627, in get_courses_order_by
    return course_overviews.order_by(order_query)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'order_by'
[02/Dec/2024 13:35:13] "GET /api/contentstore/v2/home/courses?page=1&order=display_name HTTP/1.1" 500 304112
```
![image](https://github.com/user-attachments/assets/a09835f2-6d55-4199-b9f0-9b007b34a28e)


## Supporting information

This fixes the following traceback error:

```
return course_overviews.order_by(order_query)
AttributeError: 'list' object has no attribute 'order_by'
```
The error occurred during course filtering and sorting operations in the CMS, where an invalid or empty course_overviews queryset caused the failure.

## Testing instructions

### Steps to Reproduce the Error:
1. Create a non-staff user through the registration page.
2. Access Studio; you will be redirected to course-authoring/home.
3. During an API call to `api/contentstore/v2/home/courses?page=1&order=display_name`, an error message will appear stating: "Failed to fetch courses. Please try again later."

### After Incorporating PR Changes:
1. Repeat the same steps after applying the PR changes.
2. Verify that the page loads correctly without errors and displays a component for adding a course or becoming a course instructor.

## Deadline

None

## Other information

- This change does not introduce migrations, security issues, or deprecations.
- No configuration changes are required.