### PR TITLE
fix: unit xblock adaptivity and small visual enhancements

### DIFF
--- a/cms/static/sass/course-unit-mfe-iframe-bundle.scss
+++ b/cms/static/sass/course-unit-mfe-iframe-bundle.scss
@@ -8,7 +8,7 @@
 
 html {
   body {
-    min-width: 800px;
+    min-width: 560px;
     background: transparent;
     &.openassessment_full_height.view-container {
         overflow-y: hidden;
@@ -39,11 +39,19 @@ body,
       padding: ($baseline * 1.2) ($baseline * 1.2) ($baseline / 1.67);
       border-bottom: none;
 
-      .header-details .xblock-display-name {
-        font-size: 22px;
-        line-height: 28px;
-        font-weight: 700;
-        color: $black;
+      .header-details {
+        .xblock-display-title {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .xblock-display-name {
+          font-size: 22px;
+          line-height: 28px;
+          font-weight: 700;
+          color: $black;
+        }
       }
     }
 
@@ -345,7 +353,6 @@ body,
     }
 
     .tip.setting-help {
-      color: $border-color;
       font-size: 14px;
       line-height: $base-font-size;
     }
@@ -452,6 +459,11 @@ body,
 
   .modal-lg.modal-window.confirm.openassessment_modal_window {
     height: 635px;
+    max-height: 100vh;
+
+    .edit-xblock-modal .modal-content {
+      max-height: 100%;
+    }
   }
 
   // Additions for the xblock editor on the Library Authoring
@@ -672,11 +684,21 @@ body [class*="view-"] .openassessment_editor_buttons.xblock-actions {
     max-width: 1200px;
   }
 
-  .modal-lg.modal-editor .modal-header .editor-modes .action-item {
-    .editor-button,
-    .settings-button {
-      @extend %light-button;
-    }
+  .modal-lg.modal-editor {
+      .modal-header .editor-modes .action-item {
+        .editor-button,
+        .settings-button {
+          @extend %light-button;
+        }
+      }
+
+      .edit-xblock-modal .modal-content {
+        max-height: calc(100vh - 144px);
+
+        .editor-with-buttons.wrapper-comp-settings .list-input.settings-list {
+          max-height: calc(100vh - 205px);
+        }
+      }
   }
 
   .wrapper.wrapper-modal-window .modal-window .modal-actions .action-primary {


### PR DESCRIPTION
## Description
Fix unit xblock adaptivity and small visual enhancements:
1. improve adaptability of the iframe content on small screens (cropping xblock contents)
2. improve adaptability of the iframe legacy edit modal (unable to scroll to bottom on small height windows)
3. add `...` with cropping for long xblock title (cropping titles without `...`)

## Backports:
- teak release https://github.com/openedx/edx-platform/pull/36624

## Screenshots:
| Point | Before | After |
| --- | --- | --- |
| 1 | <img width="915" alt="image" src="https://github.com/user-attachments/assets/370dc24f-bb58-4561-839e-ca3fb463222e" /> | <img width="915" alt="image" src="https://github.com/user-attachments/assets/748ba2ac-4ed4-460f-9b7e-c85f16f9ed3d" /> |
| 2 | <img width="1706" alt="image" src="https://github.com/user-attachments/assets/ab9c2632-ca42-4af1-9446-a191c4797768" /> | <img width="1696" alt="image" src="https://github.com/user-attachments/assets/49231a8d-da36-4100-85af-8867fd781510" /> |
| 3 | <img width="916" alt="image" src="https://github.com/user-attachments/assets/8eef0ffd-fcb4-4f5a-9160-450319c3bb25" /> | <img width="915" alt="image" src="https://github.com/user-attachments/assets/07264428-dff4-495e-8e37-9029f5df3522" /> |

## Testing instructions
- Go to the course unit page.
- (point 1)
-- Set the window width to 950px.
-- The right part of the XBlock should be hidden, and the user must be unable to click control buttons.
- (point 2) 
-- Set the window height to 400px.
-- Click the XBlock edit (pencil) button.
-- Try to scroll to the bottom of the modal.
- (point 3)
-- Add an XBlock with a long name.
-- The XBlock title must display `...` when the name is too long.

