### PR TITLE
build: upgrade django-stubs and djangorestframework-stubs

### DIFF
--- a/openedx/core/djangoapps/content/learning_sequences/models.py
+++ b/openedx/core/djangoapps/content/learning_sequences/models.py
@@ -37,6 +37,8 @@ that separated.
 yourself to the LearningContext and LearningSequence models. Other tables are
 not guaranteed to stick around, and values may be deleted unexpectedly.
 """
+from __future__ import annotations
+
 from django.db import models
 from model_utils.models import TimeStampedModel
 
@@ -214,7 +216,7 @@ class CourseSection(CourseContentVisibilityMixin, TimeStampedModel):
     # What is our position within the Course? (starts with 0)
     ordering = models.PositiveIntegerField(null=False)
 
-    new_user_partition_groups = models.ManyToManyField(
+    new_user_partition_groups: models.ManyToManyField[UserPartitionGroup, models.Model] = models.ManyToManyField(
         UserPartitionGroup,
         db_index=True,
         related_name='sec_user_partition_groups',
@@ -280,7 +282,7 @@ class CourseSectionSequence(CourseContentVisibilityMixin, TimeStampedModel):
     # sequences across 20 sections, the numbering here would be 0-199.
     ordering = models.PositiveIntegerField(null=False)
 
-    new_user_partition_groups = models.ManyToManyField(
+    new_user_partition_groups: models.ManyToManyField[UserPartitionGroup, models.Model] = models.ManyToManyField(
         UserPartitionGroup,
         db_index=True,
         related_name='secseq_user_partition_groups',

--- a/openedx/core/djangoapps/content_libraries/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/serializers.py
@@ -276,7 +276,7 @@ class ContentLibraryCollectionUpdateSerializer(serializers.Serializer):
     description = serializers.CharField(allow_blank=True)
 
 
-class UsageKeyV2Serializer(serializers.Serializer):
+class UsageKeyV2Serializer(serializers.BaseSerializer):
     """
     Serializes a UsageKeyV2.
     """

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -60,12 +60,12 @@ django-webpack-loader==0.7.0
 # Adding pin to avoid any major upgrade
 djangorestframework<3.15.0
 
-# Date: 2023-07-19
-# The version of django-stubs we can use depends on which Django release we're using
-# 1.16.0 works with Django 3.2 through 4.1
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35275
-django-stubs==1.16.0
-djangorestframework-stubs==3.14.0  # Pinned to match django-stubs. Remove this when we can remove the above pin.
+# Date: 2024-07-19
+# Generally speaking, the major version of django-stubs should match the major version of django.
+# Specifically, we need to perpetually constrain django-stubs to a compatible version based on:
+# https://github.com/typeddjango/django-stubs?tab=readme-ov-file#version-compatibility
+# Issue: https://github.com/openedx/edx-platform/issues/35275
+django-stubs<5
 
 # Date: 2024-07-23
 # django-storages==1.14.4 breaks course imports

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -577,7 +577,7 @@ django-storages==1.14.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-django-stubs==1.16.0
+django-stubs==4.2.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
@@ -625,10 +625,8 @@ djangorestframework==3.14.0
     #   openedx-learning
     #   ora2
     #   super-csv
-djangorestframework-stubs==3.14.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/development.in
+djangorestframework-stubs==3.14.5
+    # via -r requirements/edx/development.in
 djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1301,8 +1299,6 @@ mypy==1.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
-    #   django-stubs
-    #   djangorestframework-stubs
 mypy-extensions==1.0.0
     # via mypy
 mysqlclient==2.2.6
@@ -2121,8 +2117,6 @@ tinycss2==1.4.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   bleach
-tomli==2.2.1
-    # via django-stubs
 tomlkit==0.13.2
     # via
     #   -r requirements/edx/doc.txt


### PR DESCRIPTION
...now that we're on django>=4.2

This will allow us to annotate Django-based and DRF-based code more expressively and correctly going forward. It should have no functional impact.

See individual commits for more details.