### PR TITLE
feat: only fetch published pathways

### DIFF
--- a/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
@@ -200,7 +200,7 @@ class Command(BaseCommand):
         failure = False
         logger.info(f'Requesting pathways for {site.domain}.')
         try:
-            api_url = urljoin(f"{api_base_url}/", "pathways/")
+            api_url = urljoin(f"{api_base_url}/", "pathways/?status=published")
             next_page = 1
             while next_page:
                 response = client.get(api_url, params=dict(exclude_utm=1, page=next_page))

--- a/openedx/core/djangoapps/catalog/management/commands/tests/test_cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/tests/test_cache_programs.py
@@ -142,6 +142,7 @@ class TestCachePrograms(CatalogIntegrationMixin, CacheIsolationTestCase, SiteMix
             expected = {
                 'exclude_utm': ['1'],
                 'page': [str(page_number)],
+                'status': ['published']
             }
             assert request.querystring == expected
 
@@ -156,7 +157,7 @@ class TestCachePrograms(CatalogIntegrationMixin, CacheIsolationTestCase, SiteMix
 
         httpretty.register_uri(
             httpretty.GET,
-            self.pathway_url + f'?exclude_utm=1&page={page_number}',
+            self.pathway_url + f'?status=published&exclude_utm=1&page={page_number}',
             body=pathways_callback,
             content_type='application/json',
             match_querystring=True,

--- a/openedx/core/djangoapps/catalog/tests/factories.py
+++ b/openedx/core/djangoapps/catalog/tests/factories.py
@@ -290,3 +290,4 @@ class PathwayFactory(DictFactoryBase):
     org_name = factory.Faker('company')
     programs = factory.LazyFunction(partial(generate_instances, ProgramFactory))
     pathway_type = FuzzyChoice(path_type.value for path_type in PathwayType)
+    status = 'published'


### PR DESCRIPTION
# [PROD-4311](https://2u-internal.atlassian.net/browse/PROD-4311)

## Description

This PR changes the url for fetching pathways in the `cache_programs` job to ensure that only `published` (i.e active) pathways are fetched.