### PR TITLE
feat: remove algoliasearch package

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1624,10 +1624,6 @@ OPTIMIZELY_FULLSTACK_SDK_KEY = None
 ######################## HOTJAR ###########################
 HOTJAR_SITE_ID = 00000
 
-######################## ALGOLIA SEARCH ###########################
-ALGOLIA_APP_ID = None
-ALGOLIA_SEARCH_API_KEY = None
-
 ######################## subdomain specific settings ###########################
 COURSE_LISTINGS = {}
 

--- a/lms/envs/mock.yml
+++ b/lms/envs/mock.yml
@@ -27,8 +27,6 @@ ADMIN_PORTAL_MICROFRONTEND_URL: https://admin-portal-deploy_host
 AFFILIATE_COOKIE_NAME: sandbox.edx.affiliate_id
 AI_TRANSLATIONS_API_URL: https://ai-translations.localhost/api/v1
 AI_TRANSLATIONS_URL_ROOT: https://ai-translations.localhost
-ALGOLIA_APP_ID: hello
-ALGOLIA_SEARCH_API_KEY: '[encrypted]'
 ALLOWED_HOSTS:
 - hello
 ALLOW_ORPHANED_CONTENT_REMOVAL: true

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,13 +13,6 @@
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
 
-# Date: 2024-08-21
-# Description: This is the major upgrade of algoliasearch python client and it will
-# break one of the edX' platform plugin, so we need to make that compatible first.
-# Ticket: https://github.com/openedx/edx-platform/issues/35334
-algoliasearch<4.0.0
-
-
 # Date: 2020-02-26
 # As it is not clarified what exact breaking changes will be introduced as per
 # the next major release, ensure the installed version is within boundaries.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,10 +16,6 @@ aiohttp==3.11.13
     #   openai
 aiosignal==1.3.2
     # via aiohttp
-algoliasearch==3.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/bundled.in
 amqp==5.3.1
     # via kombu
 analytics-python==1.4.post1
@@ -1047,7 +1043,6 @@ regex==2024.11.6
     # via nltk
 requests==2.32.3
     # via
-    #   algoliasearch
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -29,7 +29,6 @@ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.
 edx-i18n-tools>=0.4.6               # Commands for developers and translators to extract, compile and validate translations
 
 ## Third party integrations
-algoliasearch                       # Algolia’s API client for indexed searching
 django-ses                          # Django email backend for Amazon’s Simple Email Service
 mailsnake                           # MailChimp API; used for two management commands in the "mailing" djangoapp
 optimizely-sdk                      # Optimizely provides A/B testing and other features, used by edx.org

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -36,11 +36,6 @@ alabaster==1.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-algoliasearch==3.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
 amqp==5.3.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1833,7 +1828,6 @@ requests==2.32.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   algoliasearch
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -25,10 +25,6 @@ aiosignal==1.3.2
     #   aiohttp
 alabaster==1.0.0
     # via sphinx
-algoliasearch==3.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
 amqp==5.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -1278,7 +1274,6 @@ regex==2024.11.6
 requests==2.32.3
     # via
     #   -r requirements/edx/base.txt
-    #   algoliasearch
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -21,10 +21,6 @@ aiosignal==1.3.2
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-algoliasearch==3.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
 amqp==5.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -1399,7 +1395,6 @@ regex==2024.11.6
 requests==2.32.3
     # via
     #   -r requirements/edx/base.txt
-    #   algoliasearch
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Removes the algoliasearch package and addresses issue https://github.com/openedx/edx-platform/issues/35334. The issue calls out a private plugin that uses this package but there doesn't appear to be any other dependency on this package in edx-platform so it has been removed.

After removing the dependency, I ran `make upgrade-package package=algoliasearch`.
