### PR TITLE
feat: Set TMPDIR for codejail executions

### DIFF
--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -21,7 +21,17 @@ CODE_PROLOG = """\
 from __future__ import absolute_import, division
 
 import os
-os.environ["OPENBLAS_NUM_THREADS"] = "1"    # See TNL-6456
+
+# openblas is a math library used by numpy. It will try to allocate multiple
+# threads by default, but this may exceed resource limits and cause a segfault.
+# Limiting to 1 thread will prevent this in all configurations.
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+# Any code that uses the tempfile module to create temporary files should use
+# the ./tmp directory that codejail creates in each sandbox, rather than trying
+# to use a global temp dir (which should be blocked by AppArmor anyhow).
+# This is needed for matplotlib among other things.
+os.environ["TMPDIR"] = os.getcwd() + "/tmp"
 
 import random2 as random_module
 import sys


### PR DESCRIPTION
This makes it easier to run matplotlib in codejail, and should prevent a number of other issues in the future with other packages that need to create tempfiles.

No change is required for existing codejail installations, but after this change operators may be able to tighten their apparmor configuration to prevent write access to global temp or cache dirs.

Manual testing instructions: Create a codejail problem that runs `import matplotlib` and confirm that it runs without error. (Unit tests aren't feasible here because this requires a fully configured codejail in order for the tmp subdirectory to exist.)

Also: Add comment for `OPENBLAS_NUM_THREADS` and numpy support.