### PR TITLE
chore: add django admin binding for course_action_state django app

### DIFF
--- a/common/djangoapps/course_action_state/admin.py
+++ b/common/djangoapps/course_action_state/admin.py
@@ -1,0 +1,9 @@
+"""
+Admin site bindings for CourseActionState
+"""
+
+from django.contrib import admin
+
+from common.djangoapps.course_action_state.models import CourseRerunState
+
+admin.site.register(CourseRerunState)


### PR DESCRIPTION
## Description

In this change, we are adding the CourseActionState django app to the django-admin site. See screenshot:

<img width="872" alt="image" src="https://github.com/user-attachments/assets/c71e1e4d-7348-4b53-ab92-547336741404" />

This is needed to manage the problematic data in this table.

## Testing instructions

* Ensure the LMS and CMS user facing apps are functioning correctly.
* Go to the django admin site for both the LMS and CMS and ensure both django admin have this new database area for the CourseActionState
