### PR TITLE
feat: remove `CONTENT_GROUPS_FOR_TEAMS` waffle flag

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1753,49 +1753,9 @@ class CourseMetadataEditingTest(CourseTestCase):
         self.request.user = self.user
         set_current_request(self.request)
 
-    def test_team_content_groups_off(self):
+    def test_team_content_groups(self):
         """
-        Tests that user_partition_id is not added to the model when content groups for teams are off.
-        """
-        course = CourseFactory.create(
-            teams_configuration=TeamsConfig({
-                'max_team_size': 2,
-                'team_sets': [{
-                    'id': 'arbitrary-topic-id',
-                    'name': 'arbitrary-topic-name',
-                    'description': 'arbitrary-topic-desc'
-                }]
-            })
-        )
-        settings_dict = {
-            "teams_configuration": {
-                "value": {
-                    "max_team_size": 2,
-                    "team_sets": [
-                        {
-                            "id": "topic_3_id",
-                            "name": "Topic 3 Name",
-                            "description": "Topic 3 desc"
-                        },
-                    ]
-                }
-            }
-        }
-
-        _, errors, updated_data = CourseMetadata.validate_and_update_from_json(
-            course,
-            settings_dict,
-            user=self.user
-        )
-
-        self.assertEqual(len(errors), 0)
-        for team_set in updated_data["teams_configuration"]["value"]["team_sets"]:
-            self.assertNotIn("user_partition_id", team_set)
-
-    @patch("cms.djangoapps.models.settings.course_metadata.CONTENT_GROUPS_FOR_TEAMS.is_enabled", lambda _: True)
-    def test_team_content_groups_on(self):
-        """
-        Tests that user_partition_id is added to the model when content groups for teams are on.
+        Tests that user_partition_id is added to the model.
         """
         course = CourseFactory.create(
             teams_configuration=TeamsConfig({

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -98,7 +98,7 @@ from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.xblock.api import get_component_from_usage_key
 from openedx.core.lib.courses import course_image_url
 from openedx.core.lib.html_to_text import html_to_text
-from openedx.core.lib.teams_config import CONTENT_GROUPS_FOR_TEAMS, TEAM_SCHEME
+from openedx.core.lib.teams_config import TEAM_SCHEME
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
@@ -2196,9 +2196,7 @@ def get_group_configurations_context(course, store):
             if should_show_enrollment_track:
                 displayable_partitions.insert(0, partition)
         elif partition['scheme'] == TEAM_SCHEME:
-            should_show_team_partitions = len(partition['groups']) > 0 and CONTENT_GROUPS_FOR_TEAMS.is_enabled(
-                course_key
-            )
+            should_show_team_partitions = len(partition['groups']) > 0
             if should_show_team_partitions:
                 displayable_partitions.append(partition)
         elif partition['scheme'] != RANDOM_SCHEME:

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -17,7 +17,7 @@ from common.djangoapps.util.db import MYSQL_MAX_INT, generate_int_id
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
 from openedx.core.djangoapps.course_apps.toggles import exams_ida_enabled
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
-from openedx.core.lib.teams_config import CONTENT_GROUPS_FOR_TEAMS, TeamsConfig, TeamsetType
+from openedx.core.lib.teams_config import TeamsConfig, TeamsetType
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from xmodule.course_block import get_available_providers  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -316,9 +316,6 @@ class CourseMetadata:
         This is used by the Dynamic Team Partition Generator to create the dynamic user partitions
         based on the team-sets defined in the course.
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(block.id):
-            return teams_config
-
         for team_set in teams_config.teamsets:
             if not team_set.user_partition_id:
                 team_set.user_partition_id = cls.get_user_partition_id(

--- a/lms/djangoapps/teams/team_partition_scheme.py
+++ b/lms/djangoapps/teams/team_partition_scheme.py
@@ -12,7 +12,6 @@ from lms.djangoapps.courseware.masquerade import (
 )
 from lms.djangoapps.teams.api import get_teams_in_teamset
 from lms.djangoapps.teams.models import CourseTeamMembership
-from openedx.core.lib.teams_config import CONTENT_GROUPS_FOR_TEAMS
 
 from xmodule.partitions.partitions import (  # lint-amnesty, pylint: disable=wrong-import-order
     Group,
@@ -37,8 +36,6 @@ class TeamUserPartition(UserPartition):
             list of Group: The groups in this partition.
         """
         course_key = CourseKey.from_string(self.parameters["course_id"])
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
-            return []
 
         # Get the team-set for this partition via the partition parameters and then get the teams in that team-set
         # to create the groups for this partition.
@@ -53,8 +50,6 @@ class TeamUserPartition(UserPartition):
 
 class TeamPartitionScheme:
     """Uses course team memberships to map learners into partition groups.
-
-    The scheme is only available if the CONTENT_GROUPS_FOR_TEAMS feature flag is enabled.
 
     This is how it works:
     - A user partition is created for each team-set in the course with a unused partition ID generated in runtime
@@ -81,9 +76,6 @@ class TeamPartitionScheme:
         Returns:
             Group: The group in the specified user partition
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
-            return None
-
         # First, check if we have to deal with masquerading.
         # If the current user is masquerading as a specific student, use the
         # same logic as normal to return that student's group. If the current
@@ -127,10 +119,6 @@ class TeamPartitionScheme:
         Returns:
             TeamUserPartition: The user partition.
         """
-        course_key = CourseKey.from_string(parameters["course_id"])
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
-            return None
-
         # Team-set used to create partition was created before this feature was
         # introduced.  In that case, we need to create a new partition with a
         # new team-set id.

--- a/lms/djangoapps/teams/tests/test_partition_scheme.py
+++ b/lms/djangoapps/teams/tests/test_partition_scheme.py
@@ -15,10 +15,6 @@ from xmodule.modulestore.django import modulestore
 from xmodule.partitions.partitions import Group
 
 
-@patch(
-    "lms.djangoapps.teams.team_partition_scheme.CONTENT_GROUPS_FOR_TEAMS.is_enabled",
-    lambda _: True
-)
 class TestTeamPartitionScheme(ModuleStoreTestCase):
     """
     Test the TeamPartitionScheme partition scheme and its related functions.

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/team_partition_groups.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/team_partition_groups.py
@@ -9,7 +9,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from openedx.core import types
 from openedx.core.djangoapps.content.learning_sequences.api.processors.base import OutlineProcessor
-from openedx.core.lib.teams_config import create_team_set_partitions_with_course_id, CONTENT_GROUPS_FOR_TEAMS
+from openedx.core.lib.teams_config import create_team_set_partitions_with_course_id
 from xmodule.partitions.partitions import Group
 from xmodule.partitions.partitions_service import get_user_partition_groups
 
@@ -37,9 +37,6 @@ class TeamPartitionGroupsOutlineProcessor(OutlineProcessor):
         """
         Pull team groups for this course and which group the user is in.
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(self.course_key):
-            return
-
         user_partitions = create_team_set_partitions_with_course_id(self.course_key)
         self.current_user_groups = get_user_partition_groups(
             self.course_key,
@@ -61,9 +58,6 @@ class TeamPartitionGroupsOutlineProcessor(OutlineProcessor):
             The user is excluded from the content if and only if, for a non-empty
             partition group, the user is not in any of the groups for that partition.
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(self.course_key):
-            return False
-
         if not user_partition_groups:
             return False
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -1969,10 +1969,6 @@ class ContentErrorTestCase(CacheIsolationTestCase):
         ]
 
 
-@patch(
-    "openedx.core.djangoapps.content.learning_sequences.api.processors.team_partition_groups.CONTENT_GROUPS_FOR_TEAMS.is_enabled",  # lint-amnesty, pylint: disable=line-too-long
-    lambda _: True
-)
 @skip_unless_lms
 class TeamPartitionGroupsTestCase(OutlineProcessorTestCase):
     """Tests for team partitions processor that affects outlines."""

--- a/openedx/core/lib/teams_config.py
+++ b/openedx/core/lib/teams_config.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 from xmodule.partitions.partitions import UserPartition, UserPartitionError
 log = logging.getLogger(__name__)
@@ -18,20 +17,6 @@ MANAGED_TEAM_MAX_TEAM_SIZE = 200
 DEFAULT_COURSE_RUN_MAX_TEAM_SIZE = 50
 TEAM_SCHEME = "team"
 TEAMS_NAMESPACE = "teams"
-
-# .. toggle_name: teams.content_groups_for_teams
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: This flag enables content groups for teams. Content groups are virtual groupings of learners
-#    who will see a particular set of course content. When this flag is enabled, course authors can create teams and
-#    assign content to each of them. Then, when a learner joins a team, they will see the content that is assigned to
-#    that team's content group. This flag is only relevant for courses that have teams enabled.
-# .. toggle_use_cases: temporary, opt_in
-# .. toggle_target_removal_date: Teak
-# .. toggle_creation_date: 2024-04-01
-CONTENT_GROUPS_FOR_TEAMS = CourseWaffleFlag(
-    f"{TEAMS_NAMESPACE}.content_groups_for_teams", __name__
-)
 
 
 class TeamsConfig:
@@ -400,8 +385,6 @@ def create_team_set_partition(course):
     """
     Get the dynamic enrollment track user partition based on the team-sets of the course.
     """
-    if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course.id):
-        return []
     return create_team_set_partitions_with_course_id(
         course.id,
         _get_team_sets(course.id),


### PR DESCRIPTION
## Description

This PR removes the `CONTENT_GROUPS_FOR_TEAMS` Waffle Flag and all related code. With this change, the connection of teams with content groups will always be available.

## Supporting information

- https://github.com/openedx/public-engineering/issues/315

## Testing instructions

1. Create a Tutor environment.
2. Create a mount of **edx-platform** with the changes in this branch.
3. Enables Teams in the platform using the `teams.enable_teams_app` flag.
4. Activates Teams in your course in **Studio > [Your Course] > Content > Pages & Resources > Teams > Teams toggle**
5. Create a few team sets (or groups) from the Course Authoring MFE for your course
6. Then, go to the **LMS > [Your Course] > Teams** and create a few teams within those team-set (or topics, or groups) 
7. As a student, try loading the sections of the course, you'll be able to load each course section. You'll be able to see them as usual.
8. Now, restrict topics for each team as you would with cohorts or enrollment tracks
9. As a student, try loading the course sections again. You won't be able to see any content.
10. As a student, join one of the teams and try again: you'll be able to see the content within your team
11. As a student, join the other team: you'll be able to see the content within both teams

For more detailed testing instructions, please refer to the [PR cover letter with the original implementation](https://github.com/openedx/edx-platform/pull/33788#issue-2008543232). The only change is that it's no longer necessary to create the Waffle Flag in the course to use the functionality.

## Deadline

None

## Other information

- **Original Implementation**: #33788
