### PR TITLE
Revert "feat: Upgrade Python dependency lti-consumer-xblock"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -705,7 +705,7 @@ lazy==1.6
     #   xblock
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.13.0
+lti-consumer-xblock==9.12.1
     # via -r requirements/edx/kernel.in
 lxml[html-clean,html_clean]==5.3.0
     # via
@@ -942,7 +942,6 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
-    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1189,7 +1189,7 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.13.0
+lti-consumer-xblock==9.12.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1610,7 +1610,6 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
-    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -860,7 +860,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.13.0
+lti-consumer-xblock==9.12.1
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.0
     # via
@@ -1158,7 +1158,6 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
-    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -903,7 +903,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.13.0
+lti-consumer-xblock==9.12.1
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.0
     # via
@@ -1222,7 +1222,6 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
-    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core


### PR DESCRIPTION
Reverts openedx/edx-platform#36084

9.13.0 does not necessarily have issues, but during testing we uncovered other issues with exams that we are now fixing. We would like to revert this PR to unblock the deployment pipeline. 