### PR TITLE
feat: make course optimizer scan only published version

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
@@ -64,7 +64,7 @@ class LinkCheckView(DeveloperErrorViewMixin, APIView):
         if not has_studio_read_access(request.user, course_key):
             self.permission_denied(request)
 
-        check_broken_links.delay(request.user.id, course_key_string, request.LANGUAGE_CODE)
+        check_broken_links.delay(request.user.id, course_id, request.LANGUAGE_CODE)
         return JsonResponse({'LinkCheckStatus': UserTaskStatus.PENDING})
 
 
@@ -180,8 +180,10 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
                     except ValueError:
                         # Wasn't JSON, just use the value as a string
                         pass
+
         # print('DTO')
         # print(broken_links_dto)
+
         # mock dto for testing
         # broken_links_dto = {
         #     'sections': [

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1166,7 +1166,8 @@ def check_broken_links(self, user_id, course_key_string, language):
           [<block_id>, <broken_link>]
         """
         broken_links = []
-        verticals = modulestore().get_items(course_key, qualifiers={'category': 'vertical'})
+        verticals = modulestore().get_items(course_key, qualifiers={'category': 'vertical'}, revision=ModuleStoreEnum.RevisionOption.published_only)
+        print('verticals: ', verticals)
         blocks = []
 
         for vertical in verticals:
@@ -1187,7 +1188,7 @@ def check_broken_links(self, user_id, course_key_string, language):
                     broken_links.append([str(usage_key), url])
 
         return broken_links
-    
+
     user = validate_user()
 
     self.status.set_state('Scanning')


### PR DESCRIPTION
Part of 2u/course-optimizer feature branch. PR target: feature branch. Does not require additional description.

I found some kind of bug in my course where the optimizer returned a block with no broken links. I think it might just return the whole unit if there's a broken link in it? Not sure.

Probably this is from the main feature branch, unless I broke this.