### PR TITLE
feat: record the user for library content writes

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -639,7 +639,10 @@ def get_or_create_olx_media_type(block_type: str) -> MediaType:
     )
 
 
-def delete_library_block(usage_key: LibraryUsageLocatorV2, remove_from_parent=True) -> None:
+def delete_library_block(
+    usage_key: LibraryUsageLocatorV2,
+    user_id: int | None = None,
+) -> None:
     """
     Delete the specified block from this library (soft delete).
     """
@@ -648,7 +651,7 @@ def delete_library_block(usage_key: LibraryUsageLocatorV2, remove_from_parent=Tr
     affected_collections = authoring_api.get_entity_collections(component.learning_package_id, component.key)
     affected_containers = get_containers_contains_component(usage_key)
 
-    authoring_api.soft_delete_draft(component.pk)
+    authoring_api.soft_delete_draft(component.pk, deleted_by=user_id)
 
     LIBRARY_BLOCK_DELETED.send_event(
         library_block=LibraryBlockData(
@@ -685,7 +688,7 @@ def delete_library_block(usage_key: LibraryUsageLocatorV2, remove_from_parent=Tr
         )
 
 
-def restore_library_block(usage_key: LibraryUsageLocatorV2) -> None:
+def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None = None) -> None:
     """
     Restore the specified library block.
     """
@@ -694,7 +697,11 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2) -> None:
     affected_collections = authoring_api.get_entity_collections(component.learning_package_id, component.key)
 
     # Set draft version back to the latest available component version id.
-    authoring_api.set_draft_version(component.pk, component.versioning.latest.pk)
+    authoring_api.set_draft_version(
+        component.pk,
+        component.versioning.latest.pk,
+        set_by=user_id,
+    )
 
     LIBRARY_BLOCK_CREATED.send_event(
         library_block=LibraryBlockData(

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -721,14 +721,14 @@ def publish_changes(library_key: LibraryLocatorV2, user_id: int | None = None):
     )
 
 
-def revert_changes(library_key: LibraryLocatorV2) -> None:
+def revert_changes(library_key: LibraryLocatorV2, user_id: int | None = None) -> None:
     """
     Revert all pending changes to the specified library, restoring it to the
     last published version.
     """
     learning_package = ContentLibrary.objects.get_by_key(library_key).learning_package
     assert learning_package is not None  # shouldn't happen but it's technically possible.
-    authoring_api.reset_drafts_to_published(learning_package.id)
+    authoring_api.reset_drafts_to_published(learning_package.id, reset_by=user_id)
 
     CONTENT_LIBRARY_UPDATED.send_event(
         content_library=ContentLibraryData(

--- a/openedx/core/djangoapps/content_libraries/rest_api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/blocks.py
@@ -140,7 +140,7 @@ class LibraryBlockView(APIView):
         """
         key = LibraryUsageLocatorV2.from_string(usage_key_str)
         api.require_permission_for_library_key(key.lib_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY)
-        api.delete_library_block(key)
+        api.delete_library_block(key, user_id=request.user.id)
         return Response({})
 
 
@@ -346,7 +346,7 @@ class LibraryBlockRestore(APIView):
         """
         key = LibraryUsageLocatorV2.from_string(usage_key_str)
         api.require_permission_for_library_key(key.lib_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY)
-        api.restore_library_block(key)
+        api.restore_library_block(key, request.user.id)
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
 

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -475,7 +475,7 @@ class LibraryCommitView(APIView):
         """
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY)
-        api.revert_changes(key)
+        api.revert_changes(key, request.user.id)
         return Response({})
 
 

--- a/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py
@@ -311,6 +311,7 @@ class LearningCoreXBlockRuntime(XBlockRuntime):
                     "block.xml": content.id,
                 },
                 created=now,
+                created_by=self.user.id if self.user else None
             )
         self.authored_data_store.mark_unchanged(block)
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -112,7 +112,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.22.0
+openedx-learning==0.23.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -820,7 +820,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/kernel.in
-openedx-learning==0.22.0
+openedx-learning==0.23.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1383,7 +1383,7 @@ openedx-forum==0.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.22.0
+openedx-learning==0.23.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -992,7 +992,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.22.0
+openedx-learning==0.23.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1050,7 +1050,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.22.0
+openedx-learning==0.23.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
We were previously not recording who was doing write/delete/reset operations.
Prior to openedx-learning 0.23.0, we didn't have a place to write the user for a
reset-to-publish.