### PR TITLE
fix: retrieve course ID when rendering DiscussionXBlock

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -189,7 +189,7 @@ class User(models.Model):
             retrieve_params['group_id'] = self.group_id
 
         # course key -> id conversation
-        course_id = retrieve_params.get('course_id')
+        course_id = retrieve_params.get('course_id') or kwargs.get("course_key")
         if course_id:
             course_id = str(course_id)
             retrieve_params['course_id'] = course_id


### PR DESCRIPTION
## Description

Without this, the `forum` package gets `"None"` as a course key and fails with `InvalidKeyError` when checking the forum backend.

<details><summary><b>Example traceback</b></summary>

```python
Traceback (most recent call last):
  File "/openedx/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/user.py", line 247, in _retrieve
    response = forum_api.get_user(
               ^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/forum/api/users.py", line 37, in get_user
    raise ForumV2RequestError(str(f"user not found with id: {user_id}"))
forum.utils.ForumV2RequestError: user not found with id: 92

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/openedx/venv/lib/python3.11/site-packages/opaque_keys/__init__.py", line 189, in from_string
    namespace, rest = cls._separate_namespace(serialized)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/opaque_keys/__init__.py", line 220, in _separate_namespace
    raise InvalidKeyError(cls, serialized)
opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.keys.CourseKey'>: None

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapper_view
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/lms/djangoapps/discussion/views.py", line 208, in wrapped_view
    return view_func(request, course_key, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/lms/djangoapps/discussion/views.py", line 221, in inline_discussion
    user_info = cc_user.to_dict(course_key=str(course_key))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/models.py", line 65, in to_dict
    self.retrieve(course_key=course_key)
  File "/openedx/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/models.py", line 70, in retrieve
    self._retrieve(*args, **kwargs)
  File "/openedx/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/user.py", line 254, in _retrieve
    self.save({"course_id": course_id})
  File "/openedx/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/models.py", line 170, in save
    response = self.handle_update(params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/models.py", line 235, in handle_update
    response = self.handle_update_user(request_params, str(course_key))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/models.py", line 248, in handle_update_user
    response = forum_api.update_user(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/forum/api/users.py", line 58, in update_user
    backend = get_backend(course_id)()
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/forum/backend.py", line 35, in _get_backend
    if is_mysql_backend_enabled(course_id):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/forum/backend.py", line 24, in is_mysql_backend_enabled
    course_key = CourseKey.from_string(course_id)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/opaque_keys/__init__.py", line 198, in from_string
    return cls.deprecated_fallback._from_deprecated_string(serialized)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/opaque_keys/edx/locator.py", line 404, in _from_deprecated_string
    raise InvalidKeyError(cls, serialized)
opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.locator.CourseLocator'>: None
```
</details>

## Testing instructions

1. Do not check out this branch.
2. Create a unit with a Discussion XBlock.
3. Go to `/admin/forum/forumuser/` and remove your user entry.
4. Visit the abovementioned unit in the LMS. You should see an error on that page.
5. Check out this branch and refresh the page with the unit.
6. Go to `/admin/forum/forumuser/` and check that your user entry was created.

## Deadline

"None"