### PR TITLE
chore: remove moto version constraint after verifying compatibility

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,11 +97,6 @@ libsass==0.10.0
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35271
 markdown<3.4.0
 
-# Date: 2024-04-24
-# moto==5.0 contains breaking changes. Needs to be updated separately.
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35270
-moto<5.0
-
 # Date: 2024-07-16
 # We need to upgrade the version of elasticsearch to atleast 7.15 before we can upgrade to Numpy 2.0.0
 # Otherwise we see a failure while running the following command:

--- a/scripts/user_retirement/requirements/testing.in
+++ b/scripts/user_retirement/requirements/testing.in
@@ -1,6 +1,6 @@
 -r base.txt
 
-moto<5.0   # moto==5.0 contains breaking changes. needs to be fixed separately.
+moto
 pytest
 requests_mock
 responses

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -130,7 +130,7 @@ more-itertools==10.6.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce
-moto==4.2.14
+moto==5.1.4
     # via -r scripts/user_retirement/requirements/testing.in
 newrelic==10.9.0
     # via

--- a/scripts/user_retirement/tests/test_retirement_archive_and_cleanup.py
+++ b/scripts/user_retirement/tests/test_retirement_archive_and_cleanup.py
@@ -10,7 +10,7 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from click.testing import CliRunner
-from moto import mock_ec2, mock_s3
+from moto import mock_aws
 
 from scripts.user_retirement.retirement_archive_and_cleanup import (
     ERR_ARCHIVING,
@@ -89,7 +89,7 @@ def fake_learners_to_retire():
     get_learners_by_date_and_status=DEFAULT,
     bulk_cleanup_retirements=DEFAULT
 )
-@mock_s3
+@mock_aws
 def test_successful(*args, **kwargs):
     conn = boto3.resource('s3')
     conn.create_bucket(Bucket=FAKE_BUCKET_NAME)
@@ -118,8 +118,7 @@ def test_successful(*args, **kwargs):
     get_learners_by_date_and_status=DEFAULT,
     bulk_cleanup_retirements=DEFAULT
 )
-@mock_ec2
-@mock_s3
+@mock_aws
 def test_successful_with_batching(*args, **kwargs):
     conn = boto3.resource('s3')
     conn.create_bucket(Bucket=FAKE_BUCKET_NAME)
@@ -149,7 +148,7 @@ def test_successful_with_batching(*args, **kwargs):
     get_learners_by_date_and_status=DEFAULT,
     bulk_cleanup_retirements=DEFAULT
 )
-@mock_s3
+@mock_aws
 def test_successful_dry_run(*args, **kwargs):
     mock_get_access_token = args[0]
     mock_get_learners = kwargs['get_learners_by_date_and_status']
@@ -253,7 +252,7 @@ def test_conflicting_cool_off_date(*_):
     assert 'End date cannot occur within the cool_off_days period' in result.output
 
 
-@mock_s3
+@mock_aws
 def test_s3_upload_data():
     """
     Test case to verify s3 upload and download.


### PR DESCRIPTION
Fixes: #35270 

### Description

This PR removes the version constraint on the `moto` package by upgrading from `moto==4.2.14` to `moto==5.1.4` and updating the relevant test code. Moto 5.x introduces a unified `mock_aws` decorator, which can simulate multiple AWS services such as EC2 and S3, simplifying the test setup.

### Changes introduced
* Updated `scripts/user_retirement/requirements/testing.in`:

  * Replaced `moto<5` with `moto`.
* Ran `make compile-requirements`, which updated `testing.txt` which updated `moto` to its latest version(5.1.4)
* Updated the test script:

  * Replaced `mock_ec2` and `mock_s3` decorators with the unified `mock_aws` decorator in:

    * `scripts/user_retirement/tests/test_retirement_archive_and_cleanup.py`

### Testing instructions
**Environment Setup (in LMS shell)**
```bash
unset DJANGO_SETTINGS_MODULE
unset SERVICE_VARIANT
pip install -r scripts/user_retirement/requirements/base.txt
pip install -r scripts/user_retirement/requirements/testing.txt
```
**Test Execution**

```bash
pytest scripts/user_retirement/tests/test_retirement_archive_and_cleanup.py
```
**All tests passed.**

### Supporting Information
* The only usage of `moto` in the repository was found in the test script:
  `scripts/user_retirement/tests/test_retirement_archive_and_cleanup.py`
* No other parts of the codebase are impacted by this upgrade.
* This change unblocks us from using future versions of `moto`.
