### PR TITLE
temp: add monitoring for cors_csfr utility

### DIFF
--- a/openedx/core/djangoapps/cors_csrf/decorators.py
+++ b/openedx/core/djangoapps/cors_csrf/decorators.py
@@ -2,6 +2,7 @@
 
 
 from django.views.decorators.csrf import ensure_csrf_cookie
+from edx_django_utils.monitoring import set_custom_attribute
 
 
 def ensure_csrf_cookie_cross_domain(func):
@@ -22,6 +23,24 @@ def ensure_csrf_cookie_cross_domain(func):
             # the cross-domain version of the CSRF cookie.
             request = args[0]
             request.META['CROSS_DOMAIN_CSRF_COOKIE_USED'] = True
+            current_authenticator = getattr(request, 'successful_authenticator', None)
+
+            if hasattr(request, "resolver_match"):
+                # .. custom_attribute_name: tmp_cors_csrf_decorator.view
+                # .. custom_attribute_description: the name of the view this request came from
+                set_custom_attribute("tmp_cors_csrf_decorator.view", request.resolver_match.view_name)
+
+            # .. custom_attribute_name: tmp_cors_csrf_decorator.authenticator
+            # .. custom_attribute_description: authenticator used for this view
+            set_custom_attribute("tmp_cors_csrf_decorator.authenticator", current_authenticator)
+
+            # .. custom_attribute_name: tmp_cors_csrf_decorator.referer
+            # .. custom_attribute_description: http_referer value obtained from the request headers
+            set_custom_attribute('tmp_cors_csrf_decorator.referer', request.META.get('HTTP_REFERER'))
+
+            # .. custom_attribute_name: tmp_cors_csrf_decorator.host
+            # .. custom_attribute_description: host value obtained from the request
+            set_custom_attribute('tmp_cors_csrf_decorator.host', request.get_host())
 
         # Decorate the request with Django's
         # `ensure_csrf_cookie` to ensure that the usual

--- a/openedx/core/djangoapps/cors_csrf/decorators.py
+++ b/openedx/core/djangoapps/cors_csrf/decorators.py
@@ -26,7 +26,7 @@ def ensure_csrf_cookie_cross_domain(func):
                 request.META['CROSS_DOMAIN_CSRF_COOKIE_USED'] = True
                 current_authenticator = getattr(request, 'successful_authenticator', None)
 
-                enable_cors_csrf_detail_monitoring = settings.FEATURES.get('CORS_CSRF_DETAIL_MONITORING', False)
+                enable_cors_csrf_detail_monitoring = getattr(settings, 'CORS_CSRF_DETAIL_MONITORING', False)
 
                 if enable_cors_csrf_detail_monitoring:
                     if hasattr(request, "resolver_match"):

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -50,6 +50,8 @@ from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
 from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.deprecation import MiddlewareMixin
 
+from edx_django_utils.monitoring import set_custom_attribute
+
 from .helpers import is_cross_domain_request_allowed, skip_cross_domain_referer_check
 
 
