### PR TITLE
chore: add missing inline code annotations in events

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -131,6 +131,8 @@ def emit_catalog_info_changed_signal(course_key: CourseKey):
     if SEND_CATALOG_INFO_SIGNAL.is_enabled():
         timestamp, catalog_info = _create_catalog_data_for_signal(course_key)
         if catalog_info is not None:
+            # .. event_implemented_name: COURSE_CATALOG_INFO_CHANGED
+            # .. event_type: org.openedx.content_authoring.course.catalog_info.changed.v1
             COURSE_CATALOG_INFO_CHANGED.send_event(time=timestamp, catalog_info=catalog_info)
 
 

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2314,6 +2314,8 @@ def send_course_update_notification(course_key, content, user):
         app_name="updates",
         audience_filters={},
     )
+    # .. event_implemented_name: COURSE_NOTIFICATION_REQUESTED
+    # .. event_type: org.openedx.learning.course.notification.requested.v1
     COURSE_NOTIFICATION_REQUESTED.send_event(course_notification_data=notification_data)
 
 

--- a/common/djangoapps/student/signals/signals.py
+++ b/common/djangoapps/student/signals/signals.py
@@ -31,6 +31,8 @@ def emit_course_access_role_added(user, course_id, org_key, role):
     """
     Emit an event to the event-bus when a CourseAccessRole is added
     """
