### PR TITLE
fix: render library v2 assets with whitespace

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -63,6 +63,13 @@ class ContentLibrariesStaticAssetsTest(ContentLibrariesRestApiTest):
         file_name = "a////////b"
         self._set_library_block_asset(block_id, file_name, SVG_DATA, expect_response=400)
 
+        # Names with spaces are allowed but replaced with underscores
+        file_name_with_space = "o w o.svg"
+        self._set_library_block_asset(block_id, file_name_with_space, SVG_DATA)
+        file_name = "o_w_o.svg"
+        assert self._get_library_block_asset(block_id, file_name)['path'] == file_name
+        assert self._get_library_block_asset(block_id, file_name)['size'] == file_size
+
     def test_video_transcripts(self):
         """
         Test that video blocks can read transcript files out of learning core.

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -799,6 +799,7 @@ class LibraryBlockAssetView(APIView):
         """
         Replace a static asset file belonging to this block.
         """
+        file_path = file_path.replace(" ", "_")  # Messes up url/name correspondence due to URL encoding.
         usage_key = LibraryUsageLocatorV2.from_string(usage_key_str)
         api.require_permission_for_library_key(
             usage_key.lib_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,


### PR DESCRIPTION
## Description

Assets that contain whitespace fail to be rendered when uploaded to library v2. 

## Supporting information

* Context: https://github.com/openedx/edx-platform/pull/35910#discussion_r1872211540

## Testing instructions

(Make sure you are running the latest frontend-app-authoring changes, and if it still doesn't work try running provisioning)

1. create a text xblock
2. upload any image that contains spaces in their name (eg."hi there.png")
3. assert that once you save, the image gets rendered correctly

## Deadline

ASAP

## Other information

Extracted from: https://github.com/openedx/edx-platform/pull/35910 
[Private-Ref](https://tasks.opencraft.com/browse/FAL-3997)
