### PR TITLE
fix: improve calculation for xblock action dropdown menu on unit page

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -73,6 +73,18 @@ function(
 
         // nav - dropdown related
         $body.click(function() {
+            // Reset iframe height to default when the XBlock action dropdown is closed
+            if ($('.nav-dd .nav-item .wrapper-nav-sub.is-shown').length && window.self !== window.top) {
+              try {
+                window.parent.postMessage({
+                  type: 'toggleCourseXBlockDropdown',
+                  message: 'Adjust the height of the dropdown menu',
+                  payload: { courseXBlockDropdownHeight: 0 }
+                }, document.referrer);
+              } catch (e) {
+                console.error('Failed to post message:', e);
+              }
+            }
             $('.nav-dd .nav-item .wrapper-nav-sub').removeClass('is-shown');
             $('.nav-dd .nav-item .title').removeClass('is-selected');
             $('.custom-dropdown .dropdown-options').hide();

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -678,33 +678,35 @@ function($, _, Backbone, gettext, BasePage,
             // Calculate the viewport height and the dropdown menu height.
             // Check if the dropdown would overflow beyond the iframe height based on the user's click position.
             // If the dropdown overflows, adjust its position to display above the click point.
-            const courseUnitXBlockIframeHeight = window.innerHeight;
-            const courseXBlockDropdownHeight = subMenu.offsetHeight;
-            const clickYPosition = event.clientY;
+            const iframeHeight = window.innerHeight;
+            const dropdownHeight = subMenu.offsetHeight;
+            const offsetBuffer = 10;
 
-            if (courseUnitXBlockIframeHeight < courseXBlockDropdownHeight) {
-                // If the dropdown menu is taller than the iframe, adjust the height of the dropdown menu.
+            const targetRect = event.target.getBoundingClientRect();
+            const targetBottom = targetRect.bottom;
+            const targetTop = targetRect.top;
+
+            // Calculate total space needed below the target to fit dropdown
+            const dropdownBottom = targetBottom + dropdownHeight + offsetBuffer;
+
+            const dropdownFitsBelow = dropdownBottom <= iframeHeight;
+            const dropdownFitsAbove = dropdownHeight + offsetBuffer < targetTop;
+
+            if (!dropdownFitsBelow) {
+              if (dropdownFitsAbove && this.options.isIframeEmbed) {
+                // Display the dropdown above the button
+                subMenu.style.top = `-${dropdownHeight}px`;
+              } else {
+                // Request parent to expand iframe height to fit dropdown
+                const requiredExtraHeight = dropdownBottom - iframeHeight;
                 this.postMessageToParent({
-                    type: 'toggleCourseXBlockDropdown',
-                    message: 'Adjust the height of the dropdown menu',
-                    payload: { courseXBlockDropdownHeight },
+                  type: 'toggleCourseXBlockDropdown',
+                  message: 'Expand iframe to fit dropdown',
+                  payload: {
+                    courseXBlockDropdownHeight: requiredExtraHeight,
+                  },
                 });
-            } else if ((courseXBlockDropdownHeight + clickYPosition) > courseUnitXBlockIframeHeight) {
-                if (courseXBlockDropdownHeight > courseUnitXBlockIframeHeight / 2) {
-                    // If the dropdown menu is taller than half the iframe, send a message to adjust its height.
-                    this.postMessageToParent({
-                      type: 'toggleCourseXBlockDropdown',
-                      message: 'Adjust the height of the dropdown menu',
-                      payload: {
-                        courseXBlockDropdownHeight: courseXBlockDropdownHeight / 2,
-                      },
-                    });
-                } else {
-                    // Move the dropdown menu upward to prevent it from overflowing out of the viewport.
-                    if (this.options.isIframeEmbed) {
-                        subMenu.style.top = `-${courseXBlockDropdownHeight}px`;
-                    }
-                }
+              }
             }
 
             // if propagation is not stopped, the event will bubble up to the


### PR DESCRIPTION
## Description
This PR resolves the issue where the XBlock action dropdown menu could be partially cut off due to limited iframe height. The fixes ensure that the dropdown is fully visible, regardless of its position within the iframe on MFE Unit page.

## Original pull request
- master branch https://github.com/openedx/edx-platform/pull/36634 

## Screenshots
![image](https://github.com/user-attachments/assets/8e9f36d3-9277-40e1-aa1a-42c0f25210ba)

![image](https://github.com/user-attachments/assets/d47ae9b8-c2e2-451d-a87e-ccc3cb070d3c)

## Testing instructions
- Create a Course Unit page in CMS.
- Add an XBlock with small height (e.g., Legacy Library).
- Open the XBlock action menu (three dots).
- Verify that the action menu renders fully and is not cut off.
- Repeat steps 2–4 two more times to ensure consistent behavior with multiple XBlocks on the page.

