### PR TITLE
fix: use MFE-aware URL instead of legacy when generating block URL

### DIFF
--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -29,6 +29,7 @@ from lms.djangoapps.edxnotes.plugins import EdxNotesTab
 from lms.lib.utils import get_parent_unit
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangolib.markup import Text
+from openedx.features.course_experience.url_helpers import get_courseware_url
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -246,6 +247,7 @@ def get_block_context(course, block):
     """
     Returns dispay_name and url for the parent block.
     """
+
     block_dict = {
         'location': str(block.location),
         'display_name': Text(block.display_name_with_default),
@@ -256,16 +258,8 @@ def get_block_context(course, block):
         course = block.get_parent()
         block_dict['index'] = get_index(block_dict['location'], course.children)
     elif block.category == 'vertical':
-        section = block.get_parent()
-        chapter = section.get_parent()
-        # Position starts from 1, that's why we add 1.
-        position = get_index(str(block.location), section.children) + 1
-        block_dict['url'] = reverse('courseware_position', kwargs={
-            'course_id': str(course.id),
-            'chapter': chapter.url_name,
-            'section': section.url_name,
-            'position': position,
-        })
+        # Use the MFE-aware URL generator instead of always using the legacy URL format
+        block_dict['url'] = get_courseware_url(block.location)
     if block.category in ('chapter', 'sequential'):
         block_dict['children'] = [str(child) for child in block.children]
 

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -247,7 +247,6 @@ def get_block_context(course, block):
     """
     Returns dispay_name and url for the parent block.
     """
-
     block_dict = {
         'location': str(block.location),
         'display_name': Text(block.display_name_with_default),


### PR DESCRIPTION


## Description

When using the Notes feature in a course with the Learning MFE enabled, clicking on a note from the Notes tab redirected users to the last visited unit rather than to the unit containing the note. This happened because the Notes component was generating URLs using the legacy format without considering whether the Learning MFE was active.

## Objective
Fix the EdxNotes feature to properly navigate to note locations when the Learning MFE is enabled, ensuring that when a user clicks on a note from the Notes tab, they are directed to the correct unit containing that note rather than to the last visited unit.

## Technical Approach

The issue was identified in the `get_block_context` function within helpers.py. This function was using a hardcoded approach to generate URLs for vertical blocks, which always produced URLs in the legacy format:

```python
elif block.category == 'vertical':
    section = block.get_parent()
    chapter = section.get_parent()
    # Position starts from 1, that's why we add 1.
    position = get_index(str(block.location), section.children) + 1
    block_dict['url'] = reverse('courseware_position', kwargs={
        'course_id': str(course.id),
        'chapter': chapter.url_name,
        'section': section.url_name,
        'position': position,
    })
```

The solution was to replace the legacy URL generation logic with a call to the existing `get_courseware_url` function from url_helpers.py. This function already handles proper URL generation based on whether the Learning MFE is active or not:

```python
elif block.category == 'vertical':
    # Use the MFE-aware URL generator instead of always using the legacy URL format
    block_dict['url'] = get_courseware_url(block.location)
```
## Achievements

- Correct navigation to notes: Users can now click on notes in the Notes tab and be taken directly to the unit containing the note, regardless of whether they're using the legacy or MFE experience.

- Consistent user experience: The navigation behavior is now consistent between the legacy view and Learning MFE, providing a seamless experience for users.

- Proper URL generation: The Notes component now generates URLs that are compatible with both legacy and MFE views by leveraging the platform's existing URL generation infrastructure.

## Testing cases

https://github.com/user-attachments/assets/f79e7044-d45b-4fa5-99a8-3d47eba0ad00

## Related Issues
[[TC_LEARNER_39] Notes tab linking not working](https://github.com/openedx/wg-build-test-release/issues/233)

