### PR TITLE
fix: Resolve digest email on new enrollment after one click email unsubscribe

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -330,7 +330,7 @@ class NotificationPreferenceSyncManager:
         return denormalized_preferences
 
     @staticmethod
-    def update_preferences(preferences):
+    def update_preferences(preferences, email_opt_out=False):
         """
         Creates a new preference version from old preferences.
         New preference is created instead of updating old preference
@@ -347,7 +347,7 @@ class NotificationPreferenceSyncManager:
             5) Denormalize new preference
         """
         old_preferences = NotificationPreferenceSyncManager.normalize_preferences(preferences)
-        default_prefs = NotificationAppManager().get_notification_app_preferences()
+        default_prefs = NotificationAppManager().get_notification_app_preferences(email_opt_out)
         new_prefs = NotificationPreferenceSyncManager.normalize_preferences(default_prefs)
 
         for app in new_prefs.get('apps'):
@@ -409,7 +409,7 @@ class NotificationTypeManager:
         return non_editable_notification_channels
 
     @staticmethod
-    def get_non_core_notification_type_preferences(non_core_notification_types):
+    def get_non_core_notification_type_preferences(non_core_notification_types, email_opt_out=False):
         """
         Returns non-core notification type preferences for the given notification types.
         """
@@ -417,13 +417,13 @@ class NotificationTypeManager:
         for notification_type in non_core_notification_types:
             non_core_notification_type_preferences[notification_type.get('name')] = {
                 'web': notification_type.get('web', False),
-                'email': notification_type.get('email', False),
+                'email': False if email_opt_out else notification_type.get('email', False),
                 'push': notification_type.get('push', False),
                 'email_cadence': notification_type.get('email_cadence', 'Daily'),
             }
         return non_core_notification_type_preferences
 
-    def get_notification_app_preference(self, notification_app):
+    def get_notification_app_preference(self, notification_app, email_opt_out=False):
         """
         Returns notification app preferences for the given notification app.
         """
@@ -431,7 +431,7 @@ class NotificationTypeManager:
             notification_app,
         )
         non_core_notification_types_preferences = self.get_non_core_notification_type_preferences(
-            non_core_notification_types,
+            non_core_notification_types, email_opt_out
         )
         non_editable_notification_channels = self.get_non_editable_notification_channels(non_core_notification_types)
         core_notification_types_name = [notification_type.get('name') for notification_type in core_notification_types]
