### PR TITLE
fix: remove double edit buttons on unit outline [teak]

### DIFF
--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -211,13 +211,12 @@ upstream_info = UpstreamLink.try_get_for_block(xblock, log_error=False)
                                 <span data-tooltip="${_('Drag to reorder')}" class="drag-handle action"></span>
                             </li>
                         % endif
-                        % if not show_inline:
-                            <li class="action-item action-edit action-edit-view-only">
-                                <a href="#" class="edit-button action-button">
-                                    <span class="action-button-text">${_("Details")}</span>
-                                </a>
-                            </li>
-                        % endif
+                    % elif not show_inline:
+                        <li class="action-item action-edit action-edit-view-only">
+                            <a href="#" class="edit-button action-button">
+                                <span class="action-button-text">${_("Details")}</span>
+                            </a>
+                        </li>
                     % endif
                 % endif
             </ul>


### PR DESCRIPTION
## Description

Backport of https://github.com/openedx/edx-platform/pull/36770

## Additional Information
- Relates to https://github.com/openedx/frontend-app-authoring/issues/1986

## Testing Instructions

Check https://github.com/openedx/edx-platform/pull/36770