### PR TITLE
fix: Pass limit overrides context to codejail execution in all places

### DIFF
--- a/xmodule/capa/responsetypes.py
+++ b/xmodule/capa/responsetypes.py
@@ -2140,6 +2140,9 @@ class CustomResponse(LoncapaResponse):
                             globals_dict,
                             python_path=self.context['python_path'],
                             extra_files=self.context['extra_files'],
+                            limit_overrides_context=get_course_id_from_capa_block(
+                                self.capa_block
+                            ),
                             slug=self.id,
                             random_seed=self.context['seed'],
                             unsafely=self.capa_system.can_execute_unsafe_code(),
@@ -2291,6 +2294,9 @@ class CustomResponse(LoncapaResponse):
                     cache=self.capa_system.cache,
                     python_path=self.context['python_path'],
                     extra_files=self.context['extra_files'],
+                    limit_overrides_context=get_course_id_from_capa_block(
+                        self.capa_block
+                    ),
                     slug=self.id,
                     random_seed=self.context['seed'],
                     unsafely=self.capa_system.can_execute_unsafe_code(),
@@ -3274,6 +3280,9 @@ class SchematicResponse(LoncapaResponse):
                 cache=self.capa_system.cache,
                 python_path=self.context['python_path'],
                 extra_files=self.context['extra_files'],
+                limit_overrides_context=get_course_id_from_capa_block(
+                    self.capa_block
+                ),
                 slug=self.id,
                 random_seed=self.context['seed'],
                 unsafely=self.capa_system.can_execute_unsafe_code(),


### PR DESCRIPTION
Some of the calls to `safe_exec` were missing the `limit_overrides_context` parameter. This normally conveys the course key to codejail so that we can give some courses different resource limits, but it's also valuable for diagnosing codejail issues in logs and other telemetry.

I wasn't able to test all of these paths manually, but the utility function `get_course_id_from_capa_block` will swallow errors, so the situation should be no worse if the `LoncapaResponse.capa_block` field has something unexpected.
