### PR TITLE
fix: Backport - Certificates preview display signer information regardless of whether they have a signature image or not

### DIFF
--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -46,17 +46,16 @@ course_mode_class = course_mode if course_mode else ''
                         <div class="list-signatories">
                             % if certificate_data:
                                 % for signatory in certificate_data.get('signatories', []):
-                                    % if signatory.get('signature_image_path'):
                                         <div class="signatory">
-                                            <img class="signatory-signature" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
-
+                                            % if signatory.get('signature_image_path'):
+                                                <img class="signatory-signature" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
+                                            % endif
                                             <h4 class="signatory-name hd-5">${signatory['name']}</h4>
                                             <p class="signatory-credentials copy copy-micro">
                                                 <span class="role">${signatory['title']}</span>
                                                 <span class="organization">${signatory['organization']}</span>
                                             </p>
                                         </div>
-                                    % endif
                                 % endfor
                             % endif
                         </div>


### PR DESCRIPTION
# Render certificate preview with signer data regardless of whether it has a signature image or not


This is a backport from https://github.com/openedx/edx-platform/pull/36293

## Description
This PR modifies the  `_accomplishment-rendering.html` template to ensure that the information of signatories is displayed even if there is no signature image available. The image will only be rendered if the `signature_image_path` is present, preventing the display of a placeholder image when the signature image is missing.

## Changes Made
- Updated the  `_accomplishment-rendering.html` template to conditionally render the signature image.
- Ensured that the name, title, and organization of the signatory are always displayed.

## Objective
The objective of this change is to improve the user experience by ensuring that the information of signatories is always visible, even if the signature image is not available. This prevents the display of a placeholder image and ensures that the certificate looks complete and professional.

## Achievements
- **Improved Visibility**: Signatory information is always displayed, regardless of the presence of a signature image.
- **Enhanced User Experience**: Prevents the display of a placeholder image, ensuring a cleaner and more professional appearance of the certificate.


## Testing
- Verified that the signatory information is displayed correctly even if the signature image is not available.

![image](https://github.com/user-attachments/assets/29bc268b-ff99-4db5-ae73-83d427ee9c0e)


![image](https://github.com/user-attachments/assets/b41b7c01-a2ee-41da-859f-5a2ad6459595)


## Test cases
- When course is in honor mode and signature is uploaded
- When course is in honor mode and signature is not uploaded
- When course is in verified mode and signature is uploaded
- When course is in verified mode and signature is not uploaded

## Related Issues
- [Issue #1370](https://github.com/openedx/frontend-app-authoring/issues/1370): Org logo and signatory info don't display without optional signature images 

## Additional Notes
- Ensure that the changes do not affect other parts of the certificate rendering process.

---

