### PR TITLE
fix: user unsub preference removal on email enable through account preferences

### DIFF
--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -537,6 +537,11 @@ class UpdateAllNotificationPreferencesView(APIView):
                             'course_id': str(preference.course_id),
                             'error': str(e)
                         })
+                if channel == 'email' and value:
+                    UserPreference.objects.filter(
+                        user_id=request.user,
+                        key=ONE_CLICK_EMAIL_UNSUB_KEY
+                    ).delete()
                 response_data = {
                     'status': 'success' if updated_courses else 'partial_success' if errors else 'error',
                     'message': 'Notification preferences update completed',


### PR DESCRIPTION
## Description

This ticket addresses an edge case where one click unsub user preferences are not updated correctly when a user enables email through Account (aggregated preferences) after unsubscribing through email.

## Supporting Ticket

https://2u-internal.atlassian.net/browse/INF-1843

## Testing instructions

1. Unsubscribe from emails.
2. Enable emails through Account (aggregated preferences).
3. Enroll in a new course.
4. Check if the unsubscribe preference is removed and if the new enrollment follows default email preferences.
