### PR TITLE
feat!: Put "How It Works" Page Behind Waffle in Preparation for Removal

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -2164,8 +2164,12 @@ class EntryPageTestCase(TestCase):
         resp = self.client.get_html(page)
         self.assertEqual(resp.status_code, status_code)
 
-    def test_how_it_works(self):
+    @override_waffle_flag(toggles.LEGACY_STUDIO_LOGGED_OUT_HOME, True)
+    def test_how_it_works_legacy(self):
         self._test_page("/howitworks")
+
+    def test_how_it_works_redirect_to_signin(self):
+        self._test_page("/howitworks", 302)
 
     def test_signup(self):
         # deprecated signup url redirects to LMS register.

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -176,6 +176,7 @@ class AuthTestCase(ContentStoreTestCase):
         (True, 'assertContains'),
         (False, 'assertNotContains'))
     @unpack
+    @override_waffle_flag(toggles.LEGACY_STUDIO_LOGGED_OUT_HOME, True)
     def test_signin_and_signup_buttons_index_page(self, allow_account_creation, assertion_method_name):
         """
         Navigate to the home page and check the Sign Up button is hidden when ALLOW_PUBLIC_ACCOUNT_CREATION flag

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -637,3 +637,25 @@ def enable_course_optimizer(course_id):
     Returns a boolean if course optimizer is enabled on the course
     """
     return ENABLE_COURSE_OPTIMIZER.is_enabled(course_id)
+
+
+# .. toggle_name: legacy_studio.logged_out_home
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Temporarily fall back to the old Studio "How it Works" page when unauthenticated
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2025-03-14
+# .. toggle_target_removal_date: 2025-09-14
+# .. toggle_tickets: https://github.com/openedx/edx-platform/issues/36275
+# .. toggle_warning: In Ulmo, this toggle will be removed, along with the legacy page. The only available
+#  behavior will be to send the user to the log-in page with a redirect to Studio Course Listing (/home).
+LEGACY_STUDIO_LOGGED_OUT_HOME = WaffleFlag('legacy_studio.logged_out_home', __name__)
+
+
+def use_legacy_logged_out_home():
+    """
+    Returns whether the old "how it works" page should be shown.
+
+    If not, then we should just go to the login page w/ redirect to studio course listing.
+    """
+    return LEGACY_STUDIO_LOGGED_OUT_HOME.is_enabled()

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -11,6 +11,7 @@ from django.shortcuts import redirect
 from common.djangoapps.edxmako.shortcuts import render_to_response
 
 from ..config.waffle import ENABLE_ACCESSIBILITY_POLICY_PAGE
+from ..toggles import use_legacy_logged_out_home
 
 __all__ = [
     'register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility',
@@ -62,11 +63,12 @@ def _build_next_param(request):
 
 
 def howitworks(request):
-    "Proxy view"
-    if request.user.is_authenticated:
-        return redirect('/home/')
-    else:
+    """
+    Deprecated logged-out home page. New behavior is just login w/ redirect to studio course list.
+    """
+    if use_legacy_logged_out_home() and not request.user.is_authenticated:
         return render_to_response('howitworks.html', {})
+    return redirect('/home/')
 
 
 def accessibility(request):


### PR DESCRIPTION
## Description

We add a a new Waffle toggle:
* legacy_studio.logged_out_home

Unless enabled, unauthenticated users accessing Studio will now be sent to the login page, and then redirected to the logged-in Studio home (the course listing). By the Ulmo release, the Waffle will be removed along with the howitworks page, and the new redirect-to-login behavior will become the only available behavior.

The howitworks page is implemented as a legacy frontend, and we are not seeing enough value in it to justify a rewrite in React. Via the DEPR process we confirmed that the new behavior is acceptable, or even preferable, as it removes edX.org-oriented language from the community release and reduces the number of clicks needed for Studio users to log in.

## Supporting info

Part of:
* https://github.com/openedx/edx-platform/issues/36269

which is part of the greater:
* #36275 

Screenshot of the removed page:
![image](https://github.com/user-attachments/assets/6506b5a5-7585-4750-939a-13857fe22497)


## Merge deadline

Would be great to have merged today in time for Teak.

## Testing instructions

Test new behavior:
* Log out
* Go to the `http://studio.<LMS_BASE>`
* Confirm that you are sent right to login, not howitworks
* Go to the `http://studio.<LMS_BASE>/howitworks`
* Again, confirm that you are send right to login, not howitworks
* Confirm that logging in sends you to the Studio course listing

Test old behavior:
* Log out
* Now, add the waffle flag `legacy_studio.logged_out_home`
* Go to the `http://studio.<LMS_BASE>`
* Confirm that you are sent to the old howitworks page
* Go to the `http://studio.<LMS_BASE>/howitworks`
* Again, confirm that you are sent to the old howitworks page
* Confirm that clicking "Sign In" and signing in sends you to the Studio course listing