### PR TITLE
Resolve accessibility issues for better WCAG compliance

### DIFF
--- a/lms/static/sass/course/base/_extends.scss
+++ b/lms/static/sass/course/base/_extends.scss
@@ -19,6 +19,10 @@ h1.top-header {
   padding-bottom: lh();
 }
 
+h1.instructor-dashboard-title {
+  border-bottom: none !important;
+}
+
 .button-reset {
   text-transform: none;
   letter-spacing: 0;

--- a/lms/static/sass/lms-course.scss
+++ b/lms/static/sass/lms-course.scss
@@ -25,6 +25,19 @@
     }
 }
 
+/* tab focus styling */
+.page-content-nav button.nav-item {
+    &:focus {
+        box-shadow: 0 0 0 2px #015FCC !important;
+        border-color: #1b6d99 !important;
+    }
+    &:not(.is-active) {
+        &:focus {
+            border-color: transparent !important;
+        }
+    }
+}
+
 @media only screen and (max-width: 767px) {
     .survey-table .survey-option .visible-mobile-only {
         width: calc(100% - 21px) !important;

--- a/lms/templates/components/header/header.underscore
+++ b/lms/templates/components/header/header.underscore
@@ -9,7 +9,7 @@
             <% }) %>
             </nav>
         <% } %>
-        <h2 class="hd hd-2 page-title"><%- title %></h2>
+        <h1 class="hd hd-2 page-title"><%- title %></h1>
         <p class="page-description"><%- description %></p>
     </div>
     <div class="page-header-secondary"></div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -114,7 +114,7 @@ from openedx.core.djangolib.js_utils import (
   <div class="instructor-dashboard-wrapper-2">
         <main id="main" aria-label="Content" tabindex="-1">
         <section class="instructor-dashboard-content-2" id="instructor-dashboard-content">
-          <h2 class="hd hd-2 instructor-dashboard-title">${_("Instructor Dashboard")}</h2>
+          <h1 class="hd hd-2 instructor-dashboard-title">${_("Instructor Dashboard")}</h1>
           <div class="wrap-instructor-info studio-view">
             %if studio_url:
             <a class="instructor-info-action" href="${studio_url}">${_("View Course in Studio")}</a>


### PR DESCRIPTION
## Description
Related to https://github.com/overhangio/tutor-indigo/issues/146
On the Teams tab, press left arrow key to bring the focus on **“My team”** notice that the bottom indicator spreads through all the tabs, and doesn't stay specific to My team's tab, also “Teams” and “Instructor Dashboard” heading(First heading of page) should be H1

![image](https://github.com/user-attachments/assets/f0ce1f6a-a549-4586-bfc6-976f8a35127e)

Useful information to include:

- All user roles "Learner", "Course Author", "Developer", and "Operator".
- When the focus at the tabs, focus should only move using left right error key, and on enter that tab should become active.
![image](https://github.com/user-attachments/assets/cf3f8da9-2756-4948-b870-017d3832ebd5)

After the fix, the focus should move with arrow key without spaning the bottom line on all the tab's bottom, and on pressing **Enter** key, it should be active.
<img width="473" alt="Screenshot 2025-04-17 at 3 47 30 AM" src="https://github.com/user-attachments/assets/b5dc303f-afdd-4423-aff2-1e55574c24e9" />

## Supporting information
You can have a look into the following issues to have more context on the issues(Access Required)
- https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/49
- https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/60

## Testing instructions

One can simply pull the changes on local and build image, the changes should be reflected.

## Deadline

N/A

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere? *No*
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility. *No Limitations*
- *No Database Migrations*