### PR TITLE
fix: link reruns & clones to correct orgs

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -37,7 +37,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import LibraryLocator, LibraryContainerLocator
 from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
-from organizations.models import Organization, OrganizationCourse
+from organizations.models import Organization
 from path import Path as path
 from pytz import UTC
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
@@ -163,12 +163,6 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
         # call edxval to attach videos to the rerun
         copy_course_videos(source_course_key, destination_course_key)
 
-        # Copy OrganizationCourse
-        organization_course = OrganizationCourse.objects.filter(course_id=source_course_key_string).first()
-
-        if organization_course:
-            clone_instance(organization_course, {'course_id': destination_course_key_string})
-
         # Copy RestrictedCourse
         restricted_course = RestrictedCourse.objects.filter(course_key=source_course_key).first()
 
@@ -178,7 +172,7 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
             for country_access_rule in country_access_rules:
                 clone_instance(country_access_rule, {'restricted_course': new_restricted_course})
 
-        org_data = ensure_organization(source_course_key.org)
+        org_data = ensure_organization(destination_course_key.org)
         add_organization_course(org_data, destination_course_key)
         return "succeeded"
 

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -189,6 +189,26 @@ class RerunCourseTaskTestCase(CourseTestCase):  # lint-amnesty, pylint: disable=
             country=restricted_country
         )
 
+    def test_success_different_org(self):
+        """
+        The task should clone the OrganizationCourse with a different org.
+        """
+        old_course_key = self.course.id
+        new_course_key = CourseLocator(org='neworg', course=old_course_key.course, run='rerun')
+
+        old_course_id = str(old_course_key)
+        new_course_id = str(new_course_key)
+
+        organization = OrganizationFactory(short_name=old_course_key.org)
+        OrganizationCourse.objects.create(course_id=old_course_id, organization=organization)
+
+        # Run the task!
+        self._rerun_course(old_course_key, new_course_key)
+
+        # Verify the OrganizationCourse is cloned with a different org
+        self.assertEqual(OrganizationCourse.objects.count(), 2)
+        OrganizationCourse.objects.get(course_id=new_course_id, organization__short_name='neworg')
+
 
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 class RegisterExamsTaskTestCase(CourseTestCase):  # pylint: disable=missing-class-docstring


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes the course and organization linking in course reruns & clones when destination course belongs to a different organization.

Note: This only fixes the Bug. To generate correct links for the existing courses, we can use an existing management command [backfill_orgs_and_org_courses](https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/contentstore/management/commands/backfill_orgs_and_org_courses.py). This management command does not deactivate or delete the existing bad course links.

## Supporting information

https://github.com/openedx/edx-platform/issues/36851

## Testing instructions

- Checkout master branch
- Go to CMS
- Create rerun of an existing course in a new organization that does not exists in the system.
- Go to CMS admin at `/admin/organizations/organizationcourse/`, See that the new course is linked to the Source Course Organization
- Now go to the CMS admin at `/admin/organizations/organization/` and see the new organization is missing
- Checkout this branch and repeat the steps.

## Deadline

Before the official Teak release?


