### PR TITLE
feat: show math in plain text in library cards

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -3,6 +3,7 @@ Utilities related to indexing content for search
 """
 from __future__ import annotations
 
+import re
 import logging
 from hashlib import blake2b
 
@@ -14,6 +15,7 @@ from opaque_keys.edx.locator import LibraryLocatorV2
 from rest_framework.exceptions import NotFound
 
 from openedx.core.djangoapps.content.search.models import SearchAccess
+from openedx.core.djangoapps.content.search.plain_text_math import process_mathjax
 from openedx.core.djangoapps.content_libraries import api as lib_api
 from openedx.core.djangoapps.content_tagging import api as tagging_api
 from openedx.core.djangoapps.xblock import api as xblock_api
@@ -220,7 +222,7 @@ def _fields_from_block(block) -> dict:
         # Generate description from the content
         description = _get_description_from_block_content(block_type, content_data)
         if description:
-            block_data[Fields.description] = description
+            block_data[Fields.description] = process_mathjax(description)
 
     except Exception as err:  # pylint: disable=broad-except
         log.exception(f"Failed to process index_dictionary for {block.usage_key}: {err}")

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -3,7 +3,6 @@ Utilities related to indexing content for search
 """
 from __future__ import annotations
 
-import re
 import logging
 from hashlib import blake2b
 

--- a/openedx/core/djangoapps/content/search/plain_text_math.py
+++ b/openedx/core/djangoapps/content/search/plain_text_math.py
@@ -30,7 +30,9 @@ class PlainTextMath:
         ("\\right", ""),
     )
     regex_replacements = (
+        # Makes text bold, so not required in plain text.
         (re.compile(r'\\mathbf{(.*?)}'), r"\1"),
+        (re.compile(r'{\\bf (.*?)}'), r"\1"),
     )
 
     def _fraction_handler(self, equation: str) -> str:

--- a/openedx/core/djangoapps/content/search/plain_text_math.py
+++ b/openedx/core/djangoapps/content/search/plain_text_math.py
@@ -46,12 +46,12 @@ class PlainTextMath:
 
     @staticmethod
     def _nested_bracket_matcher(equation: str, opening_pattern: str) -> str:
-        """
+        r"""
         Matches opening and closing brackets in given string.
 
         Args:
             equation: string
-            opening_pattern: for example, `\\mathbf{`
+            opening_pattern: for example, `\mathbf{`
 
         Returns:
             String inside the eqn brackets
@@ -75,16 +75,16 @@ class PlainTextMath:
         return (start, inner_start, inner_start + i, inner_start + i + 1)
 
     def _fraction_handler(self, equation: str) -> str:
-        """
-        Converts `\\frac{x}{y}` to `(x/y)` while handling nested `{}`.
+        r"""
+        Converts `\frac{x}{y}` to `(x/y)` while handling nested `{}`.
 
-        For example: `\\frac{2}{\\sqrt{1+y}}` is converted to `(2/\\sqrt{1+y})`.
+        For example: `\frac{2}{\sqrt{1+y}}` is converted to `(2/\sqrt{1+y})`.
 
         Args:
             equation: string
 
         Returns:
