### PR TITLE
build(eslint): Ignore Symlinks and Reduce Violation Limit

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -20,9 +20,21 @@ test_root/staticfiles
 common/static/xmodule
 
 
-# Symlinks into xmodule/js
+# Various intra-repo symlinks that we've added over the years to duct-tape the JS build together.
+# Ignore them so that we're not double-counting these violations.
+cms/static/edx-ui-toolkit
 cms/static/xmodule_js
+lms/static/common
+lms/static/course_bookmarks
+lms/static/course_experience
+lms/static/course_search
+lms/static/discussion
+lms/static/edx-ui-toolkit
+lms/static/learner_profile
+lms/static/support
+lms/static/teams
 lms/static/xmodule_js
+xmodule/js/common_static
 
 
 # Mako templates that generate .js files

--- a/scripts/eslint.py
+++ b/scripts/eslint.py
@@ -25,7 +25,7 @@ def run_eslint():
     Runs eslint on static asset directories.
     If limit option is passed, fails build if more violations than the limit are found.
     """
-    violations_limit = 1285
+    violations_limit = 734
 
     command = [
         "node",


### PR DESCRIPTION
## Description

Background: We have a large number of standing eslint violations in our
legacy frontends. Rather than fixing or amnesty-ing all of them, we've
opted to use a simple integer limit of violations. Exceeding this
limit causes the quality check to fail.
Before we moved eslint off of Paver [1], the limit was unreasonably
high (probably due to deprecations that removed violation-rich frontend
code). This was good, except for the fact that we essentially weren't
catching when new violations creeped into the JS code.

So, in [1], we lowered the limit down to the lowest possible value,
which we thought was 1285. However, we've found that this made the check
flaky-- turned out, we have been unintentionally double-counting various
violations due to the symlinks in edx-platform. Some of those symlinks'
existence is dependent on whether and how `npm ci` and `npm run build`
have been run. As a result, 1285 would pass in some contexts, and fail
in other contexts.

The fix is to simply add all the relevant edx-platform symlinks to
.eslintignore. This allows us to lower the violations limit to 734.

[1] https://github.com/openedx/edx-platform/pull/35159

## Testing

Looking at the Quality Others CI logs, we see that eslint passes with a number of violations equal to the new limit (734):
![image](https://github.com/user-attachments/assets/491ae18e-917e-41bf-861d-45e4458f0dfa)


## Merge deadline

Asap, to unblock master build