### PR TITLE
fix: Be able to run celery tasks on baremetal.

### DIFF
--- a/lms/envs/minimal.yml
+++ b/lms/envs/minimal.yml
@@ -40,3 +40,7 @@ API_ACCESS_MANAGER_EMAIL: "api-access@example.com"
 
 # So that you can login to studio on bare-metal
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT: 'http://localhost:18000'
+
+# The celery broker url needs to be set even if you're running in always eager mode.
+CELERY_BROKER_TRANSPORT: 'memory'
+CELERY_BROKER_HOSTNAME: 'localhost'


### PR DESCRIPTION
At some point something changed in upstream config or in celery and now
a black transport is no longer valid.  You have to supply some transport
even if you are running in always eager mode.  Add enough config so that
celery tasks will execute without issues when running `runserver` on
baremetal.

Fixes the "No such transport" error:

```
File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/celery/app/task.py", line 575, in apply_async
    with app.producer_or_acquire(producer) as eager_producer:                                                                                                                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/celery/app/base.py", line 932, in producer_or_acquire                                                                                                  producer, self.producer_pool.acquire, block=True,
              ^^^^^^^^^^^^^^^^^^
  File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/celery/app/base.py", line 1354, in producer_pool
    return self.amqp.producer_pool                                                                                                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/celery/app/amqp.py", line 591, in producer_pool
    self.app.connection_for_write()]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/celery/app/base.py", line 829, in connection_for_write
    return self._connection(url or self.conf.broker_write_url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                         File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/celery/app/base.py", line 880, in _connection
    return self.amqp.Connection(
           ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                 File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/kombu/connection.py", line 201, in __init__
    if not get_transport_cls(transport).can_parse_url:                                                                                                                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/kombu/transport/__init__.py", line 91, in get_transport_cls                                                                                            _transport_cache[transport] = resolve_transport(transport)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                   File "/home/feanil/.virtualenvs/edx-platform/lib/python3.11/site-packages/kombu/transport/__init__.py", line 72, in resolve_transport
    raise KeyError(f'No such transport: {transport}')                                                                                                                                                                          KeyError: 'No such transport: '

```
