### PR TITLE
fix: Dropping terrain related config and docs.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -22,7 +22,6 @@ omit =
     lms/envs/*
     lms/djangoapps/*/migrations/*
     lms/djangoapps/*/features/*
-    common/djangoapps/terrain/*
     common/djangoapps/*/migrations/*
     openedx/core/djangoapps/*/migrations/*
     openedx/core/djangoapps/debug/*

--- a/.coveragerc-local
+++ b/.coveragerc-local
@@ -21,7 +21,6 @@ omit =
     lms/envs/*
     lms/djangoapps/*/migrations/*
     lms/djangoapps/*/features/*
-    common/djangoapps/terrain/*
     common/djangoapps/*/migrations/*
     openedx/core/djangoapps/*/migrations/*
     openedx/core/djangoapps/debug/*

--- a/docs/concepts/testing/testing.rst
+++ b/docs/concepts/testing/testing.rst
@@ -226,13 +226,6 @@ Use this command to generate an HTML report::
 
 The report is then saved in reports/xmodule/cover/index.html
 
-To run tests for stub servers, for example for `YouTube stub server`_, you can
-run one of these commands::
-
-    pytest --ds=cms.env.test common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
-
-.. _YouTube stub server: https://github.com/openedx/edx-platform/blob/master/common/djangoapps/terrain/stubs/tests/test_youtube_stub.py
-
 
 Handling flaky unit tests
 =========================


### PR DESCRIPTION
The terrain app and its stub servers were removed as a part of
https://github.com/openedx/edx-platform/pull/36102 but these last few
things got missed.