-            String with `\\frac` replaced by normal `/` symbol.
+            String with `\frac` replaced by normal `/` symbol.
         """
         try:
             n_start, n_inner_start, n_inner_end, n_end = self._nested_bracket_matcher(equation, "\\frac{")

--- a/openedx/core/djangoapps/content/search/plain_text_math.py
+++ b/openedx/core/djangoapps/content/search/plain_text_math.py
@@ -1,0 +1,91 @@
+import re
+
+import unicodeit
+
+
+class PlainTextMath:
+    """
+    Converts mathjax equations to plain text using unicodeit and some preprocessing.
+    """
+    equation_pattern = re.compile(
+        r'\[mathjaxinline\](.*?)\[\/mathjaxinline\]|\[mathjax\](.*?)\[\/mathjax\]|\\\((.*?)\\\)|\\\[(.*?)\\\]'
+    )
+    eqn_replacements = (
+        # just remove prefix `\`
+        ("\\sin", "sin"),
+        ("\\cos", "cos"),
+        ("\\tan", "tan"),
+        ("\\arcsin", "arcsin"),
+        ("\\arccos", "arccos"),
+        ("\\arctan", "arctan"),
+        ("\\cot", "cot"),
+        ("\\sec", "sec"),
+        ("\\csc", "csc"),
+        # Is used for matching brackets in mathjax, should be required in plain text.
+        ("\\left", ""),
+        ("\\right", ""),
+    )
+    regex_replacements = (
+        (re.compile(r'\\mathbf{(.*?)}'), r"\1"),
+    )
+
+    def _fraction_handler(self, equation: str) -> str:
+        """
+        Converts `\frac{x}{y}` to `(x/y)` while handling nested `{}`.
+
+        For example: `\frac{2}{\sqrt{1+y}}` is converted to `(2/\sqrt{1+y})`.
+
+        Args:
+            equation: string
+
+        Returns:
+            String with `\frac` replaced by normal `/` symbol.
+        """
+        start_index = equation.find("\\frac{")
+        if start_index == -1:
+            return equation
+        mid_index = equation.find("}{")
+        numerator = equation[start_index + 6:mid_index]
+        open_count = 0
+        for i, char in enumerate(equation[mid_index + 2:]):
+            if char == "{":
+                open_count += 1
+            if char == "}":
+                if open_count == 0:
+                    break
+                open_count -= 1
+        else:
+            # Invalid `\frac` format
+            return equation
+        denominator = equation[mid_index + 2:mid_index + 2 + i]
+        equation = equation[:start_index] + f"({numerator}/{denominator})" + equation[mid_index + 2 + i + 1:]
+        return equation
+
+    def _handle_replacements(self, equation: str) -> str:
+        """
+        Makes a bunch of replacements in equation string.
+        """
+        for q, replacement in self.eqn_replacements:
+            equation = equation.replace(q, replacement)
+        for pattern, replacement in self.regex_replacements:
+            equation = re.sub(pattern, replacement, equation)
+        return equation
+
+    def run(self, eqn_matches: re.Match) -> str:
+        """
+        Takes re.Match object and runs conversion process on each match group.
+        """
+        groups = eqn_matches.groups()
+        for group in groups:
+            if group:
+                group = self._fraction_handler(group)
+                group = self._handle_replacements(group)
+                return unicodeit.replace(group)
+        return None
+
+
+processor = PlainTextMath()
+
+
+def process_mathjax(content: str) -> str:
+    return re.sub(processor.equation_pattern, processor.run, content)

--- a/openedx/core/djangoapps/content/search/plain_text_math.py
+++ b/openedx/core/djangoapps/content/search/plain_text_math.py
@@ -45,9 +45,15 @@ class PlainTextMath:
         if start_index == -1:
             return equation
         mid_index = equation.find("}{")
+        if mid_index == -1:
+            return equation
+
         numerator = equation[start_index + 6:mid_index]
+        # shift mid_index by length of }{ chars i.e., 2
+        mid_index += 2
         open_count = 0
-        for i, char in enumerate(equation[mid_index + 2:]):
+
+        for i, char in enumerate(equation[mid_index:]):
             if char == "{":
                 open_count += 1
             if char == "}":
@@ -57,8 +63,10 @@ class PlainTextMath:
         else:
             # Invalid `\frac` format
             return equation
-        denominator = equation[mid_index + 2:mid_index + 2 + i]
-        equation = equation[:start_index] + f"({numerator}/{denominator})" + equation[mid_index + 2 + i + 1:]
+
+        denominator = equation[mid_index:mid_index + i]
+        # Now re-create the equation with `(numerator / denominator)`
+        equation = equation[:start_index] + f"({numerator}/{denominator})" + equation[mid_index + i + 1:]
         return equation
 
     def _handle_replacements(self, equation: str) -> str:

--- a/openedx/core/djangoapps/content/search/plain_text_math.py
+++ b/openedx/core/djangoapps/content/search/plain_text_math.py
@@ -1,3 +1,7 @@
+"""
+Helper class to convert mathjax equations to plain text.
+"""
+
 import re
 
 import unicodeit
@@ -21,7 +25,7 @@ class PlainTextMath:
         ("\\cot", "cot"),
         ("\\sec", "sec"),
         ("\\csc", "csc"),
-        # Is used for matching brackets in mathjax, should be required in plain text.
+        # Is used for matching brackets in mathjax, should not be required in plain text.
         ("\\left", ""),
         ("\\right", ""),
     )
@@ -31,15 +35,15 @@ class PlainTextMath:
 
     def _fraction_handler(self, equation: str) -> str:
         """
-        Converts `\frac{x}{y}` to `(x/y)` while handling nested `{}`.
+        Converts `\\frac{x}{y}` to `(x/y)` while handling nested `{}`.
 
-        For example: `\frac{2}{\sqrt{1+y}}` is converted to `(2/\sqrt{1+y})`.
+        For example: `\\frac{2}{\\sqrt{1+y}}` is converted to `(2/\\sqrt{1+y})`.
 
         Args:
             equation: string
 
         Returns:
