### PR TITLE
build: Cache images in unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,15 +73,13 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install libmysqlclient-dev libxmlsec1-dev lynx
 
-      # Try to log into DockerHub so that we're less likely to be rate-limited when pulling certain images.
-      # This will fail on any edx-platform fork which doesn't explicitly define its own DockerHub creds.
-      # That's OK--if we fail to log in, we'll proceed anonymously, and hope we don't get rate-limited.
-      - name: Try to log into Docker Hub
-        uses: docker/login-action@v3.3.0
-        continue-on-error: true
+      # We pull this image a lot, and Dockerhub will rate limit us if we pull too often.
+      # This is an attempt to cache the image for better performance and to work around that.
+      # It will cache all pulled images, so if we add new images to this we'll need to update the key.
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.5.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          key: docker-${{ runner.os }}-mongo-${{ hashFiles(matrix.mongo-version) }}
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.11.0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.5.0
         with:
-          key: docker-${{ runner.os }}-mongo-${{ hashFiles(matrix.mongo-version) }}
+          key: docker-${{ runner.os }}-mongo-${{ matrix.mongo-version }}
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.11.0


### PR DESCRIPTION
## Description

Another attempt to stop Dockerhub from rate limiting us in CI. If this works here I'll try to add this caching to other relevant workflows.

## Supporting information

https://github.com/openedx/axim-engineering/issues/1350#issuecomment-2591237325

Current attempt is using this action to attempt the cache: https://github.com/marketplace/actions/docker-cache