### PR TITLE
fix: Race condition with delete component and refresh children count in collection/unit [FC-0083]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -289,14 +289,13 @@ def set_library_block_olx(usage_key: LibraryUsageLocatorV2, new_olx_str: str) ->
         )
     )
 
-    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal and set background=True to trigger
-    # container indexing asynchronously.
+    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal
+    # synchronously to avoid a race condition with query invalidation
     affected_containers = get_containers_contains_component(usage_key)
     for container in affected_containers:
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=container.container_key,
-                background=True,
             )
         )
 
@@ -658,8 +657,8 @@ def delete_library_block(
         )
     )
 
-    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
-    # collection indexing asynchronously.
+    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal
+    # synchronously to avoid a race condition with query invalidation
     #
     # To delete the component on collections
     for collection in affected_collections:
@@ -669,19 +668,17 @@ def delete_library_block(
                     library_key=library_key,
                     collection_key=collection.key,
                 ),
-                background=True,
             )
         )
 
-    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal and set background=True to trigger
-    # container indexing asynchronously.
+    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal
+    # synchronously to avoid a race condition with query invalidation
     #
     # To update the components count in containers
     for container in affected_containers:
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=container.container_key,
-                background=True,
             )
         )
 
@@ -716,8 +713,8 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None 
         ),
     )
 
-    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal and set background=True to trigger
-    # collection indexing asynchronously.
+    # For each collection, trigger LIBRARY_COLLECTION_UPDATED signal
+    # synchronously to avoid a race condition with query invalidation
     #
     # To restore the component in the collections
     for collection in affected_collections:
@@ -727,12 +724,11 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None 
                     library_key=library_key,
                     collection_key=collection.key,
                 ),
-                background=True,
             )
         )
 
-    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal and set background=True to trigger
-    # container indexing asynchronously.
+    # For each container, trigger LIBRARY_CONTAINER_UPDATED signal
+    # synchronously to avoid a race condition with query invalidation
     #
     # To update the components count in containers
     affected_containers = get_containers_contains_component(usage_key)
@@ -740,7 +736,6 @@ def restore_library_block(usage_key: LibraryUsageLocatorV2, user_id: int | None 
         LIBRARY_CONTAINER_UPDATED.send_event(
             library_container=LibraryContainerData(
                 container_key=container.container_key,
-                background=True,
             )
         )
 

--- a/openedx/core/djangoapps/content_libraries/library_context.py
+++ b/openedx/core/djangoapps/content_libraries/library_context.py
@@ -126,6 +126,5 @@ class LibraryContextImpl(LearningContext):
             LIBRARY_CONTAINER_UPDATED.send_event(
                 library_container=LibraryContainerData(
                     container_key=container.container_key,
-                    background=True,
                 )
             )

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -621,7 +621,7 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
                         self.lib1.library_key,
                         collection_key=self.col1.key,
                     ),
-                    background=True,
+                    background=False,
                 ),
             },
             event_receiver.call_args_list[0].kwargs,
@@ -684,7 +684,7 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest, OpenEdxEventsTe
                         self.lib1.library_key,
                         collection_key=self.col1.key,
                     ),
-                    background=True,
+                    background=False,
                 ),
             },
             event_receiver.call_args_list[0].kwargs,
@@ -897,7 +897,7 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, OpenEdxEventsTes
                 "sender": None,
                 "library_container": LibraryContainerData(
                     container_key=self.unit1.container_key,
-                    background=True,
+                    background=False,
                 )
             },
             event_mock.call_args_list[0].kwargs,
@@ -908,7 +908,7 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest, OpenEdxEventsTes
                 "sender": None,
                 "library_container": LibraryContainerData(
                     container_key=self.unit2.container_key,
-                    background=True,
+                    background=False,
                 )
             },
             event_mock.call_args_list[1].kwargs,


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Updates the code to send events synchronously to avoid a race condition with query invalidation
- Which edX user roles will this change impact? "Course Author.

## Supporting information

- Github comment: https://github.com/openedx/edx-platform/pull/36552#discussion_r2052753691
- Internal ticket: [FAL-4062](https://tasks.opencraft.com/browse/FAL-4062)

## Testing instructions

- You can see the issue on the actual version (2025-04-22) of [tagging-sandbox](https://app.tagging-preview.staging.do.opencraft.hosting/authoring/library/lib:SampleTaxonomyOrg1:chrislibrary3)
- Go to the library home of a Unit
- Create a Collection and a Unit
- Create a new component.
- Add the component in both Collection and Unit.
- Return to the library home and delete the component.
- Verify that the count is updated (Bug: the component is not updated in the sandbox)

## Deadline

ASAP, before Teak

## Other information

N/A