### PR TITLE
feat: Use dropdown for units when there are more than would fit in the UI 

### DIFF
--- a/lms/templates/seq_block.html
+++ b/lms/templates/seq_block.html
@@ -4,6 +4,23 @@
   from django.conf import settings
 %>
 
+<script type="text/template" id="dropdown-button-tpl">
+    <li id="dropdown-container" class="h-100">
+        <button
+            id="dropdown-sequence-list-button"
+            class="dropdown-toggle"
+            type="button"
+        >
+            <span class="icon fa fa-chevron-down" aria-hidden="true"></span>
+        </button>
+        <div id="dropdown-sequence-list" style="display: none; position: absolute; width: 240px; right: 0;">
+            <ol class="d-block dropdown-menu bg-white py-0 shadow-sm border"
+                aria-labelledby="dropdown-sequence-list-button">
+            </ol>
+        </div>
+    </li>
+</script>
+
 <div id="sequence_${element_id}" class="sequence" data-id="${item_id}"
      data-position="${position}"
      data-next-url="${next_url}" data-prev-url="${prev_url}"
@@ -46,7 +63,7 @@
         </li>
         % else:
         % for idx, item in enumerate(items):
-        <li role="presentation">
+        <li role="presentation" class="sequence-list-item">
           <button class="seq_${item['type']} inactive nav-item tab"
             role="tab"
             tabindex="-1"
@@ -97,6 +114,9 @@
             <li><a href="#" class="seq_paste_unit" data-parent="${item_id}" data-category="vertical" data-default-name="${_('Unit')}">${_("Paste as new unit")}</a></li>
           </ul>
         </li>
+        % endif
+        % if show_dropdown:
+          ## <%include file='seq_dropdown.html' args="items=items[15:], start_index=15"/>
         % endif
       </ol>
     </nav>

--- a/xmodule/static/css-builtin-blocks/SequenceBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/SequenceBlockDisplay.css
@@ -78,6 +78,13 @@
     position: relative;
     height: 100%;
     flex-grow: 1;
+    max-width: calc(100% - 80px);
+}
+
+@media (min-width: 768px) {
+    .xmodule_display.xmodule_SequenceBlock .sequence-nav .sequence-list-wrapper {
+        max-width: calc(100% - 160px);
+    }
 }
 
 @media (max-width: 575.98px) {
@@ -91,7 +98,7 @@
     display: flex;
 }
 
-.xmodule_display.xmodule_SequenceBlock .sequence-nav ol li {
+.xmodule_display.xmodule_SequenceBlock .sequence-nav ol li, .dropdown-toggle {
     box-sizing: border-box;
     min-width: 40px;
     flex-grow: 1;
@@ -104,7 +111,11 @@
     border-right-style: solid;
 }
 
-.xmodule_display.xmodule_SequenceBlock .sequence-nav ol li button {
+.xmodule_display.xmodule_SequenceBlock .sequence-nav ol li .dropdown-toggle {
+    height: 49px !important;
+}
+
+.xmodule_display.xmodule_SequenceBlock .sequence-nav ol li button, .dropdown-toggle {
     width: 100%;
     height: 49px;
     position: relative;
@@ -117,6 +128,22 @@
     border-bottom-style: solid;
     box-sizing: border-box;
     overflow: visible;
+}
+
+.xmodule_display.xmodule_SequenceBlock .sequence-nav #dropdown-container ol li button {
+    display: flex;
+    align-items: center;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
+.xmodule_display.xmodule_SequenceBlock .sequence-nav #dropdown-container ol li button .unit-title {
+    display: flex;
+    flex-grow: 1;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    margin: 0 0.5rem;
 }
 
 .xmodule_display.xmodule_SequenceBlock .sequence-nav ol li button .icon {


### PR DESCRIPTION
## Description

When using an embedded view of the subsection UI, it is rendered by the LMS rather than the learning MFE. This UX is used when a subsection is embedded via LTI for instance. 

This UI does not adapt very well when there is a large number of units in the subsection and the space is limited. You can end up with a horizontal scrollbar which can be a bad experience. 

This UI ensures that a horizontal scroll is not needed by ensuring the UI fits to different widths by creating a dropdown with the spillover units. 

[Screencast_20250802_135009.webm](https://github.com/user-attachments/assets/7b9b61ca-fa98-4ad6-99a0-2fa53f8a9e75)


## Testing instructions

You can view this UI by visiting the XBlock view here: 

    http://local.openedx.io:8000/xblock/[USAGE_KEY]

You can replace the USAGE_KEY above with the usage key of a subsection. It's best to create a subsection with dozens of units, over 10-15 for this to be a useful test. The current UI cannot adapt well with so many subsections, however once you switch to the version from this PR you should see the experience from the video above. 

Note, after switching branches you'll need to regenerate static assets with `npm run build-dev`.