### PR TITLE
docs: update dev requirements file name in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Language Packages:
 * Backend application:
 
   - ``pip install -r requirements/edx/base.txt`` (production)
-  - ``pip install -r requirements/edx/dev.txt`` (development)
+  - ``pip install -r requirements/edx/development.txt`` (development)
 
   Some Python packages have system dependencies. For example, installing these packages on Debian or Ubuntu will require first running ``sudo apt install python3-dev default-libmysqlclient-dev build-essential pkg-config`` to satisfy the requirements of the ``mysqlclient`` Python package.
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

While following the bare-metal installation guide in the README, I was able to run the setup successfully. However, I noticed a small issue: the guide references a file named `requirements/edx/dev.txt`, which does not exist. The correct path should be `requirements/edx/development.txt`.

## Proposed Change
Update the README to replace `requirements/edx/dev.txt` with `requirements/edx/development.txt` to reflect the correct file path.

![image](https://github.com/user-attachments/assets/87fe982f-94f5-4a66-9482-0d3fc63a3738)


