### PR TITLE
feat: calculate grades csv to DRF

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2790,6 +2790,7 @@ class CalculateGradesCsvView(DeveloperErrorViewMixin, APIView):
 
         return Response({"status": success_status})
 
+
 @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
 @method_decorator(transaction.non_atomic_requests, name='dispatch')
 class ProblemGradeReport(DeveloperErrorViewMixin, APIView):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2768,23 +2768,27 @@ def export_ora2_submission_files(request, course_id):
     })
 
 
-@transaction.non_atomic_requests
-@require_POST
-@ensure_csrf_cookie
-@cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.CAN_RESEARCH)
-@common_exceptions_400
-def calculate_grades_csv(request, course_id):
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
+class CalculateGradesCsvView(DeveloperErrorViewMixin, APIView):
     """
+    Initiates a Celery task to calculate grades CSV.
     AlreadyRunningError is raised if the course's grades are already being updated.
     """
-    report_type = _('grade')
-    course_key = CourseKey.from_string(course_id)
-    task_api.submit_calculate_grades_csv(request, course_key)
-    success_status = SUCCESS_MESSAGE_TEMPLATE.format(report_type=report_type)
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.CAN_RESEARCH
 
-    return JsonResponse({"status": success_status})
+    @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True))
+    @method_decorator(ensure_csrf_cookie)
+    def post(self, request, course_id):
+        """
+        Initiates a Celery task to calculate grades CSV.
+        """
+        report_type = _('grade')
+        course_key = CourseKey.from_string(course_id)
+        task_api.submit_calculate_grades_csv(request, course_key)
+        success_status = SUCCESS_MESSAGE_TEMPLATE.format(report_type=report_type)
 
+        return Response({"status": success_status})
 
 @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
 @method_decorator(transaction.non_atomic_requests, name='dispatch')

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
 
     # Grade downloads...
     path('list_report_downloads', api.ListReportDownloads.as_view(), name='list_report_downloads'),
-    path('calculate_grades_csv', api.calculate_grades_csv, name='calculate_grades_csv'),
+    path('calculate_grades_csv', api.CalculateGradesCsvView.as_view(), name='calculate_grades_csv'),
     path('problem_grade_report', api.ProblemGradeReport.as_view(), name='problem_grade_report'),
 
     # Reports..


### PR DESCRIPTION
#35356 issue for tracking

## Description

Converts the function-based calculate_grades_csv view to a DRF class-based view
This change maintains all existing functionality while providing a more standardized API structure.

Key changes:
- Created CalculateGradesCsvView class inheriting from APIView
- Maintained existing permission requirements
- No functional changes, purely architectural improvement for consistency and maintainability.

To Test the api, try POST request on this [url](http://local.openedx.io:8000/courses/course-v1:OpenedX+DemoX+DemoCourse/instructor/api/calculate_grades_csv)

expected response:
`{"status": "The grade report is being created. To view the status of the report, see Pending Tasks below."}
`

a celery task will be triggered and a csv file will be generated.


### verify via instructor dashbaord

1. go to this [page](http://local.openedx.io:8000/courses/course-v1:OpenedX+DemoX+DemoCourse/instructor#view-data_download)

2. click on the button "Generate Grade Report"

3. A csv file will be ready to be downloaded once the celery task is completed

output like this will be generated:
<img width="1309" alt="Screenshot 2025-04-22 at 2 22 44 PM" src="https://github.com/user-attachments/assets/474a72d5-6c1f-4d26-9a5a-9b9d73bc8649" />
