### PR TITLE
fix: notification count only for web

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -793,6 +793,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         Notification.objects.create(user=self.user, app_name='App Name 1', notification_type='Type B')
         Notification.objects.create(user=self.user, app_name='App Name 2', notification_type='Type A')
         Notification.objects.create(user=self.user, app_name='App Name 3', notification_type='Type C')
+        Notification.objects.create(user=self.user, app_name='App Name 4', notification_type='Type D', web=False)
 
     @override_waffle_flag(ENABLE_NOTIFICATIONS, active=True)
     @ddt.unpack

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -332,7 +332,7 @@ class NotificationCountView(APIView):
         # Get the unseen notifications count for each app name.
         count_by_app_name = (
             Notification.objects
-            .filter(user_id=request.user, last_seen__isnull=True)
+            .filter(user_id=request.user, last_seen__isnull=True, web=True)
             .values('app_name')
             .annotate(count=Count('*'))
         )


### PR DESCRIPTION
## Description 
 Only count web notifications towards the total count because this count is shown on the web bell icon. Some notifications might only be generated for email digest, and they should not be included in this count. 

## Ticket 
https://2u-internal.atlassian.net/browse/INF-1848