### PR TITLE
fix: fix accessibility issue with video editor speed option selected speed

### DIFF
--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -525,9 +525,9 @@
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container .menu li.is-active .speed-option,
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container .menu li.is-active .control-lang {
-    border-left: calc(var(--baseline, 20px) / 10) solid #0ea6ec;
+    border-left: calc(var(--baseline, 20px) / 10) solid #90d7f9;
     font-weight: var(--font-bold, 700);
-    color: #0ea6ec;
+    color: #90d7f9;
 }
 
 .xmodule_display.xmodule_VideoBlock .video .video-wrapper .video-controls .secondary-controls .menu-container.is-opened .menu {


### PR DESCRIPTION
### [TNL-11863](https://2u-internal.atlassian.net/browse/TNL-11863)

### Description 

Accessibility fix for video component in speed option

We have changed the color of the text to `#90D7F9` and achieved a `4:54:1` contrast ratio.

### Sandbox Link

[Testing Sandbox video block](https://learning-tnl11863.sandbox.edx.org/course/course-v1:OpenedX+DemoX+DemoCourse/block-v1:OpenedX+DemoX+DemoCourse+type@sequential+block@4e1de5e13fc3422997fe246b40a43aa1/block-v1:OpenedX+DemoX+DemoCourse+type@vertical+block@78b75020d3894fdfa8b4994f97275294)

### Before
![unnamed3 (1)](https://github.com/user-attachments/assets/4d265f1b-af93-4588-83e0-bd12cf0bebc5)


### After

<img width="861" alt="Screenshot 2025-02-27 at 4 44 39 PM" src="https://github.com/user-attachments/assets/ab3632ba-ccfa-4472-8f2e-3ef45b1a3351" />

<img width="752" alt="Screenshot 2025-02-27 at 4 46 19 PM" src="https://github.com/user-attachments/assets/92d3b894-38e0-41f0-9585-64e75db9929d" />
