### PR TITLE
chore: Adds fallback values to the xmodule xblocks global css variables

### DIFF
--- a/common/static/sass/_builtin-block-variables.scss
+++ b/common/static/sass/_builtin-block-variables.scss
@@ -63,7 +63,6 @@
     --shadow-l1: $shadow-l1;
     --sidebar-color: $sidebar-color;
     --small-font-size: $small-font-size;
-    --static-path: $static-path;
     --submitted: $submitted;
     --success: $success;
     --tmg-f2: $tmg-f2;

--- a/xmodule/static/css-builtin-blocks/AnnotatableBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/AnnotatableBlockDisplay.css
@@ -11,7 +11,7 @@
 .xmodule_display.xmodule_AnnotatableBlock .annotatable-section {
     position: relative;
     padding: 0.5em 1em;
-    border: 1px solid var(--gray-l3);
+    border: 1px solid var(--gray-l3, #c8c8c8);
     border-radius: 0.5em;
     margin-bottom: 0.5em;
 }
@@ -29,7 +29,7 @@
 }
 
 .xmodule_display.xmodule_AnnotatableBlock .annotatable-section .annotatable-section-body {
-    border-top: 1px solid var(--gray-l3);
+    border-top: 1px solid var(--gray-l3, #c8c8c8);
     margin-top: 0.5em;
     padding-top: 0.5em;
 }
@@ -151,7 +151,7 @@
     border: 1px solid #333;
     border-radius: 1em;
     background-color: rgba(0, 0, 0, 0.85);
-    color: var(--white);
+    color: var(--white, #fff);
     -webkit-font-smoothing: antialiased;
 }
 
@@ -176,7 +176,7 @@
 
 .xmodule_display.xmodule_AnnotatableBlock .ui-tooltip.qtip.ui-tooltip .ui-tooltip-titlebar .ui-state-hover {
     color: inherit;
-    border: 1px solid var(--gray-l3);
+    border: 1px solid var(--gray-l3, #c8c8c8);
 }
 
 .xmodule_display.xmodule_AnnotatableBlock .ui-tooltip.qtip.ui-tooltip .ui-tooltip-content {

--- a/xmodule/static/css-builtin-blocks/AnnotatableBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/AnnotatableBlockDisplay.css
@@ -159,12 +159,12 @@
     font-size: 1em;
     color: inherit;
     background-color: transparent;
-    padding: calc((var(--baseline) / 4)) calc((var(--baseline) / 2));
+    padding: calc((var(--baseline, 20px) / 4)) calc((var(--baseline, 20px) / 2));
     border: none;
 }
 
 .xmodule_display.xmodule_AnnotatableBlock .ui-tooltip.qtip.ui-tooltip .ui-tooltip-titlebar .ui-tooltip-title {
-    padding: calc((var(--baseline) / 4)) 0;
+    padding: calc((var(--baseline, 20px) / 4)) 0;
     border-bottom: 2px solid #333;
     font-weight: bold;
 }
@@ -184,7 +184,7 @@
     font-size: 0.875em;
     text-align: left;
     font-weight: 400;
-    padding: 0 calc((var(--baseline) / 2)) calc((var(--baseline) / 2)) calc((var(--baseline) / 2));
+    padding: 0 calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 2));
     background-color: transparent;
     border-color: transparent;
 }
@@ -199,12 +199,12 @@
 }
 
 .xmodule_display.xmodule_AnnotatableBlock .ui-tooltip.qtip.ui-tooltip-annotatable .ui-tooltip-content {
-    padding: 0 calc((var(--baseline) / 2));
+    padding: 0 calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_AnnotatableBlock .ui-tooltip.qtip.ui-tooltip-annotatable .ui-tooltip-content .annotatable-comment {
     display: block;
-    margin: 0 0 calc((var(--baseline) / 2)) 0;
+    margin: 0 0 calc((var(--baseline, 20px) / 2)) 0;
     max-height: 225px;
     overflow: auto;
     line-height: normal;
@@ -213,7 +213,7 @@
 .xmodule_display.xmodule_AnnotatableBlock .ui-tooltip.qtip.ui-tooltip-annotatable .ui-tooltip-content .annotatable-reply {
     display: block;
     border-top: 2px solid #333;
-    padding: calc((var(--baseline) / 4)) 0;
+    padding: calc((var(--baseline, 20px) / 4)) 0;
     margin: 0;
     text-align: center;
 }
@@ -226,7 +226,7 @@
     left: 50%;
     height: 0;
     width: 0;
-    margin-left: calc(-1 * (var(--baseline) / 4));
+    margin-left: calc(-1 * (var(--baseline, 20px) / 4));
     border: 10px solid transparent;
     border-top-color: rgba(0, 0, 0, 0.85);
 }

--- a/xmodule/static/css-builtin-blocks/HtmlBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/HtmlBlockDisplay.css
@@ -24,7 +24,7 @@
     color: #646464;
     font: normal 1.2em/1.2em var(--font-family-sans-serif);
     letter-spacing: 1px;
-    margin-bottom: calc((var(--baseline) * 0.75));
+    margin-bottom: calc((var(--baseline, 20px) * 0.75));
     -webkit-font-smoothing: antialiased;
 }
 
@@ -44,7 +44,7 @@
 .xmodule_display.xmodule_StaticTabBlock h4,
 .xmodule_display.xmodule_StaticTabBlock h5,
 .xmodule_display.xmodule_StaticTabBlock h6 {
-    margin: 0 0 calc((var(--baseline) / 2));
+    margin: 0 0 calc((var(--baseline, 20px) / 2));
     font-weight: 600;
 }
 
