### PR TITLE
feat: add redirects to mfe for catalog-related legacy pages

### DIFF
--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -8,11 +8,16 @@ import ddt
 import six
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.test import TestCase
+from django.test import override_settings, TestCase
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.branding.models import BrandingApiConfig
+from lms.djangoapps.branding.toggles import (
+    ENABLE_NEW_CATALOG_PAGE,
+    ENABLE_NEW_INDEX_PAGE,
+)
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
@@ -249,6 +254,7 @@ class TestFooter(CacheIsolationTestCase):
             assert f'<option value="{language.code}">' in content
 
 
+@ddt.ddt
 class TestIndex(SiteMixin, TestCase):
     """ Test the index view """
 
@@ -286,3 +292,79 @@ class TestIndex(SiteMixin, TestCase):
         self.client.login(username=self.user.username, password="password")
         response = self.client.get(reverse("dashboard"))
         assert self.site_configuration_other.site_values['MKTG_URLS']['ROOT'] in response.content.decode('utf-8')
+
+
+    @ddt.data(
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    )
+    @ddt.unpack
+    def test_index_redirects_to_mfe(self, catalog_mfe_enabled, use_new_index_page, expected_redirect):
+        """Test that index view redirects to MFE when both flags are enabled."""
+        old_features = settings.FEATURES.copy()
+        old_features.update({
+            "ENABLE_CATALOG_MICROFRONTEND": catalog_mfe_enabled,
+            "COURSES_ARE_BROWSABLE": True,
+        })
+        new_settings = {
+            "FEATURES": old_features,
+            "CATALOG_MICROFRONTEND_URL": "http://example.com/catalog",
+        }
+        with override_settings(**new_settings):
+            with override_waffle_flag(ENABLE_NEW_INDEX_PAGE, active=use_new_index_page):
+                response = self.client.get(reverse("root"))
+
+                if expected_redirect:
+                    expected_url = f'{settings.CATALOG_MICROFRONTEND_URL}/'
+                    self.assertRedirects(
+                        response,
+                        expected_url,
+                        status_code=301,
+                        fetch_redirect_response=False
+                    )
+                else:
+                    assert response.status_code in [200, 301, 302]
+
+
+@ddt.ddt
+class TestCourses(SiteMixin, TestCase):
+    """Test the courses view"""
+
+    def setUp(self):
+        super().setUp()
+        self.courses_url = reverse("courses")
+
+    @ddt.data(
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    )
+    @ddt.unpack
+    def test_courses_redirect_to_mfe(self, catalog_mfe_enabled, use_new_catalog_page, expected_redirect):
+        """Test that courses view redirects to MFE when both flags are enabled"""
+        old_features = settings.FEATURES.copy()
+        old_features.update({
+            "ENABLE_CATALOG_MICROFRONTEND": catalog_mfe_enabled,
+            "COURSES_ARE_BROWSABLE": True,
+        })
+        new_settings = {
+            "FEATURES": old_features,
+            "CATALOG_MICROFRONTEND_URL": "http://example.com/catalog",
+        }
+        with override_settings(**new_settings):
+            with override_waffle_flag(ENABLE_NEW_CATALOG_PAGE, active=use_new_catalog_page):
+                response = self.client.get(self.courses_url)
+
+                if expected_redirect:
+                    expected_url = f'{settings.CATALOG_MICROFRONTEND_URL}/courses'
+                    self.assertRedirects(
+                        response,
+                        expected_url,
+                        status_code=301,
+                        fetch_redirect_response=False
+                    )
+                else:
+                    assert response.status_code in [200, 301, 302]

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -10,14 +10,10 @@ from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test import override_settings, TestCase
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.branding.models import BrandingApiConfig
-from lms.djangoapps.branding.toggles import (
-    ENABLE_NEW_CATALOG_PAGE,
-    ENABLE_NEW_INDEX_PAGE,
-)
+
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
@@ -293,15 +289,14 @@ class TestIndex(SiteMixin, TestCase):
         response = self.client.get(reverse("dashboard"))
         assert self.site_configuration_other.site_values['MKTG_URLS']['ROOT'] in response.content.decode('utf-8')
 
-
     @ddt.data(
-        (True, True, True),
-        (True, False, False),
-        (False, True, False),
-        (False, False, False),
+        (True, True),
+        (True, False),
+        (False, False),
+        (False, False),
     )
     @ddt.unpack
