### PR TITLE
fix: return items in _get_render_metadata without validate prereq_met

### DIFF
--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -557,10 +557,8 @@ class SequenceBlock(
                 'This section is a prerequisite. You must complete this section in order to unlock additional content.'
             )
 
-        blocks = self._render_student_view_for_blocks(context, children, fragment, view) if prereq_met else []
-
         params = {
-            'items': blocks,
+            'items': self._render_student_view_for_blocks(context, children, fragment, view),
             'element_id': self.location.html_id(),
             'item_id': str(self.location),
             'is_time_limited': self.is_time_limited,


### PR DESCRIPTION
## Description

This PR finds a solution to the problem reported in https://github.com/openedx/frontend-app-learning/issues/1546
The endpoint `{{domain}}/api/courseware/sequence/{{sequenceId}}` was not returning the units (items) when the section (sequence) had a prerequisite.

Before:
[391659904-65c09750-21c9-47d2-b4db-ad37ee1c0ac3.webm](https://github.com/user-attachments/assets/1417cb6c-db3a-41cd-8e3a-81f271a00749)

After:
https://github.com/user-attachments/assets/c0864e2d-2ab0-4aa0-bbac-c94f31c35ba5


## Supporting information

https://github.com/openedx/frontend-app-learning/issues/1546

## Testing instructions

1. Configuring a subsection as a prerequisite
2. Making that subsection the prerequisite of another subsection
3. Go to the prerequisite subsection and navigate to the gated subsection
4. If I try to go to the previous unit right before the gated subsection, the sequence buttons works
5. If from the sidebar I try entering one of the units in the gated subsection, and the previous button works
