### PR TITLE
Remove py2neo dependency

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -102,7 +102,6 @@ celery==5.4.0
 certifi==2025.1.31
     # via
     #   elasticsearch
-    #   py2neo
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
@@ -648,8 +647,6 @@ inflection==0.5.1
     # via
     #   drf-spectacular
     #   drf-yasg
-interchange==2021.0.4
-    # via py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/kernel.in
 isodate==0.7.2
@@ -744,9 +741,7 @@ meilisearch==0.34.0
 mongoengine==0.29.1
     # via -r requirements/edx/kernel.in
 monotonic==1.6
-    # via
-    #   analytics-python
-    #   py2neo
+    # via analytics-python
 more-itertools==10.6.0
     # via cssutils
 mpmath==1.3.0
@@ -834,10 +829,7 @@ packaging==24.2
     # via
     #   drf-yasg
     #   gunicorn
-    #   py2neo
     #   snowflake-connector-python
-pansi==2024.11.0
-    # via py2neo
 paramiko==3.5.1
     # via edx-enterprise
 path==16.11.0
@@ -863,7 +855,6 @@ pillow==11.1.0
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-    #   pansi
 platformdirs==4.3.7
     # via snowflake-connector-python
 polib==1.2.0
@@ -889,10 +880,6 @@ psutil==7.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-django-utils
-py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/bundled.in
 pyasn1==0.6.1
     # via
     #   pgpy
@@ -914,8 +901,6 @@ pydantic==2.10.6
     # via camel-converter
 pydantic-core==2.27.2
     # via pydantic
-pygments==2.19.1
-    # via py2neo
 pyjwkest==1.4.2
     # via
     #   -r requirements/edx/kernel.in
@@ -1004,7 +989,6 @@ pytz==2025.1
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   interchange
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python
@@ -1113,8 +1097,6 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   html5lib
-    #   interchange
-    #   py2neo
     #   pyjwkest
     #   python-dateutil
 slumber==0.7.1
@@ -1206,7 +1188,6 @@ urllib3==2.2.3
     #   -c requirements/edx/../common_constraints.txt
     #   botocore
     #   elasticsearch
-    #   py2neo
     #   requests
 user-util==1.1.0
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -20,11 +20,6 @@
 # 4. If the package is not needed in production, add it to another file such
 #    as development.in or testing.in instead.
 
-# Driver for converting Python modulestore structures to Neo4j's schema (for Coursegraph).
-# Using the fork because official package has been removed from PyPI/GitHub
-# Follow up issue to remove this fork: https://github.com/openedx/edx-platform/issues/33456
-https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
-
 # i18n_tool is needed at build time for pulling translations
 edx-i18n-tools>=0.4.6               # Commands for developers and translators to extract, compile and validate translations
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -196,7 +196,6 @@ certifi==2025.1.31
     #   elasticsearch
     #   httpcore
     #   httpx
-    #   py2neo
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
@@ -1084,11 +1083,6 @@ iniconfig==2.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest
-interchange==2021.0.4
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   py2neo
 ipaddress==1.0.23
     # via
     #   -r requirements/edx/doc.txt
@@ -1262,7 +1256,6 @@ monotonic==1.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
-    #   py2neo
 more-itertools==10.6.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1408,7 +1401,6 @@ packaging==24.2
     #   build
     #   drf-yasg
     #   gunicorn
-    #   py2neo
     #   pydata-sphinx-theme
     #   pyproject-api
     #   pytest
@@ -1417,11 +1409,6 @@ packaging==24.2
     #   tox
 pact-python==2.0.1
     # via -r requirements/edx/testing.txt
-pansi==2024.11.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   py2neo
 paramiko==3.5.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1466,7 +1453,6 @@ pillow==11.1.0
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-    #   pansi
 pip-tools==7.4.1
     # via -r requirements/edx/../pip-tools.txt
 platformdirs==4.3.7
@@ -1523,11 +1509,6 @@ psutil==7.0.0
     #   pytest-xdist
 py==1.11.0
     # via -r requirements/edx/testing.txt
-py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
 pyasn1==0.6.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1581,7 +1562,6 @@ pygments==2.19.1
     #   -r requirements/edx/testing.txt
     #   accessible-pygments
     #   diff-cover
-    #   py2neo
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
@@ -1772,7 +1752,6 @@ pytz==2025.1
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   interchange
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python
@@ -1937,10 +1916,8 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   html5lib
-    #   interchange
     #   libsass
     #   pact-python
-    #   py2neo
     #   pyjwkest
     #   python-dateutil
     #   sphinxcontrib-httpdomain
@@ -2178,7 +2155,6 @@ urllib3==2.2.3
     #   botocore
     #   elasticsearch
     #   pact-python
