### PR TITLE
fix: clear buttons in advanced components editors in Libraries [FC-0076]

### DIFF
--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -60,13 +60,18 @@ define(
 
             /**
          * Returns just the modified metadata values, in the format used to persist to the server.
+         * Set `replaceNullWithDefault` to true to replace null values with the default values
          */
-            getModifiedMetadataValues: function() {
+            getModifiedMetadataValues: function(replaceNullWithDefault = false) {
                 var modified_values = {};
                 this.collection.each(
                     function(model) {
                         if (model.isModified()) {
-                            modified_values[model.getFieldName()] = model.getValue();
+                            let value = model.getValue();
+                            if (replaceNullWithDefault && value === null) {
+                                value = model.getDisplayValue();
+                            }
+                            modified_values[model.getFieldName()] = value
                         }
                     }
                 );

--- a/cms/static/js/views/xblock_editor.js
+++ b/cms/static/js/views/xblock_editor.js
@@ -125,10 +125,11 @@ function($, _, gettext, BaseView, XBlockView, MetadataView, MetadataCollection) 
         /**
              * Returns the metadata that has changed in the editor. This is a combination of the metadata
              * modified in the "Settings" editor, as well as any custom metadata provided by the component.
+             * Set `replaceNullWithDefault` to true to replace null values with the default values.
              */
-        getChangedMetadata: function() {
+        getChangedMetadata: function(replaceNullWithDefault = false) {
             var metadataEditor = this.getMetadataEditor();
-            return _.extend(metadataEditor.getModifiedMetadataValues(), this.getCustomMetadata());
+            return _.extend(metadataEditor.getModifiedMetadataValues(replaceNullWithDefault), this.getCustomMetadata());
         },
 
         /**

--- a/common/templates/xblock_v2/xblock_iframe.html
+++ b/common/templates/xblock_v2/xblock_iframe.html
@@ -340,7 +340,7 @@
                         $('.save-button', passElement).bind('click', function() {
                             //event.preventDefault();
                             var error_message_div = $('.xblock-editor-error-message', passElement);
-                            const modifiedData = editorView.getChangedMetadata();
+                            const modifiedData = editorView.getChangedMetadata(true);
 
                             error_message_div.html();
                             error_message_div.css('display', 'none');


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- The value is saved as null when using the Clear buttons in Word Cloud and LTI editors. This PR fixes this issue by saving the item's default value.
- Which edX user roles will this change impact? "Course Author".


## Supporting information

- Github link: https://github.com/openedx/frontend-app-authoring/issues/1716
- Internal ticket: [FAL-4113](https://tasks.opencraft.com/browse/FAL-4113)

## Testing instructions

- Run `npm run build` in the cms-shell
- Follow the steps in https://github.com/openedx/frontend-app-authoring/issues/1716

## Deadline

ASAP

## Other information

N/A
