### PR TITLE
feat: add color field for grading API & modulestore for future requirements

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/__init__.py
@@ -7,7 +7,7 @@ from .course_index import CourseIndexSerializer
 from .course_rerun import CourseRerunSerializer
 from .course_team import CourseTeamSerializer
 from .course_waffle_flags import CourseWaffleFlagsSerializer
-from .grading import CourseGradingModelSerializer, CourseGradingSerializer
+from .grading import CourseGradingModelSerializer, CourseGradingSerializer, GradingColorSerializer
 from .group_configurations import CourseGroupConfigurationsSerializer
 from .home import StudioHomeSerializer, CourseHomeTabSerializer, LibraryTabSerializer
 from .proctoring import (

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
@@ -52,12 +52,12 @@ class GradingColorSerializer(serializers.Serializer):
     """
     Serializer for grading color
     """
-    color = serializers.CharField(required=True)
+    color = serializers.CharField(required=False, allow_null=True, allow_blank=True)
 
     def validate_color(self, value: str) -> str:
         """
         Validate that the color is a valid hex color code.
         """
-        if not re.match(r'^#(?:[0-9a-fA-F]{3}){1,2}$', value):
+        if value and not re.match(r'^#(?:[0-9a-fA-F]{3}){1,2}$', value):
             raise serializers.ValidationError("Invalid color format. Must be a hex color code.")
         return value

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/grading.py
@@ -2,6 +2,8 @@
 API Serializers for course grading
 """
 
+import re
+
 from rest_framework import serializers
 
 
@@ -13,6 +15,7 @@ class GradersSerializer(serializers.Serializer):
     short_label = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     weight = serializers.IntegerField()
     id = serializers.IntegerField()
+    color = serializers.CharField()
 
 
 class GracePeriodSerializer(serializers.Serializer):
@@ -43,3 +46,18 @@ class CourseGradingSerializer(serializers.Serializer):
     default_grade_designations = serializers.ListSerializer(
         child=serializers.CharField()
     )
+
+
+class GradingColorSerializer(serializers.Serializer):
+    """
+    Serializer for grading color
+    """
+    color = serializers.CharField(required=True)
+
+    def validate_color(self, value: str) -> str:
+        """
+        Validate that the color is a valid hex color code.
+        """
+        if not re.match(r'^#(?:[0-9a-fA-F]{3}){1,2}$', value):
+            raise serializers.ValidationError("Invalid color format. Must be a hex color code.")
+        return value

--- a/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
@@ -14,7 +14,7 @@ from openedx.core.djangoapps.credit.tasks import update_credit_course_requiremen
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
 from xmodule.modulestore.django import modulestore
 
-from ..serializers import CourseGradingModelSerializer, CourseGradingSerializer
+from ..serializers import CourseGradingModelSerializer, CourseGradingSerializer, GradingColorSerializer
 from ....utils import get_course_grading
 
 
@@ -69,7 +69,8 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
                     "drop_count": 0,
                     "short_label": "",
                     "weight": 100,
-                    "id": 0
+                    "id": 0,
+                    "color": "#FF5733"
                 }
                 ],
                 "grade_cutoffs": {
@@ -140,7 +141,8 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
                     "drop_count": 0,
                     "short_label": "",
                     "weight": 100,
-                    "id": 0
+                    "id": 0,
+                    "color": "#FF5733"
                 }
             ],
             "grade_cutoffs": {
@@ -170,6 +172,7 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
         if 'minimum_grade_credit' in request.data:
             update_credit_course_requirements.delay(str(course_key))
 
+        GradingColorSerializer(data=request.data['graders'], many=True).is_valid(raise_exception=True)
         updated_data = CourseGradingModel.update_from_json(course_key, request.data, request.user)
         serializer = CourseGradingModelSerializer(updated_data)
         return Response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
@@ -103,7 +103,6 @@ class CourseGradingViewTest(CourseTestCase, PermissionAccessMixin):
                     "short_label": "",
                     "weight": 100,
                     "id": 0,
-                    "color": "#FF5733"
                 }
             ],
             "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
@@ -301,5 +300,63 @@ class CourseGradingViewTest(CourseTestCase, PermissionAccessMixin):
             data=json.dumps(request_data),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['developer_message'][0]['color'][0], 'This field is required.')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_post_course_grading_with_empty_color_field(self):
+        """
+        Test POST with grader data with empty color field
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0,
+                    "color": ""
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['graders'][0]['color'], "")
+
+    def test_post_get_course_grading_with_color_field(self):
+        """
+        Test POST and GET with grader data with color field
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0,
+                    "color": "#FF5733"
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        post_response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(post_response.status_code, status.HTTP_200_OK)
+
+        get_response = self.client.get(self.url)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(get_response.data['course_details']['graders'][0]['color'], "#FF5733")

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
@@ -103,6 +103,7 @@ class CourseGradingViewTest(CourseTestCase, PermissionAccessMixin):
                     "short_label": "",
                     "weight": 100,
                     "id": 0,
+                    "color": "#FF5733"
                 }
             ],
             "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
@@ -117,3 +118,188 @@ class CourseGradingViewTest(CourseTestCase, PermissionAccessMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_update_credit_course_requirements.assert_called_once()
+
+    def test_post_course_grading_with_valid_color(self):
+        """
+        Test POST with valid hex color in grader data
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0,
+                    "color": "#FF5733"
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual("#FF5733", response.data['graders'][0]['color'])
+
+    def test_post_course_grading_with_invalid_color_format(self):
+        """
+        Test POST with invalid hex color format
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0,
+                    "color": "invalid_color"
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['developer_message'][0]['color'][0],
+            'Invalid color format. Must be a hex color code.'
+        )
+
+    def test_post_course_grading_with_short_hex_color(self):
+        """
+        Test POST with 3-character hex color
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0,
+                    "color": "#F5A"
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['graders'][0]['color'], "#F5A")
+
+    def test_post_course_grading_with_missing_hash_symbol(self):
+        """
+        Test POST with hex color missing hash symbol
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0,
+                    "color": "FF5733"
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['developer_message'][0]['color'][0],
+            'Invalid color format. Must be a hex color code.'
+        )
+
+    def test_post_course_grading_with_multiple_graders_mixed_colors(self):
+        """
+        Test POST with multiple graders having valid and invalid colors
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 50,
+                    "id": 0,
+                    "color": "#FF5733"
+                },
+                {
+                    "type": "Exam",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 50,
+                    "id": 1,
+                    "color": "not_a_color"
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['developer_message'][1]['color'][0],
+            'Invalid color format. Must be a hex color code.'
+        )
+
+    def test_post_course_grading_without_color_field(self):
+        """
+        Test POST with grader data without color field
+        """
+        request_data = {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0,
+                }
+            ],
+            "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+            "grace_period": {"hours": 12, "minutes": 0},
+            "minimum_grade_credit": 0.7,
+        }
+        response = self.client.post(
+            path=self.url,
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['developer_message'][0]['color'][0], 'This field is required.')

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1039,7 +1039,8 @@ class CourseGradingTest(CourseTestCase):
             "min_count": 1,
             "drop_count": 2,
             "short_label": None,
