### PR TITLE
fix: restrict cohorts TAs to access threads of others

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -990,7 +990,6 @@ def get_thread_list(
             except ValueError:
                 pass
 
-
     # If no group_id was specified and the user is a TA or non-moderator,
     # get their group ID from the course discussion settings.
     # If the group ID is passed as query params to the forum API, it will filter threads with that group_id.

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -990,7 +990,12 @@ def get_thread_list(
             except ValueError:
                 pass
 
-    if (group_id is None) and not context["has_moderation_privilege"]:
+
+    # If no group_id was specified and the user is a TA or non-moderator,
+    # get their group ID from the course discussion settings.
+    # If the group ID is passed as query params to the forum API, it will filter threads with that group_id.
+    # A cohort TA can only see posts from their cohort, not all posts.
+    if (group_id is None) and (context["has_ta_privilege"] or not context["has_moderation_privilege"]):
         group_id = get_group_id_for_user(request.user, CourseDiscussionSettings.get(course.id))
 
     query_params = {

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -73,6 +73,7 @@ def get_context(course, request, thread=None):
     course_discussion_settings = CourseDiscussionSettings.get(course.id)
     is_global_staff = GlobalStaff().has_user(requester)
     has_moderation_privilege = requester.id in moderator_user_ids or requester.id in ta_user_ids or is_global_staff
+    has_ta_privilege = requester.id in ta_user_ids
     return {
         "course": course,
         "request": request,
@@ -84,6 +85,7 @@ def get_context(course, request, thread=None):
         "ta_user_ids": ta_user_ids,
         "cc_requester": cc_requester,
         "has_moderation_privilege": has_moderation_privilege,
+        "has_ta_privilege": has_ta_privilege,
         "is_global_staff": is_global_staff,
         "is_staff_or_admin": requester.id in course_staff_user_ids,
     }

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -897,7 +897,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
         _assign_role_to_user(user=self.user, course_id=cohort_course.id, role=role_name)
         self.get_thread_list([], course=cohort_course)
         actual_has_group = "group_id" in httpretty.last_request().querystring  # lint-amnesty, pylint: disable=no-member
-        expected_has_group = (course_is_cohorted and role_name == FORUM_ROLE_STUDENT)
+        expected_has_group = (course_is_cohorted and role_name in [FORUM_ROLE_STUDENT, FORUM_ROLE_COMMUNITY_TA])
         assert actual_has_group == expected_has_group
 
     def test_pagination(self):


### PR DESCRIPTION
## Description

This fix resolves issue [#152](https://github.com/openedx/forum/issues/152) in the Open edX forum, where Group Teaching Assistants (TAs) were able to access discussion posts from cohorts other than their own. The update ensures that Group TAs can now only view and manage posts within their assigned cohorts, maintaining the intended separation of cohort discussions.

### Impacted User Roles

- **Group Teaching Assistant**: Restricted access to discussion posts strictly within their assigned cohorts.

- **Learner**: Enhanced privacy, as their posts are now only accessible to TAs within their cohort.

### UI Changes

This fix does not introduce any changes to the user interface.

### Configuration Changes

No configuration changes are required for this fix.

## Supporting Information

- GitHub Issue: [[#152](https://github.com/openedx/forum/issues/152)](https://github.com/openedx/forum/issues/152)

## Testing Instructions

1. **Assign a user the Group TA role for a specific cohort.**

2. **Post discussions in multiple cohorts.**

3. **Log in as the Group TA and verify that only posts from their assigned cohort are visible.**

4. **Confirm that attempts to access posts from other cohorts are denied.**

## Deadline

None.

## Other Information

- **Dependencies**: This fix does not depend on other changes.

- **Security & Accessibility Considerations**: Enhances data privacy by limiting post visibility to appropriate TAs.

- **Database Migrations**: This fix does not involve any database migrations.

