### PR TITLE
fix: always define a student_data_store to prevent errors on XBlock load [FC-0076]

### DIFF
--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -18,7 +18,7 @@ from opaque_keys.edx.keys import UsageKeyV2, LearningContextKey
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchServiceError
-from xblock.field_data import FieldData, SplitFieldData
+from xblock.field_data import DictFieldData, FieldData, SplitFieldData
 from xblock.fields import Scope, ScopeIds
 from xblock.runtime import IdReader, KvsFieldData, MemoryIdManager, Runtime
 
@@ -351,8 +351,10 @@ class XBlockRuntime(RuntimeShim, Runtime):
         Initialize the FieldData implementation for the specified XBlock
         """
         if self.user is None:
-            # No user is specified, so we want to throw an error if anything attempts to read/write user-specific fields
-            student_data_store = None
+            # No user is specified, so we want to ignore any user-specific data. We cannot throw an
+            # error here because the XBlock loading process will write to the user_state if we have
+            # mutable fields.
+            student_data_store = DictFieldData({})
         elif self.user.is_anonymous:
             # This is an anonymous (non-registered) user:
             assert isinstance(self.user_id, str) and self.user_id.startswith("anon")

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1252,7 +1252,7 @@ wheel==0.45.1
     # via django-pipeline
 wrapt==1.17.2
     # via -r requirements/edx/kernel.in
-xblock[django]==5.1.1
+xblock[django]==5.1.2
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2239,7 +2239,7 @@ wrapt==1.17.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblock[django]==5.1.1
+xblock[django]==5.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1573,7 +1573,7 @@ wheel==0.45.1
     #   django-pipeline
 wrapt==1.17.2
     # via -r requirements/edx/base.txt
-xblock[django]==5.1.1
+xblock[django]==5.1.2
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1663,7 +1663,7 @@ wheel==0.45.1
     #   django-pipeline
 wrapt==1.17.2
     # via -r requirements/edx/base.txt
-xblock[django]==5.1.1
+xblock[django]==5.1.2
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock


### PR DESCRIPTION
## Description

This PR adds a `DictFieldData` to the `student_data_store` if the user is not defined.

## Additional Information
More info here: https://github.com/openedx/XBlock/pull/815#discussion_r1940365654

This fixes an error on the meilisearch index update after saving the `Survey` Xblock.

```
cms-1          | 2025-01-28 19:36:18,402 ERROR 2163 [celery_utils.logged_task] [user 4] [ip 172.18.0.1] logged_task.py:48 - [9d7cda4b-afd2-404f-a39c-7a185c486907] failed due to Traceback (most recent call last):
cms-1          |   File "/openedx/venv/lib/python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
cms-1          |     R = retval = fun(*args, **kwargs)
cms-1          |                  ^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/venv/lib/python3.11/site-packages/celery/app/autoretry.py", line 38, in run
cms-1          |     return task._orig_run(*args, **kwargs)
cms-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/monitoring/internal/code_owner/utils.py", line 195, in new_function
cms-1          |     return wrapped_function(*args, **kwargs)
cms-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/tasks.py", line 57, in upsert_library_block_index_doc
cms-1          |     api.upsert_library_block_index_doc(usage_key)
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 639, in upsert_library_block_index_doc
cms-1          |     searchable_doc_for_library_block(library_block_metadata)
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/documents.py", line 381, in searchable_doc_for_library_block
cms-1          |     block = xblock_api.load_block(xblock_metadata.usage_key, user=None)
cms-1          |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/xblock/api.py", line 117, in load_block
cms-1          |     return runtime.get_block(usage_key, version=version)
cms-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py", line 229, in get_block
cms-1          |     block.force_save_fields(block._get_fields_to_save())  # pylint: disable=protected-access
cms-1          |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/mnt/xblock/xblock/core.py", line 531, in force_save_fields
cms-1          |     self._field_data.set_many(self, fields_to_save_json)
cms-1          |   File "/mnt/xblock/xblock/field_data.py", line 164, in set_many
cms-1          |     field_data.set_many(block, new_update_dict)
cms-1          |     ^^^^^^^^^^^^^^^^^^^
cms-1          | AttributeError: 'NoneType' object has no attribute 'set_many'
```

The underlying issue is that the mutable fields are written on XBlock load, even if they are from `user_state` scope, as in the example of the Survey XBlock above:

```
cms-1          | block._get_fields_to_save() ['feedback', 'max_submissions', 'private_results', 'answers', 'block_name', 'choices', 'display_name', 'questions']
```

As the `LearningCoreXBlockRuntime` doesn't had the `Scope.user_state` before, the `get_block` function throws an error.

## Testing instructions
- Edit a `Survey` block on the Library Authoring page and check the error above
- Checkout the current PR and mount it on your tutor stack
- Check that the error is gone and the block document is updated successfully

___
Private ref: [FAL-4033](https://tasks.opencraft.com/browse/FAL-4033)