### PR TITLE
feat: API to delete given social auth record for user

### DIFF
--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import ddt
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.http import QueryDict
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -214,14 +215,42 @@ class UserViewV2APITests(UserViewsMixin, TpaAPITestCase):
     Test the Third Party Auth User REST API
     """
 
-    def make_url(self, identifier):
+    def setUp(self):  # pylint: disable=arguments-differ
+        """ Create users for use in the tests """
+        super().setUp()
+        admin_user = get_user_model().objects.get(username=ADMIN_USERNAME)
+        self.auth_token = f"JWT {generate_jwt(admin_user, is_restricted=False, scopes=None, filters=None)}"
+
+    def make_url(self, params):
         """
         Return the view URL, with the identifier provided
         """
         return '?'.join([
             reverse('third_party_auth_users_api_v2'),
-            urllib.parse.urlencode(identifier)
+            urllib.parse.urlencode(params)
         ])
+
+    @ddt.data(
+        ({}, 400, ["Must provide one of ['email', 'username']"]),
+        ({'username': ALICE_USERNAME}, 400, ["Must provide uid"]),
+        (
+            {'username': 'invalid-user', 'uid': f'{ALICE_USERNAME}@gmail.com'},
+            404,
+            {f"Either user invalid-user or social auth record {ALICE_USERNAME}@gmail.com does not exist."}
+        ),
+        (
+            {'username': ALICE_USERNAME, 'uid': 'invalid-uid'},
+            404,
+            {f"Either user {ALICE_USERNAME} or social auth record invalid-uid does not exist."}
+        ),
+        ({'username': ALICE_USERNAME, 'uid': f'{ALICE_USERNAME}@gmail.com'}, 204, None),
+    )
+    @ddt.unpack
+    def test_delete_social_auth_record(self, identifier, expect_code, expect_data):
+        url = self.make_url(identifier)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.auth_token)
+        assert response.status_code == expect_code
+        assert (response.data == expect_data)
 
 
 @override_settings(EDX_API_KEY=VALID_API_KEY)

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -252,6 +252,13 @@ class UserViewV2APITests(UserViewsMixin, TpaAPITestCase):
         assert response.status_code == expect_code
         assert (response.data == expect_data)
 
+    def test_unauthorized_delete_social_auth_record_call(self):
+        user = get_user_model().objects.get(username=CARL_USERNAME)
+        auth_token = f"JWT {generate_jwt(user, is_restricted=False, scopes=None, filters=None)}"
+        url = self.make_url({'username': ALICE_USERNAME, 'uid': f'{ALICE_USERNAME}@gmail.com'})
+        response = self.client.delete(url, HTTP_AUTHORIZATION=auth_token)
+        assert response.status_code == 403
+
 
 @override_settings(EDX_API_KEY=VALID_API_KEY)
 @ddt.ddt

--- a/docs/lms-openapi.yaml
+++ b/docs/lms-openapi.yaml
@@ -8890,10 +8890,35 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: 'JSON serialized list of the providers linked to this user.'
       tags:
       - third_party_auth
-    parameters: []
+    delete:
+      operationId: third_party_auth_v0_users_delete
+      summary: Delete given social auth record for a user.
+      description: Allows deleting the given social auth record if it exists for a specified user.
+      parameters:
+      - name: uid
+        in: query
+        description: UID of the social auth record to delete.
+        required: true
+        type: string
+      responses:
+        '204':
+          description: 'No content returned if delete operation successful.'
+      tags:
+      - third_party_auth
+    parameters:
+    - name: username
+      in: query
+      description: Username of user. One of 'email' or 'username'. If both are provided, the username will be ignored.
+      required: false
+      type: string
+    - name: email
+      in: query
+      description: Email of user. One of 'email' or 'username'. If both are provided, the username will be ignored.
+      required: false
+      type: string
   /third_party_auth/v0/users/{username}:
     get:
       operationId: third_party_auth_v0_users_read


### PR DESCRIPTION
## Description

This PR introduces an API to delete a social auth record with provided uid for a given user.
This API is intended for server to server calls from third party system.


## Testing instructions

1. Checkout and setup this PR branch
2. Go to social auth admin page `https://<LMS_HOST>/admin/social_django/usersocialauth/` and create a new social auth record for any user.
3. Invoke DELETE call to url `https://<LMS_HOST>/api/third_party_auth/v0/users/?username={username}&uid={uid}` with a valid JWT access token.
4. Verify the auth record with given uid is deleted.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Private Ref: [BB-9477](https://tasks.opencraft.com/browse/BB-9477)