### PR TITLE
docs: Point to nvmrc for the official Node version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Interperters/Tools:
 
 * Python 3.11
 
-* See the ``.nvmrc`` file in this repository.
+* Node: See the ``.nvmrc`` file in this repository.
 
 Services:
 

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Interperters/Tools:
 
 * Python 3.11
 
-* Node 18
+* See the ``.nvmrc`` file in this repository.
 
 Services:
 


### PR DESCRIPTION
In Frontend repos we've moved to recommending viewing the .nvmrc file instead of having to remember to update the README anytime we do a Node upgrade.