### PR TITLE
Allow for Extracted Word Cloud Block | Fix Test Cases

### DIFF
--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -138,11 +138,11 @@ class BaseTestXmodule(ModuleStoreTestCase):
         self.setup_course()
         self.initialize_module(metadata=self.METADATA, data=self.DATA)
 
-    def get_url(self, dispatch):
+    def get_url(self, dispatch, handler_name='xmodule_handler'):
         """Return item url with dispatch."""
         return reverse(
             'xblock_handler',
-            args=(str(self.course.id), quote_slashes(self.item_url), 'xmodule_handler', dispatch)
+            args=(str(self.course.id), quote_slashes(self.item_url), handler_name, dispatch)
         )
 
 

--- a/lms/djangoapps/courseware/tests/test_word_cloud.py
+++ b/lms/djangoapps/courseware/tests/test_word_cloud.py
@@ -1,15 +1,17 @@
 """Word cloud integration tests using mongo modulestore."""
-
+import json
+import re
+from operator import itemgetter
+from unittest.mock import patch
+from uuid import UUID
 
 import pytest
+from django.conf import settings
 
-import json
-from operator import itemgetter
-
+from common.djangoapps.student.tests.factories import RequestFactoryNoCsrf
 # noinspection PyUnresolvedReferences
-from xmodule.tests.helpers import override_descriptor_system  # pylint: disable=unused-import
+from xmodule.tests.helpers import override_descriptor_system, mock_render_template  # pylint: disable=unused-import
 from xmodule.x_module import STUDENT_VIEW
-
 from .helpers import BaseTestXmodule
 
 
@@ -17,6 +19,10 @@ from .helpers import BaseTestXmodule
 class TestWordCloud(BaseTestXmodule):
     """Integration test for Word Cloud Block."""
     CATEGORY = "word_cloud"
+
+    def setUp(self):
+        super().setUp()
+        self.request_factory = RequestFactoryNoCsrf()
 
     def _get_users_state(self):
         """Return current state for each user:
@@ -27,7 +33,18 @@ class TestWordCloud(BaseTestXmodule):
         users_state = {}
 
         for user in self.users:
-            response = self.clients[user.username].post(self.get_url('get_state'))
+            if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK:
+                # The extracted Word Cloud XBlock uses @XBlock.json_handler, which expects a different
+                # request format and url pattern
+                handler_url = self.get_url('', handler_name='handle_get_state')
+                response = self.clients[user.username].post(
+                    handler_url,
+                    data=json.dumps({}),
+                    content_type='application/json',
+                    HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+                )
+            else:
+                response = self.clients[user.username].post(self.get_url('get_state'))
             users_state[user.username] = json.loads(response.content.decode('utf-8'))
 
         return users_state
@@ -40,11 +57,22 @@ class TestWordCloud(BaseTestXmodule):
         users_state = {}
 
         for user in self.users:
-            response = self.clients[user.username].post(
-                self.get_url('submit'),
-                {'student_words[]': words},
-                HTTP_X_REQUESTED_WITH='XMLHttpRequest'
-            )
+            if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK:
+                # The extracted Word Cloud XBlock uses @XBlock.json_handler, which expects a different
+                # request format and url pattern
+                handler_url = self.get_url('', handler_name='handle_submit_state')
+                response = self.clients[user.username].post(
+                    handler_url,
+                    data=json.dumps({'student_words': words}),
+                    content_type='application/json',
+                    HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+                )
+            else:
+                response = self.clients[user.username].post(
+                    self.get_url('submit'),
+                    {'student_words[]': words},
+                    HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+                )
             users_state[user.username] = json.loads(response.content.decode('utf-8'))
 
         return users_state
@@ -52,7 +80,6 @@ class TestWordCloud(BaseTestXmodule):
     def _check_response(self, response_contents, correct_jsons):
         """Utility function that compares correct and real responses."""
         for username, content in response_contents.items():
-
             # Used in debugger for comparing objects.
             # self.maxDiff = None
 
@@ -120,7 +147,6 @@ class TestWordCloud(BaseTestXmodule):
 
         correct_state = {}
         for index, user in enumerate(self.users):
-
             correct_state[user.username] = {
                 'status': 'success',
                 'submitted': True,
@@ -202,6 +228,14 @@ class TestWordCloud(BaseTestXmodule):
             for user in self.users
         }
 
+        if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK:
+            # The extracted Word Cloud XBlock uses @XBlock.json_handler to handle AJAX requests,
+            # which automatically returns a 404 for unknown requests, so there's no need to test
+            # the incorrect dispatch case in this scenario.
+            for username, response in responses.items():
+                self.assertEqual(response.status_code, 404)
+            return
+
         status_codes = {response.status_code for response in responses.values()}
         assert status_codes.pop() == 200
 
@@ -214,19 +248,34 @@ class TestWordCloud(BaseTestXmodule):
                 }
             )
 
-    def test_word_cloud_constructor(self):
+    @patch('xblock.utils.resources.ResourceLoader.render_django_template', side_effect=mock_render_template)
+    def test_word_cloud_constructor(self, mock_render_django_template):
         """
         Make sure that all parameters extracted correctly from xml.
         """
         fragment = self.runtime.render(self.block, STUDENT_VIEW)
         expected_context = {
-            'ajax_url': self.block.ajax_url,
             'display_name': self.block.display_name,
             'instructions': self.block.instructions,
-            'element_class': self.block.location.block_type,
-            'element_id': self.block.location.html_id(),
+            'element_class': self.block.scope_ids.block_type,
             'num_inputs': 5,  # default value
             'submitted': False,  # default value,
         }
 
-        assert fragment.content == self.runtime.render_template('word_cloud.html', expected_context)
+        if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK:
+            # If `USE_EXTRACTED_WORD_CLOUD_BLOCK` is enabled, the `expected_context` will be different
+            # because in the extracted Word Cloud XBlock, the expected context:
+            # - contains `range_num_inputs`
+            # - uses `UUID` for `element_id` instead of `html_id()`
+            # - does not include `ajax_url` since it uses the `@XBlock.json_handler` decorator for AJAX requests
+            expected_context['range_num_inputs'] = range(5)
+            uuid_str = re.search(r"UUID\('([a-f0-9\-]+)'\)", fragment.content).group(1)
+            expected_context['element_id'] = UUID(uuid_str)
+            mock_render_django_template.assert_called_once()
+            # Remove i18n service
+            fragment_content_clean = re.sub(r"\{.*?}", "{}", fragment.content)
+            assert fragment_content_clean == self.runtime.render_template('templates/word_cloud.html', expected_context)
+        else:
+            expected_context['ajax_url'] = self.block.ajax_url
+            expected_context['element_id'] = self.block.location.html_id()
+            assert fragment.content == self.runtime.render_template('word_cloud.html', expected_context)

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -680,7 +680,7 @@ PROFILE_IMAGE_SIZES_MAP = {
 # .. toggle_warning: Not production-ready until https://github.com/openedx/edx-platform/issues/34840 is done.
 # .. toggle_creation_date: 2024-11-10
 # .. toggle_target_removal_date: 2025-06-01
-USE_EXTRACTED_WORD_CLOUD_BLOCK = False
+USE_EXTRACTED_WORD_CLOUD_BLOCK = True
 
 # .. toggle_name: USE_EXTRACTED_ANNOTATABLE_BLOCK
 # .. toggle_default: False

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -680,7 +680,7 @@ PROFILE_IMAGE_SIZES_MAP = {
 # .. toggle_warning: Not production-ready until https://github.com/openedx/edx-platform/issues/34840 is done.
 # .. toggle_creation_date: 2024-11-10
 # .. toggle_target_removal_date: 2025-06-01
-USE_EXTRACTED_WORD_CLOUD_BLOCK = True
+USE_EXTRACTED_WORD_CLOUD_BLOCK = False
 
 # .. toggle_name: USE_EXTRACTED_ANNOTATABLE_BLOCK
 # .. toggle_default: False

--- a/xmodule/tests/test_word_cloud.py
+++ b/xmodule/tests/test_word_cloud.py
@@ -94,17 +94,21 @@ class WordCloudBlockTest(TestCase):
         """
         Make sure that answer for incorrect request is error json.
         """
-        if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK:
-            return
-
         module_system = get_test_system()
         block = WordCloudBlock(module_system, DictFieldData(self.raw_field_data), Mock())
 
-        response = json.loads(block.handle_ajax('bad_dispatch', {}))
-        self.assertDictEqual(response, {
-            'status': 'fail',
-            'error': 'Unknown Command!'
-        })
+        if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK:
+            # The extracted Word Cloud XBlock uses @XBlock.json_handler for handling AJAX requests,
+            # which requires a different way of method invocation.
+            with self.assertRaises(AttributeError) as context:
+                json.loads(block.bad_dispatch('bad_dispatch', {}))
+            self.assertIn("'WordCloudBlock' object has no attribute 'bad_dispatch'", str(context.exception))
+        else:
+            response = json.loads(block.handle_ajax('bad_dispatch', {}))
+            self.assertDictEqual(response, {
+                'status': 'fail',
+                'error': 'Unknown Command!'
+            })
 
     def test_good_ajax_request(self):
         """

