### PR TITLE
fix: exclude 'course_key' field from the django admin form on course_action_state

### DIFF
--- a/common/djangoapps/course_action_state/admin.py
+++ b/common/djangoapps/course_action_state/admin.py
@@ -6,4 +6,16 @@ from django.contrib import admin
 
 from common.djangoapps.course_action_state.models import CourseRerunState
 
-admin.site.register(CourseRerunState)
+
+class CourseRerunStateAdmin(admin.ModelAdmin):
+    """ Django Admin form class for CourseRerunState model """
+    exclude = ["course_key"]
+
+    def get_queryset(self, request):
+        # For any query against this table, remove course_key field
+        # because that field might have bad data in it.
+        qs = CourseRerunState.objects.defer('course_key')
+        return qs
+
+
+admin.site.register(CourseRerunState, CourseRerunStateAdmin)


### PR DESCRIPTION
## Description

With this change, the course_action_state django admin form will not retrieve "course_key" field from the database. This is desired to use the django admin form to delete the erroneous data.

## Context
There is a piece of bad data stored on edx.org stage environment in the database table `course_action_state_coursererunstate`. The course_key value is an invalid opaque key. Because of this bad piece of data, the edX staff view of the edx studio home page fails to load any course runs. We want to use this change on the django admin to bypass the bad course_key value, so we can delete the bad piece of data in the table named above.


## Testing instructions

This change is tested on local machine with erroneous data stored on local mysql database.

