### PR TITLE
fix: visual and progress score display enhancement

### DIFF
--- a/xmodule/js/src/capa/display.js
+++ b/xmodule/js/src/capa/display.js
@@ -290,12 +290,19 @@
 
         Problem.prototype.updateProgress = function(response) {
             if (response.progress_changed) {
-                this.el.data('problem-score', response.current_score);
-                this.el.data('problem-total-possible', response.total_possible);
+                this.el.data('problem-score', this.convertToFloat(response.current_score));
+                this.el.data('problem-total-possible', this.convertToFloat(response.total_possible));
                 this.el.data('attempts-used', response.attempts_used);
                 this.el.trigger('progressChanged');
             }
             return this.renderProgressState();
+        };
+
+        Problem.prototype.convertToFloat = function(num) {
+            if (typeof num !== 'number' || !Number.isInteger(num)) {
+              return num;
+            }
+            return num.toFixed(1);
         };
 
         Problem.prototype.forceUpdate = function(response) {

--- a/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
@@ -179,6 +179,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup,
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup {
+    margin: var(--baseline, 20px) 0 0 0;
     min-width: 100px;
     width: auto !important;
     width: 100px;
@@ -405,7 +406,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"] {
     left: 0.5625em;
     position: absolute;
-    top: 0.35em;
+    top: 0.43em;
     width: calc(var(--baseline, 20px) * 1.1);
     height: calc(var(--baseline, 20px) * 1.1);
     z-index: 1;
@@ -636,10 +637,10 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .grader-status .grading {
-    margin: 0px 7px 0 0;
+    margin: 0 7px 0 0;
     padding-left: 25px;
     background: var(--icon-info) left center no-repeat;
-    text-indent: 0px;
+    text-indent: 0;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .grader-status p {
@@ -701,7 +702,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div .submit-message-container {
-    margin: var(--baseline, 20px) 0px;
+    margin: var(--baseline, 20px) 0;
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem div.inline>span {
@@ -878,6 +879,11 @@
     content: "";
 }
 
+.xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.submitted,
+.xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.submitted {
+    margin: var(--baseline, 20px) 0 0 0;
+}
+
 .xmodule_display.xmodule_ProblemBlock .problem .capa_inputtype.textline>.submitted input,
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.formulaequationinput>.submitted input {
     border: 2px solid var(--submitted, #0075b4);
@@ -914,7 +920,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.option-input {
-    margin: 0 0 0 0 !important;
+    margin: var(--baseline, 20px) 0 0 0 !important;
 }
 
 .xmodule_display.xmodule_ProblemBlock .problem .inputtype.option-input .indicator-container {
@@ -975,7 +981,7 @@
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .CodeMirror-scroll {
-    margin-right: 0px;
+    margin-right: 0;
 }
 
 .xmodule_display.xmodule_ProblemBlock .capa-message {


### PR DESCRIPTION
### Description
This pull request contains styling fixes and display problem score for Problem xblock.
- [1] Add more space between problem description and options block.
- [2] Center radio/checkbox button and answer text in options.
- [3] Display float number in the points score label above the options block (display the floating point number after sending in the same format as when loading the block).

#### Screenshots before:
| **[1]** <img width="956" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/3f005321-96ef-4d98-9e4b-0d7d96c2b599"> | **[2]** <img width="1021" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/2e246fd8-1f2e-4a06-a88d-2a8c5824fcfc"> | **[3] before submit** <img width="1219" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/b1259b35-6d70-46a9-b2cf-407e74eeb6e5">  | **[3] after submit** <img width="1164" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/d22df002-4282-4d7f-8bc6-3a85a314b759">  |
|---|---|---|---|

#### Screenshots after:
| **[1]** <img width="945" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/02906f03-695e-4408-8b03-993c6ee00b64"> | **[2]** <img width="1122" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/526ac3e0-ffaf-4688-95bb-abaaacf1bcf8"> | **[3] before submit** <img width="1109" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/9f4b0b10-e0f0-42f7-8d4e-686f024abeef">  | **[3] after submit** <img width="1094" alt="image" src="https://github.com/openedx/edx-platform/assets/17108583/a2f43505-de8c-4fb2-9a22-22dacff4c712">  |
|---|---|---|---|

#### Steps to Reproduce: 
1. Enable new video editor and sharing by adding in `/admin/waffle/flag/` => `new_core_editors.use_new_problem_editor`
2. In studio open unit -> add new component -> Problem -> Single / Multiple select
3. Check problem displaying