### PR TITLE
fix: use geom_type instead of type for Shapely objects

### DIFF
--- a/common/djangoapps/xblock_django/tests/test_commands.py
+++ b/common/djangoapps/xblock_django/tests/test_commands.py
@@ -64,7 +64,7 @@ def test_compile_xblock_translations(tmp_translations_dir):
                     'msgfmt', '--check-format', '-o', str(po_file.with_suffix('.mo')), str(po_file),
                 ], 'Compiles the .po files'
 
-            js_file_text = get_javascript_i18n_file_path('done', 'tr').text()
+            js_file_text = get_javascript_i18n_file_path('done', 'tr').read_text()
             assert 'Merhaba' in js_file_text, 'Ensures the JavaScript catalog is compiled'
             assert 'TestingDoneXBlockI18n' in js_file_text, 'Ensures the namespace is used'
             assert 'gettext' in js_file_text, 'Ensures the gettext function is defined'

--- a/common/djangoapps/xblock_django/translation.py
+++ b/common/djangoapps/xblock_django/translation.py
@@ -101,7 +101,7 @@ def compile_xblock_js_messages():
         xblock_conf_locale_dir = xmodule_api.get_python_locale_root() / xblock_module
         i18n_js_namespace = xblock_class.get_i18n_js_namespace()
 
-        for locale_dir in xblock_conf_locale_dir.listdir():
+        for locale_dir in xblock_conf_locale_dir.iterdir():
             locale_code = str(locale_dir.basename())
             locale_messages_dir = locale_dir / 'LC_MESSAGES'
             js_translations_domain = None

--- a/xmodule/capa/responsetypes.py
+++ b/xmodule/capa/responsetypes.py
@@ -3399,7 +3399,7 @@ class ImageResponse(LoncapaResponse):
                         parsed_region = [parsed_region]
                     for region in parsed_region:
                         polygon = MultiPoint(region).convex_hull
