### PR TITLE
build: Don't fail the build if DockerHub login fails

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -78,12 +78,12 @@ jobs:
       # That's OK--if we fail to log in, we'll proceed anonymously, and hope we don't get rate-limited.
       - name: Try to log into Docker Hub
         uses: docker/login-action@v3.3.0
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Start MongoDB
-        if: always()  # Continue even if the previous step (log into DockerHub) failed.
         uses: supercharge/mongodb-github-action@1.11.0
         with:
           mongodb-version: ${{ matrix.mongo-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,13 +73,17 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install libmysqlclient-dev libxmlsec1-dev lynx
 
-      - name: Login to Docker Hub
+      # Try to log into DockerHub so that we're less likely to be rate-limited when pulling certain images.
+      # This will fail on any edx-platform fork which doesn't explicitly define its own DockerHub creds.
+      # That's OK--if we fail to log in, we'll proceed anonymously, and hope we don't get rate-limited.
+      - name: Try to log into Docker Hub
         uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Start MongoDB
+        if: always()  # Continue even if the previous step (log into DockerHub) failed.
         uses: supercharge/mongodb-github-action@1.11.0
         with:
           mongodb-version: ${{ matrix.mongo-version }}


### PR DESCRIPTION
## Description

This iterates on https://github.com/openedx/edx-platform/pull/36089, which
logged us into DockerHub during unit tests in order to reduce how often
DockerHub rate-limits us.

Forks will fail to log into DockerHub unless the fork owner configures their
own DockerHub creds. This PR is an attempt to make it so that unit tests don't
fail when DockerHub login fails.

## Testing instructions

### With DockerHub credentials...

Just see this PR's build.

### Without DockerHub credentials...

I merged these changed to master of my personal fork, which has no DockerHub credentials configured.

Here is a PR against my personal fork demonstrating that the modified unit-tests action tolerates failure of the Docker Log In step: https://github.com/kdmccormick/edx-platform/pull/31