### PR TITLE
fix: expose __version__ for LXML.

### DIFF
--- a/openedx/core/lib/safe_lxml/etree.py
+++ b/openedx/core/lib/safe_lxml/etree.py
@@ -18,7 +18,7 @@ from lxml.etree import XMLParser as _XMLParser
 from lxml.etree import *  # lint-amnesty, pylint: disable=redefined-builtin
 # These private elements are used in some libraries to also defuse xml exploits for their own purposes.
 # We need to re-expose them so that the libraries still work.
-from lxml.etree import _Comment, _Element, _ElementTree, _Entity, _ProcessingInstruction
+from lxml.etree import _Comment, _Element, _ElementTree, _Entity, _ProcessingInstruction, __version__
 from .xmlparser import XML, fromstring, parse
 
 


### PR DESCRIPTION
These changes expose the LXML version since it is used by libraries to check LXML version. We faced  a problem in image-explored XBlock. Parsel needs to know the lxml version
https://github.com/scrapy/parsel/blob/master/parsel/selector.py#L35. Since this information was not being passed and etree flavor of opened.


**Testing instructions**:

1.  Use Tutor to set up master
2. Clone git@github.com:openedx/xblock-image-explorer.git repo under (tutor config printroot)/env/build/openedx/requirements/
3. Add private.txt and add `-e ./xblock-image-explorer` in that file.
4. Mount this repository `tutor mounts add ./xblock-image-explorer`
5. Build the image `tutor images build openedx-dev`
6. Now start the dev environment with `tutor dev start -d`
7. Exec in the container `tutor dev exec cms bash`
8. Then run  `./manage.py lms shell`
9. 
```python
In [1]: from xblock.core import XBlock
In [2]: XBlock.load_class('image-explorer')
```
11. This should throw errors. 
12. Once you change the branch in the PR you need to exec in the container
13. `pip install -e /mnt/xblock-image-explorer`
14. Repeat 9 again, this time it will load without error.

Private Ref: [Jira Ticket](https://tasks.opencraft.com/browse/BB-9615)