### PR TITLE
chore: move notification config, types and apps in settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2898,6 +2898,14 @@ LIBRARY_ENABLED_BLOCKS = [
     'survey',
     'word_cloud',
 ]
+# These settings allow overriding the default notification configuration.
+# `COURSE_NOTIFICATION_CONFIG_VERSION` can be used to update changes that are made.
+# `COURSE_NOTIFICATION_APPS_OVERRIDE` and `COURSE_NOTIFICATION_TYPES_OVERRIDE` allow customization
+# of notification apps and types without modifying core code.
+# Make sure these value are synced across cms and lms.
+COURSE_NOTIFICATION_CONFIG_VERSION = 16
+COURSE_NOTIFICATION_APPS_OVERRIDE = {}
+COURSE_NOTIFICATION_TYPES_OVERRIDE = {}
 
 SOCIAL_MEDIA_FOOTER_ACE_URLS = {
     'reddit': 'http://www.reddit.com/r/edx',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5642,3 +5642,12 @@ USE_EXTRACTED_PROBLEM_BLOCK = False
 # .. toggle_creation_date: 2024-11-10
 # .. toggle_target_removal_date: 2025-06-01
 USE_EXTRACTED_VIDEO_BLOCK = False
+
+# These settings allow overriding the default notification configuration.
+# `COURSE_NOTIFICATION_CONFIG_VERSION` can be used to update changes that are made.
+# `COURSE_NOTIFICATION_APPS_OVERRIDE` and `COURSE_NOTIFICATION_TYPES_OVERRIDE` allow customization
+# of notification apps and types without modifying core code.
+# Make sure these value are synced across cms and lms.
+COURSE_NOTIFICATION_CONFIG_VERSION = 0
+COURSE_NOTIFICATION_APPS_OVERRIDE = {}
+COURSE_NOTIFICATION_TYPES_OVERRIDE = {}

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -1,17 +1,21 @@
 """
 Base setup for Notification Apps and Types.
 """
+import copy
+
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
-from .email_notifications import EmailCadence
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
-from .utils import find_app_in_normalized_apps, find_pref_in_normalized_prefs
-from ..django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA
+
+from ..django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR
+from .email_notifications import EmailCadence
 from .notification_content import get_notification_type_context_function
+from .utils import deep_merge_dicts, find_app_in_normalized_apps, find_pref_in_normalized_prefs
 
 FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE = 'filter_audit_expired_users_with_no_role'
 
-COURSE_NOTIFICATION_TYPES = {
+DEFAULT_COURSE_NOTIFICATION_TYPES = {
     'new_comment_on_response': {
         'notification_app': 'discussion',
         'name': 'new_comment_on_response',
@@ -232,7 +236,11 @@ COURSE_NOTIFICATION_TYPES = {
     },
 }
 
-COURSE_NOTIFICATION_APPS = {
+COURSE_NOTIFICATION_TYPES = copy.deepcopy(DEFAULT_COURSE_NOTIFICATION_TYPES)
+COURSE_NOTIFICATION_TYPES_OVERRIDE = getattr(settings, 'COURSE_NOTIFICATION_TYPES_OVERRIDE', {})
+COURSE_NOTIFICATION_TYPES = deep_merge_dicts(COURSE_NOTIFICATION_TYPES, COURSE_NOTIFICATION_TYPES_OVERRIDE)
+
+DEFAULT_COURSE_NOTIFICATION_APPS = {
     'discussion': {
         'enabled': True,
         'core_info': _('Notifications for responses and comments on your posts, and the ones you’re '
@@ -262,6 +270,10 @@ COURSE_NOTIFICATION_APPS = {
         'non_editable': []
     },
 }
+
+COURSE_NOTIFICATION_APPS = copy.deepcopy(DEFAULT_COURSE_NOTIFICATION_APPS)
+COURSE_NOTIFICATION_APPS_OVERRIDE = getattr(settings, 'COURSE_NOTIFICATION_APPS_OVERRIDE', {})
+COURSE_NOTIFICATION_APPS = deep_merge_dicts(COURSE_NOTIFICATION_APPS, COURSE_NOTIFICATION_APPS_OVERRIDE)
 
 
 class NotificationPreferenceSyncManager:

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -4,6 +4,7 @@ Models for notifications
 import logging
 from typing import Dict
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from model_utils.models import TimeStampedModel
@@ -26,7 +27,7 @@ NOTIFICATION_CHANNELS = ['web', 'push', 'email']
 ADDITIONAL_NOTIFICATION_CHANNEL_SETTINGS = ['email_cadence']
 
 # Update this version when there is a change to any course specific notification type or app.
-COURSE_NOTIFICATION_CONFIG_VERSION = 13
+COURSE_NOTIFICATION_CONFIG_VERSION = settings.COURSE_NOTIFICATION_CONFIG_VERSION
 
 
 def get_course_notification_preference_config():

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -280,3 +280,20 @@ def filter_out_visible_preferences_by_course_ids(user, preferences: Dict, course
         forum_roles,
         course_roles
     )
+
+
+def deep_merge_dicts(base, override, is_root=True):
+    """
+    Recursively merges `override` into `base` and returns the merged result.
+    If a top-level key in `override` has a value of None, that key is removed from the final result.
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if is_root and value is None:
+            # Remove this key from the result if it's at the root level and None
+            result.pop(key, None)
+        elif key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge_dicts(result[key], value, is_root=False)
+        else:
+            result[key] = value
+    return result


### PR DESCRIPTION

## Description

Previously, COURSE_NOTIFICATION_TYPES and COURSE_NOTIFICATION_APPS were hardcoded in the codebase, making it difficult to customize or extend notification behavior without directly modifying source files.

This PR introduces a more flexible and configurable approach by moving the following variables into settings allowing overrides via environment-specific configurations:

- COURSE_NOTIFICATION_CONFIG_VERSION
- COURSE_NOTIFICATION_APPS_OVERRIDE
- COURSE_NOTIFICATION_TYPES_OVERRIDE

With this change, projects can now easily extend, override, or disable specific notification types and apps without altering core code and improving maintainability 


## Supporting ticket

https://2u-internal.atlassian.net/browse/INF-910


