### PR TITLE
fix: correct course catalog visibility for "about" setting

### DIFF
--- a/lms/lib/courseware_search/lms_filter_generator.py
+++ b/lms/lib/courseware_search/lms_filter_generator.py
@@ -9,6 +9,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import CohortPartiti
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
 from common.djangoapps.student.models import CourseEnrollment
+from xmodule.course_block import CATALOG_VISIBILITY_ABOUT, CATALOG_VISIBILITY_NONE
 
 INCLUDE_SCHEMES = [CohortPartitionScheme, RandomUserPartitionScheme, ]
 SCHEME_SUPPORTS_ASSIGNMENT = [RandomUserPartitionScheme, ]
@@ -63,6 +64,6 @@ class LmsSearchFilterGenerator(SearchFilterGenerator):
         if not getattr(settings, "SEARCH_SKIP_INVITATION_ONLY_FILTERING", True):
             exclude_dictionary['invitation_only'] = True
         if not getattr(settings, "SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING", True):
-            exclude_dictionary['catalog_visibility'] = 'none'
+            exclude_dictionary['catalog_visibility'] = [CATALOG_VISIBILITY_ABOUT, CATALOG_VISIBILITY_NONE]
 
         return exclude_dictionary

--- a/lms/lib/courseware_search/test/test_lms_filter_generator.py
+++ b/lms/lib/courseware_search/test/test_lms_filter_generator.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from lms.lib.courseware_search.lms_filter_generator import LmsSearchFilterGenerator
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
+from xmodule.course_block import CATALOG_VISIBILITY_ABOUT, CATALOG_VISIBILITY_NONE
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -139,3 +140,9 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
         assert 'org' not in exclude_dictionary
         assert 'org' in field_dictionary
         assert ['TestSite3'] == field_dictionary['org']
+
+    @patch('django.conf.settings.SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING', False)
+    def test_excludes_catalog_visibility(self):
+        _, _, exclude_dictionary = LmsSearchFilterGenerator.generate_field_filters(user=self.user)
+        assert 'catalog_visibility' in exclude_dictionary
+        assert exclude_dictionary['catalog_visibility'] == [CATALOG_VISIBILITY_ABOUT, CATALOG_VISIBILITY_NONE]


### PR DESCRIPTION
Fixes: https://github.com/openedx/edx-platform/issues/36817

## Description
This pull request fixes an issue with the Course Visibility in Catalog setting not working as expected when set to "about".

## Problem
When the `catalog_visibility` is set to `"about"`, the course should not appear in the course catalog but should still have its about page accessible. However, the current implementation only excludes courses with visibility set to "none", causing "about" courses to incorrectly appear in the catalog.

## Solution
We updated the `LmsSearchFilterGenerator` to exclude both `"none"` and `"about"` values in the `catalog_visibility` field, aligning behavior with the documented expectations.

## Impact
This change affects the Learner user role by ensuring the course catalog only displays courses intended to be shown. It may also impact Operators who configure course visibility settings.

No UI changes are introduced.