### PR TITLE
chore: replaced direct dependency with alias for edx brand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-object-assign": "^7.18.6",
         "@babel/preset-env": "^7.19.0",
         "@babel/preset-react": "7.26.3",
-        "@edx/brand-edx.org": "^2.0.7",
+        "@edx/brand": "npm:@edx/brand-edx.org@^2.1.3",
         "@edx/edx-bootstrap": "1.0.4",
         "@edx/edx-proctoring": "^4.18.1",
         "@edx/frontend-component-cookie-policy-banner": "2.2.0",
@@ -1997,11 +1997,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/@edx/brand-edx.org": {
+    "node_modules/@edx/brand": {
+      "name": "@edx/brand-edx.org",
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.3.tgz",
-      "integrity": "sha512-1TwUwW7YVgvhh7aO1ql1poAosUCA0zd7/DNuqeSO0wXui0oCHL+WQW8b9tXS2tRJ5BMRKjG8t22fcOcKX3ljbg==",
-      "license": "UNLICENSED"
+      "integrity": "sha512-1TwUwW7YVgvhh7aO1ql1poAosUCA0zd7/DNuqeSO0wXui0oCHL+WQW8b9tXS2tRJ5BMRKjG8t22fcOcKX3ljbg=="
     },
     "node_modules/@edx/edx-bootstrap": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/plugin-transform-object-assign": "^7.18.6",
     "@babel/preset-env": "^7.19.0",
     "@babel/preset-react": "7.26.3",
-    "@edx/brand-edx.org": "^2.0.7",
+    "@edx/brand": "npm:@edx/brand-edx.org@^2.1.3",
     "@edx/edx-bootstrap": "1.0.4",
     "@edx/edx-proctoring": "^4.18.1",
     "@edx/frontend-component-cookie-policy-banner": "2.2.0",


### PR DESCRIPTION
## Description

This PR replaces the direct addition of `@edx/brand-edx.org` with alias `@edx/brand`. Another PR is up in configuration to add support for other themes.
 
Related PR Link: https://github.com/edx/configuration/pull/179
Issue Link: https://github.com/edx/edx-arch-experiments/issues/943