-            String with `\frac` replaced by normal `/` symbol.
+            String with `\\frac` replaced by normal `/` symbol.
         """
         start_index = equation.find("\\frac{")
         if start_index == -1:

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -553,7 +553,15 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 'Bold text:  a ⋅ b = |a| |b| cos(θ)',
             ),
             ('Bold text: \\( \\frac{\\sqrt{\\mathbf{2}+3}}{\\sqrt{4}} \\)', 'Bold text:  (√{2+3}/√{4})'),
-            ('Nested Bold text: \\( \\mathbf{ \\frac{1}{2} } \\)', 'Nested Bold text:   (1/2)'),
+            ('Nested Bold text 1: \\( \\mathbf{ \\frac{1}{2} } \\)', 'Nested Bold text 1:   (1/2)'),
+            (
+                'Nested Bold text 2: \\( \\mathbf{a \\cdot (a \\mathbf{\\times} b)} \\)',
+                'Nested Bold text 2:  a ⋅ (a × b)'
+            ),
+            (
+                'Nested Bold text 3: \\( \\mathbf{a \\cdot (a \\bm{\\times} b)} \\)',
+                'Nested Bold text 3:  a ⋅ (a × b)'
+            ),
             ('Sqrt test 1: \\(\\sqrt\\)', 'Sqrt test 1: √'),
             ('Sqrt test 2: \\(x^2 + \\sqrt(y)\\)', 'Sqrt test 2: x² + √(y)'),
             ('Sqrt test 3: [mathjaxinline]x^2 + \\sqrt(y)[/mathjaxinline]', 'Sqrt test 3: x² + √(y)'),

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -559,6 +559,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             ('Sqrt test 3: [mathjaxinline]x^2 + \\sqrt(y)[/mathjaxinline]', 'Sqrt test 3: x² + √(y)'),
             ('Fraction test 1: \\( \\frac{2} {3} \\)', 'Fraction test 1:  (2/3)'),
             ('Fraction test 2: \\( \\frac{2}{3} \\)', 'Fraction test 2:  (2/3)'),
+            ('Fraction test 3: \\( \\frac{\\frac{2}{3}}{4} \\)', 'Fraction test 3:  ((2/3)/4)'),
+            ('Fraction test 4: \\( \\frac{\\frac{2} {3}}{4} \\)', 'Fraction test 4:  ((2/3)/4)'),
+            ('Fraction test 5: \\( \\frac{\\frac{2} {3}}{\\frac{4}{3}} \\)', 'Fraction test 5:  ((2/3)/(4/3))'),
         ]
         # pylint: enable=line-too-long
         block = BlockFactory.create(

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -477,3 +477,81 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 "num_children": 1
             }
         }
+
+    def test_mathjax_plain_text_conversion_for_search(self):
+        """
+        Test how an HTML block with mathjax equations gets converted to plain text in search description.
+        """
+        # pylint: disable=line-too-long
+        block = BlockFactory.create(
+            parent_location=self.toy_course.location,
+            category="html",
+            display_name="Non-default HTML Block",
+            editor="raw",
+            use_latex_compiler=True,
+            data=(
+                "Simple addition: \( 2 + 3 \) |||"
+                " Simple subtraction: \( 5 - 2 \) |||"
+                " Simple multiplication: \( 4 * 6 \) |||"
+                " Simple division: \( 8 / 2 \) |||"
+                " Mixed arithmetic: \( 2 + 3  4 \) |||"
+                " Simple exponentiation: \[ 2^3 \] |||"
+                " Root extraction: \[ 16^{1/2} \] |||"
+                " Exponent with multiple terms: \[ (2 + 3)^2 \] |||"
+                " Nested exponents: \[ 2^(3^2) \] |||"
+                " Mixed roots: \[ 8^{1/2}  3^2 \] |||"
+                " Simple fraction: [mathjaxinline] 3/4 [/mathjaxinline] |||"
+                " Decimal to fraction conversion: [mathjaxinline] 0.75 = 3/4 [/mathjaxinline] |||"
+                " Mixed fractions: [mathjaxinline] 1 1/2 = 3/2 [/mathjaxinline] |||"
+                " Converting decimals to mixed fractions: [mathjaxinline] 2.5 = 5/2 [/mathjaxinline] |||"
+                " Sine, cosine, and tangent: [mathjaxinline] \\sin(x) [/mathjaxinline] [mathjaxinline] \\cos(x) [/mathjaxinline] [mathjaxinline] \\tan(x) [/mathjaxinline] |||"
+                " Trig identities: [mathjaxinline] \\sin(x + y) = \\sin(x)  \\cos(y) + \\cos(x)  \\sin(y) [/mathjaxinline] |||"
+                " Hyperbolic trig functions: [mathjaxinline] \\sinh(x) [/mathjaxinline] [mathjaxinline] \\cosh(x) [/mathjaxinline] |||"
+                " Simple derivative: [mathjax] f(x) = x^2, f'(x) = 2x [/mathjax] |||"
+                " Double integral: [mathjax] int\int (x + y) dxdy [/mathjax] |||"
+                " Partial derivatives: [mathjax] f(x,y) = xy, \frac{\partial f}{\partial x} = y [/mathjax] [mathjax] \frac{\partial f}{\partial y} = x [/mathjax] |||"
+                " Mean and standard deviation: [mathjax] mu = 2, \sigma = 1 [/mathjax] |||"
+                " Binomial probability: [mathjax] P(X = k) = (\binom{n}{k} p^k (1-p)^{n-k}) [/mathjax] |||"
+                " Gaussian distribution: [mathjax] N(\mu, \sigma^2) [/mathjax] |||"
+                " Greek letters: [mathjaxinline] \\alpha [/mathjaxinline] [mathjaxinline] \\beta [/mathjaxinline] [mathjaxinline] \\gamma [/mathjaxinline] |||"
+                " Subscripted variables: [mathjaxinline] x_i [/mathjaxinline] [mathjaxinline] y_j [/mathjaxinline] |||"
+                " Superscripted variables: [mathjaxinline] x^{i} [/mathjaxinline] |||"
+                " Not supported: \( \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I \)"
+            ),
+        )
+        # pylint: enable=line-too-long
+        doc = {}
+        doc.update(searchable_doc_for_course_block(block))
+        doc.update(searchable_doc_tags(block.usage_key))
+        expected_equations = [
+            'Simple addition:  2 + 3',
+            'Simple subtraction:  5 − 2',
+            'Simple multiplication:  4 * 6',
+            'Simple division:  8 / 2',
+            'Mixed arithmetic:  2 + 3 4',
+            'Simple exponentiation:  2³',
+            'Root extraction:  16¹^/²',
+            'Exponent with multiple terms:  (2 + 3)²',
+            'Nested exponents:  2⁽3²)',
+            'Mixed roots:  8¹^/² 3²',
+            'Simple fraction:  3/4',
+            'Decimal to fraction conversion:  0.75 = 3/4',
+            'Mixed fractions:  1 1/2 = 3/2',
+            'Converting decimals to mixed fractions:  2.5 = 5/2',
+            'Sine, cosine, and tangent:  sin(x)   cos(x)   tan(x)',
+            'Trig identities:  sin(x + y) = sin(x) cos(y) + cos(x) sin(y)',
+            'Hyperbolic trig functions:  sinh(x)   cosh(x)',
+            "Simple derivative:  f(x) = x², f'(x) = 2x",
+            'Double integral:  int∫ (x + y) dxdy',
+            'Partial derivatives:  f(x,y) = xy, rac{∂ f}{∂ x} = y   rac{∂ f}{∂ y} = x',
+            'Mean and standard deviation:  mu = 2, σ = 1',
+            'Binomial probability:  P(X = k) = (inom{n}{k} pᵏ (1−p)ⁿ⁻ᵏ)',
+            'Gaussian distribution:  N(μ, σ²)',
+            'Greek letters:  α   β   γ',
+            'Subscripted variables:  xᵢ   yⱼ',
+            'Superscripted variables:  xⁱ',
+            'Not supported:  \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I',
+        ]
+        eqns = doc['description'].split('|||')
+        for i, eqn in enumerate(eqns):
+            assert eqn.strip() == expected_equations[i]

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -483,79 +483,92 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
         Test how an HTML block with mathjax equations gets converted to plain text in search description.
         """
         # pylint: disable=line-too-long
