### PR TITLE
fix Fixes the clipping of IFrame when scrollIntoView is triggered

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -176,6 +176,10 @@ function($, _, Backbone, gettext, BasePage,
                         break;
                     case 'scrollToXBlock':
                         document.getElementById(data.payload.locator)?.scrollIntoView({behavior: "smooth"});
+                        // This piece of code helps to avoid clipping the IFrame when scrollIntoView is triggered.
+                        setTimeout(() => {
+                          window.scrollBy(0, -80);
+                        }, 400);
                         break;
                     default:
                         console.warn('Unhandled message type:', data.type);


### PR DESCRIPTION
Fixed clipping issue faced when scrollToXBlock is triggered

**Issues/Ticket**: https://github.com/openedx/openedx-aspects/issues/316

**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.

**Dependencies**: None

**Screenshots**: Always include screenshots if there is any change to the UI.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

As mentioned in the ticket.