### PR TITLE
chore: replace edx-brand direct installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-object-assign": "^7.18.6",
         "@babel/preset-env": "^7.19.0",
         "@babel/preset-react": "7.26.3",
-        "@edx/brand-edx.org": "^2.0.7",
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/edx-bootstrap": "1.0.4",
         "@edx/edx-proctoring": "^4.18.1",
         "@edx/frontend-component-cookie-policy-banner": "2.2.0",
@@ -1974,11 +1974,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/@edx/brand-edx.org": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.3.tgz",
-      "integrity": "sha512-1TwUwW7YVgvhh7aO1ql1poAosUCA0zd7/DNuqeSO0wXui0oCHL+WQW8b9tXS2tRJ5BMRKjG8t22fcOcKX3ljbg==",
-      "license": "UNLICENSED"
+    "node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@edx/edx-bootstrap": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/plugin-transform-object-assign": "^7.18.6",
     "@babel/preset-env": "^7.19.0",
     "@babel/preset-react": "7.26.3",
-    "@edx/brand-edx.org": "^2.0.7",
+    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/edx-bootstrap": "1.0.4",
     "@edx/edx-proctoring": "^4.18.1",
     "@edx/frontend-component-cookie-policy-banner": "2.2.0",


### PR DESCRIPTION
## Description

This PR replaces `brand-edx.org` with openedx theme and adds it to the package file indirectly via aliasing. 

## Supporting information
Issue Link: https://github.com/edx/edx-arch-experiments/issues/943

Link to the PR which is associated with the same issue
https://github.com/edx/configuration/pull/179
