### PR TITLE
fix: Account level preference visibility WRT roles

### DIFF
--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -269,3 +269,21 @@ def aggregate_notification_configs(existing_user_configs: List[Dict]) -> Dict:
                 result_config[app]["notification_types"][type_key]["email_cadence"] = (
                     result_config[app]["notification_types"][type_key]["email_cadence"].pop())
     return result_config
+
+
+def filter_out_visible_preferences_by_course_ids(user, preferences: Dict, course_ids: List) -> Dict:
+    """
+    Filter out notifications visible to forum roles from user preferences.
+    """
+    forum_roles = Role.objects.filter(users__id=user.id).values_list('name', flat=True)
+    course_roles = CourseAccessRole.objects.filter(
+        user=user,
+        course_id__in=course_ids
+    ).values_list('role', flat=True)
+    notification_types_with_visibility = get_notification_types_with_visibility_settings()
+    return filter_out_visible_notifications(
+        preferences,
+        notification_types_with_visibility,
+        forum_roles,
+        course_roles
+    )

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -39,7 +39,8 @@ from .serializers import (
     UserNotificationPreferenceUpdateAllSerializer,
     UserNotificationPreferenceUpdateSerializer
 )
-from .utils import get_is_new_notification_view_enabled, get_show_notifications_tray, aggregate_notification_configs
+from .utils import get_is_new_notification_view_enabled, get_show_notifications_tray, aggregate_notification_configs, \
+    filter_out_visible_preferences_by_course_ids
 
 
 @allow_any_authenticated_user()
@@ -587,6 +588,11 @@ class AggregatedNotificationPreferences(APIView):
         notification_configs = notification_preferences.values_list('notification_preference_config', flat=True)
         notification_configs = aggregate_notification_configs(
             notification_configs
+        )
+        filter_out_visible_preferences_by_course_ids(
+            request.user,
+            notification_configs,
+            notification_preferences.values_list('course_id', flat=True),
         )
         notification_preferences_viewed_event(request)
         return Response({


### PR DESCRIPTION
## Description 

Filter out notification preferences with respect to user roles

