### PR TITLE
feat!: enable authoring MFE markdown editor waffle for everyone by default

### DIFF
--- a/cms/djangoapps/contentstore/migrations/0011_enable_markdown_editor_flag_by_default.py
+++ b/cms/djangoapps/contentstore/migrations/0011_enable_markdown_editor_flag_by_default.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+from cms.djangoapps.contentstore.toggles import (
+    ENABLE_REACT_MARKDOWN_EDITOR
+)
+
+
+def create_flag(apps, schema_editor):
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.get_or_create(
+        name=ENABLE_REACT_MARKDOWN_EDITOR.name, defaults={'everyone': True}
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contentstore', '0010_container_link_models'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        # Do not remove the flags for rollback.  We don't want to lose originals if
+        # they already existed, and it won't hurt if they are created.
+        migrations.RunPython(create_flag, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
(based on Anas's work: https://github.com/openedx/edx-platform/pull/36602)

## Description

This adds a migration to turn on the new React-based Markdown editing option
for newly-created ProblemBlocks for all authors. The option is nested
under "Advanced settings", just like the Advanced (OLX) problem editor.

The migration is written such that it will **not** overwrite an existing global "No" waffle flag. Furthermore, our waffle utilities are designed such that org-level and course-level overrides will still take preference over the flag that the migration creates. Therefore, this should only take effect in cases where no existing waffle flag applies.

BREAKING CHANGE: Operators who do not want the new React-based Markdown editor to be shown should create a flag `contentstore.use_react_markdown_editor` with the value "No".

## Testing information

Create a "No" entry for `contentstore.use_react_markdown_editor`.

Run migrations. Confirm that the "No" entry still exists.

Delete that "No" entry: 

Delete the record of this PR's migration from the django_migrations table.
```
tutor dev do sqlshell
> use openedx;
> delete from django_migrations where name = '0011_enable_markdown_editor_flag_by_default';
```

Run migrations again.

Follow the steps on https://github.com/openedx/frontend-app-authoring/pull/1805, but notice that the waffle flag already exists.

## Supporting information

Slack thread where we decided to turn this on in Teak: https://axim-collaborative.slack.com/archives/C058TVC79MF/p1749140304975279

Implementation and screenshots: https://github.com/openedx/frontend-app-authoring/pull/1805

Part of: https://github.com/openedx/platform-roadmap/issues/384

Prior art for turning on Waffle flags like this: https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/grades/migrations/0018_add_waffle_flag_defaults.py

## Other Information

This is all @Anas12091101 's work : https://github.com/openedx/edx-platform/pull/36602/commits/ce4fa2c9d4106aff04d8317771aea14261b24440

Teak backport: https://github.com/openedx/edx-platform/pull/36876
