### PR TITLE
fix: date label for instructor paced courses

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -268,7 +268,7 @@ class CourseStartDate(DateSummary):
     @property
     def title(self):
         enrollment = CourseEnrollment.get_enrollment(self.user, self.course_id)
-        if enrollment and self.course.end and enrollment.created > self.course.end:
+        if self.course.self_paced and enrollment and self.course.start and enrollment.created > self.course.start:
             return gettext_lazy('Enrollment Date')
         return gettext_lazy('Course starts')
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

In the instructor paced courses, in which a user enrolls after the end date, there's a bug of showing label of "Enrollment Date" instead of "Start date" on the important dates page in LMS. This PR solves this issue by matching the conditions in date and title property of `CourseStartDate` class.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner"

## Supporting information

https://github.com/mitodl/hq/issues/5889

## Testing instructions

- On the master branch, create an instructor paced course and set the start and end date to a past date in studio.
<img width="1611" alt="Screenshot 2024-12-27 at 4 16 48 PM" src="https://github.com/user-attachments/assets/e9f161a7-3432-4a15-bdfc-c8deee6605fc" />

- Enroll in the course from a test learner account and open the course in LMS
- Click the Dates tab. You will notice that the date label is 'Enrollment Date', and the displayed date corresponds to the start date.
<img width="1168" alt="Screenshot 2024-12-27 at 4 17 31 PM" src="https://github.com/user-attachments/assets/d9775f2f-2e76-4021-b96f-c171b846e6d4" />

- Now, checkout to this branch and reload the above dates page. It will show the correct label. 
<img width="1168" alt="Screenshot 2024-12-27 at 4 19 14 PM" src="https://github.com/user-attachments/assets/e2a9bb2d-22e3-4082-8458-458cbff15807" />

## Deadline

"None"

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
