### PR TITLE
chore: remove version constraint on django-simple-history

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -29,10 +29,6 @@ Django<5.0
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35277
 django-oauth-toolkit==1.7.1
 
-# Date: 2024-02-02
-# incremental upgrade
-django-simple-history==3.4.0
-
 # Date: 2021-05-17
 # greater version has breaking changes and requires some migration steps.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35276

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -186,6 +186,7 @@ django==4.2.21
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
+    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
@@ -326,9 +327,8 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/bundled.in
-django-simple-history==3.4.0
+django-simple-history==3.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-name-affirmation

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -357,6 +357,7 @@ django==4.2.21
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
+    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-stubs
@@ -548,9 +549,8 @@ django-ses==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-simple-history==3.4.0
+django-simple-history==3.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -242,6 +242,7 @@ django==4.2.21
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
+    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
@@ -398,9 +399,8 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.4.0
+django-simple-history==3.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -272,6 +272,7 @@ django==4.2.21
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
+    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
@@ -428,9 +429,8 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.4.0
+django-simple-history==3.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-name-affirmation


### PR DESCRIPTION
## Description

Remove pin on [django-simple-history ](https://github.com/jazzband/django-simple-history/)version 3.4.0 in constraints file to allow newer versions of the package. This allows for compatibility with newer versions of Django.

There are no breaking changes introduced in versions 3.5.0 through 3.8.0 (see [releases](https://github.com/jazzband/django-simple-history/releases)). Version 3.8.0 supports Django 4.2 through 5.2 and Python 3.9 through 3.13.

## Supporting information

Resolves #36747. This PR is a part of the effort to add Django 5.2 support.

The pin for django-simple-history to 3.4.0 was introduced in [this](https://github.com/openedx/edx-platform/pull/34172/) PR. I didn't find any further explanation for the pin.
