### PR TITLE
(minor) Remove usage of deprecated key types / params in libraries code [FC-0083]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -192,7 +192,7 @@ def create_container(
         slug = slugify(title, allow_unicode=True) + '-' + uuid4().hex[-6:]
     # Make sure the slug is valid by first creating a key for the new container:
     container_key = LibraryContainerLocator(
-        library_key=library_key,
+        library_key,
         container_type=container_type.value,
         container_id=slug,
     )

--- a/openedx/core/djangoapps/xblock/api.py
+++ b/openedx/core/djangoapps/xblock/api.py
@@ -19,7 +19,7 @@ from django.utils.translation import gettext as _
 from openedx_learning.api import authoring as authoring_api
 from openedx_learning.api.authoring_models import Component, ComponentVersion
 from opaque_keys.edx.keys import UsageKeyV2
-from opaque_keys.edx.locator import BundleDefinitionLocator, LibraryUsageLocatorV2
+from opaque_keys.edx.locator import LibraryUsageLocatorV2
 from rest_framework.exceptions import NotFound
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchUsage, NoSuchViewError


### PR DESCRIPTION
## Description

The opaque key type `BundleDefinitionLocator` has been [deprecated](https://github.com/openedx/public-engineering/issues/238) for some time, with a target removal of Redwood. This PR just removes the last mention of it from edx-platform so that we can safely delete it from opaque-keys anytime after this PR has merged.

Also, we realized that the very new `LibraryContainerLocator` and `LibraryCollectionLocator` key types use `library_key` for the library key instead of `lib_key` as the (more established) `LibraryUsageLocatorV2` key type does. This PR ensures that the code in edx-platform will work either way, so that [we can rename the field in the new key types to `lib_key` for consistency](https://github.com/openedx/opaque-keys/pull/377).

## Supporting information

As discovered in https://github.com/openedx/edx-platform/commit/24ec901b0c261f017eb7f760698598b57d261d57#r155569458 

## Testing instructions

Ensuring that tests are passing should be enough here.

## Deadline

Teak (Thursday)

Private ref: FAL-4147