### PR TITLE
perf: normalize LMS vs. Studio debug-toolbar settings

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -103,8 +103,12 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.request.RequestPanel',
     'debug_toolbar.panels.sql.SQLPanel',
     'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.profiling.ProfilingPanel',
+    'debug_toolbar.panels.cache.CachePanel',
     'debug_toolbar.panels.history.HistoryPanel',
+
+    # ProfilingPanel has been intentionally removed for default devstack.py
+    # runtimes for performance reasons.
+    # 'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -96,11 +96,12 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.request.RequestPanel',
     'debug_toolbar.panels.sql.SQLPanel',
     'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.cache.CachePanel',
     'debug_toolbar.panels.history.HistoryPanel',
+
     # ProfilingPanel has been intentionally removed for default devstack.py
-    # runtimes for performance reasons. If you wish to re-enable it in your
-    # local development environment, please create a new settings file
-    # that imports and extends devstack.py.
+    # runtimes for performance reasons.
+    # 'debug_toolbar.panels.profiling.ProfilingPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
```
This change disables the profiling panel for performance reasons. It's
rarely useful anyway, given the lack of granularity in the data it
displays.

This commit also enables the Cache panel, which is import for tracking
where we're making excessive calls to redis/memcached.
```