### PR TITLE
feat: add GTM integration

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1614,6 +1614,18 @@ GOOGLE_ANALYTICS_LINKEDIN = 'GOOGLE_ANALYTICS_LINKEDIN_DUMMY'
 GOOGLE_ANALYTICS_TRACKING_ID = None
 GOOGLE_ANALYTICS_4_ID = None
 
+################### GOOGLE TAG MANAGER ##################
+# .. setting_name: GOOGLE_TAG_MANAGER_ID
+# .. setting_default: None
+# .. setting_description: The container ID for Google Tag Manager.
+#    Set this in the site configuration, if you want to enable Google Tag Manager (GTM) on your site.
+#    GTM allows you to manage marketing and analytics tags (like Google Analytics).
+#    When set, the GTM script will be injected into pages.
+#    Example: "GOOGLE_TAG_MANAGER_ID": "GTM-XXXXXXX" or with environment-specific parameters:
+#    "GOOGLE_TAG_MANAGER_ID": "GTM-XXXXXXX&gtm_auth=abc&gtm_preview=env-1&gtm_cookies_win=x"
+#    If you don’t use GTM, you can leave this setting as None.
+GOOGLE_TAG_MANAGER_ID = None
+
 ######################## BRANCH.IO ###########################
 BRANCH_IO_KEY = ''
 

--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -42,6 +42,15 @@ course_mode_class = course_mode if course_mode else ''
             gtag('config', '${ga_4_id | n, js_escaped_string}');
         </script>
     % endif
+
+    <% gtm_id = static.get_value("GOOGLE_TAG_MANAGER_ID", settings.GOOGLE_TAG_MANAGER_ID) %>
+    % if gtm_id:
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer', '${gtm_id}');</script>
+    % endif
 </head>
 
 <body class="layout-accomplishment view-valid-accomplishment ${dir_rtl} certificate certificate-${course_mode_class}" data-view="valid-accomplishment">

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -177,6 +177,15 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
   </script>
 % endif
 
+<% gtm_id = static.get_value("GOOGLE_TAG_MANAGER_ID", settings.GOOGLE_TAG_MANAGER_ID) %>
+% if gtm_id:
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer', '${gtm_id}');</script>
+% endif
+
 <% branch_key = static.get_value("BRANCH_IO_KEY", settings.BRANCH_IO_KEY) %>
 % if branch_key and not is_from_mobile_app:
     <script type="text/javascript">

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -40,6 +40,14 @@
     </script>
   {% endif %}
 
+  {% if google_tag_manager_id %}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer', '{{ google_tag_manager_id }}');</script>
+  {% endif %}
+
   <meta name="path_prefix" content="{{EDX_ROOT_URL}}">
 </head>
 

--- a/openedx/core/djangoapps/site_configuration/templatetags/configuration.py
+++ b/openedx/core/djangoapps/site_configuration/templatetags/configuration.py
@@ -74,3 +74,12 @@ def google_analytics_4_id():
     {% google_analytics_4_id %}
     """
     return configuration_helpers.get_value("GOOGLE_ANALYTICS_4_ID", settings.GOOGLE_ANALYTICS_4_ID)
+
+
+@register.simple_tag
+def google_tag_manager_id():
+    """
+    Django template tag that outputs the GOOGLE_TAG_MANAGER_ID:
+    {% google_tag_manager_id %}
+    """
+    return configuration_helpers.get_value("GOOGLE_TAG_MANAGER_ID", settings.GOOGLE_TAG_MANAGER_ID)


### PR DESCRIPTION
Open edX forum post with a proposal of the feature:
https://discuss.openedx.org/t/add-gtm-support-to-open-edx-core/16234

Added GTM support to enable easier integration of analytics and tracking scripts. Making it more flexible for platform operators to manage tags via the site configuration panel in the admin section of the platform:

![admn_pnl](https://github.com/user-attachments/assets/aedfad54-5c64-45f7-b5d5-4f769f45e9cc)

If Google Tag Manager ID configured correctly it will appear on the website with corresponding GTM scripts initialisations:

![lms_legacy](https://github.com/user-attachments/assets/c1d6e5dc-d008-47b6-9b17-f6cf4cca4dc7)

Also we made PR to enable similar support on the MFE parts of edX platform:
[frontend-platform](https://github.com/openedx/frontend-platform/pull/814)