-            "weight": 15,
+            "weight": 15.0,
+            "color": None,
         }
 
         response = self.client.ajax_post(
@@ -1893,6 +1894,7 @@ class CourseGraderUpdatesTest(CourseTestCase):
             "drop_count": 10,
             "short_label": "yo momma",
             "weight": 17.3,
+            "color": None,
         }
         resp = self.client.ajax_post(self.url + '/0', grader)
         self.assertEqual(resp.status_code, 200)
@@ -1912,6 +1914,7 @@ class CourseGraderUpdatesTest(CourseTestCase):
             "drop_count": 10,
             "short_label": "yo momma",
             "weight": 17.3,
+            "color": None,
         }
         resp = self.client.ajax_post(f'{self.url}/{len(self.starting_graders) + 1}', grader)
         self.assertEqual(resp.status_code, 200)

--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -60,7 +60,8 @@ class CourseGradingModel:
                     "min_count": 0,
                     "drop_count": 0,
                     "short_label": None,
-                    "weight": 0
+                    "weight": 0,
+                    "color": None,
                     }
 
     @staticmethod
@@ -321,7 +322,8 @@ class CourseGradingModel:
                   "min_count": int(json_grader.get('min_count', 0)),
                   "drop_count": int(json_grader.get('drop_count', 0)),
                   "short_label": json_grader.get('short_label', None),
-                  "weight": float(json_grader.get('weight', 0)) / 100.0
+                  "weight": float(json_grader.get('weight', 0)) / 100.0,
+                  "color": json_grader.get('color', None),
                   }
 
         return result
@@ -338,6 +340,7 @@ class CourseGradingModel:
             "drop_count": grader.get('drop_count', 0),
             "short_label": grader.get('short_label', ""),
             "weight": grader.get('weight', 0) * 100,
+            "color": grader.get('color', None),
         }
 
 


### PR DESCRIPTION
## Description

Adds support for a required `color` field to course grading configurations via the Grading API and modulestore.

- Updates the grading serializer and model logic to accept and store a `color` value per grader.
- Adds validation to ensure the color follows the hex code format (e.g., `#FF5733` or `#F5A`).
- Extends API responses and requests to include the `color` field.
- Updates modulestore logic to serialize and deserialize the color field for future extensibility.
- Includes tests for valid, invalid, missing, and mixed color input cases.

This enhancement allows for future UI features like color-coded grading visualization while maintaining backward compatibility.
