### PR TITLE
feat: [FC-86] implement index page config api

### DIFF
--- a/lms/djangoapps/branding/api_urls.py
+++ b/lms/djangoapps/branding/api_urls.py
@@ -5,9 +5,9 @@ Branding API endpoint urls.
 
 from django.urls import path
 
-from lms.djangoapps.branding.views import footer, IndexPageConfigView
+from lms.djangoapps.branding.views import footer, LMSFrontendParamsView
 
 urlpatterns = [
     path('footer', footer, name="branding_footer"),
-    path('index', IndexPageConfigView.as_view(), name="index_page_config"),
+    path('frontend-params', LMSFrontendParamsView.as_view(), name="frontend_params"),
 ]

--- a/lms/djangoapps/branding/api_urls.py
+++ b/lms/djangoapps/branding/api_urls.py
@@ -5,8 +5,9 @@ Branding API endpoint urls.
 
 from django.urls import path
 
-from lms.djangoapps.branding.views import footer
+from lms.djangoapps.branding.views import footer, IndexPageConfigView
 
 urlpatterns = [
     path('footer', footer, name="branding_footer"),
+    path('index', IndexPageConfigView.as_view(), name="index_page_config"),
 ]

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -14,6 +14,8 @@ from django.utils import translation
 from django.utils.translation.trans_real import get_supported_language_variant
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 import lms.djangoapps.branding.api as branding_api
 import lms.djangoapps.courseware.views.views as courseware_views
@@ -312,3 +314,37 @@ def footer(request):
 
     else:
         return HttpResponse(status=406)
+
+
+class IndexPageConfigView(APIView):
+    """
+    API view to return the configuration for the index page.
+    """
+
+    def get(self, request):
+        """
+        Returns the configuration for the index page.
+        """
+        enable_course_sorting_by_start_date = configuration_helpers.get_value(
+            'ENABLE_COURSE_SORTING_BY_START_DATE',
+            settings.FEATURES['ENABLE_COURSE_SORTING_BY_START_DATE'],
+        )
+        homepage_overlay_html = configuration_helpers.get_value('homepage_overlay_html')
+        show_partners = configuration_helpers.get_value('show_partners', True)
+        show_homepage_promo_video = configuration_helpers.get_value('show_homepage_promo_video', False)
+        homepage_course_max = configuration_helpers.get_value(
+            'HOMEPAGE_COURSE_MAX', settings.HOMEPAGE_COURSE_MAX
+        )
+        homepage_promo_video_youtube_id = configuration_helpers.get_value(
+            'homepage_promo_video_youtube_id', 'your-youtube-id'
+        )
+
+        data = {
+            "enable_course_sorting_by_start_date": enable_course_sorting_by_start_date,
+            "homepage_overlay_html": homepage_overlay_html,
+            "show_partners": show_partners,
+            "show_homepage_promo_video": show_homepage_promo_video,
+            "homepage_course_max": homepage_course_max,
+            "homepage_promo_video_youtube_id": homepage_promo_video_youtube_id,
+        }
+        return Response(data)

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -25,6 +25,7 @@ from common.djangoapps.util.cache import cache_if_anonymous
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
 
 log = logging.getLogger(__name__)
 
@@ -316,15 +317,39 @@ def footer(request):
         return HttpResponse(status=406)
 
 
-class IndexPageConfigView(APIView):
+class LMSFrontendParamsView(APIView):
     """
-    API view to return the configuration for the index page.
+    **Use Case**
+
+        * Get configuration parameters to be consumed by the frontend components of various LMS pages.
+
+    **Example GET Request**
+
+        GET /api/branding/v1/frontend-params
+
+    **Example GET Response**
+
+        {
+            "enable_course_sorting_by_start_date": true,
+            "homepage_overlay_html": "<div>Custom HTML Overlay</div>",
+            "show_partners": true,
+            "show_homepage_promo_video": false,
+            "homepage_course_max": 12,
+            "homepage_promo_video_youtube_id": "your-youtube-id",
+            "sidebar_html_enabled": true,
+            "course_about_show_social_links": true,
+            "course_about_twitter_account": "@YourTwitterAccount",
+            "is_cosmetic_price_enabled": true,
+            "courses_are_browsable": true
+        }
     """
 
     def get(self, request):
         """
-        Returns the configuration for the index page.
+        Returns parameters retrieved from the site configuration (with fallback defaults provided),
+        from Django settings (including feature flags), or from Waffle Switches.
         """
+
         enable_course_sorting_by_start_date = configuration_helpers.get_value(
             'ENABLE_COURSE_SORTING_BY_START_DATE',
             settings.FEATURES['ENABLE_COURSE_SORTING_BY_START_DATE'],
@@ -338,6 +363,15 @@ class IndexPageConfigView(APIView):
         homepage_promo_video_youtube_id = configuration_helpers.get_value(
             'homepage_promo_video_youtube_id', 'your-youtube-id'
         )
+        sidebar_html_enabled = ENABLE_COURSE_ABOUT_SIDEBAR_HTML.is_enabled()
+        course_about_show_social_links = configuration_helpers.get_value(
+            'course_about_show_social_links', True
+        )
+        course_about_twitter_account = configuration_helpers.get_value(
+            'course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT
+        )
+        is_cosmetic_price_enabled = settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_PRICE')
+        courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
 
         data = {
             "enable_course_sorting_by_start_date": enable_course_sorting_by_start_date,
@@ -346,5 +380,10 @@ class IndexPageConfigView(APIView):
             "show_homepage_promo_video": show_homepage_promo_video,
             "homepage_course_max": homepage_course_max,
             "homepage_promo_video_youtube_id": homepage_promo_video_youtube_id,
+            "sidebar_html_enabled": sidebar_html_enabled,
+            "course_about_show_social_links": course_about_show_social_links,
+            "course_about_twitter_account": course_about_twitter_account,
+            "is_cosmetic_price_enabled": is_cosmetic_price_enabled,
+            "courses_are_browsable": courses_are_browsable,
         }
         return Response(data)


### PR DESCRIPTION
# Add Index Page Config API

This PR introduces a new API endpoint to provide dynamic configuration for the Catalog index page:

- `IndexPageConfigView`: A Django REST Framework view at `/branding/index` that returns a JSON payload of configuration settings.
- Settings are resolved using `configuration_helpers.get_value()` with support for `SiteConfiguration` overrides and fallbacks to `Django settings`.

The following keys are returned:
- `enable_course_sorting_by_start_date`
- `homepage_overlay_html`
- `show_partners`
- `show_homepage_promo_video`
- `homepage_course_max`
- `homepage_promo_video_youtube_id`

Unit tests verify fallback behavior, site-specific overrides, and expected default values for all fields.