### PR TITLE
Upgrade edx-sga and lti-consumer-xblock [FC-0076]

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -516,7 +516,7 @@ edx-search==4.1.3
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum
-edx-sga==0.25.0
+edx-sga==0.25.3
     # via -r requirements/edx/bundled.in
 edx-submissions==3.8.5
     # via
@@ -701,7 +701,7 @@ lazy==1.6
     #   xblock
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via -r requirements/edx/kernel.in
 lxml[html-clean,html_clean]==5.3.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -815,7 +815,7 @@ edx-search==4.1.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
-edx-sga==0.25.0
+edx-sga==0.25.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1187,7 +1187,7 @@ loremipsum==1.0.5
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -602,7 +602,7 @@ edx-search==4.1.3
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-edx-sga==0.25.0
+edx-sga==0.25.3
     # via -r requirements/edx/base.txt
 edx-submissions==3.8.5
     # via
@@ -851,7 +851,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -629,7 +629,7 @@ edx-search==4.1.3
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-edx-sga==0.25.0
+edx-sga==0.25.3
     # via -r requirements/edx/base.txt
 edx-submissions==3.8.5
     # via
@@ -905,7 +905,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==9.13.2
+lti-consumer-xblock==9.13.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.1
     # via


### PR DESCRIPTION
specifically to bump the versions for edx-sga and lti-consumer-xblock

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Ran `make upgrade` to update the requirements to include:

* https://github.com/openedx/xblock-lti-consumer/pull/536
* https://github.com/mitodl/edx-sga/pull/363

## Supporting information

Part of: https://github.com/openedx/frontend-app-authoring/issues/1514
Private-ref: [FAL-4032](https://tasks.opencraft.com/browse/FAL-4032)

## Testing instructions

1. Read through requirements updates checking for major version changes in (unrelated) packages
2. Check that xblock-lti-consumer and edx-sga are upgraded to include the above PRs
3. CI should be sufficient for verifying.

## Deadline

ASAP