### PR TITLE
feat: api to restore soft-deleted component [FC-0076] 

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -401,8 +401,6 @@ def searchable_doc_for_library_block(xblock_metadata: lib_api.LibraryXBlockMetad
 
     # Add the breadcrumbs. In v2 libraries, the library itself is not a "parent" of the XBlocks so we add it here:
     doc[Fields.breadcrumbs] = [{"display_name": library_name}]
-    # Add collections data to index if this block is part of any collection
-    doc.update(_collections_for_content_object(xblock_metadata.usage_key))
 
     return doc
 

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -306,7 +306,10 @@ def _collections_for_content_object(object_id: UsageKey | LearningContextKey) ->
 
     If the object is in no collections, returns:
         {
-            "collections":  {},
+            "collections":  {
+                "display_name": [],
+                "key": [],
+            },
         }
 
     """
@@ -398,6 +401,8 @@ def searchable_doc_for_library_block(xblock_metadata: lib_api.LibraryXBlockMetad
 
     # Add the breadcrumbs. In v2 libraries, the library itself is not a "parent" of the XBlocks so we add it here:
     doc[Fields.breadcrumbs] = [{"display_name": library_name}]
+    # Add collections data to index if this block is part of any collection
+    doc.update(_collections_for_content_object(xblock_metadata.usage_key))
 
     return doc
 

--- a/openedx/core/djangoapps/content/search/tests/test_handlers.py
+++ b/openedx/core/djangoapps/content/search/tests/test_handlers.py
@@ -185,3 +185,7 @@ class TestUpdateIndexHandlers(ModuleStoreTestCase, LiveServerTestCase):
         meilisearch_client.return_value.index.return_value.delete_document.assert_called_with(
             "lborgalib_aproblemproblem1-ca3186e9"
         )
+
+        # Restore the Library Block
+        library_api.restore_library_block(problem.usage_key)
+        meilisearch_client.return_value.index.return_value.update_documents.assert_called_with([doc_problem])

--- a/openedx/core/djangoapps/content/search/tests/test_handlers.py
+++ b/openedx/core/djangoapps/content/search/tests/test_handlers.py
@@ -188,4 +188,10 @@ class TestUpdateIndexHandlers(ModuleStoreTestCase, LiveServerTestCase):
 
         # Restore the Library Block
         library_api.restore_library_block(problem.usage_key)
-        meilisearch_client.return_value.index.return_value.update_documents.assert_called_with([doc_problem])
+        meilisearch_client.return_value.index.return_value.update_documents.assert_any_call([doc_problem])
+        meilisearch_client.return_value.index.return_value.update_documents.assert_any_call(
+            [{'id': doc_problem['id'], 'collections': {'display_name': [], 'key': []}}]
+        )
+        meilisearch_client.return_value.index.return_value.update_documents.assert_any_call(
+            [{'id': doc_problem['id'], 'tags': {}}]
+        )

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1154,7 +1154,7 @@ def restore_library_block(usage_key):
     # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
     # collection indexing asynchronously.
     #
-    # To delete the component on collections
+    # To restore the component in the collections
     for collection in affected_collections:
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1151,6 +1151,14 @@ def restore_library_block(usage_key):
         )
     )
 
+    # Add tags and collections back to index
+    CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
+        content_object=ContentObjectChangedData(
+            object_id=str(usage_key),
+            changes=["collections", "tags"],
+        ),
+    )
+
     # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
     # collection indexing asynchronously.
     #

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -591,6 +591,35 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
             event_receiver.call_args_list[0].kwargs,
         )
 
+    def test_restore_library_block(self):
+        api.update_library_collection_components(
+            self.lib1.library_key,
+            self.col1.key,
+            usage_keys=[
+                UsageKey.from_string(self.lib1_problem_block["id"]),
+                UsageKey.from_string(self.lib1_html_block["id"]),
+            ],
+        )
+
+        event_receiver = mock.Mock()
+        LIBRARY_COLLECTION_UPDATED.connect(event_receiver)
+
+        api.restore_library_block(UsageKey.from_string(self.lib1_problem_block["id"]))
+
+        assert event_receiver.call_count == 1
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_COLLECTION_UPDATED,
+                "sender": None,
+                "library_collection": LibraryCollectionData(
+                    self.lib1.library_key,
+                    collection_key=self.col1.key,
+                    background=True,
+                ),
+            },
+            event_receiver.call_args_list[0].kwargs,
+        )
+
     def test_add_component_and_revert(self):
         # Add component and publish
         api.update_library_collection_components(

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -57,6 +57,7 @@ urlpatterns = [
         path('blocks/<str:usage_key_str>/', include([
             # Get metadata about a specific XBlock in this library, or delete the block:
             path('', views.LibraryBlockView.as_view()),
+            path('restore/', views.LibraryBlockRestore.as_view()),
             # Update collections for a given component
             path('collections/', views.LibraryBlockCollectionsView.as_view(), name='update-collections'),
             # Get the LTI URL of a specific XBlock

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -644,6 +644,22 @@ class LibraryBlockView(APIView):
         return Response({})
 
 
+@view_auth_classes()
+class LibraryBlockRestore(APIView):
+    """
+    View to restore soft-deleted library xblocks.
+    """
+    @convert_exceptions
+    def post(self, request, usage_key_str) -> Response:
+        """
+        Restores a soft-deleted library block that belongs to a Content Library
+        """
+        key = LibraryUsageLocatorV2.from_string(usage_key_str)
+        api.require_permission_for_library_key(key.lib_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY)
+        api.restore_library_block(key)
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+
 @method_decorator(non_atomic_requests, name="dispatch")
 @view_auth_classes()
 class LibraryBlockCollectionsView(APIView):

--- a/openedx/core/djangoapps/content_tagging/handlers.py
+++ b/openedx/core/djangoapps/content_tagging/handlers.py
@@ -119,22 +119,6 @@ def auto_tag_library_block(**kwargs):
     )
 
 
-@receiver(LIBRARY_BLOCK_DELETED)
-def delete_tag_library_block(**kwargs):
-    """
-    Delete tags associated with a Library XBlock whenever the block is deleted.
-    """
-    library_block_data = kwargs.get("library_block", None)
-    if not library_block_data or not isinstance(library_block_data, LibraryBlockData):
-        log.error("Received null or incorrect data for event")
-        return
-
-    try:
-        delete_library_block_tags(str(library_block_data.usage_key))
-    except Exception as err:  # pylint: disable=broad-except
-        log.error(f"Failed to delete library block tags: {err}")
-
-
 @receiver(XBLOCK_DUPLICATED)
 def duplicate_tags(**kwargs):
     """

--- a/openedx/core/djangoapps/content_tagging/handlers.py
+++ b/openedx/core/djangoapps/content_tagging/handlers.py
@@ -20,7 +20,6 @@ from openedx_events.content_authoring.signals import (
     XBLOCK_DUPLICATED,
     LIBRARY_BLOCK_CREATED,
     LIBRARY_BLOCK_UPDATED,
-    LIBRARY_BLOCK_DELETED,
 )
 
 from .api import copy_object_tags
@@ -30,7 +29,6 @@ from .tasks import (
     update_course_tags,
     update_xblock_tags,
     update_library_block_tags,
-    delete_library_block_tags,
 )
 from .toggles import CONTENT_TAGGING_AUTO
 

--- a/openedx/core/djangoapps/content_tagging/tests/test_tasks.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_tasks.py
@@ -289,17 +289,16 @@ class TestAutoTagging(  # type: ignore[misc]
         # Check if the tags are created in the Library Block with the user's preferred language
         assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, 'Português (Brasil)')
 
-        # Delete the XBlock
+        # Soft delete the XBlock
         delete_library_block(library_block.usage_key)
 
-        # Check if the tags are deleted
-        assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, None)
+        # Check that the tags are not deleted
+        assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, 'Português (Brasil)')
 
         # Restore the XBlock
-        with patch('crum.get_current_request', return_value=fake_request):
-            restore_library_block(library_block.usage_key)
+        restore_library_block(library_block.usage_key)
 
-        # Check if the tags are restored in the Library Block with the user's preferred language
+        # Check if the tags are still present in the Library Block with the user's preferred language
         assert self._check_tag(usage_key_str, LANGUAGE_TAXONOMY_ID, 'Português (Brasil)')
 
     @override_waffle_flag(CONTENT_TAGGING_AUTO, active=False)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds api to handle restoring soft-deleted library blocks.

Useful information to include:

- Which edX user roles will this change impact? "Course Author","Developer", and "Operator".

## Supporting information

* Issue: https://github.com/openedx/frontend-app-authoring/issues/1418
* Related frontend PR: https://github.com/openedx/frontend-app-authoring/pull/1556
* `Private-ref`: [FAL-3986](https://tasks.opencraft.com/browse/FAL-3986)

## Testing instructions

Please see https://github.com/openedx/frontend-app-authoring/pull/1556 for instructions.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.