### PR TITLE
fix: add target='_blank' for videos hosted outside edx

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -814,6 +814,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'edx_video_id': edx_video_id,
             'result': {
                 'download_video_link': f'http://fake-video.edx.org/{edx_video_id}.mp4',
+                'is_video_from_same_origin': True,
                 'sources': ['http://fake-video.edx.org/example.mp4', 'http://fake-video.edx.org/example.webm'] +
                            [video['url'] for video in encoded_videos],
             },

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -96,6 +96,7 @@ class TestVideoYouTube(TestVideo):  # lint-amnesty, pylint: disable=missing-clas
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'id': self.block.location.html_id(),
@@ -184,6 +185,7 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
@@ -460,6 +462,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'id': self.block.location.html_id(),
@@ -592,6 +595,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'id': self.block.location.html_id(),
@@ -730,6 +734,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
@@ -809,12 +814,15 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'edx_video_id': edx_video_id,
             'result': {
                 'download_video_link': f'http://fake-video.edx.org/{edx_video_id}.mp4',
-                'sources': ['example.mp4', 'example.webm'] + [video['url'] for video in encoded_videos],
+                'sources': ['http://fake-video.edx.org/example.mp4', 'http://fake-video.edx.org/example.webm'] +
+                           [video['url'] for video in encoded_videos],
             },
         }
-        # context returned by get_html when provided with above data
-        # expected_context, a dict to assert with context
-        context, expected_context = self.helper_get_html_with_edx_video_id(data)
+        with override_settings(VIDEO_CDN_URL={'default': 'http://fake-video.edx.org'}):
+            # context returned by get_html when provided with above data
+            # expected_context, a dict to assert with context
+            context, expected_context = self.helper_get_html_with_edx_video_id(data)
+
         mako_service = self.block.runtime.service(self.block, 'mako')
         assert get_context_dict_from_string(context) ==\
                get_context_dict_from_string(mako_service.render_lms_template('video.html', expected_context))
@@ -839,12 +847,15 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'edx_video_id': f"{edx_video_id}\t",
             'result': {
                 'download_video_link': f'http://fake-video.edx.org/{edx_video_id}.mp4',
-                'sources': ['example.mp4', 'example.webm'] + [video['url'] for video in encoded_videos],
+                'is_video_from_same_origin': True,
+                'sources': ['http://fake-video.edx.org/example.mp4', 'http://fake-video.edx.org/example.webm'] +
+                           [video['url'] for video in encoded_videos],
             },
         }
-        # context returned by get_html when provided with above data
-        # expected_context, a dict to assert with context
-        context, expected_context = self.helper_get_html_with_edx_video_id(data)
+        with override_settings(VIDEO_CDN_URL={'default': 'http://fake-video.edx.org'}):
+            # context returned by get_html when provided with above data
+            # expected_context, a dict to assert with context
+            context, expected_context = self.helper_get_html_with_edx_video_id(data)
 
         mako_service = self.block.runtime.service(self.block, 'mako')
         assert get_context_dict_from_string(context) ==\
@@ -910,6 +921,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
@@ -951,6 +963,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'block_id': str(self.block.location),
             'course_id': str(self.block.location.course_key),
             'download_video_link': data['result']['download_video_link'],
+            'is_video_from_same_origin': data['result']['is_video_from_same_origin'],
             'metadata': json.dumps(expected_context['metadata'])
         })
         return context, expected_context
@@ -1029,6 +1042,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': None,
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
@@ -1129,6 +1143,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': None,
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'id': None,
@@ -2382,6 +2397,7 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
@@ -2464,6 +2480,7 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
             'cdn_exp_group': None,
             'display_name': 'A Name',
             'download_video_link': 'example.mp4',
+            'is_video_from_same_origin': False,
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -57,7 +57,7 @@ from openedx.core.djangolib.js_utils import (
                     <h4 class="hd hd-5">${_('Video')}</h4>
                     % if download_video_link:
                         <span class="icon fa fa-download" aria-hidden="true"></span>
-                        <a class="btn-link video-sources video-download-button" href="${download_video_link}">
+                        <a class="btn-link video-sources video-download-button" href="${download_video_link}" target="${'_blank' if not is_video_from_same_origin else '_self'}">
                             ${_('Download video file')}
                         </a>
                     % endif

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -481,7 +481,7 @@ class _BuiltInVideoBlock(
             'cdn_exp_group': cdn_exp_group,
             'display_name': self.display_name_with_default,
             'download_video_link': download_video_link,
-            'is_video_from_same_origin' : is_video_from_same_origin,
+            'is_video_from_same_origin': is_video_from_same_origin,
             'handout': self.handout,
             'hide_downloads': is_public_view or is_embed,
             'id': self.location.html_id(),

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -471,6 +471,8 @@ class _BuiltInVideoBlock(
 
         bumperize(self)
 
+        is_video_from_same_origin = bool(download_video_link and cdn_url and download_video_link.startswith(cdn_url))
+
         template_context = {
             'autoadvance_enabled': autoadvance_enabled,
             'branding_info': branding_info,
@@ -479,6 +481,7 @@ class _BuiltInVideoBlock(
             'cdn_exp_group': cdn_exp_group,
             'display_name': self.display_name_with_default,
             'download_video_link': download_video_link,
+            'is_video_from_same_origin' : is_video_from_same_origin,
             'handout': self.handout,
             'hide_downloads': is_public_view or is_embed,
             'id': self.location.html_id(),


### PR DESCRIPTION
## Description

When an author or learner clicks the "Download Video" button in the Video XBlock, the resulting behavior is inconsistent. Some videos download directly, while others remain in the same tab, and some redirect the user to a new page within the same tab.

Currently, when users click on a video file hosted outside of the edX platform, it opens in the same tab, disrupting the user experience. To improve consistency and usability, we propose modifying the behavior so that clicking the "Download Video" button always opens the video in a new tab, regardless of the hosting origin.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author"

## Supporting information

- [JIRA Link](https://2u-internal.atlassian.net/browse/TNL-11904)

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.
- I've created a test-course for testing
- Go to Last SubSection > Unit. ([Link](https://studio.stage.edx.org/container/block-v1:edx+HTC101+2025_T2+type@vertical+block@e219e22b238345e68593435658d32e7b))
- You'll see 4 videos. The second one should be downloadable in the same tab. Other should redirect to a anew tab for downloading.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

### before


https://github.com/user-attachments/assets/36a4bc89-4569-449e-8c1e-22b4530d83ca


### after



https://github.com/user-attachments/assets/7700d286-e0ae-4a14-b4fc-5015c8b6e349