-    def test_index_redirects_to_mfe(self, catalog_mfe_enabled, use_new_index_page, expected_redirect):
+    def test_index_redirects_to_mfe(self, catalog_mfe_enabled, expected_redirect):
         """Test that index view redirects to MFE when both flags are enabled."""
         old_features = settings.FEATURES.copy()
         old_features.update({
@@ -313,19 +308,18 @@ class TestIndex(SiteMixin, TestCase):
             "CATALOG_MICROFRONTEND_URL": "http://example.com/catalog",
         }
         with override_settings(**new_settings):
-            with override_waffle_flag(ENABLE_NEW_INDEX_PAGE, active=use_new_index_page):
-                response = self.client.get(reverse("root"))
+            response = self.client.get(reverse("root"))
 
-                if expected_redirect:
-                    expected_url = f'{settings.CATALOG_MICROFRONTEND_URL}/'
-                    self.assertRedirects(
-                        response,
-                        expected_url,
-                        status_code=301,
-                        fetch_redirect_response=False
-                    )
-                else:
-                    assert response.status_code in [200, 301, 302]
+            if expected_redirect:
+                expected_url = f'{settings.CATALOG_MICROFRONTEND_URL}/'
+                self.assertRedirects(
+                    response,
+                    expected_url,
+                    status_code=301,
+                    fetch_redirect_response=False
+                )
+            else:
+                assert response.status_code in [200, 301, 302]
 
 
 @ddt.ddt
@@ -337,13 +331,13 @@ class TestCourses(SiteMixin, TestCase):
         self.courses_url = reverse("courses")
 
     @ddt.data(
-        (True, True, True),
-        (True, False, False),
-        (False, True, False),
-        (False, False, False),
+        (True, True),
+        (True, False),
+        (False, False),
+        (False, False),
     )
     @ddt.unpack
-    def test_courses_redirect_to_mfe(self, catalog_mfe_enabled, use_new_catalog_page, expected_redirect):
+    def test_courses_redirect_to_mfe(self, catalog_mfe_enabled, expected_redirect):
         """Test that courses view redirects to MFE when both flags are enabled"""
         old_features = settings.FEATURES.copy()
         old_features.update({
@@ -355,16 +349,15 @@ class TestCourses(SiteMixin, TestCase):
             "CATALOG_MICROFRONTEND_URL": "http://example.com/catalog",
         }
         with override_settings(**new_settings):
-            with override_waffle_flag(ENABLE_NEW_CATALOG_PAGE, active=use_new_catalog_page):
-                response = self.client.get(self.courses_url)
+            response = self.client.get(self.courses_url)
 
-                if expected_redirect:
-                    expected_url = f'{settings.CATALOG_MICROFRONTEND_URL}/courses'
-                    self.assertRedirects(
-                        response,
-                        expected_url,
-                        status_code=301,
-                        fetch_redirect_response=False
-                    )
-                else:
-                    assert response.status_code in [200, 301, 302]
+            if expected_redirect:
+                expected_url = f'{settings.CATALOG_MICROFRONTEND_URL}/courses'
+                self.assertRedirects(
+                    response,
+                    expected_url,
+                    status_code=301,
+                    fetch_redirect_response=False
+                )
+            else:
+                assert response.status_code in [200, 301, 302]

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -16,7 +16,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 import lms.djangoapps.branding.api as branding_api
-from lms.djangoapps.branding.toggles import catalog_mfe_enabled, use_new_index_page, use_new_catalog_page
+from lms.djangoapps.branding.toggles import use_catalog_mfe
 import lms.djangoapps.courseware.views.views as courseware_views
 from common.djangoapps.edxmako.shortcuts import marketing_link, render_to_response
 from common.djangoapps.student import views as student_views
@@ -45,7 +45,7 @@ def index(request):
                 settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
             return redirect('dashboard')
 
-    if catalog_mfe_enabled() and use_new_index_page():
+    if use_catalog_mfe():
         return redirect(f'{settings.CATALOG_MICROFRONTEND_URL}/', permanent=True)
 
     enable_mktg_site = configuration_helpers.get_value(
@@ -91,7 +91,7 @@ def courses(request):
     to that. Otherwise, if subdomain branding is on, this is the university
     profile page. Otherwise, it's the edX courseware.views.views.courses page
     """
-    if catalog_mfe_enabled() and use_new_catalog_page():
+    if use_catalog_mfe():
         return redirect(f'{settings.CATALOG_MICROFRONTEND_URL}/courses', permanent=True)
 
     enable_mktg_site = configuration_helpers.get_value(

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -16,6 +16,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 import lms.djangoapps.branding.api as branding_api
+from lms.djangoapps.branding.toggles import catalog_mfe_enabled, use_new_index_page, use_new_catalog_page
 import lms.djangoapps.courseware.views.views as courseware_views
 from common.djangoapps.edxmako.shortcuts import marketing_link, render_to_response
 from common.djangoapps.student import views as student_views
@@ -43,6 +44,9 @@ def index(request):
                 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER',
                 settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
             return redirect('dashboard')
+
+    if catalog_mfe_enabled() and use_new_index_page():
+        return redirect(f'{settings.CATALOG_MICROFRONTEND_URL}/', permanent=True)
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
@@ -87,6 +91,9 @@ def courses(request):
     to that. Otherwise, if subdomain branding is on, this is the university
     profile page. Otherwise, it's the edX courseware.views.views.courses page
     """
+    if catalog_mfe_enabled() and use_new_catalog_page():
+        return redirect(f'{settings.CATALOG_MICROFRONTEND_URL}/courses', permanent=True)
+
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
         settings.FEATURES.get('ENABLE_MKTG_SITE', False)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -56,7 +56,6 @@ from common.djangoapps.student.tests.factories import (
 from common.djangoapps.util.tests.test_date_utils import fake_pgettext, fake_ugettext
 from common.djangoapps.util.url import reload_django_url_config
 from common.djangoapps.util.views import ensure_valid_course_key
-from lms.djangoapps.branding.toggles import ENABLE_NEW_COURSE_ABOUT_PAGE
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -3972,13 +3971,11 @@ class CourseAboutViewTests(ModuleStoreTestCase):
         self.course = CourseFactory.create()
 
     @ddt.data(
-        (True, True, True),
-        (True, False, False),
-        (False, True, False),
-        (False, False, False),
+        (True, True),
+        (False, False),
     )
     @ddt.unpack
-    def test_course_about_redirect_to_mfe(self, catalog_mfe_enabled, use_new_course_about_page, expected_redirect):
+    def test_course_about_redirect_to_mfe(self, catalog_mfe_enabled, expected_redirect):
         """
         Test that the CourseAboutView redirects to the MFE when appropriate.
         """
@@ -3991,10 +3988,9 @@ class CourseAboutViewTests(ModuleStoreTestCase):
             "CATALOG_MICROFRONTEND_URL": "http://example.com/catalog",
         }
         with override_settings(**new_settings):
-            with override_waffle_flag(ENABLE_NEW_COURSE_ABOUT_PAGE, active=use_new_course_about_page):
-                response = self.client.get(reverse('about_course', args=[str(self.course.id)]))
-                if expected_redirect:
-                    assert response.status_code == 301
-                    assert response.url == "http://example.com/catalog/courses/{}/about".format(self.course.id)
-                else:
-                    assert response.status_code == 200
+            response = self.client.get(reverse('about_course', args=[str(self.course.id)]))
+            if expected_redirect:
+                assert response.status_code == 301
+                assert response.url == "http://example.com/catalog/courses/{}/about".format(self.course.id)
+            else:
+                assert response.status_code == 200

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -19,9 +19,8 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.http.request import QueryDict
-from django.test import RequestFactory, TestCase
+from django.test import override_settings, RequestFactory, TestCase
 from django.test.client import Client
-from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
 from edx_django_utils.cache.utils import RequestCache
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
@@ -57,6 +56,7 @@ from common.djangoapps.student.tests.factories import (
 from common.djangoapps.util.tests.test_date_utils import fake_pgettext, fake_ugettext
 from common.djangoapps.util.url import reload_django_url_config
 from common.djangoapps.util.views import ensure_valid_course_key
+from lms.djangoapps.branding.toggles import ENABLE_NEW_COURSE_ABOUT_PAGE
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -3959,3 +3959,42 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
                 "enable_completion_tracking": True,
             },
         )
+
+
+@ddt.ddt
+class CourseAboutViewTests(ModuleStoreTestCase):
+    """
+    Tests for the CourseAboutView.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create()
+
+    @ddt.data(
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    )
+    @ddt.unpack
+    def test_course_about_redirect_to_mfe(self, catalog_mfe_enabled, use_new_course_about_page, expected_redirect):
+        """
+        Test that the CourseAboutView redirects to the MFE when appropriate.
+        """
+        old_features = settings.FEATURES.copy()
+        old_features.update({
+            "ENABLE_CATALOG_MICROFRONTEND": catalog_mfe_enabled,
+        })
+        new_settings = {
+            "FEATURES": old_features,
+            "CATALOG_MICROFRONTEND_URL": "http://example.com/catalog",
+        }
+        with override_settings(**new_settings):
+            with override_waffle_flag(ENABLE_NEW_COURSE_ABOUT_PAGE, active=use_new_course_about_page):
+                response = self.client.get(reverse('about_course', args=[str(self.course.id)]))
+                if expected_redirect:
+                    assert response.status_code == 301
+                    assert response.url == "http://example.com/catalog/courses/{}/about".format(self.course.id)
+                else:
+                    assert response.status_code == 200

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -68,6 +68,7 @@ from common.djangoapps.util.course import course_location_from_key
 from common.djangoapps.util.db import outer_atomic
 from common.djangoapps.util.milestones_helpers import get_prerequisite_courses_display
 from common.djangoapps.util.views import ensure_valid_course_key, ensure_valid_usage_key
+from lms.djangoapps.branding import toggles as branding_toggles
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.data import CertificateStatuses
@@ -143,6 +144,7 @@ from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 from openedx.features.course_duration_limits.access import generate_course_expired_fragment
 from openedx.features.course_experience import course_home_url
 from openedx.features.course_experience.url_helpers import (
+    get_catalog_mfe_course_about_url,
     get_courseware_url,
     get_learning_mfe_home_url,
     is_request_from_learning_mfe
@@ -801,6 +803,10 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
     # If user needs to be redirected to course home then redirect
     if _course_home_redirect_enabled():
         return redirect(course_home_url(course_key))
+
+    # If the course about page is being rendered in the MFE, redirect to the MFE.
+    if branding_toggles.catalog_mfe_enabled() and branding_toggles.use_new_course_about_page():
+        return redirect(get_catalog_mfe_course_about_url(course_key), permanent=True)
 
     with modulestore().bulk_operations(course_key):
         permission = get_permission_for_course_about()

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -805,7 +805,7 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
         return redirect(course_home_url(course_key))
 
     # If the course about page is being rendered in the MFE, redirect to the MFE.
-    if branding_toggles.catalog_mfe_enabled() and branding_toggles.use_new_course_about_page():
+    if branding_toggles.use_catalog_mfe():
         return redirect(get_catalog_mfe_course_about_url(course_key), permanent=True)
 
     with modulestore().bulk_operations(course_key):

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -217,6 +217,28 @@ def get_learning_mfe_home_url(
     return mfe_link
 
 
+def get_catalog_mfe_course_about_url(
+        course_key: CourseKey,
+        params: Optional[QueryDict] = None,
+) -> str:
+    """
+    Given a course run key, return the appropriate course about page URL in the Catalog MFE.
+
+    We're building a URL like this:
+
+    http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/about
+
+    `course_key` can be either an OpaqueKey or a string.
+    `params` is an optional QueryDict object (e.g. request.GET)
+    """
+    mfe_link = f'{settings.CATALOG_MICROFRONTEND_URL}/courses/{course_key}/about'
+
+    if params:
+        mfe_link += f'?{params.urlencode()}'
+
+    return mfe_link
+
+
 def is_request_from_learning_mfe(request: HttpRequest):
     """
     Returns whether the given request was made by the frontend-app-learning MFE.


### PR DESCRIPTION
This PR adds support for redirecting users from legacy catalog-related pages to their new Catalog MFE equivalents, based on the appropriate feature and waffle flag settings.

**Key changes:**

- Adds redirect logic to the legacy `index`, `courses`, and `course_about` views:
  - Home/index page redirects to MFE when `ENABLE_CATALOG_MICROFRONTEND` is enabled.
  - Courses listing page redirects to MFE whe `ENABLE_CATALOG_MICROFRONTEND` is enabled.
  - Course about page redirects to the Catalog MFE when `ENABLE_CATALOG_MICROFRONTEND` is enabled.
- Uses the newly added `get_catalog_mfe_course_about_url` helper for accurate about-page URL construction.
- Comprehensive tests are added for all redirection scenarios to ensure correct behavior for all flag combinations.

These changes allow for a controlled, flag-driven migration to the new Catalog MFE for all catalog-related user entry points.
