### PR TITLE
feat: Fix character range for codejail darklaunch tmpdir normalization

### DIFF
--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -301,7 +301,8 @@ def emsg_normalizers():
     """
     default = [
         {
-            'search': r'/tmp/codejail-[0-9a-zA-Z]+',
+            # Character range should be at least as broad as what Python's `tempfile` uses.
+            'search': r'/tmp/codejail-[0-9a-zA-Z_]+',
             'replace': r'/tmp/codejail-<SANDBOX_DIR_NAME>',
         },
     ]

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -351,7 +351,7 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             raise SafeExecException("stack trace involving /tmp/codejail-1234567/whatever.py")
 
         def remote_exec(data):
-            emsg = "stack trace involving /tmp/codejail-abcdefgh/whatever.py"
+            emsg = "stack trace involving /tmp/codejail-abcd_EFG/whatever.py"
             return (emsg, SafeExecException(emsg))
 
         results = self.run_dark_launch(
@@ -372,7 +372,7 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
                 ),
                 call(
                     "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg='stack trace involving /tmp/codejail-abcdefgh/whatever.py', exception=None"
+                    "emsg='stack trace involving /tmp/codejail-abcd_EFG/whatever.py', exception=None"
                 ),
             ],
             expect_globals_contains={},


### PR DESCRIPTION
Python's tempfile naming also includes underscore: https://github.com/python/cpython/blob/3.12/Lib/tempfile.py#L140

This omission would cause normalization to fail about 1/6 of the time.

Also expand test to exercise more of character range.
