### PR TITLE
fix: Remove duplicate imports of js files in instructor dashboard pages

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -61,7 +61,6 @@ from openedx.core.djangolib.js_utils import (
   <%static:webpack entry='HtmlBlockEditor'/>
   <link rel="stylesheet" href="${static.url('css/HtmlBlockEditor.css')}">
   <%static:js group='instructor_dash'/>
-  <%static:js group='application'/>
 
   ## Backbone classes declared explicitly until RequireJS is supported
   <script type="text/javascript" src="${static.url('js/models/notification.js')}"></script>


### PR DESCRIPTION
I was working on enabling the dark theme in the Instructor Dashboard using Tutor Indigo, which adds the dark theme file to the **application** JavaScript pipeline. However, the dark theme toggle wasn’t working, no matter how many times I clicked it. After digging into the issue, I found that the event listener for the theme toggle was being added twice, causing it to do nothing.

The reason for this double event listener was that the Instructor Dashboard was importing the **application** JavaScript pipeline twice. Here’s how it happened: The Instructor Dashboard inherits from main.html, which includes the **application** pipeline. On top of that, the Instructor Dashboard itself explicitly imports the **application** pipeline again. This led to every JavaScript file in the **application** pipeline, including the dark theme file, being loaded twice.

To fix this, I removed the redundant import of the **application** pipeline from the Instructor Dashboard. Now, the **application** pipeline is loaded only once, ensuring that event listeners are registered correctly. This change fixed the dark theme toggle issue and prevents similar problems from happening in the future.