### PR TITLE
fix: render library assets named xblock-

### DIFF
--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -11,7 +11,7 @@ from opaque_keys.edx.locator import AssetLocator
 from xmodule.contentstore.content import StaticContent
 
 log = logging.getLogger(__name__)
-XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock'
+XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock/'
 
 
 def _url_replace_regex(prefix):

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -86,6 +86,16 @@ def test_process_url_no_match():
     assert process_static_urls(STATIC_SOURCE, processor) == '"test/static/file.png"'
 
 
+def test_process_url_no_match_starts_with_xblock():
+    def processor(original, prefix, quote, rest):  # pylint: disable=unused-argument, redefined-outer-name
+        return quote + 'test' + prefix + rest + quote
+    assert process_static_urls(
+        '"/static/xblock-file.png"',
+        processor,
+        data_dir=DATA_DIRECTORY
+    ) == '"test/static/xblock-file.png"'
+
+
 @patch('django.http.HttpRequest', autospec=True)
 def test_static_urls(mock_request):
     mock_request.build_absolute_uri = lambda url: 'http://' + url


### PR DESCRIPTION
The previous pattern for matching was too broad and would break
the rendering of assets that were prefixed with "xblock".

(Sumac backport of https://github.com/openedx/edx-platform/pull/35910)
