### PR TITLE
refactor: downstream entity links api [FC-0076]

### DIFF
--- a/cms/djangoapps/contentstore/models.py
+++ b/cms/djangoapps/contentstore/models.py
@@ -237,6 +237,21 @@ class PublishableEntityLink(models.Model):
     def summarize_by_downstream_context(cls, downstream_context_key: CourseKey) -> QuerySet:
         """
         Returns a summary of links by upstream context for given downstream_context_key.
+        Example:
+        [
+            {
+                "upstream_context_title": "CS problems 3",
+                "upstream_context_key": "lib:OpenedX:CSPROB3",
+                "ready_to_sync_count": 11,
+                "total_count": 14
+            },
+            {
+                "upstream_context_title": "CS problems 2",
+                "upstream_context_key": "lib:OpenedX:CSPROB2",
+                "ready_to_sync_count": 15,
+                "total_count": 24
+            },
+        ]
         """
         result = cls.filter_links(downstream_context_key=downstream_context_key).values(
             "upstream_context_key",

--- a/cms/djangoapps/contentstore/models.py
+++ b/cms/djangoapps/contentstore/models.py
@@ -195,13 +195,13 @@ class PublishableEntityLink(models.Model):
     @classmethod
     def filter_links(
         cls,
-        **filter,
+        **link_filter,
     ) -> QuerySet["PublishableEntityLink"]:
         """
         Get all links along with sync flag, upstream context title and version, with optional filtering.
         """
-        ready_to_sync = filter.pop('ready_to_sync', None)
-        result = cls.objects.filter(**filter).select_related(
+        ready_to_sync = link_filter.pop('ready_to_sync', None)
+        result = cls.objects.filter(**link_filter).select_related(
             "upstream_block__published__version",
             "upstream_block__learning_package"
         ).annotate(

--- a/cms/djangoapps/contentstore/models.py
+++ b/cms/djangoapps/contentstore/models.py
@@ -175,7 +175,12 @@ class PublishableEntityLink(models.Model):
             )
         try:
             link = cls.objects.get(downstream_usage_key=downstream_usage_key)
-            has_changes = False
+            # TODO: until we save modified datetime for course xblocks in index, the modified time for links are updated
+            # everytime a downstream/course block is updated. This allows us to order links[1] based on recently
+            # modified downstream version.
+            # pylint: disable=line-too-long
+            # 1. https://github.com/open-craft/frontend-app-course-authoring/blob/0443d88824095f6f65a3a64b77244af590d4edff/src/course-libraries/ReviewTabContent.tsx#L222-L233
+            has_changes = True  # change to false once above condition is met.
             for key, value in new_values.items():
                 prev = getattr(link, key)
                 # None != None is True, so we need to check for it specially

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
@@ -3,7 +3,6 @@
 from cms.djangoapps.contentstore.rest_api.v2.serializers.downstreams import (
     PublishableEntityLinksSerializer,
     PublishableEntityLinksSummarySerializer,
-    PublishableEntityLinksUsageKeySerializer,
 )
 from cms.djangoapps.contentstore.rest_api.v2.serializers.home import CourseHomeTabSerializerV2
 
@@ -11,5 +10,4 @@ __all__ = [
     'CourseHomeTabSerializerV2',
     'PublishableEntityLinksSerializer',
     'PublishableEntityLinksSummarySerializer',
-    'PublishableEntityLinksUsageKeySerializer',
 ]

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
@@ -2,6 +2,14 @@
 
 from cms.djangoapps.contentstore.rest_api.v2.serializers.downstreams import (
     PublishableEntityLinksSerializer,
+    PublishableEntityLinksSummarySerializer,
     PublishableEntityLinksUsageKeySerializer,
 )
 from cms.djangoapps.contentstore.rest_api.v2.serializers.home import CourseHomeTabSerializerV2
+
+__all__ = [
+    'CourseHomeTabSerializerV2',
+    'PublishableEntityLinksSerializer',
+    'PublishableEntityLinksSummarySerializer',
+    'PublishableEntityLinksUsageKeySerializer',
+]

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
@@ -20,18 +20,6 @@ class PublishableEntityLinksSerializer(serializers.ModelSerializer):
         exclude = ['upstream_block', 'uuid']
 
 
-class PublishableEntityLinksUsageKeySerializer(serializers.ModelSerializer):
-    """
-    Serializer for returning a string list of the usage keys.
-    """
-    def to_representation(self, instance: PublishableEntityLink) -> str:
-        return str(instance.downstream_usage_key)
-
-    class Meta:
-        model = PublishableEntityLink
-        fields = ('downstream_usage_key')
-
-
 class PublishableEntityLinksSummarySerializer(serializers.Serializer):
     """
     Serializer for summary for publishable entity links

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
@@ -30,3 +30,13 @@ class PublishableEntityLinksUsageKeySerializer(serializers.ModelSerializer):
     class Meta:
         model = PublishableEntityLink
         fields = ('downstream_usage_key')
+
+
+class PublishableEntityLinksSummarySerializer(serializers.Serializer):
+    """
+    Serializer for summary for publishable entity links
+    """
+    upstream_context_title = serializers.CharField(read_only=True)
+    upstream_context_key = serializers.CharField(read_only=True)
+    ready_to_sync_count = serializers.IntegerField(read_only=True)
+    total_count = serializers.IntegerField(read_only=True)

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
@@ -13,15 +13,7 @@ class PublishableEntityLinksSerializer(serializers.ModelSerializer):
     """
     upstream_context_title = serializers.CharField(read_only=True)
     upstream_version = serializers.IntegerField(read_only=True)
-    ready_to_sync = serializers.SerializerMethodField()
-
-    def get_ready_to_sync(self, obj):
-        """Calculate ready_to_sync field"""
-        return bool(
-            obj.upstream_version and
-            obj.upstream_version > (obj.version_synced or 0) and
-            obj.upstream_version > (obj.version_declined or 0)
-        )
+    ready_to_sync = serializers.BooleanField()
 
     class Meta:
         model = PublishableEntityLink

--- a/cms/djangoapps/contentstore/rest_api/v2/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/urls.py
@@ -24,11 +24,6 @@ urlpatterns = [
         name="downstream"
     ),
     re_path(
-        f'^upstream/{settings.USAGE_KEY_PATTERN}/downstream-links$',
-        downstreams.DownstreamContextListView.as_view(),
-        name='downstream-link-list'
-    ),
-    re_path(
         f'^downstreams/{settings.COURSE_KEY_PATTERN}/summary$',
         downstreams.DownstreamSummaryView.as_view(),
         name='upstream-summary-list'

--- a/cms/djangoapps/contentstore/rest_api/v2/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/urls.py
@@ -13,21 +13,15 @@ urlpatterns = [
         home.HomePageCoursesViewV2.as_view(),
         name="courses",
     ),
-    # TODO: Potential future path.
-    # re_path(
-    #     fr'^downstreams/$',
-    #     downstreams.DownstreamsListView.as_view(),
-    #     name="downstreams_list",
-    # ),
+    re_path(
+        r'^downstreams/$',
+        downstreams.DownstreamListView.as_view(),
+        name="downstreams_list",
+    ),
     re_path(
         fr'^downstreams/{settings.USAGE_KEY_PATTERN}$',
         downstreams.DownstreamView.as_view(),
         name="downstream"
-    ),
-    re_path(
-        f'^upstreams/{settings.COURSE_KEY_PATTERN}$',
-        downstreams.UpstreamListView.as_view(),
-        name='upstream-list'
     ),
     re_path(
         f'^upstream/{settings.USAGE_KEY_PATTERN}/downstream-links$',
@@ -35,8 +29,8 @@ urlpatterns = [
         name='downstream-link-list'
     ),
     re_path(
-        f'^upstreams/{settings.COURSE_KEY_PATTERN}/summary$',
-        downstreams.UpstreamSummaryView.as_view(),
+        f'^downstreams/{settings.COURSE_KEY_PATTERN}/summary$',
+        downstreams.DownstreamSummaryView.as_view(),
         name='upstream-summary-list'
     ),
     re_path(

--- a/cms/djangoapps/contentstore/rest_api/v2/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/urls.py
@@ -35,6 +35,11 @@ urlpatterns = [
         name='downstream-link-list'
     ),
     re_path(
+        f'^upstreams/{settings.COURSE_KEY_PATTERN}/summary$',
+        downstreams.UpstreamSummaryView.as_view(),
+        name='upstream-summary-list'
+    ),
+    re_path(
         fr'^downstreams/{settings.USAGE_KEY_PATTERN}/sync$',
         downstreams.SyncFromUpstreamView.as_view(),
         name="sync_from_upstream"

--- a/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
@@ -132,14 +132,13 @@ class DownstreamListPaginator(DefaultPagination):
     def get_paginated_response(self, data, *args, **kwargs):
         if 'no_page' in args[0].query_params:
             return Response(data)
-        return Response({
+        response = super().get_paginated_response(data)
+        # replace next and previous links by next and previous page number
+        response.data.update({
             'next': self.page.next_page_number() if self.page.has_next() else None,
             'previous': self.page.previous_page_number() if self.page.has_previous() else None,
-            'count': self.page.paginator.count,
-            'num_pages': self.page.paginator.num_pages,
-            'current_page': self.page.number,
-            'results': data
         })
+        return response
 
 
 @view_auth_classes()

--- a/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
@@ -53,6 +53,21 @@ https://github.com/openedx/edx-platform/issues/35653):
   /api/contentstore/v2/downstreams/<course_key>/summary
       GET: List summary of links by course key
         200: A list of summary of links by course key
+        Example:
+        [
+            {
+                "upstream_context_title": "CS problems 3",
+                "upstream_context_key": "lib:OpenedX:CSPROB3",
+                "ready_to_sync_count": 11,
+                "total_count": 14
+            },
+            {
+                "upstream_context_title": "CS problems 2",
+                "upstream_context_key": "lib:OpenedX:CSPROB2",
+                "ready_to_sync_count": 15,
+                "total_count": 24
+            },
+        ]
 
 UpstreamLink response schema:
   {
@@ -182,6 +197,21 @@ class DownstreamSummaryView(DeveloperErrorViewMixin, APIView):
     def get(self, request: _AuthenticatedRequest, course_key_string: str):
         """
         Fetches publishable entity links summary for given course key
+        Example:
+        [
+            {
+                "upstream_context_title": "CS problems 3",
+                "upstream_context_key": "lib:OpenedX:CSPROB3",
+                "ready_to_sync_count": 11,
+                "total_count": 14
+            },
+            {
+                "upstream_context_title": "CS problems 2",
+                "upstream_context_key": "lib:OpenedX:CSPROB2",
+                "ready_to_sync_count": 15,
+                "total_count": 24
+            },
+        ]
         """
         try:
             course_key = CourseKey.from_string(course_key_string)

--- a/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
@@ -150,8 +150,8 @@ class DownstreamListPaginator(DefaultPagination):
         response = super().get_paginated_response(data)
         # replace next and previous links by next and previous page number
         response.data.update({
-            'next': self.page.next_page_number() if self.page.has_next() else None,
-            'previous': self.page.previous_page_number() if self.page.has_previous() else None,
+            'next_page_num': self.page.next_page_number() if self.page.has_next() else None,
+            'previous_page_num': self.page.previous_page_number() if self.page.has_previous() else None,
         })
         return response
 

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -62,7 +62,7 @@ class _BaseDownstreamViewTestMixin:
         self.video_lib_id = self._add_block_to_library(self.library_id, "video", "video-baz")["id"]
         self._publish_library_block(self.html_lib_id)
         self._publish_library_block(self.video_lib_id)
-        self.mock_upstream_link = f"{settings.COURSE_AUTHORING_MICROFRONTEND_URL}/library/{self.library_id}/components?usageKey={self.video_lib_id}"  # noqa: E501
+        self.mock_upstream_link = f"{settings.COURSE_AUTHORING_MICROFRONTEND_URL}/library/{self.library_id}/components?usageKey={self.video_lib_id}"  # pylint: disable=line-too-long  # noqa: E501
         self.course = CourseFactory.create()
         chapter = BlockFactory.create(category='chapter', parent=self.course)
         sequential = BlockFactory.create(category='sequential', parent=chapter)

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -1,6 +1,7 @@
 """
 Unit tests for /api/contentstore/v2/downstreams/* JSON APIs.
 """
+import json
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -10,6 +11,7 @@ from freezegun import freeze_time
 from cms.djangoapps.contentstore.helpers import StaticFileNotices
 from cms.lib.xblock.upstream_sync import BadUpstream, UpstreamLink
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content_libraries.tests.base import ContentLibrariesRestApiTest
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
@@ -19,11 +21,6 @@ from .. import downstreams as downstreams_views
 MOCK_LIB_KEY = "lib:OpenedX:CSPROB3"
 MOCK_UPSTREAM_REF = "lb:OpenedX:CSPROB3:video:843b4c73-1e2d-4ced-a0ff-24e503cdb3e4"
 MOCK_HTML_UPSTREAM_REF = "lb:OpenedX:CSPROB3:html:843b4c73-1e2d-4ced-a0ff-24e503cdb3e4"
-MOCK_UPSTREAM_LINK = "{mfe_url}/library/{lib_key}/components?usageKey={usage_key}".format(
-    mfe_url=settings.COURSE_AUTHORING_MICROFRONTEND_URL,
-    lib_key=MOCK_LIB_KEY,
-    usage_key=MOCK_UPSTREAM_REF,
-)
 MOCK_UPSTREAM_ERROR = "your LibraryGPT subscription has expired"
 
 
@@ -55,16 +52,27 @@ class _BaseDownstreamViewTestMixin:
         self.addCleanup(freezer.stop)
         freezer.start()
         self.maxDiff = 2000
+        self.library_title = "Test Library 1"
+        self.library_id = self._create_library(
+            slug="testlib1_preview",
+            title=self.library_title,
+            description="Testing XBlocks"
+        )["id"]
+        self.html_lib_id = self._add_block_to_library(self.library_id, "html", "html-baz")["id"]
+        self.video_lib_id = self._add_block_to_library(self.library_id, "video", "video-baz")["id"]
+        self._publish_library_block(self.html_lib_id)
+        self._publish_library_block(self.video_lib_id)
+        self.mock_upstream_link = f"{settings.COURSE_AUTHORING_MICROFRONTEND_URL}/library/{self.library_id}/components?usageKey={self.video_lib_id}"  # noqa: E501
         self.course = CourseFactory.create()
         chapter = BlockFactory.create(category='chapter', parent=self.course)
         sequential = BlockFactory.create(category='sequential', parent=chapter)
         unit = BlockFactory.create(category='vertical', parent=sequential)
         self.regular_video_key = BlockFactory.create(category='video', parent=unit).usage_key
         self.downstream_video_key = BlockFactory.create(
-            category='video', parent=unit, upstream=MOCK_UPSTREAM_REF, upstream_version=123,
+            category='video', parent=unit, upstream=self.video_lib_id, upstream_version=1,
         ).usage_key
         self.downstream_html_key = BlockFactory.create(
-            category='html', parent=unit, upstream=MOCK_HTML_UPSTREAM_REF, upstream_version=1,
+            category='html', parent=unit, upstream=self.html_lib_id, upstream_version=1,
         ).usage_key
 
         self.another_course = CourseFactory.create(display_name="Another Course")
@@ -76,13 +84,18 @@ class _BaseDownstreamViewTestMixin:
             # Adds 3 videos linked to the same upstream
             self.another_video_keys.append(
                 BlockFactory.create(
-                    category="video", parent=another_unit, upstream=MOCK_UPSTREAM_REF, upstream_version=123,
+                    category="video",
+                    parent=another_unit,
+                    upstream=self.video_lib_id,
+                    upstream_version=1
                 ).usage_key
             )
 
         self.fake_video_key = self.course.id.make_usage_key("video", "NoSuchVideo")
         self.superuser = UserFactory(username="superuser", password="password", is_staff=True, is_superuser=True)
         self.learner = UserFactory(username="learner", password="password")
+        self._set_library_block_olx(self.html_lib_id, "<html><b>Hello world!</b></html>")
+        self._publish_library_block(self.html_lib_id)
 
     def call_api(self, usage_key_string):
         raise NotImplementedError
@@ -111,7 +124,7 @@ class SharedErrorTestCases(_BaseDownstreamViewTestMixin):
         assert "not found" in response.data["developer_message"]
 
 
-class GetDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
+class GetDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase, ContentLibrariesRestApiTest):
     """
     Test that `GET /api/v2/contentstore/downstreams/...` inspects a downstream's link to an upstream.
     """
@@ -126,10 +139,10 @@ class GetDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
         self.client.login(username="superuser", password="password")
         response = self.call_api(self.downstream_video_key)
         assert response.status_code == 200
-        assert response.data['upstream_ref'] == MOCK_UPSTREAM_REF
+        assert response.data['upstream_ref'] == self.video_lib_id
         assert response.data['error_message'] is None
         assert response.data['ready_to_sync'] is True
-        assert response.data['upstream_link'] == MOCK_UPSTREAM_LINK
+        assert response.data['upstream_link'] == self.mock_upstream_link
 
     @patch.object(UpstreamLink, "get_for_block", _get_upstream_link_bad)
     def test_200_bad_upstream(self):
@@ -139,7 +152,7 @@ class GetDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
         self.client.login(username="superuser", password="password")
         response = self.call_api(self.downstream_video_key)
         assert response.status_code == 200
-        assert response.data['upstream_ref'] == MOCK_UPSTREAM_REF
+        assert response.data['upstream_ref'] == self.video_lib_id
         assert response.data['error_message'] == MOCK_UPSTREAM_ERROR
         assert response.data['ready_to_sync'] is False
         assert response.data['upstream_link'] is None
@@ -157,17 +170,17 @@ class GetDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
         assert response.data['upstream_link'] is None
 
 
-class PutDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
+class PutDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase, ContentLibrariesRestApiTest):
     """
     Test that `PUT /api/v2/contentstore/downstreams/...` edits a downstream's link to an upstream.
     """
     def call_api(self, usage_key_string, sync: str | None = None):
         return self.client.put(
             f"/api/contentstore/v2/downstreams/{usage_key_string}",
-            data={
-                "upstream_ref": MOCK_UPSTREAM_REF,
+            data=json.dumps({
+                "upstream_ref": str(self.video_lib_id),
                 **({"sync": sync} if sync else {}),
-            },
+            }),
             content_type="application/json",
         )
 
@@ -179,12 +192,12 @@ class PutDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
         Does the happy path work (with sync=True)?
         """
         self.client.login(username="superuser", password="password")
-        response = self.call_api(self.regular_video_key, sync='true')
+        response = self.call_api(str(self.regular_video_key), sync='true')
         assert response.status_code == 200
         video_after = modulestore().get_item(self.regular_video_key)
         assert mock_sync.call_count == 1
         assert mock_fetch.call_count == 0
-        assert video_after.upstream == MOCK_UPSTREAM_REF
+        assert video_after.upstream == self.video_lib_id
 
     @patch.object(downstreams_views, "fetch_customizable_fields")
     @patch.object(downstreams_views, "sync_from_upstream")
@@ -199,7 +212,7 @@ class PutDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
         video_after = modulestore().get_item(self.regular_video_key)
         assert mock_sync.call_count == 0
         assert mock_fetch.call_count == 1
-        assert video_after.upstream == MOCK_UPSTREAM_REF
+        assert video_after.upstream == self.video_lib_id
 
     @patch.object(downstreams_views, "fetch_customizable_fields", side_effect=BadUpstream(MOCK_UPSTREAM_ERROR))
     def test_400(self, sync: str):
@@ -214,7 +227,7 @@ class PutDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
         assert video_after.upstream is None
 
 
-class DeleteDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase):
+class DeleteDownstreamViewTest(SharedErrorTestCases, SharedModuleStoreTestCase, ContentLibrariesRestApiTest):
     """
     Test that `DELETE /api/v2/contentstore/downstreams/...` severs a downstream's link to an upstream.
     """
@@ -268,7 +281,7 @@ class _DownstreamSyncViewTestMixin(SharedErrorTestCases):
         assert "is not linked" in response.data["developer_message"][0]
 
 
-class PostDownstreamSyncViewTest(_DownstreamSyncViewTestMixin, SharedModuleStoreTestCase):
+class PostDownstreamSyncViewTest(_DownstreamSyncViewTestMixin, SharedModuleStoreTestCase, ContentLibrariesRestApiTest):
     """
     Test that `POST /api/v2/contentstore/downstreams/.../sync` initiates a sync from the linked upstream.
     """
@@ -291,7 +304,11 @@ class PostDownstreamSyncViewTest(_DownstreamSyncViewTestMixin, SharedModuleStore
         assert mock_clear_transcripts.call_count == 1
 
 
-class DeleteDownstreamSyncViewtest(_DownstreamSyncViewTestMixin, SharedModuleStoreTestCase):
+class DeleteDownstreamSyncViewtest(
+    _DownstreamSyncViewTestMixin,
+    SharedModuleStoreTestCase,
+    ContentLibrariesRestApiTest
+):
     """
     Test that `DELETE /api/v2/contentstore/downstreams/.../sync` declines a sync from the linked upstream.
     """
@@ -310,19 +327,35 @@ class DeleteDownstreamSyncViewtest(_DownstreamSyncViewTestMixin, SharedModuleSto
         assert mock_decline_sync.call_count == 1
 
 
-class GetUpstreamViewTest(_BaseDownstreamViewTestMixin, SharedModuleStoreTestCase):
+class GetUpstreamViewTest(
+    _BaseDownstreamViewTestMixin,
+    SharedModuleStoreTestCase,
+    ContentLibrariesRestApiTest
+):
     """
-    Test that `GET /api/v2/contentstore/upstreams/...` returns list of links in given downstream context i.e. course.
+    Test that `GET /api/v2/contentstore/downstreams?...` returns list of links based on the provided filter.
     """
-    def call_api(self, usage_key_string):
-        return self.client.get(f"/api/contentstore/v2/upstreams/{usage_key_string}")
+    def call_api(
+        self,
+        course_id: str = None,
+        ready_to_sync: bool = None,
+        upstream_usage_key: str = None,
+    ):
+        data = {}
+        if course_id is not None:
+            data["course_id"] = str(course_id)
+        if ready_to_sync is not None:
+            data["ready_to_sync"] = str(ready_to_sync)
+        if upstream_usage_key is not None:
+            data["upstream_usage_key"] = str(upstream_usage_key)
+        return self.client.get("/api/contentstore/v2/downstreams/", data=data)
 
-    def test_200_all_upstreams(self):
+    def test_200_all_downstreams_for_a_course(self):
         """
-        Returns all upstream links for given course
+        Returns all links for given course
         """
         self.client.login(username="superuser", password="password")
-        response = self.call_api(self.course.id)
+        response = self.call_api(course_id=self.course.id)
         assert response.status_code == 200
         data = response.json()
         date_format = self.now.isoformat().split("+")[0] + 'Z'
@@ -334,44 +367,90 @@ class GetUpstreamViewTest(_BaseDownstreamViewTestMixin, SharedModuleStoreTestCas
                 'id': 1,
                 'ready_to_sync': False,
                 'updated': date_format,
-                'upstream_context_key': MOCK_LIB_KEY,
-                'upstream_usage_key': MOCK_UPSTREAM_REF,
-                'upstream_version': None,
+                'upstream_context_key': self.library_id,
+                'upstream_context_title': self.library_title,
+                'upstream_usage_key': self.video_lib_id,
+                'upstream_version': 1,
                 'version_declined': None,
-                'version_synced': 123
+                'version_synced': 1
             },
             {
                 'created': date_format,
                 'downstream_context_key': str(self.course.id),
                 'downstream_usage_key': str(self.downstream_html_key),
                 'id': 2,
-                'ready_to_sync': False,
+                'ready_to_sync': True,
                 'updated': date_format,
-                'upstream_context_key': MOCK_LIB_KEY,
-                'upstream_usage_key': MOCK_HTML_UPSTREAM_REF,
-                'upstream_version': None,
+                'upstream_context_key': self.library_id,
+                'upstream_context_title': self.library_title,
+                'upstream_usage_key': self.html_lib_id,
+                'upstream_version': 2,
                 'version_declined': None,
                 'version_synced': 1,
             },
         ]
-        self.assertListEqual(data, expected)
+        self.assertListEqual(data["results"], expected)
+        self.assertEqual(data["count"], 2)
 
-
-class GetDownstreamContextsTest(_BaseDownstreamViewTestMixin, SharedModuleStoreTestCase):
-    """
-    Test that `GET /api/v2/contentstore/upstream/:usage_key/downstream-links returns list of
-    linked blocks usage_keys in given upstream entity (i.e. library block).
-    """
-    def call_api(self, usage_key_string):
-        return self.client.get(f"/api/contentstore/v2/upstream/{usage_key_string}/downstream-links")
+    def test_200_all_downstreams_ready_to_sync(self):
+        """
+        Returns all links that are syncable
+        """
+        self.client.login(username="superuser", password="password")
+        response = self.call_api(ready_to_sync=True)
+        assert response.status_code == 200
+        data = response.json()
+        self.assertTrue(all(o["ready_to_sync"] for o in data["results"]))
+        self.assertEqual(data["count"], 1)
 
     def test_200_downstream_context_list(self):
         """
         Returns all downstream courses for given library block
         """
         self.client.login(username="superuser", password="password")
-        response = self.call_api(MOCK_UPSTREAM_REF)
+        response = self.call_api(upstream_usage_key=self.video_lib_id)
         assert response.status_code == 200
         data = response.json()
         expected = [str(self.downstream_video_key)] + [str(key) for key in self.another_video_keys]
+        got = [str(o["downstream_usage_key"]) for o in data["results"]]
+        self.assertListEqual(got, expected)
+        self.assertEqual(data["count"], 4)
+
+
+class GetDownstreamSummaryViewTest(
+    _BaseDownstreamViewTestMixin,
+    SharedModuleStoreTestCase,
+    ContentLibrariesRestApiTest
+):
+    """
+    Test that `GET /api/v2/contentstore/downstreams/<course_id>/summary` returns summary of links in course.
+    """
+    def call_api(self, course_id):
+        return self.client.get(f"/api/contentstore/v2/downstreams/{course_id}/summary")
+
+    @patch.object(UpstreamLink, "get_for_block", _get_upstream_link_good_and_syncable)
+    def test_200_summary(self):
+        """
+        Does the happy path work?
+        """
+        self.client.login(username="superuser", password="password")
+        response = self.call_api(str(self.another_course.id))
+        assert response.status_code == 200
+        data = response.json()
+        expected = [{
+            'upstream_context_title': 'Test Library 1',
+            'upstream_context_key': self.library_id,
+            'ready_to_sync_count': 0,
+            'total_count': 3,
+        }]
+        self.assertListEqual(data, expected)
+        response = self.call_api(str(self.course.id))
+        assert response.status_code == 200
+        data = response.json()
+        expected = [{
+            'upstream_context_title': 'Test Library 1',
+            'upstream_context_key': self.library_id,
+            'ready_to_sync_count': 1,
+            'total_count': 2,
+        }]
         self.assertListEqual(data, expected)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2385,7 +2385,7 @@ def create_or_update_xblock_upstream_link(xblock, course_key: str | CourseKey, c
         lib_component = None
     PublishableEntityLink.update_or_create(
         lib_component,
-        upstream_usage_key=xblock.upstream,
+        upstream_usage_key=upstream_usage_key,
         upstream_context_key=str(upstream_usage_key.context_key),
         downstream_context_key=course_key,
         downstream_usage_key=xblock.usage_key,


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Refactors downstream links API to handle multiple filters using a single API. Also adds a new route to return summary of library links for a given course.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Course Author" and "Developer".

## Supporting information

* Part of: https://github.com/openedx/frontend-app-authoring/issues/1566
* `Private-ref`: [FAL-4007](https://tasks.opencraft.com/browse/FAL-4007)

Also addresses following comments

* https://github.com/openedx/edx-platform/pull/36190#discussion_r1967995443
* https://github.com/openedx/edx-platform/pull/36253#issuecomment-2682937892

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/1699 for instructions

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
