### PR TITLE
feat: added batching to managemnet command to avoid queueing errors

### DIFF
--- a/common/djangoapps/student/management/commands/backfill_is_disabled.py
+++ b/common/djangoapps/student/management/commands/backfill_is_disabled.py
@@ -21,13 +21,83 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
-    """Backfill is_disabled attribute for users with unusable passwords in Segment."""
-    help = 'Backfill is_disabled for disabled users in Segment'
+    """
+    Backfill is_disabled attribute for users with unusable passwords in Segment.
+    """
+    help = 'Backfill is_disabled attribute for existing disabled users in Segment'
 
     def add_arguments(self, parser):
-        parser.add_argument('--batch-size', type=int, default=9000, help='Users per batch')
-        parser.add_argument('--dry-run', action='store_true', help='Simulate without calling Segment')
-        parser.add_argument('--retry-limit', type=int, default=3, help='Retry attempts for failed API calls')
+        parser.add_argument(
+            '--batch-size',
+            type=int,
+            default=9000,
+            help='Users per batch'
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Simulate without calling Segment'
+        )
+        parser.add_argument(
+            '--retry-limit',
+            type=int, default=3,
+            help='Retry attempts for failed API calls'
+        )
+
+    def _process_user(self, user_id, batch_number, dry_run):
+        """Process a single user, logging success or failure."""
+        if dry_run:
+            LOGGER.info(
+                f"[Dry Run] Would update user {user_id} with is_disabled=true "
+                f"in batch {batch_number}"
+            )
+            return True
+        try:
+            segment.analytics.identify(user_id=user_id, traits={'is_disabled': True})
+            LOGGER.info(
+                f"Successfully updated user {user_id} with is_disabled=true "
+                f"in batch {batch_number}"
+            )
+            return True
+        except (ConnectionError, ValueError) as e:
+            LOGGER.error(
+                f"Failed to update user {user_id} in batch {batch_number}: "
+                f"{str(e)}"
+            )
+            return False
+
+    def _process_batch(self, users_batch, batch_number, dry_run, retry_limit):
+        """Process a batch of users with retries."""
+        current_batch_size = len(users_batch)
+        if dry_run:
+            for user_id in users_batch:
+                self._process_user(user_id, batch_number, dry_run)
+            return current_batch_size
+
+        retry_count = 0
+        success = False
+        while not success and retry_count <= retry_limit:
+            try:
+                for user_id in users_batch:
+                    self._process_user(user_id, batch_number, dry_run)
+                segment.analytics.flush()
+                LOGGER.info(f"Successfully processed batch {batch_number}")
+                success = True
+                return current_batch_size
+            except (requests.exceptions.RequestException, segment.analytics.errors.APIError) as e:
+                retry_count += 1
+                if retry_count <= retry_limit:
+                    LOGGER.warning(
+                        f"Batch {batch_number} failed (attempt {retry_count}/"
+                        f"{retry_limit}): {str(e)}"
+                    )
+                    time.sleep(2 * retry_count)
+                else:
+                    LOGGER.error(
+                        f"Batch {batch_number} failed after {retry_limit} attempts, "
+                        f"processed {{processed}} users: {str(e)}"
+                    )
+                    return None
 
     def handle(self, *args, **options):
         batch_size = options['batch_size']
@@ -35,15 +105,20 @@ class Command(BaseCommand):
         retry_limit = options['retry_limit']
 
         try:
-            LOGGER.info(f"Starting backfill (batch_size={batch_size}, dry_run={dry_run}, retry_limit={retry_limit})")
+            LOGGER.info(
+                f"Starting backfill (batch_size={batch_size}, dry_run={dry_run}, "
+                f"retry_limit={retry_limit})"
+            )
 
-            total_users = User.objects.filter(password__startswith=UNUSABLE_PASSWORD_PREFIX).count()
+            total_users = User.objects.filter(
+                password__startswith=UNUSABLE_PASSWORD_PREFIX
+            ).count()
 
             if total_users == 0:
-                LOGGER.info("No users to process")
+                LOGGER.info("No users to process, exiting")
                 return
 
-            LOGGER.info(f"Found {total_users} disabled users")
+            LOGGER.info(f"Found {total_users} users that are disabled")
 
             offset = 0
             processed = 0
@@ -54,43 +129,24 @@ class Command(BaseCommand):
                 users_batch = User.objects.filter(
                     password__startswith=UNUSABLE_PASSWORD_PREFIX
                 ).values_list('id', flat=True)[offset:offset+batch_size]
-                current_batch_size = len(users_batch)
+                LOGGER.info(f"Processing batch {batch_number} ({len(users_batch)} users)")
 
