### PR TITLE
refactor: Removed unused django setting.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5372,12 +5372,6 @@ COOL_OFF_DAYS = 14
 ############ Settings for externally hosted executive education courses ############
 EXEC_ED_LANDING_PAGE = "https://www.getsmarter.com/account"
 
-############## PLOTLY ##############
-
-ENTERPRISE_PLOTLY_SECRET = "I am a secret"
-
-############## PLOTLY ##############
-
 ############ Internal Enterprise Settings ############
 ENTERPRISE_VSF_UUID = "e815503343644ac7845bc82325c34460"
 ############ Internal Enterprise Settings ############


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Enterprise version of Plotly has been removed from admin portal. Relevant code was removed from edx-enterprise in https://github.com/openedx/edx-enterprise/pull/2295/files since the use of Django setting `ENTERPRISE_PLOTLY_SECRET` has also been removed we do not need the Django setting in edx-platform either.


## Supporting information

1. https://github.com/openedx/edx-enterprise/pull/2297
2. https://github.com/openedx/edx-enterprise/pull/2295
3. https://2u-internal.atlassian.net/browse/ENT-9612
