### PR TITLE
refactor!: remove `ENABLE_HOME_PAGE_COURSE_API_V2` feature toggle

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
@@ -15,12 +15,6 @@ from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
 
-FEATURES_WITH_HOME_PAGE_COURSE_V2_API = settings.FEATURES.copy()
-FEATURES_WITH_HOME_PAGE_COURSE_V2_API['ENABLE_HOME_PAGE_COURSE_API_V2'] = True
-FEATURES_WITHOUT_HOME_PAGE_COURSE_V2_API = settings.FEATURES.copy()
-FEATURES_WITHOUT_HOME_PAGE_COURSE_V2_API['ENABLE_HOME_PAGE_COURSE_API_V2'] = False
-
-
 @ddt.ddt
 class HomePageViewTest(CourseTestCase):
     """
@@ -99,7 +93,6 @@ class HomePageViewTest(CourseTestCase):
         )
 
 
-@override_settings(FEATURES=FEATURES_WITHOUT_HOME_PAGE_COURSE_V2_API)
 @ddt.ddt
 class HomePageCoursesViewTest(CourseTestCase):
     """
@@ -141,7 +134,6 @@ class HomePageCoursesViewTest(CourseTestCase):
         print(response.data)
         self.assertDictEqual(expected_response, response.data)
 
-    @override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API)
     def test_home_page_response_with_api_v2(self):
         """Check successful response content with api v2 modifications.
 
@@ -171,7 +163,6 @@ class HomePageCoursesViewTest(CourseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(expected_response, response.data)
 
-    @override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API)
     @ddt.data(
         ("active_only", "true", 2, 0),
         ("archived_only", "true", 0, 1),
@@ -214,7 +205,6 @@ class HomePageCoursesViewTest(CourseTestCase):
         self.assertEqual(len(response.data["archived_courses"]), expected_archived_length)
         self.assertEqual(len(response.data["courses"]), expected_active_length)
 
-    @override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API)
     @ddt.data(
         ("active_only", "true"),
         ("archived_only", "true"),
@@ -231,7 +221,6 @@ class HomePageCoursesViewTest(CourseTestCase):
         self.assertEqual(len(response.data["courses"]), 0)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API)
     @ddt.data(
         ("active_only", "true"),
         ("archived_only", "true"),
@@ -243,7 +232,7 @@ class HomePageCoursesViewTest(CourseTestCase):
         """Test home page with org filter and ordering when there are no courses for a non-staff user."""
         self.course_overview.delete()
 
-        response = self.non_staff_client.get(self.url)
+        response = self.non_staff_client.get(self.url, {filter_key: filter_value})
 
         self.assertEqual(len(response.data["courses"]), 0)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -1,8 +1,7 @@
 """HomePageCoursesViewV2 APIView for getting content available to the logged in user."""
+
 import edx_api_doc_tools as apidocs
 from collections import OrderedDict
-from django.conf import settings
-from django.http import HttpResponseNotFound
 from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework.views import APIView

--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -126,13 +126,7 @@ class HomePageCoursesViewV2(APIView):
             "in_process_course_actions": [],
         }
         ```
-
-        if the `ENABLE_HOME_PAGE_COURSE_API_V2` feature flag is not enabled, an HTTP 404 "Not Found" response
-        is returned.
         """
