### PR TITLE
feat: upgrade enterprise to 5.10.1, removing braze-client

### DIFF
--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -32,7 +32,6 @@ jobs:
             --req-file requirements/edx/base.txt \
             --req-file requirements/edx/testing.txt \
             --ignore https://github.com/edx/codejail-includes \
-            --ignore https://github.com/edx/braze-client \
             --ignore https://github.com/edx/edx-name-affirmation \
             --ignore https://github.com/mitodl/edx-sga \
             --ignore https://github.com/open-craft/xblock-poll

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -80,7 +80,7 @@ django-storages<1.14.4
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==5.9.2
+edx-enterprise==5.10.1
 
 # Date: 2024-05-09
 # This has to be constrained as well because newer versions of edx-i18n-tools need the

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -204,7 +204,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -412,10 +411,6 @@ edx-api-doc-tools==2.0.0
     #   edx-name-affirmation
 edx-auth-backends==4.4.0
     # via -r requirements/edx/kernel.in
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/bundled.in
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/kernel.in
@@ -446,7 +441,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/kernel.in
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -471,7 +465,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -1057,7 +1051,6 @@ requests==2.32.3
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -31,7 +31,6 @@ edx-i18n-tools>=0.4.6               # Commands for developers and translators to
 ## Third party integrations
 algoliasearch                       # Algolia’s API client for indexed searching
 django-ses                          # Django email backend for Amazon’s Simple Email Service
-edx-braze-client                    # a customer engagement platform used for edx.org
 mailsnake                           # MailChimp API; used for two management commands in the "mailing" djangoapp
 optimizely-sdk                      # Optimizely provides A/B testing and other features, used by edx.org
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -378,7 +378,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -678,11 +677,6 @@ edx-auth-backends==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/doc.txt
@@ -724,7 +718,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/testing.txt
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -750,7 +743,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
@@ -1845,7 +1838,6 @@ requests==2.32.3
     #   cachecontrol
     #   django-oauth-toolkit
     #   djangorestframework-stubs
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -260,7 +260,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -496,10 +495,6 @@ edx-api-doc-tools==2.0.0
     #   edx-name-affirmation
 edx-auth-backends==4.4.0
     # via -r requirements/edx/base.txt
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -530,7 +525,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -555,7 +549,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -1288,7 +1282,6 @@ requests==2.32.3
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -290,7 +290,6 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -521,10 +520,6 @@ edx-api-doc-tools==2.0.0
     #   edx-name-affirmation
 edx-auth-backends==4.4.0
     # via -r requirements/edx/base.txt
-edx-braze-client==1.0.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-enterprise
 edx-bulk-grades==1.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -555,7 +550,6 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   edx-ace
-    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -580,7 +574,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.9.2
+edx-enterprise==5.10.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -1409,7 +1403,6 @@ requests==2.32.3
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
-    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise


### PR DESCRIPTION
Draft PR to install enterprise 5.10.1 and remove edx-braze-client as a build requirement from edx-platform.
https://github.com/openedx/edx-enterprise/releases/tag/5.10.1
https://2u-internal.atlassian.net/browse/TNL-11905
