### PR TITLE
feat: container links api

### DIFF
--- a/cms/djangoapps/contentstore/models.py
+++ b/cms/djangoapps/contentstore/models.py
@@ -312,7 +312,7 @@ class ContainerLink(EntityLinkBase):
         ready_to_sync = link_filter.pop('ready_to_sync', None)
         result = cls.objects.filter(**link_filter).select_related(
             "upstream_container__publishable_entity__published__version",
-            "upstream_container__publishable_entity__learning_package"
+            "upstream_container__publishable_entity__learning_package",
             "upstream_container__publishable_entity__published__publish_log_record__publish_log",
         ).annotate(
             ready_to_sync=(

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/__init__.py
@@ -2,6 +2,7 @@
 
 from cms.djangoapps.contentstore.rest_api.v2.serializers.downstreams import (
     ComponentLinksSerializer,
+    ContainerLinksSerializer,
     PublishableEntityLinksSummarySerializer,
 )
 from cms.djangoapps.contentstore.rest_api.v2.serializers.home import CourseHomeTabSerializerV2
@@ -9,5 +10,6 @@ from cms.djangoapps.contentstore.rest_api.v2.serializers.home import CourseHomeT
 __all__ = [
     'CourseHomeTabSerializerV2',
     'ComponentLinksSerializer',
+    'ContainerLinksSerializer',
     'PublishableEntityLinksSummarySerializer',
 ]

--- a/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/serializers/downstreams.py
@@ -4,7 +4,7 @@ Serializers for upstream -> downstream entity links.
 
 from rest_framework import serializers
 
-from cms.djangoapps.contentstore.models import ComponentLink
+from cms.djangoapps.contentstore.models import ComponentLink, ContainerLink
 
 
 class ComponentLinksSerializer(serializers.ModelSerializer):
@@ -29,3 +29,16 @@ class PublishableEntityLinksSummarySerializer(serializers.Serializer):
     ready_to_sync_count = serializers.IntegerField(read_only=True)
     total_count = serializers.IntegerField(read_only=True)
     last_published_at = serializers.DateTimeField(read_only=True)
+
+
+class ContainerLinksSerializer(serializers.ModelSerializer):
+    """
+    Serializer for publishable container entity links.
+    """
+    upstream_context_title = serializers.CharField(read_only=True)
+    upstream_version = serializers.IntegerField(read_only=True, source="upstream_version_num")
+    ready_to_sync = serializers.BooleanField()
+
+    class Meta:
+        model = ContainerLink
+        exclude = ['upstream_container', 'uuid']

--- a/cms/djangoapps/contentstore/rest_api/v2/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
         name="downstreams_list",
     ),
     re_path(
+        r'^downstream-containers/$',
+        downstreams.DownstreamContainerListView.as_view(),
+        name="container_downstreams_list",
+    ),
+    re_path(
         fr'^downstreams/{settings.USAGE_KEY_PATTERN}$',
         downstreams.DownstreamView.as_view(),
         name="downstream"

--- a/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
@@ -378,7 +378,7 @@ class DownstreamContainerListView(DeveloperErrorViewMixin, APIView):
         course_key_string = request.GET.get('course_id')
         ready_to_sync = request.GET.get('ready_to_sync')
         upstream_container_key = request.GET.get('upstream_container_key')
-        link_filter: dict[str, CourseKey | UsageKey | bool] = {}
+        link_filter: dict[str, CourseKey | LibraryContainerLocator | bool] = {}
         paginator = DownstreamListPaginator()
         if course_key_string:
             try:

--- a/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/downstreams.py
@@ -95,9 +95,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from xblock.core import XBlock
 
-from cms.djangoapps.contentstore.models import ComponentLink
+from cms.djangoapps.contentstore.models import ComponentLink, ContainerLink
 from cms.djangoapps.contentstore.rest_api.v2.serializers import (
     ComponentLinksSerializer,
+    ContainerLinksSerializer,
     PublishableEntityLinksSummarySerializer,
 )
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import sync_library_content
@@ -362,6 +363,39 @@ class SyncFromUpstreamView(DeveloperErrorViewMixin, APIView):
             raise ValidationError(str(exc)) from exc
         modulestore().update_item(downstream, request.user.id)
         return Response(status=204)
+
+
+@view_auth_classes()
+class DownstreamContainerListView(DeveloperErrorViewMixin, APIView):
+    """
+    List all container blocks which are linked to an upstream context, with optional filtering.
+    """
+
+    def get(self, request: _AuthenticatedRequest):
+        """
+        Fetches publishable container entity links for given course key
+        """
+        course_key_string = request.GET.get('course_id')
+        ready_to_sync = request.GET.get('ready_to_sync')
+        upstream_container_key = request.GET.get('upstream_container_key')
+        link_filter: dict[str, CourseKey | UsageKey | bool] = {}
+        paginator = DownstreamListPaginator()
+        if course_key_string:
+            try:
+                link_filter["downstream_context_key"] = CourseKey.from_string(course_key_string)
+            except InvalidKeyError as exc:
+                raise ValidationError(detail=f"Malformed course key: {course_key_string}") from exc
+        if ready_to_sync is not None:
+            link_filter["ready_to_sync"] = BooleanField().to_internal_value(ready_to_sync)
+        if upstream_container_key:
+            try:
+                link_filter["upstream_container_key"] = LibraryContainerLocator.from_string(upstream_container_key)
+            except InvalidKeyError as exc:
+                raise ValidationError(detail=f"Malformed usage key: {upstream_container_key}") from exc
+        links = ContainerLink.filter_links(**link_filter)
+        paginated_links = paginator.paginate_queryset(links, self.request, view=self)
+        serializer = ContainerLinksSerializer(paginated_links, many=True)
+        return paginator.get_paginated_response(serializer.data, self.request)
 
 
 def _load_accessible_block(user: User, usage_key_string: str, *, require_write_access: bool) -> XBlock:

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -137,7 +137,7 @@ class _BaseDownstreamViewTestMixin:
         """
         Call a REST API
         """
-        response = getattr(self.client, method)(url, data, format="json")
+        response = getattr(self.client, method)(url, data, format="json", content_type="application/json")
         assert response.status_code == expect_response,\
             'Unexpected response code {}:\n{}'.format(response.status_code, getattr(response, 'data', '(no data)'))
         return response.data
@@ -480,9 +480,9 @@ class GetUpstreamViewTest(
     """
     def call_api(
         self,
-        course_id: str = None,
-        ready_to_sync: bool = None,
-        upstream_usage_key: str = None,
+        course_id: str | None = None,
+        ready_to_sync: bool | None = None,
+        upstream_usage_key: str | None = None,
     ):
         data = {}
         if course_id is not None:
@@ -609,9 +609,9 @@ class GetContainerUpstreamViewTest(
     """
     def call_api(
         self,
-        course_id: str = None,
-        ready_to_sync: bool = None,
-        upstream_container_key: str = None,
+        course_id: str | None = None,
+        ready_to_sync: bool | None = None,
+        upstream_container_key: str | None = None,
     ):
         data = {}
         if course_id is not None:
@@ -627,7 +627,6 @@ class GetContainerUpstreamViewTest(
         Returns all container links for given course
         """
         self.client.login(username="superuser", password="password")
-        self.maxDiff = 20000
         response = self.call_api(course_id=self.course.id)
         assert response.status_code == 200
         data = response.json()
@@ -671,7 +670,7 @@ class GetContainerUpstreamViewTest(
                 'upstream_context_key': self.library_id,
                 'upstream_context_title': self.library_title,
                 'upstream_container_key': self.unit_id,
-                'upstream_version': 1,
+                'upstream_version': 2,
                 'version_declined': None,
                 'version_synced': 1
             },
@@ -689,17 +688,3 @@ class GetContainerUpstreamViewTest(
         data = response.json()
         self.assertTrue(all(o["ready_to_sync"] for o in data["results"]))
         self.assertEqual(data["count"], 1)
-
-    def test_200_downstream_context_list(self):
-        """
-        Returns all downstream courses for given library block
-        """
-        self.client.login(username="superuser", password="password")
-        response = self.call_api(upstream_usage_key=self.video_lib_id)
-        assert response.status_code == 200
-        data = response.json()
-        expected = [str(self.downstream_video_key)] + [str(key) for key in self.another_video_keys]
-        got = [str(o["downstream_usage_key"]) for o in data["results"]]
-        self.assertListEqual(got, expected)
-        self.assertEqual(data["count"], 4)
-

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -14,7 +14,7 @@ from cms.djangoapps.contentstore.helpers import StaticFileNotices
 from cms.lib.xblock.upstream_sync import BadUpstream, UpstreamLink
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.xblock_storage_handlers import view_handlers as xblock_view_handlers
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import ContainerKey, UsageKey
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -28,6 +28,9 @@ URL_LIB_CREATE = URL_PREFIX
 URL_LIB_BLOCKS = URL_PREFIX + '{lib_key}/blocks/'
 URL_LIB_BLOCK_PUBLISH = URL_PREFIX + 'blocks/{block_key}/publish/'
 URL_LIB_BLOCK_OLX = URL_PREFIX + 'blocks/{block_key}/olx/'
+URL_LIB_CONTAINER = URL_PREFIX + 'containers/{container_key}/'  # Get a container in this library
+URL_LIB_CONTAINERS = URL_PREFIX + '{lib_key}/containers/'  # Create a new container in this library
+URL_LIB_CONTAINER_PUBLISH = URL_LIB_CONTAINER + 'publish/'  # Publish changes to the specified container + children
 
 
 def _get_upstream_link_good_and_syncable(downstream):
@@ -75,8 +78,14 @@ class _BaseDownstreamViewTestMixin:
         )["id"]
         self.html_lib_id = self._add_block_to_library(self.library_id, "html", "html-baz")["id"]
         self.video_lib_id = self._add_block_to_library(self.library_id, "video", "video-baz")["id"]
+        self.unit_id = self._create_container(self.library_id, "unit", "unit-1", "Unit 1")["id"]
+        self.subsection_id = self._create_container(self.library_id, "subsection", "subsection-1", "Subsection 1")["id"]
+        self.section_id = self._create_container(self.library_id, "section", "section-1", "Section 1")["id"]
         self._publish_library_block(self.html_lib_id)
         self._publish_library_block(self.video_lib_id)
+        self._publish_container(self.unit_id)
+        self._publish_container(self.subsection_id)
+        self._publish_container(self.section_id)
         self.mock_upstream_link = f"{settings.COURSE_AUTHORING_MICROFRONTEND_URL}/library/{self.library_id}/components?usageKey={self.video_lib_id}"  # pylint: disable=line-too-long  # noqa: E501
         self.course = CourseFactory.create()
         chapter = BlockFactory.create(category='chapter', parent=self.course)
@@ -88,6 +97,15 @@ class _BaseDownstreamViewTestMixin:
         ).usage_key
         self.downstream_html_key = BlockFactory.create(
             category='html', parent=unit, upstream=self.html_lib_id, upstream_version=1,
+        ).usage_key
+        self.downstream_chapter_key = BlockFactory.create(
+            category='chapter', parent=self.course, upstream=self.section_id, upstream_version=1,
+        ).usage_key
+        self.downstream_sequential_key = BlockFactory.create(
+            category='sequential', parent=chapter, upstream=self.subsection_id, upstream_version=1,
+        ).usage_key
+        self.downstream_unit_key = BlockFactory.create(
+            category='vertical', parent=sequential, upstream=self.unit_id, upstream_version=1,
         ).usage_key
 
         self.another_course = CourseFactory.create(display_name="Another Course")
@@ -108,6 +126,8 @@ class _BaseDownstreamViewTestMixin:
 
         self.fake_video_key = self.course.id.make_usage_key("video", "NoSuchVideo")
         self.learner = UserFactory(username="learner", password="password")
+        self._update_container(self.unit_id, display_name="Unit 2")
+        self._publish_container(self.unit_id)
         self._set_library_block_olx(self.html_lib_id, "<html><b>Hello world!</b></html>")
         self._publish_library_block(self.html_lib_id)
         self._publish_library_block(self.video_lib_id)
@@ -148,12 +168,28 @@ class _BaseDownstreamViewTestMixin:
         """ Publish changes from a specified XBlock """
         return self._api('post', URL_LIB_BLOCK_PUBLISH.format(block_key=block_key), None, expect_response)
 
+    def _publish_container(self, container_key: ContainerKey | str, expect_response=200):
+        """ Publish all changes in the specified container + children """
+        return self._api('post', URL_LIB_CONTAINER_PUBLISH.format(container_key=container_key), None, expect_response)
+
+    def _update_container(self, container_key: ContainerKey | str, display_name: str, expect_response=200):
+        """ Update a container (unit etc.) """
+        data = {"display_name": display_name}
+        return self._api('patch', URL_LIB_CONTAINER.format(container_key=container_key), data, expect_response)
+
     def _set_library_block_olx(self, block_key, new_olx, expect_response=200):
         """ Overwrite the OLX of a specific block in the library """
         return self._api('post', URL_LIB_BLOCK_OLX.format(block_key=block_key), {"olx": new_olx}, expect_response)
 
     def call_api(self, usage_key_string):
         raise NotImplementedError
+
+    def _create_container(self, lib_key, container_type, slug: str | None, display_name: str, expect_response=200):
+        """ Create a container (unit etc.) """
+        data = {"container_type": container_type, "display_name": display_name}
+        if slug:
+            data["slug"] = slug
+        return self._api('post', URL_LIB_CONTAINERS.format(lib_key=lib_key), data, expect_response)
 
 
 class SharedErrorTestCases(_BaseDownstreamViewTestMixin):
@@ -562,3 +598,108 @@ class GetDownstreamSummaryViewTest(
             'last_published_at': self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         }]
         self.assertListEqual(data, expected)
+
+
+class GetContainerUpstreamViewTest(
+    _BaseDownstreamViewTestMixin,
+    SharedModuleStoreTestCase,
+):
+    """
+    Test that `GET /api/v2/contentstore/downstream-containers?...` returns list of links based on the provided filter.
+    """
+    def call_api(
+        self,
+        course_id: str = None,
+        ready_to_sync: bool = None,
+        upstream_container_key: str = None,
+    ):
+        data = {}
+        if course_id is not None:
+            data["course_id"] = str(course_id)
+        if ready_to_sync is not None:
+            data["ready_to_sync"] = str(ready_to_sync)
+        if upstream_container_key is not None:
+            data["upstream_container_key"] = str(upstream_container_key)
+        return self.client.get("/api/contentstore/v2/downstream-containers/", data=data)
+
+    def test_200_all_container_downstreams_for_a_course(self):
+        """
+        Returns all container links for given course
+        """
+        self.client.login(username="superuser", password="password")
+        self.maxDiff = 20000
+        response = self.call_api(course_id=self.course.id)
+        assert response.status_code == 200
+        data = response.json()
+        date_format = self.now.isoformat().split("+")[0] + 'Z'
+        expected = [
+            {
+                'created': date_format,
+                'downstream_context_key': str(self.course.id),
+                'downstream_usage_key': str(self.downstream_chapter_key),
+                'id': 1,
+                'ready_to_sync': False,
+                'updated': date_format,
+                'upstream_context_key': self.library_id,
+                'upstream_context_title': self.library_title,
+                'upstream_container_key': self.section_id,
+                'upstream_version': 1,
+                'version_declined': None,
+                'version_synced': 1,
+            },
+            {
+                'created': date_format,
+                'downstream_context_key': str(self.course.id),
+                'downstream_usage_key': str(self.downstream_sequential_key),
+                'id': 2,
+                'ready_to_sync': False,
+                'updated': date_format,
+                'upstream_context_key': self.library_id,
+                'upstream_context_title': self.library_title,
+                'upstream_container_key': self.subsection_id,
+                'upstream_version': 1,
+                'version_declined': None,
+                'version_synced': 1,
+            },
+            {
+                'created': date_format,
+                'downstream_context_key': str(self.course.id),
+                'downstream_usage_key': str(self.downstream_unit_key),
+                'id': 3,
+                'ready_to_sync': True,
+                'updated': date_format,
+                'upstream_context_key': self.library_id,
+                'upstream_context_title': self.library_title,
+                'upstream_container_key': self.unit_id,
+                'upstream_version': 1,
+                'version_declined': None,
+                'version_synced': 1
+            },
+        ]
+        self.assertListEqual(data["results"], expected)
+        self.assertEqual(data["count"], 3)
+
+    def test_200_all_downstreams_ready_to_sync(self):
+        """
+        Returns all links that are syncable
+        """
+        self.client.login(username="superuser", password="password")
+        response = self.call_api(ready_to_sync=True)
+        assert response.status_code == 200
+        data = response.json()
+        self.assertTrue(all(o["ready_to_sync"] for o in data["results"]))
+        self.assertEqual(data["count"], 1)
+
+    def test_200_downstream_context_list(self):
+        """
+        Returns all downstream courses for given library block
+        """
+        self.client.login(username="superuser", password="password")
+        response = self.call_api(upstream_usage_key=self.video_lib_id)
+        assert response.status_code == 200
+        data = response.json()
+        expected = [str(self.downstream_video_key)] + [str(key) for key in self.another_video_keys]
+        got = [str(o["downstream_usage_key"]) for o in data["results"]]
+        self.assertListEqual(got, expected)
+        self.assertEqual(data["count"], 4)
+

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -369,6 +369,7 @@ def delete_container(
     library_key = container_key.lib_key
     container = _get_container_from_key(container_key)
 
+    affected_containers = get_containers_contains_item(container_key)
     affected_collections = authoring_api.get_entity_collections(
         container.publishable_entity.learning_package_id,
         container.key,
@@ -393,6 +394,14 @@ def delete_container(
                     collection_key=collection.key,
                 ),
                 background=True,
+            )
+        )
+    # Send events related to the containers that contains the updated container.
+    # This is to update the children display names used in the section/subsection previews.
+    for affected_container in affected_containers:
+        LIBRARY_CONTAINER_UPDATED.send_event(
+            library_container=LibraryContainerData(
+                container_key=affected_container.container_key,
             )
         )
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds list api to fetch container library links information. See https://github.com/openedx/frontend-app-authoring/pull/2145 for more details.

Useful information to include:

- Which edX user roles will this change impact: "Developer".

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/1981
* https://github.com/openedx/frontend-app-authoring/issues/1982
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4167
* https://github.com/openedx/frontend-app-authoring/pull/2145

## Testing instructions

Please see https://github.com/openedx/frontend-app-authoring/pull/2145 for instructions

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
