### PR TITLE
fix: adequate course key type in forum v2

### DIFF
--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -56,7 +56,7 @@ ENABLE_NEW_STRUCTURE_DISCUSSIONS = CourseWaffleFlag(
 ENABLE_FORUM_V2 = CourseWaffleFlag(f"{WAFFLE_FLAG_NAMESPACE}.enable_forum_v2", __name__)
 
 
-def is_forum_v2_enabled(course_id):
+def is_forum_v2_enabled(course_key):
     """
     Returns whether forum V2 is enabled on the course. This is a 2-step check:
 
@@ -65,7 +65,7 @@ def is_forum_v2_enabled(course_id):
     """
     if is_forum_v2_disabled_globally():
         return False
-    return ENABLE_FORUM_V2.is_enabled(course_id)
+    return ENABLE_FORUM_V2.is_enabled(course_key)
 
 
 def is_forum_v2_disabled_globally() -> bool:

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -74,7 +74,8 @@ class Model:
     def _retrieve(self, *args, **kwargs):
         course_id = self.attributes.get("course_id") or kwargs.get("course_id")
         if course_id:
-            use_forumv2 = is_forum_v2_enabled(course_id)
+            course_key = get_course_key(course_id)
+            use_forumv2 = is_forum_v2_enabled(course_key)
         else:
             use_forumv2, course_id = is_forum_v2_enabled_for_comment(self.id)
         response = None

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -174,7 +174,8 @@ class Thread(models.Model):
         request_params = utils.strip_none(request_params)
         course_id = kwargs.get("course_id")
         if course_id:
-            use_forumv2 = is_forum_v2_enabled(course_id)
+            course_key = utils.get_course_key(course_id)
+            use_forumv2 = is_forum_v2_enabled(course_key)
         else:
             use_forumv2, course_id = is_forum_v2_enabled_for_thread(self.id)
         if use_forumv2:


### PR DESCRIPTION
## Description

When checking whether forum v2 is enabled, the course waffle flag argument should be a CourseKey, not a str.

## Supporting information

See discussion here: https://app.slack.com/client/T02SNA1T6

## Testing instructions

1. Enable forum v2
2. Post a comment as a non-staff user
3. As a staff user, endorse that comment
