### PR TITLE
Support pasting units from course into libraries

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -335,8 +335,6 @@ def import_staged_content_from_user_clipboard(parent_key: UsageKey, request) -> 
     """
     from cms.djangoapps.contentstore.views.preview import _load_preview_block
 
-    if not content_staging_api:
-        raise RuntimeError("The required content_staging app is not installed")
     user_clipboard = content_staging_api.get_user_clipboard(request.user.id)
     if not user_clipboard:
         # Clipboard is empty or expired/error/loading
@@ -384,8 +382,6 @@ def import_static_assets_for_library_sync(downstream_xblock: XBlock, lib_block: 
     """
     if not lib_block.runtime.get_block_assets(lib_block, fetch_asset_data=False):
         return StaticFileNotices()
-    if not content_staging_api:
-        raise RuntimeError("The required content_staging app is not installed")
     staged_content = content_staging_api.stage_xblock_temporarily(lib_block, request.user.id, LIBRARY_SYNC_PURPOSE)
     if not staged_content:
         # expired/error/loading

--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -59,6 +59,7 @@ from .exceptions import (
 )
 from .containers import (
     create_container,
+    get_container,
     update_container_children,
     ContainerMetadata,
     ContainerType,
@@ -559,6 +560,8 @@ def _import_staged_block_as_container(
             except IncompatibleTypesError:
                 continue  # Skip blocks that won't work in libraries
         update_container_children(container.container_key, new_child_keys, user_id=user.id)
+        # Re-fetch the container because the 'last_draft_created' will have changed when we added children
+        container = get_container(container.container_key)
     return container
 
 

--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -49,6 +49,7 @@ from ..permissions import CAN_EDIT_THIS_CONTENT_LIBRARY
 from .exceptions import (
     BlockLimitReachedError,
     ContentLibraryBlockNotFound,
+    IncompatibleTypesError,
     InvalidNameError,
     LibraryBlockAlreadyExists,
 )
@@ -315,7 +316,9 @@ def validate_can_add_block_to_library(
     # Make sure the proposed ID will be valid:
     validate_unicode_slug(block_id)
     # Ensure the XBlock type is valid and installed:
-    XBlock.load_class(block_type)  # Will raise an exception if invalid
+    block_class = XBlock.load_class(block_type)  # Will raise an exception if invalid
+    if block_class.has_children:
+        raise IncompatibleTypesError("XBlocks with children are not supported in content libraries")
     # Make sure the new ID is not taken already:
     usage_key = LibraryUsageLocatorV2(  # type: ignore[abstract]
         lib_key=library_key,

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -167,6 +167,7 @@ def create_container(
     slug: str | None,
     title: str,
     user_id: int | None,
+    created: datetime | None = None,
 ) -> ContainerMetadata:
     """
     Create a container (e.g. a Unit) in the specified content library.
@@ -192,7 +193,7 @@ def create_container(
                 content_library.learning_package_id,
                 key=slug,
                 title=title,
-                created=datetime.now(),
+                created=created or datetime.now(),
                 created_by=user_id,
             )
         case _:

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -506,9 +506,7 @@ class LibraryPasteClipboardView(GenericAPIView):
                 library_key, request.user, **serializer.validated_data
             )
         except api.IncompatibleTypesError as err:
-            raise ValidationError(  # lint-amnesty, pylint: disable=raise-missing-from
-                detail={'block_type': str(err)},
-            )
+            raise ValidationError(detail={'block_type': str(err)}) from err
 
         return Response(LibraryXBlockMetadataSerializer(result).data)
 

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -12,7 +12,7 @@ from opaque_keys.edx.locator import LibraryContainerLocator
 from opaque_keys import InvalidKeyError
 
 from openedx_learning.api.authoring_models import Collection
-from openedx.core.djangoapps.content_libraries.api.containers import ContainerMetadata, ContainerType
+from openedx.core.djangoapps.content_libraries.api.containers import ContainerType
 from openedx.core.djangoapps.content_libraries.constants import (
     ALL_RIGHTS_RESERVED,
     LICENSE_OPTIONS,

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -133,20 +133,12 @@ class CollectionMetadataSerializer(serializers.Serializer):
     title = serializers.CharField()
 
 
-class LibraryXBlockMetadataSerializer(serializers.Serializer):
+class PublishableItemSerializer(serializers.Serializer):
     """
     Serializer for LibraryXBlockMetadata
     """
-    id = serializers.CharField(source="usage_key", read_only=True)
-
-    # TODO: Remove this serializer field once the frontend no longer relies on
-    # it. Learning Core doesn't use definition IDs, but we're passing this dummy
-    # value back to preserve the REST API contract (just to reduce the number of
-    # things we're changing at one time).
-    def_key = serializers.ReadOnlyField(default=None)
-
-    block_type = serializers.CharField(source="usage_key.block_type")
-    display_name = serializers.CharField(read_only=True)
+    id = serializers.SerializerMethodField()
+    display_name = serializers.CharField()
     last_published = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
     published_by = serializers.CharField(read_only=True)
     last_draft_created = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
@@ -162,6 +154,25 @@ class LibraryXBlockMetadataSerializer(serializers.Serializer):
 
     collections = CollectionMetadataSerializer(many=True, required=False)
     can_stand_alone = serializers.BooleanField(read_only=True)
+
+    # Fields that are _sometimes_ set, depending on the subclass:
+    block_type = serializers.CharField(source="usage_key.block_type", required=False)
+    container_type = serializers.CharField(source="container_key.block_type", required=False)
+
+    def get_id(self, obj) -> str:
+        """ Get a unique ID for this PublishableItem """
+        if hasattr(obj, "usage_key"):
+            return str(obj.usage_key)
+        elif hasattr(obj, "container_key"):
+            return str(obj.container_key)
+        return ""
+
+
+class LibraryXBlockMetadataSerializer(PublishableItemSerializer):
+    """
+    Serializer for LibraryXBlockMetadata
+    """
+    block_type = serializers.CharField(source="usage_key.block_type")
 
 
 class LibraryXBlockTypeSerializer(serializers.Serializer):
@@ -200,13 +211,6 @@ class LibraryXBlockCreationSerializer(serializers.Serializer):
     can_stand_alone = serializers.BooleanField(required=False, default=True)
 
 
-class LibraryPasteClipboardSerializer(serializers.Serializer):
-    """
-    Serializer for pasting clipboard data into library
-    """
-    block_id = serializers.CharField(validators=(validate_unicode_slug, ))
-
-
 class LibraryXBlockOlxSerializer(serializers.Serializer):
     """
     Serializer for representing an XBlock's OLX
@@ -237,34 +241,18 @@ class LibraryXBlockStaticFilesSerializer(serializers.Serializer):
     files = LibraryXBlockStaticFileSerializer(many=True)
 
 
-class LibraryContainerMetadataSerializer(serializers.Serializer):
+class LibraryContainerMetadataSerializer(PublishableItemSerializer):
     """
     Serializer for Containers like Sections, Subsections, Units
 
     Converts from ContainerMetadata to JSON-compatible data
     """
-    container_key = serializers.CharField(read_only=True)
-    container_type = serializers.CharField()
-    display_name = serializers.CharField()
-    last_published = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
-    published_by = serializers.CharField(read_only=True)
-    last_draft_created = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
-    last_draft_created_by = serializers.CharField(read_only=True)
-    has_unpublished_changes = serializers.BooleanField(read_only=True)
-    created = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
-    modified = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
-    tags_count = serializers.IntegerField(read_only=True)
-    collections = CollectionMetadataSerializer(many=True, required=False, read_only=True)
+    # Use 'source' to get this as a string, not an enum value instance which the container_type field has.
+    container_type = serializers.CharField(source="container_key.container_type")
 
     # When creating a new container in a library, the slug becomes the ID part of
     # the definition key and usage key:
     slug = serializers.CharField(write_only=True, required=False)
-
-    def to_representation(self, instance: ContainerMetadata):
-        """ Convert to JSON-serializable data types """
-        data = super().to_representation(instance)
-        data["container_type"] = instance.container_type.value  # Force to a string, not an enum value instance
-        return data
 
     def to_internal_value(self, data):
         """

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -135,7 +135,7 @@ class CollectionMetadataSerializer(serializers.Serializer):
 
 class PublishableItemSerializer(serializers.Serializer):
     """
-    Serializer for LibraryXBlockMetadata
+    Serializer for any PublishableItem in a library (XBlock, Container, etc.)
     """
     id = serializers.SerializerMethodField()
     display_name = serializers.CharField()

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -306,11 +306,10 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
         """ Publish changes from a specified XBlock """
         return self._api('post', URL_LIB_BLOCK_PUBLISH.format(block_key=block_key), None, expect_response)
 
-    def _paste_clipboard_content_in_library(self, lib_key, block_id, expect_response=200):
+    def _paste_clipboard_content_in_library(self, lib_key, expect_response=200):
         """ Paste's the users clipboard content into Library """
         url = URL_LIB_PASTE_CLIPBOARD.format(lib_key=lib_key)
-        data = {"block_id": block_id}
-        return self._api('post', url, data, expect_response)
+        return self._api('post', url, {}, expect_response)
 
     def _render_block_view(self, block_key, view_name, version=None, expect_response=200):
         """

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -446,7 +446,7 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
             opaque_keys=[
                 UsageKey.from_string(self.lib1_problem_block["id"]),
                 UsageKey.from_string(self.lib1_html_block["id"]),
-                LibraryContainerLocator.from_string(self.unit1["container_key"]),
+                LibraryContainerLocator.from_string(self.unit1["id"]),
             ],
         )
         assert len(self.col1.entities.all()) == 3
@@ -475,7 +475,7 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
             opaque_keys=[
                 UsageKey.from_string(self.lib1_problem_block["id"]),
                 UsageKey.from_string(self.lib1_html_block["id"]),
-                LibraryContainerLocator.from_string(self.unit1["container_key"]),
+                LibraryContainerLocator.from_string(self.unit1["id"]),
             ],
         )
 
@@ -507,7 +507,7 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
                 "content_object": ContentObjectChangedData(
-                    object_id=self.unit1["container_key"],
+                    object_id=self.unit1["id"],
                     changes=["collections"],
                 ),
             },
@@ -535,7 +535,7 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
                 opaque_keys=[
                     UsageKey.from_string(self.lib1_problem_block["id"]),
                     UsageKey.from_string(self.lib1_html_block["id"]),
-                    LibraryContainerLocator.from_string(self.unit1["container_key"]),
+                    LibraryContainerLocator.from_string(self.unit1["id"]),
                 ],
             )
             assert self.lib1_problem_block["id"] in str(exc.exception)
@@ -634,14 +634,14 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
             opaque_keys=[
                 UsageKey.from_string(self.lib1_problem_block["id"]),
                 UsageKey.from_string(self.lib1_html_block["id"]),
-                LibraryContainerLocator.from_string(self.unit1["container_key"]),
+                LibraryContainerLocator.from_string(self.unit1["id"]),
             ],
         )
 
         event_receiver = mock.Mock()
         LIBRARY_COLLECTION_UPDATED.connect(event_receiver)
 
-        api.delete_container(LibraryContainerLocator.from_string(self.unit1["container_key"]))
+        api.delete_container(LibraryContainerLocator.from_string(self.unit1["id"]))
 
         assert event_receiver.call_count == 1
         self.assertDictContainsSubset(

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -509,7 +509,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
         """
         lib = self._create_library(slug="list_blocks-slug", title="Library 1")
         block1 = self._add_block_to_library(lib["id"], "problem", "problem1")
-        self._add_block_to_library(lib["id"], "unit", "unit1")
+        self._add_block_to_library(lib["id"], "html", "html1")
 
         response = self._get_library_blocks(lib["id"])
         result = response['results']
@@ -792,7 +792,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 description="Testing XBlocks limits in a library"
             )
             lib_id = lib["id"]
-            self._add_block_to_library(lib_id, "unit", "unit1")
+            self._add_block_to_library(lib_id, "html", "html1")
             # Second block should throw error
             self._add_block_to_library(lib_id, "problem", "problem1", expect_response=400)
 
@@ -981,14 +981,14 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
 
         library_key = LibraryLocatorV2.from_string(lib_id)
 
-        block = self._add_block_to_library(lib_id, "unit", "u1")
+        block = self._add_block_to_library(lib_id, "html", "h1")
         block_id = block["id"]
         self._set_library_block_asset(block_id, "static/test.txt", b"data")
 
         usage_key = LibraryUsageLocatorV2(
             lib_key=library_key,
-            block_type="unit",
-            usage_id="u1"
+            block_type="html",
+            usage_id="h1"
         )
 
         event_receiver.assert_called_once()
@@ -1020,7 +1020,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
 
         library_key = LibraryLocatorV2.from_string(lib_id)
 
-        block = self._add_block_to_library(lib_id, "unit", "u1")
+        block = self._add_block_to_library(lib_id, "html", "h321")
         block_id = block["id"]
         self._set_library_block_asset(block_id, "static/test.txt", b"data")
 
@@ -1028,8 +1028,8 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
 
         usage_key = LibraryUsageLocatorV2(
             lib_key=library_key,
-            block_type="unit",
-            usage_id="u1"
+            block_type="html",
+            usage_id="h321"
         )
 
         event_receiver.assert_called()

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -4,7 +4,6 @@ Tests for Learning-Core-based Content Libraries
 from datetime import datetime, timezone
 from unittest import skip
 from unittest.mock import Mock, patch
-from uuid import uuid4
 
 import ddt
 from django.contrib.auth.models import Group
@@ -344,9 +343,6 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             "last_draft_created_by": "Bob",
         })
         block_id = block_data["id"]
-        # Confirm that the result contains a definition key, but don't check its value,
-        # which for the purposes of these tests is an implementation detail.
-        assert 'def_key' in block_data
 
         # now the library should contain one block and have unpublished changes:
         assert self._get_library_blocks(lib_id)['results'] == [block_data]
@@ -1123,13 +1119,8 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             save_xblock_to_user_clipboard(block, author.id)
 
             # Paste the content of the clipboard into the library
-            pasted_block_id = str(uuid4())
-            paste_data = self._paste_clipboard_content_in_library(lib_id, pasted_block_id)
-            pasted_usage_key = LibraryUsageLocatorV2(
-                lib_key=library_key,
-                block_type="problem",
-                usage_id=pasted_block_id
-            )
+            paste_data = self._paste_clipboard_content_in_library(lib_id)
+            pasted_usage_key = LibraryUsageLocatorV2.from_string(paste_data["id"])
             self._get_library_block_asset(pasted_usage_key, "static/hello.txt")
 
             # Compare the two text files
@@ -1145,7 +1136,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
                 "last_draft_created": paste_data["last_draft_created"],
                 "created": paste_data["created"],
                 "modified": paste_data["modified"],
-                "id": f"lb:CL-TEST:test_lib_paste_clipboard:problem:{pasted_block_id}",
+                "id": f"lb:CL-TEST:test_lib_paste_clipboard:problem:{pasted_usage_key.block_id}",
             })
 
     @override_settings(LIBRARY_ENABLED_BLOCKS=['problem', 'video', 'html'])

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1084,7 +1084,7 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest, OpenEdxEventsTestMix
             event_receiver.call_args.kwargs
         )
 
