### PR TITLE
feat: add schedule queryset request filter integration

### DIFF
--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from edx_ace.recipient import Recipient
 from edx_ace.recipient_resolver import RecipientResolver
 from edx_django_utils.monitoring import function_trace, set_custom_attribute
+from openedx_filters.learning.filters import ScheduleQuerySetRequested
 
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link, can_show_verified_upgrade
 from lms.djangoapps.discussion.notification_prefs.views import UsernameCipher
@@ -153,6 +154,13 @@ class BinnedSchedulesBaseResolver(PrefixedDebugLoggerMixin, RecipientResolver):
         ).order_by(order_by)
 
         schedules = self.filter_by_org(schedules)
+
+        try:
+            # .. filter_implemented_name: ScheduleQuerySetRequested
+            # .. filter_type: org.openedx.learning.schedule.queryset.requested.v1
+            schedules = ScheduleQuerySetRequested.run_filter(schedules)
+        except ScheduleQuerySetRequested.PreventScheduleQuerysetRequest as exc:
+            schedules = exc.schedules
 
         if "read_replica" in settings.DATABASES:
             schedules = schedules.using("read_replica")

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -155,12 +155,9 @@ class BinnedSchedulesBaseResolver(PrefixedDebugLoggerMixin, RecipientResolver):
 
         schedules = self.filter_by_org(schedules)
 
-        try:
-            # .. filter_implemented_name: ScheduleQuerySetRequested
-            # .. filter_type: org.openedx.learning.schedule.queryset.requested.v1
-            schedules = ScheduleQuerySetRequested.run_filter(schedules)
-        except ScheduleQuerySetRequested.PreventScheduleQuerysetRequest as exc:
-            schedules = exc.schedules
+        # .. filter_implemented_name: ScheduleQuerySetRequested
+        # .. filter_type: org.openedx.learning.schedule.queryset.requested.v1
+        schedules = ScheduleQuerySetRequested.run_filter(schedules)
 
         if "read_replica" in settings.DATABASES:
             schedules = schedules.using("read_replica")

--- a/openedx/core/djangoapps/schedules/tests/test_filters.py
+++ b/openedx/core/djangoapps/schedules/tests/test_filters.py
@@ -5,18 +5,20 @@ Test cases for the Open edX Filters associated with the schedule app.
 import datetime
 from unittest.mock import Mock
 
-from django.test import TestCase, override_settings
+from django.db.models.query import QuerySet
+from django.test import override_settings
 from openedx_filters import PipelineStep
 
 from openedx.core.djangoapps.schedules.resolvers import BinnedSchedulesBaseResolver
 from openedx.core.djangoapps.schedules.tests.test_resolvers import SchedulesResolverTestMixin
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
 class TestScheduleQuerySetRequestedPipelineStep(PipelineStep):
     """Pipeline step class to test a configured pipeline step"""
 
-    filtered_schedules = Mock()
+    filtered_schedules = Mock(spec=QuerySet)
 
     def run_filter(self, schedules):  # pylint: disable=arguments-differ
         """Pipeline step to filter the schedules"""
@@ -26,7 +28,7 @@ class TestScheduleQuerySetRequestedPipelineStep(PipelineStep):
 
 
 @skip_unless_lms
-class ScheduleQuerySetRequestedFiltersTest(SchedulesResolverTestMixin, TestCase):
+class ScheduleQuerySetRequestedFiltersTest(SchedulesResolverTestMixin, ModuleStoreTestCase):
     """
     Tests for the Open edX Filters associated with the schedule queryset requested.
 
@@ -41,7 +43,7 @@ class ScheduleQuerySetRequestedFiltersTest(SchedulesResolverTestMixin, TestCase)
             site=self.site,
             target_datetime=datetime.datetime.now(),
             day_offset=3,
-            bin_num=2,
+            bin_num=1,
         )
 
     @override_settings(

--- a/openedx/core/djangoapps/schedules/tests/test_filters.py
+++ b/openedx/core/djangoapps/schedules/tests/test_filters.py
@@ -1,0 +1,61 @@
+"""
+Test cases for the Open edX Filters associated with the schedule app.
+"""
+
+import datetime
+from unittest.mock import Mock
+
+from django.test import TestCase, override_settings
+from openedx_filters import PipelineStep
+
+from openedx.core.djangoapps.schedules.resolvers import BinnedSchedulesBaseResolver
+from openedx.core.djangoapps.schedules.tests.test_resolvers import SchedulesResolverTestMixin
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+class TestScheduleQuerySetRequestedPipelineStep(PipelineStep):
+    """Pipeline step class to test a configured pipeline step"""
+
+    filtered_schedules = Mock()
+
+    def run_filter(self, schedules):  # pylint: disable=arguments-differ
+        """Pipeline step to filter the schedules"""
+        return {
+            "schedules": self.filtered_schedules,
+        }
+
+
+@skip_unless_lms
+class ScheduleQuerySetRequestedFiltersTest(SchedulesResolverTestMixin, TestCase):
+    """
+    Tests for the Open edX Filters associated with the schedule queryset requested.
+
+    The following filters are tested:
+    - ScheduleQuerySetRequested
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.resolver = BinnedSchedulesBaseResolver(
+            async_send_task=Mock(name="async_send_task"),
+            site=self.site,
+            target_datetime=datetime.datetime.now(),
+            day_offset=3,
+            bin_num=2,
+        )
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.schedule.queryset.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.schedules.tests.test_filters.TestScheduleQuerySetRequestedPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_schedule_queryset_requested_filter(self) -> None:
+        """Test to verify the schedule queryset was modified by the pipeline step."""
+        schedules = self.resolver.get_schedules_with_target_date_by_bin_and_orgs()
+
+        self.assertEqual(TestScheduleQuerySetRequestedPipelineStep.filtered_schedules, schedules)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -836,7 +836,7 @@ openedx-events==9.15.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.12.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1390,7 +1390,7 @@ openedx-events==9.15.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.12.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1005,7 +1005,7 @@ openedx-events==9.15.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.12.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1050,7 +1050,7 @@ openedx-events==9.15.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.11.0
+openedx-filters==1.12.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock


