### PR TITLE
feat: Add support to get and save `hide_from_learners` and `enable_discussion` fields in Library Units [FC-0083]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -308,8 +308,9 @@ def create_container(
 
 def update_container(
     container_key: LibraryContainerLocator,
-    display_name: str,
     user_id: int | None,
+    display_name: str | None = None,
+    metadata: dict | None = None,
 ) -> ContainerMetadata:
     """
     Update a container (e.g. a Unit) title.
@@ -318,11 +319,14 @@ def update_container(
     library_key = container_key.lib_key
 
     assert container.unit
+    if metadata is None:
+        metadata = {}
     unit_version = authoring_api.create_next_unit_version(
         container.unit,
         title=display_name,
         created=datetime.now(),
         created_by=user_id,
+        **metadata,
     )
 
     LIBRARY_CONTAINER_UPDATED.send_event(

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -207,6 +207,7 @@ def _get_container_from_key(container_key: LibraryContainerLocator, isDeleted=Fa
     learning_package = content_library.learning_package
     assert learning_package is not None
 
+    container: Container
     match container_key.container_type:
         case ContainerType.Unit.value:
             container = authoring_api.get_unit_by_key(

--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -105,6 +105,10 @@ class LibraryContainerView(GenericAPIView):
             container_key,
             display_name=serializer.validated_data['display_name'],
             user_id=request.user.id,
+            metadata={
+                'hide_from_learners': serializer.validated_data['hide_from_learners'],
+                'enable_discussion': serializer.validated_data['enable_discussion'],
+            }
         )
 
         return Response(serializers.LibraryContainerMetadataSerializer(container).data)

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -271,7 +271,9 @@ class LibraryContainerUpdateSerializer(serializers.Serializer):
     """
     Serializer for updating metadata for Containers like Sections, Subsections, Units
     """
-    display_name = serializers.CharField()
+    display_name = serializers.CharField(default=None, required=False)
+    hide_from_learners = serializers.BooleanField(default=None, required=False)
+    enable_discussion = serializers.BooleanField(default=None, required=False)
 
 
 class ContentLibraryBlockImportTaskSerializer(serializers.ModelSerializer):

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -253,6 +253,10 @@ class LibraryContainerMetadataSerializer(PublishableItemSerializer):
     # the definition key and usage key:
     slug = serializers.CharField(write_only=True, required=False)
 
+    # Unit fields
+    hide_from_learners = serializers.BooleanField(read_only=True, required=False)
+    enable_discussion = serializers.BooleanField(read_only=True, required=False)
+
     def to_internal_value(self, data):
         """
         Convert JSON-ish data back to native python types.

--- a/openedx/core/djangoapps/content_libraries/tests/test_containers.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_containers.py
@@ -82,6 +82,8 @@ class ContainersTestCase(OpenEdxEventsTestMixin, ContentLibrariesRestApiTest):
             'created': '2024-09-08T07:06:05Z',
             'modified': '2024-09-08T07:06:05Z',
             'collections': [],
+            'hide_from_learners': False,
+            'enable_discussion': True,
         }
 
         self.assertDictContainsEntries(container_data, expected_data)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -817,7 +817,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/kernel.in
-openedx-learning==0.26.0
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-4071-new-fields-to-units
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1378,7 +1378,7 @@ openedx-forum==0.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.26.0
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-4071-new-fields-to-units
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -988,7 +988,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.26.0
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-4071-new-fields-to-units
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -118,7 +118,7 @@ openedx-django-require
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-forum                       # Open edX forum v2 application
-openedx-learning                    # Open edX Learning core (experimental)
+git+https://github.com/open-craft/openedx-learning.git@chris/FAL-4071-new-fields-to-units#egg=openedx-learning                    # Open edX Learning core (experimental)
 openedx-mongodbproxy
 openedx-django-wiki
 path

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1046,7 +1046,7 @@ openedx-filters==2.0.1
     #   ora2
 openedx-forum==0.2.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.26.0
+openedx-learning @ git+https://github.com/open-craft/openedx-learning.git@chris/FAL-4071-new-fields-to-units
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- Use `UnitMetadata` for units instead of `ContainerMetadata`.
- Adds metadata param to  `update_container` function.
- Which edX user roles will this change impact? "Developer".

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1640
- Depends on https://github.com/openedx/openedx-learning/pull/312
- Used in: https://github.com/openedx/frontend-app-authoring/pull/1912
- Internal ticket: [FAL-4071](https://tasks.opencraft.com/browse/FAL-4071)

## Testing instructions

Follow the testing instructions in https://github.com/openedx/frontend-app-authoring/pull/1912

## Deadline

"None" 

## Other information

Before merge:

- [ ] Bump openedx-learning version