-    #   py2neo
     #   requests
     #   types-requests
 user-util==1.1.0

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -141,7 +141,6 @@ certifi==2025.1.31
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
-    #   py2neo
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
@@ -775,10 +774,6 @@ inflection==0.5.1
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-interchange==2021.0.4
-    # via
-    #   -r requirements/edx/base.txt
-    #   py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
 isodate==0.7.2
@@ -904,7 +899,6 @@ monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-    #   py2neo
 more-itertools==10.6.0
     # via
     #   -r requirements/edx/base.txt
@@ -1007,14 +1001,9 @@ packaging==24.2
     #   -r requirements/edx/base.txt
     #   drf-yasg
     #   gunicorn
-    #   py2neo
     #   pydata-sphinx-theme
     #   snowflake-connector-python
     #   sphinx
-pansi==2024.11.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   py2neo
 paramiko==3.5.1
     # via
     #   -r requirements/edx/base.txt
@@ -1049,7 +1038,6 @@ pillow==11.1.0
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-    #   pansi
 platformdirs==4.3.7
     # via
     #   -r requirements/edx/base.txt
@@ -1084,10 +1072,6 @@ psutil==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
-py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
 pyasn1==0.6.1
     # via
     #   -r requirements/edx/base.txt
@@ -1122,9 +1106,7 @@ pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pygments==2.19.1
     # via
-    #   -r requirements/edx/base.txt
     #   accessible-pygments
-    #   py2neo
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
@@ -1230,7 +1212,6 @@ pytz==2025.1
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   interchange
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python
@@ -1358,8 +1339,6 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   html5lib
-    #   interchange
-    #   py2neo
     #   pyjwkest
     #   python-dateutil
     #   sphinxcontrib-httpdomain
@@ -1520,7 +1499,6 @@ urllib3==2.2.3
     #   -r requirements/edx/base.txt
     #   botocore
     #   elasticsearch
-    #   py2neo
     #   requests
 user-util==1.1.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -144,7 +144,6 @@ certifi==2025.1.31
     #   elasticsearch
     #   httpcore
     #   httpx
-    #   py2neo
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
@@ -826,10 +825,6 @@ inflection==0.5.1
     #   drf-yasg
 iniconfig==2.1.0
     # via pytest
-interchange==2021.0.4
-    # via
-    #   -r requirements/edx/base.txt
-    #   py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
 isodate==0.7.2
@@ -962,7 +957,6 @@ monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-    #   py2neo
 more-itertools==10.6.0
     # via
     #   -r requirements/edx/base.txt
@@ -1065,17 +1059,12 @@ packaging==24.2
     #   -r requirements/edx/base.txt
     #   drf-yasg
     #   gunicorn
-    #   py2neo
     #   pyproject-api
     #   pytest
     #   snowflake-connector-python
     #   tox
 pact-python==2.0.1
     # via -r requirements/edx/testing.in
-pansi==2024.11.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   py2neo
 paramiko==3.5.1
     # via
     #   -r requirements/edx/base.txt
@@ -1108,7 +1097,6 @@ pillow==11.1.0
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-    #   pansi
 platformdirs==4.3.7
     # via
     #   -r requirements/edx/base.txt
@@ -1157,10 +1145,6 @@ psutil==7.0.0
     #   pytest-xdist
 py==1.11.0
     # via -r requirements/edx/testing.in
-py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
 pyasn1==0.6.1
     # via
     #   -r requirements/edx/base.txt
@@ -1198,10 +1182,8 @@ pydantic-core==2.27.2
     #   pydantic
 pygments==2.19.1
     # via
-    #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
     #   diff-cover
-    #   py2neo
 pyjwkest==1.4.2
     # via
     #   -r requirements/edx/base.txt
@@ -1353,7 +1335,6 @@ pytz==2025.1
     #   edx-tincan-py35
     #   event-tracking
     #   fs
-    #   interchange
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python
@@ -1482,9 +1463,7 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   html5lib
-    #   interchange
     #   pact-python
-    #   py2neo
     #   pyjwkest
     #   python-dateutil
 slumber==0.7.1
@@ -1618,7 +1597,6 @@ urllib3==2.2.3
     #   botocore
     #   elasticsearch
     #   pact-python
-    #   py2neo
     #   requests
 user-util==1.1.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
```
The py2neo package exists to support CourseGraph, which required the
Neo4j database. Support for it was removed before the Sumac cut, tracked
by the following DEPR:
  https://github.com/openedx/edx-platform/issues/34342

This dependency looks like a bit of leftover code that was overlooked
during the removal process.

This also upgrades other packages via "make upgrade".
```