-        if not settings.FEATURES.get('ENABLE_HOME_PAGE_COURSE_API_V2', False):
-            return HttpResponseNotFound()
-
         courses, in_process_course_actions = get_course_context_v2(request)
         paginator = HomePageCoursesPaginator()
         courses_page = paginator.paginate_queryset(

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -16,11 +16,7 @@ from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
-FEATURES_WITH_HOME_PAGE_COURSE_V2_API = settings.FEATURES.copy()
-FEATURES_WITH_HOME_PAGE_COURSE_V2_API['ENABLE_HOME_PAGE_COURSE_API_V2'] = True
 
-
-@override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API)
 @ddt.ddt
 class HomePageCoursesViewV2Test(CourseTestCase):
     """
@@ -208,21 +204,6 @@ class HomePageCoursesViewV2Test(CourseTestCase):
         self.assertEqual(response.data["count"], 2)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @patch("cms.djangoapps.contentstore.views.course.CourseOverview")
-    @patch("cms.djangoapps.contentstore.views.course.modulestore")
-    def test_api_v2_is_disabled(self, mock_modulestore, mock_course_overview):
-        """Get list of courses when home page course v2 API is disabled.
-
-        Expected result:
-        - Courses are read from the modulestore.
-        """
-        with override_settings(FEATURES={'ENABLE_HOME_PAGE_COURSE_API_V2': False}):
-            response = self.client.get(self.api_v1_url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_modulestore().get_course_summaries.assert_called_once()
-        mock_course_overview.get_all_courses.assert_not_called()
-
     @ddt.data(
         ("active_only", "true"),
         ("archived_only", "true"),
@@ -245,7 +226,6 @@ class HomePageCoursesViewV2Test(CourseTestCase):
         self.assertEqual(len(response.data['results']['courses']), 0)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API)
     @ddt.data(
         ("active_only", "true", 2, 0),
         ("archived_only", "true", 0, 1),

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -1,14 +1,13 @@
 """
 Unit tests for home page view.
 """
+
 from collections import OrderedDict
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
 import ddt
 import pytz
 from django.conf import settings
-from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -3,14 +3,13 @@ Unit tests for getting the list of courses for a user through iterating all cour
 by reversing group name formats.
 """
 
-
 import random
 from unittest.mock import Mock, patch
 
 import ddt
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 from opaque_keys.edx.locations import CourseLocator
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
@@ -35,17 +34,12 @@ from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
-from xmodule.course_block import CourseSummary  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 TOTAL_COURSES_COUNT = 10
 USER_COURSES_COUNT = 1
-FEATURES_WITH_HOME_PAGE_COURSE_V2_API = settings.FEATURES.copy()
-FEATURES_WITH_HOME_PAGE_COURSE_V2_API['ENABLE_HOME_PAGE_COURSE_API_V2'] = True
-FEATURES_WITHOUT_HOME_PAGE_COURSE_V2_API = settings.FEATURES.copy()
-FEATURES_WITHOUT_HOME_PAGE_COURSE_V2_API['ENABLE_HOME_PAGE_COURSE_API_V2'] = False
 
 
 @ddt.ddt
@@ -185,19 +179,7 @@ class TestCourseListing(ModuleStoreTestCase):
         courses_list_by_staff, __ = get_courses_accessible_to_user(self.request)
 
         self.assertEqual(len(list(courses_list_by_staff)), TOTAL_COURSES_COUNT)
-
-        with override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API):
-            # Verify fetched accessible courses list is a list of CourseOverview instances when home page course v2
-            # api is enabled.
-            self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_list_by_staff))
-
-        with override_settings(FEATURES=FEATURES_WITHOUT_HOME_PAGE_COURSE_V2_API):
-            # Verify fetched accessible courses list is a list of CourseSummery instances
-            self.assertTrue(all(isinstance(course, CourseSummary) for course in courses_list_by_staff))
-
-            # Now count the db queries for staff
-            with check_mongo_calls(2):
-                list(_accessible_courses_summary_iter(self.request))
+        self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_list_by_staff))
 
     def test_get_course_list_with_invalid_course_location(self):
         """
@@ -212,21 +194,10 @@ class TestCourseListing(ModuleStoreTestCase):
         courses_list = list(courses_iter)
         self.assertEqual(len(courses_list), 1)
 
-        with override_settings(FEATURES=FEATURES_WITH_HOME_PAGE_COURSE_V2_API):
-            # Verify fetched accessible courses list is a list of CourseOverview instances when home page course v2
-            # api is enabled.
-            courses_summary_iter, __ = _accessible_courses_summary_iter(self.request)
-            courses_summary_list = list(courses_summary_iter)
-            self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_summary_list))
-            self.assertEqual(len(courses_summary_list), 1)
-
-        with override_settings(FEATURES=FEATURES_WITHOUT_HOME_PAGE_COURSE_V2_API):
-            # Verify fetched accessible courses list is a list of CourseSummery instances and only one course
-            # is returned
-            courses_summary_iter, __ = _accessible_courses_summary_iter(self.request)
-            courses_summary_list = list(courses_summary_iter)
-            self.assertTrue(all(isinstance(course, CourseSummary) for course in courses_summary_list))
-            self.assertEqual(len(courses_summary_list), 1)
+        courses_summary_iter, __ = _accessible_courses_summary_iter(self.request)
+        courses_summary_list = list(courses_summary_iter)
+        self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_summary_list))
+        self.assertEqual(len(courses_summary_list), 1)
 
         # get courses by reversing group name formats
         courses_list_by_groups, __ = _accessible_courses_list_from_groups(self.request)

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -317,6 +317,10 @@ class TestCourseListing(ModuleStoreTestCase):
         self.assertEqual(len(list(courses_list)), 2)
         self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_list))
 
+        # Now count the db queries for staff
+        with self.assertNumQueries(2):
+            list(_accessible_courses_summary_iter(self.request))
+
     @ddt.data(OrgStaffRole(), OrgInstructorRole())
     def test_course_listing_org_permissions_exception(self, role):
         """

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -181,6 +181,10 @@ class TestCourseListing(ModuleStoreTestCase):
         self.assertEqual(len(list(courses_list_by_staff)), TOTAL_COURSES_COUNT)
         self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_list_by_staff))
 
