### PR TITLE
fix: handle missing discussion settings when importing old courses

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -453,7 +453,7 @@ def sync_discussion_settings(course_key, user):
 
         if (
             ENABLE_NEW_STRUCTURE_DISCUSSIONS.is_enabled()
-            and not course.discussions_settings['provider_type'] == Provider.OPEN_EDX
+            and not course.discussions_settings.get('provider_type') == Provider.OPEN_EDX
         ):
             LOGGER.info(f"New structure is enabled, also updating {course_key} to use new provider")
             course.discussions_settings['enable_graded_units'] = False


### PR DESCRIPTION
This fixes the following error when importing an old course:

```python
Task cms.djangoapps.contentstore.tasks.import_olx[ID]: Course import course-v1:ID: DiscussionsConfiguration sync failed: 'provider_type'

# The traceback is hidden by default, so it needs to be manually re-raised to see the actual error:
Traceback (most recent call last):
   File "/openedx/venv/lib/python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
     R = retval = fun(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^
   File "/openedx/edx-platform/cms/djangoapps/contentstore/tasks.py", line 718, in import_olx
     sync_discussion_settings(courselike_key, user)
   File "/openedx/edx-platform/cms/djangoapps/contentstore/tasks.py", line 458, in sync_discussion_settings
     and not course.discussions_settings['provider_type'] == Provider.OPEN_EDX
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
 KeyError: 'provider_type'
```

## Testing instructions
This is a trivial change, so simply check that the tests are passing.