### PR TITLE
feat: removing get_storage_class from COURSE_IMPORT_STORAGE

### DIFF
--- a/cms/djangoapps/contentstore/storage.py
+++ b/cms/djangoapps/contentstore/storage.py
@@ -4,7 +4,7 @@ Storage backend for course import and export.
 
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from common.djangoapps.util.storage import resolve_storage_backend
 from storages.backends.s3boto3 import S3Boto3Storage
 from storages.utils import setting
 
@@ -19,4 +19,7 @@ class ImportExportS3Storage(S3Boto3Storage):  # pylint: disable=abstract-method
         super().__init__(bucket_name=bucket, custom_domain=None, querystring_auth=True)
 
 # pylint: disable=invalid-name
-course_import_export_storage = get_storage_class(settings.COURSE_IMPORT_EXPORT_STORAGE)()
+course_import_export_storage = resolve_storage_backend(
+    storage_key="course_import_export",
+    legacy_setting_key="COURSE_IMPORT_EXPORT_STORAGE"
+)

--- a/cms/djangoapps/contentstore/tests/test_import.py
+++ b/cms/djangoapps/contentstore/tests/test_import.py
@@ -21,6 +21,9 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.xml_importer import import_course_from_xml
 
+from common.djangoapps.util.storage import resolve_storage_backend
+from storages.backends.s3boto3 import S3Boto3Storage
+
 TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
 TEST_DATA_CONTENTSTORE['DOC_STORE_CONFIG']['db'] = 'test_xcontent_%s' % uuid4().hex
 
@@ -275,3 +278,81 @@ class ContentStoreImportTest(ModuleStoreTestCase):
 
         video = module_store.get_item(vertical.children[1])
         self.assertEqual(video.display_name, 'default')
+
+    @override_settings(
+        COURSE_IMPORT_EXPORT_STORAGE="cms.djangoapps.contentstore.storage.ImportExportS3Storage",
+        DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage"
+    )
+    def test_resolve_default_storage(self):
+        """ Ensure the default storage is invoked, even if course export storage is configured """
+        storage = resolve_storage_backend(
+            storage_key="default",
+            legacy_setting_key="DEFAULT_FILE_STORAGE"
+        )
+        self.assertEqual(storage.__class__.__name__, "FileSystemStorage")
+
+    @override_settings(
+        COURSE_IMPORT_EXPORT_STORAGE="cms.djangoapps.contentstore.storage.ImportExportS3Storage",
+        DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage",
+        COURSE_IMPORT_EXPORT_BUCKET="bucket_name_test"
+    )
+    def test_resolve_happy_path_storage(self):
+        """ Make sure that the correct course export storage is being used """
+        storage = resolve_storage_backend(
+            storage_key="course_import_export",
+            legacy_setting_key="COURSE_IMPORT_EXPORT_STORAGE"
+        )
+        self.assertEqual(storage.__class__.__name__, "ImportExportS3Storage")
+        self.assertEqual(storage.bucket_name, "bucket_name_test")
+
+    @override_settings()
+    def test_resolve_storage_with_no_config(self):
+        """ If no storage setup is defined, we get FileSystemStorage by default """
+        del settings.DEFAULT_FILE_STORAGE
+        del settings.COURSE_IMPORT_EXPORT_STORAGE
+        del settings.COURSE_IMPORT_EXPORT_BUCKET
+        storage = resolve_storage_backend(
+            storage_key="course_import_export",
+            legacy_setting_key="COURSE_IMPORT_EXPORT_STORAGE"
+        )
+        self.assertEqual(storage.__class__.__name__, "FileSystemStorage")
+
+    @override_settings(
+        COURSE_IMPORT_EXPORT_STORAGE=None,
+        COURSE_IMPORT_EXPORT_BUCKET="bucket_name_test",
+        STORAGES={
+            'course_import_export': {
+                'BACKEND': 'cms.djangoapps.contentstore.storage.ImportExportS3Storage',
+                'OPTIONS': {}
+            }
+        }
+    )
+    def test_resolve_storage_using_django5_settings(self):
+        """ Simulating a Django 4 environment using Django 5 Storages configuration """
+        storage = resolve_storage_backend(
+            storage_key="course_import_export",
+            legacy_setting_key="COURSE_IMPORT_EXPORT_STORAGE"
+        )
+        self.assertEqual(storage.__class__.__name__, "ImportExportS3Storage")
+        self.assertEqual(storage.bucket_name, "bucket_name_test")
+
+    @override_settings(
+        STORAGES={
+            'course_import_export': {
+                'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+                'OPTIONS': {
+                    'bucket_name': 'bucket_name_test'
+                }
+            }
+        }
+    )
+    def test_resolve_storage_using_django5_settings_with_options(self):
+        """ Ensure we call the storage class with the correct parameters and Django 5 setup """
+        del settings.COURSE_IMPORT_EXPORT_STORAGE
+        del settings.COURSE_IMPORT_EXPORT_BUCKET
+        storage = resolve_storage_backend(
+            storage_key="course_import_export",
+            legacy_setting_key="COURSE_IMPORT_EXPORT_STORAGE"
+        )
+        self.assertEqual(storage.__class__.__name__, S3Boto3Storage.__name__)
+        self.assertEqual(storage.bucket_name, "bucket_name_test")


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes: https://github.com/openedx/edx-platform/issues/36738

The file [cms/djangoapps/contentstore/storage.py](https://github.com/openedx/edx-platform/blob/9750c63f746b8e644f219312620342d3c0663261/cms/djangoapps/contentstore/storage.py#L21) was updated to use storages, as get_storage_class will be removed in Django 5.1.

These changes include:

- Ensuring the updated code is compatible with both Django 4.2 and Django 5 or above
- Adding test cases to verify the compatibility mentioned above
- Considering future compatibility with the STORAGES settings

## Testing instructions

Run `pytest -s cms/djangoapps/contentstore/tests/test_import.py`

## Functionality verified locally

![image](https://github.com/user-attachments/assets/b3109376-00a4-4436-8c29-2acba32995f4)
