### PR TITLE
fix: Use correct default for unsafely param

### DIFF
--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -726,7 +726,7 @@ class _BuiltInProblemBlock(
             # For the purposes of this report, we don't need to support those use cases.
             anonymous_student_id=None,
             cache=None,
-            can_execute_unsafe_code=lambda: None,
+            can_execute_unsafe_code=lambda: False,
             get_python_lib_zip=(
                 lambda: SandboxService(contentstore, self.scope_ids.usage_id.context_key).get_python_lib_zip()
             ),


### PR DESCRIPTION
`unsafely` should be a boolean, not None. I believe this is what was causing a 400 in remote codejail-service calls (during darklaunch) when the `calculate_problem_responses_csv.v2` instructor task ran: https://github.com/edx/edx-arch-experiments/issues/1028

There are also places in the code where this member appears to be a scalar property instead of a method, or possibly that's just buggy code that doesn't run. I decided not to touch that in this PR (we're probably going to DEPR the entire unsafe mechanism anyhow) but if this PR doesn't work, that's the next place to look -- because higher up in this file there's a `can_execute_unsafe_code=None` that we could try changing.
