### PR TITLE
feat: Improve codejail darklaunch logging

### DIFF
--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -383,7 +383,7 @@ def report_darklaunch_results(
         set_custom_attribute('codejail.darklaunch.emsg_match', 'N/A')
         log.info(
             "Codejail darklaunch had unexpected exception for "
-            f"course={limit_overrides_context}, slug={slug}:\n"
+            f"course={limit_overrides_context!r}, slug={slug!r}:\n"
             f"Local exception: {unexpected_exc_local!r}\n"
             f"Remote exception: {unexpected_exc_remote!r}"
         )
@@ -394,7 +394,7 @@ def report_darklaunch_results(
 
     if not globals_match or not emsg_match:
         log.info(
-            f"Codejail darklaunch had mismatch for course={limit_overrides_context}, slug={slug}:\n"
+            f"Codejail darklaunch had mismatch for course={limit_overrides_context!r}, slug={slug!r}:\n"
             f"{emsg_match=}, {globals_match=}\n"
             f"Local: globals={globals_local!r}, emsg={emsg_local!r}\n"
             f"Remote: globals={globals_remote!r}, emsg={emsg_remote!r}"

--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -355,6 +355,11 @@ def report_darklaunch_results(
     can_compare_output = True
 
     def report_arm(arm, emsg, unexpected_exception):
+        """
+        Set custom attributes for each arm of the darklaunch experiment.
+
+        `arm` should be 'local' or 'remote'.
+        """
         nonlocal can_compare_output
         if unexpected_exception:
             # .. custom_attribute_name: codejail.darklaunch.status.{local,remote}

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -256,12 +256,10 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch local results for slug=None: globals={'overwrite': 'mock local'}, "
-                    "emsg=None, exception=None"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={'overwrite': 'mock remote'}, "
-                    "emsg=None, exception=None"
+                    "Codejail darklaunch had mismatch for course=None, slug=None:\n"
+                    "emsg_match=True, globals_match=False\n"
+                    "Local: globals={'overwrite': 'mock local'}, emsg=None\n"
+                    "Remote: globals={'overwrite': 'mock remote'}, emsg=None"
                 ),
             ],
             # Should only see behavior of local exec
@@ -296,12 +294,9 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch local results for slug=None: globals={}, "
-                    "emsg='unexpected', exception=BaseException('unexpected')"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg=None, exception=None"
+                    "Codejail darklaunch had unexpected exception for course=None, slug=None:\n"
+                    "Local exception: BaseException('unexpected')\n"
+                    "Remote exception: None"
                 ),
             ],
             expect_globals_contains={},
@@ -332,12 +327,10 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch local results for slug=None: globals={}, "
-                    "emsg='oops', exception=None"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg='OH NO', exception=None"
+                    "Codejail darklaunch had mismatch for course=None, slug=None:\n"
+                    "emsg_match=False, globals_match=True\n"
+                    "Local: globals={}, emsg='oops'\n"
+                    "Remote: globals={}, emsg='OH NO'"
                 ),
             ],
             expect_globals_contains={},
@@ -365,16 +358,7 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
                 call('codejail.darklaunch.globals_match', True),
                 call('codejail.darklaunch.emsg_match', True),  # even though not exact match
             ],
-            expect_log_info_calls=[
-                call(
-                    "Codejail darklaunch local results for slug=None: globals={}, "
-                    "emsg='stack trace involving /tmp/codejail-1234567/whatever.py', exception=None"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg='stack trace involving /tmp/codejail-abcd_EFG/whatever.py', exception=None"
-                ),
-            ],
+            expect_log_info_calls=[],
             expect_globals_contains={},
         )
         assert isinstance(results['raised'], SafeExecException)

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -195,7 +195,10 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             mock_remote_exec.side_effect = remote
 
             try:
-                safe_exec("<IGNORED BY MOCKS>", globals_dict)
+                safe_exec(
+                    "<IGNORED BY MOCKS>", globals_dict,
+                    limit_overrides_context="course-v1:org+course+run", slug="hw1",
+                )
             except BaseException as e:
                 safe_exec_e = e
             else:
@@ -215,8 +218,8 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
 
     # These don't change between the tests
     standard_codejail_attr_calls = [
-        call('codejail.slug', None),
-        call('codejail.limit_overrides_context', None),
+        call('codejail.slug', 'hw1'),
+        call('codejail.limit_overrides_context', 'course-v1:org+course+run'),
         call('codejail.extra_files_count', 0),
     ]
 
@@ -256,7 +259,8 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch had mismatch for course=None, slug=None:\n"
+                    "Codejail darklaunch had mismatch for "
+                    "course='course-v1:org+course+run', slug='hw1':\n"
                     "emsg_match=True, globals_match=False\n"
                     "Local: globals={'overwrite': 'mock local'}, emsg=None\n"
                     "Remote: globals={'overwrite': 'mock remote'}, emsg=None"
@@ -294,7 +298,8 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch had unexpected exception for course=None, slug=None:\n"
+                    "Codejail darklaunch had unexpected exception "
+                    "for course='course-v1:org+course+run', slug='hw1':\n"
                     "Local exception: BaseException('unexpected')\n"
                     "Remote exception: None"
                 ),
@@ -327,7 +332,8 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch had mismatch for course=None, slug=None:\n"
+                    "Codejail darklaunch had mismatch for "
+                    "course='course-v1:org+course+run', slug='hw1':\n"
                     "emsg_match=False, globals_match=True\n"
                     "Local: globals={}, emsg='oops'\n"
                     "Remote: globals={}, emsg='OH NO'"


### PR DESCRIPTION
This is intended to make logs more or less a standalone source for analyzing mismatches.

- Only log mismatches or exceptions
- Merge local and remote log messages into one so they can be correlated more easily
- Different log messages for mismatch vs. unexpected exceptions
- Include course ID (as limit overrides context) in log message
