### PR TITLE
feat: update user segment attribute is_disabled when user is disabled…

### DIFF
--- a/lms/djangoapps/support/views/manage_user.py
+++ b/lms/djangoapps/support/views/manage_user.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext as _
 from django.views.generic import View
 from rest_framework.generics import GenericAPIView
 
+from common.djangoapps.track import segment
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import UserPasswordToggleHistory
 from common.djangoapps.util.json_request import JsonResponse
@@ -76,11 +77,13 @@ class ManageUserDetailView(GenericAPIView):
                 user=user, comment=comment, created_by=request.user, disabled=True
             )
             retire_dot_oauth2_models(user)
+            segment.identify(user.id, {'is_disabled': 'true'})
         else:
             user.set_password(generate_password(length=25))
             UserPasswordToggleHistory.objects.create(
                 user=user, comment=comment, created_by=request.user, disabled=False
             )
+            segment.identify(user.id, {'is_disabled': 'false'})
         user.save()
 
         if user.has_usable_password():

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -36,6 +36,7 @@ from rest_framework.viewsets import ViewSet
 from wiki.models import ArticleRevision
 from wiki.models.pluginbase import RevisionPluginRevision
 
+from common.djangoapps.track import segment
 from common.djangoapps.entitlements.models import CourseEntitlement
 from common.djangoapps.student.models import (  # lint-amnesty, pylint: disable=unused-import
     CourseEnrollmentAllowed,
@@ -510,7 +511,9 @@ class AccountDeactivationView(APIView):
 
         Marks the user as having no password set for deactivation purposes.
         """
-        _set_unusable_password(User.objects.get(username=username))
+        user = User.objects.get(username=username)
+        segment.identify(user.id, {'is_disabled': 'true'})
+        _set_unusable_password(user)
         return Response(get_account_settings(request, [username])[0])
 
 


### PR DESCRIPTION
Ticket: [INF-1887](https://2u-internal.atlassian.net/browse/INF-1887)

To make the "Disabled Users" feature more robust, we are introducing safeguards to prevent emails from being sent to users with deactivated accounts. Specifically, we are adding a new `is_disabled` attribute to user profiles shared between Segment and Braze to ensure Braze excludes these users from email campaigns.

This PR updates the system to set the `is_disabled` attribute whenever a user is disabled or re-enabled.

