### PR TITLE
Feat: Implemented single and multiselect autocomplete

### DIFF
--- a/common/djangoapps/student/constants.py
+++ b/common/djangoapps/student/constants.py
@@ -1,0 +1,3 @@
+import pycountry
+
+LANGUAGE_CHOICES = sorted({lang.name for lang in pycountry.languages if hasattr(lang, 'alpha_2')})

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3042,6 +3042,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.sites',
 
+    'dal',
+    'dal_select2',
+
     # Tweaked version of django.contrib.staticfiles
     'openedx.core.djangoapps.staticfiles.apps.EdxPlatformStaticFilesConfig',
 

--- a/openedx/core/djangoapps/site_configuration/admin.py
+++ b/openedx/core/djangoapps/site_configuration/admin.py
@@ -1,17 +1,81 @@
 """
 Django admin page for Site Configuration models
 """
+from dal import autocomplete
 
-
+from django import forms
+from django.urls import path
+from django.utils.translation import gettext_lazy as _
 from django.contrib import admin
 
+from .constants import FEATURE_FLAGS
 from .models import SiteConfiguration, SiteConfigurationHistory
 
+class FeatureFlagAutocomplete(autocomplete.Select2ListView):
+    def get_list(self):
+        return list(FEATURE_FLAGS.keys())
+
+    def get_result_label(self, item):
+        return item
+
+    def get_result_value(self, item):
+        return item
+
+class SiteConfigurationForm(forms.ModelForm):
+    feature_flags = forms.Field(
+        required=False,
+        widget=autocomplete.Select2Multiple(
+            url='admin:feature-flag-autocomplete',
+            attrs={
+                'multiple': 'multiple',
+                'data-tags': 'true',
+                'data-placeholder': 'Select features'
+            }
+        ),
+        label="Enabled Features",
+    )
+
+    class Meta:
+        model = SiteConfiguration
+        fields = '__all__'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['site_values'].widget = forms.HiddenInput()
+        current_values = self.instance.site_values or {}
+        selected_labels = []
+        for label, mapping in FEATURE_FLAGS.items():
+            if all(current_values.get(k) == v for k, v in mapping.items()):
+                selected_labels.append(label)
+
+        self.fields['feature_flags'].initial = selected_labels
+        self.fields['feature_flags'].widget.choices = [(v, v) for v in selected_labels]
+
+
+    def clean(self):
+        cleaned = super().clean()
+
+        selected_flags = self.data.getlist('feature_flags')
+        if not isinstance(selected_flags, list):
+            selected_flags = [selected_flags] if selected_flags else []
+
+        site_values = {}
+        for label in selected_flags:
+            site_values.update(FEATURE_FLAGS.get(label, {}))
+
+        cleaned['feature_flags'] = selected_flags
+        cleaned['site_values'] = site_values
+        # self.selected_flags = selected_flags
+        # self.site_values = site_values
+
+        return cleaned
 
 class SiteConfigurationAdmin(admin.ModelAdmin):
     """
     Admin interface for the SiteConfiguration object.
     """
+    form = SiteConfigurationForm
     list_display = ('site', 'enabled', 'site_values')
     search_fields = ('site__domain', 'site_values')
 
@@ -20,6 +84,17 @@ class SiteConfigurationAdmin(admin.ModelAdmin):
         Meta class for SiteConfiguration admin model
         """
         model = SiteConfiguration
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                'feature-flag-autocomplete/',
+                FeatureFlagAutocomplete.as_view(),
+                name='feature-flag-autocomplete'
+            ),
+        ]
+        return custom_urls + urls
 
 admin.site.register(SiteConfiguration, SiteConfigurationAdmin)
 

--- a/openedx/core/djangoapps/site_configuration/constants.py
+++ b/openedx/core/djangoapps/site_configuration/constants.py
@@ -1,0 +1,6 @@
+# TODO: Dummy Tags to be replaced by real values
+FEATURE_FLAGS = {
+    'Forum Notifications': {'enable_forum_notifications': True},
+    'Live Chat': {'enable_live_chat': True},
+    'Dark Mode': {'enable_dark_mode': True},
+}


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds the following to the admin panel:
- A single select autocomplete dropdown for 'language' field in the Student Application using the 'pycountry' package.
- A multi-select autocomplete dropdown to replace the 'site_values' field in Site Configuration application. This ensures that the drop down is used for creating the 'site_values' JSON - thus simplifying the entire process for non tech users. 

These changes are to improve user experience when using the admin panel for the 'Student' and 'Site Configuration' Applications.

**Screenshots**

- Languages:
Navigation Flow: Admin Panel > Users > Add/Edit User
<img width="441" alt="image" src="https://github.com/user-attachments/assets/3fad2bbc-77f1-4792-afc7-bf3e9e881b11" />
<img width="446" alt="image" src="https://github.com/user-attachments/assets/cffd6150-8d80-49b6-98f1-ee63a0785e41" />

- Site Configurations:
Navigation Flow: Admin Panel > Site Configurations > Add/Edit Site Configurations
<img width="473" alt="image" src="https://github.com/user-attachments/assets/40c68aaa-ac54-4232-8d7e-2c27f3f00669" />
<img width="972" alt="image" src="https://github.com/user-attachments/assets/9f02eb01-a272-4d88-9828-eb8fc0451549" />

## Supporting information
N/A

## Testing instructions
N/A

## Deadline
None

## Other information
1) This change adds two packages to the environment:
- pycountry
- django-autocomplete-light 

2) The 'FEATURE_FLAGS' contains dummy data and will be replaced by the real data shortly.