### PR TITLE
fix: resolved edx.course.goal.email.filtered parsing error

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -283,7 +283,7 @@ class Command(BaseCommand):
                     'uuid': session_id,
                     'timestamp': datetime.now(),
                     'reason': 'User time zone',
-                    'user_timezone': user_timezone,
+                    'user_timezone': str(user_timezone),
                     'now_in_users_timezone': now_in_users_timezone,
                 }
             )


### PR DESCRIPTION
## Description 
resolved edx.course.goal.email.filtered parsing error

```
Dec 26 07:58:03 ip-10-2-71-188 [service_variant=lms][eventtracking.backends.routing][env:prod-edx-edxapp] ERROR [ip-10-2-71-188  2106019] [user 61714135] [ip 127.0.0.1] [routing.py:146] - Unable to send edx event "edx.course.goal.email.filtered" to backend: logger
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/eventtracking/backends/routing.py", line 137, in send_to_backends
    backend.send(event)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/eventtracking/backends/logger.py", line 36, in send
    event_str = json.dumps(event, cls=DateTimeJSONEncoder)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/eventtracking/backends/logger.py", line 65, in default
    return super().default(obj)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type UTC is not JSON serializable
```