### PR TITLE
feat: Send events when update containers [FC-0090]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -335,7 +335,8 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         assert collection.created_by == self.user
 
         assert event_receiver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_COLLECTION_CREATED,
                 "sender": None,
@@ -346,7 +347,6 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     ),
                 ),
             },
-            event_receiver.call_args_list[0].kwargs,
         )
 
     def test_create_library_collection_invalid_library(self) -> None:
@@ -373,7 +373,8 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         assert self.col1.created_by == self.user
 
         assert event_receiver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_COLLECTION_UPDATED,
                 "sender": None,
@@ -384,7 +385,6 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     ),
                 ),
             },
-            event_receiver.call_args_list[0].kwargs,
         )
 
     def test_update_library_collection_wrong_library(self) -> None:
@@ -406,7 +406,8 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         )
 
         assert event_receiver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_COLLECTION_DELETED,
                 "sender": None,
@@ -417,7 +418,6 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     ),
                 ),
             },
-            event_receiver.call_args_list[0].kwargs,
         )
 
     def test_update_library_collection_items(self) -> None:
@@ -463,7 +463,8 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         )
 
         assert event_receiver.call_count == 4
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -472,9 +473,9 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     changes=["collections"],
                 ),
             },
-            event_receiver.call_args_list[0].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[1].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -483,9 +484,9 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     changes=["collections"],
                 ),
             },
-            event_receiver.call_args_list[1].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[2].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -494,9 +495,9 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     changes=["collections"],
                 ),
             },
-            event_receiver.call_args_list[2].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[3].kwargs,
             {
                 "signal": LIBRARY_COLLECTION_UPDATED,
                 "sender": None,
@@ -507,7 +508,6 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     ),
                 ),
             },
-            event_receiver.call_args_list[3].kwargs,
         )
 
     def test_update_collection_components_from_wrong_library(self) -> None:
@@ -539,14 +539,18 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         assert self.lib2.learning_package_id is not None
         assert len(authoring_api.get_collection(self.lib2.learning_package_id, self.col2.key).entities.all()) == 1
         assert len(authoring_api.get_collection(self.lib2.learning_package_id, self.col3.key).entities.all()) == 1
-        assert {
-            "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
-            "sender": None,
-            "content_object": ContentObjectChangedData(
-                object_id=self.lib2_problem_block["id"],
-                changes=["collections"],
-            ),
-        }.items() <= event_receiver.call_args_list[0].kwargs.items()
+
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
+            {
+                "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
+                "sender": None,
+                "content_object": ContentObjectChangedData(
+                    object_id=self.lib2_problem_block["id"],
+                    changes=["collections"],
+                ),
+            },
+        )
 
         assert len(collection_update_event_receiver.call_args_list) == 2
         collection_update_events = [call.kwargs for call in collection_update_event_receiver.call_args_list]
@@ -578,7 +582,8 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         api.delete_library_block(LibraryUsageLocatorV2.from_string(self.lib1_problem_block["id"]))
 
         assert event_receiver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_COLLECTION_UPDATED,
                 "sender": None,
@@ -590,7 +595,6 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     background=True,
                 ),
             },
-            event_receiver.call_args_list[0].kwargs,
         )
 
     def test_delete_library_container(self) -> None:
@@ -610,7 +614,8 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         api.delete_container(LibraryContainerLocator.from_string(self.unit1["id"]))
 
         assert event_receiver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_COLLECTION_UPDATED,
                 "sender": None,
@@ -622,7 +627,6 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     background=True,
                 ),
             },
-            event_receiver.call_args_list[0].kwargs,
         )
 
     def test_restore_library_block(self) -> None:
@@ -641,7 +645,8 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         api.restore_library_block(LibraryUsageLocatorV2.from_string(self.lib1_problem_block["id"]))
 
         assert event_receiver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_COLLECTION_UPDATED,
                 "sender": None,
@@ -653,7 +658,6 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
                     background=True,
                 ),
             },
-            event_receiver.call_args_list[0].kwargs,
         )
 
     def test_add_component_and_revert(self) -> None:
@@ -681,16 +685,19 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         api.revert_changes(self.lib1.library_key)
 
         assert collection_update_event_receiver.call_count == 1
