### PR TITLE
feat: added logs for profile image upload flow to debug on stage

### DIFF
--- a/openedx/core/djangoapps/profile_images/images.py
+++ b/openedx/core/djangoapps/profile_images/images.py
@@ -7,6 +7,7 @@ import binascii
 from collections import namedtuple
 from contextlib import closing
 from io import BytesIO
+import logging
 
 import piexif
 from django.conf import settings
@@ -38,6 +39,7 @@ IMAGE_TYPES = {
     ),
 }
 
+log = logging.getLogger(__name__)
 
 def create_profile_images(image_file, profile_image_names):
     """
@@ -71,6 +73,7 @@ def create_profile_images(image_file, profile_image_names):
         exif = _get_corrected_exif(scaled, original)
         with closing(_create_image_file(scaled, exif)) as scaled_image_file:
             storage.save(name, scaled_image_file)
+            log.info("Saved profile image '%s' for user.", name)
 
 
 def remove_profile_images(profile_image_names):

--- a/openedx/core/djangoapps/profile_images/views.py
+++ b/openedx/core/djangoapps/profile_images/views.py
@@ -155,7 +155,9 @@ class ProfileImageView(DeveloperErrorViewMixin, APIView):
                 )
 
             # generate profile pic and thumbnails and store them
+            log.info("Starting generating profile images for user %s", username)
             profile_image_names = get_profile_image_names(username)
+            log.info("Starting creating profile images for user %s", username)
             create_profile_images(uploaded_file, profile_image_names)
 
             # update the user account to reflect that a profile image is available.


### PR DESCRIPTION
Ticket: [INF-1890](https://2u-internal.atlassian.net/browse/INF-1890)

We're enabling edit functionality on the user Profile page. During staging testing, we observed that the profile image does not update, even though the API call returns a success response. This issue does not occur in the local environment.

This PR adds logging to help investigate the root cause of the image not updating on stage.

