### PR TITLE
fix: Remove horizontal scroll on instructor page in RTL version

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -708,10 +708,9 @@
     .hint {
       @extend %t-copy-sub2;
 
-      display: block;
+      display: none;
       position: absolute;
       top: ($baseline/2);
-      left: -9999em;
       padding: ($baseline/2);
       width: 50%;
       background-color: $light-gray3;
@@ -735,10 +734,7 @@
     /* ***
      * Ideally we want to handle functionality with JS.
      * This functionality should eventually be moved into CS/JS, and out of here. */
-    .has-hint:hover > .hint {
-      @include left($baseline*10);
-    }
-
+    .has-hint:hover > .hint,
     .has-hint input:focus ~ .hint {
       @include left($baseline*10);
     }

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -711,13 +711,12 @@
       display: block;
       position: absolute;
       top: ($baseline/2);
-
-      @include left(-9999em);
-
+      left: -9999em;
       padding: ($baseline/2);
       width: 50%;
       background-color: $light-gray3;
       box-shadow: 2px 2px 3px $shadow;
+      z-index: 1;
 
       .hint-caret {
         display: block;

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -736,6 +736,8 @@
      * This functionality should eventually be moved into CS/JS, and out of here. */
     .has-hint:hover > .hint,
     .has-hint input:focus ~ .hint {
+      display: block;
+
       @include left($baseline*10);
     }
 


### PR DESCRIPTION
## Description

Previously, the mixin `@include left(-9999em);` was used to set `left: -9999em` or `right: -9999em` depending on the text direction (LTR/RTL). However, using `right: -9999em` in RTL mode caused the body to expand, leading to an unwanted horizontal scroll.

This PR replaces the mixin with a fixed `left: -9999em` for both LTR and RTL, ensuring elements are correctly hidden without affecting the page width.

Additionally, `z-index: 1` has been added to ensure that hint tooltips appear above their parent label elements

https://github.com/user-attachments/assets/ba029629-4a2f-4245-a427-21ddac28e249

<img width="1840" alt="Снимок экрана 2025-03-06 в 14 53 51" src="https://github.com/user-attachments/assets/a48b42e9-eecc-4be1-a416-1280d140f398" />

## Changes

- Replaced `@include left(-9999em);` with `left: -9999em` for both LTR and RTL.
- Removed the possibility of using `right: -9999em` to prevent horizontal scrolling issues.
- Added `z-index: 1` to ensure hint tooltips are displayed above their parent label elements.

## Reason for Changes

- Using `right: -9999em` in RTL mode caused the body to expand, resulting in an unnecessary horizontal scroll. Setting `left: -9999em` ensures proper element hiding without side effects.
- Hint tooltips were sometimes rendered behind their parent `label` elements. Adding `z-index: 1` ensures they appear on top

## Testing

- Verified in both LTR and RTL modes.
- Horizontal scroll no longer appears.
- Elements remain hidden without affecting body width.
- Hint tooltips are now properly displayed above their parent labels.