### PR TITLE
Remove user tasks constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -134,8 +134,3 @@ social-auth-core==4.5.4
 # Issue: https://github.com/openedx/edx-platform/issues/36695
 lxml==5.3.2
 xmlsec==1.3.14
-
-# Date 2025-05-09
-# Pin django-user-tasks because the newest version is not compatible with Django 4.2
-# Issue: https://github.com/openedx/edx-platform/issues/36696
-django-user-tasks==3.3.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -349,10 +349,8 @@ django-storages==1.14.6
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
-django-user-tasks==3.3.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/kernel.in
+django-user-tasks==3.4.1
+    # via -r requirements/edx/kernel.in
 django-waffle==4.2.0
     # via
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -583,9 +583,8 @@ django-stubs[compatible-mypy]==5.2.0
     #   djangorestframework-stubs
 django-stubs-ext==5.2.0
     # via django-stubs
-django-user-tasks==3.3.0
+django-user-tasks==3.4.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 django-waffle==4.2.0

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -421,10 +421,8 @@ django-storages==1.14.6
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.3.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+django-user-tasks==3.4.1
+    # via -r requirements/edx/base.txt
 django-waffle==4.2.0
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -451,10 +451,8 @@ django-storages==1.14.6
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.3.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+django-user-tasks==3.4.1
+    # via -r requirements/edx/base.txt
 django-waffle==4.2.0
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description
- Resolves the issue https://github.com/openedx/edx-platform/issues/36696
- Package `django-user-tasks` was pinned because it was breaking for `Djang 4.2` after the support for `Django 5.2` was added in the package. 
- Now a proposed fix has been merged in the upstream package and a new version `3.4.1` has been released with the fix so unpinning the constraint and updating the package version to test the change.