### PR TITLE
fix: redirect to account MFE when using any legacy account URL

### DIFF
--- a/openedx/core/djangoapps/user_api/legacy_urls.py
+++ b/openedx/core/djangoapps/user_api/legacy_urls.py
@@ -1,7 +1,9 @@
 """
 Defines the URL routes for this app.
 """
+from django.conf import settings
 from django.urls import path, re_path, include
+from django.views.generic import RedirectView
 from rest_framework import routers
 
 from . import views as user_api_views
@@ -12,6 +14,7 @@ USER_API_ROUTER.register(r'users', user_api_views.UserViewSet)
 USER_API_ROUTER.register(r'user_prefs', user_api_views.UserPreferenceViewSet)
 
 urlpatterns = [
+    re_path(r'^account(?:/settings)?/?$', RedirectView.as_view(url=settings.ACCOUNT_MICROFRONTEND_URL)),
     path('user_api/v1/', include(USER_API_ROUTER.urls)),
     re_path(
         fr'^user_api/v1/preferences/(?P<pref_key>{UserPreference.KEY_REGEX})/users/$',

--- a/openedx/core/djangoapps/user_api/legacy_urls.py
+++ b/openedx/core/djangoapps/user_api/legacy_urls.py
@@ -14,6 +14,9 @@ USER_API_ROUTER.register(r'users', user_api_views.UserViewSet)
 USER_API_ROUTER.register(r'user_prefs', user_api_views.UserPreferenceViewSet)
 
 urlpatterns = [
+    # This redirect is needed for backward compatibility with the old URL structure for the authentication
+    # workflows using third-party authentication providers until the authentication workflows fully support
+    # the URL structure with MFEs.
     re_path(r'^account(?:/settings)?/?$', RedirectView.as_view(url=settings.ACCOUNT_MICROFRONTEND_URL)),
     path('user_api/v1/', include(USER_API_ROUTER.urls)),
     re_path(


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Redirect to the account MFE URL configured each time a legacy account URL like http(s)://lms/account/ or http(s)://lms/account/settings is used to avoid 404 errors while linking SSO accounts or simply trying to access the account view via URLs.

## Supporting information

This attempts to solve https://github.com/openedx/edx-platform/issues/36869

## Testing instructions

Go to the account or account/settings page, you must be redirected to the account MFE.

## Deadline

ASAP. This is a release blocker we are solving.

⚠️ I use copilot with Claude Sonnet 4 model for code suggestions.