### PR TITLE
handle AttributeError in exception clause

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1562,7 +1562,7 @@ def _get_release_date(xblock, user=None):
     reset_to_default = False
     try:
         reset_to_default = xblock.start.year < 1900
-    except ValueError:
+    except (ValueError, AttributeError):
         # For old mongo courses, accessing the start attribute calls `to_json()`,
         # which raises a `ValueError` for years < 1900.
         reset_to_default = True


### PR DESCRIPTION
### Description

## Issue:
The frontend-app-course-authoring MFE has a bug ([PR](https://github.com/openedx/frontend-app-authoring/pull/1457)) where an empty string ("") is sent to the backend instead of null when the date field is empty. This results in a 500 error, preventing users from accessing Studio.

## Fix:
To resolve this issue:

- We now handle the AttributeError exception along with the existing ValueError.

- When the backend encounters an empty string in the date field, it will catch the AttributeError, set the date to its default value, and prevent the error.


### Related Ticket
https://2u-internal.atlassian.net/browse/TNL-11914

