### PR TITLE
fix: legacy forum issues

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -584,7 +584,7 @@ def create_thread(request, course_id, commentable_id):
 
     if follow:
         cc_user = cc.User.from_django_user(user)
-        cc_user.follow(thread)
+        cc_user.follow(thread, course_id)
         thread_followed.send(sender=None, user=user, post=thread)
 
     data = thread.to_dict()

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -147,7 +147,7 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
         # If the user clicked a sort key, update their default sort key
         cc_user = cc.User.from_django_user(request.user)
         cc_user.default_sort_key = request.GET.get('sort_key')
-        cc_user.save(params={"course_id": course.id})
+        cc_user.save(params={"course_id": str(course.id)})
 
     #there are 2 dimensions to consider when executing a search with respect to group id
     #is user a moderator
@@ -219,7 +219,7 @@ def inline_discussion(request, course_key, discussion_id):
     with function_trace('get_course_and_user_info'):
         course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=True)
         cc_user = cc.User.from_django_user(request.user)
-        user_info = cc_user.to_dict()
+        user_info = cc_user.to_dict(course_key=str(course_key))
 
     try:
         with function_trace('get_threads'):
@@ -357,7 +357,7 @@ def single_thread(request, course_key, discussion_id, thread_id):
 
     if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         cc_user = cc.User.from_django_user(request.user)
-        user_info = cc_user.to_dict()
+        user_info = cc_user.to_dict(course_key=str(course_key))
         is_staff = has_permission(request.user, 'openclose_thread', course.id)
 
         try:
@@ -472,7 +472,7 @@ def _create_base_discussion_view_context(request, course_key):
     """
     user = request.user
     cc_user = cc.User.from_django_user(user)
-    user_info = cc_user.to_dict()
+    user_info = cc_user.to_dict(course_key=str(course_key))
     course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
     course_settings = make_course_settings(course, user)
     return {

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -61,8 +61,8 @@ class Model:
     def get(self, *args, **kwargs):
         return self.attributes.get(*args, **kwargs)
 
-    def to_dict(self):
-        self.retrieve()
+    def to_dict(self, course_key=None):
+        self.retrieve(course_key=course_key)
         return self.attributes
 
     def retrieve(self, *args, **kwargs):
@@ -72,7 +72,7 @@ class Model:
         return self
 
     def _retrieve(self, *args, **kwargs):
-        course_id = self.attributes.get("course_id") or kwargs.get("course_id")
+        course_id = self.attributes.get("course_id") or kwargs.get("course_key")
         if course_id:
             course_key = get_course_key(course_id)
             use_forumv2 = is_forum_v2_enabled(course_key)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -818,7 +818,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.9
+openedx-forum==0.2.0
     # via -r requirements/edx/kernel.in
 openedx-learning==0.19.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1379,7 +1379,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.9
+openedx-forum==0.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -990,7 +990,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.9
+openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
 openedx-learning==0.19.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1048,7 +1048,7 @@ openedx-filters==2.0.1
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.9
+openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
 openedx-learning==0.19.2
     # via


### PR DESCRIPTION
## Description

This PR fixes compatibility issues with legacy inline discussion module. 

The issue was that course_id was not being passed as str which was causing the non mfe discussion page to break.
Moreover, it fixes a problematic user api call in discussions which wasn't being passed the course_id leading to failure in switching the forum backend from mongo to mysql.

Issue: https://github.com/openedx/edx-platform/issues/36450