+        eqns = [
+            # (input, expected output)
+            ('Simple addition: \\( 2 + 3 \\)', 'Simple addition:  2 + 3'),
+            ('Simple subtraction: \\( 5 - 2 \\)', 'Simple subtraction:  5 − 2'),
+            ('Simple multiplication: \\( 4 * 6 \\)', 'Simple multiplication:  4 * 6'),
+            ('Simple division: \\( 8 / 2 \\)', 'Simple division:  8 / 2'),
+            ('Mixed arithmetic: \\( 2 + 3  4 \\)', 'Mixed arithmetic:  2 + 3 4'),
+            ('Simple exponentiation: \\[ 2^3 \\]', 'Simple exponentiation:  2³'),
+            ('Root extraction: \\[ 16^{1/2} \\]', 'Root extraction:  16¹^/²'),
+            ('Exponent with multiple terms: \\[ (2 + 3)^2 \\]', 'Exponent with multiple terms:  (2 + 3)²'),
+            ('Nested exponents: \\[ 2^(3^2) \\]', 'Nested exponents:  2⁽3²)'),
+            ('Mixed roots: \\[ 8^{1/2}  3^2 \\]', 'Mixed roots:  8¹^/² 3²'),
+            ('Simple fraction: [mathjaxinline] 3/4 [/mathjaxinline]', 'Simple fraction:  3/4'),
+            (
+                'Decimal to fraction conversion: [mathjaxinline] 0.75 = 3/4 [/mathjaxinline]',
+                'Decimal to fraction conversion:  0.75 = 3/4',
+            ),
+            ('Mixed fractions: [mathjaxinline] 1 1/2 = 3/2 [/mathjaxinline]', 'Mixed fractions:  1 1/2 = 3/2'),
+            (
+                'Converting decimals to mixed fractions: [mathjaxinline] 2.5 = 5/2 [/mathjaxinline]',
+                'Converting decimals to mixed fractions:  2.5 = 5/2',
+            ),
+            (
+                'Trig identities: [mathjaxinline] \\sin(x + y) = \\sin(x)  \\cos(y) + \\cos(x)  \\sin(y) [/mathjaxinline]',
+                'Trig identities:  sin(x + y) = sin(x) cos(y) + cos(x) sin(y)',
+            ),
+            (
+                'Sine, cosine, and tangent: [mathjaxinline] \\sin(x) [/mathjaxinline] [mathjaxinline] \\cos(x) [/mathjaxinline] [mathjaxinline] \\tan(x) [/mathjaxinline]',
+                'Sine, cosine, and tangent:  sin(x)   cos(x)   tan(x)',
+            ),
+            (
+                'Hyperbolic trig functions: [mathjaxinline] \\sinh(x) [/mathjaxinline] [mathjaxinline] \\cosh(x) [/mathjaxinline]',
+                'Hyperbolic trig functions:  sinh(x)   cosh(x)',
+            ),
+            (
+                "Simple derivative: [mathjax] f(x) = x^2, f'(x) = 2x [/mathjax]",
+                "Simple derivative:  f(x) = x², f'(x) = 2x",
+            ),
+            ('Double integral: [mathjax] int\\int (x + y) dxdy [/mathjax]', 'Double integral:  int∫ (x + y) dxdy'),
+            (
+                'Partial derivatives: [mathjax] f(x,y) = xy, \\frac{\\partial f}{\\partial x} = y [/mathjax] [mathjax] \\frac{\\partial f}{\\partial y} = x [/mathjax]',
+                'Partial derivatives:  f(x,y) = xy, (∂ f/∂ x) = y   (∂ f/∂ y) = x',
+            ),
+            (
+                'Mean and standard deviation: [mathjax] mu = 2, \\sigma = 1 [/mathjax]',
+                'Mean and standard deviation:  mu = 2, σ = 1',
+            ),
+            (
+                'Binomial probability: [mathjax] P(X = k) = (\\binom{n}{k} p^k (1-p)^{n-k}) [/mathjax]',
+                'Binomial probability:  P(X = k) = (\\binom{n}{k} pᵏ (1−p)ⁿ⁻ᵏ)',
+            ),
+            ('Gaussian distribution: [mathjax] N(\\mu, \\sigma^2) [/mathjax]', 'Gaussian distribution:  N(μ, σ²)'),
+            (
+                'Greek letters: [mathjaxinline] \\alpha [/mathjaxinline] [mathjaxinline] \\beta [/mathjaxinline] [mathjaxinline] \\gamma [/mathjaxinline]',
+                'Greek letters:  α   β   γ',
+            ),
+            (
+                'Subscripted variables: [mathjaxinline] x_i [/mathjaxinline] [mathjaxinline] y_j [/mathjaxinline]',
+                'Subscripted variables:  xᵢ   yⱼ',
+            ),
+            ('Superscripted variables: [mathjaxinline] x^{i} [/mathjaxinline]', 'Superscripted variables:  xⁱ'),
+            (
+                'Not supported: \\( \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I \\)',
+                'Not supported:  \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I',
+            ),
+            (
+                'Bold text: \\( {\\bf a} \\cdot {\\bf b} = |{\\bf a}| |{\\bf b}| \\cos(\\theta) \\)',
+                'Bold text:  a ⋅ b = |a| |b| cos(θ)',
+            ),
+            ('Bold text: \\( \\frac{\\sqrt{\\mathbf{2}+3}}{\\sqrt{4}} \\)', 'Bold text:  (√{2+3}/√{4})'),
+            ('Sqrt test 1: \\(\\sqrt\\)', 'Sqrt test 1: √'),
+            ('Sqrt test 2: \\(x^2 + \\sqrt(y)\\)', 'Sqrt test 2: x² + √(y)'),
+            ('Sqrt test 3: [mathjaxinline]x^2 + \\sqrt(y)[/mathjaxinline]', 'Sqrt test 3: x² + √(y)'),
+        ]
+        # pylint: enable=line-too-long
         block = BlockFactory.create(
             parent_location=self.toy_course.location,
             category="html",
             display_name="Non-default HTML Block",
             editor="raw",
             use_latex_compiler=True,
-            data=(
-                "Simple addition: \\( 2 + 3 \\) |||"
-                " Simple subtraction: \\( 5 - 2 \\) |||"
-                " Simple multiplication: \\( 4 * 6 \\) |||"
-                " Simple division: \\( 8 / 2 \\) |||"
-                " Mixed arithmetic: \\( 2 + 3  4 \\) |||"
-                " Simple exponentiation: \\[ 2^3 \\] |||"
-                " Root extraction: \\[ 16^{1/2} \\] |||"
-                " Exponent with multiple terms: \\[ (2 + 3)^2 \\] |||"
-                " Nested exponents: \\[ 2^(3^2) \\] |||"
-                " Mixed roots: \\[ 8^{1/2}  3^2 \\] |||"
-                " Simple fraction: [mathjaxinline] 3/4 [/mathjaxinline] |||"
-                " Decimal to fraction conversion: [mathjaxinline] 0.75 = 3/4 [/mathjaxinline] |||"
-                " Mixed fractions: [mathjaxinline] 1 1/2 = 3/2 [/mathjaxinline] |||"
-                " Converting decimals to mixed fractions: [mathjaxinline] 2.5 = 5/2 [/mathjaxinline] |||"
-                " Sine, cosine, and tangent: [mathjaxinline] \\sin(x) [/mathjaxinline] [mathjaxinline] \\cos(x) [/mathjaxinline] [mathjaxinline] \\tan(x) [/mathjaxinline] |||"
-                " Trig identities: [mathjaxinline] \\sin(x + y) = \\sin(x)  \\cos(y) + \\cos(x)  \\sin(y) [/mathjaxinline] |||"
-                " Hyperbolic trig functions: [mathjaxinline] \\sinh(x) [/mathjaxinline] [mathjaxinline] \\cosh(x) [/mathjaxinline] |||"
-                " Simple derivative: [mathjax] f(x) = x^2, f'(x) = 2x [/mathjax] |||"
-                " Double integral: [mathjax] int\\int (x + y) dxdy [/mathjax] |||"
-                " Partial derivatives: [mathjax] f(x,y) = xy, \\frac{\\partial f}{\\partial x} = y [/mathjax] [mathjax] \\frac{\\partial f}{\\partial y} = x [/mathjax] |||"
-                " Mean and standard deviation: [mathjax] mu = 2, \\sigma = 1 [/mathjax] |||"
-                " Binomial probability: [mathjax] P(X = k) = (\\binom{n}{k} p^k (1-p)^{n-k}) [/mathjax] |||"
-                " Gaussian distribution: [mathjax] N(\\mu, \\sigma^2) [/mathjax] |||"
-                " Greek letters: [mathjaxinline] \\alpha [/mathjaxinline] [mathjaxinline] \\beta [/mathjaxinline] [mathjaxinline] \\gamma [/mathjaxinline] |||"
-                " Subscripted variables: [mathjaxinline] x_i [/mathjaxinline] [mathjaxinline] y_j [/mathjaxinline] |||"
-                " Superscripted variables: [mathjaxinline] x^{i} [/mathjaxinline] |||"
-                " Not supported: \\( \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I \\) |||"
-                " Bold text: \\( {\\bf a} \\cdot {\\bf b} = |{\\bf a}| |{\\bf b}| \\cos(\\theta) \\) |||"
-                " Bold text: \\( \\frac{\\sqrt{\\mathbf{2}+3}}{\\sqrt{4}} \\)"
-            ),
+            data="|||".join(e[0] for e in eqns),
         )
