### PR TITLE
fix: update `openedx-learning` to fix a bug  where deleted containers were returned on the `get_containers` API method [FC-0083]

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -112,7 +112,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.25.0
+openedx-learning==0.26.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -817,7 +817,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/kernel.in
-openedx-learning==0.25.0
+openedx-learning==0.26.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1378,7 +1378,7 @@ openedx-forum==0.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.25.0
+openedx-learning==0.26.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -988,7 +988,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.25.0
+openedx-learning==0.26.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1046,7 +1046,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.25.0
+openedx-learning==0.26.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This PR updates the `openedx-learning` package, fixing a bug where deleted containers were returned on the `get_containers` API method.

## Additional Information
- Related to https://github.com/openedx/frontend-app-authoring/issues/1870
- Depends on https://github.com/openedx/openedx-learning/pull/311

## Testing Instructions

- Create a new library
- Add a new unit to it
- Delete the unit
- Run `tutor dev run cms python manage.py cms reindex_studio --experimental`
- Reload the library and check that the library is empty

___
Private ref: [FAL-4144](https://tasks.opencraft.com/browse/FAL-4144)
