### PR TITLE
Single Select Autocomplete Added to Student Admin

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -314,12 +314,14 @@ class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
 
+
 @method_decorator(login_required, name='dispatch')
 class LanguageAutocomplete(Select2ListView):
     def get_list(self):
         if not self.request.user.is_staff:
             return []
         return [lang for lang in LANGUAGE_CHOICES if self.q.lower() in lang.lower()]
+
 
 @method_decorator(login_required, name='dispatch')
 class CountryAutocomplete(Select2ListView):
@@ -349,6 +351,7 @@ class CountryAutocomplete(Select2ListView):
     def get_result_value(self, item):
         """ What gets sent back on selection (the code) """
         return item
+
 
 class UserProfileInlineForm(forms.ModelForm):
     """

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -322,7 +322,17 @@ class LanguageAutocomplete(autocomplete.Select2ListView):
 
 @method_decorator(login_required, name='dispatch')
 class CountryAutocomplete(autocomplete.Select2ListView):
+    """
+    Autocomplete view for selecting countries using Select2.
+
+    Only accessible to authenticated staff users. Filters the list of countries
+    based on the user input (query string) and returns matching results.
+    """
+
     def get_list(self):
+        """
+        Returns a filtered list of country tuples (code, name) based on the query.
+        """
         if not self.request.user.is_staff:
             return []
         results = []
@@ -340,6 +350,9 @@ class CountryAutocomplete(autocomplete.Select2ListView):
         return item
 
 class UserProfileInlineForm(forms.ModelForm):
+    """
+    A custom form for editing the UserProfile model within the admin inline.
+    """
     language = forms.CharField(
         required=False,
         widget=autocomplete.ListSelect2(url='admin:language-autocomplete')

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -314,14 +314,14 @@ class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
         return super().get_queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
 
 @method_decorator(login_required, name='dispatch')
-class LanguageAutocomplete(autocomplete.Select2ListView):
+class LanguageAutocomplete(autocomplete.Select2ListView):   # pylint: disable=no-member
     def get_list(self):
         if not self.request.user.is_staff:
             return []
         return [lang for lang in LANGUAGE_CHOICES if self.q.lower() in lang.lower()]
 
 @method_decorator(login_required, name='dispatch')
-class CountryAutocomplete(autocomplete.Select2ListView):
+class CountryAutocomplete(autocomplete.Select2ListView):    # pylint: disable=no-member
     """
     Autocomplete view for selecting countries using Select2.
 