-                        if (polygon.type == 'Polygon' and
+                        if (polygon.geom_type == 'Polygon' and
                                 polygon.contains(Point(ans_x, ans_y))):
                             correct_map.set(aid, 'correct')
                             break

--- a/xmodule/capa/tests/helpers.py
+++ b/xmodule/capa/tests/helpers.py
@@ -58,10 +58,9 @@ class StubXQueueService:
         return dispatch
 
 
-def test_capa_system(render_template=None):
+def mock_capa_system(render_template=None):
     """
     Construct a mock LoncapaSystem instance.
-
     """
     the_system = Mock(
         spec=LoncapaSystem,
@@ -102,7 +101,7 @@ def mock_capa_block():
 def new_loncapa_problem(xml, problem_id='1', capa_system=None, seed=723, use_capa_render_template=False):
     """Construct a `LoncapaProblem` suitable for unit tests."""
     render_template = capa_render_template if use_capa_render_template else None
-    return LoncapaProblem(xml, id=problem_id, seed=seed, capa_system=capa_system or test_capa_system(render_template),
+    return LoncapaProblem(xml, id=problem_id, seed=seed, capa_system=capa_system or mock_capa_system(render_template),
                           capa_block=mock_capa_block())
 
 

--- a/xmodule/capa/tests/test_answer_pool.py
+++ b/xmodule/capa/tests/test_answer_pool.py
@@ -8,7 +8,7 @@ import textwrap
 import unittest
 
 from xmodule.capa.responsetypes import LoncapaProblemError
-from xmodule.capa.tests.helpers import new_loncapa_problem, test_capa_system
+from xmodule.capa.tests.helpers import new_loncapa_problem, mock_capa_system
 
 
 class CapaAnswerPoolTest(unittest.TestCase):
@@ -16,7 +16,7 @@ class CapaAnswerPoolTest(unittest.TestCase):
 
     def setUp(self):
         super(CapaAnswerPoolTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
-        self.system = test_capa_system()
+        self.system = mock_capa_system()
 
     # XML problem setup used by a few tests.
     common_question_xml = textwrap.dedent("""

--- a/xmodule/capa/tests/test_customrender.py
+++ b/xmodule/capa/tests/test_customrender.py
@@ -6,7 +6,7 @@ import xml.sax.saxutils as saxutils
 from lxml import etree
 
 from xmodule.capa import customrender
-from xmodule.capa.tests.helpers import test_capa_system
+from xmodule.capa.tests.helpers import mock_capa_system
 
 # just a handy shortcut
 lookup_tag = customrender.registry.get_class_for_tag
@@ -30,7 +30,7 @@ class HelperTest(unittest.TestCase):
     '''
 
     def check(self, d):
-        xml = etree.XML(test_capa_system().render_template('blah', d))
+        xml = etree.XML(mock_capa_system().render_template('blah', d))
         assert d == extract_context(xml)
 
     def test_extract_context(self):
@@ -50,7 +50,7 @@ class SolutionRenderTest(unittest.TestCase):
         xml_str = """<solution id="solution_12">{s}</solution>""".format(s=solution)
         element = etree.fromstring(xml_str)
 
-        renderer = lookup_tag('solution')(test_capa_system(), element)
+        renderer = lookup_tag('solution')(mock_capa_system(), element)
 
         assert renderer.id == 'solution_12'
 
@@ -69,7 +69,7 @@ class MathRenderTest(unittest.TestCase):
         xml_str = """<math>{tex}</math>""".format(tex=latex_in)
         element = etree.fromstring(xml_str)
 
-        renderer = lookup_tag('math')(test_capa_system(), element)
+        renderer = lookup_tag('math')(mock_capa_system(), element)
 
         assert renderer.mathstr == mathjax_out
 

--- a/xmodule/capa/tests/test_html_render.py
+++ b/xmodule/capa/tests/test_html_render.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 import ddt
 from lxml import etree
-from xmodule.capa.tests.helpers import new_loncapa_problem, test_capa_system
+from xmodule.capa.tests.helpers import new_loncapa_problem, mock_capa_system
 from openedx.core.djangolib.markup import HTML
 
 from .response_xml_factory import CustomResponseXMLFactory, StringResponseXMLFactory
@@ -24,7 +24,7 @@ class CapaHtmlRenderTest(unittest.TestCase):
 
     def setUp(self):
         super(CapaHtmlRenderTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
-        self.capa_system = test_capa_system()
+        self.capa_system = mock_capa_system()
 
     def test_blank_problem(self):
         """
@@ -148,7 +148,7 @@ class CapaHtmlRenderTest(unittest.TestCase):
         xml_str = StringResponseXMLFactory().build_xml(**kwargs)
 
         # Mock out the template renderer
-        the_system = test_capa_system()
+        the_system = mock_capa_system()
         the_system.render_template = mock.Mock()
         the_system.render_template.return_value = "<div class='input-template-render'>Input Template Render</div>"
 

--- a/xmodule/capa/tests/test_inputtypes.py
+++ b/xmodule/capa/tests/test_inputtypes.py
@@ -34,7 +34,7 @@ from six.moves import zip
 
 from xmodule.capa import inputtypes
 from xmodule.capa.checker import DemoSystem
-from xmodule.capa.tests.helpers import test_capa_system
+from xmodule.capa.tests.helpers import mock_capa_system
 from xmodule.capa.xqueue_interface import XQUEUE_TIMEOUT
 from openedx.core.djangolib.markup import HTML
 
@@ -72,7 +72,7 @@ class OptionInputTest(unittest.TestCase):
             'default_option_text': 'Select an option',
             'response_data': RESPONSE_DATA
         }
-        option_input = lookup_tag('optioninput')(test_capa_system(), element, state)
+        option_input = lookup_tag('optioninput')(mock_capa_system(), element, state)
 
         context = option_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'sky_input'
@@ -138,7 +138,7 @@ class ChoiceGroupTest(unittest.TestCase):
             'response_data': RESPONSE_DATA
         }
 
-        the_input = lookup_tag(tag)(test_capa_system(), element, state)
+        the_input = lookup_tag(tag)(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
 
@@ -233,7 +233,7 @@ class JSInputTest(unittest.TestCase):
             'value': 103,
             'response_data': RESPONSE_DATA
         }
-        the_input = lookup_tag('jsinput')(test_capa_system(), element, state)
+        the_input = lookup_tag('jsinput')(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
 
@@ -270,7 +270,7 @@ class TextLineTest(unittest.TestCase):
             'value': 'BumbleBee',
             'response_data': RESPONSE_DATA
         }
-        the_input = lookup_tag('textline')(test_capa_system(), element, state)
+        the_input = lookup_tag('textline')(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -306,7 +306,7 @@ class TextLineTest(unittest.TestCase):
             'value': 'BumbleBee',
             'response_data': RESPONSE_DATA
         }
-        the_input = lookup_tag('textline')(test_capa_system(), element, state)
+        the_input = lookup_tag('textline')(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -354,7 +354,7 @@ class TextLineTest(unittest.TestCase):
                 'value': 'BumbleBee',
                 'response_data': RESPONSE_DATA
             }
-            the_input = lookup_tag('textline')(test_capa_system(), element, state)
+            the_input = lookup_tag('textline')(mock_capa_system(), element, state)
 
             context = the_input._get_render_context()  # pylint: disable=protected-access
             prob_id = 'prob_1_2'
@@ -400,7 +400,7 @@ class FileSubmissionTest(unittest.TestCase):
             'response_data': RESPONSE_DATA
         }
         input_class = lookup_tag('filesubmission')
-        the_input = input_class(test_capa_system(), element, state)
+        the_input = input_class(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -450,7 +450,7 @@ class CodeInputTest(unittest.TestCase):
         }
 
         input_class = lookup_tag('codeinput')
-        the_input = input_class(test_capa_system(), element, state)
+        the_input = input_class(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -510,7 +510,7 @@ class MatlabTest(unittest.TestCase):
         }
 
         self.input_class = lookup_tag('matlabinput')
-        self.the_input = self.input_class(test_capa_system(), elt, state)
+        self.the_input = self.input_class(mock_capa_system(), elt, state)
 
     def test_rendering(self):
         context = self.the_input._get_render_context()  # pylint: disable=protected-access
@@ -547,7 +547,7 @@ class MatlabTest(unittest.TestCase):
         }
         elt = etree.fromstring(self.xml)
 
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
         expected = {
@@ -582,7 +582,7 @@ class MatlabTest(unittest.TestCase):
             }
             elt = etree.fromstring(self.xml)
             prob_id = 'prob_1_2'
-            the_input = self.input_class(test_capa_system(), elt, state)
+            the_input = self.input_class(mock_capa_system(), elt, state)
             context = the_input._get_render_context()  # pylint: disable=protected-access
             expected = {
                 'STATIC_URL': '/dummy-static/',
@@ -616,7 +616,7 @@ class MatlabTest(unittest.TestCase):
         }
         elt = etree.fromstring(self.xml)
         prob_id = 'prob_1_2'
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         context = the_input._get_render_context()  # pylint: disable=protected-access
         expected = {
             'STATIC_URL': '/dummy-static/',
@@ -668,7 +668,7 @@ class MatlabTest(unittest.TestCase):
                  'feedback': {'message': '3'}, }
         elt = etree.fromstring(self.xml)
 
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         inner_msg = 'hello!'
         queue_msg = json.dumps({'msg': inner_msg})
 
@@ -687,7 +687,7 @@ class MatlabTest(unittest.TestCase):
                  'feedback': {'message': '3'}, }
         elt = etree.fromstring(self.xml)
 
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         inner_msg = 'hello!'
         queue_msg = json.dumps({'msg': inner_msg})
 
