### PR TITLE
feat: Mobile apis to update and retrieve  UserNotificationPreference

### DIFF
--- a/openedx/core/djangoapps/notifications/mobile_notifications/serializers.py
+++ b/openedx/core/djangoapps/notifications/mobile_notifications/serializers.py
@@ -1,0 +1,57 @@
+"""
+Serializers for the mobile notifications API.
+"""
+from rest_framework import serializers
+
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.notifications.models import (
+    CourseNotificationPreference
+)
+from ..base_notification import COURSE_NOTIFICATION_APPS, COURSE_NOTIFICATION_TYPES
+from ..utils import remove_preferences_with_no_access
+
+
+def add_info_to_notification_config(config_obj):
+    """
+    Add info of all notification types
+    """
+
+    config = config_obj['notification_preference_config']
+    for notification_app, app_prefs in config.items():
+        notification_types = app_prefs.get('notification_types', {})
+        for notification_type, type_prefs in notification_types.items():
+            if notification_type == "core":
+                type_info = COURSE_NOTIFICATION_APPS.get(notification_app, {}).get('core_info', '')
+            else:
+                type_info = COURSE_NOTIFICATION_TYPES.get(notification_type, {}).get('info', '')
+            type_prefs['info'] = type_info
+    return config_obj
+
+
+class UserNotificationPreferenceSerializer(serializers.ModelSerializer):
+    """
+    Serializer for user notification preferences.
+    """
+    course_name = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = CourseNotificationPreference
+        fields = ('id', 'course_name', 'course_id', 'notification_preference_config',)
+        read_only_fields = ('id', 'course_name', 'course_id',)
+        write_only_fields = ('notification_preference_config',)
+
+    def to_representation(self, instance):
+        """
+        Override to_representation to add info of all notification types
+        """
+        preferences = super().to_representation(instance)
+        user = self.context['user']
+        preferences = add_info_to_notification_config(preferences)
+        preferences = remove_preferences_with_no_access(preferences, user)
+        return preferences
+
+    def get_course_name(self, obj):
+        """
+        Returns course name from course id.
+        """
+        return CourseOverview.get_from_id(obj.course_id).display_name

--- a/openedx/core/djangoapps/notifications/mobile_notifications/urls.py
+++ b/openedx/core/djangoapps/notifications/mobile_notifications/urls.py
@@ -1,0 +1,17 @@
+"""
+URLs for the mobile notifications API.
+"""
+from django.urls import path
+from rest_framework import routers
+
+from .views import (
+    UserNotificationPreferenceView,
+)
+
+router = routers.DefaultRouter()
+
+urlpatterns = [
+    path('configurations/', UserNotificationPreferenceView.as_view(), name='user-configurations-list'),
+]
+
+urlpatterns += router.urls