@@ -355,11 +355,11 @@ class UserProfileInlineForm(forms.ModelForm):
     """
     language = forms.CharField(
         required=False,
-        widget=autocomplete.ListSelect2(url='admin:language-autocomplete')
+        widget=autocomplete.ListSelect2(url='admin:language-autocomplete')  # pylint: disable=no-member
     )
     country = forms.CharField(
         required=False,
-        widget=autocomplete.ListSelect2(url='admin:country-autocomplete')
+        widget=autocomplete.ListSelect2(url='admin:country-autocomplete')   # pylint: disable=no-member
     )
 
     class Meta:

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -13,12 +13,14 @@ from django.contrib.admin.sites import NotRegistered
 from django.contrib.admin.utils import unquote
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
 from django.contrib.auth.forms import UserChangeForm as BaseUserChangeForm
 from django.db import models, router, transaction
 from django.http import HttpResponseRedirect
 from django.http.request import QueryDict
 from django.urls import reverse, path
+from django.utils.decorators import method_decorator
 from django.utils.translation import ngettext
 from django.utils.translation import gettext_lazy as _
 from opaque_keys import InvalidKeyError
@@ -311,13 +313,14 @@ class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
 
-
+@method_decorator(login_required, name='dispatch')
 class LanguageAutocomplete(autocomplete.Select2ListView):
     def get_list(self):
         if not self.request.user.is_staff:
             return []
         return [lang for lang in LANGUAGE_CHOICES if self.q.lower() in lang.lower()]
 
+@method_decorator(login_required, name='dispatch')
 class CountryAutocomplete(autocomplete.Select2ListView):
     def get_list(self):
         if not self.request.user.is_staff:

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -314,10 +314,14 @@ class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
 
 class LanguageAutocomplete(autocomplete.Select2ListView):
     def get_list(self):
+        if not self.request.user.is_staff:
+            return []
         return [lang for lang in LANGUAGE_CHOICES if self.q.lower() in lang.lower()]
 
 class CountryAutocomplete(autocomplete.Select2ListView):
     def get_list(self):
+        if not self.request.user.is_staff:
+            return []
         results = []
         for code, name in countries:
             if self.q.lower() in name.lower():

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -318,9 +318,19 @@ class LanguageAutocomplete(autocomplete.Select2ListView):
 
 class CountryAutocomplete(autocomplete.Select2ListView):
     def get_list(self):
-        return [
-            name for code, name in countries if self.q.lower() in name.lower()
-        ]
+        results = []
+        for code, name in countries:
+            if self.q.lower() in name.lower():
+                results.append((code, name))
+        return results
+
+    def get_result_label(self, item):
+        """ What the user sees in the dropdown """
+        return dict(countries).get(item, item)
+
+    def get_result_value(self, item):
+        """ What gets sent back on selection (the code) """
+        return item
 
 class UserProfileInlineForm(forms.ModelForm):
     language = forms.CharField(

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -2,7 +2,8 @@
 
 
 from functools import wraps
-from dal import autocomplete
+from dal_select2.views import Select2ListView
+from dal_select2.widgets import ListSelect2
 from django_countries import countries
 
 from config_models.admin import ConfigurationModelAdmin
@@ -314,14 +315,14 @@ class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
         return super().get_queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
 
 @method_decorator(login_required, name='dispatch')
-class LanguageAutocomplete(autocomplete.Select2ListView):   # pylint: disable=no-member
+class LanguageAutocomplete(Select2ListView):
     def get_list(self):
         if not self.request.user.is_staff:
             return []
         return [lang for lang in LANGUAGE_CHOICES if self.q.lower() in lang.lower()]
 
 @method_decorator(login_required, name='dispatch')
-class CountryAutocomplete(autocomplete.Select2ListView):    # pylint: disable=no-member
+class CountryAutocomplete(Select2ListView):
     """
     Autocomplete view for selecting countries using Select2.
 
@@ -355,11 +356,11 @@ class UserProfileInlineForm(forms.ModelForm):
     """
     language = forms.CharField(
         required=False,
-        widget=autocomplete.ListSelect2(url='admin:language-autocomplete')  # pylint: disable=no-member
+        widget=ListSelect2(url='admin:language-autocomplete')  # pylint: disable=no-member
     )
     country = forms.CharField(
         required=False,
-        widget=autocomplete.ListSelect2(url='admin:country-autocomplete')   # pylint: disable=no-member
+        widget=ListSelect2(url='admin:country-autocomplete')   # pylint: disable=no-member
     )
 
     class Meta:

--- a/common/djangoapps/student/constants.py
+++ b/common/djangoapps/student/constants.py
@@ -1,0 +1,3 @@
+import pycountry
+
+LANGUAGE_CHOICES = sorted({lang.name for lang in pycountry.languages if hasattr(lang, 'alpha_2')})

--- a/common/djangoapps/student/constants.py
+++ b/common/djangoapps/student/constants.py
@@ -1,3 +1,4 @@
+"""# Generate a sorted list of unique language names from pycountry """
 import pycountry
 
 LANGUAGE_CHOICES = sorted({lang.name for lang in pycountry.languages if hasattr(lang, 'alpha_2')})

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -12,7 +12,6 @@ import pytest
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django_countries.data import COUNTRIES as countries
 from django.forms import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -651,7 +650,6 @@ class TestUserProfileAutocompleteAdmin(TestCase):
         user = UserFactory()
         user.set_password('test')
         user.save()
-        
         self.client.login(username=admin.username, password='test')  # re-login as admin
 
         response = self.client.get(reverse('admin:auth_user_change', args=[user.id]))

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -4,12 +4,15 @@ Tests student admin.py
 
 
 import datetime
+import json
 from unittest.mock import Mock
 
 import ddt
 import pytest
