### PR TITLE
refactor: remove unnecessary padding from lib component picker [FC-0076]

### DIFF
--- a/cms/static/js/views/components/add_library_content.js
+++ b/cms/static/js/views/components/add_library_content.js
@@ -22,6 +22,7 @@ function($, _, gettext, BaseModal) {
             // Translators: "title" is the name of the current component being edited.
             titleFormat: gettext('Add library content'),
             addPrimaryActionButton: false,
+            showEditorModeButtons: false,
         }),
 
         initialize: function() {

--- a/cms/static/js/views/modals/select_v2_library_content.js
+++ b/cms/static/js/views/modals/select_v2_library_content.js
@@ -17,6 +17,7 @@ function($, _, gettext, BaseModal) {
             viewSpecificClasses: 'modal-add-component-picker confirm',
             titleFormat: gettext('Add library content'),
             addPrimaryActionButton: false,
+            showEditorModeButtons: false,
         }),
 
         events: {

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -585,13 +585,16 @@
 // cms/static/js/views/components/add_library_content_with_picker.js
 .modal-add-component-picker {
   top: 10%;
+  padding: 0px !important;
   .modal-content {
     padding: 0 !important;
+    border-radius: ($baseline/5);
 
     & > iframe {
       width: 100%;
       min-height: 80vh;
       background: url('#{$static-path}/images/spinner.gif') center center no-repeat;
+      border-radius: ($baseline/5);
     }
   }
 }

--- a/cms/templates/js/basic-modal.underscore
+++ b/cms/templates/js/basic-modal.underscore
@@ -4,20 +4,22 @@
     <div class="modal-window-overlay"></div>
     <div class="modal-window <%- viewSpecificClasses %> modal-<%- size %> modal-type-<%- type %>" tabindex="-1" aria-labelledby="modal-window-title">
         <div class="<%- name %>-modal">
-            <div class="modal-header">
-                <h2 id="modal-window-title" class="title modal-window-title">
-                    <%- title %>
-                    <% if (modalSRTitle) { %>
-                        <span class="sr modal-sr-title">
-                            <%- modalSRTitle %>
-                        </span>
+            <% if (title || modalSRTitle || showEditorModeButtons) { %>
+                <div class="modal-header">
+                    <h2 id="modal-window-title" class="title modal-window-title">
+                        <%- title %>
+                        <% if (modalSRTitle) { %>
+                            <span class="sr modal-sr-title">
+                                <%- modalSRTitle %>
+                            </span>
+                        <% } %>
+                    </h2>
+                    <% if (showEditorModeButtons) { %>
+                        <ul class="editor-modes action-list action-modes">
+                        </ul>
                     <% } %>
-                </h2>
-                <% if (showEditorModeButtons) { %>
-                    <ul class="editor-modes action-list action-modes">
-                    </ul>
-                <% } %>
-            </div>
+                </div>
+            <% } %>
             <div class="modal-content">
             </div>
             <div class="modal-actions">


### PR DESCRIPTION
## Description

Library component picker and Problem bank picker iframe had unnecessary padding resulting in multiple border/shadow in the modal.

Useful information to include:

- Which edX user roles will this change impact? "Learner" and "Course Author".

<details>
  <summary>Screenshots</summary>

**Before:**

![image](https://github.com/user-attachments/assets/c550f33c-6826-4d9f-ab4c-35da31d77766)

**After:**

![image](https://github.com/user-attachments/assets/d55d81f6-bf82-4c13-8bd1-b3ac42d624b4)

![image](https://github.com/user-attachments/assets/f63c39d5-613d-4b85-be7a-503856789b1c)

![image](https://github.com/user-attachments/assets/427ae016-0c72-40f1-ab6d-90e74112294a)


</details> 


## Supporting information

* `Private-ref`: [FAL-4014](https://tasks.opencraft.com/browse/FAL-4014)
* https://github.com/openedx/frontend-app-authoring/issues/1485#issuecomment-2498499649

## Testing instructions

Check border and padding for library content and problem bank picker.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.