### PR TITLE
feat: advertised_start field added to CourseRunSerializer

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -97,6 +97,7 @@ class CourseRunSerializer(serializers.Serializer):
         max_digits=5, decimal_places=2, source="course_overview.lowest_passing_grade"
     )
     startDate = serializers.DateTimeField(source="course_overview.start")
+    advertisedStart = serializers.DateTimeField(source="course_overview.advertised_start")
     endDate = serializers.DateTimeField(source="course_overview.end")
     homeUrl = serializers.SerializerMethodField()
     marketingUrl = serializers.URLField(

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -74,7 +74,10 @@ class LearnerDashboardBaseTest(SharedModuleStoreTestCase):
 
     def create_test_enrollment(self, course_mode=CourseMode.AUDIT):
         """Create a test user, course, and enrollment. Return the enrollment."""
-        course = CourseFactory(self_paced=True)
+        course = CourseFactory(
+            self_paced=True,
+            advertised_start="Winter 2015",
+        )
         CourseModeFactory(
             course_id=course.id,
             mode_slug=course_mode,

--- a/lms/djangoapps/learner_home/test_utils.py
+++ b/lms/djangoapps/learner_home/test_utils.py
@@ -64,9 +64,12 @@ def datetime_to_django_format(datetime_obj):
         return datetime_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def create_test_enrollment(user, course_mode=CourseMode.AUDIT):
+def create_test_enrollment(user, course_mode=CourseMode.AUDIT, advertised_start=None):
     """Create a test user, course, course overview, and enrollment. Return the enrollment."""
-    course = CourseFactory(self_paced=True)
+    course = CourseFactory(
+        self_paced=True,
+        advertised_start=advertised_start,
+    )
 
     CourseModeFactory(
         course_id=course.id,

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -577,6 +577,35 @@ class TestDashboardView(BaseTestDashboardView):
         assert expected_keys == response_data.keys()
 
     @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    def test_response_course_advertised_start(self):
+        """Basic test for correct response structure"""
+
+        # Given I am logged in
+        self.log_in()
+
+        # Creating course
+        advertised_start = "Winter 2025"
+        create_test_enrollment(
+            self.user, advertised_start=advertised_start
+        )
+
+        # When I request the dashboard
+        response = self.client.get(self.view_url)
+
+        # Then I get the expected success response
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        assert "courses" in response_data
+        assert len(response_data["courses"]) > 0
+
+        for course in response_data["courses"]:
+            assert "courseRun" in course
+            course_run = course["courseRun"]
+            assert "advertisedStart" in course_run
+            assert course_run["advertisedStart"] == advertised_start
+
+    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
     @patch("lms.djangoapps.learner_home.views.get_user_account_confirmation_info")
     def test_email_confirmation(self, mock_user_conf_info):
         """Test that email confirmation info passes through correctly"""


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes: https://github.com/openedx/frontend-app-learner-dashboard/issues/558

Issue: 
Course advertised start doesn't appear in the list of courses in the learner dashboard.

![image](https://github.com/user-attachments/assets/6097dc6e-0992-4f5e-a996-2b493c52f17c)

Solution:
Add the missing field **advertisedStart** in **CourseRunSerializer** in order to get the value in the endpoint: `/api/learner_home/init`

## Supporting information

This change depends of this frontend change: https://github.com/openedx/frontend-app-learner-dashboard/pull/619

## Testing instructions

Run `pytest lms -s lms/djangoapps/learner_home/test_serializers.py::TestCourseRunSerializer::test_with_data`