@@ -63,13 +65,31 @@ class CorsCSRFMiddleware(CsrfViewMiddleware, MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature flag is disabled. """
+
+        # .. custom_attribute_name: tmp_cors_csrf.is_activated
+        # .. custom_attribute_description: Boolean flag to know if CorsCSRFMiddleware is activated
+        set_custom_attribute('tmp_cors_csrf.is_activated', settings.FEATURES.get('ENABLE_CORS_HEADERS', False))
+
         if not settings.FEATURES.get('ENABLE_CORS_HEADERS'):
             raise MiddlewareNotUsed()
         super().__init__(*args, **kwargs)
 
     def process_view(self, request, callback, callback_args, callback_kwargs):
         """Skip the usual CSRF referer check if this is an allowed cross-domain request. """
+
+        # .. custom_attribute_name: tmp_cors_csrf.referer
+        # .. custom_attribute_description: http_referer value obtained from the request headers
+        set_custom_attribute('tmp_cors_csrf.referer', request.META.get('HTTP_REFERER'))
+
+        # .. custom_attribute_name: tmp_cors_csrf.host
+        # .. custom_attribute_description: host value obtained from the request
+        set_custom_attribute('tmp_cors_csrf.host', request.get_host())
+
         if not is_cross_domain_request_allowed(request):
+            # .. custom_attribute_name: tmp_cors_csrf.is_allowed
+            # .. custom_attribute_description: False if this cross-domain request is not allowed
+            set_custom_attribute('tmp_cors_csrf.is_allowed', False)
+
             log.debug("Could not disable CSRF middleware referer check for cross-domain request.")
             return
 
@@ -96,6 +116,14 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature is not enabled. """
+
+        # .. custom_attribute_name: tmp_csrf_cross_domain.is_activated
+        # .. custom_attribute_description: Boolean flag to know if CsrfCrossDomainCookieMiddleware is activated
+        set_custom_attribute(
+            'tmp_csrf_cross_domain.is_activated',
+            settings.FEATURES.get('ENABLE_CROSS_DOMAIN_CSRF_COOKIE', False)
+        )
+
         if not settings.FEATURES.get('ENABLE_CROSS_DOMAIN_CSRF_COOKIE'):
             raise MiddlewareNotUsed()
 
@@ -110,14 +138,31 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
                 "You must set `CROSS_DOMAIN_CSRF_COOKIE_DOMAIN` when "
                 "`FEATURES['ENABLE_CROSS_DOMAIN_CSRF_COOKIE']` is True."
             )
+
+        # .. custom_attribute_name: tmp_csrf_cross_domain.is_properly_config
+        # .. custom_attribute_description: True if CsrfCrossDomainCookieMiddleware is activated
+        #   and properly configured
+        set_custom_attribute('tmp_csrf_cross_domain.is_properly_config', True)
         super().__init__(*args, **kwargs)
 
     def process_response(self, request, response):
         """Set the cross-domain CSRF cookie. """
 
+        # .. custom_attribute_name: tmp_csrf_cross_domain.referer
+        # .. custom_attribute_description: http_referer value obtained from the request headers
+        set_custom_attribute('tmp_csrf_cross_domain.referer', request.META.get('HTTP_REFERER'))
+
+        # .. custom_attribute_name: tmp_csrf_cross_domain.host
+        # .. custom_attribute_description: host value obtained from the request
+        set_custom_attribute('tmp_csrf_cross_domain.host', request.get_host())
+
         # Check whether this is a secure request from a domain on our whitelist.
         if not is_cross_domain_request_allowed(request):
             log.debug("Could not set cross-domain CSRF cookie.")
+
+            # .. custom_attribute_name: tmp_csrf_cross_domain.is_allowed
+            # .. custom_attribute_description: False if this cross-domain request is not allowed
+            set_custom_attribute('tmp_csrf_cross_domain.is_allowed', False)
             return response
 
         # Send the cross-domain CSRF cookie if this is a view decorated with
@@ -134,6 +179,11 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
             request.META.get('CROSS_DOMAIN_CSRF_COOKIE_USED', False) and
             request.META.get('CSRF_COOKIE') is not None
         )
+
+        # .. custom_attribute_name: tmp_csrf_cross_domain.should_set_cookie
+        # .. custom_attribute_description: True if CROSS_DOMAIN_CSRF_COOKIE_USED is true
+        #   and there is a csrf cookie
+        set_custom_attribute('tmp_csrf_cross_domain.should_set_cookie', should_set_cookie)
 
         if should_set_cookie:
             # This is very similar to the code in Django's CSRF middleware
@@ -154,5 +204,18 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
                 settings.CROSS_DOMAIN_CSRF_COOKIE_NAME,
                 settings.CROSS_DOMAIN_CSRF_COOKIE_DOMAIN
             )
