### PR TITLE
feat: Update containers in search index on components update/delete [FC-0083]

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -572,6 +572,7 @@ def searchable_doc_for_container(
         Fields.usage_key: str(container_key),  # Field name isn't exact but this is the closest match
         Fields.block_id: container_key.container_id,  # Field name isn't exact but this is the closest match
         Fields.access_id: _meili_access_id_from_context_key(container_key.library_key),
+        Fields.publish_status: PublishStatus.never,
     }
 
     try:

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -15,6 +15,8 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, ToyCourseFactory
 
+from openedx_learning.api import authoring as authoring_api
+
 try:
     # This import errors in the lms because content.search is not an installed app there.
     from ..documents import (
@@ -528,6 +530,7 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "access_id": self.library_access_id,
             "breadcrumbs": [{"display_name": "some content_library"}],
             "created": 1680674828.0,
+            "publish_status": "never",
             "modified": 1680674828.0,
             # "tags" should be here but we haven't implemented them yet
             # "published" is not set since we haven't published it yet

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -15,8 +15,6 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, ToyCourseFactory
 
-from openedx_learning.api import authoring as authoring_api
-
 try:
     # This import errors in the lms because content.search is not an installed app there.
     from ..documents import (
@@ -530,7 +528,6 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "access_id": self.library_access_id,
             "breadcrumbs": [{"display_name": "some content_library"}],
             "created": 1680674828.0,
-            "publish_status": "never",
             "modified": 1680674828.0,
             # "tags" should be here but we haven't implemented them yet
             # "published" is not set since we haven't published it yet

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -87,7 +87,7 @@ class ContainerMetadata(PublishableItem):
             last_draft_created_by = ""
 
         return cls(
-            container_key=container_key,  # LibraryContainerLocator
+            container_key=container_key,
             container_type=container_type,
             display_name=draft.title,
             created=container.created,

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -60,6 +60,7 @@ class ContainerMetadata(PublishableItem):
     Class that represents the metadata about a Container (e.g. Unit) in a content library.
     """
     container_key: LibraryContainerLocator
+    container_pk: int
     container_type: ContainerType
 
     @classmethod
@@ -87,7 +88,8 @@ class ContainerMetadata(PublishableItem):
             last_draft_created_by = ""
 
         return cls(
-            container_key=container_key,
+            container_key=container_key,  # LibraryContainerLocator
+            container_pk=container.pk,  # authoring_models.Container.pk
             container_type=container_type,
             display_name=draft.title,
             created=container.created,

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -60,7 +60,6 @@ class ContainerMetadata(PublishableItem):
     Class that represents the metadata about a Container (e.g. Unit) in a content library.
     """
     container_key: LibraryContainerLocator
-    container_pk: int
     container_type: ContainerType
 
     @classmethod
@@ -89,7 +88,6 @@ class ContainerMetadata(PublishableItem):
 
         return cls(
             container_key=container_key,  # LibraryContainerLocator
-            container_pk=container.pk,  # authoring_models.Container.pk
             container_type=container_type,
             display_name=draft.title,
             created=container.created,

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -13,6 +13,7 @@ from opaque_keys.edx.locator import (
     LibraryContainerLocator,
     LibraryLocatorV2,
     UsageKeyV2,
+    LibraryUsageLocatorV2,
 )
 from openedx_events.content_authoring.data import LibraryContainerData
 from openedx_events.content_authoring.signals import (
@@ -42,6 +43,7 @@ __all__ = [
     "update_container",
     "delete_container",
     "update_container_children",
+    "get_containers_contains_component",
 ]
 
 
@@ -316,3 +318,20 @@ def update_container_children(
     )
 
     return ContainerMetadata.from_container(library_key, new_version.container)
+
+
+def get_containers_contains_component(
+    usage_key: LibraryUsageLocatorV2
+) -> list[ContainerMetadata]:
+    """
+    Get containers that contains the component.
+    """
+    assert isinstance(usage_key, LibraryUsageLocatorV2)
+    component = get_component_from_usage_key(usage_key)
+    containers = authoring_api.get_containers_with_entity(
+        component.publishable_entity.pk,
+    )
+    return [
+        ContainerMetadata.from_container(usage_key.context_key, container)
+        for container in containers
+    ]

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -911,7 +911,7 @@ def set_library_block_olx(usage_key: LibraryUsageLocatorV2, new_olx_str: str) ->
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 library_key=usage_key.lib_key,
-                container_key=container.container_pk,
+                container_key=str(container.container_key),
                 background=True,
             )
         )
@@ -1252,7 +1252,7 @@ def delete_library_block(usage_key: LibraryUsageLocatorV2, remove_from_parent=Tr
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 library_key=library_key,
-                container_key=container.container_pk,
+                container_key=str(container.container_key),
                 background=True,
             )
         )

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -904,6 +904,18 @@ def set_library_block_olx(usage_key: LibraryUsageLocatorV2, new_olx_str: str) ->
         )
     )
 
