### PR TITLE
refactor!: remove md4 and related ENABLE_BLAKE2B_HASHING feature flag

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,29 +71,7 @@ jobs:
 
       - name: install system requirements
         run: |
-          sudo apt-get update && sudo apt-get install libmysqlclient-dev libxmlsec1-dev lynx openssl
-
-      # This is needed until the ENABLE_BLAKE2B_HASHING can be removed and we
-      # can stop using MD4 by default.
-      - name: enable md4 hashing in libssl
-        run: |
-          cat <<EOF | sudo tee /etc/ssl/openssl.cnf
-          # Use this in order to automatically load providers.
-          openssl_conf = openssl_init
-
-          [openssl_init]
-          providers = provider_sect
-
-          [provider_sect]
-          default = default_sect
-          legacy = legacy_sect
-
-          [default_sect]
-          activate = 1
-
-          [legacy_sect]
-          activate = 1
-          EOF
+          sudo apt-get update && sudo apt-get install libmysqlclient-dev libxmlsec1-dev lynx
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.11.0

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -566,9 +566,6 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
     'ENABLE_GRADING_METHOD_IN_PROBLEMS': False,
 
-    # See annotations in lms/envs/common.py for details.
-    'ENABLE_BLAKE2B_HASHING': False,
-
     # .. toggle_name: FEATURES['BADGES_ENABLED']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False

--- a/common/djangoapps/util/memcache.py
+++ b/common/djangoapps/util/memcache.py
@@ -7,7 +7,6 @@ so that we can cache any keys, not just ones that memcache would ordinarily acce
 import hashlib
 from urllib.parse import quote_plus
 
-from django.conf import settings
 from django.utils.encoding import smart_str
 
 
@@ -15,10 +14,7 @@ def fasthash(string):
     """
     Hashes `string` into a string representation of a 128-bit digest.
     """
-    if settings.FEATURES.get("ENABLE_BLAKE2B_HASHING", False):
-        hash_obj = hashlib.new("blake2b", digest_size=16)
-    else:
-        hash_obj = hashlib.new("md4")
+    hash_obj = hashlib.new("blake2b", digest_size=16)
     hash_obj.update(string.encode('utf-8'))
     return hash_obj.hexdigest()
 

--- a/common/djangoapps/util/tests/test_memcache.py
+++ b/common/djangoapps/util/tests/test_memcache.py
@@ -3,14 +3,10 @@ Tests for memcache in util app
 """
 
 
-from django.conf import settings
 from django.core.cache import caches
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from common.djangoapps.util.memcache import safe_key
-
-BLAKE2B_ENABLED_FEATURES = settings.FEATURES.copy()
-BLAKE2B_ENABLED_FEATURES["ENABLE_BLAKE2B_HASHING"] = True
 
 
 class MemcacheTest(TestCase):
@@ -55,20 +51,6 @@ class MemcacheTest(TestCase):
             # The key should now be valid
             assert self._is_valid_key(key), f'Failed for key length {length}'
 
-    @override_settings(FEATURES=BLAKE2B_ENABLED_FEATURES)
-    def test_safe_key_long_with_blake2b_enabled(self):
-        # Choose lengths close to memcached's cutoff (250)
-        for length in [248, 249, 250, 251, 252]:
-
-            # Generate a key of that length
-            key = 'a' * length
-
-            # Make the key safe
-            key = safe_key(key, '', '')
-
-            # The key should now be valid
-            assert self._is_valid_key(key), f'Failed for key length {length}'
-
     def test_long_key_prefix_version(self):
 
         # Long key
@@ -82,34 +64,6 @@ class MemcacheTest(TestCase):
         # Long version
         key = safe_key('key', 'prefix', 'a' * 300)
         assert self._is_valid_key(key)
-
-    @override_settings(FEATURES=BLAKE2B_ENABLED_FEATURES)
-    def test_long_key_prefix_version_with_blake2b_enabled(self):
-
-        # Long key
-        key = safe_key('a' * 300, 'prefix', 'version')
-        assert self._is_valid_key(key)
-
-        # Long prefix
-        key = safe_key('key', 'a' * 300, 'version')
-        assert self._is_valid_key(key)
-
-        # Long version
-        key = safe_key('key', 'prefix', 'a' * 300)
-        assert self._is_valid_key(key)
-
-    def test_safe_key_unicode(self):
-
-        for unicode_char in self.UNICODE_CHAR_CODES:
-
-            # Generate a key with that character
-            key = chr(unicode_char)
-
-            # Make the key safe
-            key = safe_key(key, '', '')
-
-            # The key should now be valid
-            assert self._is_valid_key(key), f'Failed for unicode character {unicode_char}'
 
     def test_safe_key_prefix_unicode(self):
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1059,18 +1059,6 @@ FEATURES = {
     # .. toggle_creation_date: 2024-04-24
     'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': False,
 
-    # .. toggle_name: FEATURES['ENABLE_BLAKE2B_HASHING']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: Enables the memcache to use the blake2b hash algorithm instead of depreciated md4 for keys
-    #   exceeding 250 characters
-    # .. toggle_use_cases: open_edx
-    # .. toggle_creation_date: 2024-04-02
-    # .. toggle_target_removal_date: 2024-12-09
-    # .. toggle_warning: For consistency, keep the value in sync with the setting of the same name in the LMS and CMS.
-    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34442
-    'ENABLE_BLAKE2B_HASHING': False,
-
     # .. toggle_name: FEATURES['BADGES_ENABLED']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR removes md4 and related ENABLE_BLAKE2B_HASHING feature flag

Useful information to include:

- Which edX user roles will this change impact?  Learner, Course Author

## Supporting information

https://github.com/openedx/edx-platform/issues/36024

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None"

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
