### PR TITLE
feat: REST API to publish the changes to a container [FC-0083]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -905,6 +905,17 @@ def publish_component_changes(usage_key: LibraryUsageLocatorV2, user: UserType):
         )
     )
 
+    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal and set background=True to trigger
+    # container indexing asynchronously.
+    affected_containers = get_containers_contains_component(usage_key)
+    for container in affected_containers:
+        LIBRARY_CONTAINER_UPDATED.send_event(
+            library_container=LibraryContainerData(
+                container_key=container.container_key,
+                background=True,
+            )
+        )
+
 
 def _component_exists(usage_key: UsageKeyV2) -> bool:
     """

--- a/openedx/core/djangoapps/content_libraries/rest_api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/blocks.py
@@ -233,7 +233,15 @@ class LibraryBlockPublishView(APIView):
 
     @convert_exceptions
     def post(self, request, usage_key_str):
+        """
+        Publish the draft changes made to this component.
+        """
         key = LibraryUsageLocatorV2.from_string(usage_key_str)
+        api.require_permission_for_library_key(
+            key.lib_key,
+            request.user,
+            permissions.CAN_EDIT_THIS_CONTENT_LIBRARY
+        )
         api.publish_component_changes(key, request.user)
         return Response({})
 

--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -328,3 +328,25 @@ class LibraryContainerCollectionsView(GenericAPIView):
         )
 
         return Response({'count': len(collection_keys)})
+
+
+@method_decorator(non_atomic_requests, name="dispatch")
+@view_auth_classes()
+class LibraryContainerPublishView(GenericAPIView):
+    """
+    View to publish a container, or revert to last published.
+    """
+    @convert_exceptions
+    def post(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
+        """
+        Publish the container and its children
+        """
+        api.require_permission_for_library_key(
+            container_key.library_key,
+            request.user,
+            permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
+        )
+        api.publish_container_changes(container_key, request.user.id)
+        # If we need to in the future, we could return a list of all the child containers/components that were
+        # auto-published as a result.
+        return Response({})

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -36,6 +36,7 @@ URL_LIB_CONTAINER = URL_PREFIX + 'containers/{container_key}/'  # Get a containe
 URL_LIB_CONTAINER_COMPONENTS = URL_LIB_CONTAINER + 'children/'  # Get, add or delete a component in this container
 URL_LIB_CONTAINER_RESTORE = URL_LIB_CONTAINER + 'restore/'  # Restore a deleted container
 URL_LIB_CONTAINER_COLLECTIONS = URL_LIB_CONTAINER + 'collections/'  # Handle associated collections
+URL_LIB_CONTAINER_PUBLISH = URL_LIB_CONTAINER + 'publish/'  # Publish changes to the specified container + children
 
 URL_LIB_LTI_PREFIX = URL_PREFIX + 'lti/1.3/'
 URL_LIB_LTI_JWKS = URL_LIB_LTI_PREFIX + 'pub/jwks/'
@@ -455,3 +456,7 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
             {'collection_keys': collection_keys},
             expect_response
         )
+
+    def _publish_container(self, container_key, expect_response=200):
+        """ Publish all changes in the specified container + children """
+        return self._api('post', URL_LIB_CONTAINER_PUBLISH.format(container_key=container_key), None, expect_response)

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -84,7 +84,8 @@ urlpatterns = [
             path('restore/', containers.LibraryContainerRestore.as_view()),
             # Update collections for a given container
             path('collections/', containers.LibraryContainerCollectionsView.as_view(), name='update-collections-ct'),
-            # path('publish/', views.LibraryContainerPublishView.as_view()),
+            # Publish a container (or reset to last published)
+            path('publish/', containers.LibraryContainerPublishView.as_view()),
         ])),
         re_path(r'^lti/1.3/', include([
             path('login/', libraries.LtiToolLoginView.as_view(), name='lti-login'),


### PR DESCRIPTION
## Description

Implements https://github.com/openedx/frontend-app-authoring/issues/1710 . Adds new REST + python APIs into content libraries that can be used to publish a single container and its children, without publishing the whole library. Publishing "all changes in the library" is already possible.

Needed for https://github.com/openedx/frontend-app-authoring/pull/1827 and can be tested using that UI.


## Testing instructions

See other PR.

## Deadline

ASAP - needed for Teak

Private ref [FAL-4069](https://tasks.opencraft.com/browse/FAL-4069)

