### PR TITLE
fix: legacy discussion issues

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -715,7 +715,7 @@ def delete_thread(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     course = get_course_with_access(request.user, 'load', course_key)
     thread = cc.Thread.find(thread_id)
-    thread.delete()
+    thread.delete(course_id=course_id)
     thread_deleted.send(sender=None, user=request.user, post=thread)
 
     track_thread_deleted_event(request, course, thread)
@@ -781,7 +781,7 @@ def openclose_thread(request, course_id, thread_id):
     thread = cc.Thread.find(thread_id)
     close_thread = request.POST.get('closed', 'false').lower() == 'true'
     thread.closed = close_thread
-    thread.save()
+    thread.save(params={"course_id": course_id})
 
     track_thread_lock_unlock_event(request, course, thread, None, close_thread)
     return JsonResponse({
@@ -976,7 +976,7 @@ def pin_thread(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
-    thread.pin(user, thread_id)
+    thread.pin(user, thread_id, course_id)
 
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
@@ -992,7 +992,7 @@ def un_pin_thread(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
-    thread.un_pin(user, thread_id)
+    thread.un_pin(user, thread_id, course_id)
 
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
@@ -1021,7 +1021,7 @@ def follow_commentable(request, course_id, commentable_id):  # lint-amnesty, pyl
     """
     user = cc.User.from_django_user(request.user)
     commentable = cc.Commentable.find(commentable_id)
-    user.follow(commentable)
+    user.follow(commentable, course_id=course_id)
     return JsonResponse({})
 
 
@@ -1053,7 +1053,7 @@ def unfollow_commentable(request, course_id, commentable_id):  # lint-amnesty, p
     """
     user = cc.User.from_django_user(request.user)
     commentable = cc.Commentable.find(commentable_id)
-    user.unfollow(commentable)
+    user.unfollow(commentable, course_id=course_id)
     return JsonResponse({})
 
 

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -222,7 +222,7 @@ class Thread(models.Model):
             url = _url_for_unflag_abuse_thread(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only flag/unflag for threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.update_thread_flag(
                 thread_id=voteable.id,
@@ -246,8 +246,8 @@ class Thread(models.Model):
             )
         voteable._update_from_response(response)
 
-    def pin(self, user, thread_id):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def pin(self, user, thread_id, course_id=None):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.pin_thread(
                 user_id=user.id,
@@ -266,8 +266,8 @@ class Thread(models.Model):
             )
         self._update_from_response(response)
 
-    def un_pin(self, user, thread_id):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def un_pin(self, user, thread_id, course_id):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.unpin_thread(
                 user_id=user.id,

--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -127,7 +127,7 @@ class User(models.Model):
             url = _url_for_vote_comment(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only vote / unvote for threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             if voteable.type == 'thread':
                 response = forum_api.delete_thread_vote(


### PR DESCRIPTION
## Description

Fixed all views where course_id was not provided to the forum v2 functions. 

## Supporting information

Related PR: https://github.com/openedx/edx-platform/pull/36315

## Testing instructions

TBD

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
