### PR TITLE
chore: update event-tracking constraint to allow newer versions

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -57,13 +57,6 @@ django-stubs<6
 # for them.
 edx-enterprise==5.13.7
 
-# Date: 2024-07-26
-# To override the constraint of edx-lint
-# This can be removed once https://github.com/openedx/edx-platform/issues/34586 is resolved
-# and the upstream constraint in edx-lint has been removed.
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35273
-event-tracking==3.0.0
-
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.
 # Here is a ticket to upgrade, but it's of debatable importance given that we are rapidly moving

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -546,9 +546,8 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-event-tracking==3.0.0
+event-tracking==3.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-completion
     #   edx-proctoring

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -860,9 +860,8 @@ enmerkar-underscore==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-event-tracking==3.0.0
+event-tracking==3.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-completion

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -637,9 +637,8 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-event-tracking==3.0.0
+event-tracking==3.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-proctoring

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -664,9 +664,8 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-event-tracking==3.0.0
+event-tracking==3.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-proctoring


### PR DESCRIPTION
Fixes: #35273

### Description
This PR removes the constraint on the _event-tracking_ package in edx-platform.

The constraint was originally introduced due to compatibility issues with _edx-lint_, as tracked in [issue #34586](https://github.com/openedx/edx-platform/issues/34586). Since that issue has now been resolved and _edx-lint_ has been removed from the constraints file, we can safely unpin _event-tracking_ constraint.