### PR TITLE
fix: resolved allow enroll email issue

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -192,11 +192,6 @@ def enroll_email(
             message_params['email_address'] = student_email
             if previous_state.user:
                 message_params['user_id'] = previous_state.user.id
-                if previous_state.user.email != student_email:
-                    log.error(
-                        'User email does not match the email being enrolled: %s != %s',
-                        previous_state.user.email, student_email
-                    )
             send_mail_to_student(student_email, message_params, language=language)
 
     after_state = EmailEnrollmentState(course_id, student_email)
@@ -596,18 +591,6 @@ def send_mail_to_student(student, param_dict, language=None):
         language=language,
         user_context=param_dict,
     )
-
-    if message_type == 'allowed_enroll':
-        log_data = {
-            'message': 'allowed_enroll email data log',
-            'message_type': message_type,
-            'student': student,
-            'recipient': message.recipient.email_address,
-            'context_email': message.context.get('email_address'),
-            'lms_user_id': lms_user_id,
-            **param_dict
-        }
-        log.error(log_data)
     ace.send(message)
 
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -837,7 +837,7 @@ def students_update_enrollment(request, course_id):  # lint-amnesty, pylint: dis
             validate_email(email)  # Raises ValidationError if invalid
             if action == 'enroll':
                 before, after, enrollment_obj = enroll_email(
-                    course_id, email, auto_enroll, email_students, email_params, language=language
+                    course_id, email, auto_enroll, email_students, {**email_params}, language=language
                 )
                 before_enrollment = before.to_dict()['enrollment']
                 before_user_registered = before.to_dict()['user']
@@ -860,7 +860,7 @@ def students_update_enrollment(request, course_id):  # lint-amnesty, pylint: dis
 
             elif action == 'unenroll':
                 before, after = unenroll_email(
-                    course_id, email, email_students, email_params, language=language
+                    course_id, email, email_students, {**email_params}, language=language
                 )
                 before_enrollment = before.to_dict()['enrollment']
                 before_allowed = before.to_dict()['allowed']


### PR DESCRIPTION
## Description 

Allow Enroll emails are sent to different users other than it was supposed to be sent, This PR fixes this issue by passing new dict instead of the same dict to enroll_email func