### PR TITLE
TIA-49: Fixed tab focus styling

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   check-requirements:
     name: Compile requirements
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       # Only run remaining steps if there are changes to requirements/**

--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python-version:
           - "3.11"
-        os: ["ubuntu-22.04"]
+        os: ["ubuntu-24.04"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Setup npm
         run: npm i -g npm@10.5.x
@@ -63,7 +64,9 @@ jobs:
         run: |
           make base-requirements
 
-      - uses: c-hive/gha-npm-cache@v1
+      - name: Install npm
+        run: npm ci  
+
       - name: Run JS Tests
         env:
           TEST_SUITE: js-unit

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         python-version:
           - "3.11"
         # 'pinned' is used to install the latest patch version of Django
@@ -126,7 +126,7 @@ jobs:
     if: always()
     needs:
       - check_migrations
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         # uses: re-actors/alls-green@v1.2.1

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-pylint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +75,7 @@ jobs:
     if: always()
     needs:
       - run-pylint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         # uses: re-actors/alls-green@v1.2.1

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         python-version:
           - "3.11"
         node-version: [20]

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         python-version:
           - "3.11"
         node-version: [18, 20]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   run-tests:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os-version }}
     strategy:
       matrix:
         python-version:
@@ -43,22 +43,27 @@ jobs:
           - "xmodule-with-cms"
         mongo-version:
           - "7.0"
+        os-version:
+          - ubuntu-24.04
 
-        # We only need to test older versions of Mongo with modules that directly interface with Mongo (that is: xmodule.modulestore)
-        # This code is left here as an example for future refernce in case we need to reduce the number of shards we're
-        # testing but still have good confidence with older versions of mongo.  We use Mongo 4.4 in the example.
+        # It's useful to run some subset of the tests on the older version of Ubuntu
+        # so that we don't spend too many resources on this but can find major issues quickly
+        # while we're in a situation where we support two versions.  This section may be commented
+        # out when not in use to easily add/drop future support for any given major dependency.
         #
-        # exclude:
-        #   - mongo-version: "4.4"
-        # include:
-        #   - shard_name: "xmodule-with-cms"
-        #     python-version: "3.11"
-        #     django-version: "pinned"
-        #     mongo-version: "4.4"
-        #   - shard_name: "xmodule-with-lms"
-        #     python-version: "3.11"
-        #     django-version: "pinned"
-        #     mongo-version: "4.4"
+        # We're testing the older version of Ubuntu and running the xmodule tests since those rely on many
+        # dependent complex libraries and will hopefully catch most issues quickly.
+        include:
+          - shard_name: "xmodule-with-cms"
+            python-version: "3.11"
+            django-version: "pinned"
+            mongo-version: "7.0"
+            os-version: "ubuntu-22.04"
+          - shard_name: "xmodule-with-lms"
+            python-version: "3.11"
+            django-version: "pinned"
+            mongo-version: "7.0"
+            os-version: "ubuntu-22.04"
 
     steps:
       - name: checkout repo
@@ -90,19 +95,10 @@ jobs:
           activate = 1
           EOF
 
