### PR TITLE
feat: api for adding, removing and updating components in container

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -575,7 +575,7 @@ def searchable_doc_for_container(
     }
 
     try:
-        container = lib_api.get_container(container_key)
+        container = lib_api.get_container_metadata(container_key)
     except lib_api.ContentLibraryCollectionNotFound:
         # Container not found, so we can only return the base doc
         pass

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import logging
 from hashlib import blake2b
 
-from django.utils.text import slugify
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils.text import slugify
 from opaque_keys.edx.keys import LearningContextKey, UsageKey
+from opaque_keys.edx.locator import LibraryContainerLocator, LibraryLocatorV2
 from openedx_learning.api import authoring as authoring_api
-from opaque_keys.edx.locator import LibraryLocatorV2, LibraryContainerLocator
+from openedx_learning.api.authoring_models import Collection
 from rest_framework.exceptions import NotFound
 
 from openedx.core.djangoapps.content.search.models import SearchAccess
@@ -19,7 +20,6 @@ from openedx.core.djangoapps.content_libraries import api as lib_api
 from openedx.core.djangoapps.content_tagging import api as tagging_api
 from openedx.core.djangoapps.xblock import api as xblock_api
 from openedx.core.djangoapps.xblock.data import LatestVersion
-from openedx_learning.api.authoring_models import Collection
 
 log = logging.getLogger(__name__)
 
@@ -554,7 +554,7 @@ def searchable_doc_for_container(
 ) -> dict:
     """
     Generate a dictionary document suitable for ingestion into a search engine
-    like Meilisearch or Elasticsearch, so that the given collection can be
+    like Meilisearch or Elasticsearch, so that the given container can be
     found using faceted search.
 
     If no container is found for the given container key, the returned document
@@ -576,29 +576,33 @@ def searchable_doc_for_container(
 
     try:
         container = lib_api.get_container_metadata(container_key)
-    except lib_api.ContentLibraryCollectionNotFound:
+    except lib_api.ContentLibraryContainerNotFound:
         # Container not found, so we can only return the base doc
-        pass
+        return doc
 
-    if container:
-        # TODO: check if there's a more efficient way to load these num_children counts?
-        draft_num_children = len(lib_api.get_container_children(container_key, published=False))
+    draft_num_children = lib_api.get_container_children_count(container_key, published=False)
+    publish_status = PublishStatus.published
+    if container.last_published is None:
+        publish_status = PublishStatus.never
+    elif container.has_unpublished_changes:
+        publish_status = PublishStatus.modified
 
-        doc.update({
-            Fields.display_name: container.display_name,
-            Fields.created: container.created.timestamp(),
-            Fields.modified: container.modified.timestamp(),
-            Fields.num_children: draft_num_children,
-        })
-        library = lib_api.get_library(container_key.library_key)
-        if library:
-            doc[Fields.breadcrumbs] = [{"display_name": library.title}]
+    doc.update({
+        Fields.display_name: container.display_name,
+        Fields.created: container.created.timestamp(),
+        Fields.modified: container.modified.timestamp(),
+        Fields.num_children: draft_num_children,
+        Fields.publish_status: publish_status,
+    })
+    library = lib_api.get_library(container_key.library_key)
+    if library:
+        doc[Fields.breadcrumbs] = [{"display_name": library.title}]
 
-        if container.published_version_num is not None:
-            published_num_children = len(lib_api.get_container_children(container_key, published=True))
-            doc[Fields.published] = {
-                # Fields.published_display_name: container_published.title, TODO: set the published title
-                Fields.published_num_children: published_num_children,
-            }
+    if container.published_version_num is not None:
+        published_num_children = lib_api.get_container_children_count(container_key, published=True)
+        doc[Fields.published] = {
+            # Fields.published_display_name: container_published.title, TODO: set the published title
+            Fields.published_num_children: published_num_children,
+        }
 
     return doc

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -575,7 +575,7 @@ def searchable_doc_for_container(
     }
 
     try:
-        container = lib_api.get_container_metadata(container_key)
+        container = lib_api.get_container(container_key)
     except lib_api.ContentLibraryContainerNotFound:
         # Container not found, so we can only return the base doc
         return doc

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -227,6 +227,7 @@ class TestSearchApi(ModuleStoreTestCase):
             "display_name": "Unit 1",
             # description is not set for containers
             "num_children": 0,
+            "publish_status": "never",
             "context_key": "lib:org1:lib",
             "org": "org1",
             "created": created_date.timestamp(),

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -259,11 +259,11 @@ def get_container_children(
     """
     container = get_container(container_key)
     if container_key.container_type == ContainerType.Unit.value:
