### PR TITLE
Fix: Prevent Duplicate Instructions Rendering in Annotatable XBlock

### DIFF
--- a/xmodule/annotatable_block.py
+++ b/xmodule/annotatable_block.py
@@ -140,9 +140,8 @@ class _BuiltInAnnotatableBlock(
         """ Renders annotatable content with annotation spans and returns HTML. """
 
         xmltree = etree.fromstring(self.data)
-        content = etree.tostring(xmltree, encoding='unicode')
+        self._extract_instructions(xmltree)
 
-        xmltree = etree.fromstring(content)
         xmltree.tag = 'div'
         if 'display_name' in xmltree.attrib:
             del xmltree.attrib['display_name']

--- a/xmodule/tests/test_annotatable_block.py
+++ b/xmodule/tests/test_annotatable_block.py
@@ -134,3 +134,11 @@ class AnnotatableBlockTestCase(unittest.TestCase):  # lint-amnesty, pylint: disa
         xmltree = etree.fromstring('<annotatable>foo</annotatable>')
         actual = self.annotatable._extract_instructions(xmltree)  # lint-amnesty, pylint: disable=protected-access
         assert actual is None
+
+    def test_instruction_removal(self):
+        xmltree = etree.fromstring(self.sample_xml)
+        instructions = self.annotatable._extract_instructions(xmltree)  # pylint: disable=protected-access
+
+        assert instructions is not None
+        assert "Read the text." in instructions
+        assert xmltree.find("instructions") is None


### PR DESCRIPTION
## Description

In the Annotatable XBlock, the `<instructions>` element was appearing twice in the student view:  
- Once in `"annotatable-instructions"` (where it should be).  
- Again in `"annotatable-content"` (where annotations and other content are rendered).  

The `_render_content` method processed and rendered the entire XML data, including `<instructions>`, without removing it. The `_extract_instructions` method, which is responsible for removing `<instructions>`, was not called in `_render_content`, leading to duplication.  

Before:
<img width="800" alt="Screenshot 2025-03-26 at 2 38 07 PM" src="https://github.com/user-attachments/assets/9ad5173b-1d30-4e66-a518-d8a2f9b08c08" />

After:
<img width="944" alt="Screenshot 2025-03-26 at 2 37 33 PM" src="https://github.com/user-attachments/assets/d28e54fa-9268-4ecb-b032-14bbdaef88df" />


This fix will:
- Prevents duplicate instructions in the student view.  
- Maintains the expected behavior of showing instructions only in `"annotatable-instructions"`.  
- No impact on existing annotation functionality.  
