### PR TITLE
feat: add markdown editor waffle flag

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -28,6 +28,7 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     use_new_textbooks_page = serializers.SerializerMethodField()
     use_new_group_configurations_page = serializers.SerializerMethodField()
     enable_course_optimizer = serializers.SerializerMethodField()
+    use_markdown_editor = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -152,3 +153,10 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         """
         course_key = self.get_course_key()
         return toggles.enable_course_optimizer(course_key)
+
+    def get_use_markdown_editor(self, obj):
+        """
+        Method to get the use_markdown_editor waffle flag
+        """
+        course_key = self.get_course_key()
+        return toggles.use_markdown_editor(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -28,7 +28,7 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     use_new_textbooks_page = serializers.SerializerMethodField()
     use_new_group_configurations_page = serializers.SerializerMethodField()
     enable_course_optimizer = serializers.SerializerMethodField()
-    react_markdown_editor = serializers.SerializerMethodField()
+    use_react_markdown_editor = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -154,9 +154,9 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         course_key = self.get_course_key()
         return toggles.enable_course_optimizer(course_key)
 
-    def get_react_markdown_editor(self, obj):
+    def get_use_react_markdown_editor(self, obj):
         """
-        Method to get the react_markdown_editor waffle flag
+        Method to get the use_react_markdown_editor waffle flag
         """
         course_key = self.get_course_key()
-        return toggles.react_markdown_editor(course_key)
+        return toggles.use_react_markdown_editor(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -28,7 +28,7 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     use_new_textbooks_page = serializers.SerializerMethodField()
     use_new_group_configurations_page = serializers.SerializerMethodField()
     enable_course_optimizer = serializers.SerializerMethodField()
-    use_markdown_editor = serializers.SerializerMethodField()
+    react_markdown_editor = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -154,9 +154,9 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         course_key = self.get_course_key()
         return toggles.enable_course_optimizer(course_key)
 
-    def get_use_markdown_editor(self, obj):
+    def get_react_markdown_editor(self, obj):
         """
-        Method to get the use_markdown_editor waffle flag
+        Method to get the react_markdown_editor waffle flag
         """
         course_key = self.get_course_key()
-        return toggles.use_markdown_editor(course_key)
+        return toggles.react_markdown_editor(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
@@ -62,7 +62,7 @@ class CourseWaffleFlagsView(APIView):
             "use_new_certificates_page": true,
             "use_new_textbooks_page": true,
             "use_new_group_configurations_page": true
-            "use_markdown_editor": true,
+            "react_markdown_editor": true,
         }
         ```
         """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
@@ -62,7 +62,7 @@ class CourseWaffleFlagsView(APIView):
             "use_new_certificates_page": true,
             "use_new_textbooks_page": true,
             "use_new_group_configurations_page": true
-            "react_markdown_editor": true,
+            "use_react_markdown_editor": true,
         }
         ```
         """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_waffle_flags.py
@@ -62,6 +62,7 @@ class CourseWaffleFlagsView(APIView):
             "use_new_certificates_page": true,
             "use_new_textbooks_page": true,
             "use_new_group_configurations_page": true
+            "use_markdown_editor": true,
         }
         ```
         """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -34,6 +34,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "use_new_certificates_page",
         "use_new_textbooks_page",
         "use_new_group_configurations_page",
+        "use_markdown_editor"
     ]
 
     other_expected_waffle_flags = ["enable_course_optimizer"]

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -72,7 +72,11 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         """
         for flag in flags:
             WaffleFlagCourseOverrideModel.objects.create(
-                waffle_flag=f"contentstore.new_studio_mfe.{flag}" if flag != "react_markdown_editor" else "contentstore.react_markdown_editor",
+                waffle_flag=(
+                    f"contentstore.new_studio_mfe.{flag}"
+                    if flag != "react_markdown_editor"
+                    else "contentstore.react_markdown_editor"
+                ),
                 course_id=self.course.id,
                 enabled=enabled,
             )

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -34,7 +34,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "use_new_certificates_page",
         "use_new_textbooks_page",
         "use_new_group_configurations_page",
