### PR TITLE
fix: enable teams with content groups connection only if teams is enabled

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2216,8 +2216,10 @@ def get_group_configurations_context(course, store):
             if should_show_enrollment_track:
                 displayable_partitions.insert(0, partition)
         elif partition['scheme'] == TEAM_SCHEME:
-            should_show_team_partitions = len(partition['groups']) > 0 and CONTENT_GROUPS_FOR_TEAMS.is_enabled(
-                course_key
+            should_show_team_partitions = (
+                course.teams_enabled
+                and len(partition["groups"]) > 0
+                and CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key)
             )
             if should_show_team_partitions:
                 displayable_partitions.append(partition)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -326,7 +326,7 @@ class CourseMetadata:
         This is used by the Dynamic Team Partition Generator to create the dynamic user partitions
         based on the team-sets defined in the course.
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(block.id):
+        if not block.teams_enabled or not CONTENT_GROUPS_FOR_TEAMS.is_enabled(block.id):
             return teams_config
 
         for team_set in teams_config.teamsets:

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -216,7 +216,7 @@ class TestGetBlocksQueryCounts(TestGetBlocksQueryCountsBase):
         )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, 24),
+        (ModuleStoreEnum.Type.split, 2, 23),
     )
     @ddt.unpack
     def test_query_counts_uncached(self, store_type, expected_mongo_queries, num_sql_queries):

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -289,7 +289,7 @@ class TestGradeIteration(SharedModuleStoreTestCase):
             else mock_course_grade.return_value
             for student in self.students
         ]
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(17):
             all_course_grades, all_errors = self._course_grades_and_errors_for(self.course, self.students)
         assert {student: str(all_errors[student]) for student in all_errors} == {
             student3: 'Error for student3.',

--- a/lms/djangoapps/teams/team_partition_scheme.py
+++ b/lms/djangoapps/teams/team_partition_scheme.py
@@ -38,7 +38,8 @@ class TeamUserPartition(UserPartition):
             list of Group: The groups in this partition.
         """
         course_key = CourseKey.from_string(self.parameters["course_id"])
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
+        course = modulestore().get_course(course_key)
+        if not course.teams_enabled or not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
             return []
 
         # Get the team-set for this partition via the partition parameters and then get the teams in that team-set

--- a/lms/djangoapps/teams/team_partition_scheme.py
+++ b/lms/djangoapps/teams/team_partition_scheme.py
@@ -14,6 +14,7 @@ from lms.djangoapps.teams.api import get_teams_in_teamset
 from lms.djangoapps.teams.models import CourseTeamMembership
 from openedx.core.lib.teams_config import CONTENT_GROUPS_FOR_TEAMS
 
+from xmodule.modulestore.django import modulestore
 from xmodule.partitions.partitions import (  # lint-amnesty, pylint: disable=wrong-import-order
     Group,
     UserPartition
@@ -81,7 +82,8 @@ class TeamPartitionScheme:
         Returns:
             Group: The group in the specified user partition
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
+        course = modulestore().get_course(course_key)
+        if not course.teams_enabled or not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
             return None
 
         # First, check if we have to deal with masquerading.
@@ -128,7 +130,8 @@ class TeamPartitionScheme:
             TeamUserPartition: The user partition.
         """
         course_key = CourseKey.from_string(parameters["course_id"])
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
+        course = modulestore().get_course(course_key)
+        if not course.teams_enabled and not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course_key):
             return None
 
         # Team-set used to create partition was created before this feature was

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/team_partition_groups.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/team_partition_groups.py
@@ -10,6 +10,7 @@ from opaque_keys.edx.keys import CourseKey
 from openedx.core import types
 from openedx.core.djangoapps.content.learning_sequences.api.processors.base import OutlineProcessor
 from openedx.core.lib.teams_config import create_team_set_partitions_with_course_id, CONTENT_GROUPS_FOR_TEAMS
+from xmodule.modulestore.django import modulestore
 from xmodule.partitions.partitions import Group
 from xmodule.partitions.partitions_service import get_user_partition_groups
 
