### PR TITLE
fix: initial link check scan

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
@@ -183,44 +183,9 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
                         # Wasn't JSON, just use the value as a string
                         pass
 
-        # print('DTO')
-        # print(broken_links_dto)
-
-        # mock dto for testing
-        # broken_links_dto = {
-        #     'sections': [
-        #         {
-        #             'id': 'sectid',
-        #             'displayName': 'sectname',
-        #             'subsections': [
-        #                 {
-        #                     'id': 'subid',
-        #                     'displayName': 'subname',
-        #                     'units': [
-        #                         {
-        #                             'id': 'unitid',
-        #                             'displayName': 'unitname',
-        #                             'blocks': [
-        #                                 {
-        #                                     'id': 'blockid',
-        #                                     'displayName': 'blockname',
-        #                                     'url': 'blockurl',
-        #                                     'brokenLinks': [
-        #                                         'link1',
-        #                                         'link2',
-        #                                     ],
-        #                                 },
-        #                             ],
-        #                         }
-        #                     ]
-        #                 }
-        #             ]
-        #         }
-        #     ]
-        # }
         data = {
             'LinkCheckStatus': status,
-            'LinkCheckCreatedAt': created_at,
+            **({'LinkCheckCreatedAt': created_at} if created_at else {}),
             **({'LinkCheckOutput': broken_links_dto} if broken_links_dto else {}),
             **({'LinkCheckError': error} if error else {})
         }


### PR DESCRIPTION
Fixes initial link check scan for a course when there has been no previous scans. This caused LinkCheckCreatedAt to be set to None which does not pass the serializer.