### PR TITLE
feat: added a new field to canvas_entry_properties in enrollment email

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -115,6 +115,7 @@ def send_course_enrollment_email(
                 "short_description": course_run.get("short_description"),
                 "pacing_type": course_run.get("pacing_type"),
                 "partner_image_url": owners[0].get("logo_image_url") if owners else "",
+                "org_name": owners[0].get("name") if owners else "",
             }
         )
     except Exception as err:  # pylint: disable=broad-except

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -85,6 +85,7 @@ class TestCourseEnrollmentEmailTask(ModuleStoreTestCase):
         return [
             {
                 "logo_image_url": "https://prod/organization/logos/2cc39992c67a.png",
+                "name": "edX University",
             }
         ]
 
@@ -164,6 +165,7 @@ class TestCourseEnrollmentEmailTask(ModuleStoreTestCase):
                     "short_description": course_run["short_description"],
                     "pacing_type": course_run["pacing_type"],
                     "partner_image_url": self._get_course_owners()[0]["logo_image_url"],
+                    "org_name": self._get_course_owners()[0]["name"],
                 }
             )
 


### PR DESCRIPTION
Ticket: [INF-1874](https://2u-internal.atlassian.net/browse/INF-1874)

Added a new field `org_name` to the `canvas_entry_properties` generated in the `send_course_enrollment_email` function. This new field is required by the rebranded Enrollment Confirmation email canvas on Braze. 