### PR TITLE
build: Drop the `whatwg-fetch` polyfill.

### DIFF
--- a/common/static/common/js/components/BlockBrowser/data/api/client.js
+++ b/common/static/common/js/components/BlockBrowser/data/api/client.js
@@ -1,5 +1,4 @@
 import Cookies from 'js-cookie';
-import 'whatwg-fetch';
 
 const COURSE_BLOCKS_API = '/api/courses/v1/blocks/';
 

--- a/lms/djangoapps/instructor/static/instructor/ProblemBrowser/data/api/client.js
+++ b/lms/djangoapps/instructor/static/instructor/ProblemBrowser/data/api/client.js
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import Cookies from 'js-cookie';
 
 const HEADERS = {

--- a/lms/djangoapps/support/static/support/jsx/entitlements/data/api/client.js
+++ b/lms/djangoapps/support/static/support/jsx/entitlements/data/api/client.js
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import Cookies from 'js-cookie';
 
 import { entitlementApi } from './endpoints';

--- a/lms/static/js/student_account/AccountsClient.js
+++ b/lms/static/js/student_account/AccountsClient.js
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import Cookies from 'js-cookie';
 
 const deactivate = (password) => fetch('/api/user/v1/accounts/deactivate_logout/', {

--- a/lms/static/js/student_account/components/PasswordResetConfirmation.jsx
+++ b/lms/static/js/student_account/components/PasswordResetConfirmation.jsx
@@ -1,6 +1,5 @@
 /* globals gettext */
 
-import 'whatwg-fetch';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
         "webpack": "^5.90.3",
         "webpack-bundle-tracker": "0.4.3",
         "webpack-merge": "4.2.2",
-        "whatwg-fetch": "2.0.4",
         "which-country": "1.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "webpack": "^5.90.3",
     "webpack-bundle-tracker": "0.4.3",
     "webpack-merge": "4.2.2",
-    "whatwg-fetch": "2.0.4",
     "which-country": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This package polyfills the Fetch api but that API is now widely
available so I don't think we need this package anymore.
