### PR TITLE
chore: calling other djangoapps from API instead of model

### DIFF
--- a/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
@@ -1,11 +1,12 @@
 """
-Unit tests for Learner Dashboard REST APIs and Views
+Unit tests for Programs REST APIs and Views
 """
 
 from unittest import mock
 from uuid import uuid4
 
 from django.core.cache import cache
+from django.test.utils import override_settings
 from django.urls import reverse_lazy
 from enterprise.models import EnterpriseCourseEnrollment
 
@@ -31,6 +32,7 @@ from openedx.core.djangoapps.site_configuration.tests.test_util import (
     with_site_configuration,
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from openedx.features.enterprise_support.api import enterprise_is_enabled
 from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerFactory,
@@ -192,6 +194,8 @@ class TestProgramsView(SharedModuleStoreTestCase, ProgramCacheMixin):
         )
 
     @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
+    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
+    @enterprise_is_enabled()
     def test_program_list(self):
         """
         Verify API returns proper response.
@@ -221,6 +225,8 @@ class TestProgramsView(SharedModuleStoreTestCase, ProgramCacheMixin):
         }
 
     @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
+    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
+    @enterprise_is_enabled()
     def test_program_empty_list_if_no_enterprise_enrollments(self):
         """
         Verify API returns empty response if no enterprise enrollments exists for a learner.

--- a/openedx/core/djangoapps/programs/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/views.py
@@ -3,12 +3,12 @@
 from typing import Any, TYPE_CHECKING
 import logging
 
-from enterprise.models import EnterpriseCourseEnrollment
+from django.db.models.query import EmptyQuerySet
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.api import get_course_enrollments
 from openedx.core.djangoapps.programs.utils import (
     ProgramProgressMeter,
     get_certificates,
@@ -16,11 +16,14 @@ from openedx.core.djangoapps.programs.utils import (
     get_program_and_course_data,
     get_program_urls,
 )
+from openedx.features.enterprise_support.api import get_enterprise_course_enrollments, enterprise_is_enabled
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
     from django.contrib.auth.models import AnonymousUser, User  # pylint: disable=imported-auth-user
     from django.contrib.sites.models import Site
+    from django.db.models.query import QuerySet
+    from common.djangoapps.student.models import CourseEnrollment
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +89,7 @@ class Programs(APIView):
         """
         user: "AnonymousUser | User" = request.user
 
-        enrollments = self._get_enterprise_course_enrollments(enterprise_uuid, user)
+        enrollments = list(self._get_enterprise_course_enrollments(enterprise_uuid, user))
         # return empty reponse if no enterprise enrollments exists for a user
         if not enrollments:
             return Response([])
@@ -170,26 +173,22 @@ class Programs(APIView):
 
         return programs
 
+    @enterprise_is_enabled(otherwise=EmptyQuerySet)
     def _get_enterprise_course_enrollments(
         self, enterprise_uuid: str, user: "AnonymousUser | User"
-    ) -> list[CourseEnrollment]:
+    ) -> "QuerySet[CourseEnrollment]":
         """
         Return only enterprise enrollments for a user.
         """
-        enterprise_enrollment_course_ids = list(
-            EnterpriseCourseEnrollment.objects.filter(
-                enterprise_customer_user__user_id=user.id,
-                enterprise_customer_user__enterprise_customer__uuid=enterprise_uuid,
-            ).values_list("course_id", flat=True)
+        enterprise_enrollment_course_ids = (
+            get_enterprise_course_enrollments(user)
+            .filter(enterprise_customer_user__enterprise_customer__uuid=enterprise_uuid)
+            .values_list("course_id", flat=True)
         )
 
-        course_enrollments = (
-            CourseEnrollment.enrollments_for_user(user)
-            .filter(course_id__in=enterprise_enrollment_course_ids)
-            .select_related("course")
-        )
+        course_enrollments = get_course_enrollments(user, True, (enterprise_enrollment_course_ids))
 
-        return list(course_enrollments)
+        return course_enrollments
 
 
 class ProgramProgressDetailView(APIView):

--- a/openedx/core/djangoapps/programs/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/views.py
@@ -186,7 +186,7 @@ class Programs(APIView):
             .values_list("course_id", flat=True)
         )
 
-        course_enrollments = get_course_enrollments(user, True, (enterprise_enrollment_course_ids))
+        course_enrollments = get_course_enrollments(user, True, list(enterprise_enrollment_course_ids))
 
         return course_enrollments
 


### PR DESCRIPTION
## Description

i converted the  Programs rest  API views from calling other djangoapps via direct model access to calling from API. This included  adding an API in the Student app.

Should be invisible to all  learners. Other developers will now have access to the new API method.

FIXES: APER-3972

