### PR TITLE
feat: send datetime

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
@@ -38,4 +38,5 @@ class LinkCheckOutputSerializer(serializers.Serializer):
 class LinkCheckSerializer(serializers.Serializer):
     """ Serializer for broken links """
     LinkCheckStatus = serializers.CharField(required=True)
+    LinkCheckCreatedAt = serializers.DateTimeField(required=False)
     LinkCheckOutput = LinkCheckOutputSerializer(required=True)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
@@ -154,6 +154,7 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
         
         task_status = _latest_task_status(request, course_id)
         status = None
+        created_at = None
         broken_links_dto = None
         error = None
         if task_status is None:
@@ -165,6 +166,7 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
                 status = 'Uninitiated'
         else:
             status = task_status.state
+            created_at = task_status.created
             if task_status.state == UserTaskStatus.SUCCEEDED:
                 artifact = UserTaskArtifact.objects.get(status=task_status, name='BrokenLinks')
                 with artifact.file as file:
@@ -218,6 +220,7 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
         # }
         data = {
             'LinkCheckStatus': status,
+            'LinkCheckCreatedAt': created_at,
             **({'LinkCheckOutput': broken_links_dto} if broken_links_dto else {}),
             **({'LinkCheckError': error} if error else {})
         }


### PR DESCRIPTION
This PR modifies `link_check_status` api to return the time of when the last task was run.

Example:
```
{
  "LinkCheckStatus": "Succeeded",
  "LinkCheckCreatedAt": "2024-12-14T00:26:50.838350Z",
  "LinkCheckOutput": {
    "sections": [
...
```