### PR TITLE
fix: Globally Enable Studio Content REST API

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_assets.py
@@ -60,13 +60,8 @@ class AssetsViewTestCase(AuthorizeStaffTestCase):
             }
         ),
     )
-    @patch(
-        f"cms.djangoapps.contentstore.rest_api.{VERSION}.views.xblock.toggles.use_studio_content_api",
-        return_value=True,
-    )
     def make_request(
         self,
-        mock_use_studio_content_api,
         mock_handle_assets,
         run_assertions=None,
         course_id=None,
@@ -125,13 +120,6 @@ class AssetsViewGetTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase):
     def send_request(self, url, data):
         return self.client.get(url)
 
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
     def test_assets_handler_called_with_correct_arguments(self):
         self.client.login(
             username=self.course_instructor.username, password=self.password
@@ -182,13 +170,6 @@ class AssetsViewPostTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase):
     def send_request(self, url, data):
         return self.client.post(url, data=data, format="multipart")
 
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
     def test_assets_handler_called_with_correct_arguments(self):
         self.client.login(
             username=self.course_instructor.username, password=self.password
@@ -232,13 +213,6 @@ class AssetsViewPutTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase):
     def send_request(self, url, data):
         return self.client.put(url, data=data, format="json")
 
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.put(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
     def test_assets_handler_called_with_correct_arguments(self):
         self.client.login(
             username=self.course_instructor.username, password=self.password
@@ -276,13 +250,6 @@ class AssetsViewDeleteTest(AssetsViewTestCase, ModuleStoreTestCase, APITestCase)
 
     def send_request(self, url, data):
         return self.client.delete(url)
-
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_assets_handler_called_with_correct_arguments(self):
         self.client.login(

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_xblock.py
@@ -55,13 +55,8 @@ class XBlockViewTestCase(AuthorizeStaffTestCase):
             }
         ),
     )
