### PR TITLE
fix: Upgrade edx-django-utils, dropping newrelic; fix test and typo

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -421,7 +421,7 @@ def _check_user_auth_flow(site, user):
             # we don't record their e-mail in case there is sensitive info accidentally
             # in there.
             set_custom_attribute("login_tpa_domain_shortcircuit_user_id", user.id)
-            log.warning("User %s has nonstandard e-mail. Shortcircuiting THIRD_PART_AUTH_ONLY_DOMAIN check.", user.id)
+            log.warning("User %s has nonstandard e-mail. Shortcircuiting THIRD_PARTY_AUTH_ONLY_DOMAIN check.", user.id)
             return
         user_domain = email_parts[1].strip().lower()
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -1027,8 +1027,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
 
             with self.assertLogs(level='WARN') as log:
                 _check_user_auth_flow(site, invalid_email_user)
-                assert len(log.output) == 1
-                assert "Shortcircuiting THIRD_PART_AUTH_ONLY_DOMAIN check." in log.output[0]
+                assert any("Shortcircuiting THIRD_PARTY_AUTH_ONLY_DOMAIN check." in warning for warning in log.output)
 
 
 @ddt.ddt

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -431,7 +431,7 @@ edx-django-release-util==1.5.0
     #   edxval
 edx-django-sites-extensions==5.1.0
     # via -r requirements/edx/kernel.in
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   django-config-models
@@ -756,8 +756,6 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum
-newrelic==10.12.0
-    # via edx-django-utils
 nh3==0.2.21
     # via -r requirements/edx/kernel.in
 nltk==3.9.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -705,7 +705,7 @@ edx-django-sites-extensions==5.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1286,11 +1286,6 @@ mysqlclient==2.2.7
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
-newrelic==10.12.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   edx-django-utils
 nh3==0.2.21
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -515,7 +515,7 @@ edx-django-release-util==1.5.0
     #   edxval
 edx-django-sites-extensions==5.1.0
     # via -r requirements/edx/base.txt
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -920,10 +920,6 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-newrelic==10.12.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-django-utils
 nh3==0.2.21
     # via -r requirements/edx/base.txt
 nltk==3.9.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -540,7 +540,7 @@ edx-django-release-util==1.5.0
     #   edxval
 edx-django-sites-extensions==5.1.0
     # via -r requirements/edx/base.txt
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -979,10 +979,6 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-newrelic==10.12.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-django-utils
 nh3==0.2.21
     # via -r requirements/edx/base.txt
 nltk==3.9.1


### PR DESCRIPTION
This upgrades edx-django-utils to a version that drops the newrelic dependency. However, I also needed to fix a test that was sensitive to the number of warnings that the code under test produced. With newrelic gone, there's an additional warning.

- Fix test so that it isn't sensitive to unrelated warnings
- Fix typo in warning

For reference, this is the new warning:

```
"WARNING:edx_django_utils.monitoring.internal.backends:Could not load OPENEDX_TELEMETRY option 'edx_django_utils.monitoring.NewRelicBackend': Exception('Could not load New Relic monitoring backend; package not present.')"
```

This is expected due to edx-django-utils still defaulting to NR for telemetry. (Perhaps the subject of a future breaking change.)