+
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django_countries.data import COUNTRIES as countries
 from django.forms import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -24,11 +27,12 @@ from common.djangoapps.student.admin import (  # lint-amnesty, pylint: disable=l
     UserAdmin
 )
 from common.djangoapps.student.models import AllowedAuthUser, CourseEnrollment, LoginFailures
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory, UserProfileFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+
 
 
 class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
@@ -532,3 +536,139 @@ class AllowedAuthUserFormTest(SiteMixin, TestCase):
         db_allowed_auth_user = AllowedAuthUser.objects.all().first()
         assert AllowedAuthUser.objects.all().count() == 1
         assert db_allowed_auth_user.email == self.other_valid_email
+
+
+@ddt.ddt
+class TestUserProfileAutocompleteAdmin(TestCase):
+    """Tests for language and country autocomplete in UserProfile inline form via Django admin."""
+
+    def setUp(self):
+        super().setUp()
+        self.staff_user = UserFactory(is_staff=True)
+        self.staff_user.set_password('test')
+        self.staff_user.save()
+
+        self.non_staff_user = UserFactory(is_staff=False)
+        self.non_staff_user.set_password('test')
+        self.non_staff_user.save()
+
+        self.client.login(username=self.staff_user.username, password='test')
+
+        self.language_url = reverse('admin:language-autocomplete')
+        self.country_url = reverse('admin:country-autocomplete')
+
+        user1 = UserFactory()
+        user1.set_password('test')
+        user1.save()
+        UserProfileFactory(user=user1, language='English', country='PK')
+
+        user2 = UserFactory()
+        user2.set_password('test')
+        user2.save()
+        UserProfileFactory(user=user2, language='French', country='GB')
+
+        user3 = UserFactory()
+        user3.set_password('test')
+        user3.save()
+        UserProfileFactory(user=user3, language='German', country='US')
+
+    def test_language_autocomplete_returns_expected_result(self):
+        """Verify language autocomplete returns expected filtered results."""
+        profile = UserProfileFactory(user=self.staff_user, language='Esperanto')
+
+        response = self.client.get(self.language_url)
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertTrue(
+            any('Esperanto' in item['text'] for item in data['results']),
+            f"Esperanto not found in: {data['results']}"
+        )
+
+        profile.language = 'French'
+        profile.save()
+
+        response = self.client.get(f'{self.language_url}?q=Fren')
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertTrue(
+            any('French' in item['text'] for item in data['results']),
+            f"French not found in: {data['results']}"
+        )
+
+    def test_country_autocomplete_returns_expected_result(self):
+        """Verify country autocomplete returns expected filtered results."""
+        profile = UserProfileFactory(user=self.staff_user, country='SE')
+
+        response = self.client.get(self.country_url)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertTrue(
+            any('Sweden' in item['text'] for item in data['results']),
+            f"Sweden not found in: {data['results']}"
+        )
+
+        profile.country = 'JP'
+        profile.save()
+
+        response = self.client.get(f'{self.country_url}?q=Japan')
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertTrue(
+            any('Japan' in item['text'] for item in data['results']),
+            f"Japan not found in: {data['results']}"
+        )
+
+    @ddt.data('eng', 'fren', 'GER')
+    def test_language_autocomplete_filters_correctly(self, term):
+        response = self.client.get(f'{self.language_url}?q={term}')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertTrue(any(term.lower() in item['text'].lower() for item in data['results']))
+
+    def test_language_autocomplete_returns_empty_on_no_match(self):
+        response = self.client.get(f'{self.language_url}?q=not-a-lang')
+        self.assertEqual(json.loads(response.content)['results'], [])
+
+    @ddt.data('United', 'Kingdom', 'Pakistan')
+    def test_country_autocomplete_filters_correctly(self, term):
+        response = self.client.get(f'{self.country_url}?q={term}')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertTrue(any(term.lower() in item['text'].lower() for item in data['results']))
+
+    def test_country_autocomplete_returns_empty_on_gibberish(self):
+        response = self.client.get(f'{self.country_url}?q=asdfghjkl')
+        self.assertEqual(json.loads(response.content)['results'], [])
+
+    def test_admin_inline_autocomplete_urls_render(self):
+        admin = UserFactory(is_staff=True, is_superuser=True)
+        admin.set_password('test')
+        admin.save()
+
+        user = UserFactory()
+        user.set_password('test')
+        user.save()
+        
+        self.client.login(username=admin.username, password='test')  # re-login as admin
+
+        response = self.client.get(reverse('admin:auth_user_change', args=[user.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.language_url)
+        self.assertContains(response, self.country_url)
+
+    def test_language_autocomplete_blocks_non_staff(self):
+        self.client.logout()
+        self.client.login(username=self.non_staff_user.username, password='test')
+        response = self.client.get(f'{self.language_url}?q=english')
+        data = json.loads(response.content)
+        self.assertEqual(data['results'], [])
+
+    def test_country_autocomplete_blocks_non_staff(self):
+        self.client.logout()
+        self.client.login(username=self.non_staff_user.username, password='test')
+        response = self.client.get(f'{self.country_url}?q=pakistan')
+        data = json.loads(response.content)
+        self.assertEqual(data['results'], [])

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -33,7 +33,6 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # 
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-
 class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
     """Test the django admin course roles form saving data in db.
     """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3042,6 +3042,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.sites',
 
+    'dal',
+    'dal_select2',
+
     # Tweaked version of django.contrib.staticfiles
     'openedx.core.djangoapps.staticfiles.apps.EdxPlatformStaticFilesConfig',
 

--- a/openedx/core/djangoapps/site_configuration/admin.py
+++ b/openedx/core/djangoapps/site_configuration/admin.py
@@ -1,85 +1,16 @@
 """
 Django admin page for Site Configuration models
 """
-from dal import autocomplete
-import json
-
-from django import forms
-from django.urls import path
 from django.utils.translation import gettext_lazy as _
 from django.contrib import admin
 
-from .constants import FEATURE_FLAGS
 from .models import SiteConfiguration, SiteConfigurationHistory
 
-class FeatureFlagAutocomplete(autocomplete.Select2ListView):
-    def get_list(self):
-        return list(FEATURE_FLAGS.keys())
-
-    def get_result_label(self, item):
-        return item
-
-    def get_result_value(self, item):
-        return item
-
-class SiteConfigurationForm(forms.ModelForm):
-    feature_flags = forms.Field(
-        required=False,
-        widget=autocomplete.Select2Multiple(
-            url='admin:feature-flag-autocomplete',
-            attrs={
-                'multiple': 'multiple',
-                'data-tags': 'true',
-                'data-placeholder': 'Select features'
-            }
-        ),
-        label="Enabled Features",
-    )
-
-    class Meta:
-        model = SiteConfiguration
-        fields = '__all__'
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        current_values = self.instance.site_values or {}
-        selected_labels = []
-        for label, mapping in FEATURE_FLAGS.items():
-            if all(current_values.get(k) == v for k, v in mapping.items()):
-                selected_labels.append(label)
-
-        self.fields['feature_flags'].initial = selected_labels
-        self.fields['feature_flags'].widget.choices = [(v, v) for v in selected_labels]
-
-
-    def clean(self):
-        cleaned = super().clean()
-        current_site_values = json.loads(self.data.get('site_values', {}))
-        selected_flags = self.data.getlist('feature_flags')
-        if not isinstance(selected_flags, list):
-            selected_flags = [selected_flags] if selected_flags else []
-
-        flag_keys = {key for group in FEATURE_FLAGS.values() for key in group}
-
-        site_values = {}
-        for label in selected_flags:
-            site_values.update(FEATURE_FLAGS.get(label, {}))
-
-        for key, value in current_site_values.items():
-            if key not in flag_keys:
-                site_values[key] = value
-
-        cleaned['feature_flags'] = selected_flags
-        cleaned['site_values'] = site_values
-
-        return cleaned
 
 class SiteConfigurationAdmin(admin.ModelAdmin):
     """
     Admin interface for the SiteConfiguration object.
     """
-    form = SiteConfigurationForm
     list_display = ('site', 'enabled', 'site_values')
     search_fields = ('site__domain', 'site_values')
 
@@ -88,17 +19,6 @@ class SiteConfigurationAdmin(admin.ModelAdmin):
         Meta class for SiteConfiguration admin model
         """
         model = SiteConfiguration
-
-    def get_urls(self):
-        urls = super().get_urls()
-        custom_urls = [
-            path(
-                'feature-flag-autocomplete/',
-                FeatureFlagAutocomplete.as_view(),
-                name='feature-flag-autocomplete'
-            ),
-        ]
-        return custom_urls + urls
 
 admin.site.register(SiteConfiguration, SiteConfigurationAdmin)
 

--- a/openedx/core/djangoapps/site_configuration/admin.py
+++ b/openedx/core/djangoapps/site_configuration/admin.py
@@ -1,17 +1,81 @@
 """
 Django admin page for Site Configuration models
 """
+from dal import autocomplete
 
-
+from django import forms
+from django.urls import path
+from django.utils.translation import gettext_lazy as _
 from django.contrib import admin
 
+from .constants import FEATURE_FLAGS
 from .models import SiteConfiguration, SiteConfigurationHistory
 
+class FeatureFlagAutocomplete(autocomplete.Select2ListView):
+    def get_list(self):
+        return list(FEATURE_FLAGS.keys())
+
+    def get_result_label(self, item):
+        return item
+
+    def get_result_value(self, item):
+        return item
+
+class SiteConfigurationForm(forms.ModelForm):
+    feature_flags = forms.Field(
+        required=False,
+        widget=autocomplete.Select2Multiple(
+            url='admin:feature-flag-autocomplete',
+            attrs={
+                'multiple': 'multiple',
+                'data-tags': 'true',
+                'data-placeholder': 'Select features'
+            }
+        ),
+        label="Enabled Features",
+    )
+
+    class Meta:
+        model = SiteConfiguration
+        fields = '__all__'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['site_values'].widget = forms.HiddenInput()
+        current_values = self.instance.site_values or {}
+        selected_labels = []
+        for label, mapping in FEATURE_FLAGS.items():
+            if all(current_values.get(k) == v for k, v in mapping.items()):
+                selected_labels.append(label)
+
+        self.fields['feature_flags'].initial = selected_labels
+        self.fields['feature_flags'].widget.choices = [(v, v) for v in selected_labels]
+
+
+    def clean(self):
+        cleaned = super().clean()
+
+        selected_flags = self.data.getlist('feature_flags')
+        if not isinstance(selected_flags, list):
+            selected_flags = [selected_flags] if selected_flags else []
+
+        site_values = {}
+        for label in selected_flags:
+            site_values.update(FEATURE_FLAGS.get(label, {}))
+
+        cleaned['feature_flags'] = selected_flags
+        cleaned['site_values'] = site_values
+        # self.selected_flags = selected_flags
+        # self.site_values = site_values
+
+        return cleaned
 
 class SiteConfigurationAdmin(admin.ModelAdmin):
     """
     Admin interface for the SiteConfiguration object.
     """
+    form = SiteConfigurationForm
     list_display = ('site', 'enabled', 'site_values')
     search_fields = ('site__domain', 'site_values')
 
@@ -20,6 +84,17 @@ class SiteConfigurationAdmin(admin.ModelAdmin):
         Meta class for SiteConfiguration admin model
         """
         model = SiteConfiguration
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                'feature-flag-autocomplete/',
+                FeatureFlagAutocomplete.as_view(),
+                name='feature-flag-autocomplete'
+            ),
+        ]
+        return custom_urls + urls
 
 admin.site.register(SiteConfiguration, SiteConfigurationAdmin)
 

