### PR TITLE
fix: don't send emails to unregistered users

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -140,7 +140,8 @@ def enroll_email(
     `auto_enroll` determines what is put in CourseEnrollmentAllowed.auto_enroll
         if auto_enroll is set, then when the email registers, they will be
         enrolled in the course automatically.
-    `message_students` determines if student should be notified of action by email or push message.
+    `message_students` determines if student(only if he has a registered user) 
+        should be notified of action by email or push message.
     `message_params` parameters used while parsing message templates (a `dict`).
     `language` is the language used to render the email.
 
@@ -192,7 +193,7 @@ def enroll_email(
             message_params['email_address'] = student_email
             if previous_state.user:
                 message_params['user_id'] = previous_state.user.id
-            send_mail_to_student(student_email, message_params, language=language)
+                send_mail_to_student(student_email, message_params, language=language)
 
     after_state = EmailEnrollmentState(course_id, student_email)
 


### PR DESCRIPTION
Ticket: [TNL-11014](https://2u-internal.atlassian.net/browse/TNL-11014)
- Don't send enrollment emails to unregistered users via batch enrollment feature from instructor tab.

Previous:
- This message (`Email cannot be sent to the following users via batch enrollment. They will be enrolled once they register:` was shown when an instructor tries to send email to unregistered user on the platform. But users were getting emails although the message clearly says Email cannot be sent to the following users via batch enrollment until user register.
2U [Doc](https://2u-internal.atlassian.net/wiki/spaces/ENGAGE/pages/12025987/Account+Activation#Account-activation-for-enrollment:~:text=Bulk/Batch%20enrollment%3A%20A%20user%20still%20needs%20to%20verify%20their%20email%20address%20before%20an%20instructor%20can%20bulk%20enroll%20them.%20Here%20is%20the%20code%20to%20check%20that%20checks%20that%20only%20verified%20learners%20can%20enroll%20through%20batch%20enrollment.).

After:
- Now emails will not be sent to unregistered emails as said in the message.