### PR TITLE
feat: add last_published_at to upstream summary endpoint [FC-0083]

### DIFF
--- a/cms/djangoapps/contentstore/models.py
+++ b/cms/djangoapps/contentstore/models.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 from config_models.models import ConfigurationModel
 from django.db import models
-from django.db.models import Count, F, Q, QuerySet
+from django.db.models import Count, F, Q, QuerySet, Max
 from django.db.models.fields import IntegerField, TextField
 from django.db.models.functions import Coalesce
 from django.db.models.lookups import GreaterThan
@@ -186,13 +186,15 @@ class ComponentLink(EntityLinkBase):
                 "upstream_context_title": "CS problems 3",
                 "upstream_context_key": "lib:OpenedX:CSPROB3",
                 "ready_to_sync_count": 11,
-                "total_count": 14
+                "total_count": 14,
+                "last_published_at": "2025-05-02T20:20:44.989042Z"
             },
             {
                 "upstream_context_title": "CS problems 2",
                 "upstream_context_key": "lib:OpenedX:CSPROB2",
                 "ready_to_sync_count": 15,
-                "total_count": 24
+                "total_count": 24,
+                "last_published_at": "2025-05-03T21:20:44.989042Z"
             },
         ]
         """
@@ -201,7 +203,8 @@ class ComponentLink(EntityLinkBase):
             upstream_context_title=F("upstream_block__publishable_entity__learning_package__title"),
         ).annotate(
             ready_to_sync_count=Count("id", Q(ready_to_sync=True)),
-            total_count=Count('id')
+            total_count=Count("id"),
+            last_published_at=Max("upstream_block__publishable_entity__published__version__created")
         )
         return result
 
@@ -332,13 +335,15 @@ class ContainerLink(EntityLinkBase):
                 "upstream_context_title": "CS problems 3",
                 "upstream_context_key": "lib:OpenedX:CSPROB3",
                 "ready_to_sync_count": 11,
-                "total_count": 14
+                "total_count": 14,
+                "last_published_at": "2025-05-02T20:20:44.989042Z"
             },
             {
                 "upstream_context_title": "CS problems 2",
                 "upstream_context_key": "lib:OpenedX:CSPROB2",
                 "ready_to_sync_count": 15,
-                "total_count": 24
+                "total_count": 24,
+                "last_published_at": "2025-05-03T21:20:44.989042Z"
             },
         ]
         """
@@ -347,7 +352,8 @@ class ContainerLink(EntityLinkBase):
             upstream_context_title=F("upstream_container__publishable_entity__learning_package__title"),
         ).annotate(
             ready_to_sync_count=Count("id", Q(ready_to_sync=True)),
-            total_count=Count('id')
+            total_count=Count('id'),
+            last_published_at=Max("upstream_container__publishable_entity__published__version__created"),
         )
         return result
 

--- a/cms/djangoapps/contentstore/models.py
+++ b/cms/djangoapps/contentstore/models.py
@@ -160,7 +160,8 @@ class ComponentLink(EntityLinkBase):
         ready_to_sync = link_filter.pop('ready_to_sync', None)
         result = cls.objects.filter(**link_filter).select_related(
             "upstream_block__publishable_entity__published__version",
-            "upstream_block__publishable_entity__learning_package"
+            "upstream_block__publishable_entity__learning_package",
+            "upstream_block__publishable_entity__published__publish_log_record__publish_log",
         ).annotate(
             ready_to_sync=(
                 GreaterThan(
@@ -204,7 +205,9 @@ class ComponentLink(EntityLinkBase):
         ).annotate(
             ready_to_sync_count=Count("id", Q(ready_to_sync=True)),
             total_count=Count("id"),
-            last_published_at=Max("upstream_block__publishable_entity__published__version__created")
+            last_published_at=Max(
+                "upstream_block__publishable_entity__published__publish_log_record__publish_log__published_at"
+            )
         )
         return result
 
@@ -310,6 +313,7 @@ class ContainerLink(EntityLinkBase):
         result = cls.objects.filter(**link_filter).select_related(
             "upstream_container__publishable_entity__published__version",
             "upstream_container__publishable_entity__learning_package"
+            "upstream_container__publishable_entity__published__publish_log_record__publish_log",
         ).annotate(
             ready_to_sync=(
                 GreaterThan(
@@ -353,7 +357,9 @@ class ContainerLink(EntityLinkBase):
         ).annotate(
             ready_to_sync_count=Count("id", Q(ready_to_sync=True)),
             total_count=Count('id'),
-            last_published_at=Max("upstream_container__publishable_entity__published__version__created"),
+            last_published_at=Max(
+                "upstream_container__publishable_entity__published__publish_log_record__publish_log__published_at"
+            )
         )
         return result
 

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
@@ -28,3 +28,4 @@ class PublishableEntityLinksSummarySerializer(serializers.Serializer):
     upstream_context_key = serializers.CharField(read_only=True)
     ready_to_sync_count = serializers.IntegerField(read_only=True)
     total_count = serializers.IntegerField(read_only=True)
+    last_published_at = serializers.DateTimeField(read_only=True)

--- a/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
@@ -205,12 +205,14 @@ class DownstreamSummaryView(DeveloperErrorViewMixin, APIView):
                 "upstream_context_key": "lib:OpenedX:CSPROB3",
                 "ready_to_sync_count": 11,
                 "total_count": 14
+                "last_published_at": "2025-05-02T20:20:44.989042Z"
             },
             {
                 "upstream_context_title": "CS problems 2",
                 "upstream_context_key": "lib:OpenedX:CSPROB2",
                 "ready_to_sync_count": 15,
-                "total_count": 24
+                "total_count": 24,
+                "last_published_at": "2025-05-03T21:20:44.989042Z"
             },
         ]
         """

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -110,6 +110,8 @@ class _BaseDownstreamViewTestMixin:
         self.learner = UserFactory(username="learner", password="password")
         self._set_library_block_olx(self.html_lib_id, "<html><b>Hello world!</b></html>")
         self._publish_library_block(self.html_lib_id)
+        self._publish_library_block(self.video_lib_id)
+        self._publish_library_block(self.html_lib_id)
 
     def _api(self, method, url, data, expect_response):
         """
@@ -546,6 +548,7 @@ class GetDownstreamSummaryViewTest(
             'upstream_context_key': self.library_id,
             'ready_to_sync_count': 0,
             'total_count': 3,
+            'last_published_at': self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         }]
         self.assertListEqual(data, expected)
         response = self.call_api(str(self.course.id))
@@ -556,5 +559,6 @@ class GetDownstreamSummaryViewTest(
             'upstream_context_key': self.library_id,
             'ready_to_sync_count': 1,
             'total_count': 2,
+            'last_published_at': self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         }]
         self.assertListEqual(data, expected)


### PR DESCRIPTION
## Description

The PR returns the `last_published_at` date from the upstream summary endpoint.
This is necessary to fix the item 5 from https://github.com/openedx/frontend-app-authoring/issues/1853

## Supporting information

- Related to https://github.com/openedx/frontend-app-authoring/issues/1853

## Testing instructions

- Check item 5 from https://github.com/openedx/frontend-app-authoring/pull/1905
___
Private ref: [FAL-4144](https://tasks.opencraft.com/browse/FAL-4144)