--- a/openedx/core/djangoapps/site_configuration/admin.py
+++ b/openedx/core/djangoapps/site_configuration/admin.py
@@ -1,7 +1,6 @@
 """
 Django admin page for Site Configuration models
 """
-from django.utils.translation import gettext_lazy as _
 from django.contrib import admin
 
 from .models import SiteConfiguration, SiteConfigurationHistory

--- a/openedx/core/djangoapps/site_configuration/constants.py
+++ b/openedx/core/djangoapps/site_configuration/constants.py
@@ -1,0 +1,6 @@
+# TODO: Dummy Tags to be replaced by real values
+FEATURE_FLAGS = {
+    'Forum Notifications': {'enable_forum_notifications': True},
+    'Live Chat': {'enable_live_chat': True},
+    'Dark Mode': {'enable_dark_mode': True},
+}

--- a/openedx/core/djangoapps/site_configuration/constants.py
+++ b/openedx/core/djangoapps/site_configuration/constants.py
@@ -1,6 +1,0 @@
-# TODO: Dummy Tags to be replaced by real values
-FEATURE_FLAGS = {
-    'Forum Notifications': {'enable_forum_notifications': True},
-    'Live Chat': {'enable_live_chat': True},
-    'Dark Mode': {'enable_dark_mode': True},
-}

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -170,6 +170,7 @@ django==4.2.21
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-appconf
+    #   django-autocomplete-light
     #   django-celery-results
     #   django-classy-tags
     #   django-config-models
