### PR TITLE
Backport codejail darklaunch fixes to Teak

### DIFF
--- a/xmodule/capa/responsetypes.py
+++ b/xmodule/capa/responsetypes.py
@@ -2140,6 +2140,9 @@ class CustomResponse(LoncapaResponse):
                             globals_dict,
                             python_path=self.context['python_path'],
                             extra_files=self.context['extra_files'],
+                            limit_overrides_context=get_course_id_from_capa_block(
+                                self.capa_block
+                            ),
                             slug=self.id,
                             random_seed=self.context['seed'],
                             unsafely=self.capa_system.can_execute_unsafe_code(),
@@ -2291,6 +2294,9 @@ class CustomResponse(LoncapaResponse):
                     cache=self.capa_system.cache,
                     python_path=self.context['python_path'],
                     extra_files=self.context['extra_files'],
+                    limit_overrides_context=get_course_id_from_capa_block(
+                        self.capa_block
+                    ),
                     slug=self.id,
                     random_seed=self.context['seed'],
                     unsafely=self.capa_system.can_execute_unsafe_code(),
@@ -3274,6 +3280,9 @@ class SchematicResponse(LoncapaResponse):
                 cache=self.capa_system.cache,
                 python_path=self.context['python_path'],
                 extra_files=self.context['extra_files'],
+                limit_overrides_context=get_course_id_from_capa_block(
+                    self.capa_block
+                ),
                 slug=self.id,
                 random_seed=self.context['seed'],
                 unsafely=self.capa_system.can_execute_unsafe_code(),