-        "use_markdown_editor"
+        "react_markdown_editor"
     ]
 
     other_expected_waffle_flags = ["enable_course_optimizer"]

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -72,7 +72,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         """
         for flag in flags:
             WaffleFlagCourseOverrideModel.objects.create(
-                waffle_flag=f"contentstore.new_studio_mfe.{flag}",
+                waffle_flag=f"contentstore.new_studio_mfe.{flag}" if flag != "react_markdown_editor" else "contentstore.react_markdown_editor",
                 course_id=self.course.id,
                 enabled=enabled,
             )
@@ -110,6 +110,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         expected_response["use_new_home_page"] = False
 
         response = self.client.get(course_url)
+        print(expected_response, response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(expected_response, response.data)
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -34,7 +34,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "use_new_certificates_page",
         "use_new_textbooks_page",
         "use_new_group_configurations_page",
-        "react_markdown_editor"
+        "use_react_markdown_editor"
     ]
 
     other_expected_waffle_flags = ["enable_course_optimizer"]
@@ -74,8 +74,8 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
             WaffleFlagCourseOverrideModel.objects.create(
                 waffle_flag=(
                     f"contentstore.new_studio_mfe.{flag}"
-                    if flag != "react_markdown_editor"
-                    else "contentstore.react_markdown_editor"
+                    if flag != "use_react_markdown_editor"
+                    else "contentstore.use_react_markdown_editor"
                 ),
                 course_id=self.course.id,
                 enabled=enabled,
@@ -114,7 +114,6 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         expected_response["use_new_home_page"] = False
 
         response = self.client.get(course_url)
-        print(expected_response, response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(expected_response, response.data)
 

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -219,20 +219,17 @@ def use_new_custom_pages(course_key):
     """
     return ENABLE_NEW_STUDIO_CUSTOM_PAGES.is_enabled(course_key)
 
-# .. toggle_name: contentstore.react_markdown_editor
+# .. toggle_name: contentstore.use_react_markdown_editor
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: This flag enables the use of the Markdown editor when creating or editing problems in the authoring MFE
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2025-4-10
-# .. toggle_target_removal_date: 2025-8-31
 # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4517232656/Re-enable+Markdown+editing+of+CAPA+problems+to+meet+various+use+cases
 # .. toggle_warning:
 ENABLE_REACT_MARKDOWN_EDITOR = CourseWaffleFlag(
-    f'{CONTENTSTORE_NAMESPACE}.react_markdown_editor', __name__)
+    f'{CONTENTSTORE_NAMESPACE}.use_react_markdown_editor', __name__)
 
 
-def react_markdown_editor(course_key):
+def use_react_markdown_editor(course_key):
     """
     Returns a boolean if new studio custom pages mfe is enabled
     """

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -222,9 +222,9 @@ def use_new_custom_pages(course_key):
 # .. toggle_name: contentstore.use_react_markdown_editor
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
+# .. toggles_use_cases: opt_in
 # .. toggle_description: This flag enables the use of the Markdown editor when creating or editing problems in the authoring MFE
 # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4517232656/Re-enable+Markdown+editing+of+CAPA+problems+to+meet+various+use+cases
-# .. toggle_warning:
 ENABLE_REACT_MARKDOWN_EDITOR = CourseWaffleFlag(
     f'{CONTENTSTORE_NAMESPACE}.use_react_markdown_editor', __name__)
 

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -219,6 +219,24 @@ def use_new_custom_pages(course_key):
     """
     return ENABLE_NEW_STUDIO_CUSTOM_PAGES.is_enabled(course_key)
 
+# .. toggle_name: contentstore.new_studio_mfe.use_markdown_editor
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the Markdown editor when creating or editing problems.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2025-4-10
+# .. toggle_target_removal_date: 2025-8-31
+# .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4517232656/Re-enable+Markdown+editing+of+CAPA+problems+to+meet+various+use+cases
+# .. toggle_warning:
+ENABLE_MARKDOWN_EDITOR = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_markdown_editor', __name__)
+
+
+def use_markdown_editor(course_key):
+    """
+    Returns a boolean if new studio custom pages mfe is enabled
+    """
+    return ENABLE_MARKDOWN_EDITOR.is_enabled(course_key)
 
 # .. toggle_name: contentstore.new_studio_mfe.use_new_schedule_details_page
 # .. toggle_implementation: CourseWaffleFlag

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -219,24 +219,24 @@ def use_new_custom_pages(course_key):
     """
     return ENABLE_NEW_STUDIO_CUSTOM_PAGES.is_enabled(course_key)
 
-# .. toggle_name: contentstore.new_studio_mfe.use_markdown_editor
+# .. toggle_name: contentstore.react_markdown_editor
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: This flag enables the use of the Markdown editor when creating or editing problems.
+# .. toggle_description: This flag enables the use of the Markdown editor when creating or editing problems in the authoring MFE
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2025-4-10
 # .. toggle_target_removal_date: 2025-8-31
 # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4517232656/Re-enable+Markdown+editing+of+CAPA+problems+to+meet+various+use+cases
 # .. toggle_warning:
-ENABLE_MARKDOWN_EDITOR = CourseWaffleFlag(
-    f'{CONTENTSTORE_NAMESPACE}.new_studio_mfe.use_markdown_editor', __name__)
+ENABLE_REACT_MARKDOWN_EDITOR = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.react_markdown_editor', __name__)
 
 
-def use_markdown_editor(course_key):
+def react_markdown_editor(course_key):
     """
     Returns a boolean if new studio custom pages mfe is enabled
     """
