### PR TITLE
feat!: Moved all notifications from core to non core

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -15,7 +15,15 @@ COURSE_NOTIFICATION_TYPES = {
     'new_comment_on_response': {
         'notification_app': 'discussion',
         'name': 'new_comment_on_response',
-        'is_core': True,
+        'is_core': False,
+        'info': '',
+
+        'web': True,
+        'email': True,
+        'push': True,
+        'non_editable': [],
+        'email_cadence': EmailCadence.DAILY,
+
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on your response to the post '
                               '<{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
@@ -28,7 +36,14 @@ COURSE_NOTIFICATION_TYPES = {
     'new_comment': {
         'notification_app': 'discussion',
         'name': 'new_comment',
-        'is_core': True,
+        'is_core': False,
+        'info': '',
+
+        'web': True,
+        'email': True,
+        'push': True,
+        'non_editable': [],
+        'email_cadence': EmailCadence.DAILY,
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on <{strong}>{author_name}'
                               '</{strong}> response to your post <{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
@@ -42,7 +57,13 @@ COURSE_NOTIFICATION_TYPES = {
     'new_response': {
         'notification_app': 'discussion',
         'name': 'new_response',
-        'is_core': True,
+        'is_core': False,
+        'info': '',
+        'web': True,
+        'email': True,
+        'push': True,
+        'non_editable': [],
+        'email_cadence': EmailCadence.DAILY,
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> responded to your '
                               'post <{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
@@ -93,7 +114,11 @@ COURSE_NOTIFICATION_TYPES = {
     'response_on_followed_post': {
         'notification_app': 'discussion',
         'name': 'response_on_followed_post',
-        'is_core': True,
+        'is_core': False,
+        'web': True,
+        'email': True,
+        'push': True,
+        'email_cadence': EmailCadence.DAILY,
         'info': '',
         'non_editable': [],
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> responded to a post you’re following: '
@@ -108,7 +133,11 @@ COURSE_NOTIFICATION_TYPES = {
     'comment_on_followed_post': {
         'notification_app': 'discussion',
         'name': 'comment_on_followed_post',
-        'is_core': True,
+        'is_core': False,
+        'web': True,
+        'email': True,
+        'push': True,
+        'email_cadence': EmailCadence.DAILY,
         'info': '',
         'non_editable': [],
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> commented on <{strong}>{author_name}'
@@ -146,9 +175,13 @@ COURSE_NOTIFICATION_TYPES = {
     'response_endorsed_on_thread': {
         'notification_app': 'discussion',
         'name': 'response_endorsed_on_thread',
-        'is_core': True,
         'info': '',
+        'is_core': False,
+        'web': True,
+        'email': True,
+        'push': True,
         'non_editable': [],
+        'email_cadence': EmailCadence.DAILY,
         'content_template': _('<{p}><{strong}>{replier_name}\'s</{strong}> response has been endorsed in your post '
                               '<{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
@@ -161,7 +194,11 @@ COURSE_NOTIFICATION_TYPES = {
     'response_endorsed': {
         'notification_app': 'discussion',
         'name': 'response_endorsed',
-        'is_core': True,
+        'is_core': False,
+        'web': True,
+        'email': True,
+        'push': True,
+        'email_cadence': EmailCadence.DAILY,
         'info': '',
         'non_editable': [],
         'content_template': _('<{p}>Your response has been endorsed on the post <{strong}>{post_title}</{strong}></{'
@@ -470,9 +507,9 @@ class NotificationAppManager:
             notification_app_preferences = {}
             notification_types, core_notifications, \
                 non_editable_channels = NotificationTypeManager().get_notification_app_preference(
-                    notification_app_key,
-                    email_opt_out
-                )
+                notification_app_key,
+                email_opt_out
+            )
             self.add_core_notification_preference(notification_app_attrs, notification_types, email_opt_out)
             self.add_core_notification_non_editable(notification_app_attrs, non_editable_channels)
 

--- a/openedx/core/djangoapps/notifications/tests/test_tasks.py
+++ b/openedx/core/djangoapps/notifications/tests/test_tasks.py
@@ -182,9 +182,9 @@ class SendNotificationsTest(ModuleStoreTestCase):
 
         preference = CourseNotificationPreference.get_user_course_preference(self.user.id, self.course_1.id)
         app_prefs = preference.notification_preference_config[app_name]
-        app_prefs['notification_types']['core']['web'] = False
-        app_prefs['notification_types']['core']['email'] = False
-        app_prefs['notification_types']['core']['push'] = False
+        app_prefs['notification_types']['new_response']['web'] = False
+        app_prefs['notification_types']['new_response']['email'] = False
+        app_prefs['notification_types']['new_response']['push'] = False
         preference.save()
 
         send_notifications([self.user.id], str(self.course_1.id), app_name, notification_type, context, content_url)

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -302,38 +302,79 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
             'notification_preference_config': {
                 'discussion': {
                     'enabled': True,
-                    'core_notification_types': [
-                        'new_comment_on_response',
-                        'new_comment',
-                        'new_response',
-                        'response_on_followed_post',
-                        'comment_on_followed_post',
-                        'response_endorsed_on_thread',
-                        'response_endorsed'
-                    ],
+                    'core_notification_types': [],
                     'notification_types': {
-                        'new_discussion_post': {
-                            'web': False,
-                            'email': False,
-                            'push': False,
-                            'email_cadence': 'Daily',
-                            'info': ''
+                        "new_comment_on_response": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": ""
                         },
-                        'new_question_post': {
-                            'web': False,
-                            'email': False,
-                            'push': False,
-                            'email_cadence': 'Daily',
-                            'info': ''
+                        "new_comment": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": ""
                         },
-                        'core': {
-                            'web': True,
-                            'email': True,
-                            'push': True,
-                            'email_cadence': 'Daily',
-                            'info': 'Notifications for responses and comments on your posts, and the ones you’re '
-                                    'following, including endorsements to your responses and on your posts.'
+                        "new_response": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": ""
                         },
+                        "new_discussion_post": {
+                            "web": False,
+                            "push": False,
+                            "email": False,
+                            "email_cadence": "Daily",
+                            "info": ""
+                        },
+                        "new_question_post": {
+                            "web": False,
+                            "push": False,
+                            "email": False,
+                            "email_cadence": "Daily",
+                            "info": ""
+                        },
+                        "response_on_followed_post": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": ""
+                        },
+                        "comment_on_followed_post": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": ""
+                        },
+                        "response_endorsed_on_thread": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": ""
+                        },
+                        "response_endorsed": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": ""
+                        },
+                        "core": {
+                            "web": True,
+                            "push": True,
+                            "email": True,
+                            "email_cadence": "Daily",
+                            "info": "Notifications for responses and comments on your posts, and the ones you’re following, including endorsements to your responses and on your posts."
+                        },
+
                         'content_reported': {
                             'web': True,
                             'email': True,


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