-        child_entities = authoring_api.get_components_in_unit(container.unit, published=published)
+        child_components = authoring_api.get_components_in_unit(container.unit, published=published)
         return [LibraryXBlockMetadata.from_component(
             container_key.library_key,
             entry.component
-        ) for entry in child_entities]
+        ) for entry in child_components]
     else:
         child_entities = authoring_api.get_entities_in_container(container, published=published)
         return [ContainerMetadata.from_container(
@@ -297,10 +297,10 @@ def update_container_children(
     container = get_container(container_key)
     match container_type:
         case ContainerType.Unit.value:
-            components = [get_component_from_usage_key(key) for key in children_ids]
+            components = [get_component_from_usage_key(key) for key in children_ids]  # type: ignore[arg-type]
             new_version = authoring_api.create_next_unit_version(
                 container.unit,
-                components=components,
+                components=components,  # type: ignore[arg-type]
                 created=datetime.now(),
                 created_by=user_id,
                 entities_action=entities_action,

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -257,7 +257,7 @@ def get_container_children(
     """
     Get the entities contained in the given container (e.g. the components/xblocks in a unit)
     """
-    container = get_container(container_key)
+    container = _get_container(container_key)
     if container_key.container_type == ContainerType.Unit.value:
         child_components = authoring_api.get_components_in_unit(container.unit, published=published)
         return [LibraryXBlockMetadata.from_component(
@@ -279,7 +279,7 @@ def get_container_children_count(
     """
     Get the count of entities contained in the given container (e.g. the components/xblocks in a unit)
     """
-    container = get_container(container_key)
+    container = _get_container(container_key)
     return authoring_api.get_container_children_count(container, published=published)
 
 
@@ -294,7 +294,7 @@ def update_container_children(
     """
     library_key = container_key.library_key
     container_type = container_key.container_type
-    container = get_container(container_key)
+    container = _get_container(container_key)
     match container_type:
         case ContainerType.Unit.value:
             components = [get_component_from_usage_key(key) for key in children_ids]  # type: ignore[arg-type]

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -2,6 +2,7 @@
 API for containers (Sections, Subsections, Units) in Content Libraries
 """
 from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -9,10 +10,10 @@ from uuid import uuid4
 
 from django.utils.text import slugify
 from opaque_keys.edx.locator import (
-    LibraryLocatorV2,
     LibraryContainerLocator,
+    LibraryLocatorV2,
+    UsageKeyV2,
 )
-
 from openedx_events.content_authoring.data import LibraryContainerData
 from openedx_events.content_authoring.signals import (
     LIBRARY_CONTAINER_CREATED,
@@ -22,8 +23,10 @@ from openedx_events.content_authoring.signals import (
 from openedx_learning.api import authoring as authoring_api
 from openedx_learning.api.authoring_models import Container
 
+from openedx.core.djangoapps.xblock.api import get_component_from_usage_key
+
 from ..models import ContentLibrary
-from .libraries import PublishableItem
+from .libraries import LibraryXBlockMetadata, PublishableItem
 
 
 # The public API is only the following symbols:
@@ -37,6 +40,7 @@ __all__ = [
     "library_container_locator",
     "update_container",
     "delete_container",
+    "add_container_children",
 ]
 
 
@@ -252,14 +256,47 @@ def get_container_children(
     """
     Get the entities contained in the given container (e.g. the components/xblocks in a unit)
     """
-    assert isinstance(container_key, LibraryContainerLocator)
-    content_library = ContentLibrary.objects.get_by_key(container_key.library_key)
-    learning_package = content_library.learning_package
-    assert learning_package is not None
-    container = authoring_api.get_container_by_key(
-        learning_package.id,
-        key=container_key.container_id,
+    container = get_container(container_key)
+    if container_key.container_type == ContainerType.Unit.value:
+        child_entities = authoring_api.get_components_in_unit(container.unit, published=published)
+        return [LibraryXBlockMetadata.from_component(
+            container_key.library_key,
+            entry.component
+        ) for entry in child_entities]
+    else:
+        child_entities = authoring_api.get_entities_in_container(container, published=published)
+        return [ContainerMetadata.from_container(entry.entity) for entry in child_entities]
+
+
+def add_container_children(
+    container_key: LibraryContainerLocator,
+    children_ids: list[UsageKeyV2] | list[LibraryContainerLocator],
+    user_id: int | None,
+):
+    """
+    Adds children components or containers to given container.
+    """
+    library_key = container_key.library_key
+    container_type = container_key.container_type
+    container = get_container(container_key)
+    match container_type:
+        case ContainerType.Unit.value:
+            components = [get_component_from_usage_key(key) for key in children_ids]
+            new_version = authoring_api.create_next_unit_version(
+                container.unit,
+                components=components,
+                created=datetime.now(),
+                created_by=user_id,
+                entities_action=authoring_api.ChildrenEntitiesAction.APPEND,
+            )
+        case _:
+            raise ValueError(f"Invalid container type: {container_type}")
+
+    LIBRARY_CONTAINER_UPDATED.send_event(
+        library_container=LibraryContainerData(
+            library_key=library_key,
+            container_key=str(container_key),
+        )
     )
-    child_entities = authoring_api.get_entities_in_container(container, published=published)
-    # TODO: convert the return type to list[ContainerMetadata | LibraryXBlockMetadata] ?
-    return child_entities
+
+    return ContainerMetadata.from_container(library_key, new_version.container)

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -40,7 +40,7 @@ __all__ = [
     "library_container_locator",
     "update_container",
     "delete_container",
-    "add_container_children",
+    "update_container_children",
 ]
 
 
@@ -268,10 +268,11 @@ def get_container_children(
         return [ContainerMetadata.from_container(entry.entity) for entry in child_entities]
 
 
-def add_container_children(
+def update_container_children(
     container_key: LibraryContainerLocator,
     children_ids: list[UsageKeyV2] | list[LibraryContainerLocator],
     user_id: int | None,
+    entities_action: authoring_api.ChildrenEntitiesAction = authoring_api.ChildrenEntitiesAction.REPLACE,
 ):
     """
     Adds children components or containers to given container.
@@ -287,7 +288,7 @@ def add_container_children(
                 components=components,
                 created=datetime.now(),
                 created_by=user_id,
-                entities_action=authoring_api.ChildrenEntitiesAction.APPEND,
+                entities_action=entities_action,
             )
         case _:
             raise ValueError(f"Invalid container type: {container_type}")

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -265,7 +265,10 @@ def get_container_children(
         ) for entry in child_entities]
     else:
         child_entities = authoring_api.get_entities_in_container(container, published=published)
-        return [ContainerMetadata.from_container(entry.entity) for entry in child_entities]
+        return [ContainerMetadata.from_container(
+            container_key.library_key,
+            entry.entity
+        ) for entry in child_entities]
 
 
 def update_container_children(

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -37,6 +37,7 @@ __all__ = [
     "get_container",
     "create_container",
     "get_container_children",
+    "get_container_children_count",
     "library_container_locator",
     "update_container",
     "delete_container",
@@ -269,6 +270,17 @@ def get_container_children(
             container_key.library_key,
             entry.entity
         ) for entry in child_entities]
+
+
+def get_container_children_count(
+    container_key: LibraryContainerLocator,
+    published=False,
+) -> int:
+    """
+    Get the count of entities contained in the given container (e.g. the components/xblocks in a unit)
+    """
+    container = get_container(container_key)
+    return authoring_api.get_container_children_count(container, published=published)
 
 
 def update_container_children(

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -969,6 +969,8 @@ def create_library_block(
 ):
     """
     Create a new XBlock in this library of the specified type (e.g. "html").
+
+    Set can_stand_alone = False when a component is created under a container, like unit.
     """
     # It's in the serializer as ``definition_id``, but for our purposes, it's
     # the block_id. See the comments in ``LibraryXBlockCreationSerializer`` for
@@ -1152,6 +1154,8 @@ def _create_component_for_block(
     in the OLX will have no attributes, e.g. `<problem />`. This first version
     will be set as the current draft. This function does not publish the
     Component.
+
+    Set can_stand_alone = False when a component is created under a container, like unit.
 
     TODO: We should probably shift this to openedx.core.djangoapps.xblock.api
     (along with its caller) since it gives runtime storage specifics. The

--- a/openedx/core/djangoapps/content_libraries/rest_api/collections.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/collections.py
@@ -21,8 +21,8 @@ from ..models import ContentLibrary
 from .utils import convert_exceptions
 from .serializers import (
     ContentLibraryCollectionSerializer,
-    ContentLibraryCollectionComponentsUpdateSerializer,
     ContentLibraryCollectionUpdateSerializer,
+    ContentLibraryComponentKeysSerializer,
 )
 from openedx.core.types.http import RestRequest
 
@@ -200,7 +200,7 @@ class LibraryCollectionsView(ModelViewSet):
         content_library = self.get_content_library()
         collection_key = kwargs["key"]
 
-        serializer = ContentLibraryCollectionComponentsUpdateSerializer(data=request.data)
+        serializer = ContentLibraryComponentKeysSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         usage_keys = serializer.validated_data["usage_keys"]

--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -80,7 +80,7 @@ class LibraryContainerView(GenericAPIView):
             request.user,
             permissions.CAN_VIEW_THIS_CONTENT_LIBRARY,
         )
-        container = api.get_container_metadata(container_key)
+        container = api.get_container(container_key)
         return Response(serializers.LibraryContainerMetadataSerializer(container).data)
 
     @convert_exceptions

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -159,6 +159,7 @@ class LibraryXBlockMetadataSerializer(serializers.Serializer):
     tags_count = serializers.IntegerField(read_only=True)
 
     collections = CollectionMetadataSerializer(many=True, required=False)
+    can_stand_alone = serializers.BooleanField(read_only=True)
 
 
 class LibraryXBlockTypeSerializer(serializers.Serializer):
@@ -192,6 +193,9 @@ class LibraryXBlockCreationSerializer(serializers.Serializer):
     # Optional param specified when pasting data from clipboard instead of
     # creating new block from scratch
     staged_content = serializers.CharField(required=False)
+
+    # Optional param defaults to True, set to False if block is being created under a container.
+    can_stand_alone = serializers.BooleanField(required=False, default=True)
 
 
 class LibraryPasteClipboardSerializer(serializers.Serializer):
@@ -345,7 +349,7 @@ class UsageKeyV2Serializer(serializers.BaseSerializer):
             raise ValidationError from err
 
 
-class ContentLibraryCollectionComponentsUpdateSerializer(serializers.Serializer):
+class ContentLibraryComponentKeysSerializer(serializers.Serializer):
     """
     Serializer for adding/removing Components to/from a Collection.
     """

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -33,6 +33,7 @@ URL_LIB_BLOCK_OLX = URL_LIB_BLOCK + 'olx/'  # Get or set the OLX of the specifie
 URL_LIB_BLOCK_ASSETS = URL_LIB_BLOCK + 'assets/'  # List the static asset files of the specified XBlock
 URL_LIB_BLOCK_ASSET_FILE = URL_LIB_BLOCK + 'assets/{file_name}'  # Get, delete, or upload a specific static asset file
 URL_LIB_CONTAINER = URL_PREFIX + 'containers/{container_key}/'  # Get a container in this library
+URL_LIB_CONTAINER_COMPONENTS = URL_LIB_CONTAINER + 'children/'  # Get, add or delete a component in this container
 
 URL_LIB_LTI_PREFIX = URL_PREFIX + 'lti/1.3/'
 URL_LIB_LTI_JWKS = URL_LIB_LTI_PREFIX + 'pub/jwks/'
@@ -229,9 +230,21 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
             expect_response
         )
 
-    def _add_block_to_library(self, lib_key, block_type, slug, parent_block=None, expect_response=200):
+    def _add_block_to_library(
+        self,
+        lib_key,
+        block_type,
+        slug,
+        parent_block=None,
+        can_stand_alone=True,
+        expect_response=200,
+    ):
         """ Add a new XBlock to the library """
-        data = {"block_type": block_type, "definition_id": slug}
+        data = {
+            "block_type": block_type,
+            "definition_id": slug,
+            "can_stand_alone": can_stand_alone,
+        }
         if parent_block:
             data["parent_block"] = parent_block
         return self._api('post', URL_LIB_BLOCKS.format(lib_key=lib_key), data, expect_response)
@@ -372,3 +385,26 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
     def _delete_container(self, container_key: str, expect_response=204):
         """ Delete a container (unit etc.) """
         return self._api('delete', URL_LIB_CONTAINER.format(container_key=container_key), None, expect_response)
+
+    def _get_container_components(self, container_key: str, expect_response=200):
+        """ Get container components"""
+        return self._api(
+            'get',
+            URL_LIB_CONTAINER_COMPONENTS.format(container_key=container_key),
+            None,
+            expect_response
+        )
+
+    def _add_container_components(
+        self,
+        container_key: str,
+        children_ids: list[str],
+        expect_response=200,
+    ):
+        """ Add container components"""
+        return self._api(
+            'post',
+            URL_LIB_CONTAINER_COMPONENTS.format(container_key=container_key),
+            {'usage_keys': children_ids},
+            expect_response
+        )

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -408,3 +408,31 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
             {'usage_keys': children_ids},
             expect_response
         )
+
+    def _remove_container_components(
+        self,
+        container_key: str,
+        children_ids: list[str],
+        expect_response=200,
+    ):
+        """ Remove container components"""
+        return self._api(
+            'delete',
+            URL_LIB_CONTAINER_COMPONENTS.format(container_key=container_key),
+            {'usage_keys': children_ids},
+            expect_response
+        )
+
+    def _patch_container_components(
+        self,
+        container_key: str,
+        children_ids: list[str],
+        expect_response=200,
+    ):
+        """ Update container components"""
+        return self._api(
+            'patch',
+            URL_LIB_CONTAINER_COMPONENTS.format(container_key=container_key),
+            {'usage_keys': children_ids},
+            expect_response
+        )

--- a/openedx/core/djangoapps/content_libraries/tests/test_containers.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_containers.py
@@ -2,10 +2,10 @@
 Tests for Learning-Core-based Content Libraries
 """
 from datetime import datetime, timezone
+from unittest import mock
 
 import ddt
 from freezegun import freeze_time
-from unittest import mock
 
 from opaque_keys.edx.locator import LibraryLocatorV2
 from openedx_events.content_authoring.data import LibraryContainerData
@@ -185,6 +185,7 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
         """
         lib = self._create_library(slug="containers", title="Container Test Library", description="Units and more")
 
+        # Create container and add some components
         container_data = self._create_container(lib["id"], "unit", display_name="Alpha Bravo", slug=None)
         problem_block = self._add_block_to_library(lib["id"], "problem", "Problem1", can_stand_alone=False)
         html_block = self._add_block_to_library(lib["id"], "html", "Html1", can_stand_alone=False)
@@ -200,13 +201,90 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
         assert not data[1]['can_stand_alone']
         problem_block_2 = self._add_block_to_library(lib["id"], "problem", "Problem2", can_stand_alone=False)
         html_block_2 = self._add_block_to_library(lib["id"], "html", "Html2")
+        # Add two more components
         self._add_container_components(
             container_data["container_key"],
             children_ids=[problem_block_2["id"], html_block_2["id"]]
         )
         data = self._get_container_components(container_data["container_key"])
+        # Verify total number of components to be 2 + 2 = 4
         assert len(data) == 4
         assert data[2]['id'] == problem_block_2['id']
         assert not data[2]['can_stand_alone']
         assert data[3]['id'] == html_block_2['id']
         assert data[3]['can_stand_alone']
+
+    def test_unit_remove_children(self):
+        """
+        Test that we can remove unit children components
+        """
+        lib = self._create_library(slug="containers", title="Container Test Library", description="Units and more")
+
+        # Create container and add some components
+        container_data = self._create_container(lib["id"], "unit", display_name="Alpha Bravo", slug=None)
+        problem_block = self._add_block_to_library(lib["id"], "problem", "Problem1", can_stand_alone=False)
+        html_block = self._add_block_to_library(lib["id"], "html", "Html1", can_stand_alone=False)
+        problem_block_2 = self._add_block_to_library(lib["id"], "problem", "Problem2", can_stand_alone=False)
+        html_block_2 = self._add_block_to_library(lib["id"], "html", "Html2")
+        self._add_container_components(
+            container_data["container_key"],
+            children_ids=[problem_block["id"], html_block["id"], problem_block_2["id"], html_block_2["id"]]
+        )
+        data = self._get_container_components(container_data["container_key"])
+        assert len(data) == 4
+        # Remove both problem blocks.
+        self._remove_container_components(
+            container_data["container_key"],
+            children_ids=[problem_block_2["id"], problem_block["id"]]
+        )
+        data = self._get_container_components(container_data["container_key"])
+        assert len(data) == 2
+        assert data[0]['id'] == html_block['id']
+        assert data[1]['id'] == html_block_2['id']
+
+    def test_unit_replace_children(self):
+        """
+        Test that we can completely replace/reorder unit children components.
+        """
+        lib = self._create_library(slug="containers", title="Container Test Library", description="Units and more")
+
+        # Create container and add some components
+        container_data = self._create_container(lib["id"], "unit", display_name="Alpha Bravo", slug=None)
+        problem_block = self._add_block_to_library(lib["id"], "problem", "Problem1", can_stand_alone=False)
+        html_block = self._add_block_to_library(lib["id"], "html", "Html1", can_stand_alone=False)
+        problem_block_2 = self._add_block_to_library(lib["id"], "problem", "Problem2", can_stand_alone=False)
+        html_block_2 = self._add_block_to_library(lib["id"], "html", "Html2")
+        self._add_container_components(
+            container_data["container_key"],
+            children_ids=[problem_block["id"], html_block["id"], problem_block_2["id"], html_block_2["id"]]
+        )
+        data = self._get_container_components(container_data["container_key"])
+        assert len(data) == 4
+        assert data[0]['id'] == problem_block['id']
+        assert data[1]['id'] == html_block['id']
+        assert data[2]['id'] == problem_block_2['id']
+        assert data[3]['id'] == html_block_2['id']
+
+        # Reorder the components
+        self._patch_container_components(
+            container_data["container_key"],
+            children_ids=[problem_block["id"], problem_block_2["id"], html_block["id"], html_block_2["id"]]
+        )
+        data = self._get_container_components(container_data["container_key"])
+        assert len(data) == 4
+        assert data[0]['id'] == problem_block['id']
+        assert data[1]['id'] == problem_block_2['id']
+        assert data[2]['id'] == html_block['id']
+        assert data[3]['id'] == html_block_2['id']
+
+        # Replace with new components
+        new_problem_block = self._add_block_to_library(lib["id"], "problem", "New_Problem", can_stand_alone=False)
+        new_html_block = self._add_block_to_library(lib["id"], "html", "New_Html", can_stand_alone=False)
+        self._patch_container_components(
+            container_data["container_key"],
+            children_ids=[new_problem_block["id"], new_html_block["id"]],
+        )
+        data = self._get_container_components(container_data["container_key"])
+        assert len(data) == 2
+        assert data[0]['id'] == new_problem_block['id']
+        assert data[1]['id'] == new_html_block['id']

--- a/openedx/core/djangoapps/content_libraries/tests/test_containers.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_containers.py
@@ -178,3 +178,35 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
         assert container1_data["container_key"].startswith("lct:CL-TEST:containers:unit:alpha-bravo-")
         assert container2_data["container_key"].startswith("lct:CL-TEST:containers:unit:alpha-bravo-")
         assert container1_data["container_key"] != container2_data["container_key"]
+
+    def test_unit_add_children(self):
+        """
+        Test that we can add and get unit children components
+        """
+        lib = self._create_library(slug="containers", title="Container Test Library", description="Units and more")
+
+        container_data = self._create_container(lib["id"], "unit", display_name="Alpha Bravo", slug=None)
+        problem_block = self._add_block_to_library(lib["id"], "problem", "Problem1", can_stand_alone=False)
+        html_block = self._add_block_to_library(lib["id"], "html", "Html1", can_stand_alone=False)
+        self._add_container_components(
+            container_data["container_key"],
+            children_ids=[problem_block["id"], html_block["id"]]
+        )
+        data = self._get_container_components(container_data["container_key"])
+        assert len(data) == 2
+        assert data[0]['id'] == problem_block['id']
+        assert not data[0]['can_stand_alone']
+        assert data[1]['id'] == html_block['id']
+        assert not data[1]['can_stand_alone']
+        problem_block_2 = self._add_block_to_library(lib["id"], "problem", "Problem2", can_stand_alone=False)
+        html_block_2 = self._add_block_to_library(lib["id"], "html", "Html2")
+        self._add_container_components(
+            container_data["container_key"],
+            children_ids=[problem_block_2["id"], html_block_2["id"]]
+        )
+        data = self._get_container_components(container_data["container_key"])
+        assert len(data) == 4
+        assert data[2]['id'] == problem_block_2['id']
+        assert not data[2]['can_stand_alone']
+        assert data[3]['id'] == html_block_2['id']
+        assert data[3]['can_stand_alone']

--- a/openedx/core/djangoapps/content_libraries/tests/test_containers.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_containers.py
@@ -183,7 +183,10 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
         """
         Test that we can add and get unit children components
         """
+        update_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(update_receiver)
         lib = self._create_library(slug="containers", title="Container Test Library", description="Units and more")
+        lib_key = LibraryLocatorV2.from_string(lib["id"])
 
         # Create container and add some components
         container_data = self._create_container(lib["id"], "unit", display_name="Alpha Bravo", slug=None)
@@ -206,6 +209,17 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
             container_data["container_key"],
             children_ids=[problem_block_2["id"], html_block_2["id"]]
         )
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    lib_key,
+                    container_key=container_data["container_key"],
+                ),
+            },
+            update_receiver.call_args_list[0].kwargs,
+        )
         data = self._get_container_components(container_data["container_key"])
         # Verify total number of components to be 2 + 2 = 4
         assert len(data) == 4
@@ -218,7 +232,10 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
         """
         Test that we can remove unit children components
         """
+        update_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(update_receiver)
         lib = self._create_library(slug="containers", title="Container Test Library", description="Units and more")
+        lib_key = LibraryLocatorV2.from_string(lib["id"])
 
         # Create container and add some components
         container_data = self._create_container(lib["id"], "unit", display_name="Alpha Bravo", slug=None)
@@ -241,12 +258,26 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
         assert len(data) == 2
         assert data[0]['id'] == html_block['id']
         assert data[1]['id'] == html_block_2['id']
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    lib_key,
+                    container_key=container_data["container_key"],
+                ),
+            },
+            update_receiver.call_args_list[0].kwargs,
+        )
 
     def test_unit_replace_children(self):
         """
         Test that we can completely replace/reorder unit children components.
         """
+        update_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(update_receiver)
         lib = self._create_library(slug="containers", title="Container Test Library", description="Units and more")
+        lib_key = LibraryLocatorV2.from_string(lib["id"])
 
         # Create container and add some components
         container_data = self._create_container(lib["id"], "unit", display_name="Alpha Bravo", slug=None)
@@ -288,3 +319,14 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
         assert len(data) == 2
         assert data[0]['id'] == new_problem_block['id']
         assert data[1]['id'] == new_html_block['id']
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    lib_key,
+                    container_key=container_data["container_key"],
+                ),
+            },
+            update_receiver.call_args_list[0].kwargs,
+        )

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -80,6 +80,8 @@ urlpatterns = [
         path('containers/<lib_container_key:container_key>/', include([
             # Get metadata about a specific container in this library, update or delete the container:
             path('', containers.LibraryContainerView.as_view()),
+            # update components under container
+            path('children/', containers.LibraryContainerChildrenView.as_view()),
             # Update collections for a given container
             # path('collections/', views.LibraryContainerCollectionsView.as_view(), name='update-collections-ct'),
             # path('publish/', views.LibraryContainerPublishView.as_view()),

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -112,7 +112,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
+openedx-learning==0.19.2
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -112,7 +112,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.19.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -820,7 +820,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.1.9
     # via -r requirements/edx/kernel.in
-openedx-learning==0.19.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -820,7 +820,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.1.9
     # via -r requirements/edx/kernel.in
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
+openedx-learning==0.19.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1383,7 +1383,7 @@ openedx-forum==0.1.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
+openedx-learning==0.19.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1383,7 +1383,7 @@ openedx-forum==0.1.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.19.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -992,7 +992,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.1.9
     # via -r requirements/edx/base.txt
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
+openedx-learning==0.19.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -992,7 +992,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.1.9
     # via -r requirements/edx/base.txt
-openedx-learning==0.19.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1050,7 +1050,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.1.9
     # via -r requirements/edx/base.txt
-openedx-learning==0.19.1
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1050,7 +1050,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.1.9
     # via -r requirements/edx/base.txt
-openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@navin/fal-4109/add-components-to-container
+openedx-learning==0.19.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Rest API to add, remove and update components under containers in content libraries.

Useful information to include:

- Which edX user roles will this change impact?: "Developer".

## Supporting information

* Part of: https://github.com/openedx/frontend-app-authoring/issues/1706 and https://github.com/openedx/frontend-app-authoring/issues/1705
* Depends on:
    * https://github.com/openedx/openedx-learning/pull/292
    * https://github.com/openedx/edx-platform/pull/36371
* `Private-ref`: [FAL-4109](https://tasks.opencraft.com/browse/FAL-4109)

## Testing instructions

* Read code
* Verify the tests and make sure they are passing.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Concerns

[Enforce restrictions on which block types are allowed.](https://github.com/openedx/frontend-app-authoring/issues/1706): Not sure about this one. Do we have a fixed list of allowed blocks that we want to restrict via rest api or is this configurable per unit/library etc.?
