### PR TITLE
feat: add waffle flag to calculate hidden grades in total grade for new progress page

### DIFF
--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -15,7 +15,7 @@ from rest_framework.response import Response
 from xmodule.modulestore.django import modulestore
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_home_api.progress.serializers import ProgressTabSerializer
-from lms.djangoapps.course_home_api.toggles import course_home_mfe_progress_tab_is_active
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_progress_tab_is_active, calculate_course_grade_including_invisible_grades_is_enabled
 from lms.djangoapps.courseware.access import has_access, has_ccx_coach_role
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.course_blocks.transformers import start_date
@@ -206,8 +206,9 @@ class ProgressTabView(RetrieveAPIView):
         collected_block_structure = get_block_structure_manager(course_key).get_collected()
         course_grade = CourseGradeFactory().read(student, collected_block_structure=collected_block_structure)
 
-        # recalculate course grade from visible grades (stored grade was calculated over all grades, visible or not)
-        course_grade.update(visible_grades_only=True, has_staff_access=is_staff)
+        if not calculate_course_grade_including_invisible_grades_is_enabled(course_key):
+            # recalculate course grade from visible grades (stored grade was calculated over all grades, visible or not)
+            course_grade.update(visible_grades_only=True, has_staff_access=is_staff)
 
         # Get has_scheduled_content data
         transformers = BlockStructureTransformers()

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -51,6 +51,21 @@ COURSE_HOME_SEND_COURSE_PROGRESS_ANALYTICS_FOR_STUDENT = CourseWaffleFlag(
 )
 
 
+# Waffle flag to calculate course grade including invisible grades
+#
+# .. toggle_name: course_home.calculate_course_grade_including_invisible_grades
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This toggle controls whether the course grade calculation includes invisible grades.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2025-06-03
+# .. toggle_target_removal_date: None
+COURSE_HOME_CALCULATE_COURSE_GRADE_INCLUDING_INVISIBLE_GRADES = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.calculate_course_grade_including_invisible_grades', __name__
+)
+
+
+
 def course_home_mfe_progress_tab_is_active(course_key):
     # Avoiding a circular dependency
     from .models import DisableProgressPageStackedConfig
@@ -73,3 +88,10 @@ def send_course_progress_analytics_for_student_is_enabled(course_key):
     Returns True if the course completion analytics feature is enabled for a given course.
     """
     return COURSE_HOME_SEND_COURSE_PROGRESS_ANALYTICS_FOR_STUDENT.is_enabled(course_key)
+
+
+def calculate_course_grade_including_invisible_grades_is_enabled(course_key):
+    """
+    Returns True if the course grade calculation including invisible grades is enabled for a given course.
+    """
+    return COURSE_HOME_CALCULATE_COURSE_GRADE_INCLUDING_INVISIBLE_GRADES.is_enabled(course_key)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds a waffle flag to calculate hidden grades for the total grade for the new progress tab in learning MFE.

## Supporting information

None for now

## Testing instructions

Will add when finalizing the PR

## Deadline

None