@@ -702,7 +702,7 @@ class MatlabTest(unittest.TestCase):
         state = {'input_state': {'queuestate': 'queued', 'queuetime': 5}}
         elt = etree.fromstring(self.xml)
 
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         assert the_input.status == 'queued'
 
     @patch('xmodule.capa.inputtypes.time.time', return_value=45)
@@ -711,7 +711,7 @@ class MatlabTest(unittest.TestCase):
         state = {'input_state': {'queuestate': 'queued', 'queuetime': 5}}
         elt = etree.fromstring(self.xml)
 
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         assert the_input.status == 'unsubmitted'
         assert the_input.msg == 'No response from Xqueue within {} seconds. Aborted.'.format(XQUEUE_TIMEOUT)
 
@@ -723,7 +723,7 @@ class MatlabTest(unittest.TestCase):
         state = {'input_state': {'queuestate': 'queued'}}
         elt = etree.fromstring(self.xml)
 
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         assert the_input.status == 'unsubmitted'
 
     def test_matlab_api_key(self):
@@ -731,7 +731,7 @@ class MatlabTest(unittest.TestCase):
         Test that api_key ends up in the xqueue payload
         """
         elt = etree.fromstring(self.xml)
-        system = test_capa_system()
+        system = mock_capa_system()
         system.matlab_api_key = 'test_api_key'
         the_input = lookup_tag('matlabinput')(system, elt, {})
 
@@ -852,7 +852,7 @@ class MatlabTest(unittest.TestCase):
         }
         elt = etree.fromstring(self.xml)
 
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         context = the_input._get_render_context()  # pylint: disable=protected-access
         self.maxDiff = None
         expected = fromstring('\n<div class="matlabResponse"><div class="commandWindowOutput" style="white-space: pre;"> <strong>if</strong> Conditionally execute statements.\nThe general form of the <strong>if</strong> statement is\n\n   <strong>if</strong> expression\n     statements\n   ELSEIF expression\n     statements\n   ELSE\n     statements\n   END\n\nThe statements are executed if the real part of the expression \nhas all non-zero elements. The ELSE and ELSEIF parts are optional.\nZero or more ELSEIF parts can be used as well as nested <strong>if</strong>\'s.\nThe expression is usually of the form expr rop expr where \nrop is ==, &lt;, &gt;, &lt;=, &gt;=, or ~=.\n<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAjAAAAGkCAIAAACgj==">\n\nExample\n   if I == J\n     A(I,J) = 2;\n   elseif abs(I-J) == 1\n     A(I,J) = -1;\n   else\n     A(I,J) = 0;\n   end\n\nSee also <a>relop</a>, <a>else</a>, <a>elseif</a>, <a>end</a>, <a>for</a>, <a>while</a>, <a>switch</a>.\n\nReference page in Help browser\n   <a>doc if</a>\n\n</div><ul></ul></div>\n')  # lint-amnesty, pylint: disable=line-too-long
@@ -901,7 +901,7 @@ class MatlabTest(unittest.TestCase):
                 'status': 'queued',
             }
             elt = etree.fromstring(self.xml)
-            the_input = self.input_class(test_capa_system(), elt, state)
+            the_input = self.input_class(mock_capa_system(), elt, state)
             assert the_input.queue_msg == queue_msg
 
     def test_matlab_queue_message_not_allowed_tag(self):
@@ -915,7 +915,7 @@ class MatlabTest(unittest.TestCase):
             'status': 'queued',
         }
         elt = etree.fromstring(self.xml)
-        the_input = self.input_class(test_capa_system(), elt, state)
+        the_input = self.input_class(mock_capa_system(), elt, state)
         expected = ""
         assert the_input.queue_msg == expected
 
@@ -974,7 +974,7 @@ class SchematicTest(unittest.TestCase):
             'response_data': RESPONSE_DATA
         }
 
-        the_input = lookup_tag('schematic')(test_capa_system(), element, state)
+        the_input = lookup_tag('schematic')(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -1021,7 +1021,7 @@ class ImageInputTest(unittest.TestCase):
             'response_data': RESPONSE_DATA
         }
 
-        the_input = lookup_tag('imageinput')(test_capa_system(), element, state)
+        the_input = lookup_tag('imageinput')(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -1079,7 +1079,7 @@ class CrystallographyTest(unittest.TestCase):
             'response_data': RESPONSE_DATA
         }
 
-        the_input = lookup_tag('crystallography')(test_capa_system(), element, state)
+        the_input = lookup_tag('crystallography')(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -1124,7 +1124,7 @@ class VseprTest(unittest.TestCase):
             'response_data': RESPONSE_DATA
         }
 
-        the_input = lookup_tag('vsepr_input')(test_capa_system(), element, state)
+        the_input = lookup_tag('vsepr_input')(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'prob_1_2'
@@ -1160,7 +1160,7 @@ class ChemicalEquationTest(unittest.TestCase):
             'value': 'H2OYeah',
             'response_data': RESPONSE_DATA
         }
-        self.the_input = lookup_tag('chemicalequationinput')(test_capa_system(), element, state)
+        self.the_input = lookup_tag('chemicalequationinput')(mock_capa_system(), element, state)
 
     def test_rendering(self):
         """
