### PR TITLE
feat: implement waffle flag to toggle new course about page

### DIFF
--- a/lms/djangoapps/branding/test_toggles.py
+++ b/lms/djangoapps/branding/test_toggles.py
@@ -1,0 +1,35 @@
+"""
+Tests for toggles, where there is logic beyond enable/disable.
+"""
+
+import ddt
+from django.test import TestCase
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+from lms.djangoapps.branding.toggles import (
+    ENABLE_NEW_COURSE_ABOUT_PAGE,
+    use_new_course_about_page,
+)
+
+
+@ddt.ddt
+class TestBrandingToggles(TestCase):
+    """
+    Tests for toggles, where there is logic beyond enable/disable.
+    """
+
+    @override_waffle_flag(ENABLE_NEW_COURSE_ABOUT_PAGE, True)
+    def test_use_new_course_about_page_enabled(self):
+        # When I check if the feature is enabled
+        should_use_new_course_about_page = use_new_course_about_page()
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_course_about_page, True)
+
+    @override_waffle_flag(ENABLE_NEW_COURSE_ABOUT_PAGE, False)
+    def test_use_new_course_about_page_disabled(self):
+        # When I check if the feature is enabled
+        should_use_new_course_about_page = use_new_course_about_page()
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_course_about_page, False)

--- a/lms/djangoapps/branding/toggles.py
+++ b/lms/djangoapps/branding/toggles.py
@@ -1,0 +1,23 @@
+"""
+Configuration for features of Branding
+"""
+from edx_toggles.toggles import WaffleFlag
+
+# Namespace for Waffle flags related to branding
+WAFFLE_FLAG_NAMESPACE = "new_catalog_mfe"
+
+# .. toggle_name: new_catalog_mfe.use_new_course_about_page
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable the new course about page.
+# .. toggle_creation_date: 2025-05-15
+# .. toggle_target_removal_date: None
+# .. toggle_use_cases: open_edx
+ENABLE_NEW_COURSE_ABOUT_PAGE = WaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.use_new_course_about_page', __name__)
+
+
+def use_new_course_about_page():
+    """
+    Returns a boolean if new course about page mfe is enabled.
+    """
+    return ENABLE_NEW_COURSE_ABOUT_PAGE.is_enabled()


### PR DESCRIPTION
# Enable New Course About Page via Waffle Flag

This PR introduces a Waffle flag to enable a new micro-frontend (MFE) version of the course about page:

- `ENABLE_NEW_COURSE_ABOUT_PAGE`: A WaffleFlag defined in the `new_catalog_mfe` namespace.
- The `use_new_course_about_page()` helper checks the status of the flag.

This allows controlled rollout of the new course about page on a per-user or per-site basis.

Unit tests confirm that the `use_new_course_about_page()` function returns correct values based on the Waffle flag state.
