### PR TITLE
fix:TNL-10093 Removed inaccurate course rerun message

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -51,7 +51,7 @@ from django.urls import reverse
       <div class="copy">
         <h2 class="title title-3">${_("This course was created as a re-run. Some manual configuration is needed.")}</h2>
 
-        <p>${_("No course content is currently visible, and no learners are enrolled. Be sure to review and reset all dates, including the Course Start Date; set up the course team; review course updates and other assets for dated material; and seed the discussions and wiki.")}</p>
+        <p>${_("Be sure to review and reset all dates, including the Course Start Date; set up the course team; review course updates and other assets for dated material; and seed the discussions and wiki.")}</p>
       </div>
 
       <ul class="nav-actions">


### PR DESCRIPTION
Removed "Inaccurate Course Re-Run Message in Studio" as requested in [TNL-10093]( https://2u-internal.atlassian.net/browse/TNL-10093)

Textual change only. No dependencies.

