### PR TITLE
build!: Delete requirements/edx-sandbox/py38.txt

### DIFF
--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -1,4 +1,0 @@
-# This file is a temporary compatibility wrapper around quince.txt.
-# It will be removed before Sumac.
-
--r releases/quince.txt


### PR DESCRIPTION
This was a temporary backcompat alias to requirements/edx-sandbox/quince.txt.

Developers relying on this file to run a python3.8 sandbox should:
* first, switch to requirements/edx-sandbox/quince.txt, which works with python3.8
* and then, upgrade their codejail sandbox to a newer `<release>.txt` since python3.8 is EOL.

See the readme in this directory for more details.