### PR TITLE
build: edx-enterprise 5.10, which removes edx-braze-client as a base req

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -80,7 +80,7 @@ django-storages<1.14.4
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==5.9.2
+edx-enterprise==5.10.0
 
 # Date: 2024-05-09
 # This has to be constrained as well because newer versions of edx-i18n-tools need the

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,7 +8,7 @@
     # via -r requirements/edx/github.in
 acid-xblock==0.4.1
     # via -r requirements/edx/kernel.in
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.11.13
     # via
@@ -37,7 +37,7 @@ asgiref==3.8.1
     #   django-countries
 asn1crypto==1.5.1
     # via snowflake-connector-python
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   aiohttp
@@ -72,13 +72,13 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.37.5
+boto3==1.37.12
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.37.5
+botocore==1.37.12
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -170,7 +170,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -204,7 +204,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -284,7 +283,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.0
+django-js-asset==3.1.2
     # via django-mptt
 django-method-override==1.0.4
     # via -r requirements/edx/kernel.in
@@ -323,7 +322,7 @@ django-object-actions==4.3.0
     # via edx-enterprise
 django-pipeline==4.0.0
     # via -r requirements/edx/kernel.in
-django-push-notifications==3.2.0
+django-push-notifications==3.2.1
     # via edx-ace
 django-ratelimit==4.1.0
     # via -r requirements/edx/kernel.in
@@ -400,7 +399,7 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-spectacular==0.28.0
     # via -r requirements/edx/kernel.in
-drf-yasg==1.21.9
+drf-yasg==1.21.10
     # via
     #   django-user-tasks
     #   edx-api-doc-tools
@@ -412,10 +411,6 @@ edx-api-doc-tools==2.0.0
     #   edx-name-affirmation
 edx-auth-backends==4.4.0
     # via -r requirements/edx/kernel.in
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/bundled.in
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/kernel.in
@@ -446,7 +441,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/kernel.in
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -471,7 +465,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -524,7 +518,7 @@ edx-search==4.1.3
     #   openedx-forum
 edx-sga==0.25.0
     # via -r requirements/edx/bundled.in
-edx-submissions==3.8.5
+edx-submissions==3.8.6
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
@@ -567,9 +561,9 @@ event-tracking==3.0.0
     #   edx-search
 fastavro==1.10.0
     # via openedx-events
-filelock==3.17.0
+filelock==3.18.0
     # via snowflake-connector-python
-firebase-admin==6.6.0
+firebase-admin==6.7.0
     # via edx-ace
 frozenlist==1.5.0
     # via
@@ -591,14 +585,14 @@ geoip2==5.0.1
     # via -r requirements/edx/kernel.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
-google-api-core[grpc]==2.24.1
+google-api-core[grpc]==2.24.2
     # via
     #   firebase-admin
     #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.162.0
+google-api-python-client==2.164.0
     # via firebase-admin
 google-auth==2.38.0
     # via
@@ -610,7 +604,7 @@ google-auth==2.38.0
     #   google-cloud-storage
 google-auth-httplib2==0.2.0
     # via google-api-python-client
-google-cloud-core==2.4.2
+google-cloud-core==2.4.3
     # via
     #   google-cloud-firestore
     #   google-cloud-storage
@@ -624,15 +618,15 @@ google-crc32c==1.6.0
     #   google-resumable-media
 google-resumable-media==2.7.2
     # via google-cloud-storage
-googleapis-common-protos==1.69.0
+googleapis-common-protos==1.69.1
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.70.0
+grpcio==1.71.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.70.0
+grpcio-status==1.71.0
     # via google-api-core
 gunicorn==23.0.0
     # via -r requirements/edx/kernel.in
@@ -666,7 +660,7 @@ ipaddress==1.0.23
     # via -r requirements/edx/kernel.in
 isodate==0.7.2
     # via python3-saml
-jinja2==3.1.5
+jinja2==3.1.6
     # via code-annotations
 jmespath==1.0.1
     # via
@@ -695,7 +689,7 @@ jwcrypto==1.5.6
     # via
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.4.2
+kombu==5.5.0
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/kernel.in
@@ -707,7 +701,7 @@ lazy==1.6
     #   xblock
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via -r requirements/edx/kernel.in
 lxml[html-clean,html_clean]==5.3.1
     # via
@@ -773,7 +767,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum
-newrelic==10.6.0
+newrelic==10.7.0
     # via edx-django-utils
 nh3==0.2.21
     # via -r requirements/edx/kernel.in
@@ -888,7 +882,7 @@ propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
-proto-plus==1.26.0
+proto-plus==1.26.1
     # via
     #   google-api-core
     #   google-cloud-firestore
