### PR TITLE
fix: async-timeout requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,6 +37,8 @@ asgiref==3.8.1
     #   django-countries
 asn1crypto==1.5.1
     # via snowflake-connector-python
+async-timeout==5.0.1
+    # via redis
 attrs==24.2.0
     # via
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -89,6 +89,11 @@ astroid==2.13.5
     #   pylint
     #   pylint-celery
     #   sphinx-autoapi
+async-timeout==5.0.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   redis
 attrs==24.2.0
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -61,6 +61,10 @@ astroid==2.13.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   sphinx-autoapi
+async-timeout==5.0.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   redis
 attrs==24.2.0
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -60,6 +60,10 @@ astroid==2.13.5
     #   -c requirements/edx/../constraints.txt
     #   pylint
     #   pylint-celery
+async-timeout==5.0.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   redis
 attrs==24.2.0
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
CI is failing because requirements are not up-to-date in the master branch. The async-timeout dependency is missing.

See for instance this build: https://github.com/openedx/edx-platform/actions/runs/12257016679/job/34193558642?pr=36002