### PR TITLE
feat: Explicit mapping from container_types to OLX tags

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 import logging
-import typing as t
 from uuid import uuid4
 
 from django.utils.text import slugify
@@ -89,7 +88,7 @@ class ContainerType(Enum):
         raise TypeError(f"unexpected ContainerType: {self!r}")
 
     @classmethod
-    def from_source_olx_tag(cls, olx_tag: str) -> t.Self:
+    def from_source_olx_tag(cls, olx_tag: str) -> 'ContainerType':
         """
         Get the ContainerType that this OLX tag maps to.
         """


### PR DESCRIPTION
This is needed by several aspects of the Teak Libraries Overhaul (https://github.com/orgs/openedx/projects/66) including:
* copy-paste of containers between courses and V2 libraries
* syncing of containers in courses from V2 libraries
* the import_from_modulestore API