### PR TITLE
fix: sort sections in course-optimizer before returning result

### DIFF
--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -307,6 +307,6 @@ def sort_course_sections(course_key, data):
         sections_map[section_id]
         for section_id in sorted_section_ids
         if section_id in sections_map
-        ]
+    ]
 
     return data

--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -303,6 +303,10 @@ def sort_course_sections(course_key, data):
     sorted_section_ids = [section.location.block_id for section in course_blocks[0].get_children()]
 
     sections_map = {section['id']: section for section in data['LinkCheckOutput']['sections']}
-    data['LinkCheckOutput']['sections'] = [sections_map[section_id] for section_id in sorted_section_ids if section_id in sections_map]
+    data['LinkCheckOutput']['sections'] = [
+        sections_map[section_id]
+        for section_id in sorted_section_ids
+        if section_id in sections_map
+        ]
 
     return data

--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -8,6 +8,8 @@ from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from cms.djangoapps.contentstore.tasks import CourseLinkCheckTask, LinkState
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import get_xblock
 from cms.djangoapps.contentstore.xblock_storage_handlers.xblock_helpers import usage_key_with_run
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
 
 
 # Restricts status in the REST API to only those which the requesting user has permission to view.
@@ -285,3 +287,22 @@ def _create_dto_recursive(xblock_node, xblock_dictionary):
         xblock_children.append(xblock_entry)
 
     return {level: xblock_children} if level else None
+
+
+def get_sorted_sections(course_key, data):
+    """Retrieve and sort course sections based on the published course structure."""
+    course_blocks = modulestore().get_items(
+        course_key,
+        qualifiers={'category': 'course'},
+        revision=ModuleStoreEnum.RevisionOption.published_only
+    )
+
+    if not course_blocks:
+        return data  # Return unchanged data if no verticals found
+
+    sorted_section_ids = [section.location.block_id for section in course_blocks[0].get_children()]
+
+    sections_map = {section['id']: section for section in data['LinkCheckOutput']['sections']}
+    sorted_sections = [sections_map[section_id] for section_id in sorted_section_ids if section_id in sections_map]
+
+    return sorted_sections

--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -307,4 +307,3 @@ def sort_course_sections(course_key, data):
     data['LinkCheckOutput']['sections'] = sorted_sections
 
     return data
-

--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -303,7 +303,6 @@ def sort_course_sections(course_key, data):
     sorted_section_ids = [section.location.block_id for section in course_blocks[0].get_children()]
 
     sections_map = {section['id']: section for section in data['LinkCheckOutput']['sections']}
-    sorted_sections = [sections_map[section_id] for section_id in sorted_section_ids if section_id in sections_map]
-    data['LinkCheckOutput']['sections'] = sorted_sections
+    data['LinkCheckOutput']['sections'] = [sections_map[section_id] for section_id in sorted_section_ids if section_id in sections_map]
 
     return data

--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -289,7 +289,7 @@ def _create_dto_recursive(xblock_node, xblock_dictionary):
     return {level: xblock_children} if level else None
 
 
-def get_sorted_sections(course_key, data):
+def sort_course_sections(course_key, data):
     """Retrieve and sort course sections based on the published course structure."""
     course_blocks = modulestore().get_items(
         course_key,
@@ -297,12 +297,14 @@ def get_sorted_sections(course_key, data):
         revision=ModuleStoreEnum.RevisionOption.published_only
     )
 
-    if not course_blocks:
-        return data  # Return unchanged data if no verticals found
+    if not course_blocks or 'LinkCheckOutput' not in data or 'sections' not in data['LinkCheckOutput']:
+        return data  # Return unchanged data if course_blocks or required keys are missing
 
     sorted_section_ids = [section.location.block_id for section in course_blocks[0].get_children()]
 
     sections_map = {section['id']: section for section in data['LinkCheckOutput']['sections']}
     sorted_sections = [sections_map[section_id] for section_id in sorted_section_ids if section_id in sections_map]
+    data['LinkCheckOutput']['sections'] = sorted_sections
 
-    return sorted_sections
+    return data
+

--- a/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
@@ -6,7 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from user_tasks.models import UserTaskStatus
 
-from cms.djangoapps.contentstore.core.course_optimizer_provider import get_link_check_data
+from cms.djangoapps.contentstore.core.course_optimizer_provider import get_link_check_data, get_sorted_sections
 from cms.djangoapps.contentstore.rest_api.v0.serializers.course_optimizer import LinkCheckSerializer
 from cms.djangoapps.contentstore.tasks import check_broken_links
 from common.djangoapps.student.auth import has_course_author_access, has_studio_read_access
@@ -139,6 +139,7 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
             self.permission_denied(request)
 
         data = get_link_check_data(request, course_id)
-        serializer = LinkCheckSerializer(data)
+        data['LinkCheckOutput']['sections'] = get_sorted_sections(course_key, data)
 
+        serializer = LinkCheckSerializer(data)
         return Response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
@@ -6,7 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from user_tasks.models import UserTaskStatus
 
-from cms.djangoapps.contentstore.core.course_optimizer_provider import get_link_check_data, get_sorted_sections
+from cms.djangoapps.contentstore.core.course_optimizer_provider import get_link_check_data, sort_course_sections
 from cms.djangoapps.contentstore.rest_api.v0.serializers.course_optimizer import LinkCheckSerializer
 from cms.djangoapps.contentstore.tasks import check_broken_links
 from common.djangoapps.student.auth import has_course_author_access, has_studio_read_access
@@ -139,7 +139,7 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
             self.permission_denied(request)
 
         data = get_link_check_data(request, course_id)
-        data['LinkCheckOutput']['sections'] = get_sorted_sections(course_key, data)
+        data = sort_course_sections(course_key, data)
 
         serializer = LinkCheckSerializer(data)
         return Response(serializer.data)


### PR DESCRIPTION
## Description

Course Optimizer detected unusual section ordering where Section 3 appears before Section 1, which is unexpected and inconsistent with standard 'Course Outline' Ordering. This PR fixes by getting ordered section_ids and place sections in sorted manner basis on sections_ids ordering.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Course Author"
- [JIRA Link](https://2u-internal.atlassian.net/browse/TNL-11929)

## Other information

### Before

<img width="1556" alt="image" src="https://github.com/user-attachments/assets/d56bab1e-187c-430c-b259-8b3bf2a2218a" />

### After

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/eba4bfc1-c5a7-48b2-98fc-ff7b51ea28b7" />
