### PR TITLE
fix: styling fix for course optimizer legacy tool link

### DIFF
--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -388,8 +388,7 @@ body.course.view-export-git .nav-course-tools-export-git,
 body.course.view-team .nav-library-settings .title,
 body.course.view-team .nav-library-settings-team,
 body.course.view-checklists .nav-course-tools .title,
-body.course.view-checklists .nav-course-tools-checklists,
-.nav-course-tools-optimizer {
+body.course.view-checklists .nav-course-tools-checklists {
   color: theme-color("primary");
 
   a {

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -244,7 +244,7 @@
                   </li>
                   % endif
                   % if export_mfe_enabled:
-                  <li class="nav-item nav-course-tools-import">
+                  <li class="nav-item nav-course-tools-export">
                     <a href="${get_export_url(course_key)}">${_("Export")}</a>
                   </li>
                   % endif
@@ -257,7 +257,7 @@
                     <a href="${checklists_url}">${_("Checklists")}</a>
                   </li>
                   % if optimizer_enabled:
-                  <li class="nav-item nav-course-tools-optimizer">
+                  <li class="nav-item">
                     <a href="${get_optimizer_url(course_key)}">${_("Optimize Course")}</a>
                   </li>
                   % endif


### PR DESCRIPTION
### Description

Fixing styling issue with course optimizer link in studio dashboard.

A rule was added that disabled the course optimizer link in the legacy experience in tools dropdown, that rule has now been removed as part of this PR.


There is also another fix here, where the incorrect class was applied to the export nav item in the tools drop down.

`nav-course-tools-import` -> `nav-course-tools-export`