### PR TITLE
remove course specific grading debug code

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -467,12 +467,6 @@ class PersistentSubsectionGrade(TimeStampedModel):
             defaults=params,
         )
 
-        # TODO: Remove as part of EDUCATOR-4602.
-        if str(usage_key.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-            log.info('Created/updated grade ***{}*** for user ***{}*** in course ***{}***'
-                     'for subsection ***{}*** with default params ***{}***'
-                     .format(grade, user_id, usage_key.course_key, usage_key, params))
-
         grade.override = PersistentSubsectionGradeOverride.get_override(user_id, usage_key)
         if first_attempted is not None and grade.first_attempted is None:
             grade.first_attempted = first_attempted
@@ -822,11 +816,6 @@ class PersistentSubsectionGradeOverride(models.Model):
         grade_defaults['override_reason'] = override_data['comment'] if 'comment' in override_data else None
         grade_defaults['system'] = override_data['system'] if 'system' in override_data else None
 
-        # TODO: Remove as part of EDUCATOR-4602.
-        if str(subsection_grade_model.course_id) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-            log.info('Creating override for user ***{}*** for PersistentSubsectionGrade'
-                     '***{}*** with override data ***{}*** and derived grade_defaults ***{}***.'
-                     .format(requesting_user, subsection_grade_model, override_data, grade_defaults))
         try:
             override = PersistentSubsectionGradeOverride.objects.get(grade=subsection_grade_model)
             for key, value in grade_defaults.items():

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -859,11 +859,6 @@ class GradebookBulkUpdateView(GradeViewMixin, PaginatedAPIView):
                 subsection = course.get_child(usage_key)
                 if subsection:
                     subsection_grade_model = self._create_subsection_grade(user, course, subsection)
-                    # TODO: Remove as part of EDUCATOR-4602.
-                    if str(course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-                        log.info('PersistentSubsectionGrade ***{}*** created for'
-                                 ' subsection ***{}*** in course ***{}*** for user ***{}***.'
-                                 .format(subsection_grade_model, subsection.location, course, user.id))
                 else:
                     self._log_update_result(request.user, requested_user_id, requested_usage_id, success=False)
                     result.append(GradebookUpdateResponseItem(

--- a/lms/djangoapps/grades/scores.py
+++ b/lms/djangoapps/grades/scores.py
@@ -102,10 +102,6 @@ def get_score(submissions_scores, csm_scores, persisted_block, block):
             weight, graded - retrieved from the latest block content
     """
     weight = _get_weight_from_block(persisted_block, block)
-    # TODO: Remove as part of EDUCATOR-4602.
-    if str(block.location.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-        log.info('Weight for block: ***{}*** is {}'
-                 .format(str(block.location), weight))
 
     # Priority order for retrieving the scores:
     # submissions API -> CSM -> grades persisted block -> latest block content
@@ -114,13 +110,6 @@ def get_score(submissions_scores, csm_scores, persisted_block, block):
         _get_score_from_csm(csm_scores, block, weight) or
         _get_score_from_persisted_or_latest_block(persisted_block, block, weight)
     )
-
-    # TODO: Remove as part of EDUCATOR-4602.
-    if str(block.location.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-        log.info('Calculated raw-earned: {}, raw_possible: {}, weighted_earned: '
-                 '{}, weighted_possible: {}, first_attempted: {} for block: ***{}***.'
-                 .format(raw_earned, raw_possible, weighted_earned,
-                         weighted_possible, first_attempted, str(block.location)))
 
     if weighted_possible is None or weighted_earned is None:
         return None
@@ -219,11 +208,6 @@ def _get_score_from_persisted_or_latest_block(persisted_block, block, weight):
     Uses the raw_possible value from the persisted_block if found, else from
     the latest block content.
     """
-    # TODO: Remove as part of EDUCATOR-4602.
-    if str(block.location.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-        log.info('Using _get_score_from_persisted_or_latest_block to calculate score for block: ***{}***.'.format(
-            str(block.location)
-        ))
     raw_earned = 0.0
     first_attempted = None
 
@@ -231,10 +215,6 @@ def _get_score_from_persisted_or_latest_block(persisted_block, block, weight):
         raw_possible = persisted_block.raw_possible
     else:
         raw_possible = block.transformer_data[GradesTransformer].max_score
-        # TODO: Remove as part of EDUCATOR-4602.
-        if str(block.location.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-            log.info('Using latest block content to calculate score for block: ***{}***.')
-            log.info(f'weight for block: ***{str(block.location)}*** is {raw_possible}.')
 
     # TODO TNL-5982 remove defensive code for scorables without max_score
     if raw_possible is None:

--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -170,39 +170,21 @@ class NonZeroSubsectionGrade(SubsectionGradeBase, metaclass=ABCMeta):
             csm_scores,
             persisted_block=None,
     ):
-        # TODO: Remove as part of EDUCATOR-4602.
-        if str(block_key.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-            log.info('Computing block score for block: ***{}*** in course: ***{}***.'.format(
-                str(block_key),
-                str(block_key.course_key),
-            ))
         try:
             block = course_structure[block_key]
         except KeyError:
-            # TODO: Remove as part of EDUCATOR-4602.
-            if str(block_key.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-                log.info('User\'s access to block: ***{}*** in course: ***{}*** has changed. '
-                         'No block score calculated.'.format(str(block_key), str(block_key.course_key)))
             # It's possible that the user's access to that
             # block has changed since the subsection grade
             # was last persisted.
+            pass
         else:
             if getattr(block, 'has_score', False):
-                # TODO: Remove as part of EDUCATOR-4602.
-                if str(block_key.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-                    log.info('Block: ***{}*** in course: ***{}*** HAS has_score attribute. Continuing.'
-                             .format(str(block_key), str(block_key.course_key)))
                 return get_score(
                     submissions_scores,
                     csm_scores,
                     persisted_block,
                     block,
                 )
-            # TODO: Remove as part of EDUCATOR-4602.
-            if str(block_key.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-                log.info('Block: ***{}*** in course: ***{}*** DOES NOT HAVE has_score attribute. '
-                         'No block score calculated.'
-                         .format(str(block_key), str(block_key.course_key)))
 
     @staticmethod
     def _aggregated_score_from_model(grade_model, is_graded):
@@ -283,22 +265,10 @@ class CreateSubsectionGrade(NonZeroSubsectionGrade):
                 start_node=subsection.location,
         ):
             problem_score = self._compute_block_score(block_key, course_structure, submissions_scores, csm_scores)
-
-            # TODO: Remove as part of EDUCATOR-4602.
-            if str(block_key.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-                log.info('Calculated problem score ***{}*** for block ***{!s}***'
-                         ' in subsection ***{}***.'
-                         .format(problem_score, block_key, subsection.location))
             if problem_score:
                 self.problem_scores[block_key] = problem_score
 
         all_total, graded_total = graders.aggregate_scores(list(self.problem_scores.values()))
-
-        # TODO: Remove as part of EDUCATOR-4602.
-        if str(subsection.location.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-            log.info('Calculated aggregate all_total ***{}***'
-                     ' and grade_total ***{}*** for subsection ***{}***'
-                     .format(all_total, graded_total, subsection.location))
 
         super().__init__(subsection, all_total, graded_total)
 
@@ -307,11 +277,6 @@ class CreateSubsectionGrade(NonZeroSubsectionGrade):
         Saves or updates the subsection grade in a persisted model.
         """
         if self._should_persist_per_attempted(score_deleted, force_update_subsections):
-            # TODO: Remove as part of EDUCATOR-4602.
-            if str(self.location.course_key) == 'course-v1:UQx+BUSLEAD5x+2T2019':
-                log.info('Updating PersistentSubsectionGrade for student ***{}*** in'
-                         ' subsection ***{}*** with params ***{}***.'
-                         .format(student.id, self.location, self._persisted_model_params(student)))
             model = PersistentSubsectionGrade.update_or_create_grade(**self._persisted_model_params(student))
 
             if hasattr(model, 'override'):


### PR DESCRIPTION
This removes special logging for course course-v1:UQx+BUSLEAD5x+2T2019 as part of an edX investigation (EDUCATOR-4568 in their internal JIRA). That issue was closed on 2021-01-08 by Mat Carter with the comment:

> Aged out, closing. If this issue continues, please create a new
> ticket optionally referencing this one.

(Note that Mat has since left edX/2U.)

The EDUCATOR-4602 ticket was created to track the cleanup of this logging code.