### PR TITLE
fix: Handle None identity providers in `_user_has_social_auth_record`

### DIFF
--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -294,9 +294,12 @@ def _user_has_social_auth_record(user, enterprise_customer):
             identity_provider = third_party_auth.provider.Registry.get(
                 provider_id=idp['provider_id']
             )
-            provider_backend_names.append(identity_provider.backend_name)
-        return UserSocialAuth.objects.select_related('user').\
-            filter(provider__in=provider_backend_names, user=user).exists()
+            if identity_provider and hasattr(identity_provider, 'backend_name'):
+                provider_backend_names.append(identity_provider.backend_name)
+
+        if provider_backend_names:
+            return UserSocialAuth.objects.select_related('user').\
+                filter(provider__in=provider_backend_names, user=user).exists()
     return False
 
 


### PR DESCRIPTION
## Description

Added safety checks to handle cases where third_party_auth.provider.Registry.get() 
returns None, preventing AttributeError when accessing backend_name. The function 
now skips invalid providers and only performs the database query when valid 
backend names are found.


## Supporting information
Link to Jira Ticket: https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/868?selectedIssue=ENT-9870