### PR TITLE
feat: Disabled MITx from program nudge emails

### DIFF
--- a/lms/djangoapps/program_enrollments/management/commands/send_program_course_nudge_email.py
+++ b/lms/djangoapps/program_enrollments/management/commands/send_program_course_nudge_email.py
@@ -15,6 +15,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 from django.utils import timezone
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 
 from common.djangoapps.track import segment
@@ -140,7 +141,9 @@ class Command(BaseCommand):
                     )
                     break
                 for course_run in candidate_course['course_runs']:
-                    if self.valid_course_run(course_run) and course_run['key'] != completed_course_id:
+                    course_org = CourseKey.from_string(course_run['key']).org
+                    if self.valid_course_run(course_run) and course_run['key'] != completed_course_id \
+                            and course_org not in settings.DISABLED_ORGS_FOR_PROGRAM_NUDGE:
                         return program, course_run, candidate_course
         return None, None, None
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5376,6 +5376,14 @@ NOTIFICATIONS_DEFAULT_FROM_EMAIL = "no-reply@example.com"
 NOTIFICATION_TYPE_ICONS = {}
 DEFAULT_NOTIFICATION_ICON_URL = ""
 
+############## NUDGE EMAILS ###############
+# .. setting_name: DISABLED_ORGS_FOR_PROGRAM_NUDGE
+# .. setting_default: []
+# .. setting_description: List of organization codes that should be disabled
+# .. for program nudge emails.
+# .. eg ['BTDx', 'MYTx']
+DISABLED_ORGS_FOR_PROGRAM_NUDGE = []
+
 ############################ AI_TRANSLATIONS ##################################
 AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 


### PR DESCRIPTION
## Description
This PR adds the ability to exclude specific organisations from the program nudge emails. (e.g. next course)


## Supporting information

Exempt an organisation's courses from the send_program_course_nudge emails that are designed to go out to a learner after they have earned a passing grade in a course for 2 reasons:

1. Timing - these are being sent out before their course end dates have passed AND before certificate display availability dates have passed. 
2. Inaccurate recommendations - one of their program series has a set sequence, and this nudge could recommended a course that is sequentially supposed to follow one more course.

As our nudge email is designed to look at the passed_timestamp and seemingly not much else, this overlooks important pieces like: has the course actually ended, has the assignment due date passed, have certificates been made available to learners in the course yet, is the learner in the course on the verified enrollment track in the course they just completed or are they an instructor or something else, etc. 