### PR TITLE
perf: reduce ORM queries needed for video quality info

### DIFF
--- a/cms/djangoapps/contentstore/api/views/course_quality.py
+++ b/cms/djangoapps/contentstore/api/views/course_quality.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 import numpy as np
-from edxval.api import get_videos_for_course
+from edxval.api import get_course_videos_qset
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from scipy import stats
@@ -180,13 +180,11 @@ class CourseQualityView(DeveloperErrorViewMixin, GenericAPIView):
 
     def _videos_quality(self, course):  # lint-amnesty, pylint: disable=missing-function-docstring
         video_blocks_in_course = modulestore().get_items(course.id, qualifiers={'category': 'video'})
-        videos, __ = get_videos_for_course(course.id)
-        videos_in_val = list(videos)
-        video_durations = [video['duration'] for video in videos_in_val]
+        video_durations = [cv.video.duration for cv in get_course_videos_qset(course.id)]
 
         return dict(
             total_number=len(video_blocks_in_course),
-            num_mobile_encoded=len(videos_in_val),
+            num_mobile_encoded=len(video_durations),
             num_with_val_id=len([v for v in video_blocks_in_course if v.edx_video_id]),
             durations=self._stats_dict(video_durations),
         )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -544,7 +544,7 @@ edx-when==2.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-edxval==2.8.0
+edxval==2.9.0
     # via -r requirements/edx/kernel.in
 elasticsearch==7.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -854,7 +854,7 @@ edx-when==2.5.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-edxval==2.8.0
+edxval==2.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -635,7 +635,7 @@ edx-when==2.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==2.8.0
+edxval==2.9.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -658,7 +658,7 @@ edx-when==2.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==2.8.0
+edxval==2.9.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.9.1
     # via


### PR DESCRIPTION
```
The CourseQualityView used to call edx-val's get_video_for_course(),
which would return a fully serialized data structure that included all
encodings and inefficiently serialized them with many n+1 queries. This
is tolerable in a paginated web view, but not when pulling all of a
large courses's videos at once.

Making this change collapsed the number of queries for a large sample
MIT course from over 3000 down to 1.
```