### PR TITLE
feat!: Import course api via URL

### DIFF
--- a/cms/djangoapps/contentstore/api/tests/test_import.py
+++ b/cms/djangoapps/contentstore/api/tests/test_import.py
@@ -18,9 +18,6 @@ from common.djangoapps.student.tests.factories import StaffFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from common.djangoapps.student.tests.factories import StaffFactory
-from common.djangoapps.student.tests.factories import UserFactory
-
 
 class CourseImportViewTest(SharedModuleStoreTestCase, APITestCase):
     """

--- a/cms/djangoapps/contentstore/api/views/course_import.py
+++ b/cms/djangoapps/contentstore/api/views/course_import.py
@@ -6,7 +6,9 @@ APIs related to Course Import.
 import base64
 import logging
 import os
+from urllib.parse import urlparse
 
+import requests
 from django.conf import settings
 from django.core.files import File
 from edx_django_utils.monitoring import set_custom_attribute, set_custom_attributes_for_course_key
@@ -116,32 +118,66 @@ class CourseImportView(CourseImportExportViewMixin, GenericAPIView):
         """
         set_custom_attribute('course_import_init', True)
         set_custom_attributes_for_course_key(course_key)
+
         try:
-            if 'course_data' not in request.FILES:
+            # Check for input source
+            if 'course_data' not in request.FILES and 'file_url' not in request.data:
                 raise self.api_error(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     developer_message='Missing required parameter',
                     error_code='internal_error',
                 )
 
-            filename = request.FILES['course_data'].name
-            if not filename.endswith(IMPORTABLE_FILE_TYPES):
-                raise self.api_error(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    developer_message='Parameter in the wrong format',
-                    error_code='internal_error',
-                )
             course_dir = path(settings.GITHUB_REPO_ROOT) / base64.urlsafe_b64encode(
                 repr(course_key).encode('utf-8')
             ).decode('utf-8')
-            temp_filepath = course_dir / filename
-            if not course_dir.isdir():
-                os.mkdir(course_dir)
 
-            log.debug(f'importing course to {temp_filepath}')
-            with open(temp_filepath, "wb+") as temp_file:
-                for chunk in request.FILES['course_data'].chunks():
-                    temp_file.write(chunk)
+            if not course_dir.isdir():
+                os.makedirs(course_dir)
+
+            if 'course_data' in request.FILES:
+                uploaded_file = request.FILES['course_data']
+                filename = uploaded_file.name
+
+                if not filename.endswith(IMPORTABLE_FILE_TYPES):
+                    raise self.api_error(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        developer_message='Missing required parameter',
+                        error_code='internal_error',
+                    )
+                temp_filepath = course_dir / filename
+
+                log.info(f"Course import {course_key}: Upload complete, file: {filename}")
+                with open(temp_filepath, "wb") as temp_file:
+                    for chunk in uploaded_file.chunks():
+                        temp_file.write(chunk)
+
+            # Handle file URL
+            elif 'file_url' in request.data:
+                file_url = request.data['file_url']
+                filename = os.path.basename(urlparse(file_url).path)
+                if not filename.endswith(IMPORTABLE_FILE_TYPES):
+                    raise self.api_error(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        developer_message=f'File type not supported: {filename}',
+                        error_code='invalid_file_type',
+                    )
+                response = requests.get(file_url, stream=True)
+                if response.status_code != 200:
+                    raise self.api_error(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        developer_message='Failed to download file from URL',
+                        error_code='download_error',
+                    )
+                temp_filepath = course_dir / filename
+                total_size = 0  # Track total size in bytes
+                with open(temp_filepath, "wb") as temp_file:
+                    for chunk in response.iter_content(chunk_size=1024):
+                        if chunk:
+                            chunk_size = len(chunk)
+                            total_size += chunk_size
+                            temp_file.write(chunk)
+                log.info(f"Course import {course_key}: File downloaded from URL, file: {filename}")
 
             log.info("Course import %s: Upload complete", course_key)
             with open(temp_filepath, 'rb') as local_file:


### PR DESCRIPTION
`Do not review still in progress`

This PR enhances the course import API by introducing the ability to import a course using a URL. Users can now provide a file URL to import a course, enabling greater flexibility and ease of use.

1. Added support for the file_url parameter to allow importing courses directly from a URL.
2. Downloads the file from the specified URL and processes it for course import.

**Test via curl** 
```
curl --location 'http://localhost:18010/api/courses/v0/import/course-v1:edX+DemoX+Demo_Course/' \
--header 'Authorization: JWT token' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'X-CSRFToken: awtUGVlYyMwLWaaS' \
--data-raw '{
    "file_url": "https://raw.githubusercontent.com/awais786/courses/main/edly/AI%20Courses/course.v2_c3p0f.tar.gz"
}'
```

```
output 
{"task_id":"e264cb4e-ea1f-4884-ab01-a374eb1ddc4c"}%
```

Now verify the task state by using taskid `e264cb4e-ea1f-4884-ab01-a374eb1ddc4c` and `filename`
```
curl --location 'http://localhost:18010/api/courses/v0/import/course-v1:edX+DemoX+Demo_Course/?task_id=e264cb4e-ea1f-4884-ab01-a374eb1ddc4c&filename=course.v2_c3p0f.tar.gz' \
--header 'Authorization: JWT token' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'X-CSRFToken: awtUGVlYyMwLWaaSS'
```

```
output

{"state":"Succeeded"}%
```