### PR TITLE
Course templates api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
@@ -26,3 +26,4 @@ from .videos import (
     VideoUploadSerializer,
     VideoUsageSerializer,
 )
+from .course_templates import CourseSerializer, CourseMetadataSerializer

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_templates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_templates.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+class CourseMetadataSerializer(serializers.Serializer):
+    course_id = serializers.CharField()
+    title = serializers.CharField()
+    description = serializers.CharField()
+    thumbnail = serializers.URLField()
+    active = serializers.BooleanField()
+
+class CourseSerializer(serializers.Serializer):
+    courses_name = serializers.CharField()
+    zip_url = serializers.URLField()
+    metadata = CourseMetadataSerializer()

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -11,13 +11,13 @@ from .views import (
     CourseDetailsView,
     CourseTeamView,
     CourseTextbooksView,
+    CourseTemplatesListView,
     CourseIndexView,
     CourseGradingView,
     CourseGroupConfigurationsView,
     CourseRerunView,
     CourseSettingsView,
     CourseVideosView,
-    CourseWaffleFlagsView,
     HomePageView,
     HomePageCoursesView,
     HomePageLibrariesView,
@@ -133,11 +133,10 @@ urlpatterns = [
         name="container_vertical"
     ),
     re_path(
-        fr'^course_waffle_flags(?:/{COURSE_ID_PATTERN})?$',
-        CourseWaffleFlagsView.as_view(),
-        name="course_waffle_flags"
+        fr'^course_templates/{settings.COURSE_ID_PATTERN}$',
+        CourseTemplatesListView.as_view(),
+        name="course_templates_api"
     ),
-
     # Authoring API
     # Do not use under v1 yet (Nov. 23). The Authoring API is still experimental and the v0 versions should be used
 ]

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -5,8 +5,8 @@ from .certificates import CourseCertificatesView
 from .course_details import CourseDetailsView
 from .course_index import CourseIndexView
 from .course_rerun import CourseRerunView
-from .course_waffle_flags import CourseWaffleFlagsView
 from .course_team import CourseTeamView
+from .course_templates import CourseTemplatesListView
 from .grading import CourseGradingView
 from .group_configurations import CourseGroupConfigurationsView
 from .help_urls import HelpUrlsView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_templates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_templates.py
@@ -1,0 +1,102 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.exceptions import NotFound
+from opaque_keys.edx.keys import CourseKey  # Import CourseKey if using edX
+from django.conf import settings
+import requests
+from openedx.core.lib.api.view_utils import (
+    DeveloperErrorViewMixin,
+    view_auth_classes,
+)
+from rest_framework.request import Request
+from ..serializers import CourseSerializer, CourseMetadataSerializer
+
+
+# @view_auth_classes(is_authenticated=True)
+class CourseTemplatesListView(DeveloperErrorViewMixin, APIView):
+    """
+    API endpoint to fetch and return course data from a GitHub repository.
+
+    This view dynamically fetches course data from a specified GitHub repository
+    and returns it in a structured JSON format. It processes directories and files
+    in the repository to extract course names, ZIP URLs, and metadata files.
+
+    Example URL:
+        /api/courses/<course_key_string>/
+
+    Query Parameters:
+        course_key_string (str): The course key in the format `org+course+run`.
+
+    Example Response:
+    [
+        {
+            "courses_name": "AI Courses",
+            "zip_url": "https://raw.githubusercontent.com/awais786/courses/main/edly/AI%20Courses/course._Rnm_t%20(1).tar.gz",
+            "metadata": {
+                "course_id": "course-v1:edX+DemoX+T2024",
+                "title": "Introduction to Open edX",
+                "description": "Learn the fundamentals of the Open edX platform, including how to create and manage courses.",
+                "thumbnail": "https://discover.ilmx.org/wp-content/uploads/2024/01/Course-image-2.webp",
+                "active": true
+            }
+        }
+    ]
+
+    Raises:
+        NotFound: If there is an error fetching data from the repository.
+
+    """
+    def get(self, request: Request, course_id: str):
+        """
+        Handle GET requests to fetch course data.
+
+        Args:
+            request: The HTTP request object.
+            course_id (str): The course id.
+
+        Returns:
+            Response: A structured JSON response containing course data.
+
+        """
+        try:
+            # Extract organization from course key
+            course_key = CourseKey.from_string(course_id)
+            organization = course_key.org
+
+            # GitHub repository details. It should come from settings.
+            templates_repo_url = f"https://api.github.com/repos/awais786/courses/contents/{organization}"
+
+            # Fetch data from GitHub
+            data = fetch_contents(templates_repo_url)
+            courses = []
+            for directory in data:
+                course_data = {'courses_name': directory["name"]}
+                contents = fetch_contents(directory["url"])  # Assume directory contains URL to course contents
+
+                for item in contents:
+                    if item['name'].endswith('.tar.gz'):  # Check if file is a ZIP file
+                        course_data['zip_url'] = item['download_url']
+                    elif item['name'].endswith('.json'):  # Check if file is a JSON metadata file
+                        course_data['metadata'] = fetch_contents(item['download_url'])
+
+                courses.append(course_data)
+
+            # Serialize and return the data
+            serializer = CourseSerializer(courses, many=True)
+            return Response(serializer.data)
+
+        except Exception as err:
+            raise NotFound(f"Error fetching course data: {str(err)}")
+
+
+def fetch_contents(url):
+    headers = {
+        "Authorization": f"token {settings.GITHUB_TOKEN_COURSE_TEMPLATES}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()  # Raise error for 4xx/5xx responses
+        return response.json()
+    except Exception as err:
+        return JsonResponseBadRequest({"error": err.message})

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import requests
 import shutil
 from wsgiref.util import FileWrapper
 
@@ -25,6 +26,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
 from django.shortcuts import render
+from django.urls import reverse
 
 from edx_django_utils.monitoring import set_custom_attribute, set_custom_attributes_for_course_key
 from opaque_keys.edx.keys import CourseKey
@@ -474,7 +476,7 @@ def course_templates(request, course_key_string):
     courselike_key = CourseKey.from_string(course_key_string)
     organization = courselike_key.org
     successful_url = f"http://localhost:18010/api/contentstore/v1/course_templates/{course_key_string}"
-    import requests
+
     courses = []
     resp = requests.get(successful_url)
     if resp.status_code == 200:

--- a/cms/templates/course_templates.html
+++ b/cms/templates/course_templates.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ organization }} Templates List</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+
+        .courses-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            justify-content: center;
+        }
+
+        .course-card {
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            padding: 16px;
+            max-width: 300px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            background-color: #fff;
+        }
+
+        .course-thumbnail img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+        }
+
+        .course-info {
+            margin-top: 12px;
+        }
+
+        .course-name {
+            font-size: 1.2em;
+            margin-bottom: 8px;
+        }
+
+        .course-id {
+            color: #555;
+            font-size: 0.9em;
+            margin-bottom: 8px;
+        }
+
+        .course-title {
+            font-size: 1.1em;
+            font-weight: bold;
+            margin-bottom: 8px;
+        }
+
+        .course-description {
+            font-size: 0.95em;
+            color: #666;
+        }
+
+        .page-header {
+            text-align: center; /* Center the text horizontally */
+            margin: 20px 0; /* Add some spacing above and below the header */
+        }
+    </style>
+</head>
+<body>
+
+<div class="page-header">
+    <h2>{{ organization }} Templates List</h2>
+</div>
+
+<div class="courses-container">
+    {% for course in courses %}
+    <div class="course-card">
+        <div class="course-thumbnail">
+            <img src="{{ course.metadata.thumbnail }}" alt="{{ course.metadata.title }}" width="354" height="218" />
+        </div>
+        <div class="course-info">
+            <h3 class="course-name">{{ course.courses_name }}</h3>
+            <p class="course-id">Course ID: {{ course.metadata.course_id }}</p>
+            <h4 class="course-title">{{ course.metadata.title }}</h4>
+            <p class="course-description">{{ course.metadata.description }}</p>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+</body>
+</html>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -252,6 +252,9 @@
                     <a href="${reverse('export_git', kwargs=dict(course_key_string=str(course_key)))}">${_("Export to Git")}</a>
                   </li>
                   % endif
