### PR TITLE
feat: deprecate get_storage_class in core/storage.py

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_import.py
+++ b/cms/djangoapps/contentstore/tests/test_import.py
@@ -308,7 +308,6 @@ class ContentStoreImportTest(ModuleStoreTestCase):
     @override_settings()
     def test_resolve_storage_with_no_config(self):
         """ If no storage setup is defined, we get FileSystemStorage by default """
-        del settings.DEFAULT_FILE_STORAGE
         del settings.COURSE_IMPORT_EXPORT_STORAGE
         del settings.COURSE_IMPORT_EXPORT_BUCKET
         storage = resolve_storage_backend(

--- a/cms/djangoapps/export_course_metadata/test_signals.py
+++ b/cms/djangoapps/export_course_metadata/test_signals.py
@@ -84,7 +84,6 @@ class TestExportCourseMetadata(SharedModuleStoreTestCase):
     @override_settings()
     def test_resolve_storage_with_no_config(self):
         """ If no storage setup is defined, we get FileSystemStorage by default """
-        del settings.DEFAULT_FILE_STORAGE
         del settings.COURSE_METADATA_EXPORT_STORAGE
         del settings.COURSE_METADATA_EXPORT_BUCKET
         storage = resolve_storage_backend(

--- a/common/djangoapps/util/storage.py
+++ b/common/djangoapps/util/storage.py
@@ -1,46 +1,49 @@
 """ Utility functions related to django storages """
 
-from typing import Optional
+from typing import Optional, List
 from django.conf import settings
-from django.core.files.storage import default_storage, storages
+from django.core.files.storage import storages
 from django.utils.module_loading import import_string
 
 
-def resolve_storage_backend(storage_key: str, legacy_setting_key: str, options: Optional[dict] = None):
+def resolve_storage_backend(
+        storage_key: str,
+        legacy_setting_key: str,
+        legacy_sec_setting_keys: List[str] = None,
+        options: Optional[dict] = None):
     """
     Configures and returns a Django `Storage` instance, compatible with both Django 4 and Django 5.
     Params:
         storage_key = The key name saved in Django storages settings.
         legacy_setting_key = The key name saved in Django settings.
+        legacy_sec_setting_keys = List of keys to get the storage class.
+            For legacy dict settings like settings.BLOCK_STRUCTURES_SETTINGS.get('STORAGE_CLASS'),
+            it is necessary to access a second-level key or above to retrieve the class path.
+        legacy_options = Kwargs for the storage class.
         options = Kwargs for the storage class.
     Returns:
         An instance of the configured storage backend.
     Raises:
         ImportError: If the specified storage class cannot be imported.
-
     Main goal:
         Deprecate the use of `django.core.files.storage.get_storage_class`.
-
     How:
         Replace `get_storage_class` with direct configuration logic,
         ensuring backward compatibility with both Django 4 and Django 5 storage settings.
     """
 
     storage_path = getattr(settings, legacy_setting_key, None)
+    if isinstance(storage_path, dict) and legacy_sec_setting_keys:
+        for deep_setting_key in legacy_sec_setting_keys:
+            # For legacy dict settings like settings.CUSTOM_STORAGE = {"BACKEND": "cms.custom.."}
+            storage_path = storage_path.get(deep_setting_key)
     storages_config = getattr(settings, 'STORAGES', {})
 
     if options is None:
         options = {}
 
-    if storage_key == "default":
-        # Use case 1: Default storage
-        # Works consistently across Django 4.2 and 5.x.
-        # In Django 4.2 and above, `default_storage` uses
-        # either `DEFAULT_FILE_STORAGE` or `STORAGES['default']`.
-        return default_storage
-
     if storage_key in storages_config:
-        # Use case 2: STORAGES is defined
+        # Use case 1: STORAGES is defined
         # If STORAGES is present, we retrieve it through the storages API
         # settings.py must define STORAGES like:
         # STORAGES = {
@@ -50,12 +53,7 @@ def resolve_storage_backend(storage_key: str, legacy_setting_key: str, options: 
         # See: https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-STORAGES
         return storages[storage_key]
 
-    if not storage_path:
-        # Use case 3: No storage settings defined
-        # If no storage settings are defined anywhere, use the default storage
-        return default_storage
-
-    # Use case 4: Legacy settings
+    # Use case 2: Legacy settings
     # Fallback to import the storage_path (Obtained from django settings) manually
-    StorageClass = import_string(storage_path)
+    StorageClass = import_string(storage_path or settings.DEFAULT_FILE_STORAGE)
     return StorageClass(**options)

--- a/common/djangoapps/util/tests/test_resolve_storage_backend.py
+++ b/common/djangoapps/util/tests/test_resolve_storage_backend.py
@@ -1,0 +1,56 @@
+"""
+Tests for the resolve_storage_backend function in common.djangoapps.util.storage.
+"""
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from common.djangoapps.util.storage import resolve_storage_backend
+
+
+DEFAULT_STORAGE_CLASS_NAME = "FileSystemStorage"
+
+
+class ResolveStorageTest(TestCase):
+    """
+    Tests for the resolve_storage_backend function.
+    """
+
+    @override_settings(
+        BLOCK_STRUCTURES_SETTINGS="cms.djangoapps.contentstore.storage.ImportExportS3Storage"
+    )
+    def test_legacy_settings(self):
+        storage = resolve_storage_backend(
+            storage_key="block_structures_settings",
+            legacy_setting_key="BLOCK_STRUCTURES_SETTINGS",
+            options={}
+        )
+        assert storage.__class__.__name__ == "ImportExportS3Storage"
+
+    @override_settings(
+        BLOCK_STRUCTURES_SETTINGS={
+            "STORAGE_CLASS": "cms.djangoapps.contentstore.storage.ImportExportS3Storage"
+        }
+    )
+    def test_nested_legacy_settings(self):
+        storage = resolve_storage_backend(
+            storage_key="block_structures_settings",
+            legacy_setting_key="BLOCK_STRUCTURES_SETTINGS",
+            legacy_sec_setting_keys=["STORAGE_CLASS"],
+            options={}
+        )
+        assert storage.__class__.__name__ == "ImportExportS3Storage"
+
+    @override_settings(
+        BLOCK_STRUCTURES_SETTINGS={
+            "OTHER_KEY": "cms.djangoapps.contentstore.storage.ImportExportS3Storage"
+        }
+    )
+    def test_nested_legacy_settings_failed(self):
+        storage = resolve_storage_backend(
+            storage_key="block_structures_settings",
+            legacy_setting_key="BLOCK_STRUCTURES_SETTINGS",
+            legacy_sec_setting_keys=["STORAGE_CLASS"],
+            options={}
+        )
+        assert storage.__class__.__name__ == DEFAULT_STORAGE_CLASS_NAME

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -914,7 +914,6 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         config = settings.VERIFY_STUDENT["SOFTWARE_SECURE"]
 
         # Default to the S3 backend for backward compatibility
-        storage_class = config.get("STORAGE_CLASS", "storages.backends.s3boto3.S3Boto3Storage")
         storage_kwargs = config.get("STORAGE_KWARGS", {})
 
         # Map old settings to the parameters expected by the storage backend
@@ -927,9 +926,9 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
             storage_kwargs["querystring_expire"] = self.IMAGE_LINK_DURATION
 
         return resolve_storage_backend(
-            storage_key="software_secure",
-            legacy_setting_key="SOFTWARE_SECURE",
-            legacy_sec_setting_key="STORAGE_CLASS",
+            storage_key="verify_student",
+            legacy_setting_key="VERIFY_STUDENT",
+            legacy_sec_setting_keys=["STORAGE_CLASS"],
             options=storage_kwargs
         )
 

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -44,8 +44,8 @@ from lms.djangoapps.verify_student.ssencrypt import (
     rsa_decrypt,
     rsa_encrypt
 )
+from openedx.core.djangoapps.content.block_structure.models import resolve_storage_backend
 from openedx.core.djangoapps.signals.signals import LEARNER_SSO_VERIFIED, PHOTO_VERIFICATION_APPROVED
-from openedx.core.storage import get_storage
 
 from .utils import auto_verify_for_testing_enabled, earliest_allowed_verification_date, submit_request_to_ss
 
@@ -926,7 +926,12 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
             storage_kwargs["bucket_name"] = config["S3_BUCKET"]
             storage_kwargs["querystring_expire"] = self.IMAGE_LINK_DURATION
 
-        return get_storage(storage_class, **storage_kwargs)
+        return resolve_storage_backend(
+            storage_key="software_secure",
+            legacy_setting_key="SOFTWARE_SECURE",
+            legacy_sec_setting_key="STORAGE_CLASS",
+            options=storage_kwargs
+        )
 
     def _get_path(self, prefix, override_receipt_id=None):
         """

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -44,7 +44,7 @@ from lms.djangoapps.verify_student.ssencrypt import (
     rsa_decrypt,
     rsa_encrypt
 )
-from openedx.core.djangoapps.content.block_structure.models import resolve_storage_backend
+from common.djangoapps.util.storage import resolve_storage_backend
 from openedx.core.djangoapps.signals.signals import LEARNER_SSO_VERIFIED, PHOTO_VERIFICATION_APPROVED
 
 from .utils import auto_verify_for_testing_enabled, earliest_allowed_verification_date, submit_request_to_ss

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -928,7 +928,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         return resolve_storage_backend(
             storage_key="verify_student",
             legacy_setting_key="VERIFY_STUDENT",
-            legacy_sec_setting_keys=["STORAGE_CLASS"],
+            legacy_sec_setting_keys=["SOFTWARE_SECURE", "STORAGE_CLASS"],
             options=storage_kwargs
         )
 

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -47,6 +47,7 @@ iwIDAQAB
         "CERT_VERIFICATION_PATH": False,
     },
     "DAYS_GOOD_FOR": 10,
+    "STORAGE_CLASS": "storages.backends.s3boto3.S3Boto3Storage"
 }
 
 

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -45,9 +45,9 @@ iwIDAQAB
         "AWS_SECRET_KEY": "FAKESECRETKEY",
         "S3_BUCKET": "fake-bucket",
         "CERT_VERIFICATION_PATH": False,
+        "STORAGE_CLASS": "storages.backends.s3boto3.S3Boto3Storage"
     },
-    "DAYS_GOOD_FOR": 10,
-    "STORAGE_CLASS": "storages.backends.s3boto3.S3Boto3Storage"
+    "DAYS_GOOD_FOR": 10
 }
 
 

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1301,6 +1301,7 @@ class TestSubmitPhotosForVerification(MockS3Boto3Mixin, TestVerificationBase):
             "CERT_VERIFICATION_PATH": False,
         },
         "DAYS_GOOD_FOR": 10,
+        "STORAGE_CLASS": "storages.backends.s3boto3.S3Boto3Storage"
     })
     @httpretty.activate
     def test_submit_photos_for_reverification(self):

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1299,9 +1299,9 @@ class TestSubmitPhotosForVerification(MockS3Boto3Mixin, TestVerificationBase):
             "AWS_SECRET_KEY": "fc595fc657c04437bb23495d8fe64881",
             "S3_BUCKET": "test.example.com",
             "CERT_VERIFICATION_PATH": False,
+            "STORAGE_CLASS": "storages.backends.s3boto3.S3Boto3Storage",
         },
         "DAYS_GOOD_FOR": 10,
-        "STORAGE_CLASS": "storages.backends.s3boto3.S3Boto3Storage"
     })
     @httpretty.activate
     def test_submit_photos_for_reverification(self):
@@ -1854,9 +1854,9 @@ class TestReverifyView(TestVerificationBase):
             "AWS_ACCESS_KEY": "c987c7efe35c403caa821f7328febfa1",
             "AWS_SECRET_KEY": "fc595fc657c04437bb23495d8fe64881",
             "CERT_VERIFICATION_PATH": False,
+            "STORAGE_CLASS": 'storages.backends.s3boto3.S3Boto3Storage',
         },
         "DAYS_GOOD_FOR": 10,
-        "STORAGE_CLASS": 'storages.backends.s3boto3.S3Boto3Storage',
         "STORAGE_KWARGS": {
             'bucket': 'test-idv',
         },
@@ -1918,9 +1918,9 @@ class TestPhotoURLView(TestVerificationBase):
             "AWS_SECRET_KEY": "fc595fc657c04437bb23495d8fe64881",
             "S3_BUCKET": "test-idv",
             "CERT_VERIFICATION_PATH": False,
+            "STORAGE_CLASS": 'storages.backends.s3boto3.S3Boto3Storage',
         },
         "DAYS_GOOD_FOR": 10,
-        "STORAGE_CLASS": 'storages.backends.s3boto3.S3Boto3Storage',
         "STORAGE_KWARGS": {
             'bucket': 'test-idv',
         },

--- a/openedx/core/djangoapps/content/block_structure/models.py
+++ b/openedx/core/djangoapps/content/block_structure/models.py
@@ -13,10 +13,10 @@ from django.core.exceptions import SuspiciousOperation
 from django.core.files.base import ContentFile
 from django.db import models, transaction
 
+from common.djangoapps.util.storage import resolve_storage_backend
 from model_utils.models import TimeStampedModel
 
 from openedx.core.djangoapps.xmodule_django.models import UsageKeyWithRunField
-from openedx.core.storage import get_storage
 
 from . import config
 from .exceptions import BlockStructureNotFound
@@ -73,7 +73,7 @@ def _bs_model_storage():
     # .. setting_default: None
     # .. setting_description: Specifies the storage used for storage-backed block structure cache.
     #   For more information, check https://github.com/openedx/edx-platform/pull/14571.
-    storage_class = settings.BLOCK_STRUCTURES_SETTINGS.get('STORAGE_CLASS')
+    # storage_class = settings.BLOCK_STRUCTURES_SETTINGS.get('STORAGE_CLASS')
 
     # .. setting_name: BLOCK_STRUCTURES_SETTINGS['STORAGE_KWARGS']
     # .. setting_default: {}
@@ -83,7 +83,12 @@ def _bs_model_storage():
     # .. setting_warnings: Depends on `BLOCK_STRUCTURES_SETTINGS['STORAGE_CLASS']`
     storage_kwargs = settings.BLOCK_STRUCTURES_SETTINGS.get('STORAGE_KWARGS', {})
 
-    return get_storage(storage_class, **storage_kwargs)
+    return resolve_storage_backend(
+        storage_key="block_structures_settings",
+        legacy_setting_key="BLOCK_STRUCTURES_SETTINGS",
+        legacy_sec_setting_key="STORAGE_CLASS",
+        options=storage_kwargs
+    )
 
 
 class CustomizableFileField(models.FileField):

--- a/openedx/core/djangoapps/content/block_structure/models.py
+++ b/openedx/core/djangoapps/content/block_structure/models.py
@@ -86,7 +86,7 @@ def _bs_model_storage():
     return resolve_storage_backend(
         storage_key="block_structures_settings",
         legacy_setting_key="BLOCK_STRUCTURES_SETTINGS",
-        legacy_sec_setting_key="STORAGE_CLASS",
+        legacy_sec_setting_keys=["STORAGE_CLASS"],
         options=storage_kwargs
     )
 

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -5,8 +5,9 @@ Django storage backends for Open edX.
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import StaticFilesStorage
-from django.core.files.storage import get_storage_class, FileSystemStorage
+from django.core.files.storage import FileSystemStorage
 from django.utils.deconstruct import deconstructible
+from django.utils.module_loading import import_string
 from functools import lru_cache
 from pipeline.storage import NonPackagingMixin
 from require.storage import OptimizedFilesMixin
@@ -111,4 +112,5 @@ def get_storage(storage_class=None, **kwargs):
     the storage implementation makes http requests when instantiated, for
     example.
     """
-    return get_storage_class(storage_class)(**kwargs)
+    storage_cls = import_string(storage_class or settings.DEFAULT_FILE_STORAGE)
+    return storage_cls(**kwargs)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes: https://github.com/openedx/edx-platform/issues/36739

The main goal is to modify the get_storage_class function referenced [here](https://github.com/openedx/edx-platform/blob/447fd0b6cbbb5a517d3490fee36a1c901c7e8a4d/openedx/core/storage.py#L114) in order to deprecate it.
However, a few special changes have been made, as described below:

- In [this file](https://github.com/openedx/edx-platform/blob/447fd0b6cbbb5a517d3490fee36a1c901c7e8a4d/lms/djangoapps/verify_student/models.py#L929), get_storage_class was replaced by the generic resolve_storage function.
- A similar update was made [here](https://github.com/openedx/edx-platform/blob/447fd0b6cbbb5a517d3490fee36a1c901c7e8a4d/openedx/core/djangoapps/content/block_structure/models.py#L86).

**Why does the [get_storage_class](https://github.com/openedx/edx-platform/blob/447fd0b6cbbb5a517d3490fee36a1c901c7e8a4d/openedx/core/storage.py#L114) function still exist with a new implementation that uses `import_string`**?
This change is related to the [DjangoStorageReportStore](https://github.com/openedx/edx-platform/blob/447fd0b6cbbb5a517d3490fee36a1c901c7e8a4d/lms/djangoapps/instructor_task/models.py#L270) class and its parent implementation. Specifically, [here](https://github.com/openedx/edx-platform/blob/447fd0b6cbbb5a517d3490fee36a1c901c7e8a4d/lms/djangoapps/instructor_task/models.py#L232), a dynamic logic is used to define the storage backend.

Given the complexity of that logic, I recommend creating a separate ticket to refactor this part of the code.

Lastly, the `resolve_storage_backend` function was updated to support a `legacy_sec_setting_keys` parameter. This allows it to handle storage settings defined as nested dictionaries. For example:

```
settings.VERIFY_STUDENT = {
    "STORAGE_CLASS": "storage.path.class"
}
```