@@ -1057,7 +1051,6 @@ requests==2.32.3
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
@@ -1095,7 +1088,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.11.3
+s3transfer==0.11.4
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
@@ -1148,7 +1141,7 @@ social-auth-app-django==5.4.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
@@ -1288,7 +1281,7 @@ xblock-utils==4.0.0
     #   xblock-poll
 xblocks-contrib==0.2.0
     # via -r requirements/edx/bundled.in
-xmlsec==1.3.14
+xmlsec==1.3.15
     # via python3-saml
 xss-utils==0.7.1
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -31,7 +31,6 @@ edx-i18n-tools>=0.4.6               # Commands for developers and translators to
 ## Third party integrations
 algoliasearch                       # Algolia’s API client for indexed searching
 django-ses                          # Django email backend for Amazon’s Simple Email Service
-edx-braze-client                    # a customer engagement platform used for edx.org
 mailsnake                           # MailChimp API; used for two management commands in the "mailing" djangoapp
 optimizely-sdk                      # Optimizely provides A/B testing and other features, used by edx.org
 

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -8,9 +8,9 @@ chardet==5.2.0
     # via diff-cover
 coverage==7.6.12
     # via -r requirements/edx/coverage.in
-diff-cover==9.2.3
+diff-cover==9.2.4
     # via -r requirements/edx/coverage.in
-jinja2==3.1.5
+jinja2==3.1.6
     # via diff-cover
 markupsafe==3.0.2
     # via jinja2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -16,7 +16,7 @@ acid-xblock==0.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -83,14 +83,14 @@ asn1crypto==1.5.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pylint
     #   pylint-celery
     #   sphinx-autoapi
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -145,14 +145,14 @@ boto==2.49.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.37.5
+boto3==1.37.12
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.37.5
+botocore==1.37.12
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -307,7 +307,7 @@ cryptography==44.0.2
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssselect==1.2.0
+cssselect==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
@@ -330,7 +330,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-diff-cover==9.2.3
+diff-cover==9.2.4
     # via -r requirements/edx/testing.txt
 dill==0.3.9
     # via
@@ -340,7 +340,7 @@ distlib==0.3.9
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -378,7 +378,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -481,7 +480,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.0
+django-js-asset==3.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -538,7 +537,7 @@ django-pipeline==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-push-notifications==3.2.0
+django-push-notifications==3.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -659,7 +658,7 @@ drf-spectacular==0.28.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-drf-yasg==1.21.9
+drf-yasg==1.21.10
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -678,11 +677,6 @@ edx-auth-backends==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/doc.txt
@@ -724,7 +718,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/testing.txt
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -750,7 +743,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
@@ -826,7 +819,7 @@ edx-sga==0.25.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-submissions==3.8.5
+edx-submissions==3.8.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -902,14 +895,14 @@ fastavro==1.10.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==6.6.0
+firebase-admin==6.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -953,7 +946,7 @@ glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-google-api-core[grpc]==2.24.1
+google-api-core[grpc]==2.24.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -962,7 +955,7 @@ google-api-core[grpc]==2.24.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.162.0
+google-api-python-client==2.164.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -982,7 +975,7 @@ google-auth-httplib2==0.2.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-python-client
-google-cloud-core==2.4.2
+google-cloud-core==2.4.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1009,23 +1002,23 @@ google-resumable-media==2.7.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-cloud-storage
-googleapis-common-protos==1.69.0
+googleapis-common-protos==1.69.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.6
+grimp==3.7.1
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
-grpcio==1.70.0
+grpcio==1.71.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.70.0
+grpcio-status==1.71.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1082,7 +1075,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-import-linter==2.2
+import-linter==2.3
     # via -r requirements/edx/testing.txt
 importlib-metadata==8.6.1
     # via
@@ -1116,7 +1109,7 @@ isort==6.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1168,7 +1161,7 @@ jwcrypto==1.5.6
     #   -r requirements/edx/testing.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.4.2
+kombu==5.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1194,7 +1187,7 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1307,7 +1300,7 @@ mysqlclient==2.2.7
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
-newrelic==10.6.0
+newrelic==10.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1514,7 +1507,7 @@ propcache==0.3.0
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-proto-plus==1.26.0
+proto-plus==1.26.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1624,7 +1617,7 @@ pylatexenc==2.10
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==3.3.4
+pylint==3.3.5
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1845,7 +1838,6 @@ requests==2.32.3
     #   cachecontrol
     #   django-oauth-toolkit
     #   djangorestframework-stubs
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
@@ -1900,7 +1892,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.11.3
+s3transfer==0.11.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1994,7 +1986,7 @@ social-auth-app-django==5.4.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2081,7 +2073,7 @@ staff-graded-xblock==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-starlette==0.46.0
+starlette==0.46.1
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
@@ -2125,7 +2117,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/testing.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.24.1
+tox==4.24.2
     # via -r requirements/edx/testing.txt
 tqdm==4.67.1
     # via
