### PR TITLE
fix: Fix misleading email confirmation message, linking to Account Settings instead of Dashboard

### DIFF
--- a/lms/templates/email_change_successful.html
+++ b/lms/templates/email_change_successful.html
@@ -12,8 +12,8 @@ from django.urls import reverse
     <h1 class="valid">${_("E-mail change successful!")}</h1>
     <hr class="horizontal-divider">
 
-    <p>${Text(_('You should see your new email in your {link_start}dashboard{link_end}.')).format(
-        link_start=HTML('<a href="{url}">').format(url=reverse('dashboard')),
+    <p>${Text(_('You should see your new email in your {link_start}account{link_end}.')).format(
+        link_start=HTML('<a href="{url}">').format(url=reverse('account_settings')),
         link_end=HTML('</a>'),
       )}</p>
   </section>


### PR DESCRIPTION
**Description**

After confirming an email change, users see the message: "You should see your new email in your dashboard." However, the dashboard does not display the user's email, leading to confusion.

**Solution:**

The message has been updated to direct users to the Account Settings page instead of the Dashboard, as the email information is available there.

This change improves user experience by providing accurate navigation instructions.

Before fix:

<img width="1840" alt="Снимок экрана 2025-03-18 в 17 06 08" src="https://github.com/user-attachments/assets/e80d0c11-6736-4952-919a-1e24c0386c2a" />

After fix:

<img width="1840" alt="Снимок экрана 2025-03-18 в 16 49 32" src="https://github.com/user-attachments/assets/b27e9604-36a9-4829-a410-45a4a994575b" />