### PR TITLE
perf: upgrade XBlock to 5.1.1 for caching unknown tags

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1256,7 +1256,7 @@ wheel==0.45.1
     # via django-pipeline
 wrapt==1.17.2
     # via -r requirements/edx/kernel.in
-xblock[django]==5.1.0
+xblock[django]==5.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2253,7 +2253,7 @@ wrapt==1.17.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-xblock[django]==5.1.0
+xblock[django]==5.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1583,7 +1583,7 @@ wrapt==1.17.2
     # via
     #   -r requirements/edx/base.txt
     #   astroid
-xblock[django]==5.1.0
+xblock[django]==5.1.1
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1673,7 +1673,7 @@ wrapt==1.17.2
     # via
     #   -r requirements/edx/base.txt
     #   astroid
-xblock[django]==5.1.0
+xblock[django]==5.1.1
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock


### PR DESCRIPTION
This should improve performance for courseware operations when there is
content that doesn't map to any existing XBlocks in the system. This
usually happens to old courses when custom XBlock types are deprecated
and removed, or when a course is imported from another instance with a
different set of installed XBlocks.