--- a/xmodule/word_cloud_block.py
+++ b/xmodule/word_cloud_block.py
@@ -318,6 +318,7 @@ class _BuiltInWordCloudBlock(  # pylint: disable=abstract-method
 
 WordCloudBlock = None
 
+
 def reset_class():
     """Reset class as per django settings flag"""
     global WordCloudBlock

--- a/xmodule/word_cloud_block.py
+++ b/xmodule/word_cloud_block.py
@@ -316,8 +316,15 @@ class _BuiltInWordCloudBlock(  # pylint: disable=abstract-method
         return xblock_body
 
 
-WordCloudBlock = (
-    _ExtractedWordCloudBlock if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK
-    else _BuiltInWordCloudBlock
-)
+WordCloudBlock = None
+
+def reset_class():
+    global WordCloudBlock
+    WordCloudBlock = (
+        _ExtractedWordCloudBlock if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK
+        else _BuiltInWordCloudBlock
+    )
+    return WordCloudBlock
+
+reset_class()
 WordCloudBlock.__name__ = "WordCloudBlock"

--- a/xmodule/word_cloud_block.py
+++ b/xmodule/word_cloud_block.py
@@ -319,6 +319,7 @@ class _BuiltInWordCloudBlock(  # pylint: disable=abstract-method
 WordCloudBlock = None
 
 def reset_class():
+    """Reset class as per django settings flag"""
     global WordCloudBlock
     WordCloudBlock = (
         _ExtractedWordCloudBlock if settings.USE_EXTRACTED_WORD_CLOUD_BLOCK


### PR DESCRIPTION
In this PR:
- We have added functionality to run Word Cloud XBlock test cases for Built-In and Extracted XBlocks.
- We have fixed the test cases for Extracted Word Cloud XBlock.

~In this PR we have enabled the usage of Extracted Word Cloud XBlock resides in `xblocks-contrib` repository.~