### PR TITLE
Fixed Revoke Access button accessibility with tab press

### DIFF
--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -172,20 +172,22 @@ such that the value can be defined later than this assignment (file load order).
                     var $revokeBtn, labelTrans;
                     labelTrans = gettext('Revoke access');
 
-                    $revokeBtn = $(_.template('<div class="revoke"><span class="icon fa fa-times-circle" aria-hidden="true"></span> <%- label %></div>')({ // eslint-disable-line max-len
+                    $revokeBtn = $(_.template('<button class="btn-link font-weight-normal revoke"><span class="icon fa fa-times-circle" aria-hidden="true"></span> <%- label %></button>')({ // eslint-disable-line max-len
                         label: labelTrans
                     }), {
                         class: 'revoke'
                     });
-                    $revokeBtn.click(function() {
-                        authListWidgetReloadList.modify_member_access(member.email, 'revoke', function(err) {
-                            if (err !== null) {
-                                authListWidgetReloadList.show_errors(err);
-                                return;
-                            }
-                            authListWidgetReloadList.clear_errors();
-                            authListWidgetReloadList.reload_list();
-                        });
+                    $revokeBtn.on('keyup click', function(event) {
+                        if (event.keyCode === 13 || event.type === 'click') {
+                            authListWidgetReloadList.modify_member_access(member.email, 'revoke', function(err) {
+                                if (err !== null) {
+                                    authListWidgetReloadList.show_errors(err);
+                                    return;
+                                }
+                                authListWidgetReloadList.clear_errors();
+                                authListWidgetReloadList.reload_list();
+                            });
+                        }
                     });
                     if (authListWidgetReloadList.rolename === 'Group Moderator') {
                         if (divisionScheme !== undefined && divisionScheme === 'none') {

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -864,6 +864,7 @@
         &:hover,
         &:focus {
           color: $alert-color;
+          text-decoration: none !important;
         }
       }
     }


### PR DESCRIPTION
## Description

This pull request enhances the **Instructor Dashboard > Membership page** by improving the accessibility of the **"Revoke Access"** action in the Course Team Management table. Previously, the revoke action was not reachable via keyboard navigation (Tab key), nor did it respond to the Enter key.

To address this, the `<div>` element previously used for the revoke action has been replaced with a semantic `<button>` element. Appropriate styling classes have been applied to maintain the existing visual appearance while making the element fully keyboard-accessible and operable via the Enter key.

Related to https://github.com/overhangio/tutor-indigo/issues/146

---

## Affected Users

This change impacts the following user role:

* **Admin side** (accessing the Course Team Management section on the Instructor Dashboard)

---

## Screenshot

![Instructor Dashboard - Revoke Access Accessibility](https://github.com/user-attachments/assets/577119fb-75df-4469-abfe-4cd5d8c25868)

---

## Related Work

For additional context, please refer to the related [[Taiga ticket](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/126)](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/126) (access required).

---

## How to Test

1. Check out this PR branch.
2. Run:

   ```bash
   paver update_assets
   ```
3. Navigate to the **Instructor Dashboard > Membership** page.
4. Locate the **Course Team Management** table at the bottom.
5. Press the **Tab** key to move focus to the "Revoke Access" button.
6. Press **Enter** to trigger the action. It should function the same as a mouse click.

---

## Deadline

N/A