### PR TITLE
fix: certificates_enabled flag now correctly returns its boolean value

### DIFF
--- a/cms/djangoapps/contentstore/api/tests/test_validation.py
+++ b/cms/djangoapps/contentstore/api/tests/test_validation.py
@@ -103,7 +103,7 @@ class CourseValidationViewTest(SharedModuleStoreTestCase, APITestCase):
                 'has_update': True,
             },
             'certificates': {
-                'is_enabled': True,
+                'is_enabled': False,
                 'is_activated': False,
                 'has_certificate': False,
             },

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -217,7 +217,7 @@ class CourseValidationView(DeveloperErrorViewMixin, GenericAPIView):
 
     def _certificates_validation(self, course):
         is_activated, certificates = CertificateManager.is_activated(course)
-        certificates_enabled = certificates is not None
+        certificates_enabled = CertificateManager.is_enabled(course)
         return dict(
             is_activated=is_activated,
             has_certificate=certificates_enabled and len(certificates) > 0,

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -2124,11 +2124,7 @@ def get_certificates_context(course, user):
         handler_name='certificate_activation_handler',
         course_key=course_key
     )
-    course_modes = [
-        mode.slug for mode in CourseMode.modes_for_course(
-            course_id=course_key, include_expired=True
-        ) if mode.slug != 'audit'
-    ]
+    course_modes = CertificateManager.get_course_modes(course)
 
     has_certificate_modes = len(course_modes) > 0
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes: https://github.com/openedx/frontend-app-authoring/issues/1914

When we are viewing the Course Launch checklist: 
![image](https://github.com/user-attachments/assets/0d9c3339-c7c1-4d68-8e74-f47ef067783d)

And if there is no a course mode, I'm not able to enable certificates 
![image](https://github.com/user-attachments/assets/4e081cc7-f5ae-4727-a052-551d04373a26)

Expected behavior:

The "Enable your certificate" check should not appear when there is no course mode.

## Supporting information

This is a backend change from openedx repository.

## Fix evidence

_Use case_:
Having no course mode.

Before:
![image](https://github.com/user-attachments/assets/c13096ce-bba5-4d87-b471-66640ed9b561)
After:
![image](https://github.com/user-attachments/assets/feb1b1fa-a99d-4b2a-b50c-32613d5dead4)


_Use case_:
Having a course mode after the fix:

![image](https://github.com/user-attachments/assets/1d2cc5a9-301c-498b-8144-8790d263793e)

![image](https://github.com/user-attachments/assets/dc57a5e8-57a0-4cb7-a4b8-efb6128a779b)

