### PR TITLE
fix: migration test to functional

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -1,7 +1,6 @@
 """Tests for util.db module."""
 
 from io import StringIO
-import unittest
 
 import ddt
 from django.core.management import call_command
@@ -121,7 +120,6 @@ class MigrationTests(TestCase):
     Tests for migrations.
     """
 
-    @unittest.skip('Skipping temporarily to add a foreign key')
     @override_settings(MIGRATION_MODULES={})
     def test_migrations_are_in_sync(self):
         """


### PR DESCRIPTION
tracking issue #36561 

`removed the skipping of test_migrations_are_in_sync test.`

verified by running test locally deleberately keeping missing migration.

<img width="564" alt="Screenshot 2025-04-29 at 4 25 45 PM" src="https://github.com/user-attachments/assets/b42d016f-19e9-41e6-b0a9-dbb04f8a5807" />
