### PR TITLE
feat: Make dump for fns, classes more stable and helpful

### DIFF
--- a/openedx/core/djangoapps/util/tests/test_dump_settings.py
+++ b/openedx/core/djangoapps/util/tests/test_dump_settings.py
@@ -26,8 +26,8 @@ def test_for_lms_settings(capsys):
     # Check: tuples are converted to lists
     assert isinstance(dump['XBLOCK_MIXINS'], list)
 
-    # Check: objects (like classes) are repr'd
-    assert "<class 'xmodule.x_module.XModuleMixin'>" in dump['XBLOCK_MIXINS']
+    # Check: classes are converted to dicts of info on the class location
+    assert {"module": "xmodule.x_module", "qualname": "XModuleMixin"} in dump['XBLOCK_MIXINS']
 
     # Check: nested dictionaries come through OK, and int'l strings are just strings
     assert dump['COURSE_ENROLLMENT_MODES']['audit']['display_name'] == "Audit"
@@ -46,8 +46,8 @@ def test_for_cms_settings(capsys):
     # Check: tuples are converted to lists
     assert isinstance(dump['XBLOCK_MIXINS'], list)
 
-    # Check: objects (like classes) are repr'd
-    assert "<class 'xmodule.x_module.XModuleMixin'>" in dump['XBLOCK_MIXINS']
+    # Check: classes are converted to dicts of info on the class location
+    assert {"module": "xmodule.x_module", "qualname": "XModuleMixin"} in dump['XBLOCK_MIXINS']
 
     # Check: nested dictionaries come through OK, and int'l strings are just strings
     assert dump['COURSE_ENROLLMENT_MODES']['audit']['display_name'] == "Audit"


### PR DESCRIPTION
## Description

This is a light iteration on https://github.com/openedx/edx-platform/pull/36162, making the `dump_settings` management command more helpful and stable for functions and classes.

## Supporting information


In particular, the `dump_settings` command currently prints out the raw `repr(...)`s for defined functions:
```
    "WIKI_CAN_ASSIGN": "<function CAN_ASSIGN at 0x74ce5e9b2020>",
    "WIKI_CAN_CHANGE_PERMISSIONS": "<function CAN_CHANGE_PERMISSIONS at 0x74ce5e9b1f80>",
    "WIKI_CAN_DELETE": "<function CAN_DELETE at 0x74ce5e9b1b20>",
    "WIKI_CAN_MODERATE": "<function CAN_MODERATE at 0x74ce5e9b1bc0>",
```

In addition to being uninformative, these `at 0x123abc...` hashes change every run, so they appear in the diff as having "changed" every time.

With this PR, here's what `dump_settings` will print out for functions:

```
    "WIKI_CAN_ASSIGN": {
        "module": "lms.djangoapps.course_wiki.settings",
        "qualname": "CAN_ASSIGN"
    },
    "WIKI_CAN_CHANGE_PERMISSIONS": {
        "module": "lms.djangoapps.course_wiki.settings",
        "qualname": "CAN_CHANGE_PERMISSIONS"
    },
    "WIKI_CAN_DELETE": {
        "module": "lms.djangoapps.course_wiki.settings",
        "qualname": "CAN_DELETE"
    },
    "WIKI_CAN_MODERATE": {
        "module": "lms.djangoapps.course_wiki.settings",
        "qualname": "CAN_MODERATE"
    },
```

It will do something similarly helpful for classes and lambdas.

## Deadline

Asap, as this unblocks several pending settings refactorings.