+
+            # .. custom_attribute_name: tmp_csrf_cross_domain.cookie_name
+            # .. custom_attribute_description: csrf cookie name configured
+            set_custom_attribute('tmp_csrf_cross_domain.cookie_name', settings.CROSS_DOMAIN_CSRF_COOKIE_NAME)
+
+            # .. custom_attribute_name: tmp_csrf_cross_domain.cookie_domain
+            # .. custom_attribute_description: csrf cookie domain configured
+            set_custom_attribute('tmp_csrf_cross_domain.cookie_domain', settings.CROSS_DOMAIN_CSRF_COOKIE_DOMAIN)
+
+            if hasattr(request, "resolver_match"):
+                # .. custom_attribute_name: tmp_csrf_cross_domain.view
+                # .. custom_attribute_description: the name of the view this request came from
+                set_custom_attribute("tmp_csrf_cross_domain.view", request.resolver_match.view_name)
 
         return response

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -63,7 +63,7 @@ class CorsCSRFMiddleware(CsrfViewMiddleware, MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature flag is disabled. """
-        self.enable_cors_csrf_detail_monitoring = settings.FEATURES.get('CORS_CSRF_DETAIL_MONITORING', False)
+        self.enable_cors_csrf_detail_monitoring = getattr(settings, 'CORS_CSRF_DETAIL_MONITORING', False)
 
         if self.enable_cors_csrf_detail_monitoring:
             # .. custom_attribute_name: tmp_cors_csrf.is_activated
@@ -86,12 +86,11 @@ class CorsCSRFMiddleware(CsrfViewMiddleware, MiddlewareMixin):
             # .. custom_attribute_description: host value obtained from the request
             set_custom_attribute('tmp_cors_csrf.host', request.get_host())
 
-        if not is_cross_domain_request_allowed(request):
-            if self.enable_cors_csrf_detail_monitoring:
-                # .. custom_attribute_name: tmp_cors_csrf.is_allowed
-                # .. custom_attribute_description: False if this cross-domain request is not allowed
-                set_custom_attribute('tmp_cors_csrf.is_allowed', False)
+            # .. custom_attribute_name: tmp_cors_csrf.is_allowed
+            # .. custom_attribute_description: False if this cross-domain request is not allowed
+            set_custom_attribute('tmp_cors_csrf.is_allowed', is_cross_domain_request_allowed(request))
 
+        if not is_cross_domain_request_allowed(request):
             log.debug("Could not disable CSRF middleware referer check for cross-domain request.")
             return
 
@@ -118,7 +117,7 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature is not enabled. """
-        self.enable_cors_csrf_detail_monitoring = settings.FEATURES.get('CORS_CSRF_DETAIL_MONITORING', False)
+        self.enable_cors_csrf_detail_monitoring = getattr(settings, 'CORS_CSRF_DETAIL_MONITORING', False)
 
         if self.enable_cors_csrf_detail_monitoring:
             # .. custom_attribute_name: tmp_csrf_cross_domain.is_activated

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -34,7 +34,8 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         return request
 
     @override_settings(
-        FEATURES={'ENABLE_CORS_HEADERS': True, 'CORS_CSRF_DETAIL_MONITORING': True},
+        FEATURES={'ENABLE_CORS_HEADERS': True},
+        CORS_CSRF_DETAIL_MONITORING=True
     )
     def setUp(self):
         super().setUp()
@@ -45,6 +46,18 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         Check that the CORS CSRF detail monitoring is enabled
         """
         assert self.middleware.enable_cors_csrf_detail_monitoring
+
+    @ddt.data(True, False)
+    def test_toggle_enable_cors_csrf_detail_monitoring(self, toggle_value):
+        """
+        Check that the CORS CSRF detail monitoring can be toggled
+        """
+        with override_settings(
+            FEATURES={'ENABLE_CORS_HEADERS': True},
+            CORS_CSRF_DETAIL_MONITORING=toggle_value
+        ):
+            middleware = CorsCSRFMiddleware(get_response=lambda request: None)
+            assert middleware.enable_cors_csrf_detail_monitoring == toggle_value
 
     def check_not_enabled(self, request):
         """
@@ -86,7 +99,7 @@ class TestCorsMiddlewareProcessRequest(TestCase):
     def test_enabled(self, http_referer, mock_set_custom_attribute):
         request = self.get_request(is_secure=True, http_referer=http_referer)
         self.check_enabled(request)
-        assert mock_set_custom_attribute.call_count == 2
+        assert mock_set_custom_attribute.call_count == 3
 
     @override_settings(
         FEATURES={'ENABLE_CORS_HEADERS': False},
@@ -141,6 +154,25 @@ class TestCorsMiddlewareProcessRequest(TestCase):
 
     @override_settings(CORS_ORIGIN_WHITELIST=['https://foo.com'])
     @mock.patch('openedx.core.djangoapps.cors_csrf.middleware.set_custom_attribute')
+    def test_cors_is_allowed(self, mock_set_custom_attribute):
+        request = self.get_request(is_secure=True, http_referer='https://foo.com/bar')
+        with patch.object(CsrfViewMiddleware, 'process_view') as mock_method:
+            res = self.middleware.process_view(request, None, None, None)
+
+        assert res is not None
+        assert mock_method.called
+
+        # Check monitoring calls
+        expected_calls = [
+            call('tmp_cors_csrf.referer', 'https://foo.com/bar'),
+            call('tmp_cors_csrf.host', 'foo.com'),
+            call('tmp_cors_csrf.is_allowed', True)
+        ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
+        assert mock_set_custom_attribute.call_count == 3
+
+    @override_settings(CORS_ORIGIN_WHITELIST=['https://foo.com'])
+    @mock.patch('openedx.core.djangoapps.cors_csrf.middleware.set_custom_attribute')
     def test_disabled_http_referer(self, mock_set_custom_attribute):
         request = self.get_request(is_secure=True, http_referer='http://foo.com/bar')
         self.check_not_enabled(request)
@@ -167,11 +199,18 @@ class TestCsrfCrossDomainCookieMiddleware(TestCase):
     @override_settings(
         FEATURES={'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True},
         CROSS_DOMAIN_CSRF_COOKIE_NAME=COOKIE_NAME,
-        CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=COOKIE_DOMAIN
+        CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=COOKIE_DOMAIN,
+        CORS_CSRF_DETAIL_MONITORING=True
     )
     def setUp(self):
         super().setUp()
         self.middleware = CsrfCrossDomainCookieMiddleware(get_response=lambda request: None)
+
+    def test_check_enable_cors_csrf_detail_monitoring(self):
+        """
+        Check that the CORS CSRF detail monitoring is enabled
+        """
+        assert self.middleware.enable_cors_csrf_detail_monitoring
 
     @override_settings(FEATURES={'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': False})
     def test_disabled_by_feature_flag(self):

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -2,8 +2,8 @@
 Tests for the CORS CSRF middleware
 """
 
-
-from unittest.mock import patch, Mock
+from unittest import mock
+from unittest.mock import patch, Mock, call
 import ddt
 import pytest
 from django.test import TestCase
@@ -30,12 +30,21 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         request = Mock()
         request.META = {'HTTP_REFERER': http_referer}
         request.is_secure = lambda: is_secure
+        request.get_host.return_value = 'foo.com'
         return request
 
-    @override_settings(FEATURES={'ENABLE_CORS_HEADERS': True})
+    @override_settings(
+        FEATURES={'ENABLE_CORS_HEADERS': True, 'CORS_CSRF_DETAIL_MONITORING': True},
+    )
     def setUp(self):
         super().setUp()
         self.middleware = CorsCSRFMiddleware(get_response=lambda request: None)
+
+    def test_check_enable_cors_csrf_detail_monitoring(self):
+        """
+        Check that the CORS CSRF detail monitoring is enabled
+        """
+        assert self.middleware.enable_cors_csrf_detail_monitoring
 
     def check_not_enabled(self, request):
         """
@@ -73,9 +82,11 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         'https://foo.com/bar/', 'https://foo.com/bar/baz/', 'https://www.foo.com/bar/baz/',
         'https://learning.edge.foo.bar', 'https://learning.edge.foo.bar/foo'
     )
-    def test_enabled(self, http_referer):
+    @mock.patch('openedx.core.djangoapps.cors_csrf.middleware.set_custom_attribute')
+    def test_enabled(self, http_referer, mock_set_custom_attribute):
         request = self.get_request(is_secure=True, http_referer=http_referer)
         self.check_enabled(request)
+        assert mock_set_custom_attribute.call_count == 2
 
     @override_settings(
         FEATURES={'ENABLE_CORS_HEADERS': False},
@@ -86,24 +97,62 @@ class TestCorsMiddlewareProcessRequest(TestCase):
             CorsCSRFMiddleware(get_response=lambda request: None)
 
     @override_settings(CORS_ORIGIN_WHITELIST=['https://bar.com'])
-    def test_disabled_wrong_cors_domain(self):
+    @mock.patch('openedx.core.djangoapps.cors_csrf.middleware.set_custom_attribute')
+    def test_disabled_wrong_cors_domain(self, mock_set_custom_attribute):
         request = self.get_request(is_secure=True, http_referer='https://foo.com/bar')
         self.check_not_enabled(request)
+        expected_calls = [
+            call('tmp_cors_csrf.referer', 'https://foo.com/bar'),
+            call('tmp_cors_csrf.host', 'foo.com'),
+            call('tmp_cors_csrf.is_allowed', False)
+        ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
+        assert mock_set_custom_attribute.call_count == 3
 
     @override_settings(CORS_ORIGIN_WHITELIST=['https://foo.com'])
-    def test_disabled_wrong_cors_domain_reversed(self):
+    @mock.patch('openedx.core.djangoapps.cors_csrf.middleware.set_custom_attribute')
+    def test_disabled_wrong_cors_domain_reversed(self, mock_set_custom_attribute):
         request = self.get_request(is_secure=True, http_referer='https://bar.com/bar')
         self.check_not_enabled(request)
 
+        # Check monitoring calls
+        expected_calls = [
+            call('tmp_cors_csrf.referer', 'https://bar.com/bar'),
+            call('tmp_cors_csrf.host', 'foo.com'),
+            call('tmp_cors_csrf.is_allowed', False)
+        ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
+        assert mock_set_custom_attribute.call_count == 3
+
     @override_settings(CORS_ORIGIN_WHITELIST=['https://foo.com'])
-    def test_disabled_http_request(self):
+    @mock.patch('openedx.core.djangoapps.cors_csrf.middleware.set_custom_attribute')
+    def test_disabled_http_request(self, mock_set_custom_attribute):
         request = self.get_request(is_secure=False, http_referer='https://foo.com/bar')
         self.check_not_enabled(request)
 
+        # Check monitoring calls
+        expected_calls = [
+            call('tmp_cors_csrf.referer', 'https://foo.com/bar'),
+            call('tmp_cors_csrf.host', 'foo.com'),
+            call('tmp_cors_csrf.is_allowed', False)
+        ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
+        assert mock_set_custom_attribute.call_count == 3
+
     @override_settings(CORS_ORIGIN_WHITELIST=['https://foo.com'])
-    def test_disabled_http_referer(self):
+    @mock.patch('openedx.core.djangoapps.cors_csrf.middleware.set_custom_attribute')
+    def test_disabled_http_referer(self, mock_set_custom_attribute):
         request = self.get_request(is_secure=True, http_referer='http://foo.com/bar')
         self.check_not_enabled(request)
+
+        # Check monitoring calls
+        expected_calls = [
+            call('tmp_cors_csrf.referer', 'http://foo.com/bar'),
+            call('tmp_cors_csrf.host', 'foo.com'),
+            call('tmp_cors_csrf.is_allowed', False)
+        ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
+        assert mock_set_custom_attribute.call_count == 3
 
 
 @ddt.ddt

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -680,6 +680,16 @@ ENABLE_OAUTH2_PROVIDER = False
 # domains
 ENABLE_CORS_HEADERS = False
 
+# .. toggle_name: CORS_CSRF_DETAIL_MONITORING
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enable this feature to allow this Open edX platform to monitor CSRF details for CORS requests.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2025-11-03
+# .. toggle_target_removal_date: None
+# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+CORS_CSRF_DETAIL_MONITORING = False
+
 # Can be turned off to disable the help link in the navbar
 # .. toggle_name: ENABLE_HELP_LINK
 # .. toggle_implementation: DjangoSetting


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds monitoring related to the `cors_csrf` utility to support the ongoing deprecation process, as outlined in this ticket: https://github.com/openedx/edx-platform/issues/33627#issuecomment-2891674624.

The goal is to identify all current usages of the cors_csrf functionality, as described in the linked comment, and move the deprecation process forward to the next phase: "**transition unblocked.**"

The cors_csfr utility relies on two middlewares, one decorator, and one custom authentication class.

**My working theory is as follows**:

I suspect this utility is not widely used. If that’s the case, I’d like to identify all the Django views where it’s applied and examine the Referer and Host headers of incoming requests.

To verify this, I added custom attributes to the middleware and decorator—just for debugging purposes.