### PR TITLE
fix: Exclude Drag and Drop blocks from the link-scanning step in the Course Optimizer

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1198,13 +1198,16 @@ def _scan_course_for_links(course_key):
         blocks.extend(vertical.get_children())
 
     for block in blocks:
-        block_id = str(block.usage_key)
-        if block.category != 'drag-and-drop-v2':
-            block_info = get_block_info(block)
-            block_data = block_info['data']
+        # Excluding 'drag-and-drop-v2' as it contains data of object type instead of string, causing errors,
+        # and it doesn't contain user-facing links to scan.
+        if block.category == 'drag-and-drop-v2':
+            continue    
 
-            url_list = _get_urls(block_data)
-            urls_to_validate += [[block_id, url] for url in url_list]
+        block_id = str(block.usage_key)
+        block_info = get_block_info(block)
+        block_data = block_info['data']
+        url_list = _get_urls(block_data)
+        urls_to_validate += [[block_id, url] for url in url_list]
 
     return urls_to_validate
 

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1199,11 +1199,12 @@ def _scan_course_for_links(course_key):
 
     for block in blocks:
         block_id = str(block.usage_key)
-        block_info = get_block_info(block)
-        block_data = block_info['data']
+        if block.category != 'drag-and-drop-v2':
+            block_info = get_block_info(block)
+            block_data = block_info['data']
 
-        url_list = _get_urls(block_data)
-        urls_to_validate += [[block_id, url] for url in url_list]
+            url_list = _get_urls(block_data)
+            urls_to_validate += [[block_id, url] for url in url_list]
 
     return urls_to_validate
 

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1201,8 +1201,7 @@ def _scan_course_for_links(course_key):
         # Excluding 'drag-and-drop-v2' as it contains data of object type instead of string, causing errors,
         # and it doesn't contain user-facing links to scan.
         if block.category == 'drag-and-drop-v2':
-            continue    
-
+            continue
         block_id = str(block.usage_key)
         block_info = get_block_info(block)
         block_data = block_info['data']

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -371,7 +371,6 @@ class CheckBrokenLinksTaskTest(ModuleStoreTestCase):
         """
         Test that `_scan_course_for_links` excludes blocks of category 'drag-and-drop-v2'.
         """
-        
         vertical = BlockFactory.create(
             category='vertical',
             parent_location=self.test_course.location
@@ -392,16 +391,16 @@ class CheckBrokenLinksTaskTest(ModuleStoreTestCase):
         vertical.get_children = mock.Mock(return_value=[drag_and_drop_block, text_block])
 
         def get_block_side_effect(block):
-            block_data = getattr(block, 'data')
+            block_data = getattr(block, 'data', '')
             if isinstance(block_data, str):
                 return {'data' : block_data}
             raise TypeError("expected string or bytes-like object, got 'dict'")
         mock_get_block_info.side_effect = get_block_side_effect
-        
+
         urls = _scan_course_for_links(self.test_course.id)
-        
         # The drag-and-drop block should not appear in the results
-        assert all(block_id != str(drag_and_drop_block.usage_key) for block_id, _ in urls), "Drag and Drop blocks should be excluded"
+        assert all(block_id != str(drag_and_drop_block.usage_key) for block_id, _ in urls), \
+                    "Drag and Drop blocks should be excluded"
         assert any(block_id == str(text_block.usage_key) for block_id, _ in urls), "Text block should be included"
 
     @pytest.mark.asyncio

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -399,9 +399,14 @@ class CheckBrokenLinksTaskTest(ModuleStoreTestCase):
 
         urls = _scan_course_for_links(self.test_course.id)
         # The drag-and-drop block should not appear in the results
-        assert all(block_id != str(drag_and_drop_block.usage_key) for block_id, _ in urls), \
+        self.assertFalse(
+            any(block_id == str(drag_and_drop_block.usage_key) for block_id, _ in urls),
             "Drag and Drop blocks should be excluded"
-        assert any(block_id == str(text_block.usage_key) for block_id, _ in urls), "Text block should be included"
+        )
+        self.assertTrue(
+            any(block_id == str(text_block.usage_key) for block_id, _ in urls),
+            "Text block should be included"
+        )
 
     @pytest.mark.asyncio
     async def test_every_detected_link_is_validated(self):

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -393,14 +393,14 @@ class CheckBrokenLinksTaskTest(ModuleStoreTestCase):
         def get_block_side_effect(block):
             block_data = getattr(block, 'data', '')
             if isinstance(block_data, str):
-                return {'data' : block_data}
+                return {'data': block_data}
             raise TypeError("expected string or bytes-like object, got 'dict'")
         mock_get_block_info.side_effect = get_block_side_effect
 
         urls = _scan_course_for_links(self.test_course.id)
         # The drag-and-drop block should not appear in the results
         assert all(block_id != str(drag_and_drop_block.usage_key) for block_id, _ in urls), \
-                    "Drag and Drop blocks should be excluded"
+            "Drag and Drop blocks should be excluded"
         assert any(block_id == str(text_block.usage_key) for block_id, _ in urls), "Text block should be included"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Description:
This PR resolves the issue where the Course Optimizer fails with a "Link Check Failed" error when a Drag and Drop block is present in a course.

[JIRA Link](https://2u-internal.atlassian.net/browse/TNL-11915?atlOrigin=eyJpIjoiOGMzMTAyNmZjMzEyNGRhMDgzMGY2YTU2MGQ1YjUwYzAiLCJwIjoiaiJ9)
test-course: https://course-authoring.stage.edx.org/course/course-v1:edx+jrr_103+H2_2023/optimizer

### Issue Details:
- The error occurred due to a TypeError: `TypeError: expected string or bytes-like object, got 'dict'.`
- This was caused by the `data` field in Drag and Drop blocks, which is stored as a `dictionary` instead of a `string`.
- The error was triggered in `re.sub( , , xblock_data)`, where xblock_data expected a string but received an object.

### Solution Implemented:
- The fix excludes Drag and Drop blocks from the link-scanning process in the Course Optimizer.
- This is done by checking the block type before processing its content.
- The solution ensures that the optimizer can successfully scan other course content without failure.

### Testing & Verification:
- Verified the fix by running the optimizer on test courses with and without Drag and Drop blocks.
- Confirmed that the scan completes successfully and broken links are detected as expected.

### How to verify locally
- Checkout this branch for edx-platform
- Export test-course from stage environment and import on local devstack
- run CMS and Cms-worker containers
- Run course optimizer on test-course

### Before
<img width="1783" alt="image" src="https://github.com/user-attachments/assets/c53d094a-0b18-4cf0-a449-907a09902b46" />


### After

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/51719aa4-fb7f-4773-bc16-68d25619c2d4" />
