### PR TITLE
feat: add course optimizer link to tools dropdown in Studio legacy

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -36,6 +36,7 @@ from pytz import UTC
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.toggles import (
+    enable_course_optimizer,
     exam_setting_view_enabled,
     libraries_v1_enabled,
     libraries_v2_enabled,
@@ -388,6 +389,19 @@ def get_export_url(course_locator) -> str:
         if mfe_base_url:
             export_url = course_mfe_url
     return export_url
+
+
+def get_optimizer_url(course_locator) -> str:
+    """
+    Gets course authoring microfrontend URL for optimizer page view.
+    """
+    optimizer_url = None
+    if enable_course_optimizer(course_locator):
+        mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/optimizer'
+        if mfe_base_url:
+            optimizer_url = course_mfe_url
+    return optimizer_url
 
 
 def get_files_uploads_url(course_locator) -> str:

--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -388,7 +388,8 @@ body.course.view-export-git .nav-course-tools-export-git,
 body.course.view-team .nav-library-settings .title,
 body.course.view-team .nav-library-settings-team,
 body.course.view-checklists .nav-course-tools .title,
-body.course.view-checklists .nav-course-tools-checklists {
+body.course.view-checklists .nav-course-tools-checklists,
+.nav-course-tools-optimizer {
   color: theme-color("primary");
 
   a {

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -8,7 +8,7 @@
   from urllib.parse import quote_plus
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
-  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url, get_optimizer_url
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
@@ -66,6 +66,7 @@
             advanced_settings_mfe_enabled = toggles.use_new_advanced_settings_page(context_course.id)
             import_mfe_enabled = toggles.use_new_import_page(context_course.id)
             export_mfe_enabled = toggles.use_new_export_page(context_course.id)
+            optimizer_enabled = toggles.enable_course_optimizer(context_course.id)
 
       %>
       <h2 class="info-course">
@@ -255,6 +256,11 @@
                   <li class="nav-item nav-course-tools-checklists">
                     <a href="${checklists_url}">${_("Checklists")}</a>
                   </li>
+                  % if optimizer_enabled:
+                  <li class="nav-item nav-course-tools-optimizer">
+                    <a href="${get_optimizer_url(course_key)}">${_("Optimize Course")}</a>
+                  </li>
+                  % endif
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
### [TNL-11860](https://2u-internal.atlassian.net/browse/TNL-11860)

### Description

Add `Course Optimizer` link to Studio legacy `Tools` dropdown.

This is only visible when the flag `contentstore.enable_course_optimizer` is enabled.

This link redirects to the `course-authoring MFE`, where the course optimizer tool page exists.


**NOTE: This PR is dependent on this https://github.com/openedx/edx-platform/pull/35887. We can push these into the dependent branch, or merge this to master after dependent branch is merged**



#### Steps to setup:

- Go to Studio legacy experience and verify there is no `Optimize Course` option
- Enable the flag `contentstore.enable_course_optimizer`
- Go to Studio legacy experience and verify there is a `Optimize Course` option
- Click on option to go to Optimizer Page in course authoring MFE


#### Link to Course Optimizer

<img width="1512" alt="Screenshot 2025-01-31 at 5 06 29 PM" src="https://github.com/user-attachments/assets/c7a659a4-4f54-42c9-a0b1-18752f8f0abc" />


#### Redirection to Course Optimizer Page

<img width="1512" alt="Screenshot 2025-01-31 at 5 06 58 PM" src="https://github.com/user-attachments/assets/535e848e-8ef8-4511-9f6a-89821056ead1" />