### PR TITLE
fix: Include metadata for blocked sequence units to enable proper navigation 

### DIFF
--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -29,6 +29,7 @@ from lms.djangoapps.edxnotes.plugins import EdxNotesTab
 from lms.lib.utils import get_parent_unit
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangolib.markup import Text
+from openedx.features.course_experience.url_helpers import get_courseware_url
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -256,16 +257,8 @@ def get_block_context(course, block):
         course = block.get_parent()
         block_dict['index'] = get_index(block_dict['location'], course.children)
     elif block.category == 'vertical':
-        section = block.get_parent()
-        chapter = section.get_parent()
-        # Position starts from 1, that's why we add 1.
-        position = get_index(str(block.location), section.children) + 1
-        block_dict['url'] = reverse('courseware_position', kwargs={
-            'course_id': str(course.id),
-            'chapter': chapter.url_name,
-            'section': section.url_name,
-            'position': position,
-        })
+        # Use the MFE-aware URL generator instead of always using the legacy URL format
+        block_dict['url'] = get_courseware_url(block.location)
     if block.category in ('chapter', 'sequential'):
         block_dict['children'] = [str(child) for child in block.children]
 

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -29,7 +29,6 @@ from lms.djangoapps.edxnotes.plugins import EdxNotesTab
 from lms.lib.utils import get_parent_unit
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangolib.markup import Text
-from openedx.features.course_experience.url_helpers import get_courseware_url
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -257,8 +256,16 @@ def get_block_context(course, block):
         course = block.get_parent()
         block_dict['index'] = get_index(block_dict['location'], course.children)
     elif block.category == 'vertical':
-        # Use the MFE-aware URL generator instead of always using the legacy URL format
-        block_dict['url'] = get_courseware_url(block.location)
+        section = block.get_parent()
+        chapter = section.get_parent()
+        # Position starts from 1, that's why we add 1.
+        position = get_index(str(block.location), section.children) + 1
+        block_dict['url'] = reverse('courseware_position', kwargs={
+            'course_id': str(course.id),
+            'chapter': chapter.url_name,
+            'section': section.url_name,
+            'position': position,
+        })
     if block.category in ('chapter', 'sequential'):
         block_dict['children'] = [str(child) for child in block.children]
 

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -557,7 +557,19 @@ class SequenceBlock(
                 'This section is a prerequisite. You must complete this section in order to unlock additional content.'
             )
 