+    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal and set background=True to trigger
+    # container indexing asynchronously.
+    affected_containers = lib_api.get_containers_contains_component(usage_key)
+    for container in affected_containers:
+        LIBRARY_CONTAINER_UPDATED.send_event(
+            library_container=LibraryContainerData(
+                library_key=usage_key.lib_key,
+                container_key=container.container_pk,
+                background=True,
+            )
+        )
+
     return new_component_version
 
 

--- a/openedx/core/djangoapps/content_libraries/library_context.py
+++ b/openedx/core/djangoapps/content_libraries/library_context.py
@@ -6,8 +6,8 @@ import logging
 from django.core.exceptions import PermissionDenied
 from rest_framework.exceptions import NotFound
 
-from openedx_events.content_authoring.data import LibraryBlockData
-from openedx_events.content_authoring.signals import LIBRARY_BLOCK_UPDATED
+from openedx_events.content_authoring.data import LibraryBlockData, LibraryContainerData
+from openedx_events.content_authoring.signals import LIBRARY_BLOCK_UPDATED, LIBRARY_CONTAINER_UPDATED
 from opaque_keys.edx.keys import UsageKeyV2
 from opaque_keys.edx.locator import LibraryUsageLocatorV2, LibraryLocatorV2
 from openedx_learning.api import authoring as authoring_api
@@ -114,3 +114,19 @@ class LibraryContextImpl(LearningContext):
                 usage_key=usage_key,
             )
         )
+
+    def send_container_updated_events(self, usage_key: UsageKeyV2):
+        """
+        Send "container updated" events for containers that contains the library block
+        with the given usage_key.
+        """
+        assert isinstance(usage_key, LibraryUsageLocatorV2)
+        affected_containers = api.get_containers_contains_component(usage_key)
+        for container in affected_containers:
+            LIBRARY_CONTAINER_UPDATED.send_event(
+                library_container=LibraryContainerData(
+                    library_key=usage_key.lib_key,
+                    container_key=container.container_pk,
+                    background=True,
+                )
+            )

--- a/openedx/core/djangoapps/content_libraries/library_context.py
+++ b/openedx/core/djangoapps/content_libraries/library_context.py
@@ -126,7 +126,7 @@ class LibraryContextImpl(LearningContext):
             LIBRARY_CONTAINER_UPDATED.send_event(
                 library_container=LibraryContainerData(
                     library_key=usage_key.lib_key,
-                    container_key=container.container_pk,
+                    container_key=str(container.container_key),
                     background=True,
                 )
             )

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -812,14 +812,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
         assert html_block_containers[1].container_key == self.unit2.container_key
 
 
-    def test_call_container_update_signal_when_delete_component(self):
-        container_update_event_receiver = mock.Mock()
-        LIBRARY_CONTAINER_UPDATED.connect(container_update_event_receiver)
-
-        api.delete_library_block(self.html_block_usage_key)
-
-        assert container_update_event_receiver.call_count == 2
-
+    def _validate_calls_of_html_block(self, event_mock):
+        assert event_mock.call_count == 2
         self.assertDictContainsSubset(
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
@@ -830,7 +824,7 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
                     background=True,
                 )
             },
-            container_update_event_receiver.call_args_list[0].kwargs,
+            event_mock.call_args_list[0].kwargs,
         )
         self.assertDictContainsSubset(
             {
@@ -842,5 +836,29 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
                     background=True,
                 )
             },
-            container_update_event_receiver.call_args_list[1].kwargs,
+            event_mock.call_args_list[1].kwargs,
         )
