### PR TITLE
fix: ensure `TagCountFactory` is bundled in production

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -332,6 +332,7 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
         }
 
         add_webpack_js_to_fragment(frag, "js/factories/xblock_validation")
+        add_webpack_js_to_fragment(frag, "js/factories/tag_count")
 
         html = render_to_string('studio_xblock_wrapper.html', template_context)
         frag = wrap_fragment(frag, html)

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -47,17 +47,14 @@ upstream_info = UpstreamLink.try_get_for_block(xblock)
         ${bool(block_is_unit) | n, dump_js_escaped_json},  // block_is_unit will be None or a boolean
         $('div.xblock-validation-messages[data-locator="${xblock.location | n, js_escaped_string}"]')
     );
-</script>
-
-<%static:webpack entry="js/factories/tag_count">
     TagCountFactory({
-        tags_count: "${tags_count | n, js_escaped_string}",
-        content_id: "${xblock.location | n, js_escaped_string}",
-        course_authoring_url: "${course_authoring_url | n, js_escaped_string}",
-    },
+            tags_count: "${tags_count | n, js_escaped_string}",
+            content_id: "${xblock.location | n, js_escaped_string}",
+            course_authoring_url: "${course_authoring_url | n, js_escaped_string}",
+        },
         $('li.tag-count[data-locator="${xblock.location | n, js_escaped_string}"]')
     );
-</%static:webpack>
+</script>
 
 % if not is_root:
     % if is_reorderable:


### PR DESCRIPTION
This removes the `static:webpack` directive and uses `add_webpack_js_to_fragment` to properly include TagCountFactory in production. The previous solution (https://github.com/openedx/edx-platform/pull/34059) did not correctly bundle this factory, causing the `ReferenceError: TagCountFactory is not defined` JS error in the Studio preview.

## Testing instructions
1. Check out this branch.
2. Run `tutor dev exec cms npm run webpack`.
3. View a unit in Studio and ensure that there is no `ReferenceError: TagCountFactory is not defined` error in the console logs.

_Private-ref: [BB-9480](https://tasks.opencraft.com/browse/BB-9480)_