+    # .. event_implemented_name: COURSE_ACCESS_ROLE_ADDED
+    # .. event_type: org.openedx.learning.user.course_access_role.added.v1
     COURSE_ACCESS_ROLE_ADDED.send_event(
         course_access_role_data=CourseAccessRoleData(
             user=UserData(
@@ -52,6 +54,8 @@ def emit_course_access_role_removed(user, course_id, org_key, role):
     """
     Emit an event to the event-bus when a CourseAccessRole is deleted
     """
+    # .. event_implemented_name: COURSE_ACCESS_ROLE_REMOVED
+    # .. event_type: org.openedx.learning.user.course_access_role.removed.v1
     COURSE_ACCESS_ROLE_REMOVED.send_event(
         course_access_role_data=CourseAccessRoleData(
             user=UserData(

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -113,6 +113,14 @@ def track_forum_event(request, event_name, course, obj, data, id_map=None):
 
     forum_event = TRACKING_LOG_TO_EVENT_MAPS.get(event_name, None)
     if forum_event is not None:
+        # .. event_implemented_name: FORUM_THREAD_CREATED
+        # .. event_type: org.openedx.learning.forum.thread.created.v1
+
+        # .. event_implemented_name: FORUM_THREAD_RESPONSE_CREATED
+        # .. event_type: org.openedx.learning.forum.thread.response.created.v1
+
+        # .. event_implemented_name: FORUM_RESPONSE_COMMENT_CREATED
+        # .. event_type: org.openedx.learning.forum.thread.response.comment.created.v1
         forum_event.send_event(
             thread=DiscussionThreadData(
                 anonymous=data.get('anonymous'),

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -73,6 +73,8 @@ class DiscussionNotificationSender:
             app_name="discussion",
             course_key=self.course.id,
         )
+        # .. event_implemented_name: USER_NOTIFICATION_REQUESTED
+        # .. event_type: org.openedx.learning.user.notification.requested.v1
         USER_NOTIFICATION_REQUESTED.send_event(notification_data=notification_data)
 
     def _send_course_wide_notification(self, notification_type, audience_filters=None, extra_context=None):
@@ -97,6 +99,8 @@ class DiscussionNotificationSender:
             app_name="discussion",
             audience_filters=audience_filters,
         )
+        # .. event_implemented_name: COURSE_NOTIFICATION_REQUESTED
+        # .. event_type: org.openedx.learning.course.notification.requested.v1
         COURSE_NOTIFICATION_REQUESTED.send_event(course_notification_data=notification_data)
 
     def _get_parent_response(self):

--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -279,6 +279,8 @@ def _emit_course_passing_status_update(user, course_id, is_passing):
     The status of event is determined by is_passing parameter.
     """
     if hasattr(course_id, 'ccx'):
+        # .. event_implemented_name: CCX_COURSE_PASSING_STATUS_UPDATED
+        # .. event_type: org.openedx.learning.ccx.course.passing.status.updated.v1
         CCX_COURSE_PASSING_STATUS_UPDATED.send_event(
             course_passing_status=CcxCoursePassingStatusData(
                 is_passing=is_passing,
@@ -298,6 +300,8 @@ def _emit_course_passing_status_update(user, course_id, is_passing):
             )
         )
     else:
+        # .. event_implemented_name: COURSE_PASSING_STATUS_UPDATED
+        # .. event_type: org.openedx.learning.course.passing.status.updated.v1
         COURSE_PASSING_STATUS_UPDATED.send_event(
             course_passing_status=CoursePassingStatusData(
                 is_passing=is_passing,

--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -220,6 +220,8 @@ def set_library_block_olx(usage_key: LibraryUsageLocatorV2, new_olx_str: str) ->
             created=now,
         )
 
+    # .. event_implemented_name: LIBRARY_BLOCK_UPDATED
+    # .. event_type: org.openedx.content_authoring.library_block.updated.v1
     LIBRARY_BLOCK_UPDATED.send_event(
         library_block=LibraryBlockData(
             library_key=usage_key.context_key,
@@ -231,6 +233,8 @@ def set_library_block_olx(usage_key: LibraryUsageLocatorV2, new_olx_str: str) ->
     # container indexing asynchronously.
     affected_containers = get_containers_contains_item(usage_key)
     for container in affected_containers:
+        # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=container.container_key,
@@ -309,6 +313,9 @@ def create_library_block(
     _create_component_for_block(content_library, usage_key, user_id, can_stand_alone)
 
     # Now return the metadata about the new block:
+
+    # .. event_implemented_name: LIBRARY_BLOCK_CREATED
+    # .. event_type: org.openedx.content_authoring.library_block.created.v1
     LIBRARY_BLOCK_CREATED.send_event(
         library_block=LibraryBlockData(
             library_key=content_library.library_key,
@@ -449,6 +456,8 @@ def _import_staged_block(
             )
 
     # Emit library block created event
+    # .. event_implemented_name: LIBRARY_BLOCK_CREATED
+    # .. event_type: org.openedx.content_authoring.library_block.created.v1
     LIBRARY_BLOCK_CREATED.send_event(
         library_block=LibraryBlockData(
             library_key=content_library.library_key,
@@ -589,6 +598,8 @@ def delete_library_block(
 
     authoring_api.soft_delete_draft(component.pk, deleted_by=user_id)
 
+    # .. event_implemented_name: LIBRARY_BLOCK_DELETED
+    # .. event_type: org.openedx.content_authoring.library_block.deleted.v1
     LIBRARY_BLOCK_DELETED.send_event(
         library_block=LibraryBlockData(
             library_key=library_key,
@@ -601,6 +612,8 @@ def delete_library_block(
     #
     # To delete the component on collections
     for collection in affected_collections:
+        # .. event_implemented_name: LIBRARY_COLLECTION_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.updated.v1
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(
                 collection_key=library_collection_locator(
@@ -616,6 +629,8 @@ def delete_library_block(
     #
     # To update the components count in containers
     for container in affected_containers:
+        # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=container.container_key,
@@ -639,6 +654,8 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None 
         set_by=user_id,
     )
 
+    # .. event_implemented_name: LIBRARY_BLOCK_CREATED
+    # .. event_type: org.openedx.content_authoring.library_block.created.v1
     LIBRARY_BLOCK_CREATED.send_event(
         library_block=LibraryBlockData(
             library_key=library_key,
@@ -646,7 +663,9 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None 
         )
     )
 
-    # Add tags, collections and units back to index
+    # Add tags and collections back to index
+    # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+    # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
     CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
         content_object=ContentObjectChangedData(
             object_id=str(usage_key),
@@ -659,6 +678,8 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None 
     #
     # To restore the component in the collections
     for collection in affected_collections:
+        # .. event_implemented_name: LIBRARY_COLLECTION_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.updated.v1
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(
                 collection_key=library_collection_locator(
@@ -675,6 +696,8 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None 
     # To update the components count in containers
     affected_containers = get_containers_contains_item(usage_key)
     for container in affected_containers:
+        # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=container.container_key,
@@ -768,6 +791,8 @@ def add_library_block_static_asset_file(
             created_by=user.id if user else None,
         )
         transaction.on_commit(
+            # .. event_implemented_name: LIBRARY_BLOCK_UPDATED
+            # .. event_type: org.openedx.content_authoring.library_block.updated.v1
             lambda: LIBRARY_BLOCK_UPDATED.send_event(
                 library_block=LibraryBlockData(
                     library_key=usage_key.context_key,
@@ -814,6 +839,8 @@ def delete_library_block_static_asset_file(usage_key, file_path, user=None):
             created_by=user.id if user else None,
         )
         transaction.on_commit(
+            # .. event_implemented_name: LIBRARY_BLOCK_UPDATED
+            # .. event_type: org.openedx.content_authoring.library_block.updated.v1
             lambda: LIBRARY_BLOCK_UPDATED.send_event(
                 library_block=LibraryBlockData(
                     library_key=usage_key.context_key,

--- a/openedx/core/djangoapps/content_libraries/api/collections.py
+++ b/openedx/core/djangoapps/content_libraries/api/collections.py
@@ -226,6 +226,8 @@ def set_library_item_collections(
     # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
     # collection indexing asynchronously.
     for collection in affected_collections:
+        # .. event_implemented_name: LIBRARY_COLLECTION_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.updated.v1
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(
                 collection_key=library_collection_locator(

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -283,6 +283,8 @@ def create_container(
         case _:
             raise NotImplementedError(f"Library does not support {container_type} yet")
 
+    # .. event_implemented_name: LIBRARY_CONTAINER_CREATED
+    # .. event_type: org.openedx.content_authoring.content_library.container.created.v1
     LIBRARY_CONTAINER_CREATED.send_event(
         library_container=LibraryContainerData(
             container_key=container_key,
@@ -348,6 +350,8 @@ def update_container(
             raise NotImplementedError(f"Library does not support {container_type} yet")
 
     # Send event related to the updated container
+    # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+    # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
     LIBRARY_CONTAINER_UPDATED.send_event(
         library_container=LibraryContainerData(
             container_key=container_key,
@@ -357,6 +361,8 @@ def update_container(
     # Send events related to the containers that contains the updated container.
     # This is to update the children display names used in the section/subsection previews.
     for affected_container in affected_containers:
+        # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=affected_container.container_key,
@@ -366,6 +372,8 @@ def update_container(
     # All subsections under a section have section key in index that needs to be updated.
     # So if parent section name has been changed, it needs to be reflected in sections key of children
     for child in children:
+        # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+        # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
             content_object=ContentObjectChangedData(
                 object_id=str(getattr(child, child_key_name)),
@@ -400,6 +408,8 @@ def delete_container(
     )
     authoring_api.soft_delete_draft(container.pk)
 
+    # .. event_implemented_name: LIBRARY_CONTAINER_DELETED
+    # .. event_type: org.openedx.content_authoring.content_library.container.deleted.v1
     LIBRARY_CONTAINER_DELETED.send_event(
         library_container=LibraryContainerData(
             container_key=container_key,
@@ -640,6 +650,8 @@ def update_container_children(
         case _:
             raise ValueError(f"Invalid container type: {container_type}")
 
+    # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+    # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
     LIBRARY_CONTAINER_UPDATED.send_event(
         library_container=LibraryContainerData(
             container_key=container_key,

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -421,6 +421,8 @@ def delete_container(
     #
     # To delete the container on collections
     for collection in affected_collections:
+        # .. event_implemented_name: LIBRARY_COLLECTION_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.updated.v1
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(
                 collection_key=library_collection_locator(
@@ -433,6 +435,8 @@ def delete_container(
     # Send events related to the containers that contains the updated container.
     # This is to update the children display names used in the section/subsection previews.
     for affected_container in affected_containers:
+        # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=affected_container.container_key,
@@ -447,6 +451,8 @@ def delete_container(
     # All subsections under a section have section key in index that needs to be updated.
     # So if parent section is deleted, it needs to be removed from sections key of children
     for child in children:
+        # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+        # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
             content_object=ContentObjectChangedData(
                 object_id=str(getattr(child, key_name)),
@@ -476,6 +482,8 @@ def restore_container(container_key: LibraryContainerLocator) -> None:
         published=False,
     )
 
+    # .. event_implemented_name: LIBRARY_CONTAINER_CREATED
+    # .. event_type: org.openedx.content_authoring.content_library.container.created.v1
     LIBRARY_CONTAINER_CREATED.send_event(
         library_container=LibraryContainerData(
             container_key=container_key,
@@ -487,6 +495,8 @@ def restore_container(container_key: LibraryContainerLocator) -> None:
         # Update parent key data in index. Eg. `sections` key in index for subsection
         content_changes.append(str(affected_containers[0].container_type.value) + "s")
     # Add tags, collections and parent data back to index
+    # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+    # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
     CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
         content_object=ContentObjectChangedData(
             object_id=str(container_key),
@@ -499,6 +509,8 @@ def restore_container(container_key: LibraryContainerLocator) -> None:
     #
     # To restore the container on collections
     for collection in affected_collections:
+        # .. event_implemented_name: LIBRARY_COLLECTION_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.updated.v1
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(
                 collection_key=library_collection_locator(
@@ -510,6 +522,8 @@ def restore_container(container_key: LibraryContainerLocator) -> None:
     # Send events related to the containers that contains the updated container.
     # This is to update the children display names used in the section/subsection previews.
     for affected_container in affected_containers:
+        # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=affected_container.container_key,
@@ -523,6 +537,8 @@ def restore_container(container_key: LibraryContainerLocator) -> None:
     # All subsections under a section have section key in index that needs to be updated.
     # Should restore removed parent section in sections key of children subsections
     for child in children:
+        # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+        # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
             content_object=ContentObjectChangedData(
                 object_id=str(getattr(child, key_name)),
@@ -607,6 +623,8 @@ def update_container_children(
             )
 
             for key in children_ids:
+                # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+                # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
                 CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
                     content_object=ContentObjectChangedData(
                         object_id=str(key),
@@ -624,6 +642,8 @@ def update_container_children(
             )
 
             for key in children_ids:
+                # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+                # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
                 CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
                     content_object=ContentObjectChangedData(
                         object_id=str(key),
@@ -641,6 +661,8 @@ def update_container_children(
             )
 
             for key in children_ids:
+                # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+                # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
                 CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
                     content_object=ContentObjectChangedData(
                         object_id=str(key),

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -445,6 +445,8 @@ def create_library(
     except IntegrityError:
         raise LibraryAlreadyExists(slug)  # lint-amnesty, pylint: disable=raise-missing-from
 
+    # .. event_implemented_name: CONTENT_LIBRARY_CREATED
+    # .. event_type: org.openedx.content_authoring.content_library.created.v1
     CONTENT_LIBRARY_CREATED.send_event(
         content_library=ContentLibraryData(
             library_key=ref.library_key
@@ -582,6 +584,8 @@ def update_library(
                 description=description,
             )
 
+    # .. event_implemented_name: CONTENT_LIBRARY_UPDATED
+    # .. event_type: org.openedx.content_authoring.content_library.updated.v1
     CONTENT_LIBRARY_UPDATED.send_event(
         content_library=ContentLibraryData(
             library_key=content_lib.library_key
@@ -607,6 +611,8 @@ def delete_library(library_key: LibraryLocatorV2) -> None:
         if learning_package:
             learning_package.delete()
 
+    # .. event_implemented_name: CONTENT_LIBRARY_DELETED
+    # .. event_type: org.openedx.content_authoring.content_library.deleted.v1
     CONTENT_LIBRARY_DELETED.send_event(
         content_library=ContentLibraryData(
             library_key=library_key

--- a/openedx/core/djangoapps/content_libraries/library_context.py
+++ b/openedx/core/djangoapps/content_libraries/library_context.py
@@ -108,6 +108,8 @@ class LibraryContextImpl(LearningContext):
         Send a "block updated" event for the library block with the given usage_key.
         """
         assert isinstance(usage_key, LibraryUsageLocatorV2)
+        # .. event_implemented_name: LIBRARY_BLOCK_UPDATED
+        # .. event_type: org.openedx.content_authoring.library_block.updated.v1
         LIBRARY_BLOCK_UPDATED.send_event(
             library_block=LibraryBlockData(
                 library_key=usage_key.lib_key,
@@ -123,6 +125,8 @@ class LibraryContextImpl(LearningContext):
         assert isinstance(usage_key, LibraryUsageLocatorV2)
         affected_containers = api.get_containers_contains_item(usage_key)
         for container in affected_containers:
+            # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+            # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
             LIBRARY_CONTAINER_UPDATED.send_event(
                 library_container=LibraryContainerData(
                     container_key=container.container_key,

--- a/openedx/core/djangoapps/content_libraries/signal_handlers.py
+++ b/openedx/core/djangoapps/content_libraries/signal_handlers.py
@@ -80,6 +80,8 @@ def library_collection_saved(sender, instance, created, **kwargs):
         return
 
     if created:
+        # .. event_implemented_name: LIBRARY_COLLECTION_CREATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.created.v1
         LIBRARY_COLLECTION_CREATED.send_event(
             library_collection=LibraryCollectionData(
                 collection_key=library_collection_locator(
@@ -89,6 +91,8 @@ def library_collection_saved(sender, instance, created, **kwargs):
             )
         )
     else:
+        # .. event_implemented_name: LIBRARY_COLLECTION_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.updated.v1
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(
                 collection_key=library_collection_locator(
@@ -110,6 +114,8 @@ def library_collection_deleted(sender, instance, **kwargs):
         log.error("{instance} is not associated with a content library.")
         return
 
+    # .. event_implemented_name: LIBRARY_COLLECTION_DELETED
+    # .. event_type: org.openedx.content_authoring.content_library.collection.deleted.v1
     LIBRARY_COLLECTION_DELETED.send_event(
         library_collection=LibraryCollectionData(
             collection_key=library_collection_locator(
@@ -156,6 +162,8 @@ def _library_collection_entity_changed(
         log.error("Unknown publishable entity type: %s", publishable_entity)
         return
 
+    # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+    # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
     CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
         content_object=ContentObjectChangedData(
             object_id=str(opaque_key),

--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -93,6 +93,9 @@ def send_events_after_publish(publish_log_pk: int, library_key_str: str) -> None
             usage_key = api.library_component_usage_key(library_key, record.entity.component)
             # Note that this item may be newly created, updated, or even deleted - but all we care about for this event
             # is that the published version is now different. Only for draft changes do we send differentiated events.
+
+            # .. event_implemented_name: LIBRARY_BLOCK_PUBLISHED
+            # .. event_type: org.openedx.content_authoring.library_block.published.v1
             LIBRARY_BLOCK_PUBLISHED.send_event(
                 library_block=LibraryBlockData(library_key=library_key, usage_key=usage_key)
             )
@@ -112,6 +115,8 @@ def send_events_after_publish(publish_log_pk: int, library_key_str: str) -> None
             )
 
     for container_key in affected_containers:
+        # .. event_implemented_name: LIBRARY_CONTAINER_PUBLISHED
+        # .. event_type: org.openedx.content_authoring.content_library.container.published.v1
         LIBRARY_CONTAINER_PUBLISHED.send_event(
             library_container=LibraryContainerData(container_key=container_key)
         )
@@ -177,6 +182,15 @@ def send_events_after_revert(draft_change_log_id: int, library_key_str: str) -> 
                 event = LIBRARY_BLOCK_DELETED
             elif is_undeleted:
                 event = LIBRARY_BLOCK_CREATED
+
+            # .. event_implemented_name: LIBRARY_BLOCK_UPDATED
+            # .. event_type: org.openedx.content_authoring.library_block.updated.v1
+
+            # .. event_implemented_name: LIBRARY_BLOCK_DELETED
+            # .. event_type: org.openedx.content_authoring.library_block.deleted.v1
+
+            # .. event_implemented_name: LIBRARY_BLOCK_CREATED
+            # .. event_type: org.openedx.content_authoring.library_block.created.v1
             event.send_event(library_block=LibraryBlockData(library_key=library_key, usage_key=usage_key))
             # If any containers contain this component, their child list / component count may need to be updated
             # e.g. if this was a newly created component in the container and is now deleted, or this was deleted and
@@ -211,6 +225,8 @@ def send_events_after_revert(draft_change_log_id: int, library_key_str: str) -> 
             affected_collection_keys.add(collection_key)
 
     for container_key in deleted_container_keys:
+        # .. event_implemented_name: LIBRARY_CONTAINER_DELETED
+        # .. event_type: org.openedx.content_authoring.content_library.container.deleted.v1
         LIBRARY_CONTAINER_DELETED.send_event(
             library_container=LibraryContainerData(container_key=container_key)
         )
@@ -218,16 +234,22 @@ def send_events_after_revert(draft_change_log_id: int, library_key_str: str) -> 
         created_container_keys.discard(container_key)
 
     for container_key in created_container_keys:
+        # .. event_implemented_name: LIBRARY_CONTAINER_CREATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.created.v1
         LIBRARY_CONTAINER_CREATED.send_event(
             library_container=LibraryContainerData(container_key=container_key)
         )
 
     for container_key in updated_container_keys:
+        # .. event_implemented_name: LIBRARY_CONTAINER_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.container.updated.v1
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(container_key=container_key)
         )
 
     for collection_key in affected_collection_keys:
+        # .. event_implemented_name: LIBRARY_COLLECTION_UPDATED
+        # .. event_type: org.openedx.content_authoring.content_library.collection.updated.v1
         LIBRARY_COLLECTION_UPDATED.send_event(
             library_collection=LibraryCollectionData(collection_key=collection_key)
         )

--- a/openedx/core/djangoapps/content_tagging/api.py
+++ b/openedx/core/djangoapps/content_tagging/api.py
@@ -304,6 +304,8 @@ def set_exported_object_tags(
             taxonomy_export_id=str(taxonomy_export_id),
         )
 
+        # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+        # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
             time=now(),
             content_object=ContentObjectChangedData(
@@ -313,6 +315,8 @@ def set_exported_object_tags(
         )
 
         # Emit a (deprecated) CONTENT_OBJECT_TAGS_CHANGED event too
+        # .. event_implemented_name: CONTENT_OBJECT_TAGS_CHANGED
+        # .. event_type: org.openedx.content_authoring.content.object.tags.changed.v1
         CONTENT_OBJECT_TAGS_CHANGED.send_event(
             time=now(),
             content_object=ContentObjectData(object_id=content_key_str)
@@ -411,6 +415,8 @@ def tag_object(
             taxonomy=taxonomy,
             tags=tags,
         )
+        # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+        # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
             time=now(),
             content_object=ContentObjectChangedData(
@@ -420,6 +426,8 @@ def tag_object(
         )
 
         # Emit a (deprecated) CONTENT_OBJECT_TAGS_CHANGED event too
+        # .. event_implemented_name: CONTENT_OBJECT_TAGS_CHANGED
+        # .. event_type: org.openedx.content_authoring.content.object.tags.changed.v1
         CONTENT_OBJECT_TAGS_CHANGED.send_event(
             time=now(),
             content_object=ContentObjectData(object_id=object_id)

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
@@ -165,6 +165,8 @@ class ObjectTagOrgView(ObjectTagView):
         if response.status_code == 200:
             object_id = kwargs.get('object_id')
 
+            # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
+            # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
             CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
                 content_object=ContentObjectChangedData(
                     object_id=object_id,
@@ -173,6 +175,8 @@ class ObjectTagOrgView(ObjectTagView):
             )
 
             # Emit a (deprecated) CONTENT_OBJECT_TAGS_CHANGED event too
+            # .. event_implemented_name: CONTENT_OBJECT_TAGS_CHANGED
+            # .. event_type: org.openedx.content_authoring.content.object.tags.changed.v1
             CONTENT_OBJECT_TAGS_CHANGED.send_event(
                 content_object=ContentObjectData(object_id=object_id)
             )

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -31,6 +31,8 @@ def update_discussions_settings_from_course_task(course_key_str: str, discussabl
     """
     course_key = CourseKey.from_string(course_key_str)
     config_data = update_discussions_settings_from_course(course_key, discussable_units)
+    # .. event_implemented_name: COURSE_DISCUSSIONS_CHANGED
+    # .. event_type: org.openedx.learning.discussions.configuration.changed.v1
     COURSE_DISCUSSIONS_CHANGED.send_event(configuration=config_data)
 
 


### PR DESCRIPTION
## Description

This PR adds the missing inline code annotations to all sent events. All sent events must have these inline code annotations:

- `# .. event_implemented_name: <EVENT_IMPLEMENTED_NAME>`
- `# .. event_type: <EVENT_TYPE>`

## Supporting information

- [In-line Code Annotations for an Open edX Event](https://docs.openedx.org/projects/openedx-events/en/latest/reference/in-line-code-annotations-for-an-event.html)

## Deadline

None