### PR TITLE
fix: discussion xblock not compatible with forum v2

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -812,7 +812,7 @@ class ViewsTestCase(
             headers=ANY,
             params=ANY,
             timeout=ANY,
-            data={"body": updated_body}
+            data={"body": updated_body, "course_id": str(self.course_id)}
         )
 
     def test_flag_thread_open(self, mock_is_forum_v2_enabled, mock_request):

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -673,7 +673,7 @@ def _create_comment(request, course_key, thread_id=None, parent_id=None):
         parent_id=parent_id,
         body=sanitize_body(post["body"]),
     )
-    comment.save()
+    comment.save(params={"course_id": str(course_key)})
 
     comment_created.send(sender=None, user=user, post=comment)
 
@@ -736,7 +736,7 @@ def update_comment(request, course_id, comment_id):
     if 'body' not in request.POST or not request.POST['body'].strip():
         return JsonError(_("Body can't be empty"))
     comment.body = sanitize_body(request.POST["body"])
-    comment.save()
+    comment.save(params={"course_id": course_id})
 
     comment_edited.send(sender=None, user=request.user, post=comment)
 
@@ -762,7 +762,7 @@ def endorse_comment(request, course_id, comment_id):
     endorsed = request.POST.get('endorsed', 'false').lower() == 'true'
     comment.endorsed = endorsed
     comment.endorsement_user_id = user.id
-    comment.save()
+    comment.save(params={"course_id": course_id})
     comment_endorsed.send(sender=None, user=user, post=comment)
     track_forum_response_mark_event(request, course, comment, endorsed)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
@@ -814,7 +814,7 @@ def delete_comment(request, course_id, comment_id):
     course_key = CourseKey.from_string(course_id)
     course = get_course_with_access(request.user, 'load', course_key)
     comment = cc.Comment.find(comment_id)
-    comment.delete()
+    comment.delete(course_id=course_id)
     comment_deleted.send(sender=None, user=request.user, post=comment)
     track_comment_deleted_event(request, course, comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
@@ -828,12 +828,12 @@ def _vote_or_unvote(request, course_id, obj, value='up', undo_vote=False):
     course = get_course_with_access(request.user, 'load', course_key)
     user = cc.User.from_django_user(request.user)
     if undo_vote:
-        user.unvote(obj)
+        user.unvote(obj, course_id)
         # TODO(smarnach): Determine the value of the vote that is undone.  Currently, you can
         # only cast upvotes in the user interface, so it is assumed that the vote value is 'up'.
         # (People could theoretically downvote by handcrafting AJAX requests.)
     else:
-        user.vote(obj, value)
+        user.vote(obj, value, course_id)
     thread_voted.send(sender=None, user=request.user, post=obj)
     track_voted_event(request, course, obj, value, undo_vote)
     return JsonResponse(prepare_content(obj.to_dict(), course_key))
@@ -899,7 +899,7 @@ def flag_abuse_for_thread(request, course_id, thread_id):
     user = cc.User.from_django_user(request.user)
     course = get_course_by_id(course_key)
     thread = cc.Thread.find(thread_id)
-    thread.flagAbuse(user, thread)
+    thread.flagAbuse(user, thread, course_id)
     track_discussion_reported_event(request, course, thread)
     thread_flagged.send(sender='flag_abuse_for_thread', user=request.user, post=thread)
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
@@ -921,7 +921,7 @@ def un_flag_abuse_for_thread(request, course_id, thread_id):
         has_permission(request.user, 'openclose_thread', course_key) or
         has_access(request.user, 'staff', course)
     )
-    thread.unFlagAbuse(user, thread, remove_all)
+    thread.unFlagAbuse(user, thread, remove_all, course_id)
     track_discussion_unreported_event(request, course, thread)
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
@@ -938,7 +938,7 @@ def flag_abuse_for_comment(request, course_id, comment_id):
     user = cc.User.from_django_user(request.user)
     course = get_course_by_id(course_key)
     comment = cc.Comment.find(comment_id)
-    comment.flagAbuse(user, comment)
+    comment.flagAbuse(user, comment, course_id)
     track_discussion_reported_event(request, course, comment)
     comment_flagged.send(sender='flag_abuse_for_comment', user=request.user, post=comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
@@ -960,7 +960,7 @@ def un_flag_abuse_for_comment(request, course_id, comment_id):
         has_access(request.user, 'staff', course)
     )
     comment = cc.Comment.find(comment_id)