@@ -238,6 +239,8 @@ django==4.2.21
     #   xss-utils
 django-appconf==1.1.0
     # via django-statici18n
+django-autocomplete-light==3.12.1
+    # via -r requirements/edx/kernel.in
 django-cache-memoize==0.2.1
     # via edx-enterprise
 django-celery-results==2.6.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -340,6 +340,7 @@ django==4.2.21
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
+    #   django-autocomplete-light
     #   django-celery-results
     #   django-classy-tags
     #   django-config-models
@@ -414,6 +415,10 @@ django-appconf==1.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-statici18n
+django-autocomplete-light==3.12.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
 django-cache-memoize==0.2.1
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -226,6 +226,7 @@ django==4.2.21
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
+    #   django-autocomplete-light
     #   django-celery-results
     #   django-classy-tags
     #   django-config-models
@@ -296,6 +297,8 @@ django-appconf==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
+django-autocomplete-light==3.12.1
+    # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -33,6 +33,7 @@ codejail-includes                   # CodeJail manages execution of untrusted co
 cryptography                        # Implementations of assorted cryptography algorithms
 defusedxml
 Django                              # Web application framework
+django-autocomplete-light           # Enhances Django admin with single-select autocomplete dropdowns for a better user experience.
 django-celery-results               # Only used for the CacheBackend for celery results
 django-config-models                # Configuration models for Django allowing config management with auditing
 django-cors-headers                 # Used to allow to configure CORS headers for cross-domain requests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -256,6 +256,7 @@ django==4.2.21
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
+    #   django-autocomplete-light
     #   django-celery-results
     #   django-classy-tags
     #   django-config-models
