### PR TITLE
feat: removed age restriction on profile image upload

### DIFF
--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -696,10 +696,6 @@ def user_profile_pre_save_callback(sender, **kwargs):
     """
     user_profile = kwargs['instance']
 
-    # Remove profile images for users who require parental consent
-    if user_profile.requires_parental_consent() and user_profile.has_profile_image:
-        user_profile.profile_image_uploaded_at = None
-
     # Cache "old" field values on the model instance so that they can be
     # retrieved in the post_save callback when we emit an event with new and
     # old field values.

--- a/common/djangoapps/student/tests/test_parental_controls.py
+++ b/common/djangoapps/student/tests/test_parental_controls.py
@@ -65,23 +65,3 @@ class ProfileParentalControlsTest(TestCase):
         self.set_year_of_birth(current_year - 14)
         assert not self.profile.requires_parental_consent()
         assert not self.profile.requires_parental_consent(year=current_year)
-
-    def test_profile_image(self):
-        """Verify that a profile's image obeys parental controls."""
-
-        # Verify that an image cannot be set for a user with no year of birth set
-        self.profile.profile_image_uploaded_at = now()
-        self.profile.save()
-        assert not self.profile.has_profile_image
-
-        # Verify that an image can be set for an adult user
-        current_year = now().year
-        self.set_year_of_birth(current_year - 20)
-        self.profile.profile_image_uploaded_at = now()
-        self.profile.save()
-        assert self.profile.has_profile_image
-
-        # verify that a user's profile image is removed when they switch to requiring parental controls
-        self.set_year_of_birth(current_year - 10)
-        self.profile.save()
-        assert not self.profile.has_profile_image

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -413,7 +413,8 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
         self._verify_profile_image_data(data, has_profile_image)
         assert self.user.username == data['username']
 
-    def _verify_full_account_response(self, response, requires_parental_consent=False, has_profile_image=True, year_of_birth=2000):
+    def _verify_full_account_response(self, response, requires_parental_consent=False,
+                                      has_profile_image=True, year_of_birth=2000):
         """
         Verify that all account fields are returned (even those that are not shareable).
         """

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -403,17 +403,17 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
         assert data['social_links'] is not None
         assert data['time_zone'] is None
 
-    def _verify_private_account_response(self, response, requires_parental_consent=False):
+    def _verify_private_account_response(self, response, requires_parental_consent=False, has_profile_image=True):
         """
         Verify that only the public fields are returned if a user does not want to share account fields
         """
         data = response.data
         assert 3 == len(data)
         assert PRIVATE_VISIBILITY == data['account_privacy']
-        self._verify_profile_image_data(data, not requires_parental_consent)
+        self._verify_profile_image_data(data, has_profile_image)
         assert self.user.username == data['username']
 
-    def _verify_full_account_response(self, response, requires_parental_consent=False, year_of_birth=2000):
+    def _verify_full_account_response(self, response, requires_parental_consent=False, has_profile_image=True, year_of_birth=2000):
         """
         Verify that all account fields are returned (even those that are not shareable).
         """
@@ -426,7 +426,7 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
             UserPreference.get_value(self.user, 'account_privacy')
         )
         assert expected_account_privacy == data['account_privacy']
-        self._verify_profile_image_data(data, not requires_parental_consent)
+        self._verify_profile_image_data(data, has_profile_image)
         assert self.user.username == data['username']
 
         # additional shareable fields (8)
@@ -1271,11 +1271,11 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
             assert data['requires_parental_consent']
             assert PRIVATE_VISIBILITY == data['account_privacy']
         else:
-            self._verify_private_account_response(response, requires_parental_consent=True)
+            self._verify_private_account_response(response, requires_parental_consent=True, has_profile_image=False)
 
         # Verify that the shared view is still private
         response = self.send_get(client, query_parameters='view=shared')
-        self._verify_private_account_response(response, requires_parental_consent=True)
+        self._verify_private_account_response(response, requires_parental_consent=True, has_profile_image=False)
 
 
 @skip_unless_lms

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -1,8 +1,9 @@
 # pylint: disable=missing-docstring
 
 
-from datetime import date
+from datetime import date, datetime
 import json
+from pytz import UTC
 from unittest.mock import MagicMock, patch
 from urllib.parse import urljoin
 from django.conf import settings
@@ -20,13 +21,18 @@ from common.djangoapps.student.tests.factories import AnonymousUserFactory, User
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from openedx.core.djangoapps.profile_images.images import create_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
 
+
+TEST_PROFILE_IMAGE_UPLOAD_DT = datetime(2002, 1, 9, 15, 43, 1, tzinfo=UTC)
 
 class CookieTests(TestCase):
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
         self.user.profile = UserProfileFactory.create(user=self.user)
+        self.user.profile.profile_image_uploaded_at = TEST_PROFILE_IMAGE_UPLOAD_DT
+        self.user.profile.save()  # lint-amnesty, pylint: disable=no-member
         self.request = RequestFactory().get('/')
         self.request.user = self.user
         self.request.session = self._get_stub_session()
@@ -42,18 +48,6 @@ class CookieTests(TestCase):
             urls_obj[url_name] = request.build_absolute_uri(url_path)
 
         return urls_obj
-
-    def _get_expected_image_urls(self):
-        expected_image_urls = {
-            'full': '/static/default_500.png',
-            'large': '/static/default_120.png',
-            'medium': '/static/default_50.png',
-            'small': '/static/default_30.png'
-        }
-
-        expected_image_urls = self._convert_to_absolute_uris(self.request, expected_image_urls)
-
-        return expected_image_urls
 
     def _get_expected_header_urls(self):
         expected_header_urls = {
@@ -112,7 +106,7 @@ class CookieTests(TestCase):
             'username': self.user.username,
             'email': self.user.email,
             'header_urls': self._get_expected_header_urls(),
-            'user_image_urls': self._get_expected_image_urls(),
+            'user_image_urls': get_profile_image_urls_for_user(self.user),
         }
 
         self.assertDictEqual(actual, expected)

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -26,6 +26,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
 
 TEST_PROFILE_IMAGE_UPLOAD_DT = datetime(2002, 1, 9, 15, 43, 1, tzinfo=UTC)
 
+
 class CookieTests(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Ticket: [INF-1890](https://2u-internal.atlassian.net/browse/INF-1890)

We're enabling edit functionality on the user Profile page. During staging testing, we observed that the profile image does not update, even though the API call returns a success response. This issue occurs because of the age restriction check placed on the profile picture for COPPA. 

This PR removes the age restriction check, allowing all users to update their profile pictures regardless of age or date of birth. 