-      - name: install mongo version
-        run: |
-          if [[ "${{ matrix.mongo-version }}" != "4.4" ]]; then
-            wget -qO - https://www.mongodb.org/static/pgp/server-${{ matrix.mongo-version }}.asc | sudo apt-key add -
-            echo "deb https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/${{ matrix.mongo-version }} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${{ matrix.mongo-version }}.list
-            sudo apt-get update && sudo apt-get install -y mongodb-org="${{ matrix.mongo-version }}.*"
-          fi
-
-      - name: start mongod server for tests
-        run: |
-          sudo mkdir -p /data/db
-          sudo chmod -R a+rw /data/db
-          mongod &
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.11.0
+        with:
+          mongodb-version: ${{ matrix.mongo-version }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -164,7 +160,7 @@ jobs:
           overwrite: true
 
   collect-and-verify:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -229,7 +225,7 @@ jobs:
   # https://github.com/orgs/community/discussions/33579
   success:
     name: Unit tests successful
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: always()
     needs: [run-tests]
     steps:
@@ -240,7 +236,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
   compile-warnings-report:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [run-tests]
     steps:
       - uses: actions/checkout@v4
@@ -268,7 +264,7 @@ jobs:
           overwrite: true
 
   merge-artifacts:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [compile-warnings-report]
     steps:
       - name: Merge Pytest Warnings JSON Artifacts
@@ -288,7 +284,7 @@ jobs:
   # Combine and upload coverage reports.
   coverage:
     if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [run-tests]
     strategy:
       matrix:

--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -496,11 +496,11 @@ def _import_xml_node_to_parent(
 
     if xblock_class.has_children and temp_xblock.children:
         raise NotImplementedError("We don't yet support pasting XBlocks with children")
-    temp_xblock.parent = parent_key
     if copied_from_block:
         _fetch_and_set_upstream_link(copied_from_block, copied_from_version_num, temp_xblock, user)
     # Save the XBlock into modulestore. We need to save the block and its parent for this to work:
     new_xblock = store.update_item(temp_xblock, user.id, allow_not_found=True)
+    new_xblock.parent = parent_key
     parent_xblock.children.append(new_xblock.location)
     store.update_item(parent_xblock, user.id)
 

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/home.py
@@ -50,6 +50,10 @@ class StudioHomeSerializer(serializers.Serializer):
         child=serializers.CharField(),
         allow_empty=True
     )
+    allowed_organizations_for_libraries = serializers.ListSerializer(
+        child=serializers.CharField(),
+        allow_empty=True
+    )
     archived_courses = CourseCommonSerializer(required=False, many=True)
     can_access_advanced_settings = serializers.BooleanField()
     can_create_organizations = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_home.py
@@ -37,9 +37,10 @@ class HomePageViewTest(CourseTestCase):
         self.url = reverse("cms.djangoapps.contentstore:v1:home")
         self.expected_response = {
             "allow_course_reruns": True,
-            "allow_to_create_new_org": False,
+            "allow_to_create_new_org": True,
             "allow_unicode_course_id": False,
             "allowed_organizations": [],
+            "allowed_organizations_for_libraries": [],
             "archived_courses": [],
             "can_access_advanced_settings": True,
             "can_create_organizations": True,
@@ -80,6 +81,17 @@ class HomePageViewTest(CourseTestCase):
 
         expected_response = self.expected_response
         expected_response["libraries_v2_enabled"] = True
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(expected_response, response.data)
+
+    @override_settings(ORGANIZATIONS_AUTOCREATE=False)
+    def test_home_page_studio_with_org_autocreate_disabled(self):
+        """Check response content when Organization autocreate is disabled"""
+        response = self.client.get(self.url)
+
+        expected_response = self.expected_response
+        expected_response["allow_to_create_new_org"] = False
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(expected_response, response.data)

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -812,7 +812,7 @@ class ViewsTestCase(
             headers=ANY,
             params=ANY,
             timeout=ANY,
-            data={"body": updated_body}
+            data={"body": updated_body, "course_id": str(self.course_id)}
         )
 
     def test_flag_thread_open(self, mock_is_forum_v2_enabled, mock_request):

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -146,7 +146,7 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
         # If the user clicked a sort key, update their default sort key
         cc_user = cc.User.from_django_user(request.user)
         cc_user.default_sort_key = request.GET.get('sort_key')
-        cc_user.save()
+        cc_user.save(params={"course_id": str(course.id)})
 
     #there are 2 dimensions to consider when executing a search with respect to group id
     #is user a moderator
@@ -218,7 +218,7 @@ def inline_discussion(request, course_key, discussion_id):
     with function_trace('get_course_and_user_info'):
         course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=True)
         cc_user = cc.User.from_django_user(request.user)
-        user_info = cc_user.to_dict()
+        user_info = cc_user.to_dict(course_key=str(course_key))
 
     try:
         with function_trace('get_threads'):
@@ -356,7 +356,7 @@ def single_thread(request, course_key, discussion_id, thread_id):
 
     if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         cc_user = cc.User.from_django_user(request.user)
-        user_info = cc_user.to_dict()
+        user_info = cc_user.to_dict(course_key=str(course_key))
         is_staff = has_permission(request.user, 'openclose_thread', course.id)
 
         try:
@@ -471,7 +471,7 @@ def _create_base_discussion_view_context(request, course_key):
     """
     user = request.user
     cc_user = cc.User.from_django_user(user)
-    user_info = cc_user.to_dict()
+    user_info = cc_user.to_dict(course_key=str(course_key))
     course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
     course_settings = make_course_settings(course, user)
     return {

--- a/lms/static/sass/course/base/_extends.scss
+++ b/lms/static/sass/course/base/_extends.scss
@@ -19,6 +19,10 @@ h1.top-header {
   padding-bottom: lh();
 }
 
+h1.instructor-dashboard-title {
+  border-bottom: none !important;
+}
+
 .button-reset {
   text-transform: none;
   letter-spacing: 0;

--- a/lms/static/sass/lms-course.scss
+++ b/lms/static/sass/lms-course.scss
@@ -25,6 +25,19 @@
     }
 }
 
+/* tab focus styling */
+.page-content-nav button.nav-item {
+    &:focus {
+        box-shadow: 0 0 0 2px #015FCC !important;
+        border-color: #1b6d99 !important;
+    }
+    &:not(.is-active) {
+        &:focus {
+            border-color: transparent !important;
+        }
+    }
+}
+
 @media only screen and (max-width: 767px) {
     .survey-table .survey-option .visible-mobile-only {
         width: calc(100% - 21px) !important;

--- a/lms/templates/components/header/header.underscore
+++ b/lms/templates/components/header/header.underscore
@@ -9,7 +9,7 @@
             <% }) %>
             </nav>
         <% } %>
-        <h2 class="hd hd-2 page-title"><%- title %></h2>
+        <h1 class="hd hd-2 page-title"><%- title %></h1>
         <p class="page-description"><%- description %></p>
     </div>
     <div class="page-header-secondary"></div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -114,7 +114,7 @@ from openedx.core.djangolib.js_utils import (
   <div class="instructor-dashboard-wrapper-2">
         <main id="main" aria-label="Content" tabindex="-1">
         <section class="instructor-dashboard-content-2" id="instructor-dashboard-content">
-          <h2 class="hd hd-2 instructor-dashboard-title">${_("Instructor Dashboard")}</h2>
+          <h1 class="hd hd-2 instructor-dashboard-title">${_("Instructor Dashboard")}</h1>
           <div class="wrap-instructor-info studio-view">
             %if studio_url:
             <a class="instructor-info-action" href="${studio_url}">${_("View Course in Studio")}</a>

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -99,6 +99,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
+from cms.djangoapps.contentstore.views.course import (
+    get_allowed_organizations_for_libraries,
+    user_can_create_organizations,
+)
 from openedx.core.djangoapps.content_libraries import api, permissions
 from openedx.core.djangoapps.content_libraries.serializers import (
     ContentLibraryBlockImportTaskCreateSerializer,
@@ -270,6 +274,14 @@ class LibraryRootView(GenericAPIView):
         except InvalidOrganizationException:
             raise ValidationError(  # lint-amnesty, pylint: disable=raise-missing-from
                 detail={"org": f"No such organization '{org_name}' found."}
+            )
+        # Ensure the user is allowed to create libraries under this org
+        if not (
+            user_can_create_organizations(request.user) or
+            org_name in get_allowed_organizations_for_libraries(request.user)
+        ):
+            raise ValidationError(  # lint-amnesty, pylint: disable=raise-missing-from
+                detail={"org": f"User not allowed to create libraries in '{org_name}'."}
             )
         org = Organization.objects.get(short_name=org_name)
 

--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -63,14 +63,14 @@ class Comment(models.Model):
         else:
             return super().url(action, params)
 
-    def flagAbuse(self, user, voteable):
+    def flagAbuse(self, user, voteable, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_flag_abuse_thread(voteable.id)
         elif voteable.type == 'comment':
             url = _url_for_flag_abuse_comment(voteable.id)
         else:
             raise CommentClientRequestError("Can only flag/unflag threads or comments")
-        course_key = get_course_key(self.attributes.get("course_id"))
+        course_key = get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             if voteable.type == 'thread':
                 response = forum_api.update_thread_flag(
@@ -91,14 +91,14 @@ class Comment(models.Model):
             )
         voteable._update_from_response(response)
 
-    def unFlagAbuse(self, user, voteable, removeAll):
+    def unFlagAbuse(self, user, voteable, removeAll, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_unflag_abuse_thread(voteable.id)
         elif voteable.type == 'comment':
             url = _url_for_unflag_abuse_comment(voteable.id)
         else:
             raise CommentClientRequestError("Can flag/unflag for threads or comments")
-        course_key = get_course_key(self.attributes.get("course_id"))
+        course_key = get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             if voteable.type == "thread":
                 response = forum_api.update_thread_flag(

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -61,8 +61,8 @@ class Model:
     def get(self, *args, **kwargs):
         return self.attributes.get(*args, **kwargs)
 
-    def to_dict(self):
-        self.retrieve()
+    def to_dict(self, course_key=None):
+        self.retrieve(course_key=course_key)
         return self.attributes
 
     def retrieve(self, *args, **kwargs):
@@ -72,7 +72,7 @@ class Model:
         return self
 
     def _retrieve(self, *args, **kwargs):
-        course_id = self.attributes.get("course_id") or kwargs.get("course_id")
+        course_id = self.attributes.get("course_id") or kwargs.get("course_key")
         if course_id:
             course_key = get_course_key(course_id)
             use_forumv2 = is_forum_v2_enabled(course_key)
@@ -175,8 +175,8 @@ class Model:
         self._update_from_response(response)
         self.after_save(self)
 
-    def delete(self):
-        course_key = get_course_key(self.attributes.get("course_id"))
+    def delete(self, course_id=None):
+        course_key = get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = None
             if self.type == "comment":

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -80,6 +80,8 @@ class Thread(models.Model):
                     search_params.pop('commentable_id', None)
                 response = forum_api.search_threads(**search_params)
             else:
+                if user_id := params.get('user_id'):
+                    params['user_id'] = str(user_id)
                 response = forum_api.get_user_threads(**params)
         else:
             response = utils.perform_request(
@@ -196,12 +198,12 @@ class Thread(models.Model):
             )
         self._update_from_response(response)
 
-    def flagAbuse(self, user, voteable):
+    def flagAbuse(self, user, voteable, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_flag_abuse_thread(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only flag/unflag threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.update_thread_flag(voteable.id, "flag", user_id=user.id, course_id=str(course_key))
         else:
@@ -215,12 +217,12 @@ class Thread(models.Model):
             )
         voteable._update_from_response(response)
 
-    def unFlagAbuse(self, user, voteable, removeAll):
+    def unFlagAbuse(self, user, voteable, removeAll, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_unflag_abuse_thread(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only flag/unflag for threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.update_thread_flag(
                 thread_id=voteable.id,
@@ -244,8 +246,8 @@ class Thread(models.Model):
             )
         voteable._update_from_response(response)
 
-    def pin(self, user, thread_id):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def pin(self, user, thread_id, course_id=None):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.pin_thread(
                 user_id=user.id,
@@ -264,8 +266,8 @@ class Thread(models.Model):
             )
         self._update_from_response(response)
 
-    def un_pin(self, user, thread_id):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def un_pin(self, user, thread_id, course_id):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.unpin_thread(
                 user_id=user.id,

--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -50,8 +50,8 @@ class User(models.Model):
                 metric_tags=self._metric_tags + [f'target.type:{source.type}'],
             )
 
-    def follow(self, source):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def follow(self, source, course_id=None):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             forum_api.create_subscription(
                 user_id=self.id,
@@ -68,8 +68,8 @@ class User(models.Model):
                 metric_tags=self._metric_tags + [f'target.type:{source.type}'],
             )
 
-    def unfollow(self, source):
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+    def unfollow(self, source, course_id=None):
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             forum_api.delete_subscription(
                 user_id=self.id,
@@ -86,14 +86,14 @@ class User(models.Model):
                 metric_tags=self._metric_tags + [f'target.type:{source.type}'],
             )
 
-    def vote(self, voteable, value):
+    def vote(self, voteable, value, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_vote_thread(voteable.id)
         elif voteable.type == 'comment':
             url = _url_for_vote_comment(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only vote / unvote for threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             if voteable.type == 'thread':
                 response = forum_api.update_thread_votes(
@@ -120,14 +120,14 @@ class User(models.Model):
             )
         voteable._update_from_response(response)
 
-    def unvote(self, voteable):
+    def unvote(self, voteable, course_id=None):
         if voteable.type == 'thread':
             url = _url_for_vote_thread(voteable.id)
         elif voteable.type == 'comment':
             url = _url_for_vote_comment(voteable.id)
         else:
             raise utils.CommentClientRequestError("Can only vote / unvote for threads or comments")
-        course_key = utils.get_course_key(self.attributes.get("course_id"))
+        course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             if voteable.type == 'thread':
                 response = forum_api.delete_thread_vote(

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -105,13 +105,6 @@ event-tracking==3.0.0
 # https://github.com/openedx/edx-platform/issues/31616
 libsass==0.10.0
 
-# Date: 2024-04-30
-# lxml>=5.0 introduced breaking changes related to system dependencies
-# lxml==5.2.1 introduced new extra so we'll nee to rename lxml --> lxml[html-clean]
-# This constraint can be removed once we upgrade to Python 3.11
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35272
-lxml<5.0
-
 # Date: 2018-12-14
 # markdown>=3.4.0 has failures due to internal refactorings which causes the tests to fail
 # pinning the version untill the issue gets resolved in the package itself
@@ -192,8 +185,3 @@ social-auth-app-django<=5.4.1
 # # Date: 2024-10-14
 # # The edx-enterprise is currently using edx-rest-api-client==5.7.1, which needs to be updated first.
 # edx-rest-api-client==5.7.1
-
-# Date: 2024-04-24
-# xmlsec==1.3.14 breaking tests or all builds, can be removed once a fix is available
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35264
-xmlsec<1.3.14

--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -2,7 +2,7 @@
 
 chem                                # A helper library for chemistry calculations
 cryptography                        # Implementations of assorted cryptography algorithms
-lxml                                # XML parser
+lxml[html_clean]                    # XML parser
 matplotlib                          # 2D plotting library
 networkx                            # Utilities for creating, manipulating, and studying network graphs
 nltk                                # Natural language processing; used by the chem package

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -26,11 +26,13 @@ joblib==1.4.2
     # via nltk
 kiwisolver==1.4.7
     # via matplotlib
-lxml==4.9.4
+lxml[html-clean,html_clean]==5.3.0
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/base.in
+    #   lxml-html-clean
     #   openedx-calc
+lxml-html-clean==0.3.1
+    # via lxml
 markupsafe==3.0.2
     # via
     #   chem

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -170,7 +170,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -715,19 +715,21 @@ loremipsum==1.0.5
     # via ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/kernel.in
-lxml==4.9.4
+lxml[html-clean,html_clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via lxml
 mailsnake==1.6.4
     # via -r requirements/edx/bundled.in
 mako==1.3.6
@@ -836,7 +838,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.2.0
     # via -r requirements/edx/kernel.in
 openedx-learning==0.18.1
     # via
@@ -1301,10 +1303,8 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   python3-saml
+xmlsec==1.3.14
+    # via python3-saml
 xss-utils==0.6.0
     # via -r requirements/edx/kernel.in
 yarl==1.16.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -337,7 +337,7 @@ distlib==0.3.9
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1193,14 +1193,14 @@ lti-consumer-xblock==9.11.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-lxml==4.9.4
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -1208,6 +1208,11 @@ lxml==4.9.4
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   lxml
 mailsnake==1.6.4
     # via
     #   -r requirements/edx/doc.txt
@@ -1388,7 +1393,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2293,9 +2298,8 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
+xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -863,19 +863,23 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/base.txt
-lxml==4.9.4
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
 mako==1.3.6
@@ -1003,7 +1007,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.1
     # via
@@ -1607,9 +1611,8 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
+xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -227,7 +227,7 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -103,7 +103,7 @@ importlib_metadata                  # Used to access entry_points in i18n_api pl
 jsonfield                           # Django model field for validated JSON; used in several apps
 laboratory                          # Library for testing that code refactors/infrastructure changes produce identical results
 importlib_metadata                  # Used to access entry_points in i18n_api plugin
-lxml                                # XML parser
+lxml[html_clean]                    # XML parser
 lti-consumer-xblock>=7.3.0
 mako                                # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -253,7 +253,7 @@ dill==0.3.9
     # via pylint
 distlib==0.3.9
     # via virtualenv
-django==4.2.19
+django==4.2.20
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -906,13 +906,13 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==9.11.3
     # via -r requirements/edx/base.txt
-lxml==4.9.4
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
     #   lti-consumer-xblock
+    #   lxml-html-clean
     #   olxcleaner
     #   openedx-calc
     #   ora2
@@ -920,6 +920,10 @@ lxml==4.9.4
     #   python3-saml
     #   xblock
     #   xmlsec
+lxml-html-clean==0.3.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   lxml
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
 mako==1.3.6
@@ -1048,7 +1052,7 @@ openedx-filters==1.11.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.1.5
+openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
 openedx-learning==0.18.1
     # via
@@ -1694,9 +1698,8 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xmlsec==1.3.13
+xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.6.0

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -77,10 +77,8 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lxml==4.9.4
-    # via
-    #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
-    #   zeep
+lxml==5.3.0
+    # via zeep
 more-itertools==10.5.0
     # via simple-salesforce
 newrelic==10.2.0

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -35,7 +35,7 @@ click==8.1.6
     #   edx-django-utils
 cryptography==43.0.3
     # via pyjwt
-django==4.2.19
+django==4.2.20
     # via
     #   -c scripts/user_retirement/requirements/../../../requirements/common_constraints.txt
     #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -116,7 +116,7 @@ jmespath==1.0.1
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
     #   botocore
-lxml==4.9.4
+lxml==5.3.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -52,7 +52,7 @@ cryptography==43.0.3
     #   pyjwt
 ddt==1.7.2
     # via -r scripts/user_retirement/requirements/testing.in
-django==4.2.19
+django==4.2.20
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django-crum


### PR DESCRIPTION
## Description
Related to https://github.com/overhangio/tutor-indigo/issues/146
On the Teams tab, press left arrow key to bring the focus on **“My team”** notice that the bottom indicator spreads through all the tabs, and doesn't stay specific to My team's tab
![image](https://github.com/user-attachments/assets/f0ce1f6a-a549-4586-bfc6-976f8a35127e)

Useful information to include:

- All user roles "Learner", "Course Author", "Developer", and "Operator".
- When the focus at the tabs, focus should only move using left right error key, and on enter that tab should become active.
![image](https://github.com/user-attachments/assets/cf3f8da9-2756-4948-b870-017d3832ebd5)

After the fix, the focus should move with arrow key without spaning the bottom line on all the tab's bottom, and on pressing **Enter** key, it should be active.
<img width="473" alt="Screenshot 2025-04-17 at 3 47 30 AM" src="https://github.com/user-attachments/assets/b5dc303f-afdd-4423-aff2-1e55574c24e9" />

## Supporting information

To have more context on the ticket, please have a look at [here](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/49)(if someone have access)

## Testing instructions

One can simply pull the changes on local and build image, the changes should be reflected.

## Deadline

N/A

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere? *No*
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility. *No Limitations*
- *No Database Migrations*