### PR TITLE
APER-3884: make sure links point to MFE not legacy

### DIFF
--- a/openedx/core/djangoapps/password_policy/compliance.py
+++ b/openedx/core/djangoapps/password_policy/compliance.py
@@ -97,7 +97,7 @@ def enforce_compliance_on_login(user, password):
                 platform_name=settings.PLATFORM_NAME,
                 deadline=strftime_localized(deadline, DEFAULT_SHORT_DATE_FORMAT),
                 anchor_tag_open=HTML('<a href="{account_settings_url}">').format(
-                    account_settings_url=settings.LMS_ROOT_URL + "/account/settings"
+                    account_settings_url=settings.ACCOUNT_MICROFRONTEND_URL
                 ),
                 anchor_tag_close=HTML('</a>')
             )


### PR DESCRIPTION
## Description

now that the legacy profile and account pages have been removed, we need to make sure that all of the links point to the MFE URLs; we were relying on the legacy applications to do redirection before.

FIXES: APER-3884
FIXES: openedx/public-engineering#71