@@ -443,13 +443,13 @@ class NotificationAppManager:
     Notification app manager
     """
 
-    def add_core_notification_preference(self, notification_app_attrs, notification_types):
+    def add_core_notification_preference(self, notification_app_attrs, notification_types, email_opt_out=False):
         """
         Adds core notification preference for the given notification app.
         """
         notification_types['core'] = {
             'web': notification_app_attrs.get('core_web', False),
-            'email': notification_app_attrs.get('core_email', False),
+            'email': False if email_opt_out else notification_app_attrs.get('core_email', False),
             'push': notification_app_attrs.get('core_push', False),
             'email_cadence': notification_app_attrs.get('core_email_cadence', 'Daily'),
         }
@@ -461,7 +461,7 @@ class NotificationAppManager:
         if notification_app_attrs.get('non_editable', None):
             non_editable_channels['core'] = notification_app_attrs.get('non_editable')
 
-    def get_notification_app_preferences(self):
+    def get_notification_app_preferences(self, email_opt_out=False):
         """
         Returns notification app preferences for the given name.
         """
@@ -469,8 +469,11 @@ class NotificationAppManager:
         for notification_app_key, notification_app_attrs in COURSE_NOTIFICATION_APPS.items():
             notification_app_preferences = {}
             notification_types, core_notifications, \
-                non_editable_channels = NotificationTypeManager().get_notification_app_preference(notification_app_key)
-            self.add_core_notification_preference(notification_app_attrs, notification_types)
+                non_editable_channels = NotificationTypeManager().get_notification_app_preference(
+                    notification_app_key,
+                    email_opt_out
+                )
+            self.add_core_notification_preference(notification_app_attrs, notification_types, email_opt_out)
             self.add_core_notification_non_editable(notification_app_attrs, non_editable_channels)
 
             notification_app_preferences['enabled'] = notification_app_attrs.get('enabled', False)

--- a/openedx/core/djangoapps/notifications/email/__init__.py
+++ b/openedx/core/djangoapps/notifications/email/__init__.py
@@ -1,0 +1,2 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
+ONE_CLICK_EMAIL_UNSUB_KEY = "one_click_email_unsubscribe"

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -14,6 +14,8 @@ from openedx.core.djangoapps.notifications.base_notification import (
     NotificationPreferenceSyncManager,
     get_notification_content
 )
+from openedx.core.djangoapps.notifications.email import ONE_CLICK_EMAIL_UNSUB_KEY
+from openedx.core.djangoapps.user_api.models import UserPreference
 
 User = get_user_model()
 log = logging.getLogger(__name__)
@@ -146,16 +148,22 @@ class CourseNotificationPreference(TimeStampedModel):
         """
         Returns updated courses preferences for a user
         """
-        preferences, _ = CourseNotificationPreference.objects.get_or_create(
-            user_id=user_id,
-            course_id=course_id,
-            is_active=True,
-        )
+        email_opt_out = False
+        try:
+            preferences = CourseNotificationPreference.objects.get(user_id=user_id, course_id=course_id, is_active=True)
+        except CourseNotificationPreference.DoesNotExist:
+            email_opt_out = UserPreference.objects.filter(user_id=user_id, key=ONE_CLICK_EMAIL_UNSUB_KEY).exists()
+            preferences = CourseNotificationPreference.objects.create(
+                user_id=user_id,
+                course_id=course_id,
+                is_active=True,
+                notification_preference_config=NotificationAppManager().get_notification_app_preferences(email_opt_out)
+            )
         current_config_version = get_course_notification_preference_config_version()
         if current_config_version != preferences.config_version:
             try:
                 current_prefs = preferences.notification_preference_config
-                new_prefs = NotificationPreferenceSyncManager.update_preferences(current_prefs)
+                new_prefs = NotificationPreferenceSyncManager.update_preferences(current_prefs, email_opt_out)
                 preferences.config_version = current_config_version
                 preferences.notification_preference_config = new_prefs
                 preferences.save()

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for the views in the notifications app.
 """