-                LOGGER.info(f"Processing batch {batch_number} ({current_batch_size} users)")
-
-                if dry_run:
-                    for user_id in users_batch:
-                        LOGGER.info(f"[Dry Run] Would update user {user_id} with is_disabled=true in batch {batch_number}")
-                    processed += current_batch_size
-                else:
-                    retry_count = 0
-                    success = False
-
-                    while not success and retry_count <= retry_limit:
-                        try:
-                            for user_id in users_batch:
-                                try:
-                                    segment.analytics.identify(user_id=user_id, traits={'is_disabled': True})
-                                    LOGGER.info(f"Successfully updated user {user_id} with is_disabled=true in batch {batch_number}")
-                                except (ConnectionError, ValueError) as e:
-                                    LOGGER.error(f"Failed to update user {user_id} in batch {batch_number}: {str(e)}")
-                            segment.analytics.flush()
-                            LOGGER.info(f"Successfully processed batch {batch_number}")
-                            success = True
-                            processed += current_batch_size
-                        except (requests.exceptions.RequestException, segment.analytics.errors.APIError) as e:
-                            retry_count += 1
-                            if retry_count <= retry_limit:
-                                LOGGER.warning(f"Batch {batch_number} failed (attempt {retry_count}/{retry_limit}): {str(e)}")
-                                time.sleep(2 * retry_count)
-                            else:
-                                LOGGER.error(f"Batch {batch_number} failed after {retry_limit} attempts, processed {processed} users: {str(e)}")
-                                return
-
+                batch_result = self._process_batch(
+                    users_batch, batch_number, dry_run, retry_limit
+                )
+                if batch_result is None:
+                    LOGGER.error(
+                        f"Backfill stopped, processed {processed} users"
+                    )
+                    return
+                processed += batch_result
                 offset += batch_size
                 LOGGER.info(f"Processed {processed}/{total_users} users")
 
-            LOGGER.info(f"Completed: processed {processed}/{total_users} users in {batch_number} batches")
+            LOGGER.info(
+                f"Completed: processed {processed}/{total_users} users in "
+                f"{batch_number} batches"
+            )
 
         except DatabaseError as e:
             LOGGER.error(f"Back fill failed: {str(e)}")

--- a/common/djangoapps/student/management/commands/backfill_is_disabled.py
+++ b/common/djangoapps/student/management/commands/backfill_is_disabled.py
@@ -31,12 +31,12 @@ class Command(BaseCommand):
             '--batch-size',
             type=int,
             default=9000,
