### PR TITLE
fix: resolved key error in notification pref apis

### DIFF
--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -192,7 +192,7 @@ def update_notification_fields(
         if field in source_config:
             target_config[field] |= source_config[field]
     if "email_cadence" in source_config:
-        if isinstance(target_config["email_cadence"], str) or not target_config["email_cadence"]:
+        if not target_config.get("email_cadence") or isinstance(target_config.get("email_cadence"), str):
             target_config["email_cadence"] = set()
 
         target_config["email_cadence"].add(source_config["email_cadence"])
@@ -263,7 +263,7 @@ def aggregate_notification_configs(existing_user_configs: List[Dict]) -> Dict:
     # if email_cadence is mixed, set it to "Mixed"
     for app in result_config:
         for type_key, type_config in result_config[app]["notification_types"].items():
-            if len(type_config["email_cadence"]) > 1:
+            if len(type_config.get("email_cadence", [])) > 1:
                 result_config[app]["notification_types"][type_key]["email_cadence"] = "Mixed"
             else:
                 result_config[app]["notification_types"][type_key]["email_cadence"] = (


### PR DESCRIPTION
Resolved index errors in notification preference APIs


```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/restframework.py", line 18, in _traced_handle_exception
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/notifications/views.py", line 579, in get
    notification_configs = aggregate_notification_configs(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/notifications/utils.py", line 261, in aggregate_notification_configs
    process_app_config(app_config, user_config, app, existing_user_configs[0])
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/notifications/utils.py", line 234, in process_app_config
    update_notification_types(app_config, user_app_config)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/notifications/utils.py", line 178, in update_notification_types
    update_notification_fields(
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/notifications/utils.py", line 195, in update_notification_fields
    if isinstance(target_config["email_cadence"], str) or not target_config["email_cadence"]:
                  ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'email_cadence'

```


```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/restframework.py", line 18, in _traced_handle_exception
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/notifications/views.py", line 579, in get
    notification_configs = aggregate_notification_configs(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/notifications/utils.py", line 266, in aggregate_notification_configs
    if len(type_config["email_cadence"]) > 1:
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'email_cadence'

```