### PR TITLE
feat: Populate notification context with post, comment and response ids

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -68,7 +68,8 @@ class DiscussionNotificationSender:
                 "sender_id": self.creator.id,
                 'thread_id': self.thread.id,
                 'parent_id': self.parent_id,
-                'comment_id': self.comment_id
+                'comment_id': self.comment_id,
+                'topic_id': self.thread.commentable_id,
                 **extra_context,
             },
             notification_type=notification_type,

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -66,6 +66,9 @@ class DiscussionNotificationSender:
                 "post_title": self.thread.title,
                 "course_name": self.course.display_name,
                 "sender_id": self.creator.id,
+                'thread_id': self.thread.id,
+                'parent_id': self.parent_id,
+                'comment_id': self.comment_id
                 **extra_context,
             },
             notification_type=notification_type,

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -66,10 +66,6 @@ class DiscussionNotificationSender:
                 "post_title": self.thread.title,
                 "course_name": self.course.display_name,
                 "sender_id": self.creator.id,
-                'thread_id': self.thread.id,
-                'parent_id': self.parent_id,
-                'comment_id': self.comment_id,
-                'topic_id': self.thread.commentable_id,
                 **extra_context,
             },
             notification_type=notification_type,
@@ -121,6 +117,7 @@ class DiscussionNotificationSender:
             context = {
                 'email_content': clean_thread_html_body(self.comment.body),
             }
+            self._populate_context_with_ids_for_mobile(context)
             self._send_notification([self.thread.user_id], "new_response", extra_context=context)
 
     def _response_and_thread_has_same_creator(self) -> bool:
@@ -160,6 +157,7 @@ class DiscussionNotificationSender:
                 "author_pronoun": str(author_pronoun),
                 "email_content": clean_thread_html_body(self.comment.body),
             }
+            self._populate_context_with_ids_for_mobile(context)
             self._send_notification([self.thread.user_id], "new_comment", extra_context=context)
 
     def send_new_comment_on_response_notification(self):
@@ -175,6 +173,7 @@ class DiscussionNotificationSender:
             context = {
                 "email_content": clean_thread_html_body(self.comment.body),
             }
+            self._populate_context_with_ids_for_mobile(context)
             self._send_notification(
                 [self.parent_response.user_id],
                 "new_comment_on_response",
@@ -220,12 +219,15 @@ class DiscussionNotificationSender:
         # Remove duplicate users from the list of users to send notification
         users = list(set(users))
         if not self.parent_id:
+            context = {
+                "email_content": clean_thread_html_body(self.comment.body),
+            }
+            self._populate_context_with_ids_for_mobile(context)
             self._send_notification(
                 users,
                 "response_on_followed_post",
-                extra_context={
-                    "email_content": clean_thread_html_body(self.comment.body),
-                })
+                extra_context=context
+            )
         else:
             author_name = f"{self.parent_response.username}'s"
             # use 'their' if comment author is also response author.
@@ -235,14 +237,16 @@ class DiscussionNotificationSender:
                 if self._response_and_comment_has_same_creator()
                 else f"{self.parent_response.username}'s"
             )
+            context = {
+                "author_name": str(author_name),
+                "author_pronoun": str(author_pronoun),
+                "email_content": clean_thread_html_body(self.comment.body),
+            }
+            self._populate_context_with_ids_for_mobile(context)
             self._send_notification(
                 users,
                 "comment_on_followed_post",
-                extra_context={
-                    "author_name": str(author_name),
-                    "author_pronoun": str(author_pronoun),
-                    "email_content": clean_thread_html_body(self.comment.body),
-                }
+                extra_context=context
             )
 
     def _create_cohort_course_audience(self):
@@ -294,6 +298,7 @@ class DiscussionNotificationSender:
             context = {
                 "email_content": clean_thread_html_body(self.comment.body)
             }
+            self._populate_context_with_ids_for_mobile(context)
             self._send_notification([self.thread.user_id], "response_endorsed_on_thread", extra_context=context)
 
     def send_response_endorsed_notification(self):
@@ -303,6 +308,7 @@ class DiscussionNotificationSender:
         context = {
             "email_content": clean_thread_html_body(self.comment.body)
         }
+        self._populate_context_with_ids_for_mobile(context)
         self._send_notification([self.creator.id], "response_endorsed", extra_context=context)
 
     def send_new_thread_created_notification(self):
@@ -334,6 +340,7 @@ class DiscussionNotificationSender:
             'post_title': self.thread.title,
             "email_content": clean_thread_html_body(self.thread.body),
         }
+        self._populate_context_with_ids_for_mobile(context)
         self._send_course_wide_notification(notification_type, audience_filters, context)
 
     def send_reported_content_notification(self):
@@ -365,6 +372,12 @@ class DiscussionNotificationSender:
             FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA
         ]}
         self._send_course_wide_notification("content_reported", audience_filters, context)
+
+    def _populate_context_with_ids_for_mobile(self, context, additional_context=False):
+        context['thread_id'] = self.thread.id
+        context['topic_id'] = self.thread.commentable_id
+        context['comment_id'] = self.comment_id
+        context['parent_id'] = self.parent_id
 
 
 def is_discussion_cohorted(course_key_str):

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -373,7 +373,7 @@ class DiscussionNotificationSender:
         ]}
         self._send_course_wide_notification("content_reported", audience_filters, context)
 
