### PR TITLE
build: Switch off deprecated C-Hive NPM cache

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Setup npm
         run: npm i -g npm@10.7.x
@@ -62,8 +63,6 @@ jobs:
       - name: Install Required Python Dependencies
         run: |
           make base-requirements
-
-      - uses: c-hive/gha-npm-cache@v1
 
       - name: Install npm
         run: npm ci  


### PR DESCRIPTION
## Description

JS tests are failing because we are using a discontinued GHA caching service:
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

This service is used by the unsupported C-Hive caching action which we are relying on:
https://github.com/c-hive/gha-npm-cache

We are switching to the supported caching mechanims which is provided by setup-node:
https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data

## Testing instructions

There is no good way to test this. I believe the PR tests will fail, because they'll use the JS test action from master rather than the on in this PR.

We just have to merge, hope it works, and fix forward if it doesn't.