### PR TITLE
build: Log in to dockerhub for unit test CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,6 +73,12 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install libmysqlclient-dev libxmlsec1-dev lynx
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.11.0
         with:
@@ -196,7 +202,6 @@ jobs:
           workflow don't match the count for unit tests for entire edx-platform suite, please update the unit-test-shards.json under .github/workflows
           to add any missing apps and match the count. for more details please take a look at scripts/gha-shards-readme.md"
           exit 1
-
 
   # This job aggregates test results. It's the required check for branch protection.
   # https://github.com/marketplace/actions/alls-green#why

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,7 +77,7 @@ jobs:
         uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.11.0


### PR DESCRIPTION
## Description

We're being rate limited by dockerhub for pulling too many images in CI. There isn't a greate solution for caching images for GH actions, but in theory we should have less strict limits as an authenticated user.

## Supporting information

See: https://github.com/openedx/axim-engineering/issues/1350 and https://github.com/openedx/edx-platform/actions/runs/12679554529/job/35339477364