@@ -1255,7 +1255,7 @@ class FormulaEquationTest(unittest.TestCase):
             'value': 'x^2+1/2',
             'response_data': RESPONSE_DATA
         }
-        self.the_input = lookup_tag('formulaequationinput')(test_capa_system(), element, state)
+        self.the_input = lookup_tag('formulaequationinput')(mock_capa_system(), element, state)
 
     def test_rendering(self):
         """
@@ -1305,7 +1305,7 @@ class FormulaEquationTest(unittest.TestCase):
                 'value': 'x^2+1/2',
                 'response_data': RESPONSE_DATA
             }
-            the_input = lookup_tag('formulaequationinput')(test_capa_system(), element, state)
+            the_input = lookup_tag('formulaequationinput')(mock_capa_system(), element, state)
 
             context = the_input._get_render_context()  # pylint: disable=protected-access
             prob_id = 'prob_1_2'
@@ -1440,7 +1440,7 @@ class DragAndDropTest(unittest.TestCase):
                         ]
         }
 
-        the_input = lookup_tag('drag_and_drop_input')(test_capa_system(), element, state)
+        the_input = lookup_tag('drag_and_drop_input')(mock_capa_system(), element, state)
         prob_id = 'prob_1_2'
         context = the_input._get_render_context()  # pylint: disable=protected-access
         expected = {
@@ -1494,7 +1494,7 @@ class AnnotationInputTest(unittest.TestCase):
 
         tag = 'annotationinput'
 
-        the_input = lookup_tag(tag)(test_capa_system(), element, state)
+        the_input = lookup_tag(tag)(mock_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
         prob_id = 'annotation_input'
@@ -1588,7 +1588,7 @@ class TestChoiceText(unittest.TestCase):
             'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
         expected.update(state)
-        the_input = lookup_tag(tag)(test_capa_system(), element, state)
+        the_input = lookup_tag(tag)(mock_capa_system(), element, state)
         context = the_input._get_render_context()  # pylint: disable=protected-access
         assert context == expected
 

--- a/xmodule/capa/tests/test_responsetypes.py
+++ b/xmodule/capa/tests/test_responsetypes.py
@@ -20,7 +20,7 @@ from pytz import UTC
 
 from xmodule.capa.correctmap import CorrectMap
 from xmodule.capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
-from xmodule.capa.tests.helpers import load_fixture, new_loncapa_problem, test_capa_system
+from xmodule.capa.tests.helpers import load_fixture, new_loncapa_problem, mock_capa_system
 from xmodule.capa.tests.response_xml_factory import (
     AnnotationResponseXMLFactory,
     ChoiceResponseXMLFactory,
@@ -2326,7 +2326,7 @@ class CustomResponseTest(ResponseTest):  # pylint: disable=missing-class-docstri
             import my_helper
             num = my_helper.seventeen()
             """)
