### PR TITLE
fix: course outline not found issue for ccx courses

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -445,10 +445,18 @@ XBLOCK_SETTINGS.setdefault("VideoBlock", {})['YOUTUBE_API_KEY'] = YOUTUBE_API_KE
 
 ##### Custom Courses for EdX #####
 if FEATURES['CUSTOM_COURSES_EDX']:
-    INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
+    INSTALLED_APPS += [
+        'lms.djangoapps.ccx',
+        'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig',
+        'cms.djangoapps.contentstore.apps.ContentstoreConfig',
+        'openedx.core.djangoapps.content.search',
+        'openedx.core.djangoapps.content_staging',
+    ]
+
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
         'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )
+    COURSE_IMPORT_EXPORT_STORAGE = DEFAULT_FILE_STORAGE
 
 FIELD_OVERRIDE_PROVIDERS = tuple(FIELD_OVERRIDE_PROVIDERS)
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -407,8 +407,16 @@ FACEBOOK_APP_ID = "Test"
 FACEBOOK_API_VERSION = "v2.8"
 
 ######### custom courses #########
-INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
+INSTALLED_APPS += [
+    'lms.djangoapps.ccx',
+    'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig',
+    'cms.djangoapps.contentstore.apps.ContentstoreConfig',
+    'openedx.core.djangoapps.content.search',
+    'openedx.core.djangoapps.content_staging',
+]
+
 FEATURES['CUSTOM_COURSES_EDX'] = True
+COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 # Set dummy values for profile image settings.
 PROFILE_IMAGE_BACKEND = {

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -407,16 +407,8 @@ FACEBOOK_APP_ID = "Test"
 FACEBOOK_API_VERSION = "v2.8"
 
 ######### custom courses #########
-INSTALLED_APPS += [
-    'lms.djangoapps.ccx',
-    'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig',
-    'cms.djangoapps.contentstore.apps.ContentstoreConfig',
-    'openedx.core.djangoapps.content.search',
-    'openedx.core.djangoapps.content_staging',
-]
-
+INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
 FEATURES['CUSTOM_COURSES_EDX'] = True
-COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 # Set dummy values for profile image settings.
 PROFILE_IMAGE_BACKEND = {


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

CCX courses are created from LMS and the course publish signals are in CMS. This PR adds `cms.djangoapps.contentstore.apps.ContentstoreConfig` in `INSTALLED_APPS` for CCX feature in LMS production settings. Without this, the course publish signals are not triggered at the time of CCX creation resulting in a `CourseOutlineData.DoesNotExist` error for the CCX courses.

Useful information to include:

- Which edX user roles will this change impact? "Learner", "Course Author"
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/mitodl/hq/issues/3880

## Testing instructions

To test this locally, follow the steps below

- In your `private.py` in LMS, add these settings to enable CCX:
```
FEATURES["CUSTOM_COURSES_EDX"]=True
INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
COURSEGRAPH_DUMP_COURSE_ON_PUBLISH = False
MODULESTORE_FIELD_OVERRIDE_PROVIDERS += ('lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',)
```
- In your `private.py` in CMS, add this setting:
```
FEATURES["CUSTOM_COURSES_EDX"]=True
```

- In Studio, create a course and go to advanced settings. Toggle the "Enable CCX" setting there.

- Next, go to the course's instructor dashboard, open the membership tab, and add a CCX coach.

- Log in as the CCX coach, open the course you created, go to the CCX coach tab, and create a CCX. (You can find all the steps to create a CCX in the [docs](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/set_up_course/studio_add_course_information/custom_courses.html)).

- Save your changes in the Schedule Tab, then check the course outline of the CCX course.  
  - You’ll notice the course outline won’t load, and you’ll see a `CourseOutlineData.DoesNotExist` error in your LMS logs.

- To fix this, update the `INSTALLED_APPS` line in LMS settings to:

```
INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig', 'cms.djangoapps.contentstore.apps.ContentstoreConfig', 'openedx.core.djangoapps.content.search', 'openedx.core.djangoapps.content_staging']
```

- Go back to the Schedule Tab, make any changes, and save again.

- Finally, revisit the course outline page of the CCX course.  
  - The outline will now load perfectly without any errors.

## Deadline

"None"

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