@@ -2137,7 +2129,7 @@ types-pyyaml==6.0.12.20241230
     # via
     #   django-stubs
     #   djangorestframework-stubs
-types-requests==2.32.0.20250301
+types-requests==2.32.0.20250306
     # via djangorestframework-stubs
 typing-extensions==4.12.2
     # via
@@ -2214,7 +2206,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.2
+virtualenv==20.29.3
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -2308,7 +2300,7 @@ xblocks-contrib==0.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xmlsec==1.3.14
+xmlsec==1.3.15
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -10,7 +10,7 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -57,9 +57,9 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==3.3.8
+astroid==3.3.9
     # via sphinx-autoapi
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -105,13 +105,13 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.37.5
+boto3==1.37.12
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.37.5
+botocore==1.37.12
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -226,7 +226,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -260,7 +260,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -348,7 +347,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.0
+django-js-asset==3.1.2
     # via
     #   -r requirements/edx/base.txt
     #   django-mptt
@@ -393,7 +392,7 @@ django-object-actions==4.3.0
     #   edx-enterprise
 django-pipeline==4.0.0
     # via -r requirements/edx/base.txt
-django-push-notifications==3.2.0
+django-push-notifications==3.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -483,7 +482,7 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-spectacular==0.28.0
     # via -r requirements/edx/base.txt
-drf-yasg==1.21.9
+drf-yasg==1.21.10
     # via
     #   -r requirements/edx/base.txt
     #   django-user-tasks
@@ -496,10 +495,6 @@ edx-api-doc-tools==2.0.0
     #   edx-name-affirmation
 edx-auth-backends==4.4.0
     # via -r requirements/edx/base.txt
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -530,7 +525,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -555,7 +549,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -610,7 +604,7 @@ edx-search==4.1.3
     #   openedx-forum
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.8.5
+edx-submissions==3.8.6
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -660,11 +654,11 @@ fastavro==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-firebase-admin==6.6.0
+firebase-admin==6.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -695,7 +689,7 @@ gitpython==3.1.44
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.24.1
+google-api-core[grpc]==2.24.2
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -703,7 +697,7 @@ google-api-core[grpc]==2.24.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.162.0
+google-api-python-client==2.164.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -720,7 +714,7 @@ google-auth-httplib2==0.2.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-python-client
-google-cloud-core==2.4.2
+google-cloud-core==2.4.3
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-firestore
@@ -742,17 +736,17 @@ google-resumable-media==2.7.2
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-storage
-googleapis-common-protos==1.69.0
+googleapis-common-protos==1.69.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.70.0
+grpcio==1.71.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.70.0
+grpcio-status==1.71.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -797,7 +791,7 @@ isodate==0.7.2
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -840,7 +834,7 @@ jwcrypto==1.5.6
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.4.2
+kombu==5.5.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -857,7 +851,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.1
     # via
@@ -938,7 +932,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-newrelic==10.6.0
+newrelic==10.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1081,7 +1075,7 @@ propcache==0.3.0
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-proto-plus==1.26.0
+proto-plus==1.26.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -1288,7 +1282,6 @@ requests==2.32.3
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
@@ -1332,7 +1325,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.11.3
+s3transfer==0.11.4
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1399,7 +1392,7 @@ social-auth-app-django==5.4.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
@@ -1612,7 +1605,7 @@ xblock-utils==4.0.0
     #   xblock-poll
 xblocks-contrib==0.2.0
     # via -r requirements/edx/base.txt
-xmlsec==1.3.14
+xmlsec==1.3.15
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   glom
     #   jsonschema
@@ -44,7 +44,7 @@ face==24.0.0
     # via glom
 glom==22.1.0
     # via semgrep
-googleapis-common-protos==1.69.0
+googleapis-common-protos==1.69.1
     # via opentelemetry-exporter-otlp-proto-http
 idna==3.10
     # via requests
@@ -116,7 +116,7 @@ ruamel-yaml==0.18.10
     # via semgrep
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-semgrep==1.110.0
+semgrep==1.112.0
     # via -r requirements/edx/semgrep.in
 tomli==2.0.2
     # via semgrep

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -8,7 +8,7 @@
     # via -r requirements/edx/base.txt
 acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -57,11 +57,11 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -105,13 +105,13 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.37.5