-        # pylint: enable=line-too-long
         doc = {}
         doc.update(searchable_doc_for_course_block(block))
         doc.update(searchable_doc_tags(block.usage_key))
-        expected_equations = [
-            'Simple addition:  2 + 3',
-            'Simple subtraction:  5 − 2',
-            'Simple multiplication:  4 * 6',
-            'Simple division:  8 / 2',
-            'Mixed arithmetic:  2 + 3 4',
-            'Simple exponentiation:  2³',
-            'Root extraction:  16¹^/²',
-            'Exponent with multiple terms:  (2 + 3)²',
-            'Nested exponents:  2⁽3²)',
-            'Mixed roots:  8¹^/² 3²',
-            'Simple fraction:  3/4',
-            'Decimal to fraction conversion:  0.75 = 3/4',
-            'Mixed fractions:  1 1/2 = 3/2',
-            'Converting decimals to mixed fractions:  2.5 = 5/2',
-            'Sine, cosine, and tangent:  sin(x)   cos(x)   tan(x)',
-            'Trig identities:  sin(x + y) = sin(x) cos(y) + cos(x) sin(y)',
-            'Hyperbolic trig functions:  sinh(x)   cosh(x)',
-            "Simple derivative:  f(x) = x², f'(x) = 2x",
-            'Double integral:  int∫ (x + y) dxdy',
-            'Partial derivatives:  f(x,y) = xy, (∂ f/∂ x) = y   (∂ f/∂ y) = x',
-            'Mean and standard deviation:  mu = 2, σ = 1',
-            'Binomial probability:  P(X = k) = (\\binom{n}{k} pᵏ (1−p)ⁿ⁻ᵏ)',
-            'Gaussian distribution:  N(μ, σ²)',
-            'Greek letters:  α   β   γ',
-            'Subscripted variables:  xᵢ   yⱼ',
-            'Superscripted variables:  xⁱ',
-            'Not supported:  \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I',
-            'Bold text:  a ⋅ b = |a| |b| cos(θ)',
-            'Bold text:  (√{2+3}/√{4})',
-        ]
-        eqns = doc['description'].split('|||')
-        for i, eqn in enumerate(eqns):
-            assert eqn.strip() == expected_equations[i]
+        result = doc['description'].split('|||')
+        for i, eqn in enumerate(result):
+            assert eqn.strip() == eqns[i][1]

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -570,6 +570,10 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             ('Fraction test 3: \\( \\frac{\\frac{2}{3}}{4} \\)', 'Fraction test 3:  ((2/3)/4)'),
             ('Fraction test 4: \\( \\frac{\\frac{2} {3}}{4} \\)', 'Fraction test 4:  ((2/3)/4)'),
             ('Fraction test 5: \\( \\frac{\\frac{2} {3}}{\\frac{4}{3}} \\)', 'Fraction test 5:  ((2/3)/(4/3))'),
