### PR TITLE
fix: strip end slash if any when using a subpath

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -188,11 +188,11 @@ class Command(BaseCommand):
             return True
 
         site = Site.objects.get_current()
-        baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,
-            'lms_verification_link': f'{baseUrl}/id-verification',
+            'lms_verification_link': f'{account_base_url}/id-verification',
             'help_center_link': settings.ID_VERIFICATION_SUPPORT_LINK
         })
 

--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -188,10 +188,11 @@ class Command(BaseCommand):
             return True
 
         site = Site.objects.get_current()
+        baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,
-            'lms_verification_link': f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification',
+            'lms_verification_link': f'{baseUrl}/id-verification',
             'help_center_link': settings.ID_VERIFICATION_SUPPORT_LINK
         })
 

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -251,7 +251,8 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        location = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        location = f'{baseUrl}/id-verification'
         if course_id:
             location += f'?course_id={quote(str(course_id))}'
 

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -251,8 +251,8 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
-        location = f'{baseUrl}/id-verification'
+        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        location = f'{account_base_url}/id-verification'
         if course_id:
             location += f'?course_id={quote(str(course_id))}'
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1128,7 +1128,8 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
         log.info("[COSMO-184] Denied verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
 
         attempt.deny(json.dumps(reason), error_code=error_code)
-        reverify_url = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        reverify_url = f'{baseUrl}/id-verification'
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url
         verification_status_email_vars['faq_url'] = settings.ID_VERIFICATION_SUPPORT_LINK

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1128,8 +1128,8 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
         log.info("[COSMO-184] Denied verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
 
         attempt.deny(json.dumps(reason), error_code=error_code)
-        baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
-        reverify_url = f'{baseUrl}/id-verification'
+        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        reverify_url = f'{account_base_url}/id-verification'
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url
         verification_status_email_vars['faq_url'] = settings.ID_VERIFICATION_SUPPORT_LINK

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -97,14 +97,14 @@ def create_email_template_context(username):
         'channel': 'email',
         'value': False
     }
-    baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+    account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
     return {
         "platform_name": settings.PLATFORM_NAME,
         "mailing_address": settings.CONTACT_MAILING_ADDRESS,
         "logo_url": get_logo_url_for_email(),
         "logo_notification_cadence_url": settings.NOTIFICATION_DIGEST_LOGO,
         "social_media": social_media_info,
-        "notification_settings_url": f"{baseUrl}/#notifications",
+        "notification_settings_url": f"{account_base_url}/#notifications",
         "unsubscribe_url": get_unsubscribe_link(username, patch)
     }
 

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -97,13 +97,14 @@ def create_email_template_context(username):
         'channel': 'email',
         'value': False
     }
+    baseUrl = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
     return {
         "platform_name": settings.PLATFORM_NAME,
         "mailing_address": settings.CONTACT_MAILING_ADDRESS,
         "logo_url": get_logo_url_for_email(),
         "logo_notification_cadence_url": settings.NOTIFICATION_DIGEST_LOGO,
         "social_media": social_media_info,
-        "notification_settings_url": f"{settings.ACCOUNT_MICROFRONTEND_URL}/#notifications",
+        "notification_settings_url": f"{baseUrl}/#notifications",
         "unsubscribe_url": get_unsubscribe_link(username, patch)
     }
 


### PR DESCRIPTION
## Description

While trying to be enrolled on a verified course, the upgrade process get's to an error screen due to a double slash on the URL that it's added while doing the redirection to the account microfrontend

Screenshot of the error:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/491fa071-8964-4d0c-b79c-169ad3e5a2ec" />

Video on how you get to the error:

https://github.com/user-attachments/assets/16465e89-f468-4de9-8e8a-84b4a267b257



This happens due to the base URL having an ending slash while also using a slash for the next part of the URL:

```
http://apps.local.openedx.io:1997/account//id-verification?course_id=course-v1%3Ademo%2BD01%2B2025_T1
```

(Notice the `//` before id-verification)

Given that the endslash is required for the base URL to work properly this PR intends to remove the endslash (if any) when also a sub-path it's being used next to it to prevent any issue even if there's slight URL changes later.

Afther this change the redirection works properly:


https://github.com/user-attachments/assets/9134c64d-5362-4479-a1e2-7508ec93d70c


## Supporting information

Fixes: https://github.com/openedx/wg-build-test-release/issues/468

## Testing instructions

Assumptions prior to testing:

- Running dev environment
- Branch for this PR is being used
- You have a course that it's configured as require ID verification

Steps to test:

- Access the list of available courses and locate your course tha requires id verif
- Select the course / Click "Enroll Now" / Click "Upgrade now"

If everything is working correctly you should be properly redirect to the account verification screen.

## Deadline

None

## Other information

Include anything else that will help reviewers and consumers understand the change.

- This changes doesn't depend on changes anywhere else
- The only concern is that probably we need an overall change for this, like manage urls not as strings but as objects that will handle this kind of "edge cases"...
