### PR TITLE
feat: implement waffle flag config api for new Catalog MFE

### DIFF
--- a/lms/djangoapps/branding/api_urls.py
+++ b/lms/djangoapps/branding/api_urls.py
@@ -3,10 +3,12 @@ Branding API endpoint urls.
 """
 
 
-from django.urls import path
+from django.urls import path, re_path
 
-from lms.djangoapps.branding.views import footer
+from lms.djangoapps.branding.views import footer, WaffleFlagsView
+from openedx.core.constants import COURSE_ID_PATTERN
 
 urlpatterns = [
     path('footer', footer, name="branding_footer"),
+    re_path(fr'^waffle-flags(?:/{COURSE_ID_PATTERN})?$', WaffleFlagsView.as_view(), name="branding_waffle_flags"),
 ]

--- a/lms/djangoapps/branding/serializers.py
+++ b/lms/djangoapps/branding/serializers.py
@@ -25,16 +25,19 @@ class WaffleFlagsSerializer(serializers.Serializer):
         """
         Returns whether the new index page is enabled.
         """
-        return branding_toggles.use_new_index_page()
+        course_key = self.get_course_key()
+        return branding_toggles.use_new_index_page(course_key)
 
     def get_use_new_catalog_page(self, obj):
         """
         Returns whether the new catalog page is enabled.
         """
-        return branding_toggles.use_new_catalog_page()
+        course_key = self.get_course_key()
+        return branding_toggles.use_new_catalog_page(course_key)
 
     def get_use_new_course_about_page(self, obj):
         """
         Returns whether the new course about page is enabled.
         """
-        return branding_toggles.use_new_course_about_page()
+        course_key = self.get_course_key()
+        return branding_toggles.use_new_course_about_page(course_key)

--- a/lms/djangoapps/branding/serializers.py
+++ b/lms/djangoapps/branding/serializers.py
@@ -1,0 +1,40 @@
+"""
+Serializers for the branding app.
+"""
+
+from rest_framework import serializers
+
+import lms.djangoapps.branding.toggles as branding_toggles
+
+
+class WaffleFlagsSerializer(serializers.Serializer):
+    """
+    Serializer for waffle flags.
+    """
+    use_new_index_page = serializers.SerializerMethodField()
+    use_new_catalog_page = serializers.SerializerMethodField()
+    use_new_course_about_page = serializers.SerializerMethodField()
+
+    def get_course_key(self):
+        """
+        Retrieve the course_key from the context.
+        """
+        return self.context.get("course_key")
+
+    def get_use_new_index_page(self, obj):
+        """
+        Returns whether the new index page is enabled.
+        """
+        return branding_toggles.use_new_index_page()
+
+    def get_use_new_catalog_page(self, obj):
+        """
+        Returns whether the new catalog page is enabled.
+        """
+        return branding_toggles.use_new_catalog_page()
+
+    def get_use_new_course_about_page(self, obj):
+        """
+        Returns whether the new course about page is enabled.
+        """
+        return branding_toggles.use_new_course_about_page()

--- a/lms/djangoapps/branding/test_toggles.py
+++ b/lms/djangoapps/branding/test_toggles.py
@@ -1,0 +1,69 @@
+"""
+Tests for toggles, where there is logic beyond enable/disable.
+"""
+
+from unittest.mock import patch
+import ddt
+from django.test import TestCase
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+from lms.djangoapps.branding.toggles import (
+    ENABLE_NEW_COURSE_ABOUT_PAGE,
+    ENABLE_NEW_INDEX_PAGE,
+    use_new_catalog_page,
+    use_new_course_about_page,
+    use_new_index_page,
+)
+
+
+@ddt.ddt
+class TestBrandingToggles(TestCase):
+    """
+    Tests for toggles, where there is logic beyond enable/disable.
+    """
+
+    @ddt.data(True, False)
+    @patch("lms.djangoapps.branding.toggles.ENABLE_NEW_CATALOG_PAGE")
+    def test_use_new_catalog_page_enabled(
+        self, is_waffle_enabled, mock_enable_new_catalog_page
+    ):
+        # Given legacy catalog feature is / not enabled
+        mock_enable_new_catalog_page.is_enabled.return_value = is_waffle_enabled
+
+        # When I check if the feature is enabled
+        should_use_new_catalog_page = use_new_catalog_page(None)
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_catalog_page, is_waffle_enabled)
+
+    @override_waffle_flag(ENABLE_NEW_COURSE_ABOUT_PAGE, True)
+    def test_use_new_course_about_page_enabled(self):
+        # When I check if the feature is enabled
+        should_use_new_course_about_page = use_new_course_about_page(None)
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_course_about_page, True)
+
+    @override_waffle_flag(ENABLE_NEW_COURSE_ABOUT_PAGE, False)
+    def test_use_new_course_about_page_disabled(self):
+        # When I check if the feature is enabled
+        should_use_new_course_about_page = use_new_course_about_page(None)
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_course_about_page, False)
+
+    @override_waffle_flag(ENABLE_NEW_INDEX_PAGE, True)
+    def test_use_new_index_page_enabled(self):
+        # When I check if the feature is enabled
+        should_use_new_index_page = use_new_index_page(None)
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_index_page, True)
+
+    @override_waffle_flag(ENABLE_NEW_INDEX_PAGE, False)
+    def test_use_new_index_page_disabled(self):
+        # When I check if the feature is enabled
+        should_use_new_index_page = use_new_index_page(None)
+
+        # Then I respects waffle setting.
+        self.assertEqual(should_use_new_index_page, False)

--- a/lms/djangoapps/branding/toggles.py
+++ b/lms/djangoapps/branding/toggles.py
@@ -1,0 +1,66 @@
+"""
+Configuration for features of Branding
+"""
+from django.conf import settings
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+# Namespace for Waffle flags related to branding
+WAFFLE_FLAG_NAMESPACE = "new_catalog_mfe"
+
+
+def catalog_mfe_enabled():
+    """
+    Determine if Catalog MFE is enabled, replacing student_dashboard
+    """
+    return configuration_helpers.get_value(
+        'ENABLE_CATALOG_MICROFRONTEND', settings.FEATURES.get('ENABLE_CATALOG_MICROFRONTEND')
+    )
+
+
+# .. toggle_name: new_catalog_mfe.use_new_catalog_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable the new catalog page.
+# .. toggle_creation_date: 2025-05-15
+# .. toggle_target_removal_date: None
+# .. toggle_use_cases: open_edx
+ENABLE_NEW_CATALOG_PAGE = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.use_new_catalog_page', __name__)
+# .. toggle_name: new_catalog_mfe.use_new_course_about_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable the new course about page.
+# .. toggle_creation_date: 2025-05-15
+# .. toggle_target_removal_date: None
+# .. toggle_use_cases: open_edx
+ENABLE_NEW_COURSE_ABOUT_PAGE = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.use_new_course_about_page', __name__)
+# .. toggle_name: new_catalog_mfe.use_new_index_page
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable the new index page.
+# .. toggle_creation_date: 2025-05-15
+# .. toggle_target_removal_date: None
+# .. toggle_use_cases: open_edx
+ENABLE_NEW_INDEX_PAGE = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.use_new_index_page', __name__)
+
+
+def use_new_catalog_page(course_key):
+    """
+    Returns a boolean if new catalog page should be used.
+    """
+    return ENABLE_NEW_CATALOG_PAGE.is_enabled(course_key)
+
+
+def use_new_course_about_page(course_key):
+    """
+    Returns a boolean if new course about page mfe is enabled.
+    """
+    return ENABLE_NEW_COURSE_ABOUT_PAGE.is_enabled(course_key)
+
+
+def use_new_index_page(course_key):
+    """
+    Returns a boolean if new index page mfe is enabled.
+    """
+    return ENABLE_NEW_INDEX_PAGE.is_enabled(course_key)

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -330,11 +330,28 @@ class WaffleFlagsView(APIView):
             request (HttpRequest): The HTTP request object.
             course_id (str, optional): The ID of the course for which to retrieve the waffle flag settings.
                                        If not provided, defaults to None.
+
         Returns:
             Response: A JSON response containing the status of various waffle flags for the specified course.
+
         **Example Request**
+
             GET .../v1/waffle-flags
             GET .../v1/waffle-flags/course-v1:test+test+test
+
+        **Response Values**
+
+            A JSON response containing the status of various waffle flags for the specified course.
+
+        **Example Response**
+
+        ```json
+        {
+            "use_new_index_page": true,
+            "use_new_catalog_page": true,
+            "use_new_course_about_page": false
+        }
+        ```
         """
         course_key = CourseKey.from_string(course_id) if course_id else None
         serializer = WaffleFlagsSerializer(context={"course_key": course_key}, data={})


### PR DESCRIPTION
# ADR: Implement Waffle Flag Config API for New Catalog MFE

This PR introduces a new API endpoint to expose the current state of waffle flags related to the Catalog Micro-Frontend (MFE) rollout.

**Key changes:**

- Adds a `/waffle-flags` API endpoint (with optional course context) to the branding Django app.
- Implements a `WaffleFlagsSerializer` to expose:
  - `use_new_index_page`
  - `use_new_catalog_page`
  - `use_new_course_about_page`
- Defines and documents the new CourseWaffleFlag toggles under the `new_catalog_mfe` namespace.
- Returns the flag states as a simple JSON object for use by frontend applications.
- Adds comprehensive tests for toggle logic and API endpoint behavior, including anonymous and authenticated user flows and all flag combinations.

> **Note:**  
> This PR can only be merged after all dependent waffle flag PRs are merged (PRs #36843 and #36844).

These changes provide a unified way for the Catalog MFE to dynamically check feature rollout status for different users and courses, enabling safe, progressive adoption of new frontend experiences.
