### PR TITLE
chore: iframe rendering optimization

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -138,6 +138,7 @@ function($, _, Backbone, gettext, BasePage,
                     if (!data) return;
 
                     const xblockElement = this.findXBlockElement(this.targetXBlock);
+                    const xblockWrapper = $("li.studio-xblock-wrapper[data-locator='" + data.payload.locator + "']");
 
                     switch (data.type) {
                     case 'refreshXBlock':
@@ -146,6 +147,13 @@ function($, _, Backbone, gettext, BasePage,
                     case 'completeManageXBlockAccess':
                         this.refreshXBlock(xblockElement, false);
                         break;
+                    case 'completeXBlockMoving':
+                      xblockWrapper.hide()
+                      break;
+                    case 'rollbackMovedXBlock':
+                      xblockWrapper.show()
+                      break;
+                    case 'updateXBlockName':
                     case 'addXBlock':
                         this.createComponent(this, xblockElement, event.data);
                         break;
@@ -217,6 +225,25 @@ function($, _, Backbone, gettext, BasePage,
                         target.scrollIntoView({ behavior: 'smooth', inline: 'center' });
                     }
 
+                    if (self.options.isIframeEmbed) {
+                        const scrollOffset = parseInt(localStorage.getItem('modalEditLastYPosition'));
+                        if (localStorage.getItem('modalEditLastYPosition')) {
+                        try {
+                            setTimeout(() => {
+                                window.parent.postMessage(
+                                    {
+                                        type: 'scrollToXBlock',
+                                        message: 'Scroll to XBlock',
+                                        payload: {scrollOffset}
+                                    }, document.referrer
+                                );
+                            localStorage.removeItem('modalEditLastYPosition');
+                            }, 1000);
+                        } catch (e) {
+                            console.error(e);
+                        }
+                    }
+                  }
                 },
                 block_added: options && options.block_added
             });
@@ -455,6 +482,7 @@ function($, _, Backbone, gettext, BasePage,
 
                     try {
                         if (this.options.isIframeEmbed) {
+                            localStorage.setItem('modalEditLastYPosition', event.clientY.toString());
                             return window.parent.postMessage(
                                 {
                                     type: 'newXBlockEditor',


### PR DESCRIPTION
🚨 **Dependencies:**
- 🔗 [frontend-app-authoring PR](https://github.com/openedx/frontend-app-authoring/pull/1544)

## Description

This PR provides iframe reload optimizations for various xblock related actions. Added some improvements related to scrolling to the current xblock. Fixed behavior of the xblock action dropdown list.

## Testing instructions

1. Open New Course Unit page.
2. When duplicating a block, a scroll to a new copy of the block occurs.
3. Delete, duplicate, drag xblock - a full iframe reboot should not occur.
4. Open a new xblock editor, save the changes - after returning to the course unit page, the page should scroll to the xblock for which the changes were made.

https://github.com/user-attachments/assets/c9fa0f0a-5b5d-48a8-b443-c5dd8e040c19

## Other information

Improvements to the editing modals and tagging will be added in future PRs.