-    def test_library_paste_clipboard(self):
+    def test_library_paste_xblock(self):
         """
         Check the a new block is created in the library after pasting from clipboard.
         The content of the new block should match the content of the block in the clipboard.

--- a/openedx/core/djangoapps/content_libraries/tests/test_course_to_library.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_course_to_library.py
@@ -1,0 +1,87 @@
+"""
+Tests for Imports from Courses to Learning-Core-based Content Libraries
+"""
+import ddt
+from opaque_keys.edx.locator import LibraryContainerLocator
+from openedx_events.content_authoring import signals
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import ToyCourseFactory
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content_libraries.tests.base import ContentLibrariesRestApiTest
+from openedx.core.djangolib.testing.utils import skip_unless_cms
+
+
+@skip_unless_cms
+@ddt.ddt
+class CourseToLibraryTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest, ModuleStoreTestCase):
+    """
+    Tests that involve copying content from courses to libraries.
+    """
+    ENABLED_OPENEDX_EVENTS = [
+        signals.LIBRARY_CONTAINER_CREATED.event_type,
+        signals.LIBRARY_CONTAINER_DELETED.event_type,
+        signals.LIBRARY_CONTAINER_UPDATED.event_type,
+    ]
+
+    def test_library_paste_unit_from_course(self):
+        """
+        Test that we can paste a Unit from a course into a Library, and it gets
+        converted from an XBlock to a Container.
+        """
+        # Create user to perform tests on
+        author = UserFactory.create(username="Author", email="author@example.com", is_staff=True)
+        with self.as_user(author):
+            lib = self._create_library(
+                slug="test_lib_paste_clipboard",
+                title="Paste Clipboard Test Library",
+                description="Testing pasting clipboard in library"
+            )
+            lib_id = lib["id"]
+
+            course_key = ToyCourseFactory.create().id  # See xmodule/modulestore/tests/sample_courses.py
+            unit_key = course_key.make_usage_key("vertical", "vertical_test")
+
+            # Copy the unit
+            self._api('post', "/api/content-staging/v1/clipboard/", {"usage_key": str(unit_key)}, expect_response=200)
+
+            # Paste the content of the clipboard into the library
+            paste_data = self._paste_clipboard_content_in_library(lib_id)
+            pasted_container_key = LibraryContainerLocator.from_string(paste_data["id"])
+
+            self.assertDictContainsEntries(self._get_container(paste_data["id"]), {
+                "id": str(pasted_container_key),
+                "container_type": "unit",
+                "display_name": "Unit",
+                "last_draft_created_by": author.username,
+                "last_draft_created": paste_data["last_draft_created"],
+                "created": paste_data["created"],
+                "modified": paste_data["modified"],
+                "last_published": None,
+                "published_by": "",
+                "has_unpublished_changes": True,
+                "collections": [],
+                "can_stand_alone": True,
+            })
+
+            children = self._get_container_components(paste_data["id"])
+            assert len(children) == 4
+
+            self.assertDictContainsEntries(children[0], {"display_name": "default", "block_type": "video"})
+            assert children[0]["id"].startswith("lb:CL-TEST:test_lib_paste_clipboard:video:default-")
+            assert "container_type" not in children[0]
+
+            self.assertDictContainsEntries(children[1], {"display_name": "default", "block_type": "video"})
+            assert children[1]["id"].startswith("lb:CL-TEST:test_lib_paste_clipboard:video:default-")
+            assert children[0]["id"] != children[1]["id"]
+
+            self.assertDictContainsEntries(children[2], {"display_name": "default", "block_type": "video"})
+            assert children[2]["id"].startswith("lb:CL-TEST:test_lib_paste_clipboard:video:default-")
+            assert children[0]["id"] != children[2]["id"]
+
+            self.assertDictContainsEntries(children[3], {
+                "display_name": "Change your answer",
+                "block_type": "poll_question",
+            })
+            assert children[3]["id"].startswith("lb:CL-TEST:test_lib_paste_clipboard:poll_question:change-your-answer-")

--- a/openedx/core/djangoapps/content_staging/api.py
+++ b/openedx/core/djangoapps/content_staging/api.py
@@ -110,17 +110,17 @@ def _save_static_assets_to_staged_content(
         )
         # Compute the MD5 hash and get the content:
         content: bytes | None = f.data
-        md5_hash = ""  # Unknown
         if content:
-            md5_hash = hashlib.md5(content).hexdigest()
             # This asset came from the XBlock's filesystem, e.g. a video block's transcript file
             source_key = usage_key
         # Check if the asset file exists. It can be absent if an XBlock contains an invalid link.
         elif source_key and (sc := contentstore().find(source_key, throw_on_not_found=False)):
-            md5_hash = sc.content_digest
             content = sc.data
-        else:
+            # Note that sc.content_digest has an md5_hash but it's sometimes NULL so we just compute it ourselves.
+        if not content:
             continue  # Skip this file - we don't need a reference to a non-existent file.
+        # Compute the md5 hash
+        md5_hash = hashlib.md5(content).hexdigest()
 
         # Because we store clipboard files on S3, uploading really large files will be too slow. And it's wasted if
         # the copy-paste is just happening within a single course. So for files > 10MB, users must copy the files


### PR DESCRIPTION
## Description

This PR provides the backend API updates requires so that users can [paste a unit from a course into a library](https://github.com/openedx/frontend-app-authoring/pull/1812).

It also fixes the pasting code so that the `block_id` (used in the URL) is now generated from the title of the copied thing, which creates much nicer usage keys / URLs while still avoiding conflicts.

It also cleans up the serializers and makes them use more common code.

It also fixes the following bugs 🐛:
* Sometimes when copying a block with static assets, the CMS console would show an error traceback: `fix: IntegrityError: "Column 'md5_hash' cannot be null"`
* Unsupported XBlocks like Vertical, Problem Builder, Split Test, etc. (i.e. blocks that have children) could be pasted into libraries if you requested it with the API, then all kinds of errors would show when trying to view them or index them.
* Remove deprecated `def_key` from the REST API response

## Supporting information

Relates to https://github.com/openedx/frontend-app-authoring/issues/1647 though this is technically the opposite of that. Pasting into a course proved too complicated to implement for now because it requires converting a container to an XBlock.

## Testing instructions

Test using https://github.com/openedx/frontend-app-authoring/pull/1812

## Deadline

ASAP

## Other information

Private ref: [FAL-4067](https://tasks.opencraft.com/browse/FAL-4067)