### PR TITLE
fix: enable migration checks

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -1,7 +1,6 @@
 """Tests for util.db module."""
 
 from io import StringIO
-import unittest
 
 import ddt
 from django.core.management import call_command
@@ -121,7 +120,6 @@ class MigrationTests(TestCase):
     Tests for migrations.
     """
 
-    @unittest.skip('Skipping temporarily to add a foreign key')
     @override_settings(MIGRATION_MODULES={})
     def test_migrations_are_in_sync(self):
         """


### PR DESCRIPTION
## Description

When adding a foreign key to edx-enterprise ECU table in https://github.com/openedx/edx-enterprise/pull/2338, I temporarily disabled the migration sync checks. I'm re-enabling them here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/openedx/edx-enterprise/pull/2338

Slack convo with Kyle: https://twou.slack.com/archives/C05BH88RYG6/p1746209945051189

## Testing instructions

If the pipeline passes it should be fine.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