+            # Invalid equations.
+            ('Fraction error: \\( \\frac{2} \\)', 'Fraction error:  \\frac{2}'),
+            ('Fraction error 2: \\( \\frac{\\frac{2}{3}{4} \\)', 'Fraction error 2:  \\frac{\\frac{2}{3}{4}'),
+            ('Unclosed: [mathjaxinline]x^2', 'Unclosed: [mathjaxinline]x^2'),
         ]
         # pylint: enable=line-too-long
         block = BlockFactory.create(

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -490,16 +490,16 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             editor="raw",
             use_latex_compiler=True,
             data=(
-                "Simple addition: \( 2 + 3 \) |||"
-                " Simple subtraction: \( 5 - 2 \) |||"
-                " Simple multiplication: \( 4 * 6 \) |||"
-                " Simple division: \( 8 / 2 \) |||"
-                " Mixed arithmetic: \( 2 + 3  4 \) |||"
-                " Simple exponentiation: \[ 2^3 \] |||"
-                " Root extraction: \[ 16^{1/2} \] |||"
-                " Exponent with multiple terms: \[ (2 + 3)^2 \] |||"
-                " Nested exponents: \[ 2^(3^2) \] |||"
-                " Mixed roots: \[ 8^{1/2}  3^2 \] |||"
+                "Simple addition: \\( 2 + 3 \\) |||"
+                " Simple subtraction: \\( 5 - 2 \\) |||"
+                " Simple multiplication: \\( 4 * 6 \\) |||"
+                " Simple division: \\( 8 / 2 \\) |||"
+                " Mixed arithmetic: \\( 2 + 3  4 \\) |||"
+                " Simple exponentiation: \\[ 2^3 \\] |||"
+                " Root extraction: \\[ 16^{1/2} \\] |||"
+                " Exponent with multiple terms: \\[ (2 + 3)^2 \\] |||"
+                " Nested exponents: \\[ 2^(3^2) \\] |||"
+                " Mixed roots: \\[ 8^{1/2}  3^2 \\] |||"
                 " Simple fraction: [mathjaxinline] 3/4 [/mathjaxinline] |||"
                 " Decimal to fraction conversion: [mathjaxinline] 0.75 = 3/4 [/mathjaxinline] |||"
                 " Mixed fractions: [mathjaxinline] 1 1/2 = 3/2 [/mathjaxinline] |||"
@@ -508,15 +508,15 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 " Trig identities: [mathjaxinline] \\sin(x + y) = \\sin(x)  \\cos(y) + \\cos(x)  \\sin(y) [/mathjaxinline] |||"
                 " Hyperbolic trig functions: [mathjaxinline] \\sinh(x) [/mathjaxinline] [mathjaxinline] \\cosh(x) [/mathjaxinline] |||"
                 " Simple derivative: [mathjax] f(x) = x^2, f'(x) = 2x [/mathjax] |||"
-                " Double integral: [mathjax] int\int (x + y) dxdy [/mathjax] |||"
-                " Partial derivatives: [mathjax] f(x,y) = xy, \frac{\partial f}{\partial x} = y [/mathjax] [mathjax] \frac{\partial f}{\partial y} = x [/mathjax] |||"
-                " Mean and standard deviation: [mathjax] mu = 2, \sigma = 1 [/mathjax] |||"
-                " Binomial probability: [mathjax] P(X = k) = (\binom{n}{k} p^k (1-p)^{n-k}) [/mathjax] |||"
-                " Gaussian distribution: [mathjax] N(\mu, \sigma^2) [/mathjax] |||"
+                " Double integral: [mathjax] int\\int (x + y) dxdy [/mathjax] |||"
+                " Partial derivatives: [mathjax] f(x,y) = xy, \\frac{\\partial f}{\\partial x} = y [/mathjax] [mathjax] \\frac{\\partial f}{\\partial y} = x [/mathjax] |||"
+                " Mean and standard deviation: [mathjax] mu = 2, \\sigma = 1 [/mathjax] |||"
+                " Binomial probability: [mathjax] P(X = k) = (\\binom{n}{k} p^k (1-p)^{n-k}) [/mathjax] |||"
+                " Gaussian distribution: [mathjax] N(\\mu, \\sigma^2) [/mathjax] |||"
                 " Greek letters: [mathjaxinline] \\alpha [/mathjaxinline] [mathjaxinline] \\beta [/mathjaxinline] [mathjaxinline] \\gamma [/mathjaxinline] |||"
                 " Subscripted variables: [mathjaxinline] x_i [/mathjaxinline] [mathjaxinline] y_j [/mathjaxinline] |||"
                 " Superscripted variables: [mathjaxinline] x^{i} [/mathjaxinline] |||"
-                " Not supported: \( \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I \)"
+                " Not supported: \\( \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I \\)"
             ),
         )
         # pylint: enable=line-too-long
