### PR TITLE
fix: Add info for ORA notifications and fix for account preferences

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -193,7 +193,7 @@ COURSE_NOTIFICATION_TYPES = {
         'notification_app': 'grading',
         'name': 'ora_staff_notifications',
         'is_core': False,
-        'info': '',
+        'info': 'Notifications for when a submission is made for ORA that includes staff grading step.',
         'web': True,
         'email': False,
         'push': False,

--- a/openedx/core/djangoapps/notifications/serializers.py
+++ b/openedx/core/djangoapps/notifications/serializers.py
@@ -21,10 +21,48 @@ from .utils import remove_preferences_with_no_access
 
 def add_info_to_notification_config(config_obj):
     """
-    Add info of all notification types
+    Enhances the notification configuration by appending descriptive 'info' to each notification type.
+
+    This function supports two different structures of `config_obj`, depending on the source of the data:
+    either from the account preferences API (`AggregatedNotificationPreferences`) or the course preferences
+    API (`UserNotificationPreferenceView`).
+
+    Supported input structures:
+
+    1. From account preferences API:
+        {
+            'notification_app': {
+                'notification_types': {
+                    'core': { ... },
+                    'non-core': { ... }
+                }
+            }
+        }
+
+    2. From course preferences API:
+        {
+            'notification_preference_config': {
+                'notification_app': {
+                    'notification_types': {
+                        'core': { ... },
+                        'non-core': { ... }
+                    }
+                }
+            }
+        }
+
+    For each notification type:
+    - If the type is 'core', its info is fetched from `COURSE_NOTIFICATION_APPS[notification_app]['core_info']`.
+    - For all other types, info is fetched from `COURSE_NOTIFICATION_TYPES[notification_type]['info']`.
+
+    Parameters:
+        config_obj (dict): The notification configuration object to enhance.
+
+    Returns:
+        dict: The enhanced configuration object with added 'info' fields.
     """
 
-    config = config_obj['notification_preference_config']
+    config = config_obj.get('notification_preference_config', config_obj)
     for notification_app, app_prefs in config.items():
         notification_types = app_prefs.get('notification_types', {})
         for notification_type, type_prefs in notification_types.items():

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -374,7 +374,8 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'email': False,
                             'push': False,
                             'email_cadence': 'Daily',
-                            'info': ''
+                            'info': 'Notifications for when a submission is made for ORA that includes staff grading '
+                                    'step.'
                         },
                         'core': {
                             'web': True,
@@ -1360,7 +1361,7 @@ class GetAggregateNotificationPreferencesTest(APITestCase):
         Test case: Active notification preferences found for the user
         """
         # Mock aggregate_notification_configs for a controlled output
-        mock_aggregate.return_value = {'mocked': 'data'}
+        mock_aggregate.return_value = {'mocked': {'notification_types': {}}}
 
         # Create active notification preferences for the user
         CourseNotificationPreference.objects.create(
@@ -1368,12 +1369,11 @@ class GetAggregateNotificationPreferencesTest(APITestCase):
             is_active=True,
             notification_preference_config={'example': 'config'}
         )
-
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'success')
         self.assertEqual(response.data['message'], 'Notification preferences retrieved')
-        self.assertEqual(response.data['data'], {'mocked': 'data'})
+        self.assertEqual(response.data['data'], {'mocked': {'notification_types': {}}})
 
     def test_unauthenticated_user(self):
         """

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -18,9 +18,12 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.djangoapps.student.models import CourseEnrollment
+from openedx.core.djangoapps.notifications.email import ONE_CLICK_EMAIL_UNSUB_KEY
 from openedx.core.djangoapps.notifications.email.utils import update_user_preferences_from_patch
 from openedx.core.djangoapps.notifications.models import get_course_notification_preference_config_version
 from openedx.core.djangoapps.notifications.permissions import allow_any_authenticated_user
+from openedx.core.djangoapps.notifications.serializers import add_info_to_notification_config
+from openedx.core.djangoapps.user_api.models import UserPreference
 
 from .base_notification import COURSE_NOTIFICATION_APPS
 from .config.waffle import ENABLE_NOTIFICATIONS
@@ -29,7 +32,7 @@ from .events import (
     notification_preferences_viewed_event,
     notification_read_event,
     notification_tray_opened_event,
-    notifications_app_all_read_event,
+    notifications_app_all_read_event
 )
 from .models import CourseNotificationPreference, Notification
 from .serializers import (
@@ -39,10 +42,11 @@ from .serializers import (
     UserNotificationPreferenceUpdateAllSerializer,
     UserNotificationPreferenceUpdateSerializer
 )
-from .utils import get_show_notifications_tray, aggregate_notification_configs, \
-    filter_out_visible_preferences_by_course_ids
-from openedx.core.djangoapps.user_api.models import UserPreference
-from openedx.core.djangoapps.notifications.email import ONE_CLICK_EMAIL_UNSUB_KEY
+from .utils import (
+    aggregate_notification_configs,
+    filter_out_visible_preferences_by_course_ids,
+    get_show_notifications_tray
+)
 
 
 @allow_any_authenticated_user()
@@ -605,6 +609,7 @@ class AggregatedNotificationPreferences(APIView):
             notification_preferences.values_list('course_id', flat=True),
         )
         notification_preferences_viewed_event(request)
+        notification_configs = add_info_to_notification_config(notification_configs)
         return Response({
             'status': 'success',
             'message': 'Notification preferences retrieved',


### PR DESCRIPTION
## Description

This PR 
1. Added Info Icon for ORA Staff Grading Notification Included an info icon with the tooltip: “Notifications for when a submission is made for ORA that includes staff grading step.”
2. Added Info Icons to Account Preferences Notification Types

## Supporting information

https://2u-internal.atlassian.net/browse/INF-1376

## Testing instructions

1. Hover over the info icon next to the "New ORA submission for staff grading" preference. Tooltip appears with the text:
“Notifications for when a submission is made for ORA that includes staff grading step.”
2. On the Account Preferences, Verify info icon is present next to notification type for New ORA submission for staff grading and Activity notifications




