### PR TITLE
Remove karma-selenium-webdriver-launcher and dependent configs

### DIFF
--- a/common/static/common/js/karma.common.conf.js
+++ b/common/static/common/js/karma.common.conf.js
@@ -285,7 +285,6 @@ function getBaseConfig(config, useRequireJs) {
             'karma-chrome-launcher',
             'karma-firefox-launcher',
             'karma-spec-reporter',
-            'karma-selenium-webdriver-launcher',
             'karma-webpack',
             'karma-sourcemap-loader',
             customPlugin
@@ -339,33 +338,8 @@ function getBaseConfig(config, useRequireJs) {
                     'media.autoplay.enabled.user-gestures-needed': false,
                 }
             },
-            ChromeDocker: {
-                base: 'SeleniumWebdriver',
-                browserName: 'chrome',
-                getDriver: function() {
-                    return new webdriver.Builder()
-                        .forBrowser('chrome')
-                        .usingServer('http://edx.devstack.chrome:4444/wd/hub')
-                        .build();
-                }
-            },
-            FirefoxDocker: {
-                base: 'SeleniumWebdriver',
-                browserName: 'firefox',
-                getDriver: function() {
-                    var options = new firefox.Options(),
-                        profile = new firefox.Profile();
-                    profile.setPreference('focusmanager.testmode', true);
-                    options.setProfile(profile);
-                    return new webdriver.Builder()
-                        .forBrowser('firefox')
-                        .usingServer('http://edx.devstack.firefox:4444/wd/hub')
-                        .setFirefoxOptions(options)
-                        .build();
-                }
-            }
         },
-        
+
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
         singleRun: config.singleRun,

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
         "karma-jasmine-html-reporter": "0.2.2",
         "karma-junit-reporter": "2.0.1",
         "karma-requirejs": "1.1.0",
-        "karma-selenium-webdriver-launcher": "github:openedx/karma-selenium-webdriver-launcher#0.0.4-openedx.0",
         "karma-sourcemap-loader": "0.4.0",
         "karma-spec-reporter": "0.0.20",
         "karma-webpack": "^5.0.1",
@@ -12923,19 +12922,6 @@
       "peerDependencies": {
         "karma": ">=0.9",
         "requirejs": "^2.1.0"
-      }
-    },
-    "node_modules/karma-selenium-webdriver-launcher": {
-      "version": "0.0.4-openedx.0",
-      "resolved": "git+ssh://git@github.com/openedx/karma-selenium-webdriver-launcher.git#79cfdc5037eb8585dd3e584875e4343febb6d61f",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "q": "~0.9.6"
-      },
-      "peerDependencies": {
-        "karma": ">=0.9",
-        "selenium-webdriver": ">=2.44.0"
       }
     },
     "node_modules/karma-sourcemap-loader": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "karma-jasmine-html-reporter": "0.2.2",
     "karma-junit-reporter": "2.0.1",
     "karma-requirejs": "1.1.0",
-    "karma-selenium-webdriver-launcher": "github:openedx/karma-selenium-webdriver-launcher#0.0.4-openedx.0",
     "karma-sourcemap-loader": "0.4.0",
     "karma-spec-reporter": "0.0.20",
     "karma-webpack": "^5.0.1",


### PR DESCRIPTION
## Description

This change request address the issue: https://github.com/openedx/public-engineering/issues/248 by removing the reference to ```karma-selenium-webdriver-launcher``` in the package.json and the karma configs. 

Useful information to include:

- This would affect "Developer"s and would need to reinstall their node_modules.

## Supporting information

Original issue: https://github.com/openedx/public-engineering/issues/248
Follow up issue: https://github.com/openedx/edx-platform/issues/35956

Originally, I also took it a step further to comment out the tests in the ```lms/static/karma_lms.conf.js``` that reference webpack: 
```
  // Define the Webpack-built spec files first
   {pattern: 'course_experience/js/**/*_spec.js', webpack: true},
   {pattern: 'js/learner_dashboard/**/*_spec.js', webpack: true},
   {pattern: 'js/student_account/components/**/*_spec.js', webpack: true},
   {pattern: 'completion/js/**/*_spec.js', webpack: true},
```
so that we could potentially have more code coverage if deemed useful. Otherwise, we may want to go through and delete all spec files within the LMS folder since they aren't being run, and/or maintained.

However, I think this might be better tracked in a separate ticket. Please feel free to weigh in and I can include the removal or comment of these tests.

## Testing instructions

These affect tests that run in the CI on a linux machine. Unable to run the npm commands locally on my mac machine.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
