### PR TITLE
fix: Build docs with python 3.11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.12"
+    python: "3.11"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
We're still running with 3.11 in sumac so we should be building the docs
with python 3.11