+
+    def test_call_container_update_signal_when_delete_component(self):
+        container_update_event_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(container_update_event_receiver)
+
+        api.delete_library_block(self.html_block_usage_key)
+        self._validate_calls_of_html_block(container_update_event_receiver)
+        
+
+    def test_call_container_update_signal_when_update_olx(self):
+        block_olx = "<html><b>Hello world!</b></html>"
+        container_update_event_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(container_update_event_receiver)
+
+        self._set_library_block_olx(self.html_block_usage_key, block_olx)
+        self._validate_calls_of_html_block(container_update_event_receiver)
+
+    def test_call_container_update_signal_when_update_component(self):
+        block_olx = "<html><b>Hello world!</b></html>"
+        container_update_event_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(container_update_event_receiver)
+
+        self._set_library_block_fields(self.html_block_usage_key, {"data": block_olx, "metadata": {}})
+        self._validate_calls_of_html_block(container_update_event_receiver)

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -778,16 +778,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
         # TODO build API for this
         self.problem_block_component = api.get_component_from_usage_key(self.problem_block_usage_key)
         self.html_block_component = api.get_component_from_usage_key(self.html_block_usage_key)
-        self.unit1_container = authoring_api.get_container_by_key(
-            self.lib1.learning_package.id,
-            self.unit1.container_key.container_id,
-        )
-        self.unit2_container = authoring_api.get_container_by_key(
-            self.lib1.learning_package.id,
-            self.unit2.container_key.container_id,
-        )
         authoring_api.create_next_container_version(
-            self.unit1_container.pk,
+            self.unit1.container_pk,
             publishable_entities_pks=[
                 self.problem_block_component.publishable_entity.id,
                 self.html_block_component.publishable_entity.id,
@@ -798,7 +790,7 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
             created_by=None,
         )
         authoring_api.create_next_container_version(
-            self.unit2_container.pk,
+            self.unit2.container_pk,
             publishable_entities_pks=[self.html_block_component.publishable_entity.id],
             title=None,
             entity_version_pks=None,

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -797,7 +797,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
         assert html_block_containers[0].container_key == self.unit1.container_key
         assert html_block_containers[1].container_key == self.unit2.container_key
 
-
     def _validate_calls_of_html_block(self, event_mock):
         """
         Validate that the `event_mock` has been called twice

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -766,38 +766,25 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
 
         # Create XBlocks
         # Create some library blocks in lib1
-        self.problem_block_dict = self._add_block_to_library(
+        self.problem_block = self._add_block_to_library(
             self.lib1.library_key, "problem", "problem1",
         )
-        self.problem_block_usage_key = UsageKey.from_string(self.problem_block_dict["id"])
-        self.html_block_dict = self._add_block_to_library(
+        self.problem_block_usage_key = UsageKey.from_string(self.problem_block["id"])
+        self.html_block = self._add_block_to_library(
             self.lib1.library_key, "html", "html1",
         )
-        self.html_block_usage_key = UsageKey.from_string(self.html_block_dict["id"])
-        now = datetime.now(tz=timezone.utc)
+        self.html_block_usage_key = UsageKey.from_string(self.html_block["id"])
 
         # Add content to units
-        # TODO build API for this
-        self.problem_block_component = api.get_component_from_usage_key(self.problem_block_usage_key)
-        self.html_block_component = api.get_component_from_usage_key(self.html_block_usage_key)
-        authoring_api.create_next_container_version(
-            self.unit1.container_pk,
-            publishable_entities_pks=[
-                self.problem_block_component.publishable_entity.id,
-                self.html_block_component.publishable_entity.id,
-            ],
-            title=None,
-            entity_version_pks=None,
-            created=now,
-            created_by=None,
+        api.update_container_children(
+            self.unit1.container_key,
+            [self.problem_block_usage_key, self.html_block_usage_key],
+            None,
         )
-        authoring_api.create_next_container_version(
-            self.unit2.container_pk,
-            publishable_entities_pks=[self.html_block_component.publishable_entity.id],
-            title=None,
-            entity_version_pks=None,
-            created=now,
-            created_by=None,
+        api.update_container_children(
+            self.unit2.container_key,
+            [self.html_block_usage_key],
+            None,
         )
 
     def test_get_containers_contains_component(self):

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -5,7 +5,6 @@ Tests for Content Library internal api.
 import base64
 import hashlib
 from unittest import mock
-from datetime import datetime, timezone
 
 from django.test import TestCase
 
@@ -800,6 +799,10 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
 
 
     def _validate_calls_of_html_block(self, event_mock):
+        """
+        Validate that the `event_mock` has been called twice
+        using the `LIBRARY_CONTAINER_UPDATED` signal.
+        """
         assert event_mock.call_count == 2
         self.assertDictContainsSubset(
             {
@@ -832,7 +835,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
 
         api.delete_library_block(self.html_block_usage_key)
         self._validate_calls_of_html_block(container_update_event_receiver)
-        
 
     def test_call_container_update_signal_when_update_olx(self):
         block_olx = "<html><b>Hello world!</b></html>"

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -820,7 +820,7 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
                 "sender": None,
                 "library_container": LibraryContainerData(
                     library_key=self.lib1.library_key,
-                    container_key=self.unit1.container_pk,
+                    container_key=str(self.unit1.container_key),
                     background=True,
                 )
             },
@@ -832,7 +832,7 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, TestCase):
                 "sender": None,
                 "library_container": LibraryContainerData(
                     library_key=self.lib1.library_key,
-                    container_key=self.unit2.container_pk,
+                    container_key=str(self.unit2.container_key),
                     background=True,
                 )
             },

--- a/openedx/core/djangoapps/xblock/learning_context/learning_context.py
+++ b/openedx/core/djangoapps/xblock/learning_context/learning_context.py
@@ -76,3 +76,11 @@ class LearningContext:
 
         usage_key: the UsageKeyV2 subclass used for this learning context
         """
+
+    def send_container_updated_events(self, usage_key):
+        """
+        Send "container updated" events for containers that contains the block with
+        the given usage_key in this context.
+
+        usage_key: the UsageKeyV2 subclass used for this learning context
+        """

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -317,6 +317,7 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
         # Signal that we've modified this block
         learning_context = get_learning_context_impl(usage_key)
         learning_context.send_block_updated_event(usage_key)
+        learning_context.send_container_updated_events(usage_key)
 
     def _get_component_from_usage_key(self, usage_key):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- Added `publish_status` field to Container document in search index.
- Created `content_libraries/api/dataclass.py` and moved API Data classes to this file.
- Added `get_containers_contains_component` in containers API.
- Added `send_container_updated_events` in library context
- Call `LIBRARY_CONTAINER_UPDATED` in
    - `set_library_block_olx`
    - `delete_library_block`
- Which edX user roles will this change impact? "Developer".

## Supporting information

- Depends on https://github.com/openedx/edx-platform/pull/36371
- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1707
- Internal ticket: [FAL-4110](https://tasks.opencraft.com/browse/FAL-4110)

## Testing instructions

- Verify that the test covers the new code.
- On cms python shell run this code to create a library, create components, create units and add the components to the units:

```
from openedx.core.djangoapps.content_libraries import api
from organizations.models import Organization
from opaque_keys.edx.keys import UsageKey
from openedx_learning.api import authoring as authoring_api
from datetime import datetime, timezone
org = Organization.objects.get(name='SampleTaxonomyOrg1')
lib = api.create_library(org, 'lib1', 'Lib 1')
html_block = api.create_library_block(lib.key, 'html', 'html1')
problem_block = api.create_library_block(lib.key, 'problem', 'problem1')
unit1 = api.create_container(lib.key, api.ContainerType.Unit, 'unit-1', 'Unit 1', None)
unit2 = api.create_container(lib.key, api.ContainerType.Unit, 'unit-2', 'Unit 2', None)
api.update_container_children(
    unit1.container_key,
    [problem_block.usage_key, html_block.usage_key],
    None,
)
api.update_container_children(
    unit2.container_key,
    [html_block.usage_key],
    None,
)

```
- Run `tutor dev exec cms ./manage.py cms reindex_studio --experimental`
- Go to http://meilisearch.local.openedx.io:7700/ and verify the `num_children` of the units.
- On cms python shell run: `api.delete_library_block(problem_block.usage_key)`
- Go to meilisearch and verify the `num_children` of the units.
- On cms python shell run: `api.set_library_block_olx(html_block.usage_key, "<html><b>Hello world!</b></html>")`
- Check that there are no errors, as units cannot be published yet, the meilisearch does not change because it has never been published.

## Deadline

None

## Other information

N/A
