### PR TITLE
Handle /jump_to_id/ URLs in course optimizer urls

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1297,11 +1297,14 @@ def _convert_to_standard_url(url, course_key):
             ...asset-v1:edX+DemoX+Demo_Course+type@asset+block/getting-started_x250.png
         /static/getting-started_x250.png
         /container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@2152d4a4aadc4cb0af5256394a3d1fc7
+        /jump_to_id/2152d4a4aadc4cb0af5256394a3d1fc7
     """
     if _is_studio_url_without_base(url):
         if url.startswith('/static/'):
             processed_url = replace_static_urls(f'\"{url}\"', course_id=course_key)[1:-1]
             return 'https://' + settings.CMS_BASE + processed_url
+        elif url.startswith('/jump_to_id/'):
+            return f'https://{settings.LMS_BASE}/courses/{course_key}{url}'
         elif url.startswith('/'):
             return 'https://' + settings.CMS_BASE + url
         else:

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -39,7 +39,8 @@ from ..tasks import (
     _get_urls,
     _check_broken_links,
     _is_studio_url,
-    _scan_course_for_links
+    _scan_course_for_links,
+    _convert_to_standard_url
 )
 
 logging = logging.getLogger(__name__)
@@ -548,3 +549,31 @@ class CheckBrokenLinksTaskTest(ModuleStoreTestCase):
         mock_filter.assert_called_once_with(validated_url_list)
         if retry_list:
             mock_retry_validation.assert_called_once_with(retry_list, course_key, retry_count=3)
+
+    def test_convert_to_standard_url(self):
+        """Test _convert_to_standard_url function with expected URLs."""
+        course_key = CourseKey.from_string("course-v1:test+course1+run1")
+        test_cases = [
+            (
+                "/static/getting-started_x250.png",
+                f"https://{settings.CMS_BASE}/asset-v1:test+course1+run1+type@asset+block/getting-started_x250.png",
+            ),
+            (
+                "/jump_to_id/123abc",
+                f"https://{settings.LMS_BASE}/courses/{course_key}/jump_to_id/123abc",
+            ),
+            (
+                "/container/block-v1:test+course1+type@vertical+block@123",
+                f"https://{settings.CMS_BASE}/container/block-v1:test+course1+type@vertical+block@123",
+            ),
+            ("/unknown/path", f"https://{settings.CMS_BASE}/unknown/path"),
+            ("https://external.com/some/path", "https://external.com/some/path"),
+            ("studio-url", "https://localhost:8001/container/studio-url"),
+        ]
+
+        for url, expected in test_cases:
+            self.assertEqual(
+                _convert_to_standard_url(url, course_key),
+                expected,
+                f"Failed for URL: {url}",
+            )


### PR DESCRIPTION
## Description

This PR updates the _convert_to_standard_url function to ensure that jump_to_id URLs are correctly prefixed with LMS_BASE. Modified _convert_to_standard_url(url, course_key) to handle /jump_to_id/ URLs by prefixing them with https://{settings.LMS_BASE}. 

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11927

## Testing instructions

Run the Course Optimizer on a course that contains /jump_to_id/ URLs.


