### PR TITLE
fix: inline discussions fix for legacy cs_comments_service

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -147,7 +147,7 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
         # If the user clicked a sort key, update their default sort key
         cc_user = cc.User.from_django_user(request.user)
         cc_user.default_sort_key = request.GET.get('sort_key')
-        cc_user.save(params={"course_id": course.id})
+        cc_user.save(params={"course_id": str(course.id)})
 
     #there are 2 dimensions to consider when executing a search with respect to group id
     #is user a moderator


### PR DESCRIPTION
## Description

This pr fixes issue introduced in this [commit](https://github.com/openedx/edx-platform/commit/0d4281aa2eef677bcde2c149aa1b92ead13807b7) and reported in this [issue](https://github.com/openedx/edx-platform/issues/36450). The legacy `cs_comments_service` wasn't working with inline discussions module as `course.id` was not being passed as `string`