-    def _populate_context_with_ids_for_mobile(self, context, additional_context=False):
+    def _populate_context_with_ids_for_mobile(self, context):
         context['thread_id'] = self.thread.id
         context['topic_id'] = self.thread.commentable_id
         context['comment_id'] = self.comment_id

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -270,6 +270,8 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
                 "username": thread.username,
                 "thread_type": 'discussion',
                 "title": thread.title,
+                "commentable_id": thread.commentable_id,
+
             })
         self._register_subscriptions_endpoint()
 
@@ -319,7 +321,11 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'post_title': 'test thread',
             'email_content': self.comment.body,
             'course_name': self.course.display_name,
-            'sender_id': self.user_2.id
+            'sender_id': self.user_2.id,
+            'parent_id': None,
+            'topic_id': None,
+            'thread_id': 1,
+            'comment_id': 4,
         }
         self.assertDictEqual(args.context, expected_context)
         self.assertEqual(
@@ -365,7 +371,11 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'author_name': 'dummy\'s',
             'author_pronoun': 'dummy\'s',
             'course_name': self.course.display_name,
-            'sender_id': self.user_3.id
+            'sender_id': self.user_3.id,
+            'parent_id': 2,
+            'topic_id': None,
+            'thread_id': 1,
+            'comment_id': 4,
         }
         self.assertDictEqual(args_comment.context, expected_context)
         self.assertEqual(
@@ -382,7 +392,11 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'post_title': self.thread.title,
             'email_content': self.comment.body,
             'course_name': self.course.display_name,
-            'sender_id': self.user_3.id
+            'sender_id': self.user_3.id,
+            'parent_id': 2,
+            'topic_id': None,
+            'thread_id': 1,
+            'comment_id': 4,
         }
         self.assertDictEqual(args_comment_on_response.context, expected_context)
         self.assertEqual(
@@ -442,7 +456,11 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'author_pronoun': 'your',
             'course_name': self.course.display_name,
             'sender_id': self.user_3.id,
-            'email_content': self.comment.body
+            'email_content': self.comment.body,
+            'parent_id': 2,
+            'topic_id': None,
+            'thread_id': 1,
+            'comment_id': 4,
         }
         self.assertDictEqual(args_comment.context, expected_context)
         self.assertEqual(
@@ -487,6 +505,10 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'email_content': self.comment.body,
             'course_name': self.course.display_name,
             'sender_id': self.user_2.id,
+            'parent_id': parent_id,
+            'topic_id': None,
+            'thread_id': 1,
+            'comment_id': 4,
         }
         if parent_id:
             expected_context['author_name'] = 'dummy\'s'
@@ -571,6 +593,8 @@ class TestSendCommentNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCas
             "username": thread.username,
             "thread_type": 'discussion',
             "title": thread.title,
+            "commentable_id": thread.commentable_id,
+
         })
         self.register_get_comment_response({
             'id': response.id,
@@ -636,6 +660,7 @@ class TestResponseEndorsedNotifications(DiscussionAPIViewTestMixin, ModuleStoreT
             "username": thread.username,
             "thread_type": 'discussion',
             "title": thread.title,
+            "commentable_id": thread.commentable_id,
         })
         self.register_get_comment_response({
             'id': 1,
@@ -663,7 +688,11 @@ class TestResponseEndorsedNotifications(DiscussionAPIViewTestMixin, ModuleStoreT
             'post_title': 'test thread',
             'course_name': self.course.display_name,
             'sender_id': int(self.user_2.id),
-            'email_content': 'dummy'
+            'email_content': 'dummy',
+            'parent_id': None,
+            'topic_id': None,
+            'thread_id': 1,
+            'comment_id': 2,
         }
         self.assertDictEqual(notification_data.context, expected_context)
         self.assertEqual(notification_data.content_url, _get_mfe_url(self.course.id, thread.id))
@@ -681,7 +710,11 @@ class TestResponseEndorsedNotifications(DiscussionAPIViewTestMixin, ModuleStoreT
             'post_title': 'test thread',
             'course_name': self.course.display_name,
             'sender_id': int(response.user_id),
-            'email_content': 'dummy'
+            'email_content': 'dummy',
+            'parent_id': None,
+            'topic_id': None,
+            'thread_id': 1,
+            'comment_id': 2,
         }
         self.assertDictEqual(notification_data.context, expected_context)
         self.assertEqual(notification_data.content_url, _get_mfe_url(self.course.id, thread.id))

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -675,13 +675,14 @@ class ThreadMock(object):
     A mock thread object
     """
 
-    def __init__(self, thread_id, creator, title, parent_id=None, body=''):
+    def __init__(self, thread_id, creator, title, parent_id=None, body='', commentable_id=None):
         self.id = thread_id
         self.user_id = str(creator.id)
         self.username = creator.username
         self.title = title
         self.parent_id = parent_id
         self.body = body
+        self.commentable_id = commentable_id
 
     def url_with_id(self, params):
         return f"http://example.com/{params['id']}"


### PR DESCRIPTION
## Description

This change will populate notification context with post, comment and response ids. In mobile we need these ids to load relevant screen for a notification.

Useful information to include:

- This change will effect all clients using notification get api.
- 
## Supporting information

https://2u-internal.atlassian.net/browse/LEARNER-10328

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

ASAP.
