### PR TITLE
feat: update default retirement states in devstack config

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -553,6 +553,20 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:1996',  # frontend-app-learner-dashboard
 ]
 
+RETIREMENT_STATES = [
+    'PENDING',
+    'LOCKING_ACCOUNT',
+    'LOCKING_COMPLETE',
+    'RETIRING_ENROLLMENTS',
+    'ENROLLMENTS_COMPLETE',
+    'RETIRING_LMS_MISC',
+    'LMS_MISC_COMPLETE',
+    'RETIRING_LMS',
+    'LMS_COMPLETE',
+    'ERRORED',
+    'ABORTED',
+    'COMPLETE',
+]
 
 ################# New settings must go ABOVE this line #################
 ########################################################################


### PR DESCRIPTION
## Description

We would like new devstack instances to better support the user retirement pipeline out of the box after provisioning. The first step is to update the default list of retirement states devstack is configured to add/use.

