### PR TITLE
fix: enable content.search app to support Feedback tab in Instructor Dashboard

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3288,6 +3288,9 @@ INSTALLED_APPS = [
     'openedx_tagging.core.tagging.apps.TaggingConfig',
     'openedx.core.djangoapps.content_tagging',
 
+    # Search
+    'openedx.core.djangoapps.content.search',
+
     # Features
     'openedx.features.calendar_sync',
     'openedx.features.course_bookmarks',


### PR DESCRIPTION
## Description

This PR adds openedx.core.djangoapps.content.search to INSTALLED_APPS in lms/envs/common.py to restore the functionality of the Feedback XBlock tab in the Instructor tab.

The Feedback XBlock tab relies on the [get_lms_link_for_item](https://github.com/openedx/FeedbackXBlock/blob/master/feedback/extensions/filters.py#L12) utility, which internally depends on openedx.core.djangoapps.content.search

## Testing instructions
1. Install [FeedbackXblock](https://github.com/openedx/FeedbackXBlock)
2. Add the following patch as an inline plug-in in tutor.
``` yml
  openedx-common-settings: |
    OPEN_EDX_FILTERS_CONFIG = {
      "org.openedx.learning.instructor.dashboard.render.started.v1": {
        "fail_silently": False,
        "pipeline": [
          "feedback.extensions.filters.AddFeedbackTab",
        ]
      },
    }
```
3. Activate the Tutor inline plug-in.
4. Go to the Instructor tab and feedback tab in the course with a feedback xblock

# Other information

![image](https://github.com/user-attachments/assets/9828370d-c45d-4090-b68e-439db480c0f7)