+import itertools
 import json
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -30,6 +31,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_MODERATOR
 )
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
+from openedx.core.djangoapps.notifications.email import ONE_CLICK_EMAIL_UNSUB_KEY
 from openedx.core.djangoapps.notifications.email.utils import encrypt_object, encrypt_string
 from openedx.core.djangoapps.notifications.models import (
     CourseNotificationPreference,
@@ -37,6 +39,8 @@ from openedx.core.djangoapps.notifications.models import (
     get_course_notification_preference_config_version
 )
 from openedx.core.djangoapps.notifications.serializers import NotificationCourseEnrollmentSerializer
+from openedx.core.djangoapps.user_api.models import UserPreference
+from openedx.core.djangoapps.notifications.email.utils import update_user_preferences_from_patch
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -115,6 +119,7 @@ class CourseEnrollmentListViewTest(ModuleStoreTestCase):
 
 
 @override_waffle_flag(ENABLE_NOTIFICATIONS, active=True)
+@ddt.ddt
 class CourseEnrollmentPostSaveTest(ModuleStoreTestCase):
     """
     Tests for the post_save signal for CourseEnrollment.
@@ -172,6 +177,68 @@ class CourseEnrollmentPostSaveTest(ModuleStoreTestCase):
 
         self.assertEqual(notification_preferences.count(), 1)
         self.assertEqual(notification_preferences[0].user, self.user)
+
+    def test_disabled_email_preference_is_generated_after_unsubscribe(self):
+        """
+        Test the post_save signal for CourseEnrollment for user with one-click unsubscribe.
+        """
+        UserPreference.objects.create(user_id=self.user.id, key=ONE_CLICK_EMAIL_UNSUB_KEY)
+        enrollment_data = CourseEnrollmentData(
+            user=UserData(
+                pii=UserPersonalData(
+                    username=self.user.username,
+                    email=self.user.email,
+                    name=self.user.profile.name,
+                ),
+                id=self.user.id,
+                is_active=self.user.is_active,
+            ),
+            course=CourseData(
+                course_key=self.course.id,
+                display_name=self.course.display_name,
+            ),
+            mode=self.course_enrollment.mode,
+            is_active=self.course_enrollment.is_active,
+            creation_date=self.course_enrollment.created,
+        )
+        COURSE_ENROLLMENT_CREATED.send_event(
+            enrollment=enrollment_data
+        )
+
+        notification_preferences = CourseNotificationPreference.objects.all()
+
+        self.assertEqual(notification_preferences.count(), 1)
+        self.assertEqual(notification_preferences[0].user, self.user)
+
+        email_preferences = [
+            notification["email"]
+            for app in notification_preferences[0].notification_preference_config.values()
+            for notification in app["notification_types"].values()
+        ]
+
+        self.assertEqual(email_preferences, [False] * len(email_preferences))
+
+    @ddt.data(*itertools.product(('web', 'email'), (True, False)))
+    @ddt.unpack
+    def test_course_preference_creation_for_inactive_enrollments_on_unsub(
+        self,
+        channel,
+        value
+    ):
+        """
+        Test that unsubscribing through one click email does not create new course preferences for inactive enrollments
+        if not already exists.
+        """
+        self.course_enrollment.is_active = False
+        self.course_enrollment.save()
+        encrypted_username = encrypt_string(self.user.username)
+        encrypted_patch = encrypt_object({
+            'channel': channel,
+            'value': value
+        })
+        update_user_preferences_from_patch(encrypted_username, encrypted_patch)
+
+        self.assertEqual(CourseNotificationPreference.objects.all().count(), 0)
 
 
 @override_waffle_flag(ENABLE_NOTIFICATIONS, active=True)
@@ -470,6 +537,24 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
         for notification_app, app_prefs in default_prefs.items():
             for _, type_prefs in app_prefs.get('notification_types', {}).items():
                 assert 'info' not in type_prefs.keys()
+
+    @ddt.data(*itertools.product(('email', 'web'), (True, False)))
+    @ddt.unpack
+    def test_unsub_user_preferences_removal_on_email_enabled(self, channel, value):
+        """
+        Test one click unsub user preference should be removed on email enable for any app.
+        """
+        UserPreference.objects.create(user=self.user, key=ONE_CLICK_EMAIL_UNSUB_KEY)
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
+        payload = {
+            'notification_app': 'discussion',
+            'notification_type': 'core',
+            'notification_channel': channel,
+            'value': value
+        }
+        self.client.patch(self.path, json.dumps(payload), content_type='application/json')
+        result = 0 if channel == 'email' and value else 1
+        self.assertEqual(UserPreference.objects.count(), result)
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -41,6 +41,8 @@ from .serializers import (
 )
 from .utils import get_is_new_notification_view_enabled, get_show_notifications_tray, aggregate_notification_configs, \
     filter_out_visible_preferences_by_course_ids
+from openedx.core.djangoapps.user_api.models import UserPreference
+from openedx.core.djangoapps.notifications.email import ONE_CLICK_EMAIL_UNSUB_KEY
 
 
 @allow_any_authenticated_user()
@@ -228,6 +230,12 @@ class UserNotificationPreferenceView(APIView):
         )
         preference_update.is_valid(raise_exception=True)
         updated_notification_preferences = preference_update.save()
+
+        if request.data.get('notification_channel', '') == 'email' and request.data.get('value', False):
+            UserPreference.objects.filter(
+                user_id=request.user.id,
+                key=ONE_CLICK_EMAIL_UNSUB_KEY
+            ).delete()
         notification_preference_update_event(request.user, course_id, preference_update.validated_data)
 
         serializer_context = {


### PR DESCRIPTION
## Description

This PR addresses an issue where users who have previously unsubscribed via the one-click unsubscribe link still receive email digests when enrolling in a new course.

We have implemented a fix to ensure that users who opt for one-click unsubscription do not have their email preferences set to true by default when they enroll in new courses. Instead, their preferences will remain disabled until they manually enable email notifications from their settings.

## Supporting information

2U ticket: https://2u-internal.atlassian.net/browse/INF-1805

## Testing instructions

1. Click the unsubscribe link in the digest email → The user is unsubscribed from all email notifications.
2. Enroll in a new course after unsubscribing → The email digest preference remains disabled by default.
3. Manually enable email notifications from settings → The email digest is re-enabled based on the user’s choice.
4. After manually enabling email notifications for any course → Future course enrollments will have the email digest enabled by default.