### PR TITLE
build!: Remove edx-proctoring-proctortrack from base requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "css-loader": "7.1.2",
         "datatables": "1.10.18",
         "datatables.net-fixedcolumns": "5.0.4",
-        "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732",
         "edx-ui-toolkit": "1.8.7",
         "exports-loader": "0.6.4",
         "file-loader": "^6.2.0",
@@ -7954,15 +7953,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    },
-    "node_modules/edx-proctoring-proctortrack": {
-      "version": "1.1.1",
-      "resolved": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732",
-      "integrity": "sha512-IQkVQPaTOrC23IpnylBZx7072bRz//OaZEp0uQaF0jiNROny3fXo3ebtKreEqyrEpNv1UEpdzuVh1uAfQC1JDg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@edx/edx-proctoring": "^4.8.1"
-      }
     },
     "node_modules/edx-ui-toolkit": {
       "version": "1.8.7",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "css-loader": "7.1.2",
     "datatables": "1.10.18",
     "datatables.net-fixedcolumns": "5.0.4",
-    "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732",
     "edx-ui-toolkit": "1.8.7",
     "exports-loader": "0.6.4",
     "file-loader": "^6.2.0",

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via -r requirements/edx/github.in
 acid-xblock==0.4.1
     # via -r requirements/edx/kernel.in
 aiohappyeyeballs==2.6.1
@@ -496,9 +494,7 @@ edx-opaque-keys[django]==2.12.0
 edx-organizations==6.13.0
     # via -r requirements/edx/kernel.in
 edx-proctoring==5.1.2
-    # via
-    #   -r requirements/edx/kernel.in
-    #   edx-proctoring-proctortrack
+    # via -r requirements/edx/kernel.in
 edx-rbac==1.10.0
     # via edx-enterprise
 edx-rest-api-client==6.1.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
 accessible-pygments==0.0.5
     # via
     #   -r requirements/edx/doc.txt
@@ -791,7 +787,6 @@ edx-proctoring==5.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   edx-proctoring-proctortrack
 edx-rbac==1.10.0
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via -r requirements/edx/base.txt
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 acid-xblock==0.4.1
@@ -580,9 +578,7 @@ edx-opaque-keys[django]==2.12.0
 edx-organizations==6.13.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.1.2
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-proctoring-proctortrack
+    # via -r requirements/edx/base.txt
 edx-rbac==1.10.0
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -86,7 +86,3 @@
 ##############################################################################
 
 # ... add dependencies here
-
-# django42 support PR merged but new release is pending.
-# https://github.com/openedx/edx-platform/issues/33431
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -78,8 +78,6 @@ edx-name-affirmation
 edx-opaque-keys>=2.12.0
 edx-organizations
 edx-proctoring>=2.0.1
-# using hash to support django42
-# edx-proctoring-proctortrack==1.2.1  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client
 edx-search
 edx-submissions

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/anupdhabarde/edx-proctoring-proctortrack.git@31c6c9923a51c903ae83760ecbbac191363aa2a2#egg=edx_proctoring_proctortrack
-    # via -r requirements/edx/base.txt
 acid-xblock==0.4.1
     # via -r requirements/edx/base.txt
 aiohappyeyeballs==2.6.1
@@ -607,9 +605,7 @@ edx-opaque-keys[django]==2.12.0
 edx-organizations==6.13.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.1.2
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-proctoring-proctortrack
+    # via -r requirements/edx/base.txt
 edx-rbac==1.10.0
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Removes this git-based requirement from both NPM requirements and from pip requirements.

Part of: https://github.com/openedx/edx-platform/issues/36329

To do before merging:

* Wait until closer to the Teak cut. Monday 4/21?
* Test with Mockprock.
* Encourage early deployers to test with proctortrack as a privately-installed requirement.