### PR TITLE
feat: implement waffle flag to toggle new index page

### DIFF
--- a/lms/djangoapps/branding/test_toggles.py
+++ b/lms/djangoapps/branding/test_toggles.py
@@ -1,0 +1,35 @@
+"""
+Tests for toggles, where there is logic beyond enable/disable.
+"""
+
+import ddt
+from django.test import TestCase
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+from lms.djangoapps.branding.toggles import (
+    ENABLE_NEW_INDEX_PAGE,
+    use_new_index_page,
+)
+
+
+@ddt.ddt
+class TestBrandingToggles(TestCase):
+    """
+    Tests for toggles, where there is logic beyond enable/disable.
+    """
+
+    @override_waffle_flag(ENABLE_NEW_INDEX_PAGE, True)
+    def test_use_new_index_page_enabled(self):
+        # When I check if the feature is enabled
+        should_use_new_index_page = use_new_index_page()
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_index_page, True)
+
+    @override_waffle_flag(ENABLE_NEW_INDEX_PAGE, False)
+    def test_use_new_index_page_disabled(self):
+        # When I check if the feature is enabled
+        should_use_new_index_page = use_new_index_page()
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_index_page, False)

--- a/lms/djangoapps/branding/toggles.py
+++ b/lms/djangoapps/branding/toggles.py
@@ -1,0 +1,24 @@
+"""
+Configuration for features of Branding
+"""
+from edx_toggles.toggles import WaffleFlag
+
+
+# Namespace for Waffle flags related to branding
+WAFFLE_FLAG_NAMESPACE = "new_catalog_mfe"
+
+# .. toggle_name: new_catalog_mfe.use_new_index_page
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable the new index page.
+# .. toggle_creation_date: 2025-05-15
+# .. toggle_target_removal_date: None
+# .. toggle_use_cases: open_edx
+ENABLE_NEW_INDEX_PAGE = WaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.use_new_index_page', __name__)
+
+
+def use_new_index_page():
+    """
+    Returns a boolean if new index page mfe is enabled.
+    """
+    return ENABLE_NEW_INDEX_PAGE.is_enabled()


### PR DESCRIPTION
# Enable New Index Page via Waffle Flag

This PR introduces a Waffle flag to toggle the new micro-frontend (MFE) implementation of the LMS index page:

- `ENABLE_NEW_INDEX_PAGE`: A WaffleFlag under the `new_catalog_mfe` namespace.
- The `use_new_index_page()` helper checks if the new index page should be shown.

This flag enables a controlled rollout of the new index page experience.

Unit tests validate that `use_new_index_page()` returns correct values based on the flag's enabled state.
