### PR TITLE
fix: security issue

### DIFF
--- a/cms/templates/container_chromeless.html
+++ b/cms/templates/container_chromeless.html
@@ -215,8 +215,8 @@ from openedx.core.release import RELEASE_LINE
         // it will report the height of its contents to the parent window when the
         // document loads, window resizes, or DOM mutates.
         if (window !== window.parent) {
-            var lastHeight = window.parent[0].offsetHeight;
-            var lastWidth = window.parent[0].offsetWidth;
+            var lastHeight = window.offsetHeight;
+            var lastWidth = window.offsetWidth;
             var contentElement = document.getElementById('content');
 
             function dispatchResizeMessage(event) {


### PR DESCRIPTION
- Attaching error for context:
`Uncaught SecurityError: Failed to read a named property 'offsetHeight' from 'Window': Blocked a frame with origin "https://studio.stage.edx.org/" from accessing a cross-origin frame.`
- It's related previous PR: https://github.com/openedx/edx-platform/pull/36643/files.
- This time followed [LMS template](https://github.com/openedx/edx-platform/blob/5b3caa93e218e38e7459bdc1ff99ee175e93a22b/lms/templates/courseware/courseware-chromeless.html#L126C7-L127C42) as we are not getting any error on LMS.