-    comment.unFlagAbuse(user, comment, remove_all)
+    comment.unFlagAbuse(user, comment, remove_all, course_id)
     track_discussion_unreported_event(request, course, comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
 
@@ -1005,7 +1005,7 @@ def follow_thread(request, course_id, thread_id):  # lint-amnesty, pylint: disab
     course_key = CourseKey.from_string(course_id)
     course = get_course_by_id(course_key)
     thread = cc.Thread.find(thread_id)
-    user.follow(thread)
+    user.follow(thread, course_id=course_id)
     thread_followed.send(sender=None, user=request.user, post=thread)
     track_thread_followed_event(request, course, thread, True)
     return JsonResponse({})
@@ -1037,7 +1037,7 @@ def unfollow_thread(request, course_id, thread_id):  # lint-amnesty, pylint: dis
     course = get_course_by_id(course_key)
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
-    user.unfollow(thread)
+    user.unfollow(thread, course_id=course_id)
     thread_unfollowed.send(sender=None, user=request.user, post=thread)
     track_thread_followed_event(request, course, thread, False)
     return JsonResponse({})

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -147,7 +147,7 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
         # If the user clicked a sort key, update their default sort key
         cc_user = cc.User.from_django_user(request.user)
         cc_user.default_sort_key = request.GET.get('sort_key')
-        cc_user.save()
+        cc_user.save(params={"course_id": course.id})
 
     #there are 2 dimensions to consider when executing a search with respect to group id
     #is user a moderator

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -175,8 +175,8 @@ class Model:
         self._update_from_response(response)
         self.after_save(self)
 
-    def delete(self):
-        course_key = get_course_key(self.attributes.get("course_id"))
+    def delete(self, course_id=None):
+        course_key = get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = None
             if self.type == "comment":

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -80,6 +80,8 @@ class Thread(models.Model):
                     search_params.pop('commentable_id', None)
                 response = forum_api.search_threads(**search_params)
             else:
+                if user_id := params.get('user_id'):
+                    params['user_id'] = str(user_id)
                 response = forum_api.get_user_threads(**params)
         else:
             response = utils.perform_request(
@@ -196,14 +198,14 @@ class Thread(models.Model):
             )
         self._update_from_response(response)
 
-    def flagAbuse(self, user, voteable):
+    def flagAbuse(self, user, voteable, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_flag_abuse_thread(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only flag/unflag threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
-            response = forum_api.update_thread_flag(voteable.id, "flag", user.id, str(course_key))
+            response = forum_api.update_thread_flag(voteable.id, "flag", user_id=user.id, course_id=str(course_key))
         else:
             params = {'user_id': user.id}
             response = utils.perform_request(
@@ -215,7 +217,7 @@ class Thread(models.Model):
             )
         voteable._update_from_response(response)
 
-    def unFlagAbuse(self, user, voteable, removeAll):
+    def unFlagAbuse(self, user, voteable, removeAll, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_unflag_abuse_thread(voteable.id)
         else:

--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -50,8 +50,8 @@ class User(models.Model):
                 metric_tags=self._metric_tags + [f'target.type:{source.type}'],
             )
 
-    def follow(self, source):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def follow(self, source, course_id=None):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             forum_api.create_subscription(
                 user_id=self.id,
@@ -68,8 +68,8 @@ class User(models.Model):
                 metric_tags=self._metric_tags + [f'target.type:{source.type}'],
             )
 
-    def unfollow(self, source):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def unfollow(self, source, course_id=None):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             forum_api.delete_subscription(
                 user_id=self.id,
@@ -86,14 +86,14 @@ class User(models.Model):
                 metric_tags=self._metric_tags + [f'target.type:{source.type}'],
             )
 
-    def vote(self, voteable, value):
+    def vote(self, voteable, value, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_vote_thread(voteable.id)
         elif voteable.type == 'comment':
             url = _url_for_vote_comment(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only vote / unvote for threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             if voteable.type == 'thread':
                 response = forum_api.update_thread_votes(
@@ -120,7 +120,7 @@ class User(models.Model):
             )
         voteable._update_from_response(response)
 
-    def unvote(self, voteable):
+    def unvote(self, voteable, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_vote_thread(voteable.id)
         elif voteable.type == 'comment':


### PR DESCRIPTION
## Description

Fix all endpoints that were currently breaking with the discussion xblock while using the new forum app.

## Supporting information

Issue reported on forum: https://github.com/openedx/forum/issues/149

## Testing instructions

TBD

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
