### PR TITLE
fix: new discussion post should only be grouped if old notification is not seen

### DIFF
--- a/openedx/core/djangoapps/notifications/grouping_notifications.py
+++ b/openedx/core/djangoapps/notifications/grouping_notifications.py
@@ -128,15 +128,12 @@ def get_user_existing_notifications(user_ids, notification_type, group_by_id, co
     """
     Returns user last group able notification
     """
-    notification_type_params = {
-        'new_discussion_post': {'last_seen__isnull': True},
-    }
     notifications = Notification.objects.filter(
         user__in=user_ids,
         notification_type=notification_type,
         group_by_id=group_by_id,
         course_id=course_id,
-        **notification_type_params.get(notification_type, {})
+        last_seen__isnull=True,
     )
     notifications_mapping = {user_id: [] for user_id in user_ids}
     for notification in notifications:

--- a/openedx/core/djangoapps/notifications/grouping_notifications.py
+++ b/openedx/core/djangoapps/notifications/grouping_notifications.py
@@ -128,11 +128,15 @@ def get_user_existing_notifications(user_ids, notification_type, group_by_id, co
     """
     Returns user last group able notification
     """
+    notification_type_params = {
+        'new_discussion_post': {'last_seen__isnull': True},
+    }
     notifications = Notification.objects.filter(
         user__in=user_ids,
         notification_type=notification_type,
         group_by_id=group_by_id,
-        course_id=course_id
+        course_id=course_id,
+        **notification_type_params.get(notification_type, {})
     )
     notifications_mapping = {user_id: [] for user_id in user_ids}
     for notification in notifications:

--- a/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
+++ b/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
@@ -2,11 +2,13 @@
 Tests for notification grouping module
 """
 
+import ddt
 import unittest
 from unittest.mock import MagicMock, patch
 from datetime import datetime
 from pytz import utc
 
+from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.notifications.grouping_notifications import (
     BaseNotificationGrouper,
     NotificationRegistry,
@@ -15,6 +17,8 @@ from openedx.core.djangoapps.notifications.grouping_notifications import (
     get_user_existing_notifications, NewPostGrouper
 )
 from openedx.core.djangoapps.notifications.models import Notification
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class TestNotificationRegistry(unittest.TestCase):
@@ -102,7 +106,8 @@ class TestNewCommentGrouper(unittest.TestCase):
         self.assertEqual(content_context['email_content'], 'new content')
 
 
-class TestNewPostGrouper(unittest.TestCase):
+@ddt.ddt
+class TestNewPostGrouper(ModuleStoreTestCase):
     """
     Tests for the NewPostGrouper class
     """
@@ -141,6 +146,36 @@ class TestNewPostGrouper(unittest.TestCase):
         updated_context = NewPostGrouper().group(new_notification, old_notification)
 
         self.assertFalse(updated_context.get('grouped', False))
+
+    @ddt.data(datetime(2023, 1, 1, tzinfo=utc), None)
+    def test_not_grouped_when_notification_is_seen(self, last_seen):
+        """
+        Notification is not grouped if the notification is marked as seen
+        """
+        course = CourseFactory()
+        user = UserFactory()
+        notification_params = {
+            'app_name': 'discussion',
+            'notification_type': 'new_discussion_post',
+            'course_id': course.id,
+            'group_by_id': course.id,
+            'content_url': 'http://example.com',
+            'user': user,
+            'last_seen': last_seen,
+        }
+        Notification.objects.create(content_context={
+            'username': 'User1',
+            'post_title': ' Post title',
+            'replier_name': 'User 1',
+
+        }, **notification_params)
+        existing_notifications = get_user_existing_notifications(
+            [user.id], 'new_discussion_post', course.id, course.id
+        )
+        if last_seen is None:
+            assert existing_notifications[user.id] is not None
+        else:
+            assert existing_notifications[user.id] is None
 
 
 class TestGroupUserNotifications(unittest.TestCase):

--- a/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
+++ b/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
@@ -106,8 +106,7 @@ class TestNewCommentGrouper(unittest.TestCase):
         self.assertEqual(content_context['email_content'], 'new content')
 
 
-@ddt.ddt
-class TestNewPostGrouper(ModuleStoreTestCase):
+class TestNewPostGrouper(unittest.TestCase):
     """
     Tests for the NewPostGrouper class
     """
@@ -147,38 +146,9 @@ class TestNewPostGrouper(ModuleStoreTestCase):
 
         self.assertFalse(updated_context.get('grouped', False))
 
-    @ddt.data(datetime(2023, 1, 1, tzinfo=utc), None)
-    def test_not_grouped_when_notification_is_seen(self, last_seen):
-        """
-        Notification is not grouped if the notification is marked as seen
-        """
-        course = CourseFactory()
-        user = UserFactory()
-        notification_params = {
-            'app_name': 'discussion',
-            'notification_type': 'new_discussion_post',
-            'course_id': course.id,
-            'group_by_id': course.id,
-            'content_url': 'http://example.com',
-            'user': user,
-            'last_seen': last_seen,
-        }
-        Notification.objects.create(content_context={
-            'username': 'User1',
-            'post_title': ' Post title',
-            'replier_name': 'User 1',
 
-        }, **notification_params)
-        existing_notifications = get_user_existing_notifications(
-            [user.id], 'new_discussion_post', course.id, course.id
-        )
-        if last_seen is None:
-            assert existing_notifications[user.id] is not None
-        else:
-            assert existing_notifications[user.id] is None
-
-
-class TestGroupUserNotifications(unittest.TestCase):
+@ddt.ddt
+class TestGroupUserNotifications(ModuleStoreTestCase):
     """
     Tests for the group_user_notifications function
     """
@@ -213,6 +183,36 @@ class TestGroupUserNotifications(unittest.TestCase):
         group_user_notifications(new_notification, old_notification)
 
         self.assertFalse(old_notification.save.called)
+
+    @ddt.data(datetime(2023, 1, 1, tzinfo=utc), None)
+    def test_not_grouped_when_notification_is_seen(self, last_seen):
+        """
+        Notification is not grouped if the notification is marked as seen
+        """
+        course = CourseFactory()
+        user = UserFactory()
+        notification_params = {
+            'app_name': 'discussion',
+            'notification_type': 'new_discussion_post',
+            'course_id': course.id,
+            'group_by_id': course.id,
+            'content_url': 'http://example.com',
+            'user': user,
+            'last_seen': last_seen,
+        }
+        Notification.objects.create(content_context={
+            'username': 'User1',
+            'post_title': ' Post title',
+            'replier_name': 'User 1',
+
+        }, **notification_params)
+        existing_notifications = get_user_existing_notifications(
+            [user.id], 'new_discussion_post', course.id, course.id
+        )
+        if last_seen is None:
+            assert existing_notifications[user.id] is not None
+        else:
+            assert existing_notifications[user.id] is None
 
 
 class TestGetUserExistingNotifications(unittest.TestCase):


### PR DESCRIPTION
`new_discussion_post` notification should only be grouped when old notification is not seen. If old notification is seen, create a new notification.

Ticket: [INF-1723](https://2u-internal.atlassian.net/browse/INF-1723)