### PR TITLE
fix: remove lti-consumer-xblock pin and upgrade package

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -184,8 +184,3 @@ social-auth-app-django<=5.4.1
 # We are pinning this until we can upgrade to a version of elasticsearch that uses a more recent version of urllib3.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35126
 elasticsearch==7.9.1
-
-# Date 2025-01-10
-# Cause: https://github.com/openedx/edx-platform/issues/36095
-# Issue for unpinning https://github.com/openedx/edx-platform/issues/36096
-lti-consumer-xblock==9.12.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -705,10 +705,8 @@ lazy==1.6
     #   xblock
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.12.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/kernel.in
+lti-consumer-xblock==9.13.1
+    # via -r requirements/edx/kernel.in
 lxml[html-clean,html_clean]==5.3.0
     # via
     #   -r requirements/edx/kernel.in
@@ -944,6 +942,7 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
+    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1189,9 +1189,8 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.12.1
+lti-consumer-xblock==9.13.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 lxml[html-clean]==5.3.0
@@ -1611,6 +1610,7 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
+    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -860,10 +860,8 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.12.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+lti-consumer-xblock==9.13.1
+    # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -1160,6 +1158,7 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
+    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -903,10 +903,8 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.12.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+lti-consumer-xblock==9.13.1
+    # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -1224,6 +1222,7 @@ pyjwt[crypto]==2.10.1
     #   edx-proctoring
     #   edx-rest-api-client
     #   firebase-admin
+    #   lti-consumer-xblock
     #   pylti1p3
     #   snowflake-connector-python
     #   social-auth-core


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description
The latest version of the lti-consumer-xblock library v9.13.1, contains a fix for broken LTI 1.3 launches introduced in v9.13.0. 
