### PR TITLE
fix: Remove Some Pointless CMS Settings and Toggles

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -160,37 +160,6 @@ def use_new_problem_editor():
     return ENABLE_NEW_PROBLEM_EDITOR_FLAG.is_enabled()
 
 
-# .. toggle_name: new_core_editors.use_advanced_problem_editor
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: This flag enables the use of the new core problem xblock advanced editor as the default
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2024-07-25
-# .. toggle_target_removal_date: 2024-08-31
-# .. toggle_tickets: TNL-11694
-# .. toggle_warning:
-ENABLE_DEFAULT_ADVANCED_PROBLEM_EDITOR_FLAG = WaffleFlag('new_core_editors.use_advanced_problem_editor', __name__)
-
-
-# .. toggle_name: new_editors.add_game_block_button
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: This flag enables the creation of the new games block
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2023-07-26
-# .. toggle_target_removal_date: 2023-09-31
-# .. toggle_tickets: TNL-10924
-# .. toggle_warning:
-ENABLE_ADD_GAME_BLOCK_FLAG = WaffleFlag('new_editors.add_game_block_button', __name__)
-
-
-def use_add_game_block():
-    """
-    Returns a boolean if add game block button is enabled
-    """
-    return ENABLE_ADD_GAME_BLOCK_FLAG.is_enabled()
-
-
 # .. toggle_name: contentstore.individualize_anonymous_user_id
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -560,9 +560,6 @@ class GetItemTest(ItemTest):
             else:
                 self.assertNotIn("ancestors", response)
                 xblock_info = get_block_info(xblock)
-                # TODO: remove after beta testing for the new problem editor parser
-                if xblock_info["category"] == "problem":
-                    xblock_info["metadata"]["default_to_advanced"] = False
                 self.assertEqual(xblock_info, response)
 
 

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -33,7 +33,6 @@ from xblock.core import XBlock
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
-from cms.djangoapps.contentstore.toggles import ENABLE_DEFAULT_ADVANCED_PROBLEM_EDITOR_FLAG
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.lib.ai_aside_summary_config import AiAsideSummaryConfig
 from cms.lib.xblock.upstream_sync import BadUpstream, sync_from_upstream
@@ -187,11 +186,6 @@ def handle_xblock(request, usage_key_string=None):
                 # TODO: pass fields to get_block_info and only return those
                 with modulestore().bulk_operations(usage_key.course_key):
                     response = get_block_info(get_xblock(usage_key, request.user))
-                    # TODO: remove after beta testing for the new problem editor parser
-                    if response["category"] == "problem":
-                        response["metadata"]["default_to_advanced"] = (
-                            ENABLE_DEFAULT_ADVANCED_PROBLEM_EDITOR_FLAG.is_enabled()
-                        )
                     if "customReadToken" in fields:
                         parent_children = _get_block_parent_children(get_xblock(usage_key, request.user))
                         response.update(parent_children)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1317,16 +1317,6 @@ EMBARGO_SITE_REDIRECT_URL = None
 
 ##### custom vendor plugin variables #####
 
-# .. setting_name: JS_ENV_EXTRA_CONFIG
-# .. setting_default: {}
-# .. setting_description: JavaScript code can access this dictionary using `process.env.JS_ENV_EXTRA_CONFIG`
-#   One of the current use cases for this is enabling custom TinyMCE plugins
-#   (TINYMCE_ADDITIONAL_PLUGINS) and overriding the TinyMCE configuration (TINYMCE_CONFIG_OVERRIDES).
-# .. setting_warning: This Django setting is DEPRECATED! Starting in Sumac, Webpack will no longer
-#   use Django settings. Please set the JS_ENV_EXTRA_CONFIG environment variable to an equivalent JSON
-#   string instead. For details, see: https://github.com/openedx/edx-platform/issues/31895
-JS_ENV_EXTRA_CONFIG = json.loads(os.environ.get('JS_ENV_EXTRA_CONFIG', '{}'))
-
 ############################### PIPELINE #######################################
 
 PIPELINE = {
@@ -1507,14 +1497,6 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(STATIC_ROOT, 'webpack-worker-stats.json')
     }
 }
