### PR TITLE
Revert "Issue 36744 default file storage settings"

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1301,6 +1301,7 @@ PIPELINE = {
     'YUI_BINARY': 'yui-compressor',
 }
 
+STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 STATICFILES_STORAGE_KWARGS = {}
 
 # List of finder classes that know how to find static files in various locations.
@@ -2552,14 +2553,7 @@ BULK_EMAIL_DEFAULT_FROM_EMAIL = 'no-reply@example.com'
 BULK_EMAIL_LOG_SENT_EMAILS = False
 
 ############### Settings for django file storage ##################
-STORAGES = {
-    "default": {
-        "BACKEND": 'django.core.files.storage.FileSystemStorage'
-    },
-    "staticfiles": {
-        "BACKEND": 'openedx.core.storage.ProductionStorage',
-    }
-}
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 ###################### Grade Downloads ######################
 # These keys are used for all of our asynchronous downloadable files, including

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -9,7 +9,7 @@ from os.path import abspath, dirname, join
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
-STORAGES['default']['BACKEND'] = 'django.core.files.storage.FileSystemStorage'
+del DEFAULT_FILE_STORAGE
 COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
 
@@ -56,7 +56,7 @@ FEATURES['ENABLE_VIDEO_UPLOAD_PIPELINE'] = True
 
 # Skip packaging and optimization in development
 PIPELINE['PIPELINE_ENABLED'] = False
