### PR TITLE
fix: next/previous buttons in gated contents now works

### DIFF
--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -571,7 +571,6 @@ class SequenceBlock(
                     'content': '',  # Real content not included
                 })
 
-
         params = {
             'items': blocks,
             'element_id': self.location.html_id(),

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -557,7 +557,20 @@ class SequenceBlock(
                 'This section is a prerequisite. You must complete this section in order to unlock additional content.'
             )
 
-        blocks = self._render_student_view_for_blocks(context, children, fragment, view) if prereq_met else []
+        if prereq_met:
+            blocks = self._render_student_view_for_blocks(context, children, fragment, view)
+        else:
+            blocks = []
+            for child in children:
+                usage_id = child.scope_ids.usage_id
+                blocks.append({
+                    'id': str(usage_id),
+                    'type': child.scope_ids.block_type,
+                    'display_name': child.display_name_with_default,
+                    'is_gated': True,  # Mark as blocked
+                    'content': '',  # Real content not included
+                })
+
 
         params = {
             'items': blocks,

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -567,8 +567,8 @@ class SequenceBlock(
                     'id': str(usage_id),
                     'type': child.scope_ids.block_type,
                     'display_name': child.display_name_with_default,
-                    'is_gated': True,  # Mark as blocked
-                    'content': '',  # Real content not included
+                    'is_gated': True,  #Mark as blocked
+                    'content': '',  #Real content not included
                 })
 
         params = {


### PR DESCRIPTION

## Description

The original issue was that when a sequence was locked due to prerequisites, the API returned an empty items array ([]). This prevented the frontend from knowing what units were inside the locked sequence, meaning it couldn't construct the URLs correctly for navigation so the next/previous buttons stop working.

This modification ensured that even when the sequence is locked, basic metadata for each unit is included. This allows the frontend to:

- Know how many units exist and their IDs

- Correctly construct URLs for "Previous" and "Next" buttons

- Still enforce access restrictions (thanks to the is_gated: True flag)

With this change, the Mfe can continue functioning normally without requiring modifications, as it now consistently receives the necessary information, regardless of whether the sequence is locked or not.

**_This fix can be backported to main branch._**

## Test cases and test instructions



https://github.com/user-attachments/assets/0d343e18-60a3-4b8f-a341-3e2aab4f0169




## Achievements

- Users can now navigate between sequences correctly, even when some are blocked by prerequisites.
- The prerequisite system’s security and integrity are maintained—the actual content remains blocked.
- No frontend modifications were needed, as the solution is compatible with the existing implementation.
- Significant improvement in user experience, preventing students from getting "stuck" in blocked sequences.

## Related issues
https://github.com/openedx/edx-platform/issues/36826
https://github.com/openedx/frontend-app-learning/issues/1546