-        assert {
-            "signal": LIBRARY_COLLECTION_UPDATED,
-            "sender": None,
-            "library_collection": LibraryCollectionData(
-                collection_key=api.library_collection_locator(
-                    self.lib1.library_key,
-                    collection_key=self.col1.key,
+        self.assertDictContainsEntries(
+            collection_update_event_receiver.call_args_list[0].kwargs,
+            {
+                "signal": LIBRARY_COLLECTION_UPDATED,
+                "sender": None,
+                "library_collection": LibraryCollectionData(
+                    collection_key=api.library_collection_locator(
+                        self.lib1.library_key,
+                        collection_key=self.col1.key,
+                    ),
                 ),
-            ),
-        }.items() <= collection_update_event_receiver.call_args_list[0].kwargs.items()
+            },
+        )
 
     def test_delete_component_and_revert(self) -> None:
         """
@@ -717,16 +724,19 @@ class ContentLibraryCollectionsTest(ContentLibrariesRestApiTest):
         api.revert_changes(self.lib1.library_key)
 
         assert collection_update_event_receiver.call_count == 1
-        assert {
-            "signal": LIBRARY_COLLECTION_UPDATED,
-            "sender": None,
-            "library_collection": LibraryCollectionData(
-                collection_key=api.library_collection_locator(
-                    self.lib1.library_key,
-                    collection_key=self.col1.key,
+        self.assertDictContainsEntries(
+            collection_update_event_receiver.call_args_list[0].kwargs,
+            {
+                "signal": LIBRARY_COLLECTION_UPDATED,
+                "sender": None,
+                "library_collection": LibraryCollectionData(
+                    collection_key=api.library_collection_locator(
+                        self.lib1.library_key,
+                        collection_key=self.col1.key,
+                    ),
                 ),
-            ),
-        }.items() <= collection_update_event_receiver.call_args_list[0].kwargs.items()
+            },
+        )
 
 
 class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
@@ -865,7 +875,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         using the `LIBRARY_CONTAINER_UPDATED` signal.
         """
         assert event_mock.call_count == 2
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_mock.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -874,9 +885,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     background=True,
                 )
             },
-            event_mock.call_args_list[0].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_mock.call_args_list[1].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -885,7 +896,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     background=True,
                 )
             },
-            event_mock.call_args_list[1].kwargs,
         )
 
     def test_call_container_update_signal_when_delete_component(self) -> None:
@@ -926,7 +936,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         self._update_container(self.unit1.container_key, 'New Unit Display Name')
 
         assert container_update_event_receiver.call_count == 3
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            container_update_event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -934,9 +945,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     container_key=self.unit1.container_key,
                 )
             },
-            container_update_event_receiver.call_args_list[0].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            container_update_event_receiver.call_args_list[1].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -944,9 +955,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     container_key=self.subsection1.container_key,
                 )
             },
-            container_update_event_receiver.call_args_list[1].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            container_update_event_receiver.call_args_list[2].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -954,7 +965,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     container_key=self.subsection2.container_key,
                 )
             },
-            container_update_event_receiver.call_args_list[2].kwargs,
         )
 
     def test_call_container_update_signal_when_update_subsection(self) -> None:
@@ -963,7 +973,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         self._update_container(self.subsection1.container_key, 'New Subsection Display Name')
 
         assert container_update_event_receiver.call_count == 3
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            container_update_event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -971,9 +982,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     container_key=self.subsection1.container_key,
                 )
             },
-            container_update_event_receiver.call_args_list[0].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            container_update_event_receiver.call_args_list[1].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -981,9 +992,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     container_key=self.section1.container_key,
                 )
             },
-            container_update_event_receiver.call_args_list[1].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            container_update_event_receiver.call_args_list[2].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -991,7 +1002,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     container_key=self.section2.container_key,
                 )
             },
-            container_update_event_receiver.call_args_list[2].kwargs,
         )
 
     def test_call_container_update_signal_when_update_section(self) -> None:
@@ -1000,7 +1010,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         self._update_container(self.section1.container_key, 'New Section Display Name')
 
         assert container_update_event_receiver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            container_update_event_receiver.call_args_list[0].kwargs,
             {
                 "signal": LIBRARY_CONTAINER_UPDATED,
                 "sender": None,
@@ -1008,7 +1019,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     container_key=self.section1.container_key,
                 )
             },
-            container_update_event_receiver.call_args_list[0].kwargs,
         )
 
     def test_call_object_changed_signal_when_remove_component(self) -> None:
@@ -1032,7 +1042,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         )
 
         assert event_reciver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[0].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1041,7 +1052,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["units"],
                 ),
             },
-            event_reciver.call_args_list[0].kwargs,
         )
 
     def test_call_object_changed_signal_when_remove_unit(self) -> None:
@@ -1064,7 +1074,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         )
 
         assert event_reciver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[0].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1073,7 +1084,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["subsections"],
                 ),
             },
-            event_reciver.call_args_list[0].kwargs,
         )
 
     def test_call_object_changed_signal_when_remove_subsection(self) -> None:
@@ -1102,7 +1112,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         )
 
         assert event_reciver.call_count == 1
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[0].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1111,7 +1122,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["sections"],
                 ),
             },
-            event_reciver.call_args_list[0].kwargs,
         )
 
     def test_call_object_changed_signal_when_add_component(self) -> None:
@@ -1135,7 +1145,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         )
 
         assert event_reciver.call_count == 2
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[0].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1144,9 +1155,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["units"],
                 ),
             },
-            event_reciver.call_args_list[0].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[1].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1155,7 +1166,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["units"],
                 ),
             },