--- a/openedx/core/djangoapps/notifications/mobile_notifications/views.py
+++ b/openedx/core/djangoapps/notifications/mobile_notifications/views.py
@@ -1,0 +1,156 @@
+from django.utils.translation import gettext as _
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from common.djangoapps.student.models import CourseEnrollment
+from openedx.core.djangoapps.notifications.models import (
+    CourseNotificationPreference,
+    get_course_notification_preference_config_version
+)
+from openedx.core.djangoapps.notifications.permissions import allow_any_authenticated_user
+from .serializers import (
+    UserNotificationPreferenceSerializer,
+)
+from ..config.waffle import ENABLE_NOTIFICATIONS
+from ..events import (
+    notification_preference_update_event
+)
+from ..serializers import UserNotificationPreferenceUpdateSerializer
+
+
+@allow_any_authenticated_user()
+class UserNotificationPreferenceView(APIView):
+    """
+    Supports retrieving and patching the UserNotificationPreference
+    model.
+
+    **Example Requests**
+        GET /api/notifications/configurations/
+        PATCH /api/notifications/configurations/
+
+    **Example Response**:
+    [
+        {
+            'id': 1,
+            'course_name': 'testcourse',
+            'course_id': 'course-v1:testorg+testcourse+testrun',
+            'notification_preference_config': {
+                'discussion': {
+                    'enabled': False,
+                    'core': {
+                        'info': '',
+                        'web': False,
+                        'push': False,
+                        'email': False,
+                    },
+                    'notification_types': {
+                        'new_post': {
+                            'info': '',
+                            'web': False,
+                            'push': False,
+                            'email': False,
+                        },
+                    },
+                    'not_editable': {},
+                },
+            }
+        },
+        {
+            'id': 2,
+            'course_name': 'testcourse2',
+            'course_id': 'course-v1:testorg+testcourse2+testrun',
+            'notification_preference_config': {
+                'discussion': {
+                    'enabled': False,
+                    'core': {
+                        'info': '',
+                        'web': False,
+                        'push': False,
+                        'email': False,
+                    },
+                    'notification_types': {
+                        'new_post': {
+                            'info': '',
+                            'web': False,
+                            'push': False,
+                            'email': False,
+                        },
+                    },
+                    'not_editable': {},
+                },
+            }
+        },
+
+    ]
+    """
+
+    def get(self, request, *args, **kwargs):
+        """
+        Returns notification preferences of all courses user is enrolled in.
+
+         Parameters:
+             request (Request): The request object.
+         """
+        course_ids = self._get_user_active_course_ids(request.user)
+
+        preferences = []
+        for course_id in course_ids:
+            if ENABLE_NOTIFICATIONS.is_enabled(course_id):
+                preference = CourseNotificationPreference.get_updated_user_course_preferences(request.user, course_id)
+                preferences.append(preference)
+
+        serializer = UserNotificationPreferenceSerializer(preferences, context={'user': request.user}, many=True)
+        return Response(serializer.data)
+
+    def patch(self, request):
+        """
+        Update all existing user notification preferences with the data in the request body.
+
+        Parameters:
+            request (Request): The request object
+
+        Returns:
+            200: The updated preference, serialized using the UserNotificationPreferenceSerializer
+            404: If the preference does not exist
+            403: If the user does not have permission to update the preference
+            400: Validation error
+        """
+        course_ids = self._get_user_active_course_ids(request.user)
+
+        user_course_notification_preferences = list(CourseNotificationPreference.objects.filter(
+            user=request.user,
+            course_id__in=course_ids,
+            is_active=True,
+        ))
+        updated_notification_preferences = []
+        for course_notification_preference in user_course_notification_preferences:
+            course_id = course_notification_preference.course_id
+
+            if course_notification_preference.config_version != get_course_notification_preference_config_version():
+                error_msg = 'The notification preference config version is not up to date for {}.'.format(course_id)
+                return Response({'error': _(error_msg)}, status=status.HTTP_409_CONFLICT, )
+
+            if request.data.get('notification_channel', '') == 'email_cadence':
+                request.data['email_cadence'] = request.data['value']
+                del request.data['value']
+
+            preference_update = UserNotificationPreferenceUpdateSerializer(
+                course_notification_preference, data=request.data, partial=True
+            )
+            preference_update.is_valid(raise_exception=True)
+            updated_notification_preferences.append(preference_update.save())
+            notification_preference_update_event(request.user, course_id, preference_update.validated_data)
+
+        serializer_context = {
+            'user': request.user
+        }
+        serializer = UserNotificationPreferenceSerializer(updated_notification_preferences,
+                                                          context=serializer_context,
+                                                          many=True)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def _get_user_active_course_ids(self, user):
+        enrollments = CourseEnrollment.objects.filter(user=user, is_active=True)
+        return enrollments.values_list('course_id', flat=True)

--- a/openedx/core/djangoapps/notifications/urls.py
+++ b/openedx/core/djangoapps/notifications/urls.py
@@ -2,9 +2,10 @@
 URLs for the notifications API.
 """
 from django.conf import settings
-from django.urls import path, re_path
+from django.urls import path, re_path, include
 from rest_framework import routers
 
+from .mobile_notifications.urls import urlpatterns as mobile_notifications_urlpatterns
 from .views import (
     CourseEnrollmentListView,
     MarkNotificationsSeenAPIView,
@@ -16,7 +17,6 @@ from .views import (
 )
 
 router = routers.DefaultRouter()
-
 
 urlpatterns = [
     path('enrollments/', CourseEnrollmentListView.as_view(), name='enrollment-list'),
@@ -35,6 +35,10 @@ urlpatterns = [
     path('read/', NotificationReadAPIView.as_view(), name='notifications-read'),
     path('preferences/update/<str:username>/<str:patch>/', preference_update_from_encrypted_username_view,
          name='preference_update_from_encrypted_username_view'),
+]
+
+urlpatterns += [
+    path('mobile/', include(mobile_notifications_urlpatterns)),
 ]
 
 urlpatterns += router.urls


### PR DESCRIPTION
## Description

These apis will handle all  UserNotificationPreference in one call. Existing apis were written to handle a user's specific course UserNotificationPreference. This api does the same thing but for all courses a user is enrolled in. 

Useful information to include:

- This change will effect users who are using mobile apps.

## Supporting information
Jira issue: https://2u-internal.atlassian.net/browse/LEARNER-10325


## Deadline
ASAP.
