### PR TITLE
feat: Only display Preview Language Setting (dark_lang) in LMS

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -9,6 +9,7 @@ from django.urls import include
 from django.urls import path, re_path
 from django.utils.translation import gettext_lazy as _
 from django.contrib import admin
+from django.shortcuts import redirect
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from auth_backends.urls import oauth2_urlpatterns
 from edx_api_doc_tools import make_docs_urls
@@ -87,7 +88,7 @@ urlpatterns = oauth2_urlpatterns + [
          ),
 
     # Darklang View to change the preview language (or dark language)
-    path('update_lang/', include('openedx.core.djangoapps.dark_lang.urls', namespace='dark_lang')),
+    path('update_lang/', lambda request: redirect(f'{settings.LMS_ROOT_URL}/update_lang/')),
 
     # For redirecting to help pages.
     path('help_token/', include('help_tokens.urls')),

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -251,6 +251,9 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         """
         Sends a post request to set the preview language
         """
+        # @@TODO make this call set_user_preference,
+        # and then have a small separate LMS-only test class just to call the
+        # POST and ensure it sets the user preference.
         return self.client.post('/update_lang/', {'preview_language': preview_language, 'action': 'set_preview_language'})  # lint-amnesty, pylint: disable=line-too-long
 
     def _post_clear_preview_lang(self):


### PR DESCRIPTION
## Description

We disable the Studio Preview Language Setting Page, and redirect it to the identical LMS Preview Language Setting page. This is one of the final bits of the legacy Studio frontend. By making it render only in LMS, we unblock the [full retirement of the legacy Studio frontend](https://github.com/openedx/edx-platform/issues/31620).

## Supporting info

### Before

There were two views allowing to staff to choose to preview a "dark" language, both of which are completely identical in functionality. The only difference is the header, footer, and styling surrounding them.

#### 1. Studio Context (`<CMS_ROOT_URL>/update_lang`)

![image](https://github.com/user-attachments/assets/cfb2e61e-a483-4478-a523-14764d7c1d04)

#### 2. LMS Context (`<LMS_ROOT_URL>/update_lang`)

![image](https://github.com/user-attachments/assets/fb646f97-68bb-46d1-85e1-3f36792f8639)

### After

The Studio URL (1) will simply redirect to the LMS URL (2). In other words, the Preview Language Setting page will only render in an LMS context.

This has no impact on end-user functionality. It has only a very minor UX end-user impact (LMS header+footer rather than Studio header+footer). The LMS styling seems to be better, anyway.

## Test instructions

* Navigate to `<CMS_BASE>/update_lang`
* Log in as global staff
* You should be redirected to `<LMS_BASE>/update_lang`.
* Enter a language code (e.g., `es`)
* Confirm that both Studio and LMS appear in that language.

## Other information

The actual affect of this simple page is to set a UserPreference item with the key `dark-lang`, allowing staff to see what their Open edX looks like in a language which is not (yet) available to users in general. Assuming that this is a useful feature, we will need to reimplement the page in an MFE eventually. My thought is that the Account Settings page in frontend-app-account is the correct destination for this if and when it is written. If it is not rewritten, we will need to DEPR it.