### PR TITLE
fix: prevent duplicate unsubscribe events in snowflake by tracking preference updates

### DIFF
--- a/openedx/core/djangoapps/notifications/events.py
+++ b/openedx/core/djangoapps/notifications/events.py
@@ -183,7 +183,7 @@ def notification_tray_opened_event(user, unseen_notifications_count):
     )
 
 
-def notification_preference_unsubscribe_event(user):
+def notification_preference_unsubscribe_event(user, is_preference_updated=False):
     """
     Emits an event when user clicks on one-click-unsubscribe url
     """
@@ -193,6 +193,7 @@ def notification_preference_unsubscribe_event(user):
     }
     event_data = context_data.copy()
     event_data['event_type'] = 'email_digest_unsubscribe'
+    event_data['is_preference_updated'] = is_preference_updated
 
     with tracker.get_tracker().context(NOTIFICATION_PREFERENCE_UNSUBSCRIBE, context_data):
         tracker.emit(NOTIFICATION_PREFERENCE_UNSUBSCRIBE, event_data)


### PR DESCRIPTION
## Description

This PR improves the handling of `edx.notifications.preferences.one_click_unsubscribe` events by ensuring that event data correctly reflects whether a preference was updated. Previously, multiple events can be recorded in Snowflake when a user clicked the unsubscribe link multiple times, even if their preference remained unchanged. 

## Ticket information
https://2u-internal.atlassian.net/browse/INF-1806


## Testing instructions

1. Enroll in a course, by default preferences will be true 
2. Click the unsubscribe link in a digest email
3. On click, verify event data captured in Snowflake
4. On the first click, the event should have `is_preference_updated: true`
5. On subsequent clicks, the event should still be captured but with `is_preference_updated: false`