+        # Now count the db queries for staff
+        with self.assertNumQueries(2):
+            list(_accessible_courses_summary_iter(self.request))
+
     def test_get_course_list_with_invalid_course_location(self):
         """
         Test getting courses with invalid course location (course deleted from modulestore).
@@ -316,10 +320,6 @@ class TestCourseListing(ModuleStoreTestCase):
         # course count is returned
         self.assertEqual(len(list(courses_list)), 2)
         self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_list))
-
-        # Now count the db queries for staff
-        with self.assertNumQueries(2):
-            list(_accessible_courses_summary_iter(self.request))
 
     @ddt.data(OrgStaffRole(), OrgInstructorRole())
     def test_course_listing_org_permissions_exception(self, role):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -405,23 +405,15 @@ def _accessible_courses_summary_iter(request):
 
         return has_studio_read_access(request.user, course_summary.id)
 
-    enable_home_page_api_v2 = settings.FEATURES["ENABLE_HOME_PAGE_COURSE_API_V2"]
-
-    if enable_home_page_api_v2:
-        # If the new home page API is enabled, we should use the Django ORM to filter and order the courses
-        courses_summary = CourseOverview.get_all_courses()
-    else:
-        courses_summary = modulestore().get_course_summaries()
-
-    if enable_home_page_api_v2:
-        search_query, order, active_only, archived_only = get_query_params_if_present(request)
-        courses_summary = get_filtered_and_ordered_courses(
-            courses_summary,
-            active_only,
-            archived_only,
-            search_query,
-            order,
-        )
+    courses_summary = CourseOverview.get_all_courses()
+    search_query, order, active_only, archived_only = get_query_params_if_present(request)
+    courses_summary = get_filtered_and_ordered_courses(
+        courses_summary,
+        active_only,
+        archived_only,
+        search_query,
+        order,
+    )
 
     courses_summary = filter(course_filter, courses_summary)
     in_process_course_actions = get_in_process_course_actions(request)

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -450,12 +450,10 @@ class TestCourseIndexArchived(CourseTestCase):
         features = settings.FEATURES.copy()
         features['ENABLE_SEPARATE_ARCHIVED_COURSES'] = separate_archived_courses
         with override_settings(FEATURES=features):
-            self.check_index_page_with_query_count(
-                separate_archived_courses=separate_archived_courses,
-                org=org,
-                mongo_queries=mongo_queries,
-                sql_queries=sql_queries,
-            )
+            self.check_index_page_with_query_count(separate_archived_courses=separate_archived_courses,
+                                                   org=org,
+                                                   mongo_queries=mongo_queries,
+                                                   sql_queries=sql_queries)
 
     @ddt.data(
         # Staff user has course staff access

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -427,16 +427,16 @@ class TestCourseIndexArchived(CourseTestCase):
 
     @ddt.data(
         # Staff user has course staff access
-        (True, 'staff', None, 0, 23),
-        (False, 'staff', None, 0, 23),
+        (True, 'staff', None, 23),
+        (False, 'staff', None, 23),
         # Base user has global staff access
-        (True, 'user', ORG, 0, 23),
-        (False, 'user', ORG, 0, 23),
-        (True, 'user', None, 0, 23),
-        (False, 'user', None, 0, 23),
+        (True, 'user', ORG, 23),
+        (False, 'user', ORG, 23),
+        (True, 'user', None, 23),
+        (False, 'user', None, 23),
     )
     @ddt.unpack
-    def test_separate_archived_courses(self, separate_archived_courses, username, org, mongo_queries, sql_queries):
+    def test_separate_archived_courses(self, separate_archived_courses, username, org, sql_queries):
         """
         Ensure that archived courses are shown as expected for all user types, when the feature is enabled/disabled.
         Also ensure that enabling the feature does not adversely affect the database query count.
