### PR TITLE
fix: CourseEnrollment list serializer error on deleted Course

### DIFF
--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -1017,7 +1017,7 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         emails = form.cleaned_data.get("email")
 
         if course_id:
-            queryset = queryset.filter(course_id=course_id)
+            queryset = queryset.filter(course__id=course_id)
         if usernames:
             queryset = queryset.filter(user__username__in=usernames)
         if emails:


### PR DESCRIPTION
If a course is deleted or unpublished, the CourseEnrollment list serializer was causing an `AttributeError` when called for a learner who had been enrolled in the formerly-existing course. By switching from `course_id` to `course__id` in the queryset filter, we switched from the direct django table column reference (which is  never deleted, because the deletion of the course doesn't cascade into the CourseEnrollment), to the dereferenced `id`  column, which is not going to match when the  Course object itself no longer exists.

Why no test? Because cache invalidation is the worst problem. tl;dr I could create a mock response for the `course_overview` property, but if I mocked up a response to the queryset filter in `CourseEnrollmentsApiListView`, I was effectively guessing that my code worked correctly and then creating a mock response that was an assertion of correctness. That would make any mocked test deceptive; it would appear to test behavior but it would actually just test that I had constructed a mock that passed the test.

I wanted to make an actual test for what would happen if a Course was deleted, so I made one character code fix, and then spent two days unsuccessfully attempting to completely clear out the ModuleStore so I could actually test what would happen in this instance.

IMO an actual verification by hand (which I performed, and it works) was the better part of valor.

in short, cache invalidation aaaaaaaaargh.

FIXES: APER-3913
