### PR TITLE
fix: ensure unsubscribe event captures user context for logged-out users

### DIFF
--- a/openedx/core/djangoapps/notifications/events.py
+++ b/openedx/core/djangoapps/notifications/events.py
@@ -162,10 +162,13 @@ def notification_preference_unsubscribe_event(user):
     """
     Emits an event when user clicks on one-click-unsubscribe url
     """
-    event_data = {
+    context_data = {
         'user_id': user.id,
-        'username': user.username,
-        'event_type': 'email_digest_unsubscribe'
+        'username': user.username
     }
-    tracker.emit(NOTIFICATION_PREFERENCE_UNSUBSCRIBE, event_data)
+    event_data = context_data.copy()
+    event_data['event_type'] = 'email_digest_unsubscribe'
+
+    with tracker.get_tracker().context(NOTIFICATION_PREFERENCE_UNSUBSCRIBE, context_data):
+        tracker.emit(NOTIFICATION_PREFERENCE_UNSUBSCRIBE, event_data)
     segment.track(user.id, NOTIFICATION_PREFERENCE_UNSUBSCRIBE, event_data)


### PR DESCRIPTION
<!--

-->

## Description

When a user unsubscribed from email digests using a browser where they were not logged in, the event tracker (tracker.emit) did not store the user context. As a result, the user_id and username fields were recorded as NULL in the tracking_events_with_metadata table.

This PR fixes the issue by ensuring that, even if the user is not logged in, the event captures and stores the user context from the unsubscribe request. The event payload now always includes user_id and username, preventing data inconsistencies in tracking.


## Related ticket
https://2u-internal.atlassian.net/browse/INF-1790

## Testing instructions

1. Click on the unsubscribe link for email digests.
2. In a browser where the user is not logged in, confirm the unsubscription.
3. In Snowflake, verify that the recorded event includes the correct username and user_id.
