### PR TITLE
fix: removed unwanted param to course blocks api

### DIFF
--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -323,6 +323,10 @@ class BlocksInfoInCourseView(BlocksInCourseView):
 
         api_version = self.kwargs.get('api_version')
         if api_version == 'v4':
+            # Introduced a new version of the Course Blocks API to avoid breaking existing clients.
+            # The previous implementation unintentionally passed **kwargs as the positional argument to
+            # `hide_access_denial`, leading to potential issues. This new version removes that risk
+            # while preserving the original behavior for older clients.
             response = super().list(request)
         else:
             response = super().list(request, kwargs)

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -322,14 +322,14 @@ class BlocksInfoInCourseView(BlocksInCourseView):
         """
 
         api_version = self.kwargs.get('api_version')
-        if api_version == 'v4':
-            # Introduced a new version of the Course Blocks API to avoid breaking existing clients.
-            # The previous implementation unintentionally passed **kwargs as the positional argument to
-            # `hide_access_denial`, leading to potential issues. This new version removes that risk
+        if api_version is None or api_version in ['v0.5', 'v1', 'v2', 'v3']:
+            response = super().list(request, kwargs)
+        else:
+            # The previous implementation unintentionally passed kwargs as the positional argument to
+            # `hide_access_denial`, leading to potential issues. This new condition for version > v3 removes that risk
             # while preserving the original behavior for older clients.
             response = super().list(request)
-        else:
-            response = super().list(request, kwargs)
+
 
         if request.GET.get('return_type', 'dict') == 'dict':
             course_id = request.query_params.get('course_id', None)

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -330,7 +330,6 @@ class BlocksInfoInCourseView(BlocksInCourseView):
             # while preserving the original behavior for older clients.
             response = super().list(request)
 
-
         if request.GET.get('return_type', 'dict') == 'dict':
             course_id = request.query_params.get('course_id', None)
             course_key = CourseKey.from_string(course_id)

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -321,10 +321,13 @@ class BlocksInfoInCourseView(BlocksInCourseView):
             request - Django request object
         """
 
-        response = super().list(request)
+        api_version = self.kwargs.get('api_version')
+        if api_version == 'v4':
+            response = super().list(request)
+        else:
+            response = super().list(request, kwargs)
 
         if request.GET.get('return_type', 'dict') == 'dict':
-            api_version = self.kwargs.get('api_version')
             course_id = request.query_params.get('course_id', None)
             course_key = CourseKey.from_string(course_id)
             course_overview = CourseOverview.get_from_id(course_key)

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -321,7 +321,7 @@ class BlocksInfoInCourseView(BlocksInCourseView):
             request - Django request object
         """
 
-        response = super().list(request, kwargs)
+        response = super().list(request)
 
         if request.GET.get('return_type', 'dict') == 'dict':
             api_version = self.kwargs.get('api_version')


### PR DESCRIPTION
## Description

Removed unwanted kwargs param to parent course blocks api. This param was going in hide_access_denials which wasn't meant here. After removing this param we are now getting gated xblocks in course blocks api.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
This change will effect all clients consuming mobile apis, so mainly mobile users will affect with this change.

## Deadline
ASAP.
