### PR TITLE
fix: save video asides during XML course import

### DIFF
--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -752,10 +752,11 @@ class _BuiltInVideoBlock(
         block_type = 'video'
         definition_id = runtime.id_generator.create_definition(block_type, url_name)
         usage_id = runtime.id_generator.create_usage(definition_id)
+        aside_children = []
         if is_pointer_tag(node):
             filepath = cls._format_filepath(node.tag, name_to_pathname(url_name))
             node = cls.load_file(filepath, runtime.resources_fs, usage_id)
-            runtime.parse_asides(node, definition_id, usage_id, runtime.id_generator)
+            aside_children = runtime.parse_asides(node, definition_id, usage_id, runtime.id_generator)
         field_data = cls.parse_video_xml(node, runtime.id_generator)
         kvs = InheritanceKeyValueStore(initial_values=field_data)
         field_data = KvsFieldData(kvs)
@@ -774,6 +775,9 @@ class _BuiltInVideoBlock(
             runtime.resources_fs,
             getattr(runtime.id_generator, 'target_course_id', None)
         )
+
+        if aside_children:
+            cls.add_applicable_asides_to_block(video, runtime, aside_children)
 
         return video
 

--- a/xmodule/xml_block.py
+++ b/xmodule/xml_block.py
@@ -381,13 +381,20 @@ class XmlMixin:
                     )
 
         if aside_children:
-            asides_tags = [x.tag for x in aside_children]
-            asides = runtime.get_asides(xblock)
-            for asd in asides:
-                if asd.scope_ids.block_type in asides_tags:
-                    xblock.add_aside(asd)
+            cls.add_applicable_asides_to_block(xblock, runtime, aside_children)
 
         return xblock
+
+    @classmethod
+    def add_applicable_asides_to_block(cls, block, runtime, aside_children):
+        """
+        Add asides to the block. Moved this out of the parse_xml method to use it in the VideoBlock.parse_xml
+        """
+        asides_tags = [aside_child.tag for aside_child in aside_children]
+        asides = runtime.get_asides(block)
+        for aside in asides:
+            if aside.scope_ids.block_type in asides_tags:
+                block.add_aside(aside)
 
     @classmethod
     def parse_xml_new_runtime(cls, node, runtime, keys):


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

During course import, the video asides are not loaded from the XML properly. This results in inconsistent states after the export and reimport of a course. This works fine for the Problem and Other blocks.

This PR saves the Asides for the videos during course XML import.

## Supporting information

https://github.com/openedx/edx-platform/issues/36489

## Testing instructions

- Checkout master branch
- Create an Aside that applies to video blocks and problem blocks.
  - Alternatively, you can use [ol_openedx_chat](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat)
    - Create a studio config in CMS Admin at `/admin/xblock_config/studioconfig/`. Keep it enabled.
    - Go to the CMS Shell and run `pip install ol-openedx-chat`
    - Now restart CMS
    - Go to `{LMS_BASE_URL}/admin/waffle/flag/` and add waffle flag `ol_openedx_chat.ol_openedx_chat_enabled`. Keep it enabled.
    - Now go to Any course in CMS, and open advanced settings.
    - Now add the below code in `Other Course Settings`
    ```
     {
        "OL_OPENEDX_CHAT_PROBLEM_BLOCK_ENABLED": true,
        "OL_OPENEDX_CHAT_VIDEO_BLOCK_ENABLED": true
     }
     ```

    - If you cannot find `Other Course Settings`, you will need to enable it by doing `FEATURES["ENABLE_OTHER_COURSE_SETTINGS"] = True` in CMS settings.
    - Once all of this is done, you can go to a Unit in the CMS. You will see `Enable AI Chat Assistant` against problem and video blocks.
- Now, change the Aside fields to a value other than the defaults.
  - If you are testing with ol_openedx_chat](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat), you should disable the `Enable AI Chat Assistant` for a few problems and videos.
- Export the course
- Import it in another course in CMS.
- You will notice that for videos, it does not retain the Aside state from the exported course. It retains the state for the Problems.
- Now check out this branch and repeat the above steps.

## Deadline

24-02-25
So that it is included in Teak.