+boto3==1.37.12
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
-botocore==1.37.5
+botocore==1.37.12
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -233,7 +233,7 @@ cryptography==44.0.2
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssselect==1.2.0
+cssselect==1.3.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
@@ -250,13 +250,13 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-diff-cover==9.2.3
+diff-cover==9.2.4
     # via -r requirements/edx/coverage.txt
 dill==0.3.9
     # via pylint
 distlib==0.3.9
     # via virtualenv
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
@@ -290,7 +290,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -378,7 +377,7 @@ django-ipware==7.0.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-django-js-asset==3.1.0
+django-js-asset==3.1.2
     # via
     #   -r requirements/edx/base.txt
     #   django-mptt
@@ -423,7 +422,7 @@ django-object-actions==4.3.0
     #   edx-enterprise
 django-pipeline==4.0.0
     # via -r requirements/edx/base.txt
-django-push-notifications==3.2.0
+django-push-notifications==3.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -508,7 +507,7 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-spectacular==0.28.0
     # via -r requirements/edx/base.txt
-drf-yasg==1.21.9
+drf-yasg==1.21.10
     # via
     #   -r requirements/edx/base.txt
     #   django-user-tasks
@@ -521,10 +520,6 @@ edx-api-doc-tools==2.0.0
     #   edx-name-affirmation
 edx-auth-backends==4.4.0
     # via -r requirements/edx/base.txt
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -555,7 +550,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -580,7 +574,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -637,7 +631,7 @@ edx-search==4.1.3
     #   openedx-forum
 edx-sga==0.25.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.8.5
+edx-submissions==3.8.6
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -695,13 +689,13 @@ fastavro==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==6.6.0
+firebase-admin==6.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -730,7 +724,7 @@ geoip2==5.0.1
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.24.1
+google-api-core[grpc]==2.24.2
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -738,7 +732,7 @@ google-api-core[grpc]==2.24.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.162.0
+google-api-python-client==2.164.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -755,7 +749,7 @@ google-auth-httplib2==0.2.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-python-client
-google-cloud-core==2.4.2
+google-cloud-core==2.4.3
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-firestore
@@ -777,19 +771,19 @@ google-resumable-media==2.7.2
     # via
     #   -r requirements/edx/base.txt
     #   google-cloud-storage
-googleapis-common-protos==1.69.0
+googleapis-common-protos==1.69.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grimp==3.6
+grimp==3.7.1
     # via import-linter
-grpcio==1.70.0
+grpcio==1.71.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.70.0
+grpcio-status==1.71.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -827,7 +821,7 @@ idna==3.10
     #   rfc3986
     #   snowflake-connector-python
     #   yarl
-import-linter==2.2
+import-linter==2.3
     # via -r requirements/edx/testing.in
 importlib-metadata==8.6.1
     # via -r requirements/edx/base.txt
@@ -852,7 +846,7 @@ isort==6.0.1
     # via
     #   -r requirements/edx/testing.in
     #   pylint
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
@@ -894,7 +888,7 @@ jwcrypto==1.5.6
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
     #   pylti1p3
-kombu==5.4.2
+kombu==5.5.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -911,7 +905,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.1
     # via
@@ -996,7 +990,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-newrelic==10.6.0
+newrelic==10.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1150,7 +1144,7 @@ propcache==0.3.0
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-proto-plus==1.26.0
+proto-plus==1.26.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -1237,7 +1231,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==3.3.4
+pylint==3.3.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -1409,7 +1403,6 @@ requests==2.32.3
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
@@ -1453,7 +1446,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.11.3
+s3transfer==0.11.4
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1524,7 +1517,7 @@ social-auth-app-django==5.4.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.4
+social-auth-core==4.5.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
@@ -1547,7 +1540,7 @@ sqlparse==0.5.3
     #   django
 staff-graded-xblock==3.0.1
     # via -r requirements/edx/base.txt
-starlette==0.46.0
+starlette==0.46.1
     # via fastapi
 stevedore==5.4.1
     # via
@@ -1583,7 +1576,7 @@ tomlkit==0.13.2
     #   -r requirements/edx/base.txt
     #   pylint
     #   snowflake-connector-python
-tox==4.24.1
+tox==4.24.2
     # via -r requirements/edx/testing.in
 tqdm==4.67.1
     # via
@@ -1647,7 +1640,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.2
+virtualenv==20.29.3
     # via tox
 voluptuous==0.15.2
     # via
@@ -1714,7 +1707,7 @@ xblock-utils==4.0.0
     #   xblock-poll
 xblocks-contrib==0.2.0
     # via -r requirements/edx/base.txt
