### PR TITLE
docs: add event_type inline code annotation for events

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1208,6 +1208,7 @@ def duplicate_block(
             store.update_item(parent, user.id)
 
         # .. event_implemented_name: XBLOCK_DUPLICATED
+        # .. event_type: org.openedx.content_authoring.xblock.duplicated.v1
         XBLOCK_DUPLICATED.send_event(
             time=datetime.now(timezone.utc),
             xblock_info=DuplicatedXBlockData(

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -512,6 +512,7 @@ class CourseEnrollment(models.Model):
             )
 
             # .. event_implemented_name: COURSE_ENROLLMENT_CHANGED
+            # .. event_type: org.openedx.learning.course.enrollment.changed.v1
             COURSE_ENROLLMENT_CHANGED.send_event(
                 enrollment=CourseEnrollmentData(
                     user=UserData(
@@ -539,6 +540,7 @@ class CourseEnrollment(models.Model):
                 self.send_signal(EnrollStatusChange.unenroll)
 
                 # .. event_implemented_name: COURSE_UNENROLLMENT_COMPLETED
+                # .. event_type: org.openedx.learning.course.unenrollment.completed.v1
                 COURSE_UNENROLLMENT_COMPLETED.send_event(
                     enrollment=CourseEnrollmentData(
                         user=UserData(
@@ -777,6 +779,7 @@ class CourseEnrollment(models.Model):
         enrollment.send_signal(EnrollStatusChange.enroll)
 
         # .. event_implemented_name: COURSE_ENROLLMENT_CREATED
+        # .. event_type: org.openedx.learning.course.enrollment.created.v1
         COURSE_ENROLLMENT_CREATED.send_event(
             enrollment=CourseEnrollmentData(
                 user=UserData(

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -403,6 +403,7 @@ class GeneratedCertificate(models.Model):
         )
 
         # .. event_implemented_name: CERTIFICATE_REVOKED
+        # .. event_type: org.openedx.learning.certificate.revoked.v1
         CERTIFICATE_REVOKED.send_event(
             time=self.modified_date.astimezone(timezone.utc),
             certificate=CertificateData(
@@ -487,6 +488,7 @@ class GeneratedCertificate(models.Model):
         )
 
         # .. event_implemented_name: CERTIFICATE_CHANGED
+        # .. event_type: org.openedx.learning.certificate.changed.v1
         CERTIFICATE_CHANGED.send_event(
             time=timestamp,
             certificate=CertificateData(
@@ -520,6 +522,7 @@ class GeneratedCertificate(models.Model):
             )
 
             # .. event_implemented_name: CERTIFICATE_CREATED
+            # .. event_type: org.openedx.learning.certificate.created.v1
             CERTIFICATE_CREATED.send_event(
                 time=timestamp,
                 certificate=CertificateData(

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -716,6 +716,7 @@ class PersistentCourseGrade(TimeStampedModel):
         When called emits an event when a persistent grade is created or updated.
         """
         # .. event_implemented_name: PERSISTENT_GRADE_SUMMARY_CHANGED
+        # .. event_type: org.openedx.learning.course.persistent_grade_summary.changed.v1
         PERSISTENT_GRADE_SUMMARY_CHANGED.send_event(
             grade=PersistentCourseGradeData(
                 user_id=user_id,

--- a/lms/djangoapps/verify_student/signals/signals.py
+++ b/lms/djangoapps/verify_student/signals/signals.py
@@ -41,6 +41,7 @@ def emit_idv_attempt_created_event(attempt_id, user, status, name, expiration_da
     user_data = _create_user_data(user)
 
     # .. event_implemented_name: IDV_ATTEMPT_CREATED
+    # .. event_type: org.openedx.learning.idv_attempt.created.v1
     IDV_ATTEMPT_CREATED.send_event(
         idv_attempt=VerificationAttemptData(
             attempt_id=attempt_id,
@@ -60,6 +61,7 @@ def emit_idv_attempt_pending_event(attempt_id, user, status, name, expiration_da
     user_data = _create_user_data(user)
 
     # .. event_implemented_name: IDV_ATTEMPT_PENDING
+    # .. event_type: org.openedx.learning.idv_attempt.pending.v1
     IDV_ATTEMPT_PENDING.send_event(
         idv_attempt=VerificationAttemptData(
             attempt_id=attempt_id,
@@ -79,6 +81,7 @@ def emit_idv_attempt_approved_event(attempt_id, user, status, name, expiration_d
     user_data = _create_user_data(user)
 
     # .. event_implemented_name: IDV_ATTEMPT_APPROVED
+    # .. event_type: org.openedx.learning.idv_attempt.approved.v1
     IDV_ATTEMPT_APPROVED.send_event(
         idv_attempt=VerificationAttemptData(
             attempt_id=attempt_id,
@@ -98,6 +101,7 @@ def emit_idv_attempt_denied_event(attempt_id, user, status, name, expiration_dat
     user_data = _create_user_data(user)
 
     # .. event_implemented_name: IDV_ATTEMPT_DENIED
+    # .. event_type: org.openedx.learning.idv_attempt.denied.v1
     IDV_ATTEMPT_DENIED.send_event(
         idv_attempt=VerificationAttemptData(
             attempt_id=attempt_id,

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -163,6 +163,7 @@ class CohortMembership(models.Model):
         self.full_clean(validate_unique=False)
 
         # .. event_implemented_name: COHORT_MEMBERSHIP_CHANGED
+        # .. event_type: org.openedx.learning.cohort_membership.changed.v1
         COHORT_MEMBERSHIP_CHANGED.send_event(
             cohort=CohortData(
                 user=UserData(

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -329,6 +329,7 @@ def _handle_successful_authentication_and_login(user, request):
         log.debug("Setting user session expiry to 4 weeks")
 
         # .. event_implemented_name: SESSION_LOGIN_COMPLETED
+        # .. event_type: org.openedx.learning.auth.session.login.completed.v1
         SESSION_LOGIN_COMPLETED.send_event(
             user=UserData(
                 pii=UserPersonalData(

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -263,6 +263,7 @@ def create_account_with_params(request, params):  # pylint: disable=too-many-sta
     REGISTER_USER.send(sender=None, user=user, registration=registration)
 
     # .. event_implemented_name: STUDENT_REGISTRATION_COMPLETED
+    # .. event_type: org.openedx.learning.student.registration.completed.v1
     STUDENT_REGISTRATION_COMPLETED.send_event(
         user=UserData(
             pii=UserPersonalData(

--- a/xmodule/modulestore/mixed.py
+++ b/xmodule/modulestore/mixed.py
@@ -678,6 +678,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         self.mappings[course_key] = store
 
         # .. event_implemented_name: COURSE_CREATED
+        # .. event_type: org.openedx.content_authoring.course.created.v1
         COURSE_CREATED.send_event(
             time=datetime.now(timezone.utc),
             course=CourseData(
@@ -761,6 +762,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         def send_created_event():
             # .. event_implemented_name: XBLOCK_CREATED
+            # .. event_type: org.openedx.content_authoring.xblock.created.v1
             XBLOCK_CREATED.send_event(
                 time=datetime.now(timezone.utc),
                 xblock_info=XBlockData(
@@ -799,6 +801,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         def send_created_event():
             # .. event_implemented_name: XBLOCK_CREATED
+            # .. event_type: org.openedx.content_authoring.xblock.created.v1
             XBLOCK_CREATED.send_event(
                 time=datetime.now(timezone.utc),
                 xblock_info=XBlockData(
@@ -843,6 +846,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         def send_updated_event():
             # .. event_implemented_name: XBLOCK_UPDATED
+            # .. event_type: org.openedx.content_authoring.xblock.updated.v1
             XBLOCK_UPDATED.send_event(
                 time=datetime.now(timezone.utc),
                 xblock_info=XBlockData(
@@ -866,6 +870,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         def send_deleted_event():
             # .. event_implemented_name: XBLOCK_DELETED
+            # .. event_type: org.openedx.content_authoring.xblock.deleted.v1
             XBLOCK_DELETED.send_event(
                 time=datetime.now(timezone.utc),
                 xblock_info=XBlockData(
@@ -991,6 +996,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._verify_modulestore_support(location.course_key, 'publish')
         item = store.publish(location, user_id, **kwargs)
         # .. event_implemented_name: XBLOCK_PUBLISHED
+        # .. event_type: org.openedx.content_authoring.xblock.published.v1
         XBLOCK_PUBLISHED.send_event(
             time=datetime.now(timezone.utc),
             xblock_info=XBlockData(

--- a/xmodule/modulestore/xml_importer.py
+++ b/xmodule/modulestore/xml_importer.py
@@ -731,6 +731,7 @@ class CourseImportManager(ImportManager):
         Trigger celery task to create upstream links for newly imported blocks.
         """
         # .. event_implemented_name: COURSE_IMPORT_COMPLETED
+        # .. event_type: org.openedx.content_authoring.course.import.completed.v1
         COURSE_IMPORT_COMPLETED.send_event(
             time=datetime.now(timezone.utc),
             course=CourseData(


### PR DESCRIPTION
## Description

This PR adds an inline code annotation (`# .. event_type`) for all events according to the inline code annotation in filters (`# .. filter_type`). This change is mainly made to maintain consistency in both Hooks Extension packages.

Filter example:
https://github.com/openedx/edx-platform/blob/5735058d7e40970ede55cc8c03ad8ac68f6fdce0/common/djangoapps/student/models/course_enrollment.py#L719-L724