-        blocks = self._render_student_view_for_blocks(context, children, fragment, view) if prereq_met else []
+        if prereq_met:
+            blocks = self._render_student_view_for_blocks(context, children, fragment, view)
+        else:
+            blocks = []
+            for child in children:
+                usage_id = child.scope_ids.usage_id
+                blocks.append({
+                    'id': str(usage_id),
+                    'type': child.scope_ids.block_type,
+                    'display_name': child.display_name_with_default,
+                    'is_gated': True,  # Mark as blocked
+                    'content': '',  # Real content not included
+                })
 
         params = {
             'items': blocks,

--- a/xmodule/tests/test_sequence.py
+++ b/xmodule/tests/test_sequence.py
@@ -478,3 +478,97 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         # Replace tuple and un-necessary info from inside string and get the dictionary.
         cleaned_data = data.replace("(('seq_block.html',\n", '').replace("),\n {})", '').strip()
         return ast.literal_eval(cleaned_data)
+
+    def test_not_gated_blocks_rendered_normally(self):
+        """
+        Test that non-gated blocks are rendered with full content when prerequisites are met.
+        """
+        # Mock child block
+        child = Mock()
+        child.scope_ids.usage_id = "block1"
+        child.scope_ids.block_type = "vertical"
+        child.display_name_with_default = "Test Block"
+        children = [child]
+
+        # Mock context
+        context = {"next_url": "next_url", "prev_url": "prev_url"}
+        fragment = Mock()
+
+        # Mock `_render_student_view_for_blocks`
+        self.sequence_3_1._render_student_view_for_blocks = Mock(return_value="rendered_blocks")  # pylint: disable=protected-access
+
+        # Call `_get_render_metadata` with prerequisites met
+        metadata = self.sequence_3_1._get_render_metadata(  # pylint: disable=protected-access
+            context, children, prereq_met=True, prereq_meta_info={}, fragment=fragment
+        )
+
+        # Assert that blocks are rendered normally
+        assert metadata["items"] == "rendered_blocks"
+        assert metadata["next_url"] == "next_url"
+        assert metadata["prev_url"] == "prev_url"
+
+    def test_gated_blocks_rendered_with_basic_info(self):
+        """
+        Test that gated blocks are rendered with minimal metadata when prerequisites are not met.
+        """
+        # Mock child block
+        child = Mock()
+        child.scope_ids.usage_id = "block1"
+        child.scope_ids.block_type = "vertical"
+        child.display_name_with_default = "Test Block"
+        children = [child]
+
+        # Mock context
+        context = {"next_url": "next_url", "prev_url": "prev_url"}
+
+        # Mock prereq_meta_info with required keys
+        prereq_meta_info = {
+            "url": "http://example.com/prereq",
+            "display_name": "Prerequisite Section",
+            "id": "prereq_block_id",
+        }
+
+        # Call `_get_render_metadata` with prerequisites not met
+        metadata = self.sequence_3_1._get_render_metadata(  # pylint: disable=protected-access
+            context, children, prereq_met=False, prereq_meta_info=prereq_meta_info
+        )
+
+        # Assert that gated blocks are rendered with basic info
+        assert len(metadata["items"]) == 1
+        assert metadata["items"][0]["id"] == "block1"
+        assert metadata["items"][0]["type"] == "vertical"
+        assert metadata["items"][0]["display_name"] == "Test Block"
+        assert metadata["items"][0]["is_gated"] is True
+        assert metadata["items"][0]["content"] == ""
+
+        # Assert that next and previous URLs are present
+        assert metadata["next_url"] == "next_url"
+        assert metadata["prev_url"] == "prev_url"
+
+    def test_prereqs_met_content_rendered_normally(self):
+        """
+        Test that content is rendered normally when prerequisites are met.
+        """
+        # Mock child block
+        child = Mock()
+        child.scope_ids.usage_id = "block1"
+        child.scope_ids.block_type = "vertical"
+        child.display_name_with_default = "Test Block"
+        children = [child]
+
+        # Mock context
+        context = {"next_url": "next_url", "prev_url": "prev_url"}
+        fragment = Mock()
+
+        # Mock `_render_student_view_for_blocks`
+        self.sequence_3_1._render_student_view_for_blocks = Mock(return_value="rendered_blocks")  # pylint: disable=protected-access
+
+        # Call `_get_render_metadata` with prerequisites met
+        metadata = self.sequence_3_1._get_render_metadata(  # pylint: disable=protected-access
+            context, children, prereq_met=True, prereq_meta_info={}, fragment=fragment
+        )
+
+        # Assert that content is rendered normally
+        assert metadata["items"] == "rendered_blocks"
+        assert metadata["next_url"] == "next_url"
+        assert metadata["prev_url"] == "prev_url"


### PR DESCRIPTION
Backport from https://github.com/openedx/edx-platform/pull/36485

## Description

The original issue was that when a sequence was locked due to prerequisites, the API returned an empty items array ([]). This prevented the frontend from knowing what units were inside the locked sequence, meaning it couldn't construct the URLs correctly for navigation so the next/previous buttons stop working.

This modification ensured that even when the sequence is locked, basic metadata for each unit is included. This allows the frontend to:

- Know how many units exist and their IDs

- Correctly construct URLs for "Previous" and "Next" buttons

- Still enforce access restrictions (thanks to the is_gated: True flag)

With this change, the Mfe can continue functioning normally without requiring modifications, as it now consistently receives the necessary information, regardless of whether the sequence is locked or not.

**_This fix can be backported._**

## Test cases and test instructions



https://github.com/user-attachments/assets/0d343e18-60a3-4b8f-a341-3e2aab4f0169




## Achievements

- Users can now navigate between sequences correctly, even when some are blocked by prerequisites.
- The prerequisite system’s security and integrity are maintained—the actual content remains blocked.
- No frontend modifications were needed, as the solution is compatible with the existing implementation.
- Significant improvement in user experience, preventing students from getting "stuck" in blocked sequences.

## Related issues
https://github.com/openedx/edx-platform/issues/36826
https://github.com/openedx/frontend-app-learning/issues/1546