### PR TITLE
fix: Get last existing notification for grouping

### DIFF
--- a/openedx/core/djangoapps/notifications/grouping_notifications.py
+++ b/openedx/core/djangoapps/notifications/grouping_notifications.py
@@ -140,6 +140,6 @@ def get_user_existing_notifications(user_ids, notification_type, group_by_id, co
         notifications_mapping[notification.user_id].append(notification)
 
     for user_id, notifications in notifications_mapping.items():
-        notifications.sort(key=lambda elem: elem.created)
+        notifications.sort(key=lambda elem: elem.created, reverse=True)
         notifications_mapping[user_id] = notifications[0] if notifications else None
     return notifications_mapping

--- a/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
+++ b/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
@@ -188,5 +188,5 @@ class TestGetUserExistingNotifications(unittest.TestCase):
         result = get_user_existing_notifications(user_ids, notification_type, group_by_id, course_id)
 
         # Verify the results
-        self.assertEqual(result[1], mock_notification1)
+        self.assertEqual(result[1], mock_notification2)
         self.assertIsNone(result[2])  # user 2 has no notifications


### PR DESCRIPTION
## Description

This PR resolves the issue of retrieving the last notification for grouping when the group_by_id matches for a course among the relevant batch users.

## Supporting ticket
https://2u-internal.atlassian.net/browse/INF-1872