@@ -326,6 +327,8 @@ django-appconf==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
+django-autocomplete-light==3.12.1
+    # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->
[**Related Issue**](https://github.com/openedx/edx-platform/issues/36594)


## Description

This PR adds the following to the admin panel:
- A single select autocomplete dropdown for 'language' field in the Student Application using the 'pycountry' package.
- A single select autocomplete dropdown for 'country' field in the Student Application using the 'pycountry' package 

These changes are to improve user experience when using the admin panel for the 'Student' Application.

**Screenshots**
Navigation Flow: Admin Panel > Users > Add/Edit User

- Languages:
<img width="441" alt="image" src="https://github.com/user-attachments/assets/3fad2bbc-77f1-4792-afc7-bf3e9e881b11" />
<img width="446" alt="image" src="https://github.com/user-attachments/assets/cffd6150-8d80-49b6-98f1-ee63a0785e41" />

- Country:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/1875f3b8-d7bf-4797-86ba-251fe10e49ca" />


## Supporting information
N/A

## Testing instructions
- Check out the `musa/admin-revamp-dropdown` branch.
- Install the required package by running either:
     1. `pip install -r requirements/dev.txt`, or
     2. `pip install django-autocomplete-light` inside your container.
- Navigate to `http://local.openedx.io:8000/admin/auth/user/`.
- Try adding a new user or updating an existing one to test the single select Autocomplete functionality.

## Deadline
None

## Other information
1) This change adds one package to the environment:
- django-autocomplete-light


## Test Cases
- Tests added for the User Admin Autocomplete fields.
- Test file: common/djangoapps/student/tests/test_admin_views.py::TestUserProfileAutocompleteAdmin
- Test class name: TestUserProfileAutocompleteAdmin