-            event_reciver.call_args_list[1].kwargs,
         )
 
     def test_call_object_changed_signal_when_add_unit(self) -> None:
@@ -1172,7 +1182,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
             entities_action=authoring_api.ChildrenEntitiesAction.APPEND,
         )
         assert event_reciver.call_count == 2
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[0].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1181,9 +1192,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["subsections"],
                 ),
             },
-            event_reciver.call_args_list[0].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[1].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1192,7 +1203,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["subsections"],
                 ),
             },
-            event_reciver.call_args_list[1].kwargs,
         )
 
     def test_call_object_changed_signal_when_add_subsection(self) -> None:
@@ -1220,7 +1230,8 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
             entities_action=authoring_api.ChildrenEntitiesAction.APPEND,
         )
         assert event_reciver.call_count == 2
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[0].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1229,9 +1240,9 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["sections"],
                 ),
             },
-            event_reciver.call_args_list[0].kwargs,
         )
-        self.assertDictContainsSubset(
+        self.assertDictContainsEntries(
+            event_reciver.call_args_list[1].kwargs,
             {
                 "signal": CONTENT_OBJECT_ASSOCIATIONS_CHANGED,
                 "sender": None,
@@ -1240,7 +1251,6 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
                     changes=["sections"],
                 ),
             },
-            event_reciver.call_args_list[1].kwargs,
         )
 
     def test_delete_component_and_revert(self) -> None:
@@ -1263,8 +1273,13 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         api.revert_changes(self.lib1.library_key)
 
         assert container_event_receiver.call_count == 1
-        assert {
-            "signal": LIBRARY_CONTAINER_UPDATED,
-            "sender": None,
-            "library_container": LibraryContainerData(container_key=self.unit3.container_key),
-        }.items() <= container_event_receiver.call_args_list[0].kwargs.items()
+        self.assertDictContainsEntries(
+            container_event_receiver.call_args_list[0].kwargs,
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.unit3.container_key
+                ),
+            },
+        )

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -920,6 +920,97 @@ class ContentLibraryContainersTest(ContentLibrariesRestApiTest):
         self._set_library_block_fields(self.html_block_usage_key, {"data": block_olx, "metadata": {}})
         self._validate_calls_of_html_block(container_update_event_receiver)
 
+    def test_call_container_update_signal_when_update_unit(self) -> None:
+        container_update_event_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(container_update_event_receiver)
+        self._update_container(self.unit1.container_key, 'New Unit Display Name')
+
+        assert container_update_event_receiver.call_count == 3
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.unit1.container_key,
+                )
+            },
+            container_update_event_receiver.call_args_list[0].kwargs,
+        )
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.subsection1.container_key,
+                )
+            },
+            container_update_event_receiver.call_args_list[1].kwargs,
+        )
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.subsection2.container_key,
+                )
+            },
+            container_update_event_receiver.call_args_list[2].kwargs,
+        )
+
+    def test_call_container_update_signal_when_update_subsection(self) -> None:
+        container_update_event_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(container_update_event_receiver)
+        self._update_container(self.subsection1.container_key, 'New Subsection Display Name')
+
+        assert container_update_event_receiver.call_count == 3
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.subsection1.container_key,
+                )
+            },
+            container_update_event_receiver.call_args_list[0].kwargs,
+        )
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.section1.container_key,
+                )
+            },
+            container_update_event_receiver.call_args_list[1].kwargs,
+        )
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.section2.container_key,
+                )
+            },
+            container_update_event_receiver.call_args_list[2].kwargs,
+        )
+
+    def test_call_container_update_signal_when_update_section(self) -> None:
+        container_update_event_receiver = mock.Mock()
+        LIBRARY_CONTAINER_UPDATED.connect(container_update_event_receiver)
+        self._update_container(self.section1.container_key, 'New Section Display Name')
+
+        assert container_update_event_receiver.call_count == 1
+        self.assertDictContainsSubset(
+            {
+                "signal": LIBRARY_CONTAINER_UPDATED,
+                "sender": None,
+                "library_container": LibraryContainerData(
+                    container_key=self.section1.container_key,
+                )
+            },
+            container_update_event_receiver.call_args_list[0].kwargs,
+        )
+
     def test_call_object_changed_signal_when_remove_component(self) -> None:
         html_block_1 = self._add_block_to_library(
             self.lib1.library_key, "html", "html3",


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description


- Send `LIBRARY_CONTAINER_UPDATED` for containers that contains the updated unit/section when calling `update_container`
- Which edX user roles will this change impact? "Course Author", "Developer".

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/1630
- Used in: https://github.com/openedx/frontend-app-authoring/pull/2057
- Internal ticket: [FAL-4169](https://tasks.opencraft.com/browse/FAL-4169)

## Testing instructions

- Verify that the tests cover the new code.
- Follow the testing instructions of https://github.com/openedx/frontend-app-authoring/pull/2057

## Other information

N/A