### PR TITLE
fix: use a single 'provider_type' key for storing discussion provider type in course

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -474,11 +474,11 @@ def sync_discussion_settings(course_key, user):
         if (
             ENABLE_NEW_STRUCTURE_DISCUSSIONS.is_enabled()
             and not course.discussions_settings['provider_type'] == Provider.OPEN_EDX
+            and not course.discussions_settings['provider'] == Provider.OPEN_EDX
         ):
             LOGGER.info(f"New structure is enabled, also updating {course_key} to use new provider")
             course.discussions_settings['enable_graded_units'] = False
             course.discussions_settings['unit_level_visibility'] = True
-            course.discussions_settings['provider'] = Provider.OPEN_EDX
             course.discussions_settings['provider_type'] = Provider.OPEN_EDX
             modulestore().update_item(course, user.id)
 

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -473,8 +473,8 @@ def sync_discussion_settings(course_key, user):
 
         if (
             ENABLE_NEW_STRUCTURE_DISCUSSIONS.is_enabled()
-            and not course.discussions_settings['provider_type'] == Provider.OPEN_EDX
-            and not course.discussions_settings['provider'] == Provider.OPEN_EDX
+            and not course.discussions_settings.get('provider_type', None) == Provider.OPEN_EDX
+            and not course.discussions_settings.get('provider', None) == Provider.OPEN_EDX
         ):
             LOGGER.info(f"New structure is enabled, also updating {course_key} to use new provider")
             course.discussions_settings['enable_graded_units'] = False

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -201,7 +201,10 @@ def update_unit_discussion_state_from_discussion_blocks(
     """
     store = modulestore()
     course = store.get_course(course_key)
-    provider = course.discussions_settings.get('provider', None)
+    provider = course.discussions_settings.get(
+        'provider_type',
+        course.discussions_settings.get('provider', None),
+    )
     # Only migrate to the new discussion provider if the current provider is the legacy provider.
     log.info(f"Current provider for {course_key} is {provider}")
     if provider is not None and provider != Provider.LEGACY and not force:

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -201,6 +201,10 @@ def update_unit_discussion_state_from_discussion_blocks(
     """
     store = modulestore()
     course = store.get_course(course_key)
+    # The provider information has been written to both `provider_type` and `provider`.
+    # Both of these serve the same purpose and this is an accident of early development.
+    # The `provider_type` key is now treated as read-only to allow existing values
+    # to be respected while moving to the `provider` key in the future.
     provider = course.discussions_settings.get(
         'provider_type',
         course.discussions_settings.get('provider', None),


### PR DESCRIPTION
## Description

Both 'provider' and 'provider_type' have been used for storing the discussion provider type in course 'discussions_settings' field, there are some places in the code checking for 'provider' and others checking for 'provider_type', in some cases this can cause a bug where it doesn't detect the correct provider which causes discussion settings not being copied correctly when a course is cloned.

This change prioritises the `provider_type` setting over `provider` and reads `provider` only as a fallback. The `provider` setting is now made read-only just for backwards-compatibility, to avoid confusion.

## Testing instructions

- Create a course structure with discussions enable or disabled in different sections. You can use this [test course](https://github.com/user-attachments/files/18163715/course.zyqcabcj.tar.gz).
- Use the course clone API to clone the course: `studio.local.openedx.io:8001/api/v1/course_runs/clone/`
- Check that the discussion enabled/disabled statues is copied over. 

## Deadline

None