@@ -142,14 +142,14 @@
 .xmodule_display.xmodule_StaticTabBlock p+p,
 .xmodule_display.xmodule_StaticTabBlock ul+p,
 .xmodule_display.xmodule_StaticTabBlock ol+p {
-    margin-top: var(--baseline);
+    margin-top: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_AboutBlock blockquote,
 .xmodule_display.xmodule_CourseInfoBlock blockquote,
 .xmodule_display.xmodule_HtmlBlock blockquote,
 .xmodule_display.xmodule_StaticTabBlock blockquote {
-    margin: 1em calc((var(--baseline) * 2));
+    margin: 1em calc((var(--baseline, 20px) * 2));
 }
 
 .xmodule_display.xmodule_AboutBlock ol,
@@ -248,7 +248,7 @@
 .xmodule_display.xmodule_HtmlBlock table,
 .xmodule_display.xmodule_StaticTabBlock table {
     width: 100%;
-    margin: var(--baseline) 0;
+    margin: var(--baseline, 20px) 0;
     border-collapse: collapse;
     font-size: 16px;
 }
@@ -261,8 +261,8 @@
 .xmodule_display.xmodule_HtmlBlock table th,
 .xmodule_display.xmodule_StaticTabBlock table td,
 .xmodule_display.xmodule_StaticTabBlock table th {
-    margin: var(--baseline) 0;
-    padding: calc((var(--baseline) / 2));
+    margin: var(--baseline, 20px) 0;
+    padding: calc((var(--baseline, 20px) / 2));
     border: 1px solid var(--gray-l3);
     font-size: 14px;
 }
@@ -314,7 +314,7 @@
 .xmodule_display.xmodule_StaticTabBlock .wrapper-modal-image .modal-ui-icon {
     position: absolute;
     display: block;
-    padding: calc((var(--baseline) / 4)) 7px;
+    padding: calc((var(--baseline, 20px) / 4)) 7px;
     border-radius: 5px;
     opacity: 0.9;
     background: var(--white);
@@ -446,14 +446,14 @@
 .xmodule_display.xmodule_CourseInfoBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.action-zoom-in,
 .xmodule_display.xmodule_HtmlBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.action-zoom-in,
 .xmodule_display.xmodule_StaticTabBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.action-zoom-in {
-    margin-right: calc((var(--baseline) / 4));
+    margin-right: calc((var(--baseline, 20px) / 4));
 }
 
 .xmodule_display.xmodule_AboutBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.action-zoom-out,
 .xmodule_display.xmodule_CourseInfoBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.action-zoom-out,
 .xmodule_display.xmodule_HtmlBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.action-zoom-out,
 .xmodule_display.xmodule_StaticTabBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.action-zoom-out {
-    margin-left: calc((var(--baseline) / 4));
+    margin-left: calc((var(--baseline, 20px) / 4));
 }
 
 .xmodule_display.xmodule_AboutBlock .wrapper-modal-image .image-modal .image-content .image-controls .image-control .modal-ui-icon.is-disabled,

--- a/xmodule/static/css-builtin-blocks/HtmlBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/HtmlBlockDisplay.css
@@ -11,7 +11,7 @@
 .xmodule_display.xmodule_CourseInfoBlock h1,
 .xmodule_display.xmodule_HtmlBlock h1,
 .xmodule_display.xmodule_StaticTabBlock h1 {
-    color: var(--body-color);
+    color: var(--body-color, #313131);
     font: normal 2em/1.4em var(--font-family-sans-serif);
     letter-spacing: 1px;
     margin: 0 0 1.416em;
@@ -83,7 +83,7 @@
     margin-bottom: 1.416em;
     font-size: 1em;
     line-height: 1.6em !important;
-    color: var(--body-color);
+    color: var(--body-color, #313131);
 }
 
 .xmodule_display.xmodule_AboutBlock em,
@@ -162,7 +162,7 @@
 .xmodule_display.xmodule_StaticTabBlock ul {
     padding: 0 0 0 1em;
     margin: 1em 0;
-    color: var(--body-color);
+    color: var(--body-color, #313131);
 }
 
 .xmodule_display.xmodule_AboutBlock ol li,
@@ -210,7 +210,7 @@
 .xmodule_display.xmodule_StaticTabBlock a:hover,
 .xmodule_display.xmodule_StaticTabBlock a:active,
 .xmodule_display.xmodule_StaticTabBlock a:focus {
-    color: var(--blue);
+    color: var(--blue, #0075b4);
 }
 
 .xmodule_display.xmodule_AboutBlock img,
@@ -226,7 +226,7 @@
 .xmodule_display.xmodule_HtmlBlock pre,
 .xmodule_display.xmodule_StaticTabBlock pre {
     margin: 1em 0;
-    color: var(--body-color);
+    color: var(--body-color, #313131);
     font-family: monospace, serif;
     font-size: 1em;
     white-space: pre-wrap;
@@ -237,7 +237,7 @@
 .xmodule_display.xmodule_CourseInfoBlock code,
 .xmodule_display.xmodule_HtmlBlock code,
 .xmodule_display.xmodule_StaticTabBlock code {
-    color: var(--body-color);
+    color: var(--body-color, #313131);
     font-family: monospace, serif;
     background: none;
     padding: 0;
@@ -263,7 +263,7 @@
 .xmodule_display.xmodule_StaticTabBlock table th {
     margin: var(--baseline, 20px) 0;
     padding: calc((var(--baseline, 20px) / 2));
-    border: 1px solid var(--gray-l3);
+    border: 1px solid var(--gray-l3, #c8c8c8);
     font-size: 14px;
 }
 
@@ -317,9 +317,9 @@
     padding: calc((var(--baseline, 20px) / 4)) 7px;
     border-radius: 5px;
     opacity: 0.9;
-    background: var(--white);
-    color: var(--black);
-    border: 2px solid var(--black);
+    background: var(--white, #fff);
+    color: var(--black, #000);
+    border: 2px solid var(--black, #000);
 }
 
 .xmodule_display.xmodule_AboutBlock .wrapper-modal-image .modal-ui-icon .label,

--- a/xmodule/static/css-builtin-blocks/HtmlBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/HtmlBlockEditor.css
@@ -172,8 +172,8 @@
 .xmodule_edit.xmodule_CourseInfoBlock .editor .editor-tabs .tab.current,
 .xmodule_edit.xmodule_HtmlBlock .editor .editor-tabs .tab.current,
 .xmodule_edit.xmodule_StaticTabBlock .editor .editor-tabs .tab.current {
-    background: var(--white);
-    border-bottom-color: var(--white);
+    background: var(--white, #fff);
+    border-bottom-color: var(--white, #fff);
 }
 
 .xmodule_edit.xmodule_AboutBlock .html-editor:after,

--- a/xmodule/static/css-builtin-blocks/HtmlBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/HtmlBlockEditor.css
@@ -159,9 +159,9 @@
     padding: 7px 20px 3px;
     border: 1px solid #a5aaaf;
     border-radius: 3px 3px 0 0;
-    background-color: var(--transparent);
-    background-image: -webkit-linear-gradient(top, var(--transparent) 87%, rgba(0, 0, 0, 0.06));
-    background-image: linear-gradient(to bottom, var(--transparent) 87%, rgba(0, 0, 0, 0.06));
+    background-color: var(--transparent, transparent);
+    background-image: -webkit-linear-gradient(top, var(--transparent, transparent) 87%, rgba(0, 0, 0, 0.06));
+    background-image: linear-gradient(to bottom, var(--transparent, transparent) 87%, rgba(0, 0, 0, 0.06));
     background-color: #e5ecf3;
     font-size: 13px;
     color: #3c3c3c;

--- a/xmodule/static/css-builtin-blocks/HtmlBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/HtmlBlockEditor.css
@@ -80,7 +80,7 @@
     background-image: -webkit-linear-gradient(top, #d4dee8, #c9d5e2);
     background-image: linear-gradient(to bottom, #d4dee8, #c9d5e2);
     position: relative;
-    padding: calc(var(--baseline) / 4);
+    padding: calc(var(--baseline, 20px) / 4);
     border-bottom-color: #a5aaaf;
 }
 
@@ -99,7 +99,7 @@
 .xmodule_edit.xmodule_StaticTabBlock .editor .editor-bar button {
     display: inline-block;
     float: left;
-    padding: 3px calc(var(--baseline) / 2) 5px;
+    padding: 3px calc(var(--baseline, 20px) / 2) 5px;
     margin-left: 7px;
     border: 0;
     border-radius: 2px;
@@ -140,7 +140,7 @@
 .xmodule_edit.xmodule_HtmlBlock .editor .editor-tabs li,
 .xmodule_edit.xmodule_StaticTabBlock .editor .editor-tabs li {
     float: left;
-    margin-right: calc(var(--baseline) / 4);
+    margin-right: calc(var(--baseline, 20px) / 4);
 }
 
 .xmodule_edit.xmodule_AboutBlock .editor .editor-tabs li:last-child,

--- a/xmodule/static/css-builtin-blocks/LTIBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/LTIBlockDisplay.css
@@ -7,7 +7,7 @@
 
 .xmodule_display.xmodule_LTIBlock div.problem-progress {
     display: inline-block;
-    padding-left: calc((var(--baseline) / 4));
+    padding-left: calc((var(--baseline, 20px) / 4));
     color: #666;
     font-weight: 100;
     font-size: 1em;
@@ -20,7 +20,7 @@
 .xmodule_display.xmodule_LTIBlock div.lti .wrapper-lti-link {
     font-size: 14px;
     background-color: var(--sidebar-color);
-    padding: var(--baseline);
+    padding: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_LTIBlock div.lti .wrapper-lti-link .lti-link {
@@ -51,6 +51,6 @@
 }
 
 .xmodule_display.xmodule_LTIBlock div.lti div.problem-feedback {
-    margin-top: calc((var(--baseline) / 4));
-    margin-bottom: calc((var(--baseline) / 4));
+    margin-top: calc((var(--baseline, 20px) / 4));
+    margin-bottom: calc((var(--baseline, 20px) / 4));
 }

--- a/xmodule/static/css-builtin-blocks/LTIBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/LTIBlockDisplay.css
@@ -19,7 +19,7 @@
 
 .xmodule_display.xmodule_LTIBlock div.lti .wrapper-lti-link {
     font-size: 14px;
-    background-color: var(--sidebar-color);
+    background-color: var(--sidebar-color, #f6f6f6);
     padding: var(--baseline, 20px);
 }
 

--- a/xmodule/static/css-builtin-blocks/PollBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/PollBlockDisplay.css
@@ -19,13 +19,13 @@
 
 .xmodule_display.xmodule_PollBlock div.poll_question h3 {
     margin-top: 0;
-    margin-bottom: calc((var(--baseline) * 0.75));
+    margin-bottom: calc((var(--baseline, 20px) * 0.75));
     color: #fe57a1;
     font-size: 1.9em;
 }
 
 .xmodule_display.xmodule_PollBlock div.poll_question h3.problem-header div.staff {
-    margin-top: calc((var(--baseline) * 1.5));
+    margin-top: calc((var(--baseline, 20px) * 1.5));
     font-size: 80%;
 }
 
@@ -43,7 +43,7 @@
 }
 
 .xmodule_display.xmodule_PollBlock div.poll_question .poll_answer {
-    margin-bottom: var(--baseline);
+    margin-bottom: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_PollBlock div.poll_question .poll_answer.short {
@@ -105,7 +105,7 @@
     font-weight: bold;
     letter-spacing: normal;
     line-height: 25.59375px;
-    margin-bottom: calc((var(--baseline) * 0.75));
+    margin-bottom: calc((var(--baseline, 20px) * 0.75));
     margin: 0;
     padding: 0px;
     text-align: center;
@@ -141,9 +141,9 @@
     width: 80%;
     text-align: left;
     min-height: 30px;
-    margin-left: var(--baseline);
+    margin-left: var(--baseline, 20px);
     height: auto;
-    margin-bottom: var(--baseline);
+    margin-bottom: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_PollBlock div.poll_question .poll_answer .question .text.short {
@@ -152,7 +152,7 @@
 
 .xmodule_display.xmodule_PollBlock div.poll_question .poll_answer .stats {
     min-height: 40px;
-    margin-top: var(--baseline);
+    margin-top: var(--baseline, 20px);
     clear: both;
 }
 
@@ -170,7 +170,7 @@
     border: 1px solid black;
     display: inline;
     float: left;
-    margin-right: calc((var(--baseline) / 2));
+    margin-right: calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_PollBlock div.poll_question .poll_answer .stats .bar.short {

--- a/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
@@ -78,12 +78,12 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-incorrect .icon {
-    color: var(--incorrect);
+    color: var(--incorrect, #b20610);
 }
 
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-partially-correct .icon,
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-correct .icon {
-    color: var(--correct);
+    color: var(--correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-text {
@@ -116,12 +116,12 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock .inline-error {
-    color: var(--error-color-dark);
+    color: var(--error-color-dark, #95050d);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem-progress {
     display: inline-block;
-    color: var(--gray-d1);
+    color: var(--gray-d1, #5e5e5e);
     font-size: 0.875em;
 }
 
@@ -155,7 +155,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .question-description {
-    color: var(--gray-d1);
+    color: var(--gray-d1, #5e5e5e);
     font-size: var(--small-font-size);
 }
 
@@ -197,7 +197,7 @@
     display: inline-block;
     clear: both;
     margin-bottom: calc((var(--baseline, 20px) / 2));
-    border: 2px solid var(--gray-l4);
+    border: 2px solid var(--gray-l4, #e4e4e4);
     border-radius: 3px;
     padding: calc((var(--baseline, 20px) / 2));
     width: 100%;
@@ -232,7 +232,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:focus+label,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input:hover+label,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label {
-    border: 2px solid var(--blue);
+    border: 2px solid var(--blue, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input+label.choicegroup_correct,
@@ -253,7 +253,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label.choicetextgroup_correct,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup .choicegroup input:hover+section.choicetextgroup_correct,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+section.choicetextgroup_correct {
-    border: 2px solid var(--correct);
+    border: 2px solid var(--correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input+label.choicegroup_correct .status-icon::after,
@@ -274,7 +274,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label.choicetextgroup_correct .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup .choicegroup input:hover+section.choicetextgroup_correct .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+section.choicetextgroup_correct .status-icon::after {
-    color: var(--correct);
+    color: var(--correct, #008100);
     font-size: 1.2em;
     content: "";
 }
@@ -297,7 +297,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label.choicetextgroup_partially-correct,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup .choicegroup input:hover+section.choicetextgroup_partially-correct,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+section.choicetextgroup_partially-correct {
-    border: 2px solid var(--partially-correct);
+    border: 2px solid var(--partially-correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input+label.choicegroup_partially-correct .status-icon::after,
@@ -318,7 +318,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label.choicetextgroup_partially-correct .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup .choicegroup input:hover+section.choicetextgroup_partially-correct .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+section.choicetextgroup_partially-correct .status-icon::after {
-    color: var(--partially-correct);
+    color: var(--partially-correct, #008100);
     font-size: 1.2em;
     content: "";
 }
@@ -341,7 +341,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label.choicetextgroup_incorrect,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup .choicegroup input:hover+section.choicetextgroup_incorrect,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+section.choicetextgroup_incorrect {
-    border: 2px solid var(--incorrect);
+    border: 2px solid var(--incorrect, #b20610);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input+label.choicegroup_incorrect .status-icon::after,
@@ -362,7 +362,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label.choicetextgroup_incorrect .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup .choicegroup input:hover+section.choicetextgroup_incorrect .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+section.choicetextgroup_incorrect .status-icon::after {
-    color: var(--incorrect);
+    color: var(--incorrect, #b20610);
     font-size: 1.2em;
     content: "";
 }
@@ -385,7 +385,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+label.choicetextgroup_submitted,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup .choicegroup input:hover+section.choicetextgroup_submitted,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input:hover+section.choicetextgroup_submitted {
-    border: 2px solid var(--submitted);
+    border: 2px solid var(--submitted, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup .field {
@@ -432,19 +432,19 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .indicator-container .status.correct .status-icon::after {
-    color: var(--correct);
+    color: var(--correct, #008100);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .indicator-container .status.partially-correct .status-icon::after {
-    color: var(--partially-correct);
+    color: var(--partially-correct, #008100);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .indicator-container .status.incorrect .status-icon::after {
-    color: var(--incorrect);
+    color: var(--incorrect, #b20610);
     font-size: 1.2em;
     content: "";
 }
@@ -490,17 +490,17 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div p span.clarification i:hover {
-    color: var(--blue);
+    color: var(--blue, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.correct input,
 .xmodule_display.xmodule_ProblemBlock div.problem div.ui-icon-check input {
-    border-color: var(--correct);
+    border-color: var(--correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.partially-correct input,
 .xmodule_display.xmodule_ProblemBlock div.problem div.ui-icon-check input {
-    border-color: var(--partially-correct);
+    border-color: var(--partially-correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.processing input {
@@ -508,17 +508,17 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.ui-icon-close input {
-    border-color: var(--incorrect);
+    border-color: var(--incorrect, #b20610);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.incorrect input,
 .xmodule_display.xmodule_ProblemBlock div.problem div.incomplete input {
-    border-color: var(--incorrect);
+    border-color: var(--incorrect, #b20610);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.submitted input,
 .xmodule_display.xmodule_ProblemBlock div.problem div.ui-icon-check input {
-    border-color: var(--submitted);
+    border-color: var(--submitted, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div p.answer {
@@ -618,7 +618,7 @@
     margin: calc(var(--baseline, 20px) / 2) 0;
     padding: calc(var(--baseline, 20px) / 2);
     border-radius: 5px;
-    background: var(--gray-l6);
+    background: var(--gray-l6, #f8f8f8);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .grader-status:after {
@@ -654,7 +654,7 @@
     padding: var(--baseline, 20px) 0 0 0;
     border: 0;
     border-top: 1px solid #eee;
-    background: var(--white);
+    background: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .grader-status.file p.debug {
@@ -803,7 +803,7 @@
     padding: 0px 5px;
     border: 1px solid #eaeaea;
     border-radius: 3px;
-    background-color: var(--gray-l6);
+    background-color: var(--gray-l6, #f8f8f8);
     white-space: nowrap;
     font-size: .9em;
 }
@@ -811,9 +811,9 @@
 .xmodule_display.xmodule_ProblemBlock div.problem pre {
     overflow: auto;
     padding: 6px calc(var(--baseline, 20px) / 2);
-    border: 1px solid var(--gray-l3);
+    border: 1px solid var(--gray-l3, #c8c8c8);
     border-radius: 3px;
-    background-color: var(--gray-l6);
+    background-color: var(--gray-l6, #f8f8f8);
     font-size: .9em;
     line-height: 1.4;
 }
@@ -829,7 +829,7 @@
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput input {
     box-sizing: border-box;
-    border: 2px solid var(--gray-l4);
+    border: 2px solid var(--gray-l4, #e4e4e4);
     border-radius: 3px;
     min-width: 160px;
     height: 46px;
@@ -844,43 +844,43 @@
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.incorrect input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.incorrect input {
-    border: 2px solid var(--incorrect);
+    border: 2px solid var(--incorrect, #b20610);
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.incorrect .status .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.incorrect .status .status-icon::after {
-    color: var(--incorrect);
+    color: var(--incorrect, #b20610);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.partially-correct input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.partially-correct input {
-    border: 2px solid var(--partially-correct);
+    border: 2px solid var(--partially-correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.partially-correct .status .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.partially-correct .status .status-icon::after {
-    color: var(--partially-correct);
+    color: var(--partially-correct, #008100);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.correct input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.correct input {
-    border: 2px solid var(--correct);
+    border: 2px solid var(--correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.correct .status .status-icon::after,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.correct .status .status-icon::after {
-    color: var(--correct);
+    color: var(--correct, #008100);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.submitted input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.submitted input {
-    border: 2px solid var(--submitted);
+    border: 2px solid var(--submitted, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.submitted .status,
@@ -892,7 +892,7 @@
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.unsubmitted input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.unanswered input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.unsubmitted input {
-    border: 2px solid var(--gray-l4);
+    border: 2px solid var(--gray-l4, #e4e4e4);
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.unanswered .status .status-icon::after,
@@ -961,7 +961,7 @@
     visibility: hidden;
     width: 0;
     border-right: none;
-    border-left: 1px solid var(--black);
+    border-left: 1px solid var(--black, #000);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .CodeMirror-focused pre.CodeMirror-cursor {
@@ -980,7 +980,7 @@
 
 .xmodule_display.xmodule_ProblemBlock .capa-message {
     display: inline-block;
-    color: var(--gray-d1);
+    color: var(--gray-d1, #5e5e5e);
     -webkit-font-smoothing: antialiased;
 }
 
@@ -1003,7 +1003,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .problem-action-button-wrapper {
-    border-right: 1px solid var(--gray-300);
+    border-right: 1px solid var(--gray-300, #d9d9d9);
     padding: 0 13px;
     display: inline-block;
 }
@@ -1021,7 +1021,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .action .problem-action-btn:hover,
 .xmodule_display.xmodule_ProblemBlock div.problem .action .problem-action-btn:focus,
 .xmodule_display.xmodule_ProblemBlock div.problem .action .problem-action-btn:active {
-    color: var(--primary) !important;
+    color: var(--primary, #0075b4) !important;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .problem-action-btn .icon {
@@ -1056,13 +1056,13 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container .submit-cta-description {
-    color: var(--primary);
+    color: var(--primary, #0075b4);
     font-size: small;
     padding-right: calc(var(--baseline, 20px) / 2);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container .submit-cta-link-button {
-    color: var(--primary);
+    color: var(--primary, #0075b4);
     padding-right: calc(var(--baseline, 20px) / 4);
 }
 
@@ -1070,7 +1070,7 @@
     margin-right: calc((var(--baseline, 20px) / 2));
     margin-top: calc(var(--baseline, 20px) / 2);
     display: inline-block;
-    color: var(--gray-d1);
+    color: var(--gray-d1, #5e5e5e);
     font-size: var(--medium-font-size);
     -webkit-font-smoothing: antialiased;
     vertical-align: middle;
@@ -1105,7 +1105,7 @@
     display: block;
     margin: lh() 0;
     padding: lh();
-    border: 1px solid var(--gray-l3);
+    border: 1px solid var(--gray-l3, #c8c8c8);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .message {
@@ -1130,9 +1130,9 @@
 .xmodule_display.xmodule_ProblemBlock div.problem div.capa_alert {
     margin-top: var(--baseline, 20px);
     padding: 8px 12px;
-    border: 1px solid var(--warning-color);
+    border: 1px solid var(--warning-color, #ffc01f);
     border-radius: 3px;
-    background: var(--warning-color-accent);
+    background: var(--warning-color-accent, #fffcdd);
     font-size: 0.9em;
 }
 
@@ -1144,57 +1144,57 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.success {
-    border-top: 3px solid var(--success);
+    border-top: 3px solid var(--success, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.success .icon {
     margin-right: 15px;
-    color: var(--success);
+    color: var(--success, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.error {
-    border-top: 3px solid var(--danger);
+    border-top: 3px solid var(--danger, #b20610);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.error .icon {
     margin-right: 15px;
-    color: var(--danger);
+    color: var(--danger, #b20610);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.warning {
-    border-top: 3px solid var(--warning);
+    border-top: 3px solid var(--warning, #e2c01f);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.warning .icon {
     margin-right: 15px;
-    color: var(--warning);
+    color: var(--warning, #e2c01f);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.general {
-    border-top: 3px solid var(--general-color-accent);
+    border-top: 3px solid var(--general-color-accent, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.general .icon {
     margin-right: 15px;
-    color: var(--general-color-accent);
+    color: var(--general-color-accent, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.problem-hint {
-    border: 1px solid var(--uxpl-gray-background);
+    border: 1px solid var(--uxpl-gray-background, #d9d9d9);
     border-radius: 6px;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.problem-hint .icon {
     margin-right: calc(3 * var(--baseline, 20px) / 4);
-    color: var(--uxpl-gray-dark);
+    color: var(--uxpl-gray-dark, #111111);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.problem-hint li {
-    color: var(--uxpl-gray-base);
+    color: var(--uxpl-gray-base, #414141);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.problem-hint li strong {
-    color: var(--uxpl-gray-dark);
+    color: var(--uxpl-gray-dark, #111111);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification .icon {
@@ -1249,21 +1249,21 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem button.btn-brand:hover {
-    background-color: var(--btn-brand-focus-background);
+    background-color: var(--btn-brand-focus-background, #065683);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .review-btn {
-    color: var(--blue);
+    color: var(--blue, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .review-btn.sr {
-    color: var(--blue);
+    color: var(--blue, #0075b4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.capa_reset {
     padding: 25px;
-    background-color: var(--error-color-light);
-    border: 1px solid var(--error-color);
+    background-color: var(--error-color-light, #f95861);
+    border: 1px solid var(--error-color, #cb0712);
     border-radius: 3px;
     font-size: 1em;
     margin-top: calc(var(--baseline, 20px) / 2);
@@ -1279,14 +1279,14 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .hints {
-    border: 1px solid var(--gray-l3);
+    border: 1px solid var(--gray-l3, #c8c8c8);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .hints h3 {
     padding: 9px;
     border-bottom: 1px solid #e3e3e3;
     background: #eee;
-    text-shadow: 0 1px 0 var(--white);
+    text-shadow: 0 1px 0 var(--white, #fff);
     font-size: 1em;
 }
 
@@ -1305,8 +1305,8 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .hints div header a {
     display: block;
     padding: 9px;
-    background: var(--gray-l6);
-    box-shadow: inset 0 0 0 1px var(--white);
+    background: var(--gray-l6, #f8f8f8);
+    box-shadow: inset 0 0 0 1px var(--white, #fff);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .hints div>section {
@@ -1333,7 +1333,7 @@
     padding: 9px 9px var(--baseline, 20px);
     border: 1px solid #ddd;
     border-radius: 3px;
-    background: var(--white);
+    background: var(--white, #fff);
     box-shadow: inset 0 0 0 1px #eee;
 }
 
@@ -1354,7 +1354,7 @@
     box-sizing: border-box;
     display: block;
     padding: calc((var(--baseline, 20px) / 5));
-    background: var(--gray-l4);
+    background: var(--gray-l4, #e4e4e4);
     text-align: right;
     font-size: 1em;
 }
@@ -1492,7 +1492,7 @@
     min-height: 50px;
     width: 150px;
     height: 100%;
-    background-color: var(--gray-l3);
+    background-color: var(--gray-l3, #c8c8c8);
     font-size: .9em;
 }
 
@@ -1519,14 +1519,14 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input {
     margin: 0 0 1em 0;
-    border: 1px solid var(--gray-l3);
+    border: 1px solid var(--gray-l3, #c8c8c8);
     border-radius: 1em;
     /* for debugging the input value field. enable the debug flag on the inputtype */
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .annotation-header {
     padding: .5em 1em;
-    border-bottom: 1px solid var(--gray-l3);
+    border-bottom: 1px solid var(--gray-l3, #c8c8c8);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .annotation-body {
@@ -1608,9 +1608,9 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .debug-value {
     margin: 1em 0;
     padding: 1em;
-    border: 1px solid var(--black);
+    border: 1px solid var(--black, #000);
     background-color: #999;
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .debug-value input[type="text"] {
@@ -1618,8 +1618,8 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .debug-value pre {
-    background-color: var(--gray-l3);
-    color: var(--black);
+    background-color: var(--gray-l3, #c8c8c8);
+    color: var(--black, #000);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .debug-value::before {
@@ -1634,12 +1634,12 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup label.choicetextgroup_correct input[type="text"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup section.choicetextgroup_correct input[type="text"] {
-    border-color: var(--correct);
+    border-color: var(--correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup label.choicetextgroup_partially-correct input[type="text"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup section.choicetextgroup_partially-correct input[type="text"] {
-    border-color: var(--partially-correct);
+    border-color: var(--partially-correct, #008100);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup label.choicetextgroup_show_correct::after,
@@ -1671,19 +1671,19 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .imageinput.capa_inputtype .correct .status-icon::after {
-    color: var(--correct);
+    color: var(--correct, #008100);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .imageinput.capa_inputtype .incorrect .status-icon::after {
-    color: var(--incorrect);
+    color: var(--incorrect, #b20610);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .imageinput.capa_inputtype .partially-correct .status-icon::after {
-    color: var(--partially-correct);
+    color: var(--partially-correct, #008100);
     font-size: 1.2em;
     content: "";
 }
@@ -1711,19 +1711,19 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .correct .status-icon::after {
-    color: var(--correct);
+    color: var(--correct, #008100);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .incorrect .status-icon::after {
-    color: var(--incorrect);
+    color: var(--incorrect, #b20610);
     font-size: 1.2em;
     content: "";
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input .partially-correct .status-icon::after {
-    color: var(--partially-correct);
+    color: var(--partially-correct, #008100);
     font-size: 1.2em;
     content: "";
 }
@@ -1734,5 +1734,5 @@
 
 .xmodule_display.xmodule_ProblemBlock .problems-wrapper .loading-spinner {
     text-align: center;
-    color: var(--gray-d1);
+    color: var(--gray-d1, #5e5e5e);
 }

--- a/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
@@ -156,7 +156,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .question-description {
     color: var(--gray-d1, #5e5e5e);
-    font-size: var(--small-font-size);
+    font-size: var(--small-font-size, 80%);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem form>label,
@@ -396,7 +396,7 @@
     padding: calc((var(--baseline, 20px) / 2));
     padding-left: calc((var(--baseline, 20px) * 2.3));
     position: relative;
-    font-size: var(--base-font-size);
+    font-size: var(--base-font-size, 18px);
     line-height: normal;
     cursor: pointer;
 }
@@ -1042,7 +1042,7 @@
     align-items: center;
 }
 
-@media (max-width: var(--bp-screen-lg)) {
+@media (max-width: var(--bp-screen-lg, 1024px)) {
     .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container {
         max-width: 100%;
         padding-bottom: var(--baseline, 20px);
@@ -1071,7 +1071,7 @@
     margin-top: calc(var(--baseline, 20px) / 2);
     display: inline-block;
     color: var(--gray-d1, #5e5e5e);
-    font-size: var(--medium-font-size);
+    font-size: var(--medium-font-size, 0.9em);
     -webkit-font-smoothing: antialiased;
     vertical-align: middle;
 }
@@ -1140,7 +1140,7 @@
     float: left;
     margin-top: calc(var(--baseline, 20px) / 2);
     padding: calc((var(--baseline, 20px) / 2.5)) calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 5)) calc((var(--baseline, 20px) / 2));
-    line-height: var(--base-line-height);
+    line-height: var(--base-line-height, 1.5em);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.success {

--- a/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
@@ -41,7 +41,7 @@
 
 .xmodule_display.xmodule_ProblemBlock h2 {
     margin-top: 0;
-    margin-bottom: calc((var(--baseline) * 0.75));
+    margin-bottom: calc((var(--baseline, 20px) * 0.75));
 }
 
 .xmodule_display.xmodule_ProblemBlock h2.problem-header {
@@ -49,7 +49,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock h2.problem-header section.staff {
-    margin-top: calc((var(--baseline) * 1.5));
+    margin-top: calc((var(--baseline, 20px) * 1.5));
     font-size: 80%;
 }
 
@@ -68,13 +68,13 @@
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-incorrect,
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-partially-correct,
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-correct {
-    margin-top: calc((var(--baseline) / 4));
+    margin-top: calc((var(--baseline, 20px) / 4));
 }
 
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-incorrect .icon,
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-partially-correct .icon,
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-correct .icon {
-    margin-right: calc((var(--baseline) / 4));
+    margin-right: calc((var(--baseline, 20px) / 4));
 }
 
 .xmodule_display.xmodule_ProblemBlock .feedback-hint-incorrect .icon {
@@ -126,7 +126,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem {
-    padding-top: var(--baseline);
+    padding-top: var(--baseline, 20px);
 }
 
 @media print {
@@ -151,7 +151,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .inline+p {
-    margin-top: var(--baseline);
+    margin-top: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .question-description {
@@ -162,19 +162,19 @@
 .xmodule_display.xmodule_ProblemBlock div.problem form>label,
 .xmodule_display.xmodule_ProblemBlock div.problem .problem-group-label {
     display: block;
-    margin-bottom: var(--baseline);
+    margin-bottom: var(--baseline, 20px);
     font: inherit;
     color: inherit;
     -webkit-font-smoothing: initial;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .problem-group-label+.question-description {
-    margin-top: calc(-1 * var(--baseline));
+    margin-top: calc(-1 * var(--baseline, 20px));
 }
 
 .xmodule_display.xmodule_ProblemBlock .wrapper-problem-response+.wrapper-problem-response,
 .xmodule_display.xmodule_ProblemBlock .wrapper-problem-response+p {
-    margin-top: calc((var(--baseline) * 1.5));
+    margin-top: calc((var(--baseline, 20px) * 1.5));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup,
@@ -196,16 +196,16 @@
     box-sizing: border-box;
     display: inline-block;
     clear: both;
-    margin-bottom: calc((var(--baseline) / 2));
+    margin-bottom: calc((var(--baseline, 20px) / 2));
     border: 2px solid var(--gray-l4);
     border-radius: 3px;
-    padding: calc((var(--baseline) / 2));
+    padding: calc((var(--baseline, 20px) / 2));
     width: 100%;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup label::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup label::after {
-    margin-left: calc((var(--baseline) * 0.75));
+    margin-left: calc((var(--baseline, 20px) * 0.75));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup .indicator-container,
@@ -224,8 +224,8 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input[type="radio"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input[type="checkbox"] {
-    margin: calc((var(--baseline) / 4));
-    margin-right: calc((var(--baseline) / 2));
+    margin: calc((var(--baseline, 20px) / 4));
+    margin-right: calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input:focus+label,
@@ -393,8 +393,8 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup label {
-    padding: calc((var(--baseline) / 2));
-    padding-left: calc((var(--baseline) * 2.3));
+    padding: calc((var(--baseline, 20px) / 2));
+    padding-left: calc((var(--baseline, 20px) * 2.3));
     position: relative;
     font-size: var(--base-font-size);
     line-height: normal;
@@ -406,29 +406,29 @@
     left: 0.5625em;
     position: absolute;
     top: 0.35em;
-    width: calc(var(--baseline) * 1.1);
-    height: calc(var(--baseline) * 1.1);
+    width: calc(var(--baseline, 20px) * 1.1);
+    height: calc(var(--baseline, 20px) * 1.1);
     z-index: 1;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup legend {
-    margin-bottom: var(--baseline);
+    margin-bottom: var(--baseline, 20px);
     max-width: 100%;
     white-space: normal;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup legend+.question-description {
-    margin-top: calc(-1 * var(--baseline));
+    margin-top: calc(-1 * var(--baseline, 20px));
     max-width: 100%;
     white-space: normal;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .indicator-container {
-    margin-left: calc((var(--baseline) * 0.75));
+    margin-left: calc((var(--baseline, 20px) * 0.75));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .indicator-container .status {
-    width: var(--baseline);
+    width: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .indicator-container .status.correct .status-icon::after {
@@ -463,7 +463,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .solution-span>span {
-    margin: var(--baseline) 0;
+    margin: var(--baseline, 20px) 0;
     display: block;
     position: relative;
 }
@@ -523,7 +523,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem div p.answer {
     display: inline-block;
-    margin-top: calc((var(--baseline) / 2));
+    margin-top: calc((var(--baseline, 20px) / 2));
     margin-bottom: 0;
 }
 
@@ -546,7 +546,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div div.equation img.loading {
-    padding-left: calc((var(--baseline) / 2));
+    padding-left: calc((var(--baseline, 20px) / 2));
     display: inline-block;
 }
 
@@ -611,12 +611,12 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .reload {
     float: right;
-    margin: calc((var(--baseline) / 2));
+    margin: calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .grader-status {
-    margin: calc(var(--baseline) / 2) 0;
-    padding: calc(var(--baseline) / 2);
+    margin: calc(var(--baseline, 20px) / 2) 0;
+    padding: calc(var(--baseline, 20px) / 2);
     border-radius: 5px;
     background: var(--gray-l6);
 }
@@ -650,8 +650,8 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .grader-status.file {
-    margin-top: var(--baseline);
-    padding: var(--baseline) 0 0 0;
+    margin-top: var(--baseline, 20px);
+    padding: var(--baseline, 20px) 0 0 0;
     border: 0;
     border-top: 1px solid #eee;
     background: var(--white);
@@ -666,11 +666,11 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .evaluation p {
-    margin-bottom: calc((var(--baseline) / 5));
+    margin-bottom: calc((var(--baseline, 20px) / 5));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .feedback-on-feedback {
-    margin-right: var(--baseline);
+    margin-right: var(--baseline, 20px);
     height: 100px;
 }
 
@@ -701,7 +701,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .submit-message-container {
-    margin: var(--baseline) 0px;
+    margin: var(--baseline, 20px) 0px;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.inline>span {
@@ -810,7 +810,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem pre {
     overflow: auto;
-    padding: 6px calc(var(--baseline) / 2);
+    padding: 6px calc(var(--baseline, 20px) / 2);
     border: 1px solid var(--gray-l3);
     border-radius: 3px;
     background-color: var(--gray-l6);
@@ -838,7 +838,7 @@
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline .status,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput .status {
     display: inline-block;
-    margin-top: calc((var(--baseline) / 2));
+    margin-top: calc((var(--baseline, 20px) / 2));
     background: none;
 }
 
@@ -909,7 +909,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .trailing_text {
-    margin-right: calc((var(--baseline) / 2));
+    margin-right: calc((var(--baseline, 20px) / 2));
     display: inline-block;
 }
 
@@ -985,7 +985,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action {
-    min-height: var(--baseline);
+    min-height: var(--baseline, 20px);
     width: 100%;
     display: flex;
     display: -ms-flexbox;
@@ -999,7 +999,7 @@
     display: inline-flex;
     justify-content: flex-end;
     width: 100%;
-    padding-bottom: var(--baseline);
+    padding-bottom: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .problem-action-button-wrapper {
@@ -1025,7 +1025,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .problem-action-btn .icon {
-    margin-bottom: calc(var(--baseline) / 10);
+    margin-bottom: calc(var(--baseline, 20px) / 10);
     display: block;
 }
 
@@ -1036,7 +1036,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container {
-    padding-bottom: var(--baseline);
+    padding-bottom: var(--baseline, 20px);
     flex-grow: 1;
     display: flex;
     align-items: center;
@@ -1045,12 +1045,12 @@
 @media (max-width: var(--bp-screen-lg)) {
     .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container {
         max-width: 100%;
-        padding-bottom: var(--baseline);
+        padding-bottom: var(--baseline, 20px);
     }
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container .submit {
-    margin-right: calc((var(--baseline) / 2));
+    margin-right: calc((var(--baseline, 20px) / 2));
     float: left;
     white-space: nowrap;
 }
@@ -1058,17 +1058,17 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container .submit-cta-description {
     color: var(--primary);
     font-size: small;
-    padding-right: calc(var(--baseline) / 2);
+    padding-right: calc(var(--baseline, 20px) / 2);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .submit-attempt-container .submit-cta-link-button {
     color: var(--primary);
-    padding-right: calc(var(--baseline) / 4);
+    padding-right: calc(var(--baseline, 20px) / 4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .action .submission-feedback {
-    margin-right: calc((var(--baseline) / 2));
-    margin-top: calc(var(--baseline) / 2);
+    margin-right: calc((var(--baseline, 20px) / 2));
+    margin-top: calc(var(--baseline, 20px) / 2);
     display: inline-block;
     color: var(--gray-d1);
     font-size: var(--medium-font-size);
@@ -1128,7 +1128,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.capa_alert {
-    margin-top: var(--baseline);
+    margin-top: var(--baseline, 20px);
     padding: 8px 12px;
     border: 1px solid var(--warning-color);
     border-radius: 3px;
@@ -1138,8 +1138,8 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification {
     float: left;
-    margin-top: calc(var(--baseline) / 2);
-    padding: calc((var(--baseline) / 2.5)) calc((var(--baseline) / 2)) calc((var(--baseline) / 5)) calc((var(--baseline) / 2));
+    margin-top: calc(var(--baseline, 20px) / 2);
+    padding: calc((var(--baseline, 20px) / 2.5)) calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 5)) calc((var(--baseline, 20px) / 2));
     line-height: var(--base-line-height);
 }
 
@@ -1185,7 +1185,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification.problem-hint .icon {
-    margin-right: calc(3 * var(--baseline) / 4);
+    margin-right: calc(3 * var(--baseline, 20px) / 4);
     color: var(--uxpl-gray-dark);
 }
 
@@ -1200,7 +1200,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .notification .icon {
     float: left;
     position: relative;
-    top: calc(var(--baseline) / 5);
+    top: calc(var(--baseline, 20px) / 5);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification .notification-message {
@@ -1216,7 +1216,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification .notification-message ol li:not(:last-child) {
-    margin-bottom: calc(var(--baseline) / 4);
+    margin-bottom: calc(var(--baseline, 20px) / 4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification .notification-btn-wrapper {
@@ -1225,14 +1225,14 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification-btn {
     float: right;
-    padding: calc((var(--baseline) / 10)) calc((var(--baseline) / 4));
-    min-width: calc((var(--baseline) * 3));
+    padding: calc((var(--baseline, 20px) / 10)) calc((var(--baseline, 20px) / 4));
+    min-width: calc((var(--baseline, 20px) * 3));
     display: block;
     clear: both;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .notification-btn:first-child {
-    margin-bottom: calc(var(--baseline) / 4);
+    margin-bottom: calc(var(--baseline, 20px) / 4);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem button:hover {
@@ -1266,8 +1266,8 @@
     border: 1px solid var(--error-color);
     border-radius: 3px;
     font-size: 1em;
-    margin-top: calc(var(--baseline) / 2);
-    margin-bottom: calc(var(--baseline) / 2);
+    margin-top: calc(var(--baseline, 20px) / 2);
+    margin-bottom: calc(var(--baseline, 20px) / 2);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .capa_reset>h2 {
@@ -1329,8 +1329,8 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .test>section {
     position: relative;
-    margin-bottom: calc((var(--baseline) / 2));
-    padding: 9px 9px var(--baseline);
+    margin-bottom: calc((var(--baseline, 20px) / 2));
+    padding: 9px 9px var(--baseline, 20px);
     border: 1px solid #ddd;
     border-radius: 3px;
     background: var(--white);
@@ -1353,7 +1353,7 @@
     left: 0;
     box-sizing: border-box;
     display: block;
-    padding: calc((var(--baseline) / 5));
+    padding: calc((var(--baseline, 20px) / 5));
     background: var(--gray-l4);
     text-align: right;
     font-size: 1em;
@@ -1376,8 +1376,8 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section {
-    padding-top: calc((var(--baseline) * 1.5));
-    padding-left: var(--baseline);
+    padding-top: calc((var(--baseline, 20px) * 1.5));
+    padding-left: var(--baseline, 20px);
     background-color: #fafafa;
     color: #2c2c2c;
     font-size: 1em;
@@ -1394,8 +1394,8 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-errors {
-    margin: calc((var(--baseline) / 4));
-    padding: calc((var(--baseline) / 2)) calc((var(--baseline) / 2)) calc((var(--baseline) / 2)) calc((var(--baseline) * 2));
+    margin: calc((var(--baseline, 20px) / 4));
+    padding: calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) * 2));
     background: url("var(--static-path)/images/incorrect-icon.png") center left no-repeat;
 }
 
@@ -1404,10 +1404,10 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-output {
-    margin: calc(var(--baseline) / 4);
-    padding: var(--baseline) 0 calc((var(--baseline) * 0.75)) 50px;
+    margin: calc(var(--baseline, 20px) / 4);
+    padding: var(--baseline, 20px) 0 calc((var(--baseline, 20px) * 0.75)) 50px;
     border-top: 1px solid #ddd;
-    border-left: var(--baseline) solid #fafafa;
+    border-left: var(--baseline, 20px) solid #fafafa;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-output h4 {
@@ -1420,7 +1420,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-output dt {
-    margin-top: var(--baseline);
+    margin-top: var(--baseline, 20px);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-output dd {
@@ -1452,8 +1452,8 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .markup-text {
-    margin: calc((var(--baseline) / 4));
-    padding: var(--baseline) 0 15px 50px;
+    margin: calc((var(--baseline, 20px) / 4));
+    padding: var(--baseline, 20px) 0 15px 50px;
     border-top: 1px solid #ddd;
     border-left: 20px solid #fafafa;
 }
@@ -1467,19 +1467,19 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .rubric tr {
-    margin: calc((var(--baseline) / 2)) 0;
+    margin: calc((var(--baseline, 20px) / 2)) 0;
     height: 100%;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .rubric td {
-    margin: calc((var(--baseline) / 2)) 0;
-    padding: var(--baseline) 0;
+    margin: calc((var(--baseline, 20px) / 2)) 0;
+    padding: var(--baseline, 20px) 0;
     height: 100%;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .rubric th {
-    margin: calc((var(--baseline) / 4));
-    padding: calc((var(--baseline) / 4));
+    margin: calc((var(--baseline, 20px) / 4));
+    padding: calc((var(--baseline, 20px) / 4));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .rubric label,
@@ -1487,7 +1487,7 @@
     position: relative;
     display: inline-block;
     margin: 3px;
-    padding: calc((var(--baseline) * 0.75));
+    padding: calc((var(--baseline, 20px) * 0.75));
     min-width: 50px;
     min-height: 50px;
     width: 150px;
@@ -1500,7 +1500,7 @@
     position: absolute;
     right: 0;
     bottom: 0;
-    margin: calc((var(--baseline) / 2));
+    margin: calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .rubric .selected-grade {
@@ -1575,7 +1575,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .annotation-input ul.tags li .tag {
     display: inline-block;
-    margin-left: calc((var(--baseline) * 2));
+    margin-left: calc((var(--baseline, 20px) * 2));
     border: 1px solid #666666;
 }
 
@@ -1644,7 +1644,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup label.choicetextgroup_show_correct::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup section.choicetextgroup_show_correct::after {
-    margin-left: calc((var(--baseline) * 0.75));
+    margin-left: calc((var(--baseline, 20px) * 0.75));
     content: url("var(--static-path)/images/correct-icon.png");
 }
 

--- a/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
@@ -577,7 +577,7 @@
     top: 4px;
     width: 14px;
     height: 14px;
-    background: url("var(--static-path)/images/unanswered-icon.png") center center no-repeat;
+    background: var(--icon-unanswered) center center no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div span.processing,
@@ -587,7 +587,7 @@
     top: 6px;
     width: 25px;
     height: 20px;
-    background: url("var(--static-path)/images/spinner.gif") center center no-repeat;
+    background: var(--icon-spinner) center center no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div span.ui-icon-check {
@@ -596,7 +596,7 @@
     top: 3px;
     width: 25px;
     height: 20px;
-    background: url("var(--static-path)/images/correct-icon.png") center center no-repeat;
+    background: var(--icon-correct) center center no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div span.incomplete,
@@ -606,7 +606,7 @@
     top: 3px;
     width: 20px;
     height: 20px;
-    background: url("var(--static-path)/images/incorrect-icon.png") center center no-repeat;
+    background: var(--icon-incorrect) center center no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .reload {
@@ -638,7 +638,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem div .grader-status .grading {
     margin: 0px 7px 0 0;
     padding-left: 25px;
-    background: url("var(--static-path)/images/info-icon.png") left center no-repeat;
+    background: var(--icon-info) left center no-repeat;
     text-indent: 0px;
 }
 
@@ -1396,7 +1396,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-errors {
     margin: calc((var(--baseline, 20px) / 4));
     padding: calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) * 2));
-    background: url("var(--static-path)/images/incorrect-icon.png") center left no-repeat;
+    background: var(--icon-incorrect) center left no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-errors li {
@@ -1428,7 +1428,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-correct {
-    background: url("var(--static-path)/images/correct-icon.png") left 20px no-repeat;
+    background: var(--icon-correct) left 20px no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-correct .result-actual-output {
@@ -1436,7 +1436,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-partially-correct {
-    background: url("var(--static-path)/images/partially-correct-icon.png") left 20px no-repeat;
+    background: var(--icon-partially-correct) left 20px no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-partially-correct .result-actual-output {
@@ -1444,7 +1444,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-incorrect {
-    background: url("var(--static-path)/images/incorrect-icon.png") left 20px no-repeat;
+    background: var(--icon-incorrect) left 20px no-repeat;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .external-grader-message section .longform .result-incorrect .result-actual-output {
@@ -1645,7 +1645,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup label.choicetextgroup_show_correct::after,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup section.choicetextgroup_show_correct::after {
     margin-left: calc((var(--baseline, 20px) * 0.75));
-    content: url("var(--static-path)/images/correct-icon.png");
+    content: var(--icon-correct);
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup span.mock_label {

--- a/xmodule/static/css-builtin-blocks/ProblemBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockEditor.css
@@ -101,9 +101,9 @@
     padding: 7px 20px 3px;
     border: 1px solid #a5aaaf;
     border-radius: 3px 3px 0 0;
-    background-color: var(--transparent);
-    background-image: -webkit-linear-gradient(top, var(--transparent) 87%, rgba(0, 0, 0, 0.06));
-    background-image: linear-gradient(to bottom, var(--transparent) 87%, rgba(0, 0, 0, 0.06));
+    background-color: var(--transparent, transparent);
+    background-image: -webkit-linear-gradient(top, var(--transparent, transparent) 87%, rgba(0, 0, 0, 0.06));
+    background-image: linear-gradient(to bottom, var(--transparent, transparent) 87%, rgba(0, 0, 0, 0.06));
     background-color: #e5ecf3;
     font-size: 13px;
     color: #3c3c3c;

--- a/xmodule/static/css-builtin-blocks/ProblemBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockEditor.css
@@ -111,8 +111,8 @@
 }
 
 .xmodule_edit.xmodule_ProblemBlock .editor .editor-tabs .tab.current {
-    background: var(--white);
-    border-bottom-color: var(--white);
+    background: var(--white, #fff);
+    border-bottom-color: var(--white, #fff);
 }
 
 .xmodule_edit.xmodule_ProblemBlock .editor-bar .editor-tabs .advanced-toggle {
@@ -120,14 +120,14 @@
     margin-top: -4px;
     padding: 3px 9px;
     font-size: 12px;
-    color: var(--link-color);
+    color: var(--link-color, #1b6d99);
 }
 
 .xmodule_edit.xmodule_ProblemBlock .editor-bar .editor-tabs .advanced-toggle.current {
-    border: 1px solid var(--lightGrey) !important;
+    border: 1px solid var(--lightGrey, #edf1f5) !important;
     border-radius: 3px !important;
-    background: var(--lightGrey) !important;
-    color: var(--darkGrey) !important;
+    background: var(--lightGrey, #edf1f5) !important;
+    color: var(--darkGrey, #8891a1) !important;
     pointer-events: none;
     cursor: none;
 }
@@ -135,7 +135,7 @@
 .xmodule_edit.xmodule_ProblemBlock .editor-bar .editor-tabs .advanced-toggle.current:hover,
 .xmodule_edit.xmodule_ProblemBlock .editor-bar .editor-tabs .advanced-toggle.current:focus {
     box-shadow: 0 0 0 0 !important;
-    background-color: var(--white);
+    background-color: var(--white, #fff);
 }
 
 .xmodule_edit.xmodule_ProblemBlock .simple-editor-cheatsheet {
@@ -143,8 +143,8 @@
     top: 41px;
     left: 70%;
     width: 0;
-    border-left: 1px solid var(--gray-l2);
-    background-color: var(--lightGrey);
+    border-left: 1px solid var(--gray-l2, #adadad);
+    background-color: var(--lightGrey, #edf1f5);
     overflow: hidden;
 }
 
@@ -217,5 +217,5 @@
     width: 26px;
     height: 21px;
     vertical-align: middle;
-    color: var(--body-color);
+    color: var(--body-color, #313131);
 }

--- a/xmodule/static/css-builtin-blocks/ProblemBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockEditor.css
@@ -49,7 +49,7 @@
     background-image: -webkit-linear-gradient(top, #d4dee8, #c9d5e2);
     background-image: linear-gradient(to bottom, #d4dee8, #c9d5e2);
     position: relative;
-    padding: calc(var(--baseline) / 4);
+    padding: calc(var(--baseline, 20px) / 4);
     border-bottom-color: #a5aaaf;
 }
 
@@ -62,7 +62,7 @@
 .xmodule_edit.xmodule_ProblemBlock .editor .editor-bar button {
     display: inline-block;
     float: left;
-    padding: 3px calc(var(--baseline) / 2) 5px;
+    padding: 3px calc(var(--baseline, 20px) / 2) 5px;
     margin-left: 7px;
     border: 0;
     border-radius: 2px;
@@ -88,7 +88,7 @@
 
 .xmodule_edit.xmodule_ProblemBlock .editor .editor-tabs li {
     float: left;
-    margin-right: calc(var(--baseline) / 4);
+    margin-right: calc(var(--baseline, 20px) / 4);
 }
 
 .xmodule_edit.xmodule_ProblemBlock .editor .editor-tabs li:last-child {
@@ -194,7 +194,7 @@
 }
 
 .xmodule_edit.xmodule_ProblemBlock .simple-editor-cheatsheet .col.sample .icon {
-    height: calc(var(--baseline) * 1.5);
+    height: calc(var(--baseline, 20px) * 1.5);
 }
 
 .xmodule_edit.xmodule_ProblemBlock .simple-editor-cheatsheet pre {

--- a/xmodule/static/css-builtin-blocks/SequenceBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/SequenceBlockDisplay.css
@@ -59,7 +59,7 @@
 }
 
 .xmodule_display.xmodule_SequenceBlock .sequence-nav {
-    margin: 0 auto var(--baseline);
+    margin: 0 auto var(--baseline, 20px);
     position: relative;
     border-bottom: none;
     z-index: 0;
@@ -213,7 +213,7 @@ body.touch-based-device .xmodule_display.xmodule_SequenceBlock .sequence-nav ol 
     }
 
     .xmodule_display.xmodule_SequenceBlock .sequence-nav-button span:not(:last-child) {
-        padding-right: calc((var(--baseline) / 2));
+        padding-right: calc((var(--baseline, 20px) / 2));
     }
 }
 

--- a/xmodule/static/css-builtin-blocks/SequenceBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/SequenceBlockDisplay.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,700");
 
 .xmodule_display.xmodule_SequenceBlock .block-link {
-    border-left: 1px solid var(--border-color);
+    border-left: 1px solid var(--border-color, #e7e7e7);
     display: block;
 }
 
@@ -12,7 +12,7 @@
 
 .xmodule_display.xmodule_SequenceBlock .topbar,
 .xmodule_display.xmodule_SequenceBlock .sequence-nav {
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color, #e7e7e7);
 }
 
 .xmodule_display.xmodule_SequenceBlock .topbar:after,
@@ -32,7 +32,7 @@
 
 .xmodule_display.xmodule_SequenceBlock .topbar a.block-link,
 .xmodule_display.xmodule_SequenceBlock .sequence-nav a.block-link {
-    border-left: 1px solid var(--border-color);
+    border-left: 1px solid var(--border-color, #e7e7e7);
     display: block;
 }
 
@@ -95,7 +95,7 @@
     box-sizing: border-box;
     min-width: 40px;
     flex-grow: 1;
-    border-color: var(--border-color);
+    border-color: var(--border-color, #e7e7e7);
     border-width: 1px;
     border-top-style: solid;
 }
@@ -112,7 +112,7 @@
     padding: 0;
     display: block;
     text-align: center;
-    border-color: var(--border-color);
+    border-color: var(--border-color, #e7e7e7);
     border-width: 1px;
     border-bottom-style: solid;
     box-sizing: border-box;
@@ -127,7 +127,7 @@
 }
 
 .xmodule_display.xmodule_SequenceBlock .sequence-nav ol li button .fa-bookmark {
-    color: var(--link-color);
+    color: var(--link-color, #1b6d99);
 }
 
 .xmodule_display.xmodule_SequenceBlock .sequence-nav ol li button.seq_video .icon::before {
@@ -150,14 +150,14 @@
     text-align: left;
     margin-top: 12px;
     background: #333333;
-    color: var(--white);
+    color: var(--white, #fff);
     font-family: var(--font-family-sans-serif);
     line-height: lh();
     right: 0;
     padding: 6px;
     position: absolute;
     top: 48px;
-    text-shadow: 0 -1px 0 var(--black);
+    text-shadow: 0 -1px 0 var(--black, #000);
     white-space: pre;
     pointer-events: none;
 }
@@ -196,7 +196,7 @@ body.touch-based-device .xmodule_display.xmodule_SequenceBlock .sequence-nav ol 
     text-shadow: none;
     background: none;
     background-color: #fff;
-    border-color: var(--border-color);
+    border-color: var(--border-color, #e7e7e7);
     box-shadow: none;
     font-size: inherit;
     font-weight: normal;
@@ -342,7 +342,7 @@ body.touch-based-device .xmodule_display.xmodule_SequenceBlock .sequence-nav ol 
     .xmodule_display.xmodule_SequenceBlock .sequence-nav button:hover,
     .xmodule_display.xmodule_SequenceBlock .sequence-nav button:active,
     .xmodule_display.xmodule_SequenceBlock .sequence-nav button.active {
-        border-bottom: 3px solid var(--link-color);
+        border-bottom: 3px solid var(--link-color, #1b6d99);
         background-color: #fff;
     }
 

--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -125,7 +125,7 @@
     left: -9999em;
     display: inline-block;
     vertical-align: middle;
-    color: var(--body-color);
+    color: var(--body-color, #313131);
 }
 
 .xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .branding .brand-logo {
@@ -219,7 +219,7 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .btn-play::after {
-    background: var(--white);
+    background: var(--white, #fff);
     position: absolute;
     width: 50%;
     height: 50%;
@@ -246,7 +246,7 @@
     border-radius: calc((var(--baseline, 20px) / 5));
     padding: 8px calc((var(--baseline, 20px) / 2)) 8px calc((var(--baseline, 20px) * 1.5));
     background: rgba(0, 0, 0, 0.75);
-    color: var(--yellow);
+    color: var(--yellow, #e2c01f);
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .closed-captions.is-visible::before {
@@ -257,7 +257,7 @@
     margin-top: -0.6em;
     font-family: 'FontAwesome';
     content: "\f142";
-    color: var(--white);
+    color: var(--white, #fff);
     opacity: 0.5;
 }
 
@@ -844,7 +844,7 @@
     padding: lh();
     box-sizing: border-box;
     transition: none;
-    background: var(--black);
+    background: var(--black, #000);
     visibility: visible;
 }
 
@@ -853,7 +853,7 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video.video-fullscreen .subtitles li.current {
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_VideoBlock .video.is-touch .tc-wrapper .video-wrapper object,
@@ -872,7 +872,7 @@
     background-position: 50% 50%;
     background-repeat: no-repeat;
     background-size: 100%;
-    background-color: var(--black);
+    background-color: var(--black, #000);
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-pre-roll.is-html5 {
@@ -898,7 +898,7 @@
 
 .xmodule_display.xmodule_VideoBlock .video .video-pre-roll .btn-play.btn-pre-roll:hover,
 .xmodule_display.xmodule_VideoBlock .video .video-pre-roll .btn-play.btn-pre-roll:focus {
-    background: var(--blue);
+    background: var(--blue, #0075b4);
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .slider .ui-slider-handle,
@@ -956,7 +956,7 @@
     display: none;
     position: absolute;
     list-style: none;
-    background-color: var(--white);
+    background-color: var(--white, #fff);
     border: 1px solid #eee;
 }
 
@@ -964,7 +964,7 @@
     margin: 0;
     padding: 0;
     border-bottom: 1px solid #eee;
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_VideoBlock .a11y-menu-container .a11y-menu-list li a {
@@ -972,14 +972,14 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: var(--gray-l2);
+    color: var(--gray-l2, #adadad);
     font-size: 14px;
     line-height: 23px;
 }
 
 .xmodule_display.xmodule_VideoBlock .a11y-menu-container .a11y-menu-list li a:hover,
 .xmodule_display.xmodule_VideoBlock .a11y-menu-container .a11y-menu-list li a:focus {
-    color: var(--gray-d1);
+    color: var(--gray-d1, #5e5e5e);
 }
 
 .xmodule_display.xmodule_VideoBlock .a11y-menu-container .a11y-menu-list li.active a {
@@ -999,7 +999,7 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video-tracks .a11y-menu-container.open>a {
-    background-color: var(--action-primary-active-bg);
+    background-color: var(--action-primary-active-bg, #0075b4);
     color: var(--very-light-text);
 }
 
@@ -1014,7 +1014,7 @@
     border-radius: 0 3px 3px 0;
     background-color: var(--very-light-text);
     padding: calc((var(--baseline, 20px) * 0.75)) calc((var(--baseline, 20px) * 1.25)) calc((var(--baseline, 20px) * 0.75)) calc((var(--baseline, 20px) * 0.75));
-    color: var(--gray-l2);
+    color: var(--gray-l2, #adadad);
     min-width: 1.5em;
     line-height: 14px;
     text-align: center;
@@ -1027,7 +1027,7 @@
     position: absolute;
     right: calc((var(--baseline, 20px) * 0.5));
     top: 33%;
-    color: var(--lighter-base-font-color);
+    color: var(--lighter-base-font-color, #646464);
 }
 
 .xmodule_display.xmodule_VideoBlock .video-tracks .a11y-menu-container .a11y-menu-list {
@@ -1050,7 +1050,7 @@
 .xmodule_display.xmodule_VideoBlock .contextmenu,
 .xmodule_display.xmodule_VideoBlock .submenu {
     border: 1px solid #333;
-    background: var(--white);
+    background: var(--white, #fff);
     color: #333;
     padding: 0;
     margin: 0;
@@ -1072,7 +1072,7 @@
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item,
 .xmodule_display.xmodule_VideoBlock .submenu .menu-item,
 .xmodule_display.xmodule_VideoBlock .submenu .submenu-item {
-    border-top: 1px solid var(--gray-l3);
+    border-top: 1px solid var(--gray-l3, #c8c8c8);
     padding: calc((var(--baseline, 20px) / 4)) calc((var(--baseline, 20px) / 2));
     outline: none;
 }
@@ -1096,14 +1096,14 @@
 .xmodule_display.xmodule_VideoBlock .submenu .menu-item:focus,
 .xmodule_display.xmodule_VideoBlock .submenu .submenu-item:focus {
     background: #333;
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_VideoBlock .contextmenu .menu-item:focus>span,
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item:focus>span,
 .xmodule_display.xmodule_VideoBlock .submenu .menu-item:focus>span,
 .xmodule_display.xmodule_VideoBlock .submenu .submenu-item:focus>span {
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item,
@@ -1129,12 +1129,12 @@
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item.is-opened,
 .xmodule_display.xmodule_VideoBlock .submenu .submenu-item.is-opened {
     background: #333;
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item.is-opened>span,
 .xmodule_display.xmodule_VideoBlock .submenu .submenu-item.is-opened>span {
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item.is-opened>.submenu,
@@ -1150,7 +1150,7 @@
 .xmodule_display.xmodule_VideoBlock .contextmenu .is-disabled,
 .xmodule_display.xmodule_VideoBlock .submenu .is-disabled {
     pointer-events: none;
-    color: var(--gray-l3);
+    color: var(--gray-l3, #c8c8c8);
 }
 
 .xmodule_display.xmodule_VideoBlock .overlay {

--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -883,7 +883,7 @@
     padding: var(--baseline, 20px);
     border: none;
     border-radius: var(--baseline, 20px);
-    background: var(--black-t2);
+    background: var(--black-t2, rgba(0, 0, 0, 0.5));
     box-shadow: none;
 }
 
@@ -1000,11 +1000,11 @@
 
 .xmodule_display.xmodule_VideoBlock .video-tracks .a11y-menu-container.open>a {
     background-color: var(--action-primary-active-bg, #0075b4);
-    color: var(--very-light-text);
+    color: var(--very-light-text, white);
 }
 
 .xmodule_display.xmodule_VideoBlock .video-tracks .a11y-menu-container.open>a::after {
-    color: var(--very-light-text);
+    color: var(--very-light-text, white);
 }
 
 .xmodule_display.xmodule_VideoBlock .video-tracks .a11y-menu-container>a {
@@ -1012,7 +1012,7 @@
     font-size: 12px;
     display: block;
     border-radius: 0 3px 3px 0;
-    background-color: var(--very-light-text);
+    background-color: var(--very-light-text, white);
     padding: calc((var(--baseline, 20px) * 0.75)) calc((var(--baseline, 20px) * 1.25)) calc((var(--baseline, 20px) * 0.75)) calc((var(--baseline, 20px) * 0.75));
     color: var(--gray-l2, #adadad);
     min-width: 1.5em;

--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -526,7 +526,7 @@
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container .menu li.is-active .speed-option,
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container .menu li.is-active .control-lang {
     border-left: calc(var(--baseline, 20px) / 10) solid #0ea6ec;
-    font-weight: var(--font-bold);
+    font-weight: var(--font-bold, 700);
     color: #0ea6ec;
 }
 
@@ -613,7 +613,7 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .volume .volume-slider-container .volume-slider .ui-slider-handle {
-    transition: height var(--tmg-s2) ease-in-out 0s, width var(--tmg-s2) ease-in-out 0s;
+    transition: height var(--tmg-s2, 2s) ease-in-out 0s, width var(--tmg-s2, 2s) ease-in-out 0s;
     left: -5px;
     box-sizing: border-box;
     height: 13px;
@@ -1008,7 +1008,7 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video-tracks .a11y-menu-container>a {
-    transition: all var(--tmg-f2) ease-in-out 0s;
+    transition: all var(--tmg-f2, 0.25s) ease-in-out 0s;
     font-size: 12px;
     display: block;
     border-radius: 0 3px 3px 0;

--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,700");
 
 .xmodule_display.xmodule_VideoBlock {
-    margin-bottom: calc((var(--baseline) * 1.5));
+    margin-bottom: calc((var(--baseline, 20px) * 1.5));
 }
 
 .xmodule_display.xmodule_VideoBlock .is-hidden,
@@ -81,8 +81,8 @@
 .xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section .branding,
 .xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section .wrapper-transcript-feedback {
     flex: 1;
-    margin-top: var(--baseline);
-    padding-right: var(--baseline);
+    margin-top: var(--baseline, 20px);
+    padding-right: var(--baseline, 20px);
     vertical-align: top;
 }
 
@@ -131,8 +131,8 @@
 .xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .branding .brand-logo {
     display: inline-block;
     max-width: 100%;
-    max-height: calc((var(--baseline) * 2));
-    padding: calc((var(--baseline) / 4)) 0;
+    max-height: calc((var(--baseline, 20px) * 2));
+    padding: calc((var(--baseline, 20px) / 4)) 0;
     vertical-align: middle;
 }
 
@@ -157,8 +157,8 @@
 
 .xmodule_display.xmodule_VideoBlock .video .google-disclaimer {
     display: none;
-    margin-top: var(--baseline);
-    padding-right: var(--baseline);
+    margin-top: var(--baseline, 20px);
+    padding-right: var(--baseline, 20px);
     vertical-align: top;
 }
 
@@ -242,9 +242,9 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .closed-captions.is-visible {
-    max-height: calc((var(--baseline) * 3));
-    border-radius: calc((var(--baseline) / 5));
-    padding: 8px calc((var(--baseline) / 2)) 8px calc((var(--baseline) * 1.5));
+    max-height: calc((var(--baseline, 20px) * 3));
+    border-radius: calc((var(--baseline, 20px) / 5));
+    padding: 8px calc((var(--baseline, 20px) / 2)) 8px calc((var(--baseline, 20px) * 1.5));
     background: rgba(0, 0, 0, 0.75);
     color: var(--yellow);
 }
@@ -253,7 +253,7 @@
     position: absolute;
     display: inline-block;
     top: 50%;
-    left: var(--baseline);
+    left: var(--baseline, 20px);
     margin-top: -0.6em;
     font-family: 'FontAwesome';
     content: "\f142";
@@ -287,7 +287,7 @@
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-player .video-error,
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-player .video-hls-error {
-    padding: calc((var(--baseline) / 5));
+    padding: calc((var(--baseline, 20px) / 5));
     background: black;
     color: white !important;
 }
@@ -336,7 +336,7 @@
     margin: 0;
     border: 0;
     border-radius: 0;
-    padding: calc((var(--baseline) / 2)) calc((var(--baseline) / 1.5));
+    padding: calc((var(--baseline, 20px) / 2)) calc((var(--baseline, 20px) / 1.5));
     background: #282c2e;
     box-shadow: none;
     text-shadow: none;
@@ -371,7 +371,7 @@
     left: 0;
     right: 0;
     z-index: 1;
-    height: calc((var(--baseline) / 4));
+    height: calc((var(--baseline, 20px) / 4));
     margin-left: 0;
     border: 1px solid #4f595d;
     border-radius: 0;
@@ -402,11 +402,11 @@
     transition: all 0.7s ease-in-out 0s;
     box-sizing: border-box;
     top: -1px;
-    height: calc((var(--baseline) / 4));
-    width: calc((var(--baseline) / 4));
-    margin-left: calc(-1 * (var(--baseline) / 8));
+    height: calc((var(--baseline, 20px) / 4));
+    width: calc((var(--baseline, 20px) / 4));
+    margin-left: calc(-1 * (var(--baseline, 20px) / 8));
     border: 1px solid #cb598d;
-    border-radius: calc((var(--baseline) / 5));
+    border-radius: calc((var(--baseline, 20px) / 5));
     padding: 0;
     background: #cb598d;
     box-shadow: none;
@@ -483,7 +483,7 @@
     transition: none;
     position: absolute;
     display: none;
-    bottom: calc((var(--baseline) * 2));
+    bottom: calc((var(--baseline, 20px) * 2));
     right: 0;
     width: 120px;
     margin: 0;
@@ -525,7 +525,7 @@
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container .menu li.is-active .speed-option,
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container .menu li.is-active .control-lang {
-    border-left: calc(var(--baseline) / 10) solid #0ea6ec;
+    border-left: calc(var(--baseline, 20px) / 10) solid #0ea6ec;
     font-weight: var(--font-bold);
     color: #0ea6ec;
 }
@@ -545,7 +545,7 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .speeds .speed-button .label {
-    padding: 0 calc((var(--baseline) / 3)) 0 0;
+    padding: 0 calc((var(--baseline, 20px) / 3)) 0 0;
     font-family: var(--font-family-sans-serif);
     color: #e7ecee;
 }
@@ -570,8 +570,8 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .lang .language-menu {
-    width: var(--baseline);
-    padding: calc((var(--baseline) / 2)) 0;
+    width: var(--baseline, 20px);
+    padding: calc((var(--baseline, 20px) / 2)) 0;
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .lang.is-opened .control .icon {
@@ -596,7 +596,7 @@
     transition: none;
     display: none;
     position: absolute;
-    bottom: calc((var(--baseline) * 2));
+    bottom: calc((var(--baseline, 20px) * 2));
     right: 0;
     width: 41px;
     height: 120px;
@@ -605,7 +605,7 @@
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .volume .volume-slider-container .volume-slider {
     height: 100px;
-    width: calc((var(--baseline) / 4));
+    width: calc((var(--baseline, 20px) / 4));
     margin: 14px auto;
     box-sizing: border-box;
     border: 1px solid #4f595d;
@@ -619,7 +619,7 @@
     height: 13px;
     width: 13px;
     border: 1px solid #cb598d;
-    border-radius: calc((var(--baseline) / 5));
+    border-radius: calc((var(--baseline, 20px) / 5));
     padding: 0;
     background: #cb598d;
     box-shadow: none;
@@ -661,12 +661,12 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper:hover .video-controls .slider {
-    height: calc((var(--baseline) / 1.5));
+    height: calc((var(--baseline, 20px) / 1.5));
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper:hover .video-controls .slider .ui-slider-handle {
-    height: calc((var(--baseline) / 1.5));
-    width: calc((var(--baseline) / 1.5));
+    height: calc((var(--baseline, 20px) / 1.5));
+    width: calc((var(--baseline, 20px) / 1.5));
 }
 
 .xmodule_display.xmodule_VideoBlock .video.video-fullscreen .closed-captions {
@@ -768,7 +768,7 @@
     bottom: 0;
     top: 0;
     width: 275px;
-    padding: 0 var(--baseline);
+    padding: 0 var(--baseline, 20px);
     display: none;
 }
 
@@ -880,9 +880,9 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-pre-roll .btn-play.btn-pre-roll {
-    padding: var(--baseline);
+    padding: var(--baseline, 20px);
     border: none;
-    border-radius: var(--baseline);
+    border-radius: var(--baseline, 20px);
     background: var(--black-t2);
     box-shadow: none;
 }
@@ -892,8 +892,8 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-pre-roll .btn-play.btn-pre-roll img {
-    height: calc((var(--baseline) * 4));
-    width: calc((var(--baseline) * 4));
+    height: calc((var(--baseline, 20px) * 4));
+    width: calc((var(--baseline, 20px) * 4));
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-pre-roll .btn-play.btn-pre-roll:hover,
@@ -1013,7 +1013,7 @@
     display: block;
     border-radius: 0 3px 3px 0;
     background-color: var(--very-light-text);
-    padding: calc((var(--baseline) * 0.75)) calc((var(--baseline) * 1.25)) calc((var(--baseline) * 0.75)) calc((var(--baseline) * 0.75));
+    padding: calc((var(--baseline, 20px) * 0.75)) calc((var(--baseline, 20px) * 1.25)) calc((var(--baseline, 20px) * 0.75)) calc((var(--baseline, 20px) * 0.75));
     color: var(--gray-l2);
     min-width: 1.5em;
     line-height: 14px;
@@ -1025,7 +1025,7 @@
 .xmodule_display.xmodule_VideoBlock .video-tracks .a11y-menu-container>a::after {
     content: "\f0d7";
     position: absolute;
-    right: calc((var(--baseline) * 0.5));
+    right: calc((var(--baseline, 20px) * 0.5));
     top: 33%;
     color: var(--lighter-base-font-color);
 }
@@ -1073,7 +1073,7 @@
 .xmodule_display.xmodule_VideoBlock .submenu .menu-item,
 .xmodule_display.xmodule_VideoBlock .submenu .submenu-item {
     border-top: 1px solid var(--gray-l3);
-    padding: calc((var(--baseline) / 4)) calc((var(--baseline) / 2));
+    padding: calc((var(--baseline, 20px) / 4)) calc((var(--baseline, 20px) / 2));
     outline: none;
 }
 
@@ -1109,7 +1109,7 @@
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item,
 .xmodule_display.xmodule_VideoBlock .submenu .submenu-item {
     position: relative;
-    padding: calc((var(--baseline) / 4)) var(--baseline) calc((var(--baseline) / 4)) calc((var(--baseline) / 2));
+    padding: calc((var(--baseline, 20px) / 4)) var(--baseline, 20px) calc((var(--baseline, 20px) / 4)) calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_VideoBlock .contextmenu .submenu-item::after,

--- a/xmodule/static/css-builtin-blocks/VideoBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockEditor.css
@@ -64,9 +64,9 @@
     padding: 18px var(--baseline, 20px);
     top: 0 !important;
     right: 0;
-    background-color: var(--blue);
-    border-bottom: 1px solid var(--blue-d2);
-    color: var(--white);
+    background-color: var(--blue, #0075b4);
+    border-bottom: 1px solid var(--blue-d2, #00466c);
+    color: var(--white, #fff);
 }
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .component-name {
@@ -74,7 +74,7 @@
     top: 0;
     left: 0;
     width: 50%;
-    color: var(--white);
+    color: var(--white, #fff);
     font-weight: 600;
 }
 
@@ -82,7 +82,7 @@
     display: inline-block;
     margin-right: calc((var(--baseline, 20px) / 4));
     font-weight: 400;
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .editor-tabs {
@@ -104,21 +104,21 @@
     background-color: rgba(255, 255, 255, 0.3);
     background-image: -webkit-linear-gradient(top, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0));
     background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0));
-    border: 1px solid var(--blue-d1);
+    border: 1px solid var(--blue-d1, #005e90);
     border-radius: 3px;
     padding: calc((var(--baseline, 20px) / 4)) var(--baseline, 20px);
-    background-color: var(--blue);
+    background-color: var(--blue, #0075b4);
     font-weight: bold;
-    color: var(--white);
+    color: var(--white, #fff);
 }
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .editor-tabs .inner_tab_wrap a.tab.current {
-    background-color: var(--blue);
-    background-image: -webkit-linear-gradient(var(--blue), var(--blue));
-    background-image: linear-gradient(to, var(--blue));
-    color: var(--blue-d1);
+    background-color: var(--blue, #0075b4);
+    background-image: -webkit-linear-gradient(var(--blue, #0075b4), var(--blue, #0075b4));
+    background-image: linear-gradient(to, var(--blue, #0075b4));
+    color: var(--blue-d1, #005e90);
     box-shadow: inset 0 1px 2px 1px var(--shadow-l1);
-    background-color: var(--blue-d4);
+    background-color: var(--blue-d4, #001724);
     cursor: default;
 }
 
@@ -154,7 +154,7 @@
 }
 
 .xmodule_edit.xmodule_VideoBlock .component-tab {
-    background: var(--white);
+    background: var(--white, #fff);
     position: relative;
     border-top: 1px solid #8891a1;
 }

--- a/xmodule/static/css-builtin-blocks/VideoBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockEditor.css
@@ -61,7 +61,7 @@
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header {
     box-sizing: border-box;
-    padding: 18px var(--baseline);
+    padding: 18px var(--baseline, 20px);
     top: 0 !important;
     right: 0;
     background-color: var(--blue);
@@ -80,7 +80,7 @@
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .component-name em {
     display: inline-block;
-    margin-right: calc((var(--baseline) / 4));
+    margin-right: calc((var(--baseline, 20px) / 4));
     font-weight: 400;
     color: var(--white);
 }
@@ -88,9 +88,9 @@
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .editor-tabs {
     list-style: none;
     right: 0;
-    top: calc((var(--baseline) / 4));
+    top: calc((var(--baseline, 20px) / 4));
     position: absolute;
-    padding: 12px calc((var(--baseline) * 0.75));
+    padding: 12px calc((var(--baseline, 20px) * 0.75));
 }
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .editor-tabs .inner_tab_wrap {
@@ -106,7 +106,7 @@
     background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0));
     border: 1px solid var(--blue-d1);
     border-radius: 3px;
-    padding: calc((var(--baseline) / 4)) var(--baseline);
+    padding: calc((var(--baseline, 20px) / 4)) var(--baseline, 20px);
     background-color: var(--blue);
     font-weight: bold;
     color: var(--white);
@@ -142,7 +142,7 @@
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .comp-subtitles-entry .comp-subtitles-import-list>li {
     display: block;
-    margin: calc(var(--baseline) / 2) 0;
+    margin: calc(var(--baseline, 20px) / 2) 0;
 }
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .comp-subtitles-entry .comp-subtitles-import-list .blue-button {

--- a/xmodule/static/css-builtin-blocks/VideoBlockEditor.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockEditor.css
@@ -117,14 +117,14 @@
     background-image: -webkit-linear-gradient(var(--blue, #0075b4), var(--blue, #0075b4));
     background-image: linear-gradient(to, var(--blue, #0075b4));
     color: var(--blue-d1, #005e90);
-    box-shadow: inset 0 1px 2px 1px var(--shadow-l1);
+    box-shadow: inset 0 1px 2px 1px var(--shadow-l1, rgba(0, 0, 0, 0.1));
     background-color: var(--blue-d4, #001724);
     cursor: default;
 }
 
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .editor-tabs .inner_tab_wrap a.tab:hover,
 .xmodule_edit.xmodule_VideoBlock .editor-with-tabs .edit-header .editor-tabs .inner_tab_wrap a.tab:focus {
-    box-shadow: inset 0 1px 2px 1px var(--shadow);
+    box-shadow: inset 0 1px 2px 1px var(--shadow, rgba(0, 0, 0, 0.2));
     background-image: linear-gradient(#009fe6, #009fe6) !important;
 }
 

--- a/xmodule/static/css-builtin-blocks/WordCloudBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/WordCloudBlockDisplay.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,700");
 
 .xmodule_display.xmodule_WordCloudBlock .input-cloud {
-    margin: calc((var(--baseline) / 4));
+    margin: calc((var(--baseline, 20px) / 4));
 }
 
 .xmodule_display.xmodule_WordCloudBlock .result_cloud_section {


### PR DESCRIPTION
Adds fallback to variables.
In case required global css variables are not provided by the runtime, XBlocks should render normally on its default values.

## Predecessor PR/stories:
https://github.com/openedx/edx-platform/issues/35300
https://github.com/openedx/edx-platform/pull/35233


## Fallbacks of following global css variables has not been added (or not been added yet):
#### CSS
```css
--font-family-sans-serif: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif

--icon-correct: url("../images/correct-icon.png")
--icon-incorrect: url("../images/incorrect-icon.png")
--icon-info: url("../images/info-icon.png")
--icon-partially-correct: url("../images/partially-correct-icon.png")
--icon-spinner: url("../images/spinner.gif")
--icon-unanswered: url("../images/unanswered-icon.png")
```
#### SCSS
```scss
    --font-family-sans-serif: $font-family-sans-serif;

    --icon-correct: url($static-path + '/images/correct-icon.png');
    --icon-incorrect: url($static-path + '/images/incorrect-icon.png');
    --icon-info: url($static-path + '/images/info-icon.png');
    --icon-partially-correct: url($static-path + '/images/partially-correct-icon.png');
    --icon-spinner: url($static-path + '/images/spinner.gif');
    --icon-unanswered: url($static-path + '/images/unanswered-icon.png');
```

## Where I have taken the fallback values from?
I have copied the fallback values from ```cms/static/css/studio-main-v1.css``` file which generates when we compile the sass files like via `npm run compile-sass` command.

```css
:root {
  --action-primary-active-bg: #0075b4;
  --base-font-size: 18px;
  --base-line-height: 1.5em;
  --baseline: 20px;
  --black: #000;
  --black-t2: rgba(0, 0, 0, 0.5);
  --blue: #0075b4;
  --blue-d1: #005e90;
  --blue-d2: #00466c;
  --blue-d4: #001724;
  --blue-s1: #0075b4;
  --body-color: #313131;
  --border-color: #e7e7e7;
  --bp-screen-lg: 1024px;
  --btn-brand-focus-background: #065683;
  --correct: #008100;
  --danger: #b20610;
  --darkGrey: #8891a1;
  --error-color: #cb0712;
  --error-color-dark: #95050d;
  --error-color-light: #f95861;
  --font-bold: 700;
  --font-family-sans-serif: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
  --general-color-accent: #0075b4;
  --gray: #767676;
  --gray-300: #d9d9d9;
  --gray-d1: #5e5e5e;
  --gray-l2: #adadad;
  --gray-l3: #c8c8c8;
  --gray-l4: #e4e4e4;
  --gray-l6: #f8f8f8;
  --icon-correct: url("../images/correct-icon.png");
  --icon-incorrect: url("../images/incorrect-icon.png");
  --icon-info: url("../images/info-icon.png");
  --icon-partially-correct: url("../images/partially-correct-icon.png");
  --icon-spinner: url("../images/spinner.gif");
  --icon-unanswered: url("../images/unanswered-icon.png");
  --incorrect: #b20610;
  --lightGrey: #edf1f5;
  --lighter-base-font-color: #646464;
  --link-color: #1b6d99;
  --medium-font-size: 0.9em;
  --partially-correct: #008100;
  --primary: #0075b4;
  --shadow: rgba(0, 0, 0, 0.2);
  --shadow-l1: rgba(0, 0, 0, 0.1);
  --sidebar-color: #f6f6f6;
  --small-font-size: 80%;
  --submitted: #0075b4;
  --success: #008100;
  --tmg-f2: 0.25s;
  --tmg-s2: 2s;
  --transparent: transparent;
  --uxpl-gray-background: #d9d9d9;
  --uxpl-gray-base: #414141;
  --uxpl-gray-dark: #111111;
  --very-light-text: white;
  --warning: #e2c01f;
  --warning-color: #ffc01f;
  --warning-color-accent: #fffcdd;
  --white: #fff;
  --yellow: #e2c01f; 
}
```