@@ -543,9 +543,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             'Hyperbolic trig functions:  sinh(x)   cosh(x)',
             "Simple derivative:  f(x) = x², f'(x) = 2x",
             'Double integral:  int∫ (x + y) dxdy',
-            'Partial derivatives:  f(x,y) = xy, rac{∂ f}{∂ x} = y   rac{∂ f}{∂ y} = x',
+            'Partial derivatives:  f(x,y) = xy, (∂ f/∂ x) = y   (∂ f/∂ y) = x',
             'Mean and standard deviation:  mu = 2, σ = 1',
-            'Binomial probability:  P(X = k) = (inom{n}{k} pᵏ (1−p)ⁿ⁻ᵏ)',
+            'Binomial probability:  P(X = k) = (\\binom{n}{k} pᵏ (1−p)ⁿ⁻ᵏ)',
             'Gaussian distribution:  N(μ, σ²)',
             'Greek letters:  α   β   γ',
             'Subscripted variables:  xᵢ   yⱼ',

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -553,9 +553,12 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 'Bold text:  a ⋅ b = |a| |b| cos(θ)',
             ),
             ('Bold text: \\( \\frac{\\sqrt{\\mathbf{2}+3}}{\\sqrt{4}} \\)', 'Bold text:  (√{2+3}/√{4})'),
