### PR TITLE
fix: The studio api-docs swagger URL throwing 500

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/authoring_grading.py
@@ -7,6 +7,9 @@ from rest_framework import serializers
 
 class GradersSerializer(serializers.Serializer):
     """ Serializer for graders """
+    class Meta:
+        ref_name='authoring_grading.GradersSerializer'
+
     type = serializers.CharField()
     min_count = serializers.IntegerField()
     drop_count = serializers.IntegerField()
@@ -17,4 +20,7 @@ class GradersSerializer(serializers.Serializer):
 
 class CourseGradingModelSerializer(serializers.Serializer):
     """ Serializer for course grading model data """
+    class Meta:
+        ref_name='authoring_grading.CourseGradingModelSerializer'
+    
     graders = GradersSerializer(many=True, allow_null=True, allow_empty=True)

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
@@ -7,6 +7,9 @@ from rest_framework import serializers
 
 class GradersSerializer(serializers.Serializer):
     """ Serializer for graders """
+    class Meta:
+        ref_name='course_grading.GradersSerializer'
+
     type = serializers.CharField()
     min_count = serializers.IntegerField()
     drop_count = serializers.IntegerField()
@@ -23,6 +26,9 @@ class GracePeriodSerializer(serializers.Serializer):
 
 class CourseGradingModelSerializer(serializers.Serializer):
     """ Serializer for course grading model data """
+    class Meta:
+        ref_name = 'course_grading.CourseGradingModelSerializer'
+    
     graders = GradersSerializer(many=True)
     grade_cutoffs = serializers.DictField(child=serializers.FloatField())
     grace_period = GracePeriodSerializer(required=False, allow_null=True)

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -348,9 +348,9 @@ urlpatterns += [
 ]
 
 # Content tagging
-#urlpatterns += [
-#    path('api/content_tagging/', include(('openedx.core.djangoapps.content_tagging.urls', 'content_tagging'))),
-#]
+urlpatterns += [
+    path('api/content_tagging/', include(('openedx.core.djangoapps.content_tagging.urls', 'content_tagging'))),
+]
 
 # Authoring-api specific API docs (using drf-spectacular and openapi-v3).
 # This is separate from and in addition to the full studio swagger documentation already existing at /api-docs.

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -348,9 +348,9 @@ urlpatterns += [
 ]
 
 # Content tagging
-urlpatterns += [
-    path('api/content_tagging/', include(('openedx.core.djangoapps.content_tagging.urls', 'content_tagging'))),
-]
+#urlpatterns += [
+#    path('api/content_tagging/', include(('openedx.core.djangoapps.content_tagging.urls', 'content_tagging'))),
+#]
 
 # Authoring-api specific API docs (using drf-spectacular and openapi-v3).
 # This is separate from and in addition to the full studio swagger documentation already existing at /api-docs.

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/urls.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/urls.py
@@ -3,6 +3,7 @@ Taxonomies API v1 URLs.
 """
 
 from django.urls.conf import include, path
+from drf_yasg.utils import swagger_auto_schema
 from openedx_tagging.core.tagging.rest_api.v1 import views as oel_tagging_views
 from openedx_tagging.core.tagging.rest_api.v1 import views_import as oel_tagging_views_import
 from openedx_tagging.core.tagging.rest_api.v1.views import ObjectTagCountsView
@@ -14,6 +15,7 @@ router = DefaultRouter()
 router.register("taxonomies", views.TaxonomyOrgView, basename="taxonomy")
 router.register("object_tags", views.ObjectTagOrgView, basename="object_tag")
 router.register("object_tag_counts", ObjectTagCountsView, basename="object_tag_counts")
+swagger_auto_schema(auto_schema=None)(ObjectTagCountsView)
 
 urlpatterns = [
     path(


### PR DESCRIPTION
## Description

With this PR, the Studio/CMS swagger docs at `localhost:18010/api-docs` would no longer throw 500 error.
This change had to exclude URLs from openedx-tagging from swagger doc schema because of it issue at https://github.com/openedx/openedx-learning/issues/272



## Testing instructions

Go to studio domain `/api-docs` url and see all the studio url schemas are generated as swagger docs

