### PR TITLE
feat: update preference config when version is changed

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_models.py
+++ b/openedx/core/djangoapps/notifications/tests/test_models.py
@@ -1,0 +1,44 @@
+"""
+Test the notification app models
+"""
+import unittest
+from unittest import mock
+
+import pytest
+
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.notifications.base_notification import NotificationAppManager
+from openedx.core.djangoapps.notifications.models import CourseNotificationPreference, \
+    COURSE_NOTIFICATION_CONFIG_VERSION
+
+
+@pytest.mark.django_db
+class TestPreferenceModel(unittest.TestCase):
+    """
+    Test the CourseNotificationPreference model.
+    """
+
+    def test_get_user_notification_preferences_method(self):
+        """
+        Test the get_user_notification_preferences method. and check if version is updated properly.
+        """
+        # Create a mock user and notification preference
+        user = UserFactory()
+        CourseNotificationPreference.objects.create(
+            user_id=user.id,
+            course_id='course-v1:edX+DemoX+Demo_Course',
+            is_active=True,
+            notification_preference_config=NotificationAppManager().get_notification_app_preferences(True)
+        )
+        # Check if the notification preference is created
+        preference = CourseNotificationPreference.objects.get(user_id=user.id)
+        self.assertIsNotNone(preference)
+        self.assertTrue(preference.is_active)
+
+        with mock.patch(
+            'openedx.core.djangoapps.notifications.models.COURSE_NOTIFICATION_CONFIG_VERSION',
+            COURSE_NOTIFICATION_CONFIG_VERSION + 1
+        ):
+            updated_preferences = preference.get_user_notification_preferences(user)
+            for updated_preference in updated_preferences:
+                assert updated_preference.config_version == COURSE_NOTIFICATION_CONFIG_VERSION + 1

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -591,8 +591,7 @@ class AggregatedNotificationPreferences(APIView):
         """
         API view for getting the aggregate notification preferences for the current user.
         """
-        notification_preferences = CourseNotificationPreference.objects.filter(user=request.user, is_active=True)
-
+        notification_preferences = CourseNotificationPreference.get_user_notification_preferences(request.user)
         if not notification_preferences.exists():
             return Response({
                 'status': 'error',


### PR DESCRIPTION
## Description
Update notification preference version when a new version is available. This feature exists for course level settings API , this PR adds that feature for account-level settings. 


This pull request introduces a new method to handle user notification preferences and updates the associated tests and views. The main changes include adding the `get_user_notification_preferences` method, updating the test cases, and modifying the view to use the new method.

New method for handling user notification preferences:

* [`openedx/core/djangoapps/notifications/models.py`](diffhunk://#diff-afe3a5d9ce60e01c94f598693172702bf3db0fd73fbb6738eb31593ed071203aR175-R203): Added the `get_user_notification_preferences` method to check and update user preferences to the latest configuration version.

Updates to tests:

* [`openedx/core/djangoapps/notifications/tests/test_models.py`](diffhunk://#diff-850faacef450b9f3e06a8e878e48fd864157ca0866802da4111725c36781be58R1-R44): Added a test case for the `get_user_notification_preferences` method to ensure it correctly updates the version of user preferences.

Modifications to views:

* [`openedx/core/djangoapps/notifications/views.py`](diffhunk://#diff-ff9c6979d67deaf0053d33346b0f3eb30ab3ec9ae530227826ce685fa2a9e635L594-R594): Updated the view to use the new `get_user_notification_preferences` method for fetching user notification preferences.