-            help='Users per batch'
+            help='Number of users to process per batch'
         )
         parser.add_argument(
             '--dry-run',
             action='store_true',
-            help='Simulate without calling Segment'
+            help='Simulate the back fill without calling Segment'
         )
         parser.add_argument(
             '--retry-limit',
@@ -141,10 +141,10 @@ class Command(BaseCommand):
                     return
                 processed += batch_result
                 offset += batch_size
-                LOGGER.info(f"Processed {processed}/{total_users} users")
+                LOGGER.info(f"Processed {processed} / {total_users} users")
 
             LOGGER.info(
-                f"Completed: processed {processed}/{total_users} users in "
+                f"Completed: processed {processed} / {total_users} users in "
                 f"{batch_number} batches"
             )
 

--- a/common/djangoapps/student/management/commands/backfill_is_disabled.py
+++ b/common/djangoapps/student/management/commands/backfill_is_disabled.py
@@ -8,67 +8,89 @@ batches to minimize memory usage and supports a dry-run mode for testing.
 """
 
 import logging
+import time
 from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.db import DatabaseError
 from common.djangoapps.track import segment
+import requests
 
 LOGGER = logging.getLogger(__name__)
 User = get_user_model()
 
 
 class Command(BaseCommand):
-    """
-    Backfill is_disabled attribute for users with unusable passwords in Segment.
-    """
-    help = 'Backfill is_disabled attribute for existing disabled users in Segment'
+    """Backfill is_disabled attribute for users with unusable passwords in Segment."""
+    help = 'Backfill is_disabled for disabled users in Segment'
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            '--batch-size',
-            type=int,
-            default=100,
-            help='Number of users to process per batch'
-        )
-        parser.add_argument(
-            '--dry-run',
-            action='store_true',
-            help='Simulate the back fill without calling Segment'
-        )
+        parser.add_argument('--batch-size', type=int, default=9000, help='Users per batch')
+        parser.add_argument('--dry-run', action='store_true', help='Simulate without calling Segment')
+        parser.add_argument('--retry-limit', type=int, default=3, help='Retry attempts for failed API calls')
 
     def handle(self, *args, **options):
         batch_size = options['batch_size']
         dry_run = options['dry_run']
+        retry_limit = options['retry_limit']
 
         try:
-            LOGGER.info(f"Starting back fill with batch_size={batch_size}, dry_run={dry_run}")
+            LOGGER.info(f"Starting backfill (batch_size={batch_size}, dry_run={dry_run}, retry_limit={retry_limit})")
 
-            queryset = User.objects.filter(
-                password__startswith=UNUSABLE_PASSWORD_PREFIX
-            ).values('id', 'password')
-
-            total_users = queryset.count()
+            total_users = User.objects.filter(password__startswith=UNUSABLE_PASSWORD_PREFIX).count()
 
             if total_users == 0:
-                LOGGER.info("No users to process, exiting")
+                LOGGER.info("No users to process")
                 return
 
-            LOGGER.info(f"Found {total_users} users that are disabled")
+            LOGGER.info(f"Found {total_users} disabled users")
 
+            offset = 0
             processed = 0
-            for user in queryset.iterator(chunk_size=batch_size):
-                try:
-                    if dry_run:
-                        LOGGER.info(f"[Dry Run] Would update user {user['id']} with is_disabled=true")
-                    else:
-                        segment.identify(user['id'], {'is_disabled': 'true'})
-                        LOGGER.info(f"Successfully updated user {user['id']} with is_disabled=true")
-                    processed += 1
-                except (ConnectionError, ValueError) as e:
-                    LOGGER.error(f"Failed to update user {user['id']}: {str(e)}")
+            batch_number = 0
 
-            LOGGER.info(f"Back fill completed: processed {processed}/{total_users} users")
+            while offset < total_users:
+                batch_number += 1
+                users_batch = User.objects.filter(
+                    password__startswith=UNUSABLE_PASSWORD_PREFIX
+                ).values_list('id', flat=True)[offset:offset+batch_size]
+                current_batch_size = len(users_batch)
+
+                LOGGER.info(f"Processing batch {batch_number} ({current_batch_size} users)")
+
+                if dry_run:
+                    for user_id in users_batch:
+                        LOGGER.info(f"[Dry Run] Would update user {user_id} with is_disabled=true in batch {batch_number}")
+                    processed += current_batch_size
+                else:
+                    retry_count = 0
+                    success = False
+
+                    while not success and retry_count <= retry_limit:
+                        try:
+                            for user_id in users_batch:
+                                try:
+                                    segment.analytics.identify(user_id=user_id, traits={'is_disabled': True})
+                                    LOGGER.info(f"Successfully updated user {user_id} with is_disabled=true in batch {batch_number}")
+                                except (ConnectionError, ValueError) as e:
+                                    LOGGER.error(f"Failed to update user {user_id} in batch {batch_number}: {str(e)}")
+                            segment.analytics.flush()
+                            LOGGER.info(f"Successfully processed batch {batch_number}")
+                            success = True
+                            processed += current_batch_size
+                        except (requests.exceptions.RequestException, segment.analytics.errors.APIError) as e:
+                            retry_count += 1
+                            if retry_count <= retry_limit:
+                                LOGGER.warning(f"Batch {batch_number} failed (attempt {retry_count}/{retry_limit}): {str(e)}")
+                                time.sleep(2 * retry_count)
+                            else:
+                                LOGGER.error(f"Batch {batch_number} failed after {retry_limit} attempts, processed {processed} users: {str(e)}")
+                                return
+
+                offset += batch_size
+                LOGGER.info(f"Processed {processed}/{total_users} users")
+
+            LOGGER.info(f"Completed: processed {processed}/{total_users} users in {batch_number} batches")
 
         except DatabaseError as e:
             LOGGER.error(f"Back fill failed: {str(e)}")

--- a/common/djangoapps/student/management/commands/backfill_is_disabled.py
+++ b/common/djangoapps/student/management/commands/backfill_is_disabled.py
@@ -128,7 +128,7 @@ class Command(BaseCommand):
                 batch_number += 1
                 users_batch = User.objects.filter(
                     password__startswith=UNUSABLE_PASSWORD_PREFIX
-                ).values_list('id', flat=True)[offset:offset+batch_size]
+                ).values_list('id', flat=True)[offset:offset + batch_size]
                 LOGGER.info(f"Processing batch {batch_number} ({len(users_batch)} users)")
 
                 batch_result = self._process_batch(


### PR DESCRIPTION
Ticket: [INF-1894](https://2u-internal.atlassian.net/browse/INF-1894)

While running the management command in the staging environment, we encountered a `segment error: analytics-python queue is full.` This led to `identify` calls being silently dropped, which in turn prevented the `is_disabled` attribute from being synced for many users.

To address this, we've implemented batching using a simple pagination strategy. We now call `flush() `after processing every 9,000 users (as the queue limit is 10,000) to prevent the queue from overflowing and ensure reliable delivery of all analytics events.