### PR TITLE
build: remove outdated dependency path

### DIFF
--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -31,7 +31,6 @@ jobs:
           find_python_dependencies \
             --req-file requirements/edx/base.txt \
             --req-file requirements/edx/testing.txt \
-            --ignore https://github.com/edx/codejail-includes \
             --ignore https://github.com/edx/edx-name-affirmation \
             --ignore https://github.com/mitodl/edx-sga \
             --ignore https://github.com/open-craft/xblock-poll


### PR DESCRIPTION
## Description
- The workflow `Check Python Dependencies` started failing (see failed [build](https://github.com/openedx/edx-platform/actions/runs/15466373781/job/43541227764) )because the dependency path `edx/codejail-includes` has been removed now so the url is not accessible anymore. 
- Removed the parameter from workflow script for the build to succeed.