### PR TITLE
Improve regex to exclude data: urls

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1215,7 +1215,7 @@ def _get_urls(content):
     """
     Finds and returns a list of URLs in the given content.
     Includes strings following 'href=' and 'src='.
-    Excludes strings that are only '#'.
+    Excludes strings that are only '#' or start with 'data:'.
 
     Arguments:
         content (str): entire content of a block
@@ -1223,7 +1223,7 @@ def _get_urls(content):
     Returns:
         list: urls
     """
-    regex = r'\s+(?:href|src)=["\'](?!#)([^"\']*)["\']'
+    regex = r'\s+(?:href|src)=["\'](?!#|data:)([^"\']*)["\']'
     url_list = re.findall(regex, content)
     return url_list
 

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -577,3 +577,28 @@ class CheckBrokenLinksTaskTest(ModuleStoreTestCase):
                 expected,
                 f"Failed for URL: {url}",
             )
+
+    def test_get_urls(self):
+        """Test _get_urls function for correct URL extraction."""
+
+        content = '''
+            <a href="https://example.com">Link</a>
+            <img src="https://images.com/pic.jpg">
+            <link href="https://fonts.googleapis.com/css?family=Roboto">
+            <a href="#">Home</a>
+            <a href="https://validsite.com">Valid</a>
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...">
+            <a href="data:application/pdf;base64,JVBERi0xLjQK...">
+            <a href="https://another-valid.com">Another</a>
+            <p>No links here!</p>
+            <img alt="Just an image without src">
+        '''
+
+        expected = [
+            "https://example.com",
+            "https://images.com/pic.jpg",
+            "https://fonts.googleapis.com/css?family=Roboto",
+            "https://validsite.com",
+            "https://another-valid.com"
+        ]
+        self.assertEqual(_get_urls(content), expected)


### PR DESCRIPTION
## Description

Updated the regex to exclude data: URLs in addition to # fragments.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11932

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