@@ -37,7 +38,8 @@ class TeamPartitionGroupsOutlineProcessor(OutlineProcessor):
         """
         Pull team groups for this course and which group the user is in.
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(self.course_key):
+        course = modulestore().get_course(self.course_key)
+        if not course.teams_enabled or not CONTENT_GROUPS_FOR_TEAMS.is_enabled(self.course_key):
             return
 
         user_partitions = create_team_set_partitions_with_course_id(self.course_key)
@@ -61,7 +63,8 @@ class TeamPartitionGroupsOutlineProcessor(OutlineProcessor):
             The user is excluded from the content if and only if, for a non-empty
             partition group, the user is not in any of the groups for that partition.
         """
-        if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(self.course_key):
+        course = modulestore().get_course(self.course_key)
+        if not course.teams_enabled or not CONTENT_GROUPS_FOR_TEAMS.is_enabled(self.course_key):
             return False
 
         if not user_partition_groups:

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -21,7 +21,7 @@ from openedx.core.djangoapps.content.learning_sequences.api.processors.team_part
     TeamPartitionGroupsOutlineProcessor,
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 import pytest
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -206,7 +206,6 @@ class UserCourseOutlineTestCase(CacheIsolationTestCase, ModuleStoreTestCase):
             course=self.course_key.course,
             run=self.course_key.run,
             display_name=f"Team Partitions Test Course {self.course_key.run}",
-            # teams_enabled=True,
         )
 
     def test_simple_outline(self):
@@ -1824,9 +1823,10 @@ class CohortPartitionGroupsTestCase(OutlineProcessorTestCase, ModuleStoreTestCas
         super().setUp()
         self.course_key = CourseKey.from_string("course-v1:OpenEdX+Outlines+2021")
         self.course = CourseFactory.create(
-            org="OpenEdX",
-            number="Outlines",
-            display_name="2021",
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Cohort User Partition Test Course {self.course_key.run}",
         )
 
     def _create_and_enroll_learner(self, username, is_staff=False):

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -21,6 +21,8 @@ from openedx.core.djangoapps.content.learning_sequences.api.processors.team_part
     TeamPartitionGroupsOutlineProcessor,
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 import pytest
 
 from openedx.core.djangoapps.course_apps.toggles import EXAMS_IDA
@@ -57,6 +59,7 @@ from ..outlines import (
 )
 from ..processors.enrollment_track_partition_groups import EnrollmentTrackPartitionGroupsOutlineProcessor
 from .test_data import generate_sections
+from openedx.core.lib.teams_config import TeamsConfig
 
 
 class OutlineSupportTestCase(unittest.TestCase):
@@ -159,14 +162,14 @@ class CourseOutlineTestCase(CacheIsolationTestCase):
             assert new_version_outline == new_version_outline  # lint-amnesty, pylint: disable=comparison-with-itself
 
 
-class UserCourseOutlineTestCase(CacheIsolationTestCase):
+class UserCourseOutlineTestCase(CacheIsolationTestCase, ModuleStoreTestCase):
     """
     Tests for basic UserCourseOutline functionality.
     """
 
     @classmethod
     def setUpTestData(cls):  # lint-amnesty, pylint: disable=super-method-not-called
-        course_key = CourseKey.from_string("course-v1:OpenEdX+Outline+T1")
+        cls.course_key = CourseKey.from_string("course-v1:OpenEdX+Outline+T1")
         # Users...
         cls.global_staff = UserFactory.create(
             username='global_staff', email='gstaff@example.com', is_staff=True
@@ -174,11 +177,10 @@ class UserCourseOutlineTestCase(CacheIsolationTestCase):
         cls.student = UserFactory.create(
             username='student', email='student@example.com', is_staff=False
         )
-        cls.beta_tester = BetaTesterFactory(course_key=course_key)
+        cls.beta_tester = BetaTesterFactory(course_key=cls.course_key)
         cls.anonymous_user = AnonymousUser()
 
         # Seed with data
-        cls.course_key = course_key
         cls.simple_outline = CourseOutlineData(
             course_key=cls.course_key,
             title="User Outline Test Course!",
@@ -196,6 +198,16 @@ class UserCourseOutlineTestCase(CacheIsolationTestCase):
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
         # Enroll beta tester in the course
         cls.beta_tester.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            course=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Team Partitions Test Course {self.course_key.run}",
+            # teams_enabled=True,
+        )
 
     def test_simple_outline(self):
         """This outline is the same for everyone."""
@@ -264,7 +276,7 @@ class OutlineProcessorTestCase(CacheIsolationTestCase):  # lint-amnesty, pylint:
         return [key for key in self.all_seq_keys if key not in exclude]
 
 
-class ContentGatingTestCase(OutlineProcessorTestCase):
+class ContentGatingTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):
     """
     Content Gating specific outline tests
     """
@@ -384,6 +396,15 @@ class ContentGatingTestCase(OutlineProcessorTestCase):
     This logic matches the existing transformer. Is this right?
     """
 
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+        )
+
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.content_gating.EntranceExamConfiguration.user_can_skip_entrance_exam')  # lint-amnesty, pylint: disable=line-too-long
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.content_gating.milestones_helpers.get_required_content')  # lint-amnesty, pylint: disable=line-too-long
     def test_user_can_skip_entrance_exam(self, required_content_mock, user_can_skip_entrance_exam_mock):
@@ -417,7 +438,7 @@ class ContentGatingTestCase(OutlineProcessorTestCase):
             assert key not in student_details.outline.accessible_sequences
 
 
-class MilestonesTestCase(OutlineProcessorTestCase):
+class MilestonesTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):
     """
     Milestones specific outline tests
     """
@@ -496,6 +517,15 @@ class MilestonesTestCase(OutlineProcessorTestCase):
         # Enroll student in the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
 
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+        )
+
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.milestones.milestones_helpers.get_course_content_milestones')  # lint-amnesty, pylint: disable=line-too-long
     def test_user_can_skip_entrance_exam(self, get_course_content_milestones_mock):
         # Only return that there are milestones required for the
@@ -518,7 +548,7 @@ class MilestonesTestCase(OutlineProcessorTestCase):
         assert self.milestone_required_seq_key not in student_details.outline.accessible_sequences
 
 
-class ScheduleTestCase(OutlineProcessorTestCase):
+class ScheduleTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):
     """
     Schedule-specific Outline tests.
 
@@ -647,6 +677,15 @@ class ScheduleTestCase(OutlineProcessorTestCase):
         cls.beta_tester.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
         assert user_has_role(cls.beta_tester, CourseBetaTesterRole(cls.course_key))
         assert cls.outline.days_early_for_beta is None
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+        )
 
     def test_before_course_starts(self):
         staff_details, student_details, beta_tester_details = self.get_details(
@@ -799,7 +838,7 @@ class ScheduleTestCase(OutlineProcessorTestCase):
         assert len(beta_tester_details.outline.accessible_sequences) == 4
 
 
-class SelfPacedTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
+class SelfPacedTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpTestData(cls):
@@ -879,6 +918,15 @@ class SelfPacedTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: disa
         # Enroll student in the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
 
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+        )
+
     def test_sequences_accessible_after_due(self):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # lint-amnesty, pylint: disable=unused-variable
 