-    return ENABLE_MARKDOWN_EDITOR.is_enabled(course_key)
+    return ENABLE_REACT_MARKDOWN_EDITOR.is_enabled(course_key)
 
 # .. toggle_name: contentstore.new_studio_mfe.use_new_schedule_details_page
 # .. toggle_implementation: CourseWaffleFlag

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -222,8 +222,9 @@ def use_new_custom_pages(course_key):
 # .. toggle_name: contentstore.use_react_markdown_editor
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggles_use_cases: opt_in
 # .. toggle_description: This flag enables the use of the Markdown editor when creating or editing problems in the authoring MFE
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2025-4-11
 # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4517232656/Re-enable+Markdown+editing+of+CAPA+problems+to+meet+various+use+cases
 ENABLE_REACT_MARKDOWN_EDITOR = CourseWaffleFlag(
     f'{CONTENTSTORE_NAMESPACE}.use_react_markdown_editor', __name__)

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -155,9 +155,7 @@ def handle_xblock(request, usage_key_string=None):
     This method is used both by the internal xblock_handler API and by
     the public CMS API.
     """
-    print("\n\n\n In handle_xblock\n\n\n")
     if usage_key_string:
-        print("\n\n\nIn usage key string\n\n\n")
 
         usage_key = usage_key_with_run(usage_key_string)
 
@@ -203,7 +201,6 @@ def handle_xblock(request, usage_key_string=None):
             return modified_xblock
 
     elif request.method in ("PUT", "POST"):
-        print("\n\n\nIn put post\n\n\n")
         if "duplicate_source_locator" in request.json:
             parent_usage_key = usage_key_with_run(request.json["parent_locator"])
             duplicate_source_usage_key = usage_key_with_run(
@@ -360,7 +357,7 @@ def _save_xblock(
         if fields:
             for field_name in fields:
                 setattr(xblock, field_name, fields[field_name])
-        print(xblock.__dict__)
+
         if children_strings is not None:
             children = []
             for child_string in children_strings:
@@ -529,7 +526,6 @@ def create_item(request):
 @expect_json
 def _create_block(request):
     """View for create blocks."""
-    print("\n\n\n\n\nhere\n\n\n\n\n")
     parent_locator = request.json["parent_locator"]
     usage_key = usage_key_with_run(parent_locator)
     if not has_studio_write_access(request.user, usage_key.course_key):

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -155,7 +155,9 @@ def handle_xblock(request, usage_key_string=None):
     This method is used both by the internal xblock_handler API and by
     the public CMS API.
     """
+    print("\n\n\n In handle_xblock\n\n\n")
     if usage_key_string:
+        print("\n\n\nIn usage key string\n\n\n")
 
         usage_key = usage_key_with_run(usage_key_string)
 
@@ -201,6 +203,7 @@ def handle_xblock(request, usage_key_string=None):
             return modified_xblock
 
     elif request.method in ("PUT", "POST"):
+        print("\n\n\nIn put post\n\n\n")
         if "duplicate_source_locator" in request.json:
             parent_usage_key = usage_key_with_run(request.json["parent_locator"])
             duplicate_source_usage_key = usage_key_with_run(
@@ -357,7 +360,7 @@ def _save_xblock(
         if fields:
             for field_name in fields:
                 setattr(xblock, field_name, fields[field_name])
-
+        print(xblock.__dict__)
         if children_strings is not None:
             children = []
             for child_string in children_strings:
@@ -526,6 +529,7 @@ def create_item(request):
 @expect_json
 def _create_block(request):
     """View for create blocks."""
+    print("\n\n\n\n\nhere\n\n\n\n\n")
     parent_locator = request.json["parent_locator"]
     usage_key = usage_key_with_run(parent_locator)
     if not has_studio_write_access(request.user, usage_key.course_key):

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -340,6 +340,11 @@ class _BuiltInProblemBlock(
                "or to report an issue, please contact moocsupport@mathworks.com"),
         scope=Scope.settings
     )
+    markdown_edited = Boolean(
+        help=_("Indicates if the problem was edited using the Markdown editor in the Authoring MFE."),
+        scope=Scope.settings,
+        default=False
+    )
 
     def bind_for_student(self, *args, **kwargs):  # lint-amnesty, pylint: disable=signature-differs
         super().bind_for_student(*args, **kwargs)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds `contentstore.use_react_markdown_editor` course waffle flag in cms. This flag helps in enabling the markdown editor in the authoring mfe. 

This PR also adds the `markdown_edited` field in the Problem Xblock to persist the user's choice of switching to the markdown editor on the authoring MFE.

More details in the authoring MFE PR: https://github.com/openedx/frontend-app-authoring/pull/1805


Useful information to include:

- Which edX user roles will this change impact? "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4517232656/Re-enable+Markdown+editing+of+CAPA+problems+to+meet+various+use+cases

https://github.com/mitodl/hq/issues/6812

## Testing instructions

Please follow the instructions in the authoring PR: 

## Deadline

Before Teak's cut.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere? Yes, on https://github.com/openedx/frontend-app-authoring/pull/1805