### PR TITLE
fix: swagger docs ref_name conflicts

### DIFF
--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -23,6 +23,7 @@ class CourseRunViewSet(viewsets.GenericViewSet):  # lint-amnesty, pylint: disabl
     lookup_value_regex = settings.COURSE_KEY_REGEX
     permission_classes = (permissions.IsAdminUser,)
     serializer_class = CourseRunSerializer
+    queryset = []
 
     def get_object(self):
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field

--- a/cms/djangoapps/contentstore/api/views/course_import.py
+++ b/cms/djangoapps/contentstore/api/views/course_import.py
@@ -106,7 +106,7 @@ class CourseImportView(CourseImportExportViewMixin, GenericAPIView):
     # TODO: ARCH-91
     # This view is excluded from Swagger doc generation because it
     # does not specify a serializer class.
-    exclude_from_schema = True
+    swagger_schema = None
 
     @course_author_access_required
     def post(self, request, course_key):

--- a/cms/djangoapps/contentstore/api/views/course_quality.py
+++ b/cms/djangoapps/contentstore/api/views/course_quality.py
@@ -77,6 +77,11 @@ class CourseQualityView(DeveloperErrorViewMixin, GenericAPIView):
                 * mode
 
     """
+    # TODO: ARCH-91
+    # This view is excluded from Swagger doc generation because it
+    # does not specify a serializer class.
+    swagger_schema = None
+
     @course_author_access_required
     def get(self, request, course_key):
         """

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -65,6 +65,11 @@ class CourseValidationView(DeveloperErrorViewMixin, GenericAPIView):
             * has_proctoring_escalation_email - whether the course has a proctoring escalation email
 
     """
+    # TODO: ARCH-91
+    # This view is excluded from Swagger doc generation because it
+    # does not specify a serializer class.
+    swagger_schema = None
+
     @course_author_access_required
     def get(self, request, course_key):
         """

--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/authoring_grading.py
@@ -14,7 +14,13 @@ class GradersSerializer(serializers.Serializer):
     weight = serializers.IntegerField()
     id = serializers.IntegerField()
 
+    class Meta:
+        ref_name = "authoring_grading.Graders.v0"
+
 
 class CourseGradingModelSerializer(serializers.Serializer):
     """ Serializer for course grading model data """
     graders = GradersSerializer(many=True, allow_null=True, allow_empty=True)
+
+    class Meta:
+        ref_name = "authoring_grading.CourseGrading.v0"

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -63,7 +63,7 @@ urlpatterns = [
         authoring_videos.VideoEncodingsDownloadView.as_view(), name='cms_api_videos_encodings'
     ),
     re_path(
-        fr'grading/{settings.COURSE_ID_PATTERN}',
+        fr'grading/{settings.COURSE_ID_PATTERN}$',
         AuthoringGradingView.as_view(), name='cms_api_update_grading'
     ),
     path(

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_videos.py
@@ -128,6 +128,11 @@ class VideoEncodingsDownloadView(DeveloperErrorViewMixin, RetrieveAPIView):
     course_key: required argument, needed to authorize course authors and identify relevant videos.
     """
 
+    # TODO: ARCH-91
+    # This view is excluded from Swagger doc generation because it
+    # does not specify a serializer class.
+    swagger_schema = None
+
     def dispatch(self, request, *args, **kwargs):
         # TODO: probably want to refactor this to a decorator.
         """
@@ -150,6 +155,11 @@ class VideoFeaturesView(DeveloperErrorViewMixin, RetrieveAPIView):
     """
     public rest API endpoint providing a list of enabled video features.
     """
+
+    # TODO: ARCH-91
+    # This view is excluded from Swagger doc generation because it
+    # does not specify a serializer class.
+    swagger_schema = None
 
     def dispatch(self, request, *args, **kwargs):
         # TODO: probably want to refactor this to a decorator.

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -168,7 +168,7 @@ urlpatterns = oauth2_urlpatterns + [
             contentstore_views.textbooks_detail_handler, name='textbooks_detail_handler'),
     re_path(fr'^videos/{settings.COURSE_KEY_PATTERN}(?:/(?P<edx_video_id>[-\w]+))?$',
             contentstore_views.videos_handler, name='videos_handler'),
-    re_path(fr'^generate_video_upload_link/{settings.COURSE_KEY_PATTERN}',
+    re_path(fr'^generate_video_upload_link/{settings.COURSE_KEY_PATTERN}$',
             contentstore_views.generate_video_upload_link_handler, name='generate_video_upload_link'),
     re_path(fr'^video_images/{settings.COURSE_KEY_PATTERN}(?:/(?P<edx_video_id>[-\w]+))?$',
             contentstore_views.video_images_handler, name='video_images_handler'),

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -131,7 +131,7 @@ optimizely-sdk<5.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.18.1
+openedx-learning==0.18.2
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -827,7 +827,7 @@ openedx-filters==1.12.0
     #   ora2
 openedx-forum==0.1.6
     # via -r requirements/edx/kernel.in
-openedx-learning==0.18.1
+openedx-learning==0.18.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1381,7 +1381,7 @@ openedx-forum==0.1.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.18.1
+openedx-learning==0.18.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1000,7 +1000,7 @@ openedx-filters==1.12.0
     #   ora2
 openedx-forum==0.1.6
     # via -r requirements/edx/base.txt
-openedx-learning==0.18.1
+openedx-learning==0.18.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1048,7 +1048,7 @@ openedx-filters==1.12.0
     #   ora2
 openedx-forum==0.1.6
     # via -r requirements/edx/base.txt
-openedx-learning==0.18.1
+openedx-learning==0.18.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes following error while rendering automatic swagger docs:

```log
cms-1  | drf_yasg.errors.SwaggerGenerationError: Schema for <class 'cms.djangoapps.contentstore.rest_api.v0.serializers.authoring_grading.CourseGradingModelSerializer'> would override distinct serializer <class 'cms.djangoapps.contentstore.rest_api.v1.serializers.grading.CourseGradingModelSerializer'> because they implicitly share the same ref_name; explicitly set the ref_name attribute on both serializers' Meta classes

```

## Supporting information

* Private-ref: [FAL-4039](https://tasks.opencraft.com/browse/FAL-4039)
* Relates to: https://github.com/openedx/openedx-learning/pull/273
* Part-of: https://github.com/openedx/openedx-learning/issues/272

## Testing instructions

* Checkout this PR and https://github.com/openedx/openedx-learning/pull/273
* Visit the Studio API docs page, e.g http://studio.local.openedx.io:8001/api-docs/
Note that the page renders now without error.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
