### PR TITLE
chore: upgrade openedx-forum version to 0.1.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -830,7 +830,7 @@ openedx-filters==1.12.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.1.6
     # via -r requirements/edx/kernel.in
 openedx-learning==0.18.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1389,7 +1389,7 @@ openedx-filters==1.12.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.1.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1007,7 +1007,7 @@ openedx-filters==1.12.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.1.6
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1054,7 +1054,7 @@ openedx-filters==1.12.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.1.6
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.1
     # via


### PR DESCRIPTION
upgrade openedx-forum to newer version [0.1.6](https://github.com/openedx/forum/releases/tag/0.1.6) that include bugfixes.