### PR TITLE
fix: sort Advanced components alphabetically by display name

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -494,6 +494,11 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
             course_advanced_keys
         )
     if advanced_component_templates['templates']:
+        # Advanced component templates should be sorted alphabetically by display name.
+        advanced_component_templates['templates'] = sorted(
+            advanced_component_templates['templates'],
+            key=lambda x: x.get('display_name')
+        )
         component_templates.append(advanced_component_templates)
 
     return component_templates

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -2909,7 +2909,7 @@ class TestComponentTemplates(CourseTestCase):
 
         self.templates = get_component_templates(self.course)
 
-        self.default_advanced_modules_titles = [
+        self.default_advanced_modules_titles = sorted([
             "Google Calendar",
             "Google Document",
             "LTI Consumer",
@@ -2917,7 +2917,7 @@ class TestComponentTemplates(CourseTestCase):
             "Content Experiment",
             "Survey",
             "Word cloud",
-        ]
+        ])
 
     def get_templates_of_type(self, template_type):
         """


### PR DESCRIPTION
## Description

This PR is addressed at adding sorting of Advanced components in the studio by display name.

Related issue - https://github.com/openedx/frontend-app-authoring/issues/2010

Useful information to include:
<img width="505" alt="Знімок екрана 2025-05-21 о 18 01 06" src="https://github.com/user-attachments/assets/b873b839-2a0a-4bc6-a05a-8b0fab2107de" />

