### PR TITLE
fix: enable core notification pref editing

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -241,7 +241,7 @@ COURSE_NOTIFICATION_APPS = {
         'core_email': True,
         'core_push': True,
         'core_email_cadence': EmailCadence.DAILY,
-        'non_editable': ['web']
+        'non_editable': []
     },
     'updates': {
         'enabled': True,

--- a/openedx/core/djangoapps/notifications/email/tests/test_utils.py
+++ b/openedx/core/djangoapps/notifications/email/tests/test_utils.py
@@ -8,7 +8,7 @@ import pytest
 from django.http.response import Http404
 from itertools import product
 from pytz import utc
-from waffle import get_waffle_flag_model   # pylint: disable=invalid-django-waffle-import
+from waffle import get_waffle_flag_model  # pylint: disable=invalid-django-waffle-import
 
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.notifications.base_notification import (
@@ -42,6 +42,7 @@ class TestUtilFunctions(ModuleStoreTestCase):
     """
     Test utils functions
     """
+
     def setUp(self):
         """
         Setup
@@ -102,6 +103,7 @@ class TestContextFunctions(ModuleStoreTestCase):
     """
     Test template context functions in utils.py
     """
+
     def setUp(self):
         """
         Setup
@@ -172,6 +174,7 @@ class TestWaffleFlag(ModuleStoreTestCase):
     """
     Test user level email notifications waffle flag
     """
+
     def setUp(self):
         """
         Setup
@@ -224,6 +227,7 @@ class TestEncryption(ModuleStoreTestCase):
     """
     Tests all encryption methods
     """
+
     def test_string_encryption(self):
         """
         Tests if decrypted string is equal original string
@@ -250,6 +254,7 @@ class TestUpdatePreferenceFromPatch(ModuleStoreTestCase):
     """
     Tests if preferences are update according to patch data
     """
+
     def setUp(self):
         """
         Setup test cases

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -275,9 +275,7 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'email_cadence': 'Daily',
                         },
                     },
-                    'non_editable': {
-                        'core': ['web']
-                    }
+                    'non_editable': {}
                 },
                 'updates': {
                     'enabled': True,
@@ -1130,12 +1128,12 @@ class UpdateAllNotificationPreferencesViewTests(APITestCase):
         response = self.client.post(self.url, data, format='json')
 
         # Should fail because 'web' is non-editable for 'core' in discussion
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['status'], 'error')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'success')
 
         # Verify database remains unchanged
         for pref in CourseNotificationPreference.objects.filter(is_active=True):
-            self.assertTrue(
+            self.assertFalse(
                 pref.notification_preference_config['discussion']['notification_types']['core']['web']
             )
 


### PR DESCRIPTION
## Description
Make core notification preferences editable.

## Ticket 

https://2u-internal.atlassian.net/browse/INF-1794