### PR TITLE
feat: Add hide_after_due field in blocks api

### DIFF
--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
+from lms.djangoapps.course_blocks.transformers.hidden_content import HiddenContentTransformer
 from lms.djangoapps.course_blocks.transformers.visibility import VisibilityTransformer
 from openedx.core.djangoapps.discussions.transformers import DiscussionsTopicLinkTransformer
 
@@ -81,6 +82,13 @@ SUPPORTED_FIELDS = [
         VisibilityTransformer,
         requested_field_name='visible_to_staff_only',
     ),
+
+    SupportedFieldType(
+        'merged_hide_after_due',
+        HiddenContentTransformer,
+        requested_field_name='hide_after_due'
+    ),
+
     SupportedFieldType(BlockCompletionTransformer.COMPLETION, BlockCompletionTransformer),
     SupportedFieldType(BlockCompletionTransformer.COMPLETE),
     SupportedFieldType(BlockCompletionTransformer.RESUME_BLOCK),

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -84,6 +84,7 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
             'student_view_multi_device',
             'lti_url',
             'visible_to_staff_only',
+            'hide_after_due'
         ])
 
     def assert_extended_block(self, serialized_block):
@@ -100,7 +101,8 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
             'graded',
             'student_view_multi_device',
             'lti_url',
-            'visible_to_staff_only'
+            'visible_to_staff_only',
+            'hide_after_due'
         } <= set(serialized_block.keys())
 
         # video blocks should have student_view_data


### PR DESCRIPTION

## Description

This PR adds hide_after_due field to blocks api. Api consumer can add hide_after_due in requested fields to get this flag. On mobile we need this flag to make decision whether to show this subsection or not.

Useful information to include:

This change will effect all services consuming blocks api.

## Deadline

ASAP.
