### PR TITLE
fix: exclude fields from UpstreamSyncMixin in advanced settings api

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -82,6 +82,10 @@ class CourseMetadata:
         'is_onboarding_exam',
         'discussions_settings',
         'copied_from_block',
+        "upstream",
+        "upstream_version",
+        "upstream_version_declined",
+        "upstream_display_name",
     ]
 
     @classmethod


### PR DESCRIPTION
## Description

The [UpstreamSyncMixin](https://github.com/openedx/edx-platform/blob/master/cms/lib/xblock/upstream_sync.py#L289) (introduced in https://github.com/openedx/edx-platform/pull/34925) which is added as a XBlock mixin, currently contains four fields - `upstream`, `upstream_version`, `upstream_version_declined`, and `upstream_display_name`. These fields are coming through in the course advanced settings API endpoint (`/api/contentstore/v0/advanced_settings/{course_id}`), and subsequently show up in the Advanced Settings view in the frontend-app-authoring MFE.

Here is a JSON snippet showing one of those fields coming through in the API response:
```json
    "upstream_display_name": {
        "value": null,
        "display_name": "upstream_display_name",
        "help": "The value of display_name on the linked upstream block/container.",
        "deprecated": false,
        "hide_on_enabled_publisher": false
    },
```

As can be seen in https://github.com/openedx/frontend-app-authoring/issues/2018, these fields are showing up in the Advanced Settings view for a course, when they shouldn't be.

This PR resolves this issue by adding the fields from the `UpstreamSyncMixin` into the [FIELDS_EXCLUDE_LIST](https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/models/settings/course_metadata.py#L41) of the `CourseMetadata` class. Unless the API is called with `fetch_all=1` (the authoring MFE uses `fetch_all=0`), then these fields will be filtered out.

Once this PR is merged in, the upstream fields will no longer show by default in the Advanced Settings view in the cms.

## Supporting information

Resolves https://github.com/openedx/frontend-app-authoring/issues/2018.

## Testing instructions

1. Open a course in the Studio
2. On the top bar choose Settings and then Advanced Settings
3. No settings starting with "Upstream" should appear

## Other information

This issue appears to be in Teak:
https://github.com/openedx/edx-platform/blob/release/teak/cms/djangoapps/models/settings/course_metadata.py#L41
https://github.com/openedx/edx-platform/blob/release/teak/cms/lib/xblock/upstream_sync.py#L289

You can see the fields appear [here in this Teak sandbox](https://apps.teak.demo.edly.io/authoring/course/course-v1:OpenedX+DemoX+DemoCourse/settings/advanced), for example.

This issue appears to be in Sumac:
https://github.com/openedx/edx-platform/blob/open-release/sumac.master/cms/lib/xblock/upstream_sync.py#L379
https://github.com/openedx/edx-platform/blob/open-release/sumac.master/cms/djangoapps/models/settings/course_metadata.py#L41