### PR TITLE
fix: unpin thread api calling returning 500 error

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -266,7 +266,7 @@ class Thread(models.Model):
             )
         self._update_from_response(response)
 
-    def un_pin(self, user, thread_id, course_id):
+    def un_pin(self, user, thread_id, course_id=None):
         course_key = utils.get_course_key(self.attributes.get("course_id") or course_id)
         if is_forum_v2_enabled(course_key):
             response = forum_api.unpin_thread(


### PR DESCRIPTION
Unpin thread API call returning 500 error

Ticket: [INF-1849](https://2u-internal.atlassian.net/browse/INF-1849)