### PR TITLE
feat: make it possible to globally disable forum v2 with setting

### DIFF
--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -2,6 +2,7 @@
 This module contains various configuration settings via
 waffle switches for the discussions app.
 """
+from django.conf import settings
 
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
@@ -57,6 +58,18 @@ ENABLE_FORUM_V2 = CourseWaffleFlag(f"{WAFFLE_FLAG_NAMESPACE}.enable_forum_v2", _
 
 def is_forum_v2_enabled(course_id):
     """
-    Returns a boolean if forum V2 is enabled on the course
+    Returns whether forum V2 is enabled on the course. This is a 2-step check:
+
+    1. Check value of settings.DISABLE_FORUM_V2: if it exists and is true, this setting overrides any course flag.
+    2. Else, check the value of the corresponding course waffle flag.
     """
+    if is_forum_v2_disabled_globally():
+        return False
     return ENABLE_FORUM_V2.is_enabled(course_id)
+
+
+def is_forum_v2_disabled_globally() -> bool:
+    """
+    Return True if DISABLE_FORUM_V2 is defined and true-ish.
+    """
+    return getattr(settings, "DISABLE_FORUM_V2", False)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -836,7 +836,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.4
+openedx-forum==0.1.5
     # via -r requirements/edx/kernel.in
 openedx-learning==0.18.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1388,7 +1388,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.4
+openedx-forum==0.1.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1003,7 +1003,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.4
+openedx-forum==0.1.5
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1048,7 +1048,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.4
+openedx-forum==0.1.5
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.1
     # via


### PR DESCRIPTION
## Description

We introduce a setting that allows us to bypass any course waffle flag check. The advantage of such a setting is that we don't need to find the course ID: in some cases, we might not have access to the course ID, and we need to look for it... in forum v2.


## Supporting information

See discussion here: https://github.com/openedx/forum/issues/137