### PR DESCRIPTION
## Description

This PR introduces the integration of a new openedx-filter (`ScheduleQuerySetRequested`) designed to provide an intermediate point to perform more specific filtering on the Schedules QuerySet.

### Use Case Example
A practical example of its application is in NAU, where this filter will be used in a [specific pipeline](https://github.com/fccn/nau-openedx-extensions/pull/56). Currently, when the _Schedule Emails_ feature is enabled, learners receive emails by default without the option to disable it. With this new filter, it becomes possible to customize the behavior by applying additional filtering to include only learners who meet certain conditions, such as having the `allow_newsletter` field equal to `True`.

### Benefits:
- **Greater Control**: Enables fine-tuning of Schedules QuerySets to meet specific project or client requirements.
- **Flexibility**: Facilitates the implementation of custom rules without altering the platform's default logic.
- **Scalability**: This intermediate point is reusable for similar use cases in the future.

## Supporting information

- The filter definition in: https://github.com/openedx/openedx-filters/pull/235
- A filter pipeline example in: https://github.com/fccn/nau-openedx-extensions/pull/56

## Testing instructions

1. Create a Tutor environment.
2. Create a mount of `edx-platform` with the changes in [this branch](https://github.com/eduNEXT/edx-platform/tree/bav/schedule-queryset-filter-integration-debugging) _(For testing purposes_).
3. Install `nau-openedx-extensions` plugin with the changes in [this PR](https://github.com/fccn/nau-openedx-extensions/pull/56). :warning: Don't forget to run migrations.
4. Install `openedx-filters` with the changes in [this PR](https://github.com/openedx/openedx-filters/pull/235).
5. Create a new Schedule config for your site in `{lms_domain}/admin/schedules/scheduleconfig/`
   
    ![image](https://github.com/user-attachments/assets/22fa9c02-c334-46eb-9f82-e794c48ec684)
6. Create some users and enroll them in a course.
7. Create an NAU user extended model for each user in `{lms_domain}/admin/nau_openedx_extensions/nauuserextendedmodel/`. Update the following field, depending on whether you want to receive the newsletter.

    ![image](https://github.com/user-attachments/assets/13edefc4-f661-472c-884f-b1fa73978b66)
8. Create a Tutor inline plugin with the filter configuration:

    ```yml
    name: filter-settings
    version: 0.1.0
    patches:
      openedx-common-settings: |
        OPEN_EDX_FILTERS_CONFIG = {
          "org.openedx.learning.schedule.queryset.requested.v1": {
            "fail_silently": False,
            "pipeline": [
              "nau_openedx_extensions.filters.pipeline.FilterUsersWithAllowedNewsletter",
            ],
          },
        }
    ```
9. Send a message of recurring nudge using the following command in the LMS container:

    ```bash
    python manage.py lms send_recurring_nudge {site} --date {enroll-date + 3 days}
   # Example
    python manage.py lms send_recurring_nudge local.edly.io:8000 --date 2024-12-07
    ```
10. Depending on the value of each user's `allow_newsletter` field, you should see the filtered QuerySet of `Schedules` in the console. For example, here the Schedule was filtered because the user does not have the field set to **True**

    ![image](https://github.com/user-attachments/assets/85e9b6b3-a3c5-4ef5-ae46-ea1807a2d8d9)

## Deadline

None

## Other information

> [!IMPORTANT]
> The PR in openedx-filters should be merged before this one.
> - https://github.com/openedx/openedx-filters/pull/235 