--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -301,7 +301,8 @@ def emsg_normalizers():
     """
     default = [
         {
-            'search': r'/tmp/codejail-[0-9a-zA-Z]+',
+            # Character range should be at least as broad as what Python's `tempfile` uses.
+            'search': r'/tmp/codejail-[0-9a-zA-Z_]+',
             'replace': r'/tmp/codejail-<SANDBOX_DIR_NAME>',
         },
     ]

--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -272,7 +272,7 @@ def safe_exec(
                 local_exc_unexpected = None if isinstance(exception, SafeExecException) else exception
 
                 report_darklaunch_results(
-                    slug=slug,
+                    limit_overrides_context=limit_overrides_context, slug=slug,
                     globals_local=globals_dict, emsg_local=emsg, unexpected_exc_local=local_exc_unexpected,
                     globals_remote=darklaunch_globals, emsg_remote=remote_emsg, unexpected_exc_remote=remote_exception,
                 )
@@ -347,14 +347,19 @@ def normalize_error_message(emsg):
 
 
 def report_darklaunch_results(
-        *, slug,
+        *, limit_overrides_context, slug,
         globals_local, emsg_local, unexpected_exc_local,
         globals_remote, emsg_remote, unexpected_exc_remote,
 ):
     """Send telemetry for results of darklaunch."""
     can_compare_output = True
 
-    def report_arm(arm, globals_dict, emsg, unexpected_exception):
+    def report_arm(arm, emsg, unexpected_exception):
+        """
+        Set custom attributes for each arm of the darklaunch experiment.
+
+        `arm` should be 'local' or 'remote'.
+        """
         nonlocal can_compare_output
         if unexpected_exception:
             # .. custom_attribute_name: codejail.darklaunch.status.{local,remote}
@@ -373,24 +378,32 @@ def report_darklaunch_results(
             set_custom_attribute(f'codejail.darklaunch.status.{arm}', 'ok' if emsg is None else 'safe_error')
             set_custom_attribute(f'codejail.darklaunch.exception.{arm}', None)
 
-        # Logs include full globals and emsg
-        log.info(
-            f"Codejail darklaunch {arm} results for slug={slug}: globals={globals_dict!r}, "
-            f"emsg={emsg!r}, exception={unexpected_exception!r}"
-        )
-
-    report_arm('local', globals_local, emsg_local, unexpected_exc_local)
-    report_arm('remote', globals_remote, emsg_remote, unexpected_exc_remote)
+    report_arm('local', emsg_local, unexpected_exc_local)
+    report_arm('remote', emsg_remote, unexpected_exc_remote)
 
     # If the arms can't be compared (unexpected errors), stop early -- the rest
     # is about output comparison.
     if not can_compare_output:
         set_custom_attribute('codejail.darklaunch.globals_match', 'N/A')
         set_custom_attribute('codejail.darklaunch.emsg_match', 'N/A')
+        log.info(
+            "Codejail darklaunch had unexpected exception for "
+            f"course={limit_overrides_context!r}, slug={slug!r}:\n"
+            f"Local exception: {unexpected_exc_local!r}\n"
+            f"Remote exception: {unexpected_exc_remote!r}"
+        )
         return
 
     globals_match = globals_local == globals_remote
     emsg_match = normalize_error_message(emsg_local) == normalize_error_message(emsg_remote)
+
+    if not globals_match or not emsg_match:
+        log.info(
+            f"Codejail darklaunch had mismatch for course={limit_overrides_context!r}, slug={slug!r}:\n"
+            f"{emsg_match=}, {globals_match=}\n"
+            f"Local: globals={globals_local!r}, emsg={emsg_local!r}\n"
+            f"Remote: globals={globals_remote!r}, emsg={emsg_remote!r}"
+        )
 
     # .. custom_attribute_name: codejail.darklaunch.globals_match
     # .. custom_attribute_description: True if local and remote globals_dict

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -351,7 +351,7 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             raise SafeExecException("stack trace involving /tmp/codejail-1234567/whatever.py")
 
         def remote_exec(data):
-            emsg = "stack trace involving /tmp/codejail-abcdefgh/whatever.py"
+            emsg = "stack trace involving /tmp/codejail-abcd_EFG/whatever.py"
             return (emsg, SafeExecException(emsg))
 
         results = self.run_dark_launch(
@@ -372,7 +372,7 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
                 ),
                 call(
                     "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg='stack trace involving /tmp/codejail-abcdefgh/whatever.py', exception=None"
+                    "emsg='stack trace involving /tmp/codejail-abcd_EFG/whatever.py', exception=None"
                 ),
             ],
             expect_globals_contains={},

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -195,7 +195,10 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             mock_remote_exec.side_effect = remote
 
             try:
-                safe_exec("<IGNORED BY MOCKS>", globals_dict)
+                safe_exec(
+                    "<IGNORED BY MOCKS>", globals_dict,
+                    limit_overrides_context="course-v1:org+course+run", slug="hw1",
+                )
             except BaseException as e:
                 safe_exec_e = e
             else:
@@ -215,8 +218,8 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
 
     # These don't change between the tests
     standard_codejail_attr_calls = [
-        call('codejail.slug', None),
-        call('codejail.limit_overrides_context', None),
+        call('codejail.slug', 'hw1'),
+        call('codejail.limit_overrides_context', 'course-v1:org+course+run'),
         call('codejail.extra_files_count', 0),
     ]
 
@@ -256,12 +259,11 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch local results for slug=None: globals={'overwrite': 'mock local'}, "
-                    "emsg=None, exception=None"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={'overwrite': 'mock remote'}, "
-                    "emsg=None, exception=None"
+                    "Codejail darklaunch had mismatch for "
+                    "course='course-v1:org+course+run', slug='hw1':\n"
+                    "emsg_match=True, globals_match=False\n"
+                    "Local: globals={'overwrite': 'mock local'}, emsg=None\n"
+                    "Remote: globals={'overwrite': 'mock remote'}, emsg=None"
                 ),
             ],
             # Should only see behavior of local exec
@@ -296,12 +298,10 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch local results for slug=None: globals={}, "
-                    "emsg='unexpected', exception=BaseException('unexpected')"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg=None, exception=None"
+                    "Codejail darklaunch had unexpected exception "
+                    "for course='course-v1:org+course+run', slug='hw1':\n"
+                    "Local exception: BaseException('unexpected')\n"
+                    "Remote exception: None"
                 ),
             ],
             expect_globals_contains={},
@@ -332,12 +332,11 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
             ],
             expect_log_info_calls=[
                 call(
-                    "Codejail darklaunch local results for slug=None: globals={}, "
-                    "emsg='oops', exception=None"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg='OH NO', exception=None"
+                    "Codejail darklaunch had mismatch for "
+                    "course='course-v1:org+course+run', slug='hw1':\n"
+                    "emsg_match=False, globals_match=True\n"
+                    "Local: globals={}, emsg='oops'\n"
+                    "Remote: globals={}, emsg='OH NO'"
                 ),
             ],
             expect_globals_contains={},
@@ -365,16 +364,7 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
                 call('codejail.darklaunch.globals_match', True),
                 call('codejail.darklaunch.emsg_match', True),  # even though not exact match
             ],
-            expect_log_info_calls=[
-                call(
-                    "Codejail darklaunch local results for slug=None: globals={}, "
-                    "emsg='stack trace involving /tmp/codejail-1234567/whatever.py', exception=None"
-                ),
-                call(
-                    "Codejail darklaunch remote results for slug=None: globals={}, "
-                    "emsg='stack trace involving /tmp/codejail-abcd_EFG/whatever.py', exception=None"
-                ),
-            ],
+            expect_log_info_calls=[],
             expect_globals_contains={},
         )
         assert isinstance(results['raised'], SafeExecException)

--- a/xmodule/capa/safe_exec/tests/test_safe_exec.py
+++ b/xmodule/capa/safe_exec/tests/test_safe_exec.py
@@ -370,32 +370,71 @@ class TestCodeJailDarkLaunch(unittest.TestCase):
         assert isinstance(results['raised'], SafeExecException)
         assert 'whatever.py' in repr(results['raised'])
 
+    def test_default_normalizers(self):
+        """
+        Default normalizers handle false mismatches we've observed.
+
+        This just provides coverage for some of the more complicated patterns.
+        """
+        side_1 = (
+            'Couldn\'t execute jailed code: stdout: b\'\', stderr: b\'Traceback'
+            ' (most recent call last):\\n  File "/tmp/codejail-9g9715g_/jailed_code"'
+            ', line 19, in <module>\\n    exec(code, g_dict)\\n  File "<string>"'
+            ', line 1, in <module>\\n  File "<string>", line 89, in test_add\\n'
+            '  File "<string>", line 1\\n    import random random.choice(range(10))'
+            '\\n    ^\\nSyntaxError: invalid syntax\\n\' with status code: 1'
+        )
+        side_2 = (
+            'Couldn\'t execute jailed code: stdout: b\'\', stderr: b\'Traceback'
+            ' (most recent call last):\\n  File "jailed_code"'
+            ', line 19, in <module>\\n    exec(code, g_dict)\\n  File "<string>"'
+            ', line 203, in <module>\\n  File "<string>", line 89, in test_add\\n'
+            '  File "<string>", line 1\\n    import random random.choice(range(10))'
+            '\\n    ^^^^^^\\nSyntaxError: invalid syntax\\n\' with status code: 1'
+        )
+        assert normalize_error_message(side_1) == normalize_error_message(side_2)
+
     @override_settings(CODEJAIL_DARKLAUNCH_EMSG_NORMALIZERS=[
-        {
-            'search': r'/tmp/codejail-[0-9a-zA-Z]+',
-            'replace': r'/tmp/codejail-<RAND>',
-        },
         {
             'search': r'[0-9]+',
             'replace': r'<NUM>',
         },
     ])
     def test_configurable_normalizers(self):
-        """We can override the normalizers, and they run in order."""
+        """We can augment the normalizers, and they run in order."""
         emsg_in = "Error in /tmp/codejail-1234abcd/whatever.py: something 12 34 other"
-        expect_out = "Error in /tmp/codejail-<RAND>/whatever.py: something <NUM> <NUM> other"
+        expect_out = "Error in /tmp/codejail-<SANDBOX_DIR_NAME>/whatever.py: something <NUM> <NUM> other"
+        assert expect_out == normalize_error_message(emsg_in)
+
+    @override_settings(
+        CODEJAIL_DARKLAUNCH_EMSG_NORMALIZERS=[
+            {
+                'search': r'[0-9]+',
+                'replace': r'<NUM>',
+            },
+        ],
+        CODEJAIL_DARKLAUNCH_EMSG_NORMALIZERS_COMBINE='replace',
+    )
+    def test_can_replace_normalizers(self):
+        """We can replace the normalizers."""
+        emsg_in = "Error in /tmp/codejail-1234abcd/whatever.py: something 12 34 other"
+        expect_out = "Error in /tmp/codejail-<NUM>abcd/whatever.py: something <NUM> <NUM> other"
         assert expect_out == normalize_error_message(emsg_in)
 
     @override_settings(CODEJAIL_DARKLAUNCH_EMSG_NORMALIZERS=[
         {
-            'search': r'broken [',
-            'replace': r'replace',
+            'search': r'broken',
+            'replace': r'replace \g<>',  # invalid replacement pattern
         },
     ])
     @patch('xmodule.capa.safe_exec.safe_exec.record_exception')
-    def test_normalizers_validate(self, mock_record_exception):
-        """Normalizers are validated, and fall back to empty list on error."""
-        assert emsg_normalizers() == []  # pylint: disable=use-implicit-booleaness-not-comparison
+    @patch('xmodule.capa.safe_exec.safe_exec.log.error')
+    def test_normalizers_validate(self, mock_log_error, mock_record_exception):
+        """Normalizers are validated, and fall back to default list on error."""
+        assert len(emsg_normalizers()) > 0  # pylint: disable=use-implicit-booleaness-not-comparison
+        mock_log_error.assert_called_once_with(
+            "Could not load custom codejail darklaunch emsg normalizers"
+        )
         mock_record_exception.assert_called_once()
 
 

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -726,7 +726,7 @@ class _BuiltInProblemBlock(
             # For the purposes of this report, we don't need to support those use cases.
             anonymous_student_id=None,
             cache=None,
-            can_execute_unsafe_code=lambda: None,
+            can_execute_unsafe_code=lambda: False,
             get_python_lib_zip=(
                 lambda: SandboxService(contentstore, self.scope_ids.usage_id.context_key).get_python_lib_zip()
             ),


### PR DESCRIPTION
The darklaunch feature is already in Teak, but in an incomplete state; these changes cherrypicked from master will allow proper use of the feature.

For context, see pending addition to release notes:

https://openedx.atlassian.net/wiki/spaces/COMM/pages/4991582211/pending+release+notes+Codejail+darklaunch+feature