### PR TITLE
[sumac] fix: allow_to_create_new_org checks org autocreate [FC-0076]

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/home.py
@@ -50,6 +50,10 @@ class StudioHomeSerializer(serializers.Serializer):
         child=serializers.CharField(),
         allow_empty=True
     )
+    allowed_organizations_for_libraries = serializers.ListSerializer(
+        child=serializers.CharField(),
+        allow_empty=True
+    )
     archived_courses = CourseCommonSerializer(required=False, many=True)
     can_access_advanced_settings = serializers.BooleanField()
     can_create_organizations = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
@@ -37,9 +37,10 @@ class HomePageViewTest(CourseTestCase):
         self.url = reverse("cms.djangoapps.contentstore:v1:home")
         self.expected_response = {
             "allow_course_reruns": True,
-            "allow_to_create_new_org": False,
+            "allow_to_create_new_org": True,
             "allow_unicode_course_id": False,
             "allowed_organizations": [],
+            "allowed_organizations_for_libraries": [],
             "archived_courses": [],
             "can_access_advanced_settings": True,
             "can_create_organizations": True,
@@ -80,6 +81,17 @@ class HomePageViewTest(CourseTestCase):
 
         expected_response = self.expected_response
         expected_response["libraries_v2_enabled"] = True
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(expected_response, response.data)
+
+    @override_settings(ORGANIZATIONS_AUTOCREATE=False)
+    def test_home_page_studio_with_org_autocreate_disabled(self):
+        """Check response content when Organization autocreate is disabled"""
+        response = self.client.get(self.url)
+
+        expected_response = self.expected_response
+        expected_response["allow_to_create_new_org"] = False
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(expected_response, response.data)

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -99,6 +99,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
+from cms.djangoapps.contentstore.views.course import (
+    get_allowed_organizations_for_libraries,
+    user_can_create_organizations,
+)
 from openedx.core.djangoapps.content_libraries import api, permissions
 from openedx.core.djangoapps.content_libraries.serializers import (
     ContentLibraryBlockImportTaskCreateSerializer,
@@ -270,6 +274,14 @@ class LibraryRootView(GenericAPIView):
         except InvalidOrganizationException:
             raise ValidationError(  # lint-amnesty, pylint: disable=raise-missing-from
                 detail={"org": f"No such organization '{org_name}' found."}
+            )
+        # Ensure the user is allowed to create libraries under this org
+        if not (
+            user_can_create_organizations(request.user) or
+            org_name in get_allowed_organizations_for_libraries(request.user)
+        ):
+            raise ValidationError(  # lint-amnesty, pylint: disable=raise-missing-from
+                detail={"org": f"User not allowed to create libraries in '{org_name}'."}
             )
         org = Organization.objects.get(short_name=org_name)
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Backports https://github.com/openedx/edx-platform/pull/36094 to support this bugfix: https://github.com/openedx/frontend-app-authoring/pull/1678

## Supporting information

Part of: https://github.com/openedx/frontend-app-authoring/issues/1577
Private ref: [FAL-4089](https://tasks.opencraft.com/browse/FAL-4089)

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/1678

## Deadline

None