-STORAGES['staticfiles']['BACKEND'] = 'openedx.core.storage.DevelopmentStorage'
+STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [

--- a/cms/envs/devstack_optimized.py
+++ b/cms/envs/devstack_optimized.py
@@ -33,7 +33,7 @@ DEBUG = True
 REQUIRE_DEBUG = False
 
 # Fetch static files out of the pipeline's static root
-STORAGES['staticfiles']['BACKEND'] = 'pipeline.storage.PipelineManifestStorage'
+STATICFILES_STORAGE = 'pipeline.storage.PipelineManifestStorage'
 
 #  Serve static files at /static directly from the staticfiles directory under test root.
 # Note: optimized files for testing are generated with settings from test_static_optimized

--- a/cms/envs/openstack.py
+++ b/cms/envs/openstack.py
@@ -22,11 +22,11 @@ if AUTH_TOKENS.get('SWIFT_REGION_NAME'):
     SWIFT_EXTRA_OPTIONS = {'region_name': AUTH_TOKENS['SWIFT_REGION_NAME']}
 
 if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
-    STORAGES["default"]["BACKEND"] = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
+    DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
 elif SWIFT_AUTH_URL and SWIFT_USERNAME and SWIFT_KEY:
-    STORAGES["default"]["BACKEND"] = 'swift.storage.SwiftStorage'
+    DEFAULT_FILE_STORAGE = 'swift.storage.SwiftStorage'
 else:
-    STORAGES["default"]["BACKEND"] = 'django.core.files.storage.FileSystemStorage'
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 # Use default file storage class set above for course import/export
-COURSE_IMPORT_EXPORT_STORAGE = STORAGES["default"]["BACKEND"]
+COURSE_IMPORT_EXPORT_STORAGE = DEFAULT_FILE_STORAGE

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -222,8 +222,7 @@ if 'staticfiles' in CACHES:
 # we need to run asset collection twice, once for local disk and once for S3.
 # Once we have migrated to service assets off S3, then we can convert this back to
 # managed by the yaml file contents
-STORAGES['staticfiles']['BACKEND'] = os.environ.get(
-    'STATICFILES_STORAGE', STORAGES['staticfiles']['BACKEND'])
+STATICFILES_STORAGE = os.environ.get('STATICFILES_STORAGE', STATICFILES_STORAGE)
 CSRF_TRUSTED_ORIGINS = _YAML_TOKENS.get("CSRF_TRUSTED_ORIGINS", [])
 
 MKTG_URL_LINK_MAP.update(_YAML_TOKENS.get('MKTG_URL_LINK_MAP', {}))
@@ -266,19 +265,19 @@ AWS_QUERYSTRING_EXPIRE = 7 * 24 * 60 * 60  # 7 days
 
 # Change to S3Boto3 if we haven't specified another default storage AND we have specified AWS creds.
 if (not _YAML_TOKENS.get('DEFAULT_FILE_STORAGE')) and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-    STORAGES["default"]["BACKEND"] = 'storages.backends.s3boto3.S3Boto3Storage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 if COURSE_IMPORT_EXPORT_BUCKET:
     COURSE_IMPORT_EXPORT_STORAGE = 'cms.djangoapps.contentstore.storage.ImportExportS3Storage'
 else:
-    COURSE_IMPORT_EXPORT_STORAGE = STORAGES["default"]["BACKEND"]
+    COURSE_IMPORT_EXPORT_STORAGE = DEFAULT_FILE_STORAGE
 
 USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
 
 if COURSE_METADATA_EXPORT_BUCKET:
     COURSE_METADATA_EXPORT_STORAGE = 'cms.djangoapps.export_course_metadata.storage.CourseMetadataExportS3Storage'
 else:
-    COURSE_METADATA_EXPORT_STORAGE = STORAGES["default"]["BACKEND"]
+    COURSE_METADATA_EXPORT_STORAGE = DEFAULT_FILE_STORAGE
 
 # The normal database user does not have enough permissions to run migrations.
 # Migrations are run with separate credentials, given as DB_MIGRATION_*

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -29,6 +29,7 @@ from .common import *
 from lms.envs.test import (  # pylint: disable=wrong-import-order, disable=unused-import
     ACCOUNT_MICROFRONTEND_URL,
     COMPREHENSIVE_THEME_DIRS,  # unimport:skip
+    DEFAULT_FILE_STORAGE,
     ECOMMERCE_API_URL,
     ENABLE_COMPREHENSIVE_THEMING,
     JWT_AUTH,
@@ -90,7 +91,7 @@ STATICFILES_DIRS += [
 # If we don't add these settings, then Django templates that can't
 # find pipelined assets will raise a ValueError.
 # http://stackoverflow.com/questions/12816941/unit-testing-with-django-pipeline
-STORAGES['staticfiles']['BACKEND'] = "pipeline.storage.NonPackagingPipelineStorage"
+STATICFILES_STORAGE = "pipeline.storage.NonPackagingPipelineStorage"
 STATIC_URL = "/static/"
 
 # Update module store settings per defaults for tests

--- a/cms/envs/test_static_optimized.py
+++ b/cms/envs/test_static_optimized.py
@@ -28,7 +28,6 @@ DATABASES = {
 
 # Use RequireJS optimized storage
 STATICFILES_STORAGE = f"{OptimizedCachedRequireJsStorage.__module__}.{OptimizedCachedRequireJsStorage.__name__}"
-STORAGES['staticfiles']['BACKEND'] = STATICFILES_STORAGE
 
 # Revert to the default set of finders as we don't want to dynamically pick up files from the pipeline
 STATICFILES_FINDERS = [

--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -78,7 +78,7 @@ def store_uploaded_file(
         file_storage = DefaultStorage()
         # If a file already exists with the supplied name, file_storage will make the filename unique.
         stored_file_name = file_storage.save(stored_file_name, uploaded_file)
-        if is_private and settings.STORAGES["default"]["BACKEND"] == 'storages.backends.s3boto3.S3Boto3Storage':
+        if is_private and settings.DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage':
             S3Boto3Storage().connection.meta.client.put_object_acl(
                 ACL='private',
                 Bucket=settings.AWS_STORAGE_BUCKET_NAME,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2356,6 +2356,7 @@ PIPELINE = {
     'UGLIFYJS_BINARY': 'node_modules/.bin/uglifyjs',
 }
 
+STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 STATICFILES_STORAGE_KWARGS = {}
 
 # List of finder classes that know how to find static files in various locations.
@@ -5203,14 +5204,7 @@ VIDEO_UPLOAD_PIPELINE = {
 }
 
 ############### Settings for django file storage ##################
-STORAGES = {
-    "default": {
-        "BACKEND": 'django.core.files.storage.FileSystemStorage'
-    },
-    "staticfiles": {
-        "BACKEND": 'openedx.core.storage.ProductionStorage'
-    }
-}
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 ### Proctoring configuration (redirct URLs and keys shared between systems) ####
 PROCTORING_BACKENDS = {

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -16,7 +16,7 @@ from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
-STORAGES['default']['BACKEND'] = 'django.core.files.storage.FileSystemStorage'
+del DEFAULT_FILE_STORAGE
 ORA2_FILEUPLOAD_BACKEND = 'django'
 
 
@@ -119,7 +119,7 @@ def should_show_debug_toolbar(request):  # lint-amnesty, pylint: disable=missing
 ########################### PIPELINE #################################
 
 PIPELINE['PIPELINE_ENABLED'] = False
-STORAGES['staticfiles']['BACKEND'] = 'openedx.core.storage.DevelopmentStorage'
+STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [

--- a/lms/envs/devstack_optimized.py
+++ b/lms/envs/devstack_optimized.py
@@ -34,7 +34,7 @@ DEBUG = True
 REQUIRE_DEBUG = False
 
 # Fetch static files out of the pipeline's static root
-STORAGES['staticfiles']['BACKEND'] = 'pipeline.storage.PipelineManifestStorage'
+STATICFILES_STORAGE = 'pipeline.storage.PipelineManifestStorage'
 
 #  Serve static files at /static directly from the staticfiles directory under test root.
 # Note: optimized files for testing are generated with settings from test_static_optimized

--- a/lms/envs/openstack.py
+++ b/lms/envs/openstack.py
@@ -23,10 +23,10 @@ if AUTH_TOKENS.get('SWIFT_REGION_NAME'):
     SWIFT_EXTRA_OPTIONS = {'region_name': AUTH_TOKENS['SWIFT_REGION_NAME']}
 
 if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
-    STORAGES["default"]["BACKEND"] = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
+    DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
 elif SWIFT_AUTH_URL and SWIFT_USERNAME and SWIFT_KEY:
-    STORAGES["default"]["BACKEND"] = 'swift.storage.SwiftStorage'
+    DEFAULT_FILE_STORAGE = 'swift.storage.SwiftStorage'
 else:
-    STORAGES["default"]["BACKEND"] = 'django.core.files.storage.FileSystemStorage'
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 ORA2_FILEUPLOAD_BACKEND = "django"

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -341,7 +341,7 @@ AWS_BUCKET_ACL = AWS_DEFAULT_ACL
 
 # Change to S3Boto3 if we haven't specified another default storage AND we have specified AWS creds.
 if (not _YAML_TOKENS.get('DEFAULT_FILE_STORAGE')) and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-    STORAGES["default"]["BACKEND"] = 'storages.backends.s3boto3.S3Boto3Storage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 # The normal database user does not have enough permissions to run migrations.
 # Migrations are run with separate credentials, given as DB_MIGRATION_*

--- a/lms/envs/static.py
+++ b/lms/envs/static.py
@@ -62,7 +62,7 @@ CACHES = {
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 
 ############################ FILE UPLOADS (for discussion forums) #############################
-STORAGES["default"]["BACKEND"] = 'django.core.files.storage.FileSystemStorage'
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 MEDIA_ROOT = ENV_ROOT / "uploads"
 MEDIA_URL = "/discussion/upfiles/"
 FILE_UPLOAD_TEMP_DIR = ENV_ROOT / "uploads"

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -145,6 +145,12 @@ STATICFILES_DIRS += [
     if os.path.isdir(COMMON_TEST_DATA_ROOT / course_dir)
 ]
 
+# Avoid having to run collectstatic before the unit test suite
+# If we don't add these settings, then Django templates that can't
+# find pipelined assets will raise a ValueError.
+# http://stackoverflow.com/questions/12816941/unit-testing-with-django-pipeline
+STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
+
 # Don't use compression during tests
 PIPELINE['JS_COMPRESSOR'] = None
 
@@ -289,14 +295,7 @@ ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS = OrderedDict([
 ])
 
 ############################ STATIC FILES #############################
-STORAGES = {
-    "default": {
-        "BACKEND": 'django.core.files.storage.FileSystemStorage'
-    },
-    "staticfiles": {
-        "BACKEND": 'pipeline.storage.NonPackagingPipelineStorage'
-    }
-}
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 MEDIA_ROOT = TEST_ROOT / "uploads"
 MEDIA_URL = "/uploads/"
 STATICFILES_DIRS.append(("uploads", MEDIA_ROOT))

--- a/lms/envs/test_static_optimized.py
+++ b/lms/envs/test_static_optimized.py
@@ -45,7 +45,6 @@ PROCTORING_BACKENDS = {
 
 # Use RequireJS optimized storage
 STATICFILES_STORAGE = f"{OptimizedCachedRequireJsStorage.__module__}.{OptimizedCachedRequireJsStorage.__name__}"
-STORAGES['staticfiles']['BACKEND'] = STATICFILES_STORAGE
 
 # Revert to the default set of finders as we don't want to dynamically pick up files from the pipeline
 STATICFILES_FINDERS = [


### PR DESCRIPTION
Reverts openedx/edx-platform#36885

Failed with:
```
raceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 255, in fetch_command
    app_name = commands[subcommand]
               ~~~~~~~~^^^^^^^^^^^^
KeyError: 'print_setting'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/manage.py", line 99, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 262, in fetch_command
    settings.INSTALLED_APPS
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/conf/__init__.py", line 102, in __getattr__
    self._setup(name)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/conf/__init__.py", line 89, in _setup
    self._wrapped = Settings(settings_module)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/conf/__init__.py", line 271, in __init__
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: DEFAULT_FILE_STORAGE/STORAGES are mutually exclusive.
```