### PR TITLE
fix: use course_key if course_id is none in get inline discussions endpoint

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -234,7 +234,7 @@ class User(models.Model):
             retrieve_params['group_id'] = self.group_id
 
         # course key -> id conversation
-        course_id = retrieve_params.get('course_id')
+        course_id = retrieve_params.get('course_id') or retrieve_params.get("course_key")
         if course_id:
             course_id = str(course_id)
             retrieve_params['course_id'] = course_id


### PR DESCRIPTION
## Description

This PR fixes the get inline discussions endpoint. Currently, when a student creates or accesses a team for the first time, they cannot view the posts that have been created.

## Supporting information

- https://github.com/openedx/edx-platform/issues/36841

## Testing instructions

1. Create a course from Studio.
2. Create a **Group** _(Topic)_ in **Content > Pages & Resources > Teams**.
3. In the **LMS > Teams** create a Team in the Topic previously created.
4. Now, you can see all posts in discussions.

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/380c321c-5882-434b-bf7f-10d925a30a16)

### After
![image](https://github.com/user-attachments/assets/556e8ef0-1e96-47dd-a280-36127e89ec4c)

## Deadline

None

