### PR TITLE
feat: Also set `MPLCONFIGDIR` to make matplotlib complain less

### DIFF
--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -31,7 +31,13 @@ os.environ["OPENBLAS_NUM_THREADS"] = "1"
 # the ./tmp directory that codejail creates in each sandbox, rather than trying
 # to use a global temp dir (which should be blocked by AppArmor anyhow).
 # This is needed for matplotlib among other things.
+#
+# matplotlib will complain on stderr about the non-standard temp dir if we
+# don't explicitly tell it "no really, use this". This pollutes the output
+# when codejail returns an error message (which includes stderr). So we also
+# set MPLCONFIGDIR as a special case.
 os.environ["TMPDIR"] = os.getcwd() + "/tmp"
+os.environ["MPLCONFIGDIR"] = os.environ["TMPDIR"]
 
 import random2 as random_module
 import sys


### PR DESCRIPTION
Example output from running `import matplotlib; 1/0`, before and after the change:

```diff
--- tmp/before	2025-03-28 03:34:06.633689552 +0000
+++ tmp/after	2025-03-28 03:34:37.268688891 +0000
@@ -1,6 +1,5 @@
-Matplotlib created a temporary cache directory at /tmp/codejail-hveq16ah/tmp/matplotlib-tv0c_vzt because the default path (/home/sandbox/.config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.
 Traceback (most recent call last):
   File "jailed_code", line 19, in <module>
     exec(code, g_dict)
   File "<string>", line 1, in <module>
 ZeroDivisionError: division by zero
```
