### PR TITLE
chore: update edx-i18n-tools constraint to allow newer versions

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -70,13 +70,6 @@ django-storages<1.14.4
 # for them.
 edx-enterprise==5.13.4
 
-# Date: 2024-05-09
-# This has to be constrained as well because newer versions of edx-i18n-tools need the
-# newer version of lxml but that requirement was not made expilict in the 1.6.0 version
-# of the package.  This can be un-pinned when we're upgrading lxml.
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35274
-edx-i18n-tools<1.6.0
-
 # Date: 2024-07-26
 # To override the constraint of edx-lint
 # This can be removed once https://github.com/openedx/edx-platform/issues/34586 is resolved

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -468,9 +468,8 @@ edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/kernel.in
 edx-event-bus-redis==0.6.1
     # via -r requirements/edx/kernel.in
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.9.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
     #   ora2
     #   xblocks-contrib

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -750,9 +750,8 @@ edx-event-bus-redis==0.6.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.9.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -552,9 +552,8 @@ edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.6.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.9.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   ora2
     #   xblocks-contrib

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -577,9 +577,8 @@ edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/base.txt
 edx-event-bus-redis==0.6.1
     # via -r requirements/edx/base.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.9.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   ora2
     #   xblocks-contrib


### PR DESCRIPTION
Fixes: #35274

### Description
This PR updates the **edx-i18n-tools** package from version `v1.6.0` to the latest compatible release, `v1.9.0`. This constraint can be removed as the **lxml** is upgraded to its newer version.

### Supporting Information
The recent [PR](https://github.com/openedx/i18n-tools/pull/197) shows the upgrade of **lxml** to version `5.3.2` recently, which resolves the need for the previous version constraint.