### PR TITLE
fix: fixed escaped characters in goal reminder email

### DIFF
--- a/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.html
+++ b/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.html
@@ -51,11 +51,13 @@
                 <tr>
                 <p style="color: rgba(0,0,0,.75); font-size: 16px; font-size: 1rem; margin: 0; padding-top: 20px; padding-bottom: 14px">
                     {% filter force_escape %}
-                        {% blocktrans count count=days_per_week asvar goal_text %}
-                            You set a goal of learning {start_bold}{{days_per_week}} time a week in {{course_name}}{end_bold}. You’re not quite there, but there's still time to reach that goal!
-                            {% plural %}
-                            You set a goal of learning {start_bold}{{days_per_week}} times a week in {{course_name}}{end_bold}. You're not quite there, but there's still time to reach that goal!
-                        {% endblocktrans %}
+                        {% autoescape off %}
+                            {% blocktrans count count=days_per_week asvar goal_text %}
+                                You set a goal of learning {start_bold}{{days_per_week}} time a week in {{course_name}}{end_bold}. You’re not quite there, but there's still time to reach that goal!
+                                {% plural %}
+                                You set a goal of learning {start_bold}{{days_per_week}} times a week in {{course_name}}{end_bold}. You're not quite there, but there's still time to reach that goal!
+                            {% endblocktrans %}
+                        {% endautoescape %}
                     {% endfilter %}
                     {% interpolate_html goal_text start_bold='<b>'|safe end_bold='</b>'|safe %}
                  </p>
@@ -107,7 +109,7 @@
                         {% filter force_escape %}{% blocktrans %}
                             Adjust my goal
                         {% endblocktrans %}{% endfilter %}
-                    </div>                
+                    </div>
                 </a>
 
                 <center>

--- a/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.txt
+++ b/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.txt
@@ -1,7 +1,9 @@
 {% load i18n %}
 {% trans "You're almost there!" %}
 {% trans "There's still time to reach your goal" as tmsg %}
+{% autoescape off %}
 {% blocktrans %}You set a goal of learning {{days_per_week}} times a week in {{course_name}}. You're not quite there, but there's still time to reach that goal!{% endblocktrans %}
+{% endautoescape %}
 {% trans "Jump back in"}
 {{course_url}}
 {% blocktrans %}Remember, you can always change your learning goal. The best goal is one that you can stick to.  {% endblocktrans %}


### PR DESCRIPTION
Ticket: [INF-1767](https://2u-internal.atlassian.net/browse/INF-1767)

Fixed escaped characters in goal reminder email template. 

### Before:
<img width="744" alt="Screenshot 2025-02-15 at 1 37 58 AM" src="https://github.com/user-attachments/assets/78e512a9-0e15-4779-9eaf-0c3340063ddd" />

### After:
<img width="744" alt="Screenshot 2025-02-15 at 1 38 02 AM" src="https://github.com/user-attachments/assets/51c56714-1c9f-4d7b-a9b3-bfbb6c9cdeef" />