+                      <li class="nav-item nav-course-tools-export-git">
+                        <a href="${reverse('course_templates', args=[str(course_key)])}">${_("Course Templates")}</a>
+                      </li>
                   <li class="nav-item nav-course-tools-checklists">
                     <a href="${checklists_url}">${_("Checklists")}</a>
                   </li>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -23,6 +23,7 @@ from openedx.core.apidocs import api_info
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.password_policy.forms import PasswordPolicyAwareAdminAuthForm
 from openedx.core import toggles as core_toggles
+from cms.djangoapps.contentstore.views.import_export import course_templates
 
 
 django_autodiscover()
@@ -359,4 +360,6 @@ urlpatterns += [
 urlpatterns += [
     re_path('^authoring-api/ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     re_path('^authoring-api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    re_path(fr'^course_templates/{settings.COURSE_KEY_PATTERN}?$', course_templates, name='course_templates'),
+
 ]


### PR DESCRIPTION
**In progress PR dont review.**

This PR is about the course templates implementation.

A sample github repo contains the courses of different organizations.
https://github.com/awais786/courses

An API has been added to interact with the repository, allowing retrieval of courses based 
on the organization.

API endpoint which hit the github repo and brings the course information.
`http://localhost:18010/api/contentstore/v1/course_templates/edly/course-v1:edly+cs202+2024`

```
[
{'courses_name': 'Course1', 'zip_url': 'https://raw.githubusercontent.com/awais786/courses/main/edx/Course1/course.tar.gz',
 'metadata': {'course_id': 'course-v1:edX+DemoX+T2024', 'title': 'Introduction to Open edX', 
'description': 'Learn the fundamentals of the Open edX platform, including how to create and manage courses.', 'thumbnail': 'https://discover.ilmx.org/wp-content/uploads/2024/04/course-card-banner.png',
 'active': True}},
 {'courses_name': 'Course2', 'zip_url': 'https://raw.githubusercontent.com/awais786/courses/main/edx/Course2/course.tar.gz', 
'metadata': {'course_id': 'course-v1:edX+DemoX+T2024', 'title': 'Introduction to Open edX', 
'description': 'Learn the fundamentals of the Open edX platform, including how to create and manage courses.', 'thumbnail': 'https://discover.ilmx.org/wp-content/uploads/2024/01/Course-image-2.webp', 
'active': True}}
]
```

**Course detail page will show the course template menu.**

<img width="919" alt="Screenshot 2024-12-12 at 4 28 19 PM" src="https://github.com/user-attachments/assets/59025b05-fb99-4331-ba16-97029471096d" />

------

**All templates will be appear here** 


<img width="1324" alt="Screenshot 2024-12-12 at 4 29 29 PM" src="https://github.com/user-attachments/assets/11da54f7-1f1c-485a-922c-c7ce2b8fd61a" />

