### PR TITLE
[TEAK] fix: recurse through pasted block data to replace static paths (#36723)

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -315,7 +315,8 @@ def _insert_static_files_into_downstream_xblock(
     if hasattr(downstream_xblock, "data") and substitutions:
         data_with_substitutions = downstream_xblock.data
         for old_static_ref, new_static_ref in substitutions.items():
-            data_with_substitutions = data_with_substitutions.replace(
+            data_with_substitutions = _replace_strings(
+                data_with_substitutions,
                 old_static_ref,
                 new_static_ref,
             )
@@ -323,6 +324,26 @@ def _insert_static_files_into_downstream_xblock(
         if store is not None:
             store.update_item(downstream_xblock, request.user.id)
     return notices
+
+
+def _replace_strings(obj: dict | list | str, old_str: str, new_str: str):
+    """
+    Replacing any instances of the given `old_str` string with `new_str` in any strings found in the the given object.
+
+    Returns the updated object.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            obj[key] = _replace_strings(value, old_str, new_str)
+
+    elif isinstance(obj, list):
+        for index, item in enumerate(obj):
+            obj[index] = _replace_strings(item, old_str, new_str)
+
+    elif isinstance(obj, str):
+        return obj.replace(old_str, new_str)
+
+    return obj
 
 
 def import_staged_content_from_user_clipboard(parent_key: UsageKey, request) -> tuple[XBlock | None, StaticFileNotices]:


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Backports bugfix https://github.com/openedx/edx-platform/pull/36723 to Teak.

This fix helps Course Authors use content staging in their Courses.

## Supporting information

No github issue -- discovered this bug while doing something else.
Private-ref: [FAL-4080](https://tasks.opencraft.com/browse/FAL-4080)

## Testing instructions

See https://github.com/openedx/edx-platform/pull/36723

## Deadline

ASAP