-        capa_system = test_capa_system()
+        capa_system = mock_capa_system()
         capa_system.get_python_lib_zip = lambda: zipstring.getvalue()  # lint-amnesty, pylint: disable=unnecessary-lambda
         problem = self.build_problem(script=script, capa_system=capa_system)
         assert problem.context['num'] == 17

--- a/xmodule/capa/tests/test_shuffle.py
+++ b/xmodule/capa/tests/test_shuffle.py
@@ -5,7 +5,7 @@ import textwrap
 import unittest
 
 from xmodule.capa.responsetypes import LoncapaProblemError
-from xmodule.capa.tests.helpers import new_loncapa_problem, test_capa_system
+from xmodule.capa.tests.helpers import new_loncapa_problem, mock_capa_system
 
 
 class CapaShuffleTest(unittest.TestCase):
@@ -13,7 +13,7 @@ class CapaShuffleTest(unittest.TestCase):
 
     def setUp(self):
         super(CapaShuffleTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
-        self.system = test_capa_system()
+        self.system = mock_capa_system()
 
     def test_shuffle_4_choices(self):
         xml_str = textwrap.dedent("""

--- a/xmodule/capa/tests/test_targeted_feedback.py
+++ b/xmodule/capa/tests/test_targeted_feedback.py
@@ -6,7 +6,7 @@ i.e. those with the <multiplechoiceresponse> element
 
 import textwrap
 import unittest
-from xmodule.capa.tests.helpers import load_fixture, new_loncapa_problem, test_capa_system
+from xmodule.capa.tests.helpers import load_fixture, new_loncapa_problem, mock_capa_system
 
 
 class CapaTargetedFeedbackTest(unittest.TestCase):
@@ -16,7 +16,7 @@ class CapaTargetedFeedbackTest(unittest.TestCase):
 
     def setUp(self):
         super(CapaTargetedFeedbackTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
-        self.system = test_capa_system()
+        self.system = mock_capa_system()
 
     def test_no_targeted_feedback(self):
         xml_str = textwrap.dedent("""

--- a/xmodule/capa/tests/test_util.py
+++ b/xmodule/capa/tests/test_util.py
@@ -9,7 +9,7 @@ import unittest
 import ddt
 from lxml import etree
 
-from xmodule.capa.tests.helpers import test_capa_system
+from xmodule.capa.tests.helpers import mock_capa_system
 from xmodule.capa.util import (
     compare_with_tolerance,
     contextualize_text,
@@ -25,7 +25,7 @@ class UtilTest(unittest.TestCase):
 
     def setUp(self):
         super(UtilTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
-        self.system = test_capa_system()
+        self.system = mock_capa_system()
 
     def test_compare_with_tolerance(self):  # lint-amnesty, pylint: disable=too-many-statements
         # Test default tolerance '0.001%' (it is relative)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes: https://github.com/openedx/edx-platform/issues/35176, https://github.com/openedx/edx-platform/issues/35044

These changes update references to Shapely's `type` property to use `geom_type` instead, due to deprecation warnings.

Useful information to include:

Here is the evidence of the deprecation warning message:

Before:
![image](https://github.com/user-attachments/assets/e60a07a4-257d-48ad-92e2-4a0087366260)

After:
![image](https://github.com/user-attachments/assets/ad75add5-0007-4167-b319-dcaa5a9224b0)

Additionally. The helper called test_capa_system was updated by get_capa_system. The reason is pytest was taken this function as a test but actually is a helper.

Here the evidence of the deprecation message:

![image](https://github.com/user-attachments/assets/45415a6c-2562-4326-8aa9-60d8a5a8e5af)

After the fix:

![image](https://github.com/user-attachments/assets/7fc5d5ce-4b11-44a1-8bca-7fc38873188b)


## Supporting information

This PR addresses the following ticket: https://github.com/openedx/edx-platform/issues/35176

## Testing instructions

Simply run this test:  `pytest xmodule xmodule/capa/tests/test_responsetypes.py`
