### PR TITLE
feat: added a policy to prevent sending ace messages to disabled users

### DIFF
--- a/lms/djangoapps/bulk_email/messages.py
+++ b/lms/djangoapps/bulk_email/messages.py
@@ -83,6 +83,7 @@ class ACEEmail(CourseEmailMessage):
             language=email_context['course_language'],
             user_context={"name": email_context['name']},
         )
+        message.options['skip_disable_user_policy'] = True
         self.message = message
 
     def send(self):

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -105,16 +105,18 @@ def send_ace_message(goal, session_id):
         'programs_url': getattr(settings, 'ACE_EMAIL_PROGRAMS_URL', None),
     })
 
-    options = {'transactional': True}
+    options = {
+        'transactional': True,
+        'skip_disable_user_policy': True
+    }
 
     is_ses_enabled = ENABLE_SES_FOR_GOALREMINDER.is_enabled(goal.course_key)
 
     if is_ses_enabled:
-        options = {
-            'transactional': True,
+        options.update({
             'from_address': settings.LMS_COMM_DEFAULT_FROM_EMAIL,
             'override_default_channel': 'django_email',
-        }
+        })
 
     msg = Message(
         name="goalreminder",

--- a/openedx/core/djangoapps/ace_common/policies.py
+++ b/openedx/core/djangoapps/ace_common/policies.py
@@ -1,0 +1,29 @@
+"""Disable User Email OptOut Policy"""
+
+import logging
+
+from django.contrib.auth import get_user_model
+from edx_ace.channel import ChannelType
+from edx_ace.policy import Policy, PolicyResult
+
+
+User = get_user_model()
+log = logging.getLogger(__name__)
+
+
+class DisableUserOptout(Policy):
+    """
+    Skips sending ace messages to disabled users
+    """
+    def check(self, message):
+        """
+        Checks if the user is disabled and if so, skips sending the message
+        """
+        skip_disable_user_policy = message.options.get('skip_disable_user_policy', False)
+        if skip_disable_user_policy:
+            return PolicyResult(deny=set())
+        user = User.objects.get(id=message.recipient.lms_user_id)
+        if user.has_usable_password():
+            return PolicyResult(deny=set())
+        log.info(f"===> User is disabled - {user.email} - {message.name}")
+        return PolicyResult(deny=set(ChannelType))

--- a/openedx/core/djangoapps/notifications/email/message_type.py
+++ b/openedx/core/djangoapps/notifications/email/message_type.py
@@ -16,3 +16,4 @@ class EmailNotificationMessageType(MessageType):
         super().__init__(*args, **kwargs)
         self.options['transactional'] = True
         self.options['from_address'] = settings.NOTIFICATIONS_DEFAULT_FROM_EMAIL
+        self.options['skip_disable_user_policy'] = True

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -274,6 +274,7 @@ def _schedule_send(msg_str, site_id, delivery_config_var, log_prefix):  # lint-a
     site = Site.objects.select_related('configuration').get(pk=site_id)
     if _is_delivery_enabled(site, delivery_config_var, log_prefix):
         msg = Message.from_string(msg_str)
+        msg.options['skip_disable_user_policy'] = True
 
         user = User.objects.get(id=msg.recipient.lms_user_id)
         if not user.has_usable_password():

--- a/openedx/core/djangoapps/user_authn/message_types.py
+++ b/openedx/core/djangoapps/user_authn/message_types.py
@@ -14,6 +14,7 @@ class PasswordReset(BaseMessageType):
 
         # pylint: disable=unsupported-assignment-operation
         self.options['transactional'] = True
+        self.options['skip_disable_user_policy'] = True
 
 
 class PasswordResetSuccess(BaseMessageType):

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
         "openedx.ace.policy": [
             "bulk_email_optout = lms.djangoapps.bulk_email.policies:CourseEmailOptout",
             "course_push_notification_optout = openedx.core.djangoapps.notifications.policies:CoursePushNotificationOptout",  # lint-amnesty, pylint: disable=line-too-long
+            "disabled_user_optout = openedx.core.djangoapps.ace_common.policies:DisableUserOptout",
         ],
         "openedx.call_to_action": [
             "personalized_learner_schedules = openedx.features.personalized_learner_schedules.call_to_action:PersonalizedLearnerScheduleCallToAction"  # lint-amnesty, pylint: disable=line-too-long


### PR DESCRIPTION
Added a policy to prevent sending ace messages to disabled users

To use this policy, add this to settings
```
ACE_ENABLED_POLICIES = ['disabled_user_optout']
```

Ticket: [INF-1871](https://2u-internal.atlassian.net/browse/INF-1871)