@@ -895,7 +943,7 @@ class SelfPacedTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: disa
         assert len(student_details.outline.accessible_sequences) == 2
 
 
-class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
+class SpecialExamsTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpTestData(cls):
@@ -997,6 +1045,15 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
 
         # Enroll student in the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+        )
 
     @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
     def test_special_exams_enabled_all_sequences_visible(self):
@@ -1105,7 +1162,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
         assert attempt_summary["short_description"] == "Proctored Exam"
 
 
-class VisbilityTestCase(OutlineProcessorTestCase):
+class VisbilityTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):
     """
     Visibility-related tests.
     """
@@ -1189,6 +1246,15 @@ class VisbilityTestCase(OutlineProcessorTestCase):
         # Enroll student in the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
 
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+        )
+
     def test_visibility(self):
         at_time = datetime(2020, 5, 21, tzinfo=timezone.utc)  # Exact value doesn't matter  # lint-amnesty, pylint: disable=unused-variable
 
@@ -1206,7 +1272,7 @@ class VisbilityTestCase(OutlineProcessorTestCase):
         assert self.normal_in_normal_key in student_details.outline.sequences
 
 
-class SequentialVisibilityTestCase(CacheIsolationTestCase):
+class SequentialVisibilityTestCase(CacheIsolationTestCase, ModuleStoreTestCase):
     """
     Tests sequentials visibility under different course visibility settings i.e public, public_outline, private
     and different types of users e.g unenrolled, enrolled, anonymous, staff
@@ -1248,6 +1314,15 @@ class SequentialVisibilityTestCase(CacheIsolationTestCase):
 
         # enroll student into the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+        )
 
     @override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True)
     def test_public_course_outline(self):
@@ -1324,7 +1399,7 @@ class SequentialVisibilityTestCase(CacheIsolationTestCase):
 
 
 @ddt.ddt
-class EnrollmentTrackPartitionGroupsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
+class EnrollmentTrackPartitionGroupsTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
     """Tests for enrollment track partitions outline processor that affect outlines"""
 
     @classmethod
@@ -1333,6 +1408,15 @@ class EnrollmentTrackPartitionGroupsTestCase(OutlineProcessorTestCase):  # lint-
         cls.visibility = VisibilityData(
             hide_from_toc=False,
             visible_to_staff_only=False
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
         )
 
     def _add_course_mode(
@@ -1725,7 +1809,7 @@ class EnrollmentTrackPartitionGroupsTestCase(OutlineProcessorTestCase):  # lint-
 
 
 @ddt.ddt
-class CohortPartitionGroupsTestCase(OutlineProcessorTestCase):
+class CohortPartitionGroupsTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):
     """Tests for cohort partitions outline processor that affects outlines"""
 
     @classmethod
@@ -1734,6 +1818,15 @@ class CohortPartitionGroupsTestCase(OutlineProcessorTestCase):
         cls.visibility = VisibilityData(
             hide_from_toc=False,
             visible_to_staff_only=False
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.course_key = CourseKey.from_string("course-v1:OpenEdX+Outlines+2021")
+        self.course = CourseFactory.create(
+            org="OpenEdX",
+            number="Outlines",
+            display_name="2021",
         )
 
     def _create_and_enroll_learner(self, username, is_staff=False):
@@ -1974,7 +2067,7 @@ class ContentErrorTestCase(CacheIsolationTestCase):
     lambda _: True
 )
 @skip_unless_lms
-class TeamPartitionGroupsTestCase(OutlineProcessorTestCase):
+class TeamPartitionGroupsTestCase(OutlineProcessorTestCase, ModuleStoreTestCase):
     """Tests for team partitions processor that affects outlines."""
 
     @classmethod
@@ -2087,6 +2180,25 @@ class TeamPartitionGroupsTestCase(OutlineProcessorTestCase):
                     ]
                 )
             ]
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name=f"Outline Test Course {self.course_key.run}",
+            teams_configuration=TeamsConfig({
+                "max_team_size": 4,
+                "topics": [
+                    {
+                        "name": "General Discussion",
+                        "id": "general",
+                        "description": "General team topic"
+                    }
+                ]
+            })
         )
 
     @patch("lms.djangoapps.teams.team_partition_scheme.TeamsConfigurationService")

--- a/openedx/core/djangoapps/content/learning_sequences/tests/test_views.py
+++ b/openedx/core/djangoapps/content/learning_sequences/tests/test_views.py
@@ -25,6 +25,8 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..api import replace_course_outline
 from ..api.tests.test_data import generate_sections
@@ -32,7 +34,7 @@ from ..data import CourseOutlineData, CourseVisibility
 
 
 @skip_unless_lms
-class CourseOutlineViewTest(CacheIsolationTestCase, APITestCase):
+class CourseOutlineViewTest(CacheIsolationTestCase, APITestCase, ModuleStoreTestCase):
     """
     General tests for the CourseOutline.
     """
@@ -62,6 +64,9 @@ class CourseOutlineViewTest(CacheIsolationTestCase, APITestCase):
 
     def setUp(self):
         super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org, number=self.course_key.course, run=self.course_key.run, display_name="Test Course"
+        )
         self.client = APIClient()
 
     def test_non_existent_course_404(self):
@@ -122,7 +127,7 @@ class CourseOutlineViewTest(CacheIsolationTestCase, APITestCase):
 
 @ddt.ddt
 @skip_unless_lms
-class CourseOutlineViewTargetUserTest(CacheIsolationTestCase, APITestCase):
+class CourseOutlineViewTargetUserTest(CacheIsolationTestCase, APITestCase, ModuleStoreTestCase):
     """
     Tests permissions of specifying a target user via url parameter.
     """
@@ -181,6 +186,15 @@ class CourseOutlineViewTargetUserTest(CacheIsolationTestCase, APITestCase):
 
     def setUp(self):
         super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org, number=self.course_key.course, run=self.course_key.run, display_name="Test Course"
+        )
+        self.not_staff_course = CourseFactory.create(
+            org=self.not_staff_course_key.org,
+            number=self.not_staff_course_key.course,
+            run=self.not_staff_course_key.run,
+            display_name="Test Course",
+        )
         self.client = APIClient()
 
     def test_global_staff(self):
@@ -245,7 +259,7 @@ class CourseOutlineViewTargetUserTest(CacheIsolationTestCase, APITestCase):
 
 @ddt.ddt
 @skip_unless_lms
-class CourseOutlineViewMasqueradingTest(MasqueradeMixin, CacheIsolationTestCase):
+class CourseOutlineViewMasqueradingTest(MasqueradeMixin, CacheIsolationTestCase, ModuleStoreTestCase):
     """
     Tests permissions of session masquerading.
     """
@@ -279,6 +293,12 @@ class CourseOutlineViewMasqueradingTest(MasqueradeMixin, CacheIsolationTestCase)
 
     def setUp(self):
         super().setUp()
+        self.course = CourseFactory.create(
+            org=self.course_key.org,
+            number=self.course_key.course,
+            run=self.course_key.run,
+            display_name="Test Course"
+        )
         self.client.login(username=self.staff.username, password='test')
 
     def test_masquerading_works(self):

--- a/openedx/core/lib/teams_config.py
+++ b/openedx/core/lib/teams_config.py
@@ -400,7 +400,7 @@ def create_team_set_partition(course):
     """
     Get the dynamic enrollment track user partition based on the team-sets of the course.
     """
-    if not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course.id):
+    if not course.teams_enabled or not CONTENT_GROUPS_FOR_TEAMS.is_enabled(course.id):
         return []
     return create_team_set_partitions_with_course_id(
         course.id,


### PR DESCRIPTION
## Description

This PR modifies the connection between Teams with Content Groups to enable only if **Teams** is enabled.

Currently, when a Course Author decides to disable **Teams**, the configured restrictions remain on the units and it’s possible to remove/add restrictions. However, as **Teams** is disabled, the tab in the LMS doesn’t appear, Learners cannot join/leave any teams, and Course Authors cannot manage them either.

For now on, if the Course Author decides to disable **Teams** all restrictions applied in the units are disabled and the Course Author can't edit them. If the Course Author decides to re-enable **Teams** the restrictions applied to the units are enabled and the Course Author can edit them.

## Supporting information

- [Connecting Teams to Content Groups Proposal](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3885662226/Connecting+Teams+to+Content+Groups?focusedCommentId=4900618247)
- [[DEPR] Remove `CONTENT_GROUPS_FOR_TEAMS` Waffle Flag](https://github.com/openedx/public-engineering/issues/315)

## Testing instructions

1. Create a Tutor environment.
2. Create a mount of **edx-platform** with the changes in this branch PR.
3. Create a course waffle flag in [`{lms_domain}/admin/waffle_utils/waffleflagcourseoverridemodel/`](http://local.openedx.io:8000/admin/waffle_utils/waffleflagcourseoverridemodel/)

    - Waffle Flag: `teams.content_groups_for_teams`
    - Course id: [Your Course ID]
    - Enabled: ✅ 
4. Enables **Teams** in the platform creating a `teams.enable_teams_app` waffle flag in [`{lms_domain}/admin/waffle/flag/`](http://local.openedx.io:8000/admin/waffle/flag/)
5. Activates **Teams** in your course in **Studio > [Your Course] > Content > Pages & Resources > Teams :gear: > ◉ Teams Toggle**.
6. Create a few team sets (or groups) from the Course Authoring MFE for your course.
7. Then, go to the **LMS > [Your Course] > Teams** and create a few teams within those team sets (or groups/topics) 
8. As a **Student**, try loading the sections of the course, you'll be able to load each course section. You'll be able to see them as usual.
9. Now, restrict units for each team as you would with cohorts or enrollment tracks. **Studio > Outline > Unit > Configure > Restric access to**
10. As a **Student**, try loading the units again. You won't be able to see any content.
11. As **Course Author** disable **Teams** in your course similar to step **5**.
12. The **Course Author** cannot edit unit restrictions by teams, only per cohort and course enrollments.
13. As a **Student**, you will be able to see the content of the units restricted by teams without any problem.

## Deadline

None
