### PR TITLE
Make computation of due date for edx-proctoring powered exams consistent.

### DIFF
--- a/cms/djangoapps/contentstore/exams.py
+++ b/cms/djangoapps/contentstore/exams.py
@@ -71,7 +71,16 @@ def register_exams(course_key):
             timed_exam.is_onboarding_exam
         )
 
-        due_date = timed_exam.due.isoformat() if timed_exam.due else (course.end.isoformat() if course.end else None)
+        # Exams in courses not using an LTI based proctoring provider should use the original definition of due_date
+        # from contentstore/proctoring.py. These exams are powered by the edx-proctoring plugin and not the edx-exams
+        # microservice.
+        if course.proctoring_provider == 'lti_external':
+            due_date = (
+                timed_exam.due.isoformat() if timed_exam.due
+                else (course.end.isoformat() if course.end else None)
+            )
+        else:
+            due_date = timed_exam.due if not course.self_paced else None
 
         exams_list.append({
             'course_id': str(course_key),


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This commit fixes an inconsistency in the way an exam due date is computed for courses that do not use an LTI based proctoring provider.

The `edx-exams` microservice was released last year to provide support for LTI based proctoring providers. After the release of this microservice, all proctoring requests initiated by the platform began to be funneled through the microservice, which acted as a broker for these requests, routing them directly to the service for exams in courses using an LTI based proctoring provider or to the platform `edx-proctoring` plugin for all other cases.

There is an asynchronous task in the platform that syncs exams from the platform to either the `edx-exams` microservice or the `edx-proctoring` plugin. Prior to the release of the microservice, this task computed the due date on exams as the exam subsection due date if the course was instructor-paced or None. After the release of the microservice, the task computed due dates differently than before. The due date on exams was computed as the due date on the exam, if there was one, or the end date of the course, if there was one, or `None`. This differed from the prior definition.

This resulted in inconsistent due date behavior. The exams in courses that were published or republished after the `edx-exams microservice` was released had the new computation of due date, while exams in courses that were published or republished before the `edx-exams` microservice was released had the old computation of due date.

This causes an issue for all exams in courses using non-LTI based providers. This is because the due date on exams across all courses that either do not use proctoring or that use a non-LTI based provider are inconsistent, depending on when they were last published.

This commit reintroduces the old computation to the task for exams in courses using a non-LTI based proctoring provider (i.e. those courses whose exams are not powered by the `edx-exams` microservice). In order to maintain the functionality of `edx-exams`, we continue to compute the due date as before for exams in courses using an LTI based proctoring provider (i.e. those courses whose exams are powered by the `edx-exams` microservice).

## Supporting information

* Jira: [COSMO-605](https://2u-internal.atlassian.net/browse/COSMO-605) (private)

## Testing instructions

* Set up the [edx-exams microservice](https://github.com/edx/edx-exams) using your preferred development environment.
* Create a course in Studio using your preferred method.
* Set up the special exam/proctored exam feature in your course.
* Create a proctored exam with a due date.
* Using the Proctoring Settings page, linked to from the Studio course outline, set the proctoring provider to "lti_external" or "null".
* Publish the course and observe that the due dates saved in the `edx-proctoring` tables or the `edx-exams` tables conforms to the rule in the code.
  * You may want to test this with different pacing types as well.

## Deadline

None.