### PR TITLE
feat: add setting for config private fields in profile information report

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2741,7 +2741,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             assert student_json['country'] == ''
 
     @ddt.data(True, False)
-    def test_get_students_features_private_fields(self, show_private_fields):
+    def test_get_students_features_private_fields(self, show_private_fields: bool):
         """
         Test that the get_students_features returns the expected private fields
         """
@@ -2817,6 +2817,16 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
                 assert student_json['external_user_key'] == external_key_dict[student.username]
             else:
                 assert student_json['external_user_key'] == ''
+
+    def test_get_students_features_without_permissions(self):
+        """ Test that get_students_features returns 403 without credentials. """
+
+        # removed both roles from courses for instructor
+        CourseDataResearcherRole(self.course.id).remove_users(self.instructor)
+        CourseInstructorRole(self.course.id).remove_users(self.instructor)
+        url = reverse('get_students_features', kwargs={'course_id': str(self.course.id)})
+        response = self.client.post(url, {})
+        assert response.status_code == 403
 
     def test_get_students_who_may_enroll(self):
         """

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2752,7 +2752,8 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         assert "students" in res_json
         for student in res_json["students"]:
-            assert "year_of_birth" not in student
+            for field in settings.PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS:
+                assert field not in student
 
     def test_get_students_features_private_fields_with_custom_config(self):
         """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1512,9 +1512,9 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
             'external_user_key': _('External User Key'),
         }
 
-        if not settings.FEATURES.get('SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT', False):
-            keep_field_private(query_features, 'year_of_birth')
-            query_features_names.pop('year_of_birth', None)
+        for field in settings.PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS:
+            keep_field_private(query_features, field)
+            query_features_names.pop(field, None)
 
         if is_course_cohorted(course.id):
             # Translators: 'Cohort' refers to a group of students within a course.

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1490,7 +1490,6 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
                 'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
                 'goals', 'enrollment_mode', 'last_login', 'date_joined', 'external_user_key'
             ]
-        keep_field_private(query_features, 'year_of_birth')  # protected information
 
         # Provide human-friendly and translatable names for these features. These names
         # will be displayed in the table generated in data_download.js. It is not (yet)
@@ -1502,8 +1501,7 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
             'email': _('Email'),
             'language': _('Language'),
             'location': _('Location'),
-            #  'year_of_birth': _('Birth Year'),  treated as privileged information as of TNL-10683,
-            #  not to go in reports
+            'year_of_birth': _('Birth Year'),
             'gender': _('Gender'),
             'level_of_education': _('Level of Education'),
             'mailing_address': _('Mailing Address'),
@@ -1513,6 +1511,10 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
             'date_joined': _('Date Joined'),
             'external_user_key': _('External User Key'),
         }
+
+        if not settings.FEATURES.get('SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_CSV', False):
+            keep_field_private(query_features, 'year_of_birth')
+            query_features_names.pop('year_of_birth', None)
 
         if is_course_cohorted(course.id):
             # Translators: 'Cohort' refers to a group of students within a course.

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1512,7 +1512,7 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
             'external_user_key': _('External User Key'),
         }
 
-        if not settings.FEATURES.get('SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_CSV', False):
+        if not settings.FEATURES.get('SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT', False):
             keep_field_private(query_features, 'year_of_birth')
             query_features_names.pop('year_of_birth', None)
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1080,7 +1080,7 @@ FEATURES = {
     # .. toggle_name: FEATURES['SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Adds private fields to the profile information CSV export.
+    # .. toggle_description: Adds private fields to the profile information report.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2025-05-12
     # .. toggle_target_removal_date: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1077,15 +1077,15 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     'BADGES_ENABLED': False,
 
-    # .. toggle_name: FEATURES['SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_CSV']
+    # .. toggle_name: FEATURES['SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Adds private fields to the profile information CSV export.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2025-05-12
     # .. toggle_target_removal_date: None
-    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/xxxxx
-    'SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_CSV': False,
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/36688
+    'SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1076,16 +1076,6 @@ FEATURES = {
     # .. toggle_creation_date: 2024-04-02
     # .. toggle_target_removal_date: None
     'BADGES_ENABLED': False,
-
-    # .. toggle_name: FEATURES['SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: Adds private fields to the profile information report.
-    # .. toggle_use_cases: open_edx
-    # .. toggle_creation_date: 2025-05-12
-    # .. toggle_target_removal_date: None
-    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/36688
-    'SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
@@ -4267,6 +4257,14 @@ ACCOUNT_VISIBILITY_CONFIGURATION = {
         'username',
     ],
 }
+
+# .. setting_name: PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS
+# .. setting_default: ["year_of_birth"]
+# .. setting_description: List of private fields that will be hidden from the profile information report.
+# .. setting_use_cases: open_edx
+# .. setting_creation_date: 2025-07-07
+# .. setting_tickets: https://github.com/openedx/edx-platform/pull/36688
+PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS = ["year_of_birth"]
 
 # The list of all fields that are shared with other users using the bulk 'all_users' privacy setting
 ACCOUNT_VISIBILITY_CONFIGURATION["bulk_shareable_fields"] = (

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1076,6 +1076,16 @@ FEATURES = {
     # .. toggle_creation_date: 2024-04-02
     # .. toggle_target_removal_date: None
     'BADGES_ENABLED': False,
+
+    # .. toggle_name: FEATURES['SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_CSV']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Adds private fields to the profile information CSV export.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2025-05-12
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/xxxxx
+    'SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_CSV': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
## Description

This PR introduces a new setting called `PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS`. This setting allows operators to include or remove the private fields in the profile information JSON report or CSV file.

### Context

In [this PR](https://github.com/openedx/edx-platform/pull/32200), the `year_of_birth` field was removed from the report containing enrolled students' profile information for a specific course.

The new setting gives operators the option to include or exclude private fields in these reports. By default, the `year_of_birth` private field remains hidden, preserving the current behavior.

## Testing instructions

1. Create a Tutor environment.
2. Create a mount of **edx-platform** with the changes in this PR.
3. Create a course and enroll some students in it.
4. Then, go to the **LMS > [Your Course] > Instructor > Data Download > Download profile information as a CSV**.
5. You shouldn't see the `year_of_birth` column in the CSV **_(Current behavior)_**.
6. Now, add an empty list in the new setting. You can use this tutor inline plugin:

    ```yaml
    name: common-settings
    version: 1.0.0
    patches:
      openedx-common-settings: |
        PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS = [] # This config shows all fields
        PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS = ["email", "gender"] # This config removes the 'email' and 'gender' fields
    ```

7. Again, download profile information as a CSV.
8. According to your config, you should only see specific columns in the CSV.

## Deadline

None

## Other information

- [Discuss Thread](https://discuss.openedx.org/t/how-to-add-column-year-of-birth-to-export-download-a-csv-of-learners-who-can-enroll/14973/1
)
