### PR TITLE
fix: generate identity verification URL only if ACCOUNT_MICROFRONTEND_URL is available

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -188,7 +188,7 @@ class Command(BaseCommand):
             return True
 
         site = Site.objects.get_current()
-        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,

--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -188,7 +188,7 @@ class Command(BaseCommand):
             return True
 
         site = Site.objects.get_current()
-        account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
+        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -251,7 +251,7 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
+        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
         location = f'{account_base_url}/id-verification'
         if course_id:
             location += f'?course_id={quote(str(course_id))}'

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -251,7 +251,7 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
         location = f'{account_base_url}/id-verification'
         if course_id:
             location += f'?course_id={quote(str(course_id))}'

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1128,7 +1128,7 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
         log.info("[COSMO-184] Denied verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
 
         attempt.deny(json.dumps(reason), error_code=error_code)
-        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
         reverify_url = f'{account_base_url}/id-verification'
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1128,7 +1128,7 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
         log.info("[COSMO-184] Denied verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
 
         attempt.deny(json.dumps(reason), error_code=error_code)
-        account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
+        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
         reverify_url = f'{account_base_url}/id-verification'
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -97,7 +97,7 @@ def create_email_template_context(username):
         'channel': 'email',
         'value': False
     }
-    account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+    account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
     return {
         "platform_name": settings.PLATFORM_NAME,
         "mailing_address": settings.CONTACT_MAILING_ADDRESS,

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -97,7 +97,7 @@ def create_email_template_context(username):
         'channel': 'email',
         'value': False
     }
-    account_base_url = (getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "") or "").rstrip('/')
+    account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
     return {
         "platform_name": settings.PLATFORM_NAME,
         "mailing_address": settings.CONTACT_MAILING_ADDRESS,


### PR DESCRIPTION
#### Related Tickets
https://github.com/mitodl/hq/issues/7549

## Description

The [api/courseware/course](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/courseware_api/views.py#L374) fails for all the verified enrollments if you are not using Account MFE, which means that you probably won't set `ACCOUNT_MICROFRONTEND_URL` in your settings/configurations. So this PR adds a check safely try to do `rstrip`.

## Useful information to include:

The [api/courseware/course](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/courseware_api/views.py#L374) is currently broken for enrollments in verified mode if you are not using Account MFE. API current edx-platform master 

**Impacts**: All roles

## Supporting information

This issue was a side effect of a recent change https://github.com/openedx/edx-platform/pull/36870


## Testing instructions

- Get yourself enrolled in a verified mode in any course. (This means you will need to create `verified` mode in the course modes and have a verified enrollment)
- Make sure that you set `ACCOUNT_MICROFRONTEND_URL = None` in your settings
- Load any course in learning MFE, and it should load fine and not throw any errors.


## Deadline
Probably soon because this breaks verified enrollments for deployments not using accounts MFE.
