### PR TITLE
feat: preserve image alt text while converting html to text

### DIFF
--- a/xmodule/annotator_mixin.py
+++ b/xmodule/annotator_mixin.py
@@ -37,6 +37,13 @@ class MLStripper(HTMLParser):  # lint-amnesty, pylint: disable=abstract-method
         self.reset()
         self.fed = []
 
+    def handle_starttag(self, tag, attrs):
+        if tag != 'img':
+            return
+        for attr in attrs:
+            if len(attr) >= 2 and attr[0] == 'alt':
+                self.fed.append(attr[1])
+
     def handle_data(self, data):
         """takes the data in separate chunks"""
         self.fed.append(data)

--- a/xmodule/tests/test_annotator_mixin.py
+++ b/xmodule/tests/test_annotator_mixin.py
@@ -22,6 +22,10 @@ class HelperFunctionTest(unittest.TestCase):
     sample_sourceurl = "http://video-js.zencoder.com/oceans-clip.mp4"
     sample_youtubeurl = "http://www.youtube.com/watch?v=yxLIu-scR9Y"
     sample_html = '<p><b>Testing here</b> and not bolded here</p>'
+    # pylint: disable=line-too-long
+    sample_html_with_image_alt = '''<p>Testing here with image: </p><p><img src="/static/image.jpg" alt="the alt text" width="560" height="315" /></p>'''
+    # pylint: disable=line-too-long
+    sample_html_with_no_image_alt = '''<p>Testing here with image: </p><p><img src="/static/image.jpg" width="560" height="315" /></p>'''
 
     def test_get_instructions(self):
         """
@@ -53,4 +57,14 @@ class HelperFunctionTest(unittest.TestCase):
     def test_html_to_text(self):
         expectedtext = "Testing here and not bolded here"
         result = html_to_text(self.sample_html)
+        assert expectedtext == result
+
+    def test_html_image_with_alt_text(self):
+        expectedtext = "Testing here with image: the alt text"
+        result = html_to_text(self.sample_html_with_image_alt)
+        assert expectedtext == result
+
+    def test_html_image_with_no_alt_text(self):
+        expectedtext = "Testing here with image: "
+        result = html_to_text(self.sample_html_with_no_image_alt)
         assert expectedtext == result


### PR DESCRIPTION
## Description

Replace image with its alt text while converting html to plain text for indexing.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", and "Developer".

![image](https://github.com/user-attachments/assets/fa837a2d-32af-4922-b26a-867e46c966a7)


## Supporting information

* Part of: https://github.com/openedx/frontend-app-authoring/issues/1670
* `Private-ref`: [FAL-4092](https://tasks.opencraft.com/browse/FAL-4092)


## Testing instructions

* Create or edit any html component with image and alt text in library and save it (to reindex it)
* Verify that the card preview shows the alt text in place of the image.