-    @patch(
-        f"cms.djangoapps.contentstore.rest_api.{VERSION}.views.xblock.toggles.use_studio_content_api",
-        return_value=True,
-    )
     def make_request(
         self,
-        mock_use_studio_content_api,
         mock_handle_xblock,
         run_assertions=None,
         course_id=None,
@@ -110,13 +105,6 @@ class XBlockViewGetTest(XBlockViewTestCase, ModuleStoreTestCase, APITestCase):
 
     def send_request(self, url, data):
         return self.client.get(url)
-
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_xblock_handler_called_with_correct_arguments(self):
         self.client.login(
@@ -167,13 +155,6 @@ class XBlockViewPostTest(XBlockViewTestCase, ModuleStoreTestCase, APITestCase):
     def send_request(self, url, data):
         return self.client.post(url, data=data, format="json")
 
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
     def test_xblock_handler_called_with_correct_arguments(self):
         self.client.login(
             username=self.course_instructor.username, password=self.password
@@ -217,13 +198,6 @@ class XBlockViewPutTest(XBlockViewTestCase, ModuleStoreTestCase, APITestCase):
 
     def send_request(self, url, data):
         return self.client.put(url, data=data, format="json")
-
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.put(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_xblock_handler_called_with_correct_arguments(self):
         self.client.login(
@@ -269,13 +243,6 @@ class XBlockViewPatchTest(XBlockViewTestCase, ModuleStoreTestCase, APITestCase):
     def send_request(self, url, data):
         return self.client.patch(url, data=data, format="json")
 
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.patch(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
     def test_xblock_handler_called_with_correct_arguments(self):
         self.client.login(
             username=self.course_instructor.username, password=self.password
@@ -309,13 +276,6 @@ class XBlockViewDeleteTest(XBlockViewTestCase, ModuleStoreTestCase, APITestCase)
 
     def send_request(self, url, data):
         return self.client.delete(url)
-
-    def test_api_behind_feature_flag(self):
-        # should return 404 if the feature flag is not enabled
-        url = self.get_url()
-
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_xblock_handler_called_with_correct_arguments(self):
         self.client.login(

--- a/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/api_heartbeat.py
@@ -5,7 +5,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
-import cms.djangoapps.contentstore.toggles as toggles
 
 
 class APIHeartBeatView(DeveloperErrorViewMixin, APIView):
@@ -43,6 +42,4 @@ class APIHeartBeatView(DeveloperErrorViewMixin, APIView):
         }
         ```
         """
-        if toggles.use_studio_content_api():
-            return Response({'status': 'heartbeat successful'}, status=status.HTTP_200_OK)
-        return Response(status=status.HTTP_403_FORBIDDEN)
+        return Response({'status': 'heartbeat successful'}, status=status.HTTP_200_OK)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/assets.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/assets.py
@@ -4,7 +4,6 @@ Public rest API endpoints for the CMS API Assets.
 import logging
 from rest_framework.generics import CreateAPIView, RetrieveAPIView, UpdateAPIView, DestroyAPIView
 from django.views.decorators.csrf import csrf_exempt
-from django.http import Http404
 
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from common.djangoapps.util.json_request import expect_json_in_class_view
@@ -12,7 +11,6 @@ from common.djangoapps.util.json_request import expect_json_in_class_view
 from cms.djangoapps.contentstore.api import course_author_access_required
 
 from cms.djangoapps.contentstore.asset_storage_handlers import handle_assets
-import cms.djangoapps.contentstore.toggles as contentstore_toggles
 
 from ..serializers.assets import AssetSerializer
 from .utils import validate_request_with_serializer
@@ -20,7 +18,6 @@ from rest_framework.parsers import (MultiPartParser, FormParser, JSONParser)
 from openedx.core.lib.api.parsers import TypedFileUploadParser
 
 log = logging.getLogger(__name__)
-toggles = contentstore_toggles
 
 
 @view_auth_classes()
@@ -32,17 +29,6 @@ class AssetsCreateRetrieveView(DeveloperErrorViewMixin, CreateAPIView, RetrieveA
     """
     serializer_class = AssetSerializer
     parser_classes = (JSONParser, MultiPartParser, FormParser, TypedFileUploadParser)
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     @csrf_exempt
     @course_author_access_required
@@ -65,17 +51,6 @@ class AssetsUpdateDestroyView(DeveloperErrorViewMixin, UpdateAPIView, DestroyAPI
     """
     serializer_class = AssetSerializer
     parser_classes = (JSONParser, MultiPartParser, FormParser, TypedFileUploadParser)
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     @course_author_access_required
     @expect_json_in_class_view

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_videos.py
@@ -9,7 +9,6 @@ from rest_framework.generics import (
 )
 from rest_framework.parsers import (MultiPartParser, FormParser)
 from django.views.decorators.csrf import csrf_exempt
-from django.http import Http404
 
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from openedx.core.lib.api.parsers import TypedFileUploadParser
@@ -27,12 +26,10 @@ from cms.djangoapps.contentstore.rest_api.v1.serializers import (
     VideoUploadSerializer,
     VideoImageSerializer,
 )
-import cms.djangoapps.contentstore.toggles as contentstore_toggles
 from .utils import validate_request_with_serializer
 
 
 log = logging.getLogger(__name__)
-toggles = contentstore_toggles
 
 
 @view_auth_classes()
@@ -43,17 +40,6 @@ class VideosUploadsView(DeveloperErrorViewMixin, RetrieveAPIView, DestroyAPIView
     video_id: required argument, needed to identify the video.
     """
     serializer_class = VideoUploadSerializer
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     @course_author_access_required
     def retrieve(self, request, course_key, edx_video_id=None):  # pylint: disable=arguments-differ
@@ -73,17 +59,6 @@ class VideosCreateUploadView(DeveloperErrorViewMixin, CreateAPIView):
     """
     serializer_class = VideoUploadSerializer
 
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
-
     @csrf_exempt
     @course_author_access_required
     @expect_json_in_class_view
@@ -101,17 +76,6 @@ class VideoImagesView(DeveloperErrorViewMixin, CreateAPIView):
     """
     serializer_class = VideoImageSerializer
     parser_classes = (MultiPartParser, FormParser, TypedFileUploadParser)
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     @csrf_exempt
     @course_author_access_required
@@ -133,17 +97,6 @@ class VideoEncodingsDownloadView(DeveloperErrorViewMixin, RetrieveAPIView):
     # does not specify a serializer class.
     swagger_schema = None
 
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
-
     @csrf_exempt
     @course_author_access_required
     def retrieve(self, request, course_key):  # pylint: disable=arguments-differ
@@ -160,17 +113,6 @@ class VideoFeaturesView(DeveloperErrorViewMixin, RetrieveAPIView):
     # This view is excluded from Swagger doc generation because it
     # does not specify a serializer class.
     swagger_schema = None
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     @csrf_exempt
     def retrieve(self, request):  # pylint: disable=arguments-differ

--- a/cms/djangoapps/contentstore/rest_api/v0/views/transcripts.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/transcripts.py
@@ -8,7 +8,6 @@ from rest_framework.generics import (
     DestroyAPIView
 )
 from django.views.decorators.csrf import csrf_exempt
-from django.http import Http404
 
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from common.djangoapps.util.json_request import expect_json_in_class_view
@@ -20,7 +19,6 @@ from cms.djangoapps.contentstore.transcript_storage_handlers import (
     delete_video_transcript_or_404,
     handle_transcript_download,
 )
-import cms.djangoapps.contentstore.toggles as contentstore_toggles
 from ..serializers import TranscriptSerializer, YoutubeTranscriptCheckSerializer, YoutubeTranscriptUploadSerializer
 from rest_framework.parsers import (MultiPartParser, FormParser)
 from openedx.core.lib.api.parsers import TypedFileUploadParser
@@ -28,7 +26,6 @@ from openedx.core.lib.api.parsers import TypedFileUploadParser
 from cms.djangoapps.contentstore.rest_api.v0.views.utils import validate_request_with_serializer
 
 log = logging.getLogger(__name__)
-toggles = contentstore_toggles
 
 
 @view_auth_classes()
@@ -41,11 +38,6 @@ class TranscriptView(DeveloperErrorViewMixin, CreateAPIView, RetrieveAPIView, De
     """
     serializer_class = TranscriptSerializer
     parser_classes = (MultiPartParser, FormParser, TypedFileUploadParser)
-
-    def dispatch(self, request, *args, **kwargs):
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     @csrf_exempt
     @course_author_access_required
@@ -81,11 +73,6 @@ class YoutubeTranscriptCheckView(DeveloperErrorViewMixin, RetrieveAPIView):
     serializer_class = YoutubeTranscriptCheckSerializer
     parser_classes = (MultiPartParser, FormParser, TypedFileUploadParser)
 
-    def dispatch(self, request, *args, **kwargs):
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
-
     @course_author_access_required
     def retrieve(self, request, course_key_string):  # pylint: disable=arguments-differ
         """
@@ -103,11 +90,6 @@ class YoutubeTranscriptUploadView(DeveloperErrorViewMixin, RetrieveAPIView):
     """
     serializer_class = YoutubeTranscriptUploadSerializer
     parser_classes = (MultiPartParser, FormParser, TypedFileUploadParser)
-
-    def dispatch(self, request, *args, **kwargs):
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     @course_author_access_required
     def retrieve(self, request, course_key_string):  # pylint: disable=arguments-differ

--- a/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
@@ -4,21 +4,18 @@ Public rest API endpoints for the CMS API.
 import logging
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, CreateAPIView
 from django.views.decorators.csrf import csrf_exempt
-from django.http import Http404
 
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from common.djangoapps.util.json_request import expect_json_in_class_view
 
 from cms.djangoapps.contentstore.api import course_author_access_required
 from cms.djangoapps.contentstore.xblock_storage_handlers import view_handlers
-import cms.djangoapps.contentstore.toggles as contentstore_toggles
 
 from ..serializers import XblockSerializer
 from .utils import validate_request_with_serializer
 
 
 log = logging.getLogger(__name__)
-toggles = contentstore_toggles
 handle_xblock = view_handlers.handle_xblock
 
 
@@ -31,17 +28,6 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
     xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"
     """
     serializer_class = XblockSerializer
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     # pylint: disable=arguments-differ
     @course_author_access_required
@@ -76,17 +62,6 @@ class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
     xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"
     """
     serializer_class = XblockSerializer
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: probably want to refactor this to a decorator.
-        """
-        The dispatch method of a View class handles HTTP requests in general
-        and calls other methods to handle specific HTTP methods.
-        We use this to raise a 404 if the content api is disabled.
-        """
-        if not toggles.use_studio_content_api():
-            raise Http404
-        return super().dispatch(request, *args, **kwargs)
 
     # pylint: disable=arguments-differ
     @csrf_exempt

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -5,6 +5,7 @@ from edx_toggles.toggles import SettingDictToggle, WaffleFlag
 from openedx.core.djangoapps.content.search import api as search_api
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
+
 # .. toggle_name: FEATURES['ENABLE_EXPORT_GIT']
 # .. toggle_implementation: SettingDictToggle
 # .. toggle_default: False
@@ -209,30 +210,6 @@ def individualize_anonymous_user_id(course_id):
     Returns a boolean if individualized anonymous_user_id is enabled on the course
     """
     return INDIVIDUALIZE_ANONYMOUS_USER_ID.is_enabled(course_id)
-
-
-# .. toggle_name: contentstore.enable_studio_content_api
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enables the new (experimental and unsafe!) Studio Content REST API for course authors,
-# .. which provides CRUD capabilities for course content and xblock editing.
-# .. Use at your own peril - you can easily delete learner data when editing running courses.
-# .. This can be triggered by deleting blocks, editing subsections, problems, assignments, discussions,
-# .. creating new problems or graded sections, and by other things you do.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2023-05-26
-# .. toggle_tickets: TNL-10208
-ENABLE_STUDIO_CONTENT_API = WaffleFlag(
-    f'{CONTENTSTORE_NAMESPACE}.enable_studio_content_api',
-    __name__,
-)
-
-
-def use_studio_content_api():
-    """
-    Returns a boolean if studio editing API is enabled
-    """
-    return ENABLE_STUDIO_CONTENT_API.is_enabled()
 
 
 # .. toggle_name: new_studio_mfe.use_new_home_page


### PR DESCRIPTION
## Description

There was a waffle flag `contentstore.enable_studio_content_api`, intended to gate the "experimental" REST APIs at  `<CMS_ROOT>/api/contentstore/v{0,1,2}/*`. In practice, these APIs are no longer experimental: for the past few named releases, they have been enabled in Tutor and used to power the Authoring MFE.

We are making the Authoring MFE default-on in all Open edX sites starting in Teak, with the legacy authoring frontend slated for removal by Ulmo. Therefore, we need to remove flag which is gating the REST API. We are _not_ introducing a temporary opt-out toggle, as we do need feel it is necessary.

## Supporting information

Part of: https://github.com/openedx/edx-platform/issues/36275

## Testing instructions

None-- unit tests are sufficient.

## Other information

None

## Merge deadline

ASAP - We'd like to get the Authoring MFE fully default-on by the Teak cutoff (23 Apr) and this is the first step.