### PR TITLE
fix: remove unnecessary disclaimer prefix

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -183,16 +183,14 @@ from openedx.core.djangolib.js_utils import (
         </div>
         % endif
         <div class="google-disclaimer">
-            <span className="text-dark-300 x-small">Powered by
-                <a href="https://translate.google.com/" target="_blank">
-                    <img
-                        width="100"
-                        id="google-translate-logo"
-                        src="https://learning.edx.org/d4ab1b25143ecad62d69d855b00e7313.png"
-                        alt="Translated by Google logo"
-                    >
-                </a>
-            </span>
+            <a href="https://translate.google.com/" target="_blank">
+                <img
+                    width="200"
+                    id="google-translate-logo"
+                    src="https://learning.edx.org/d4ab1b25143ecad62d69d855b00e7313.png"
+                    alt="Translated by Google logo"
+                >
+            </a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR removes unnecessary `Powered by` prefix in the google translate disclaimer.
