### PR TITLE
fix: move links with 500 status to forbidden links

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1375,7 +1375,7 @@ def _filter_by_status(results):
             continue
         elif status == 403 and _is_studio_url(url):
             filtered_results.append([block_id, url, LinkState.LOCKED])
-        elif status in [403, None] and not _is_studio_url(url):
+        elif status in [403, 500, None] and not _is_studio_url(url):
             filtered_results.append([block_id, url, LinkState.EXTERNAL_FORBIDDEN])
         else:
             filtered_results.append([block_id, url, LinkState.BROKEN])


### PR DESCRIPTION
Ticket: [TNL-11944](https://2u-internal.atlassian.net/browse/TNL-11944)

- move links with 500 status_code to external forbidden links category for manual checking

