### PR TITLE
fix: added content search to lms installed apps

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3284,6 +3284,9 @@ INSTALLED_APPS = [
     # Course Goals
     'lms.djangoapps.course_goals.apps.CourseGoalsConfig',
 
+    # Search
+    'openedx.core.djangoapps.content.search',
+
     # Tagging
     'openedx_tagging.core.tagging.apps.TaggingConfig',
     'openedx.core.djangoapps.content_tagging',


### PR DESCRIPTION
This is a backport for teak to fix the content search app not being installed in the lms