### PR TITLE
[TNL-11731] fix: studio edx.org-next theme

### DIFF
--- a/cms/static/sass/studio-main-v1.scss
+++ b/cms/static/sass/studio-main-v1.scss
@@ -16,7 +16,7 @@
 // +Libs and Resets - *do not edit*
 // ====================
 
-@import '_builtin-block-variables';
 @import 'bourbon/bourbon'; // lib - bourbon
 @import 'vendor/bi-app/bi-app-ltr'; // set the layout for left to right languages
 @import 'build-v1'; // shared app style assets/rendering
+@import '_builtin-block-variables';


### PR DESCRIPTION
Attaching jira ticket for reference: [TNL-11731](https://2u-internal.atlassian.net/browse/TNL-11731)

- compile_sass script was generating the `studio-main-v1.scss` file but it wasn't correct and wasn't picking the changes from paragon. As a result, `edx.org-next` theme wasn't being applied to the studio. And the reason was this [line](https://github.com/openedx/edx-platform/pull/35233/files#:~:text=//%20%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D-,%40import%20%27_builtin%2Dblock%2Dvariables%27%3B,-%40import%20%27bourbon).
- This PR fixes the studio theme as I have rearranged `studio-main-v1.scss` file so that theme changes can be applied correctly.

**BEFORE:**
<img width="1792" alt="Screenshot 2025-02-12 at 10 52 59 AM" src="https://github.com/user-attachments/assets/8051a04d-f521-4d81-85f7-b96252ba876e" />

**AFTER:**
<img width="1792" alt="Screenshot 2025-02-12 at 11 01 09 AM" src="https://github.com/user-attachments/assets/487379cc-47a1-49d3-a9ed-35d9017b818e" />

