### PR TITLE
fix: import authoring filter from content_authoring instead

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -25,7 +25,7 @@ from common.djangoapps.util.date_utils import get_default_time_display
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx_filters.course_authoring.filters import LMSPageURLRequested
+from openedx_filters.content_authoring.filters import LMSPageURLRequested
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.exceptions import NotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -717,7 +717,7 @@ def get_asset_json(display_name, content_type, date, location, thumbnail_locatio
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
 
     ## .. filter_implemented_name: LMSPageURLRequested
-    ## .. filter_type: org.openedx.course_authoring.lms.page.url.requested.v1
+    ## .. filter_type: org.openedx.content_authoring.lms.page.url.requested.v1
     lms_root, _ = LMSPageURLRequested.run_filter(
         url=configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
         org=location.org,

--- a/cms/djangoapps/contentstore/tests/test_filters.py
+++ b/cms/djangoapps/contentstore/tests/test_filters.py
@@ -48,7 +48,7 @@ class LMSPageURLRequestedFiltersTest(ModuleStoreTestCase):
 
     @override_settings(
         OPEN_EDX_FILTERS_CONFIG={
-            "org.openedx.course_authoring.lms.page.url.requested.v1": {
+            "org.openedx.content_authoring.lms.page.url.requested.v1": {
                 "pipeline": [
                     "common.djangoapps.util.tests.test_filters.TestPageURLRequestedPipelineStep",
                 ],

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -499,6 +499,7 @@ edx-opaque-keys[django]==2.11.0
     #   edx-when
     #   lti-consumer-xblock
     #   openedx-events
+    #   openedx-filters
     #   ora2
 edx-organizations==6.13.0
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -820,7 +820,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.12.0
+git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -820,7 +820,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
+openedx-filters==2.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1371,7 +1371,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.12.0
+git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1371,7 +1371,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
+openedx-filters==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -790,6 +790,7 @@ edx-opaque-keys[django]==2.11.0
     #   edx-when
     #   lti-consumer-xblock
     #   openedx-events
+    #   openedx-filters
     #   ora2
 edx-organizations==6.13.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -993,7 +993,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
+openedx-filters==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -584,6 +584,7 @@ edx-opaque-keys[django]==2.11.0
     #   edx-when
     #   lti-consumer-xblock
     #   openedx-events
+    #   openedx-filters
     #   ora2
 edx-organizations==6.13.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -993,7 +993,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.12.0
+git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1041,7 +1041,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-openedx-filters==1.12.0
+git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1041,7 +1041,7 @@ openedx-events==9.18.0
     #   edx-name-affirmation
     #   event-tracking
     #   ora2
-git+https://github.com/openedx/openedx-filters.git@MJG/fix-authoring-subdomain
+openedx-filters==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -608,6 +608,7 @@ edx-opaque-keys[django]==2.11.0
     #   edx-when
     #   lti-consumer-xblock
     #   openedx-events
+    #   openedx-filters
     #   ora2
 edx-organizations==6.13.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

When reviewing https://github.com/openedx/openedx-filters/pull/200, I suggested using the subdomain `course_authoring` when it was called `content_authoring`. This PR correctly imports the filter implemented in the PR I previously mentioned from the `content_authoring` subdomain instead of the `course_authoring` subdomain. This change was made according to the DDD docs for the Open edX ecosystem: https://openedx.atlassian.net/wiki/spaces/AC/pages/663224968/edX+DDD+Bounded+Contexts 

Depends on https://github.com/openedx/openedx-filters/pull/252

## Deadline

Once openedx-filters PR is merged.

## Other information

I suggest not backporting this breaking change to the sumac branch to not break existing plugins that are using this filter. It'd be better for them to migrate to this fix once Teak is out.
