### PR TITLE
fix: downgrade karma-spec-reporter to fix JS test logging

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,11 @@
   // When adding an ignoreDep, please include a reason and a public link that we can use to follow up and ensure
   // that the ignoreDep is removed.
   // This can be done as a comment within the ignoreDeps list.
-  "ignoreDeps": [],
+  "ignoreDeps": [
+    // karma-spec-reporter>0.20.0 does not seem compatible with our super-old 2016 Karma version (0.13.22).
+    // Ticket link: None, as upgrading Karma does not strike as worth the benefit.
+    "karma-spec-reporter"
+  ],
   "timezone": "America/New_York",
   "prConcurrentLimit": 3,
   "enabledManagers": ["npm"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "karma-requirejs": "1.1.0",
         "karma-selenium-webdriver-launcher": "github:openedx/karma-selenium-webdriver-launcher#0.0.4-openedx.0",
         "karma-sourcemap-loader": "0.4.0",
-        "karma-spec-reporter": "0.0.36",
+        "karma-spec-reporter": "0.0.20",
         "karma-webpack": "^5.0.1",
         "plato": "1.7.0",
         "react-test-renderer": "16.14.0",
@@ -17139,16 +17139,24 @@
       }
     },
     "node_modules/karma-spec-reporter": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.36.tgz",
-      "integrity": "sha512-11bvOl1x6ryKZph7kmbmMpbi8vsngEGxGOoeTlIcDaH3ab3j8aPJnZ+r+K/SS0sBSGy5VGkGYO2+hLct7hw/6w==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.20.tgz",
+      "integrity": "sha512-pl+KmLNwnu802F/q9cZx5n20FuxA0ebwM3uMuy4Qh+GGfviy4EFK8I5Bl2cWogSRBUC2Fhg5oOsUFVlv/j5tuA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "colors": "1.4.0"
+        "colors": "~0.6.0"
       },
       "peerDependencies": {
         "karma": ">=0.9"
+      }
+    },
+    "node_modules/karma-spec-reporter/node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/karma-webpack": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "karma-requirejs": "1.1.0",
     "karma-selenium-webdriver-launcher": "github:openedx/karma-selenium-webdriver-launcher#0.0.4-openedx.0",
     "karma-sourcemap-loader": "0.4.0",
-    "karma-spec-reporter": "0.0.36",
+    "karma-spec-reporter": "0.0.20",
     "karma-webpack": "^5.0.1",
     "plato": "1.7.0",
     "react-test-renderer": "16.14.0",


### PR DESCRIPTION
## Description

The karma-spec-reporter npm package is a Karma plugin which tells Karma to print the name of each spec (e.g. test case). This is extremely useful as a maintainer to be able to visually inspect the CI logs and confirm that we are actually running JS tests and not just giving false-positives.

We are stuck on an ancient Karma version (0.13.22, lastest is 6.x), which seems to be incompatible with the latest karma-spec-reporter version (0.0.36). Since upgrading karma-spec-reporter, spec name printing has failed with:

    02 12 2024 20:59:28.164:WARN [plugin]: Error during loading "karma-spec-reporter" plugin:
      Cannot read properties of undefined (reading 'LOG_PRIORITIES')

Downgrading to karma-spec-reporter@0.0.20 eliminates this error and restoring spec name printing to our JS CI logs.

## Context

This is one of the several existing CI issues we have encountered while [removing paver from edx-platform CI](https://github.com/openedx/edx-platform/pull/35159).

## Testing

 Just compare the logs of "Javascript tests / JS / Run JS Tests" CI step with those on master.

### this pr

![image](https://github.com/user-attachments/assets/27ef2b24-cb84-44bf-830f-32a7906177ce)

### master 
![image](https://github.com/user-attachments/assets/c66cb7fe-cc2f-44b1-b314-dca815dd716c)

## Merge Considerations

Open Q for reviewers: **How do we prevent renovate from repeating [the same upgrade](https://github.com/openedx/edx-platform/pull/34953) in the future?**
