### PR TITLE
feat: prevent sending course update, recurring nudge and upgrade reminder email to disabled users

### DIFF
--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -276,6 +276,9 @@ def _schedule_send(msg_str, site_id, delivery_config_var, log_prefix):  # lint-a
         msg = Message.from_string(msg_str)
 
         user = User.objects.get(id=msg.recipient.lms_user_id)
+        if not user.has_usable_password():
+            LOG.info(f'{delivery_config_var} Scheduled email User is disabled {user.username}')
+            return
         with emulate_http_request(site=site, user=user):
             _annonate_send_task_for_monitoring(msg)
             LOG.debug('%s: Sending message = %s', log_prefix, msg_str)


### PR DESCRIPTION
Implementation to prevent sending course update, recurring nudge and upgrade reminder email to disabled users

Ticket: [INF-1860](https://2u-internal.atlassian.net/browse/INF-1860)