### PR TITLE
Problem Bank "view" button

### DIFF
--- a/xmodule/item_bank_block.py
+++ b/xmodule/item_bank_block.py
@@ -512,7 +512,7 @@ class ItemBankBlock(ItemBankMixin, XBlock):
             # Show a summary message and instructions.
             summary_html = loader.render_django_template('templates/item_bank/author_view.html', {
                 # Due to template interpolation limitations, we have to pass some HTML for the link here:
-                "view_link": f'<a href="/container/{self.usage_key}">',
+                "view_link": f'<a target="_top" href="/container/{self.usage_key}">',
                 "blocks": [
                     {"display_name": display_name_with_default(child)}
                     for child in self.get_children()


### PR DESCRIPTION
## Description

Fixes: https://github.com/openedx/wg-build-test-release/issues/480

This change adds _top target to the view link (seen on the red circle below, ignore the green for this issue) on the Problem Bank component to open separate route outside of iframe.

![image](https://github.com/user-attachments/assets/a5683737-1a15-420e-b703-6e347582a35b)

Useful information to include:

- Which edX user roles will this change impact? "Course Author"

Previous behavior:

Screen Recording 2025-05-21 at 2.02.57 PM

New behavior:

Screen Recording 2025-05-22 at 2.25.34 PM

## Supporting information

Original Issue: https://github.com/openedx/frontend-app-authoring/issues/1895

## Testing instructions

1. Create Library:
- Add 3 Drag and Drop components
- Publish those components on the library
2. Create Course:
- Create Section
- Create Sub-section
- Add New unit
    - Add Problem Bank (beta) component within new unit
    - "Add Component" from a content library to this problem bank.
    - Choose the library you created in step 1
    - Select 3 drag and drop components > Add selected components

Once the authoring page loads those new components into the problem bank, you can see and click the "view" button as shown in the video.

## Deadline

Teak build-test-release high priority.

## Other information

This does not address the other "view" button as mentioned in this ticket for the MFE: https://github.com/openedx/frontend-app-authoring/issues/2007
