### PR TITLE
test: removing unused tests related to masking

### DIFF
--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -2798,48 +2798,6 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
                    ('shuffle', ['choice_3', 'choice_1', 'choice_2', 'choice_0'])
             assert event_info['success'] == 'correct'
 
-    @unittest.skip("masking temporarily disabled")
-    def test_save_unmask(self):
-        """On problem save, unmasked data should appear on publish."""
-        block = CapaFactory.create(xml=self.common_shuffle_xml)
-        with patch.object(block.runtime, 'publish') as mock_publish:
-            get_request_dict = {CapaFactory.input_key(): 'mask_0'}
-            block.save_problem(get_request_dict)
-            mock_call = mock_publish.mock_calls[0]
-            event_info = mock_call[1][1]
-            assert event_info['answers'][CapaFactory.answer_key()] == 'choice_2'
-            assert event_info['permutation'][CapaFactory.answer_key()] is not None
-
-    @unittest.skip("masking temporarily disabled")
-    def test_reset_unmask(self):
-        """On problem reset, unmask names should appear publish."""
-        block = CapaFactory.create(xml=self.common_shuffle_xml)
-        get_request_dict = {CapaFactory.input_key(): 'mask_0'}
-        block.submit_problem(get_request_dict)
-        # On reset, 'old_state' should use unmasked names
-        with patch.object(block.runtime, 'publish') as mock_publish:
-            block.reset_problem(None)
-            mock_call = mock_publish.mock_calls[0]
-            event_info = mock_call[1][1]
-            assert mock_call[1][0] == 'reset_problem'
-            assert event_info['old_state']['student_answers'][CapaFactory.answer_key()] == 'choice_2'
-            assert event_info['permutation'][CapaFactory.answer_key()] is not None
-
-    @unittest.skip("masking temporarily disabled")
-    def test_rescore_unmask(self):
-        """On problem rescore, unmasked names should appear on publish."""
-        block = CapaFactory.create(xml=self.common_shuffle_xml)
-        get_request_dict = {CapaFactory.input_key(): 'mask_0'}
-        block.submit_problem(get_request_dict)
-        # On rescore, state/student_answers should use unmasked names
-        with patch.object(block.runtime, 'publish') as mock_publish:
-            block.rescore_problem(only_if_higher=False)  # lint-amnesty, pylint: disable=no-member
-            mock_call = mock_publish.mock_calls[0]
-            event_info = mock_call[1][1]
-            assert mock_call[1][0] == 'problem_rescore'
-            assert event_info['state']['student_answers'][CapaFactory.answer_key()] == 'choice_2'
-            assert event_info['permutation'][CapaFactory.answer_key()] is not None
-
     def test_check_unmask_answerpool(self):
         """Check answer-pool question publish uses unmasked names"""
         xml = textwrap.dedent("""


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

These changes concern unused test cases related to masking, a feature that has not existed for seven years.

## Supporting information

Fixes: https://github.com/openedx/edx-platform/issues/31695

## Testing instructions

Run `pytest xmodule xmodule/tests/test_capa_block.py` 
Expected result: No errors in unit tests

