### PR TITLE
docs: Make the graph render correctly.

### DIFF
--- a/scripts/user_retirement/docs/special_cases.rst
+++ b/scripts/user_retirement/docs/special_cases.rst
@@ -19,9 +19,10 @@ re-tried.  You can do this using the Django admin. In this example, a user
 retirement errored during forums retirement, so we manually reset their state
 from ``ERRORED`` to ``ENROLLMENTS_COMPLETE``.
 
-.. digraph:: retirement_states_example
+.. graphviz::
    :align: center
 
+    digraph G {
       //rankdir=LR;  // Rank Direction Left to Right
       ranksep = "0.3";
 
@@ -49,6 +50,7 @@ from ``ERRORED`` to ``ENROLLMENTS_COMPLETE``.
       }
 
       ERRORED -> ENROLLMENTS_COMPLETE[style="bold,dashed",color=black,label=" via django\nadmin"]
+    }
 
 Now, the user retirement driver scripts will automatically resume this user's
 retirement the next time they are executed.


### PR DESCRIPTION
I'm not sure how this worked before but I corrected to use the
`graphviz` directive and then full graphviz graph syntax which seemed to
fix whatever issues it was having.

Page Effected: https://docs.openedx.org/projects/edx-platform/en/latest/references/docs/scripts/user_retirement/docs/special_cases.html

Before:
![image](https://github.com/user-attachments/assets/c1d3abb6-f6ef-4f23-b47e-4448640cf067)

After:
![image](https://github.com/user-attachments/assets/6ec686d3-4bef-4e56-8478-95ce20c4a465)