+            ('Nested Bold text: \\( \\mathbf{ \\frac{1}{2} } \\)', 'Nested Bold text:   (1/2)'),
             ('Sqrt test 1: \\(\\sqrt\\)', 'Sqrt test 1: √'),
             ('Sqrt test 2: \\(x^2 + \\sqrt(y)\\)', 'Sqrt test 2: x² + √(y)'),
             ('Sqrt test 3: [mathjaxinline]x^2 + \\sqrt(y)[/mathjaxinline]', 'Sqrt test 3: x² + √(y)'),
+            ('Fraction test 1: \\( \\frac{2} {3} \\)', 'Fraction test 1:  (2/3)'),
+            ('Fraction test 2: \\( \\frac{2}{3} \\)', 'Fraction test 2:  (2/3)'),
         ]
         # pylint: enable=line-too-long
         block = BlockFactory.create(

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -516,7 +516,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 " Greek letters: [mathjaxinline] \\alpha [/mathjaxinline] [mathjaxinline] \\beta [/mathjaxinline] [mathjaxinline] \\gamma [/mathjaxinline] |||"
                 " Subscripted variables: [mathjaxinline] x_i [/mathjaxinline] [mathjaxinline] y_j [/mathjaxinline] |||"
                 " Superscripted variables: [mathjaxinline] x^{i} [/mathjaxinline] |||"
-                " Not supported: \\( \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I \\)"
+                " Not supported: \\( \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I \\) |||"
+                " Bold text: \\( {\\bf a} \\cdot {\\bf b} = |{\\bf a}| |{\\bf b}| \\cos(\\theta) \\) |||"
+                " Bold text: \\( \\frac{\\sqrt{\\mathbf{2}+3}}{\\sqrt{4}} \\)"
             ),
         )
         # pylint: enable=line-too-long
@@ -551,6 +553,8 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             'Subscripted variables:  xᵢ   yⱼ',
             'Superscripted variables:  xⁱ',
             'Not supported:  \\begin{bmatrix} 1 & 0 \\ 0 & 1 \\end{bmatrix} = I',
+            'Bold text:  a ⋅ b = |a| |b| cos(θ)',
+            'Bold text:  (√{2+3}/√{4})',
         ]
         eqns = doc['description'].split('|||')
         for i, eqn in enumerate(eqns):

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -574,6 +574,11 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             ('Fraction error: \\( \\frac{2} \\)', 'Fraction error:  \\frac{2}'),
             ('Fraction error 2: \\( \\frac{\\frac{2}{3}{4} \\)', 'Fraction error 2:  \\frac{\\frac{2}{3}{4}'),
             ('Unclosed: [mathjaxinline]x^2', 'Unclosed: [mathjaxinline]x^2'),
+            (
+                'Missing closing bracket: \\( \\frac{\\frac{2} {3}{\\frac{4}{3}} \\)',
+                'Missing closing bracket:  \\frac{\\frac{2} {3}{\\frac{4}{3}}'
+            ),
+            ('No equation: normal text', 'No equation: normal text'),
         ]
         # pylint: enable=line-too-long
         block = BlockFactory.create(

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1208,6 +1208,8 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
+unicodeit==0.7.5
+    # via -r requirements/edx/kernel.in
 uritemplate==4.1.1
     # via
     #   drf-spectacular

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2160,6 +2160,10 @@ unicodecsv==0.14.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
+unicodeit==0.7.5
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
 unidiff==0.7.5
     # via -r requirements/edx/testing.txt
 uritemplate==4.1.1

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1521,6 +1521,8 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+unicodeit==0.7.5
+    # via -r requirements/edx/base.txt
 uritemplate==4.1.1
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -163,3 +163,4 @@ web-fragments                       # Provides the ability to render fragments o
 wrapt                               # Better functools.wrapped. TODO: functools has since improved, maybe we can switch?
 XBlock[django]                      # Courseware component architecture
 xss-utils                           # https://github.com/openedx/edx-platform/pull/20633 Fix XSS via Translations
+unicodeit                           # Converts mathjax equation to plain text by using unicode symbols

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1605,6 +1605,8 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+unicodeit==0.7.5
+    # via -r requirements/edx/base.txt
 unidiff==0.7.5
     # via -r requirements/edx/testing.in
 uritemplate==4.1.1


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Converts mathjax equations to unicode to be rendered as plain text in library card previews.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author".


**Screenshot:**

![image](https://github.com/user-attachments/assets/b0821ad2-643d-42f9-a672-8beca2a79ee2)


## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/1508
* `Private-ref`: [FAL-3990](https://tasks.opencraft.com/browse/FAL-3990)

## Testing instructions

* Create some text or problem components with mathjax equations in the body. Make sure to add the equation within first few characters to see the preview in library card.
* Verify that the card shows a plain text preview using unicode.
* Examples of mathjax equations can be found in tests.

## Notes

* [unicodeit](https://github.com/svenkreiss/unicodeit) supports many latex tags but some of them are missing like `\frac`, `\mathbf`, `\bf` etc. which I have handled using replacements.
* Some tags like `\begin{bmatrix}`, `\begin{cases}` etc. cannot be displayed properly in plain text so they are rendered raw. 
* If you come up with some equations which are not rendered properly please let me know.