### PR TITLE
Allow tests for Extracted & Builtin Annotatable XBlock

### DIFF
--- a/xmodule/annotatable_block.py
+++ b/xmodule/annotatable_block.py
@@ -202,8 +202,17 @@ class _BuiltInAnnotatableBlock(
         return fragment
 
 
-AnnotatableBlock = (
-    _ExtractedAnnotatableBlock if settings.USE_EXTRACTED_ANNOTATABLE_BLOCK
-    else _BuiltInAnnotatableBlock
-)
+AnnotatableBlock = None
+
+
+def reset_class():
+    """Reset class as per django settings flag"""
+    global AnnotatableBlock
+    AnnotatableBlock = (
+        _ExtractedAnnotatableBlock if settings.USE_EXTRACTED_ANNOTATABLE_BLOCK else _BuiltInAnnotatableBlock
+    )
+    return AnnotatableBlock
+
+
+reset_class()
 AnnotatableBlock.__name__ = "AnnotatableBlock"


### PR DESCRIPTION
Test Annotatable XBlock in both built-in and extracted modes to keep them in sync.

Related to: https://github.com/openedx/edx-platform/issues/34841