### PR TITLE
fix: message after email is sent via batch enrollment

### DIFF
--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -789,7 +789,7 @@ such that the value can be defined later than this assignment (file load order).
             }
             if (allowed.length && emailStudents) {
                 // Translators: A list of users appears after this sentence;
-                renderList(gettext('Email cannot be sent to the following users via batch enrollment. They will be allowed to enroll once they register:'), (function() { // eslint-disable-line max-len
+                renderList(gettext('Email was sent to the following users. They will be allowed to enroll once they register:'), (function() { // eslint-disable-line max-len
                     var k, len2, results;
                     results = [];
                     for (k = 0, len2 = allowed.length; k < len2; k++) {
@@ -813,7 +813,7 @@ such that the value can be defined later than this assignment (file load order).
             }
             if (autoenrolled.length && emailStudents) {
                 // Translators: A list of users appears after this sentence;
-                renderList(gettext('Email cannot be sent to the following users via batch enrollment. They will be enrolled once they register:'), (function() { // eslint-disable-line max-len
+                renderList(gettext('Email was sent to the following users. They will be enrolled once they register:'), (function() { // eslint-disable-line max-len
                     var k, len2, results;
                     results = [];
                     for (k = 0, len2 = autoenrolled.length; k < len2; k++) {


### PR DESCRIPTION
Ticket: [TNL-11014](https://2u-internal.atlassian.net/browse/TNL-11014)

**Before:**
Message was being sent to email with unregistered user and the message wasn't correct before.

<img width="1792" alt="Screenshot 2025-04-23 at 11 15 53 AM" src="https://github.com/user-attachments/assets/fe58e3c3-f805-4c8c-984d-3e71ced133f0" />

**After:** 
When both `Auto Enroll` and `Notify users by email` options are selected.
See the message below farazm.ab@gmail.com email as it does not has a registered user.

<img width="1792" alt="Screenshot 2025-04-23 at 11 39 30 AM" src="https://github.com/user-attachments/assets/6b2ac6d6-c0cf-471f-bdbf-b86b355e0a22" />

When only `Notify users by email` option is selected.
See the message below farazm.ab@gmail.com email as it does not has a registered user.

<img width="1792" alt="Screenshot 2025-04-23 at 11 40 00 AM" src="https://github.com/user-attachments/assets/1dc8a1db-4124-493c-83fe-538c5d826399" />


