### PR TITLE
feanil/update courseware links

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -62,6 +62,7 @@ from openedx.core.djangoapps.user_authn.toggles import (
 )
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
 from openedx.features.discounts.applicability import FIRST_PURCHASE_DISCOUNT_OVERRIDE_FLAG
 from openedx.features.enterprise_support.utils import is_enterprise_learner
 from common.djangoapps.student.email_helpers import generate_activation_email_context
@@ -408,7 +409,7 @@ def change_enrollment(request, check_access=True):
             return HttpResponse(redirect_url)
 
         if CourseEntitlement.check_for_existing_entitlement_and_enroll(user=user, course_run_key=course_id):
-            return HttpResponse(reverse('courseware', args=[str(course_id)]))
+            return HttpResponse(make_learning_mfe_courseware_url(course_id))
 
         # Check that auto enrollment is allowed for this course
         # (= the course is NOT behind a paywall)
@@ -438,7 +439,7 @@ def change_enrollment(request, check_access=True):
             )
 
         if should_redirect_to_courseware_after_enrollment():
-            return HttpResponse(reverse('courseware', args=[str(course_id)]))
+            return HttpResponse(make_learning_mfe_courseware_url(course_id))
         else:
             return HttpResponse()
     elif action == "unenroll":

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -4,7 +4,6 @@
 import logging
 from urllib.parse import urljoin
 
-from django.urls import reverse
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -24,6 +23,7 @@ from openedx.core.djangoapps.enrollments.api import add_enrollment
 from openedx.core.djangoapps.enrollments.views import EnrollmentCrossDomainSessionAuth
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
 
 from ...constants import Messages
 from ...http import DetailResponse
@@ -122,7 +122,7 @@ class BasketsView(APIView):
         if CourseEntitlement.check_for_existing_entitlement_and_enroll(user=user, course_run_key=course_key):
             return JsonResponse(
                 {
-                    'redirect_destination': reverse('courseware', args=[str(course_id)]),
+                    'redirect_destination': make_learning_mfe_courseware_url(course_id),
                 },
             )
 

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.urls import reverse
 
 from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
+from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
@@ -121,7 +122,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         self.create_course_page(self.toy)
 
         course_wiki_page = reverse('wiki:get', kwargs={'path': self.toy.wiki_slug + '/'})
-        referer = reverse("courseware", kwargs={'course_id': str(self.toy.id)})
+        referer = make_learning_mfe_courseware_url(self.toy.id)
 
         resp = self.client.get(course_wiki_page, follow=True, HTTP_REFERER=referer)
 
@@ -141,7 +142,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
 
         self.login(self.student, self.password)
         course_wiki_page = reverse('wiki:get', kwargs={'path': self.toy.wiki_slug + '/'})
-        referer = reverse("courseware", kwargs={'course_id': str(self.toy.id)})
+        referer = make_learning_mfe_courseware_url(self.toy.id)
 
         # When not enrolled, we should get a 302
         resp = self.client.get(course_wiki_page, follow=False, HTTP_REFERER=referer)
@@ -195,7 +196,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         self.create_course_page(course)
 
         course_wiki_page = reverse('wiki:get', kwargs={'path': course.wiki_slug + '/'})
-        referer = reverse("courseware", kwargs={'course_id': str(course.id)})
+        referer = make_learning_mfe_courseware_url(self.toy.id)
 
         resp = self.client.get(course_wiki_page, follow=True, HTTP_REFERER=referer)
         assert resp.status_code == 200

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -17,6 +17,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, set_preview_mode
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG
+from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
 
 
 @set_preview_mode(True)
@@ -111,7 +112,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             assert ('course-navigation' in response.content.decode('utf-8')) == accordion
 
         self.assertTabInactive('progress', response)
-        self.assertTabActive('courseware', response)
+        self.assertTabActive(make_learning_mfe_courseware_url(self.course.id), response)
 
         response = self.client.get(reverse('courseware_section', kwargs={
             'course_id': str(self.course.id),
@@ -120,7 +121,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         }))
 
         self.assertTabActive('progress', response)
-        self.assertTabInactive('courseware', response)
+        self.assertTabInactive(make_learning_mfe_courseware_url(self.course.id), response)
 
     @override_settings(SESSION_INACTIVITY_TIMEOUT_IN_SECONDS=1)
     def test_inactive_session_timeout(self):

--- a/openedx/core/djangoapps/user_api/tests/test_middleware.py
+++ b/openedx/core/djangoapps/user_api/tests/test_middleware.py
@@ -7,11 +7,15 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 
 from common.djangoapps.student.tests.factories import AnonymousUserFactory, UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from ..middleware import UserTagsEventContextMiddleware
 from ..tests.factories import UserCourseTagFactory
 
 
+# This middleware only gets installed in the LMS so no need to test
+# it in the CMS context.
+@skip_unless_lms
 class TagsMiddlewareTest(TestCase):
     """
     Test the UserTagsEventContextMiddleware

--- a/openedx/core/djangoapps/user_api/tests/test_middleware.py
+++ b/openedx/core/djangoapps/user_api/tests/test_middleware.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from common.djangoapps.student.tests.factories import AnonymousUserFactory, UserFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -29,9 +30,7 @@ class TagsMiddlewareTest(TestCase):
         self.course_id = 'mock/course/id'
         self.request_factory = RequestFactory()
 
-        # TODO: Make it so we can use reverse. Appears to fail depending on the order in which tests are run
-        #self.request = RequestFactory().get(reverse('courseware', kwargs={'course_id': self.course_id}))
-        self.request = RequestFactory().get(f'/courses/{self.course_id}/courseware')
+        self.request = RequestFactory().get(reverse('progress', kwargs={'course_id': self.course_id}))
         self.request.user = self.user
 
         self.response = Mock(spec=HttpResponse)

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -104,7 +104,9 @@ def default_course_url(course_key):
     from .url_helpers import get_learning_mfe_home_url
 
     if DISABLE_COURSE_OUTLINE_PAGE_FLAG.is_enabled(course_key):
-        return reverse('courseware', args=[str(course_key)])
+        # Prevent a circular dependency
+        from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
+        return make_learning_mfe_courseware_url(course_key)
 
     return get_learning_mfe_home_url(course_key, url_fragment='home')
 


### PR DESCRIPTION
This is a small increment related to https://github.com/openedx/edx-platform/issues/35803

There are portions of the LMS that were redirecting to the old courseware URL which in turn would redirect to the new MFE url.  The changes here bypass the extra hop in many of those cases.  This is a pre-requisite to dropping the old legacy page.
