### PR TITLE
fix: move links with status None to forbidden link

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1369,13 +1369,13 @@ def _filter_by_status(results):
     retry_list = []
     for result in results:
         status, block_id, url = result['status'], result['block_id'], result['url']
-        if status is None:
+        if status is None and _is_studio_url(url):
             retry_list.append([block_id, url])
         elif status == 200:
             continue
         elif status == 403 and _is_studio_url(url):
             filtered_results.append([block_id, url, LinkState.LOCKED])
-        elif status == 403 and not _is_studio_url(url):
+        elif status in [403, None] and not _is_studio_url(url):
             filtered_results.append([block_id, url, LinkState.EXTERNAL_FORBIDDEN])
         else:
             filtered_results.append([block_id, url, LinkState.BROKEN])

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -498,18 +498,20 @@ class CheckBrokenLinksTaskTest(ModuleStoreTestCase):
             {'status': 200, 'block_id': 'block1', 'url': 'https://example.com'},
             {'status': None, 'block_id': 'block2', 'url': 'https://retry.com'},
             {'status': 403, 'block_id': 'block3', 'url': 'https://' + settings.CMS_BASE},
+            {'status': None, 'block_id': 'block3', 'url': 'https://' + settings.CMS_BASE},
             {'status': 403, 'block_id': 'block4', 'url': 'https://external.com'},
             {'status': 404, 'block_id': 'block5', 'url': 'https://broken.com'}
         ]
 
         expected_filtered_results = [
+            ['block2', 'https://retry.com', LinkState.EXTERNAL_FORBIDDEN],
             ['block3', 'https://' + settings.CMS_BASE, LinkState.LOCKED],
             ['block4', 'https://external.com', LinkState.EXTERNAL_FORBIDDEN],
             ['block5', 'https://broken.com', LinkState.BROKEN],
         ]
 
         expected_retry_list = [
-            ['block2', 'https://retry.com']
+            ['block3', 'https://' + settings.CMS_BASE]
         ]
 
         filtered_results, retry_list = _filter_by_status(results)


### PR DESCRIPTION
Ticket: [TNL-11930](https://2u-internal.atlassian.net/browse/TNL-11930)

This link: https://www.geo.arizona.edu/Antevs/ecol438/lect18.html#01 belongs to retries_list and has status None.  But in browser this link works fine. So in this commit, moving the external links with status None to external forbidden links category.

**Before:**
As shown below, this [link](https://www.geo.arizona.edu/Antevs/ecol438/lect18.html#01) goes to general broken link category.
<img width="1792" alt="Screenshot 2025-03-27 at 1 54 28 PM" src="https://github.com/user-attachments/assets/6862529e-a007-4dd4-8561-0bdba82d15db" />

**After:**
Now this [link](https://www.geo.arizona.edu/Antevs/ecol438/lect18.html#01) goes to Manual link check category.
<img width="1792" alt="Screenshot 2025-03-27 at 1 56 50 PM" src="https://github.com/user-attachments/assets/0b774f29-9e43-4b57-b985-96491e751d5f" />
