### PR TITLE
fix: Edit components in unit that comes from libraries

### DIFF
--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -211,12 +211,6 @@ upstream_info = UpstreamLink.try_get_for_block(xblock, log_error=False)
                                 <span data-tooltip="${_('Drag to reorder')}" class="drag-handle action"></span>
                             </li>
                         % endif
-                    % elif not show_inline:
-                        <li class="action-item action-edit action-edit-view-only">
-                            <a href="#" class="edit-button action-button">
-                                <span class="action-button-text">${_("Details")}</span>
-                            </a>
-                        </li>
                     % endif
                 % endif
             </ul>


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- Deletes the edit button on units that comes from a library

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2144

## Testing instructions

- Go to a library
- Create a unit and add some components
- On a course, add a unit from a library
- Add the unit created
- Verify that you can't edit the component.
- On the course, create a unit and add a component.
- Verify that you can edit the component.

## Deadline

ASAP

## Other information

N/A
