### PR TITLE
fix: updated goal reminder email time logger

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -1,6 +1,7 @@
 """
 Command to trigger sending reminder emails for learners to achieve their Course Goals
 """
+import time
 from datetime import date, datetime, timedelta
 from eventtracking import tracker
 import logging
@@ -119,9 +120,9 @@ def send_ace_message(goal, session_id):
 
     with emulate_http_request(site, user):
         try:
-            start_time = datetime.now()
+            start_time = time.perf_counter()
             ace.send(msg)
-            end_time = datetime.now()
+            end_time = time.perf_counter()
             log.info(f"Goal Reminder for {user.id} for course {goal.course_key} sent in {end_time - start_time} "
                      f"using {'SES' if is_ses_enabled else 'others'}")
         except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
## Description 
Updated Goal reminder time logger to `perf_counter` because the previous implementation was logging zero values.