### PR TITLE
fix: Updates task in topics sync API

### DIFF
--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -12,7 +12,6 @@ from django.core.exceptions import ValidationError
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 from lti_consumer.models import CourseAllowPIISharingInLTIFlag
-from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -853,7 +852,7 @@ class SyncDiscussionTopicsViewTests(ModuleStoreTestCase, APITestCase):
         IsStaffOrCourseTeam.has_permission = self.original_has_permission
         super().tearDown()
 
-    @patch('openedx.core.djangoapps.discussions.views.update_unit_discussion_state_from_discussion_blocks')
+    @patch('openedx.core.djangoapps.discussions.views.update_discussions_settings_from_course_task')
     def test_sync_discussion_topics_staff_user(self, mock_update):
         """
         Test that staff users can sync discussion topics
@@ -863,14 +862,9 @@ class SyncDiscussionTopicsViewTests(ModuleStoreTestCase, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'success')
-        mock_update.assert_called_once_with(
-            course_key=CourseKey.from_string(self.course_key_string),
-            user_id=self.staff_user.id,
-            force=True,
-            async_topics=False
-        )
+        mock_update.assert_called_once_with(self.course_key_string)
 
-    @patch('openedx.core.djangoapps.discussions.views.update_unit_discussion_state_from_discussion_blocks')
+    @patch('openedx.core.djangoapps.discussions.views.update_discussions_settings_from_course_task')
     def test_sync_discussion_topics_course_team(self, mock_update):
         """
         Test that course team members can sync discussion topics

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -6,7 +6,6 @@ from typing import Dict
 import edx_api_doc_tools as apidocs
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
-from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -21,7 +20,7 @@ from .config.waffle import ENABLE_NEW_STRUCTURE_DISCUSSIONS
 from .models import AVAILABLE_PROVIDER_MAP, DiscussionsConfiguration, Features, Provider
 from .permissions import IsStaffOrCourseTeam, check_course_permissions
 from .serializers import DiscussionsConfigurationSerializer, DiscussionsProvidersSerializer
-from .tasks import update_unit_discussion_state_from_discussion_blocks
+from .tasks import update_discussions_settings_from_course_task
 
 
 class DiscussionsConfigurationSettingsView(APIView):
@@ -272,13 +271,7 @@ class SyncDiscussionTopicsView(APIView):
         Returns:
             Response: modified course configuration data
         """
-        update_unit_discussion_state_from_discussion_blocks(
-            course_key=CourseKey.from_string(course_key_string),
-            user_id=request.user.id,
-            force=True,
-            async_topics=False
-        )
-
+        update_discussions_settings_from_course_task(course_key_string)
         return Response({
             "status": "success",
             "message": "Discussion topics synced successfully."


### PR DESCRIPTION
## Description 
Updated task to update_discussions_settings_from_course_task because it uses a slightly different mechanism for creating topics . The existing implementation is causing unexpected results.