### PR TITLE
chore: update openedx-forum version to 0.1.9

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -820,7 +820,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.8
+openedx-forum==0.1.9
     # via -r requirements/edx/kernel.in
 openedx-learning==0.18.3
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1381,7 +1381,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.8
+openedx-forum==0.1.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -992,7 +992,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.8
+openedx-forum==0.1.9
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.3
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1050,7 +1050,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.8
+openedx-forum==0.1.9
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.3
     # via


### PR DESCRIPTION
## Description

Chore: Bump `openedx-forum` version to latest tag `0.1.9` which fixes inline issues.