### PR TITLE
Make copied tags editable again after breaking the upstream link to library content [FC-0076]

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -477,6 +477,16 @@ class ClipboardPasteFromV2LibraryTestCase(ModuleStoreTestCase):
             assert object_tag.value in self.lib_block_tags
             assert object_tag.is_copied
 
+        # If we delete the upstream library block...
+        library_api.delete_library_block(self.lib_block_key)
+
+        # ...the copied tags remain, but should no longer be marked as "copied"
+        object_tags = tagging_api.get_object_tags(new_block_key)
+        assert len(object_tags) == len(self.lib_block_tags)
+        for object_tag in object_tags:
+            assert object_tag.value in self.lib_block_tags
+            assert not object_tag.is_copied
+
     def test_paste_from_library_copies_asset(self):
         """
         Assets from a library component copied into a subdir of Files & Uploads.

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -6,6 +6,13 @@ APIs.
 import ddt
 from opaque_keys.edx.keys import UsageKey
 from rest_framework.test import APIClient
+from openedx_events.content_authoring.signals import (
+    LIBRARY_BLOCK_DELETED,
+    XBLOCK_CREATED,
+    XBLOCK_DELETED,
+    XBLOCK_UPDATED,
+)
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 from openedx_tagging.core.tagging.models import Tag
 from organizations.models import Organization
 from xmodule.modulestore.django import contentstore, modulestore
@@ -393,10 +400,16 @@ class ClipboardPasteTestCase(ModuleStoreTestCase):
         assert source_pic2_hash != dest_pic2_hash  # Because there was a conflict, this file was unchanged.
 
 
-class ClipboardPasteFromV2LibraryTestCase(ModuleStoreTestCase):
+class ClipboardPasteFromV2LibraryTestCase(OpenEdxEventsTestMixin, ModuleStoreTestCase):
     """
     Test Clipboard Paste functionality with a "new" (as of Sumac) library
     """
+    ENABLED_OPENEDX_EVENTS = [
+        LIBRARY_BLOCK_DELETED.event_type,
+        XBLOCK_CREATED.event_type,
+        XBLOCK_DELETED.event_type,
+        XBLOCK_UPDATED.event_type,
+    ]
 
     def setUp(self):
         """

--- a/openedx/core/djangoapps/content_tagging/api.py
+++ b/openedx/core/djangoapps/content_tagging/api.py
@@ -441,3 +441,4 @@ resync_object_tags = oel_tagging.resync_object_tags
 get_object_tags = oel_tagging.get_object_tags
 add_tag_to_taxonomy = oel_tagging.add_tag_to_taxonomy
 copy_tags_as_read_only = oel_tagging.copy_tags
+make_copied_tags_editable = oel_tagging.unmark_copied_tags

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -131,7 +131,7 @@ optimizely-sdk<5.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.18.2
+openedx-learning==0.18.3
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -827,7 +827,7 @@ openedx-filters==1.12.0
     #   ora2
 openedx-forum==0.1.6
     # via -r requirements/edx/kernel.in
-openedx-learning==0.18.2
+openedx-learning==0.18.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1381,7 +1381,7 @@ openedx-forum==0.1.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.18.2
+openedx-learning==0.18.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1000,7 +1000,7 @@ openedx-filters==1.12.0
     #   ora2
 openedx-forum==0.1.6
     # via -r requirements/edx/base.txt
-openedx-learning==0.18.2
+openedx-learning==0.18.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1048,7 +1048,7 @@ openedx-filters==1.12.0
     #   ora2
 openedx-forum==0.1.6
     # via -r requirements/edx/base.txt
-openedx-learning==0.18.2
+openedx-learning==0.18.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

When deleting an upstream library block, ensure that any tags that may have been copied to downstream blocks are made editable again. This is achieved by un-setting the `is_copied` flag on the downstream tags.

This change affects Content Authors using linked library content.

## Supporting information

Part of: https://github.com/openedx/modular-learning/issues/244
Based on: https://github.com/openedx/edx-platform/pull/36111 -- [compare changes](https://github.com/open-craft/edx-platform/compare/navin/fal-4004/link-table...jill/fal-4008-edit-tags-broken-link)
Depends on: https://github.com/openedx/openedx-learning/pull/276
Private-ref: [FAL-4008](https://tasks.opencraft.com/browse/FAL-4008)

## Testing instructions

Note: There's a bug in the Authoring MFE's Course Unit page that prevents the tag drawer from opening. So ensure you have disabled the `contentstore.new_studio_mfe.use_new_unit_page` waffle flag to use the legacy Studio unit interface during testing.

0. Run migrations to add new link tables.
1. Create a block in a content library, and add some tags to it.
2. Publish the block.
3. Copy the library block into a course, either using the staged content copy/paste, or by adding a Library Content block, and selecting your published block.
   Should see the tags copied from the library block on the new course block, and they should not be deleteable.
4. Add some more tags to the new course block.
   These tags should be deletable.
5. Go back to your content library block, and delete it.
6. Return to the course block, and re-open the "manage tags" sidebar.
   All the tags should remain, and all are deletable now.

## Deadline

None