### PR TITLE
fix: do not require output or error

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
@@ -39,4 +39,5 @@ class LinkCheckSerializer(serializers.Serializer):
     """ Serializer for broken links """
     LinkCheckStatus = serializers.CharField(required=True)
     LinkCheckCreatedAt = serializers.DateTimeField(required=False)
-    LinkCheckOutput = LinkCheckOutputSerializer(required=True)
+    LinkCheckOutput = LinkCheckOutputSerializer(required=False)
+    LinkCheckError = serializers.CharField(required=False)


### PR DESCRIPTION
Fix serializer for cases when there is no broken links in the course. (Change output to not be required.)