-
-# .. setting_name: WEBPACK_CONFIG_PATH
-# .. setting_default: "webpack.prod.config.js"
-# .. setting_description: Path to the Webpack configuration file. Used by Paver scripts.
-# .. setting_warning: This Django setting is DEPRECATED! Starting in Sumac, Webpack will no longer
-#   use Django settings. Please set the WEBPACK_CONFIG_PATH environment variable instead. For details,
-#   see: https://github.com/openedx/edx-platform/issues/31895
-WEBPACK_CONFIG_PATH = os.environ.get('WEBPACK_CONFIG_PATH', 'webpack.prod.config.js')
 
 
 ############################ SERVICE_VARIANT ##################################

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -66,9 +66,6 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]
 
-# Load development webpack donfiguration
-WEBPACK_CONFIG_PATH = 'webpack.dev.config.js'
-
 ############################ PYFS XBLOCKS SERVICE #############################
 # Set configuration for Django pyfilesystem
 

--- a/cms/envs/mock.yml
+++ b/cms/envs/mock.yml
@@ -501,7 +501,6 @@ IDA_LOGOUT_URI_LIST:
 - https://discovery.localhost/logout/
 - https://commerce-coordinator.localhost/logout/
 ID_VERIFICATION_SUPPORT_LINK: https://support.localhost/hc/en-us/articles/206503858-How-do-I-complete-photo-verification-
-JS_ENV_EXTRA_CONFIG: {}
 JWT_AUTH:
   JWT_AUDIENCE: test_jwt_audience
   JWT_AUTH_COOKIE_HEADER_PAYLOAD: jwt-cookie-header-payload

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2806,14 +2806,6 @@ WEBPACK_LOADER = {
     }
 }
 
-# .. setting_name: WEBPACK_CONFIG_PATH
-# .. setting_default: "webpack.prod.config.js"
-# .. setting_description: Path to the Webpack configuration file. Used by Paver scripts.
-# .. setting_warning: This Django setting is DEPRECATED! Starting in Sumac, Webpack will no longer
-#   use Django settings. Please set the WEBPACK_CONFIG_PATH environment variable instead. For details,
-#   see: https://github.com/openedx/edx-platform/issues/31895
-WEBPACK_CONFIG_PATH = os.environ.get('WEBPACK_CONFIG_PATH', 'webpack.prod.config.js')
-
 ########################## DJANGO DEBUG TOOLBAR ###############################
 
 # We don't enable Django Debug Toolbar universally, but whenever we do, we want

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -136,9 +136,6 @@ REQUIRE_DEBUG = DEBUG
 
 PIPELINE['SASS_ARGUMENTS'] = '--debug-info'
 
-# Load development webpack configuration
-WEBPACK_CONFIG_PATH = 'webpack.dev.config.js'
-
 ########################### VERIFIED CERTIFICATES #################################
 
 FEATURES['AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING'] = True


### PR DESCRIPTION
## Description

These waffle flags never had any effect, so they are being removed:

* new_core_editors.use_advanced_problem_editor
* new_editors.add_game_block_button

These Django settings were left over from the static assets cleanup, and are also being removed:

* JS_ENV_EXTRA_CONFIG
* WEBPACK_CONFIG_PATH

## Supporting info

The "advanced problem editor" (misnomer) waffle was removed from frontend-app-uthoring already: https://github.com/openedx/frontend-app-authoring/pull/1753

The waffle changes were cleared via the DEPR process as part of: #36275 

The Django settings removal was just a miss from a previous DEPR: https://github.com/openedx/edx-platform/issues/36407

## Testing instructions

None

## Merge deadline

Before Teak cutoff (23 Apr). Ideally earlier, as it'd simplify other waffle changes which we need to merge by then.