### PR TITLE
[backport] fix: static assets used in problem bank and library content block

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -4,6 +4,7 @@ Unit tests for /api/contentstore/v2/downstreams/* JSON APIs.
 from unittest.mock import patch
 from django.conf import settings
 
+from cms.djangoapps.contentstore.helpers import StaticFileNotices
 from cms.lib.xblock.upstream_sync import UpstreamLink, BadUpstream
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
@@ -247,7 +248,8 @@ class PostDownstreamSyncViewTest(_DownstreamSyncViewTestMixin, SharedModuleStore
 
     @patch.object(UpstreamLink, "get_for_block", _get_upstream_link_good_and_syncable)
     @patch.object(downstreams_views, "sync_from_upstream")
-    def test_200(self, mock_sync_from_upstream):
+    @patch.object(downstreams_views, "import_static_assets_for_library_sync", return_value=StaticFileNotices())
+    def test_200(self, mock_sync_from_upstream, mock_import_staged_content):
         """
         Does the happy path work?
         """
@@ -255,6 +257,7 @@ class PostDownstreamSyncViewTest(_DownstreamSyncViewTestMixin, SharedModuleStore
         response = self.call_api(self.downstream_video_key)
         assert response.status_code == 200
         assert mock_sync_from_upstream.call_count == 1
+        assert mock_import_staged_content.call_count == 1
 
 
 class DeleteDownstreamSyncViewtest(_DownstreamSyncViewTestMixin, SharedModuleStoreTestCase):

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -80,6 +80,7 @@ from .xblock_helpers import usage_key_with_run
 from ..helpers import (
     get_parent_xblock,
     import_staged_content_from_user_clipboard,
+    import_static_assets_for_library_sync,
     is_unit,
     xblock_embed_lms_url,
     xblock_lms_url,
@@ -598,7 +599,7 @@ def _create_block(request):
         try:
             # Set `created_block.upstream` and then sync this with the upstream (library) version.
             created_block.upstream = upstream_ref
-            sync_from_upstream(downstream=created_block, user=request.user)
+            lib_block = sync_from_upstream(downstream=created_block, user=request.user)
         except BadUpstream as exc:
             _delete_item(created_block.location, request.user)
             log.exception(
@@ -606,8 +607,10 @@ def _create_block(request):
                 f"using provided library_content_key='{upstream_ref}'"
             )
             return JsonResponse({"error": str(exc)}, status=400)
+        static_file_notices = import_static_assets_for_library_sync(created_block, lib_block, request)
         modulestore().update_item(created_block, request.user.id)
-        response['upstreamRef'] = upstream_ref
+        response["upstreamRef"] = upstream_ref
+        response["static_file_notices"] = asdict(static_file_notices)
 
     return JsonResponse(response)
 

--- a/cms/lib/xblock/upstream_sync.py
+++ b/cms/lib/xblock/upstream_sync.py
@@ -186,7 +186,7 @@ class UpstreamLink:
         )
 
 
-def sync_from_upstream(downstream: XBlock, user: User) -> None:
+def sync_from_upstream(downstream: XBlock, user: User) -> XBlock:
     """
     Update `downstream` with content+settings from the latest available version of its linked upstream content.
 
@@ -200,6 +200,7 @@ def sync_from_upstream(downstream: XBlock, user: User) -> None:
     _update_non_customizable_fields(upstream=upstream, downstream=downstream)
     _update_tags(upstream=upstream, downstream=downstream)
     downstream.upstream_version = link.version_available
+    return upstream
 
 
 def fetch_customizable_fields(*, downstream: XBlock, user: User, upstream: XBlock | None = None) -> None:

--- a/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_static_assets.py
@@ -63,6 +63,13 @@ class ContentLibrariesStaticAssetsTest(ContentLibrariesRestApiTest):
         file_name = "a////////b"
         self._set_library_block_asset(block_id, file_name, SVG_DATA, expect_response=400)
 
+        # Names with spaces are allowed but replaced with underscores
+        file_name_with_space = "o w o.svg"
+        self._set_library_block_asset(block_id, file_name_with_space, SVG_DATA)
+        file_name = "o_w_o.svg"
+        assert self._get_library_block_asset(block_id, file_name)['path'] == file_name
+        assert self._get_library_block_asset(block_id, file_name)['size'] == file_size
+
     def test_video_transcripts(self):
         """
         Test that video blocks can read transcript files out of learning core.

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -788,6 +788,7 @@ class LibraryBlockAssetView(APIView):
         """
         Replace a static asset file belonging to this block.
         """
+        file_path = file_path.replace(" ", "_")  # Messes up url/name correspondence due to URL encoding.
         usage_key = LibraryUsageLocatorV2.from_string(usage_key_str)
         api.require_permission_for_library_key(
             usage_key.lib_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,

--- a/openedx/core/djangoapps/content_staging/data.py
+++ b/openedx/core/djangoapps/content_staging/data.py
@@ -25,6 +25,10 @@ class StagedContentStatus(TextChoices):
 
 # Value of the "purpose" field on StagedContent objects used for clipboards.
 CLIPBOARD_PURPOSE = "clipboard"
+
+# Value of the "purpose" field on StagedContent objects used for library to course sync.
+LIBRARY_SYNC_PURPOSE = "library_sync"
+
 # There may be other valid values of "purpose" which aren't defined within this app.
 
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description
(backport of the following PR https://github.com/openedx/edx-platform/pull/36173)

Handles static asset sync when creating or refreshing library content and problem bank components to a unit.

This is done through refactoring the logic already in place in the staged content app which implemented generic logic for the clipboard feature.

Also backports the following related fix https://github.com/openedx/edx-platform/pull/35974

## Supporting information

- Fixes: https://github.com/openedx/modular-learning/issues/246

## Testing instructions

1. create a text library component
2. upload an image either in the advanced tab or directly in the text editor
3. if uploaded in the advanced tab, add it to the component html
4. Publish the component
5. Now in the cms add a new library v2 component referencing the text component above.
6. Assert it renders the image.
![image](https://github.com/user-attachments/assets/0d8f966c-dd6d-464b-bb3e-0b319278ee8b)

7. Repeat the steps above with the problem bank component

![image](https://github.com/user-attachments/assets/853bd80b-e299-4796-add9-9c9d4c2c8fca)


## Deadline

ASAP

## Other information

- Private-Ref: [FAL-4027](https://tasks.opencraft.com/browse/FAL-4027)