@@ -452,18 +452,18 @@ class TestCourseIndexArchived(CourseTestCase):
         with override_settings(FEATURES=features):
             self.check_index_page_with_query_count(separate_archived_courses=separate_archived_courses,
                                                    org=org,
-                                                   mongo_queries=mongo_queries,
+                                                   mongo_queries=0,
                                                    sql_queries=sql_queries)
 
     @ddt.data(
         # Staff user has course staff access
-        (True, 'staff', None, 0, 23),
-        (False, 'staff', None, 0, 23),
+        (True, 'staff', None, 23),
+        (False, 'staff', None, 23),
         # Base user has global staff access
-        (True, 'user', ORG, 0, 23),
-        (False, 'user', ORG, 0, 23),
-        (True, 'user', None, 0, 23),
-        (False, 'user', None, 0, 23),
+        (True, 'user', ORG, 23),
+        (False, 'user', ORG, 23),
+        (True, 'user', None, 23),
+        (False, 'user', None, 23),
     )
     @ddt.unpack
     def test_separate_archived_courses_with_home_page_course_v2_api(
@@ -471,7 +471,6 @@ class TestCourseIndexArchived(CourseTestCase):
         separate_archived_courses,
         username,
         org,
-        mongo_queries,
         sql_queries
     ):
         """
@@ -489,7 +488,7 @@ class TestCourseIndexArchived(CourseTestCase):
         with override_settings(FEATURES=features):
             self.check_index_page_with_query_count(separate_archived_courses=separate_archived_courses,
                                                    org=org,
-                                                   mongo_queries=mongo_queries,
+                                                   mongo_queries=0,
                                                    sql_queries=sql_queries)
 
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -547,16 +547,6 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33952
     'ENABLE_HIDE_FROM_TOC_UI': False,
 
-    # .. toggle_name: FEATURES['ENABLE_HOME_PAGE_COURSE_API_V2']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: True
-    # .. toggle_description: Enables the new home page course v2 API, which is a new version of the home page course
-    #   API with pagination, filter and ordering capabilities.
-    # .. toggle_use_cases: open_edx
-    # .. toggle_creation_date: 2024-03-14
-    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34173
-    'ENABLE_HOME_PAGE_COURSE_API_V2': True,
-
     # .. toggle_name: FEATURES['ENABLE_GRADING_METHOD_IN_PROBLEMS']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False


### PR DESCRIPTION
## Description

This PR removes the `ENABLE_HOME_PAGE_COURSE_API_V2` feature toggle and all its related code. With this change, the API v2 will always be available.

This helps implement:
- https://github.com/openedx/public-engineering/issues/287

### Other Changes
Since the feature toggle was removed, as well as API v2, API v1 will obtain the courses summary from the `CourseOverview.get_all_courses()`

## Testing instructions

1. Create a Tutor environment.
2. Create a mount of **edx-platform** with the changes in this branch.
3. Consume the endpoints of HomePageCourseAPI:

    **API v2**
    ```
    http://studio.local.openedx.io:8001/api/contentstore/v2/home/courses
    ```
    **API v1**
    ```
    http://studio.local.openedx.io:8001/api/contentstore/v1/home/courses
    ```
4. You should see the endpoint responses without any problem.

## Deadline

None

## Other information

None