-xmlsec==1.3.14
+xmlsec==1.3.15
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.8.2
+setuptools==76.0.0
     # via -r requirements/pip.in

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -6,13 +6,13 @@
 #
 asgiref==3.8.1
     # via django
-attrs==25.1.0
+attrs==25.3.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-boto3==1.37.5
+boto3==1.37.12
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.37.5
+botocore==1.37.12
     # via
     #   boto3
     #   s3transfer
@@ -35,7 +35,7 @@ click==8.1.6
     #   edx-django-utils
 cryptography==44.0.2
     # via pyjwt
-django==4.2.19
+django==4.2.20
     # via
     #   -c scripts/user_retirement/requirements/../../../requirements/common_constraints.txt
     #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
@@ -50,9 +50,9 @@ edx-django-utils==7.2.0
     # via edx-rest-api-client
 edx-rest-api-client==6.1.0
     # via -r scripts/user_retirement/requirements/base.in
-google-api-core==2.24.1
+google-api-core==2.24.2
     # via google-api-python-client
-google-api-python-client==2.162.0
+google-api-python-client==2.164.0
     # via -r scripts/user_retirement/requirements/base.in
 google-auth==2.38.0
     # via
@@ -61,7 +61,7 @@ google-auth==2.38.0
     #   google-auth-httplib2
 google-auth-httplib2==0.2.0
     # via google-api-python-client
-googleapis-common-protos==1.69.0
+googleapis-common-protos==1.69.1
     # via google-api-core
 httplib2==0.22.0
     # via
@@ -81,13 +81,13 @@ lxml==5.3.1
     # via zeep
 more-itertools==10.6.0
     # via simple-salesforce
-newrelic==10.6.0
+newrelic==10.7.0
     # via edx-django-utils
 pbr==6.1.1
     # via stevedore
 platformdirs==4.3.6
     # via zeep
-proto-plus==1.26.0
+proto-plus==1.26.1
     # via google-api-core
 protobuf==5.29.3
     # via
@@ -136,7 +136,7 @@ requests-toolbelt==1.0.0
     # via zeep
 rsa==4.9
     # via google-auth
-s3transfer==0.11.3
+s3transfer==0.11.4
     # via boto3
 simple-salesforce==1.12.6
     # via -r scripts/user_retirement/requirements/base.in

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -8,17 +8,17 @@ asgiref==3.8.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-boto3==1.37.5
+boto3==1.37.12
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.37.5
+botocore==1.37.12
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -52,7 +52,7 @@ cryptography==44.0.2
     #   pyjwt
 ddt==1.7.2
     # via -r scripts/user_retirement/requirements/testing.in
-django==4.2.19
+django==4.2.20
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django-crum
@@ -72,11 +72,11 @@ edx-django-utils==7.2.0
     #   edx-rest-api-client
 edx-rest-api-client==6.1.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-api-core==2.24.1
+google-api-core==2.24.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.162.0
+google-api-python-client==2.164.0
     # via -r scripts/user_retirement/requirements/base.txt
 google-auth==2.38.0
     # via
@@ -88,7 +88,7 @@ google-auth-httplib2==0.2.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-googleapis-common-protos==1.69.0
+googleapis-common-protos==1.69.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
@@ -109,7 +109,7 @@ isodate==0.7.2
     #   zeep
 jenkinsapi==0.3.13
     # via -r scripts/user_retirement/requirements/base.txt
-jinja2==3.1.5
+jinja2==3.1.6
     # via moto
 jmespath==1.0.1
     # via
@@ -132,7 +132,7 @@ more-itertools==10.6.0
     #   simple-salesforce
 moto==4.2.14
     # via -r scripts/user_retirement/requirements/testing.in
-newrelic==10.6.0
+newrelic==10.7.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
@@ -148,7 +148,7 @@ platformdirs==4.3.6
     #   zeep
 pluggy==1.5.0
     # via pytest
-proto-plus==1.26.0
+proto-plus==1.26.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
@@ -227,7 +227,7 @@ requests-toolbelt==1.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-responses==0.25.6
+responses==0.25.7
     # via
     #   -r scripts/user_retirement/requirements/testing.in
     #   moto
@@ -235,7 +235,7 @@ rsa==4.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-s3transfer==0.11.3
+s3transfer==0.11.4
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3


### PR DESCRIPTION
Draft PR to install enterprise 5.10.0 and remove edx-braze-client as a build requirement from edx-platform.
https://github.com/openedx/edx-enterprise/releases/tag/5.10.0
https://2u-internal.atlassian.net/browse/TNL-11905
