### PR TITLE
feat: Add notify all learners option for discussion post

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -127,7 +127,8 @@ from .utils import (
     get_usernames_for_course,
     get_usernames_from_search_string,
     set_attribute,
-    is_posting_allowed
+    is_posting_allowed,
+    can_user_notify_all_learners
 )
 
 User = get_user_model()
@@ -333,6 +334,8 @@ def get_course(request, course_key, check_tab=True):
         course.get_discussion_blackout_datetimes()
     )
     discussion_tab = CourseTabList.get_tab_by_type(course.tabs, 'discussion')
+    is_course_staff = CourseStaffRole(course_key).has_user(request.user)
+    is_course_admin = CourseInstructorRole(course_key).has_user(request.user)
     return {
         "id": str(course_key),
         "is_posting_enabled": is_posting_enabled,
@@ -358,8 +361,8 @@ def get_course(request, course_key, check_tab=True):
         }),
         "is_group_ta": bool(user_roles & {FORUM_ROLE_GROUP_MODERATOR}),
         "is_user_admin": request.user.is_staff,
-        "is_course_staff": CourseStaffRole(course_key).has_user(request.user),
-        "is_course_admin": CourseInstructorRole(course_key).has_user(request.user),
+        "is_course_staff": is_course_staff,
+        "is_course_admin": is_course_admin,
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
         "group_at_subsection": course_config.plugin_configuration.get("group_at_subsection", False),
@@ -372,6 +375,9 @@ def get_course(request, course_key, check_tab=True):
             for (reason_code, label) in CLOSE_REASON_CODES.items()
         ],
         'show_discussions': bool(discussion_tab and discussion_tab.is_enabled(course, request.user)),
+        'is_notify_all_learners_enabled': can_user_notify_all_learners(
+            course_key, user_roles, is_course_staff, is_course_admin
+        ),
     }
 
 
@@ -1469,6 +1475,8 @@ def create_thread(request, thread_data):
     if not discussion_open_for_user(course, user):
         raise DiscussionBlackOutException
 
+    notify_all_learners = thread_data.pop("notify_all_learners", False)
+
     context = get_context(course, request)
     _check_initializable_thread_fields(thread_data, context)
     discussion_settings = CourseDiscussionSettings.get(course_key)
@@ -1484,7 +1492,7 @@ def create_thread(request, thread_data):
         raise ValidationError(dict(list(serializer.errors.items()) + list(actions_form.errors.items())))
     serializer.save()
     cc_thread = serializer.instance
-    thread_created.send(sender=None, user=user, post=cc_thread)
+    thread_created.send(sender=None, user=user, post=cc_thread, notify_all_learners=notify_all_learners)
     api_thread = serializer.data
     _do_extra_actions(api_thread, cc_thread, list(thread_data.keys()), actions_form, context, request)
 

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -318,17 +318,18 @@ class DiscussionNotificationSender:
         self._populate_context_with_ids_for_mobile(context, notification_type)
         self._send_notification([self.creator.id], notification_type, extra_context=context)
 
-    def send_new_thread_created_notification(self):
+    def send_new_thread_created_notification(self, notify_all_learners=False):
         """
         Send notification based on notification_type
         """
         thread_type = self.thread.attributes['thread_type']
-        notification_type = (
+
+        notification_type = "new_instructor_all_learners_post" if notify_all_learners else (
             "new_question_post"
             if thread_type == "question"
             else ("new_discussion_post" if thread_type == "discussion" else "")
         )
-        if notification_type not in ['new_discussion_post', 'new_question_post']:
+        if notification_type not in ['new_discussion_post', 'new_question_post', 'new_instructor_all_learners_post']:
             raise ValueError(f'Invalid notification type {notification_type}')
 
         audience_filters = self._create_cohort_course_audience()

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -217,6 +217,7 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
             'edit_reasons': [{'code': 'test-edit-reason', 'label': 'Test Edit Reason'}],
             'post_close_reasons': [{'code': 'test-close-reason', 'label': 'Test Close Reason'}],
             'show_discussions': True,
+            'is_notify_all_learners_enabled': False
         }
 
     @ddt.data(
@@ -1918,7 +1919,9 @@ class CreateThreadTest(
             "read": True,
         })
         self.register_post_thread_response(cs_thread)
-        with self.assert_signal_sent(api, 'thread_created', sender=None, user=self.user, exclude_args=('post',)):
+        with self.assert_signal_sent(
+            api, 'thread_created', sender=None, user=self.user, exclude_args=('post', 'notify_all_learners')
+        ):
             actual = create_thread(self.request, self.minimal_data)
         expected = self.expected_thread_data({
             "id": "test_id",
@@ -1984,7 +1987,9 @@ class CreateThreadTest(
 
         _assign_role_to_user(user=self.user, course_id=self.course.id, role=FORUM_ROLE_MODERATOR)
 
-        with self.assert_signal_sent(api, 'thread_created', sender=None, user=self.user, exclude_args=('post',)):
+        with self.assert_signal_sent(
+            api, 'thread_created', sender=None, user=self.user, exclude_args=('post', 'notify_all_learners')
+        ):
             actual = create_thread(self.request, self.minimal_data)
         expected = self.expected_thread_data({
             "author_label": "Moderator",
@@ -2056,7 +2061,9 @@ class CreateThreadTest(
             "read": True,
         })
         self.register_post_thread_response(cs_thread)
-        with self.assert_signal_sent(api, 'thread_created', sender=None, user=self.user, exclude_args=('post',)):
+        with self.assert_signal_sent(
+            api, 'thread_created', sender=None, user=self.user, exclude_args=('post', 'notify_all_learners')
+        ):
             create_thread(self.request, data)
         event_name, event_data = mock_emit.call_args[0]
         assert event_name == 'edx.forum.thread.created'

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -190,35 +190,46 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
         """
 
     @ddt.data(
-        ('new_question_post', False),
-        ('new_discussion_post', False),
-        ('new_discussion_post', True),
+        ('new_question_post', False, False),
+        ('new_discussion_post', False, False),
+        ('new_discussion_post', True, True),
+        ('new_discussion_post', True, False),
     )
     @ddt.unpack
-    @mock.patch('lms.djangoapps.discussion.rest_api.utils.can_user_notify_all_learners', return_value=True)
-    @override_waffle_flag(ENABLE_NOTIFY_ALL_LEARNERS, active=True)
     def test_notification_is_send_to_all_enrollments(
-        self, notification_type, notify_all_learners, mock_notify_all_learners
+        self, notification_type, notify_all_learners, waffle_flag_enabled
     ):
         """
         Tests notification is sent to all users if course is not cohorted
         """
         self._assign_enrollments()
         thread_type = (
-            "discussion"
-            if notification_type == "new_discussion_post"
-            else ("question" if notification_type == "new_question_post" else "")
+            "discussion" if notification_type == "new_discussion_post" else "question"
         )
-        thread = self._create_thread(thread_type=thread_type)
-        handler = mock.Mock()
-        COURSE_NOTIFICATION_REQUESTED.connect(handler)
-        send_thread_created_notification(thread['id'], str(self.course.id), self.author.id, notify_all_learners)
-        self.assertEqual(handler.call_count, 1)
-        course_notification_data = handler.call_args[1]['course_notification_data']
-        assert course_notification_data.notification_type == 'new_instructor_all_learners_post' if notify_all_learners \
-            else notification_type
-        notification_audience_filters = {}
-        assert notification_audience_filters == course_notification_data.audience_filters
+
+        with override_waffle_flag(ENABLE_NOTIFY_ALL_LEARNERS, active=waffle_flag_enabled):
+            thread = self._create_thread(thread_type=thread_type)
+            handler = mock.Mock()
+            COURSE_NOTIFICATION_REQUESTED.connect(handler)
+
+            send_thread_created_notification(
+                thread['id'],
+                str(self.course.id),
+                self.author.id,
+                notify_all_learners
+            )
+            expected_handler_calls = 0 if notify_all_learners and not waffle_flag_enabled else 1
+            self.assertEqual(handler.call_count, expected_handler_calls)
+
+            if handler.call_count:
+                course_notification_data = handler.call_args[1]['course_notification_data']
+                expected_type = (
+                    'new_instructor_all_learners_post'
+                    if notify_all_learners and waffle_flag_enabled
+                    else notification_type
+                )
+                self.assertEqual(course_notification_data.notification_type, expected_type)
+                self.assertEqual(course_notification_data.audience_filters, {})
 
     @ddt.data(
         ('cohort_1', 'new_question_post'),

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -557,6 +557,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "edit_reasons": [{"code": "test-edit-reason", "label": "Test Edit Reason"}],
                 "post_close_reasons": [{"code": "test-close-reason", "label": "Test Close Reason"}],
                 'show_discussions': True,
+                'is_notify_all_learners_enabled': False
             }
         )
 

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -11,6 +11,7 @@ from pytz import UTC
 
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFY_ALL_LEARNERS
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, PostingRestriction
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -379,3 +380,25 @@ def is_posting_allowed(posting_restrictions: str, blackout_schedules: List):
         return not any(schedule["start"] <= now <= schedule["end"] for schedule in blackout_schedules)
     else:
         return False
+
+
+def can_user_notify_all_learners(course_key, user_roles, is_course_staff, is_course_admin):
+    """
+    Check if user posting is allowed to notify all learners based on the given restrictions
+
+    Args:
+        course_key (CourseKey): CourseKey for which user creating any discussion post.
+        user_roles (Dict): Roles of the posting user
+        is_course_staff (Boolean): Whether the user has a course staff access.
+        is_course_admin (Boolean): Whether the user has a course admin access.
+
+    Returns:
+        bool: True if posting for all learner is allowed to this user, False otherwise.
+    """
+    is_staff_or_instructor = any([
+        user_roles.intersection({FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR}),
+        is_course_staff,
+        is_course_admin,
+    ])
+
+    return is_staff_or_instructor and ENABLE_NOTIFY_ALL_LEARNERS.is_enabled(course_key)

--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -166,7 +166,10 @@ def create_thread_created_notification(*args, **kwargs):
     """
     user = kwargs['user']
     post = kwargs['post']
-    send_thread_created_notification.apply_async(args=[post.id, post.attributes['course_id'], user.id])
+    notify_all_learners = kwargs.get('notify_all_learners', False)
+    send_thread_created_notification.apply_async(
+        args=[post.id, post.attributes['course_id'], user.id, notify_all_learners]
+    )
 
 
 @receiver(signals.comment_created)

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -3,6 +3,8 @@ Base setup for Notification Apps and Types.
 """
 from django.utils.translation import gettext_lazy as _
 
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFY_ALL_LEARNERS
+
 from .email_notifications import EmailCadence
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from .utils import find_app_in_normalized_apps, find_pref_in_normalized_prefs
@@ -229,6 +231,25 @@ COURSE_NOTIFICATION_TYPES = {
         },
         'email_template': '',
         'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE],
+    },
+    'new_instructor_all_learners_post': {
+        'notification_app': 'discussion',
+        'name': 'new_instructor_all_learners_post',
+        'is_core': False,
+        'info': '',
+        'web': True,
+        'email': False,
+        'email_cadence': EmailCadence.DAILY,
+        'push': False,
+        'non_editable': [],
+        'content_template': _('<{p}>Your instructor posted <{strong}>{post_title}</{strong}></{p}>'),
+        'grouped_content_template': '',
+        'content_context': {
+            'post_title': 'Post title',
+        },
+        'email_template': '',
+        'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE],
+        'waffle_flag': ENABLE_NOTIFY_ALL_LEARNERS
     },
 }
 

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -3,8 +3,6 @@ Base setup for Notification Apps and Types.
 """
 from django.utils.translation import gettext_lazy as _
 
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFY_ALL_LEARNERS
-
 from .email_notifications import EmailCadence
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from .utils import find_app_in_normalized_apps, find_pref_in_normalized_prefs
@@ -248,8 +246,7 @@ COURSE_NOTIFICATION_TYPES = {
             'post_title': 'Post title',
         },
         'email_template': '',
-        'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE],
-        'waffle_flag': ENABLE_NOTIFY_ALL_LEARNERS
+        'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE]
     },
 }
 

--- a/openedx/core/djangoapps/notifications/config/waffle.py
+++ b/openedx/core/djangoapps/notifications/config/waffle.py
@@ -49,3 +49,13 @@ ENABLE_ORA_GRADE_NOTIFICATION = CourseWaffleFlag(f"{WAFFLE_NAMESPACE}.enable_ora
 # .. toggle_warning: When the flag is ON, Notifications Grouping feature is enabled.
 # .. toggle_tickets: INF-1472
 ENABLE_NOTIFICATION_GROUPING = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_notification_grouping', __name__)
+
+# .. toggle_name: notifications.post_enable_notify_all_learners
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable the notify all learners on discussion post
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2025-06-11
+# .. toggle_warning: When the flag is ON, notification to all learners feature is enabled on discussion post.
+# .. toggle_tickets: INF-1917
+ENABLE_NOTIFY_ALL_LEARNERS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_post_notify_all_learners', __name__)

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -26,7 +26,7 @@ NOTIFICATION_CHANNELS = ['web', 'push', 'email']
 ADDITIONAL_NOTIFICATION_CHANNEL_SETTINGS = ['email_cadence']
 
 # Update this version when there is a change to any course specific notification type or app.
-COURSE_NOTIFICATION_CONFIG_VERSION = 13
+COURSE_NOTIFICATION_CONFIG_VERSION = 14
 
 
 def get_course_notification_preference_config():

--- a/openedx/core/djangoapps/notifications/tests/test_utils.py
+++ b/openedx/core/djangoapps/notifications/tests/test_utils.py
@@ -5,11 +5,15 @@ import copy
 import unittest
 
 import pytest
+from unittest.mock import patch
+
+from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFY_ALL_LEARNERS
 from openedx.core.djangoapps.django_comment_common.models import assign_role, FORUM_ROLE_MODERATOR
 from openedx.core.djangoapps.notifications.utils import aggregate_notification_configs, \
-    filter_out_visible_preferences_by_course_ids
+    filter_out_visible_preferences_by_course_ids, remove_disabled_flagged_notifications
 
 
 class TestAggregateNotificationConfigs(unittest.TestCase):
@@ -311,7 +315,10 @@ class TestVisibilityFilter(unittest.TestCase):
                     'core': {'web': True, 'push': True, 'email': True, 'email_cadence': 'Daily'},
                     'content_reported': {'web': True, 'push': True, 'email': True, 'email_cadence': 'Daily'},
                     'new_question_post': {'web': False, 'push': False, 'email': False, 'email_cadence': 'Daily'},
-                    'new_discussion_post': {'web': False, 'push': False, 'email': False, 'email_cadence': 'Daily'}
+                    'new_discussion_post': {'web': False, 'push': False, 'email': False, 'email_cadence': 'Daily'},
+                    'new_instructor_all_learners_post': {
+                        'web': True, 'push': False, 'email': False, 'email_cadence': 'Daily'
+                    }
                 },
                 'core_notification_types': [
                     'new_response', 'comment_on_followed_post',
@@ -344,3 +351,23 @@ class TestVisibilityFilter(unittest.TestCase):
         )
         assign_role(self.course_key, self.user, FORUM_ROLE_MODERATOR)
         assert updated_preferences == self.mock_preferences
+
+    @patch.object(ENABLE_NOTIFY_ALL_LEARNERS, 'is_enabled')
+    def test_visibility_of_flagged_notifications(self, mock_is_enabled):
+        """
+        Test that the preferences are filtered out correctly when the waffle flag is enabled and disabled.
+        """
+        course_keys = [CourseKey.from_string(self.course_key)]
+
+        for flag_state in [True, False]:
+            mock_is_enabled.return_value = flag_state
+
+            updated_preferences = remove_disabled_flagged_notifications(
+                copy.deepcopy(self.mock_preferences),
+                course_keys
+            )
+
+            if flag_state:
+                assert "new_instructor_all_learners_post" in updated_preferences["discussion"]["notification_types"]
+            else:
+                assert "new_instructor_all_learners_post" not in updated_preferences["discussion"]["notification_types"]

--- a/openedx/core/djangoapps/notifications/tests/test_utils.py
+++ b/openedx/core/djangoapps/notifications/tests/test_utils.py
@@ -5,15 +5,11 @@ import copy
 import unittest
 
 import pytest
-from unittest.mock import patch
-
-from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.student.tests.factories import UserFactory
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFY_ALL_LEARNERS
 from openedx.core.djangoapps.django_comment_common.models import assign_role, FORUM_ROLE_MODERATOR
 from openedx.core.djangoapps.notifications.utils import aggregate_notification_configs, \
-    filter_out_visible_preferences_by_course_ids, remove_disabled_flagged_notifications
+    filter_out_visible_preferences_by_course_ids
 
 
 class TestAggregateNotificationConfigs(unittest.TestCase):
@@ -351,23 +347,3 @@ class TestVisibilityFilter(unittest.TestCase):
         )
         assign_role(self.course_key, self.user, FORUM_ROLE_MODERATOR)
         assert updated_preferences == self.mock_preferences
-
-    @patch.object(ENABLE_NOTIFY_ALL_LEARNERS, 'is_enabled')
-    def test_visibility_of_flagged_notifications(self, mock_is_enabled):
-        """
-        Test that the preferences are filtered out correctly when the waffle flag is enabled and disabled.
-        """
-        course_keys = [CourseKey.from_string(self.course_key)]
-
-        for flag_state in [True, False]:
-            mock_is_enabled.return_value = flag_state
-
-            updated_preferences = remove_disabled_flagged_notifications(
-                copy.deepcopy(self.mock_preferences),
-                course_keys
-            )
-
-            if flag_state:
-                assert "new_instructor_all_learners_post" in updated_preferences["discussion"]["notification_types"]
-            else:
-                assert "new_instructor_all_learners_post" not in updated_preferences["discussion"]["notification_types"]

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -4,6 +4,8 @@ Utils function for notifications app
 import copy
 from typing import Dict, List, Set
 
+from opaque_keys.edx.keys import CourseKey
+
 from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment
 from openedx.core.djangoapps.django_comment_common.models import Role
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
@@ -117,6 +119,44 @@ def filter_out_visible_notifications(
     return user_preferences
 
 
+def filter_out_flagged_notifications(
+    user_preferences: dict,
+    waffle_flags: dict,
+    course_id
+) -> dict:
+    """
+    Removes flagged notification types from user preferences
+    only if their waffle flag is disabled for the course.
+    """
+    flagged_types = set(waffle_flags.keys())
+    for user_preferences_app, app_config in user_preferences.items():
+        notification_types = app_config.get('notification_types', {})
+        for notif_type in set(notification_types.keys()) & flagged_types:
+            flag = waffle_flags[notif_type]
+            if not flag.is_enabled(CourseKey.from_string(course_id)):
+                if notif_type in user_preferences[user_preferences_app]['notification_types']:
+                    user_preferences[user_preferences_app]['notification_types'].pop(notif_type)
+
+    return user_preferences
+
+
+@request_cached()
+def get_notification_types_with_waffle_flag() -> Dict[str, str]:
+    """
+    Get notification types with their waffle flag
+
+    :return: List of dictionaries with notification type names and corresponding waffle flag
+    """
+    from .base_notification import COURSE_NOTIFICATION_TYPES
+
+    notification_types_with_flags = {}
+    for notification_type in COURSE_NOTIFICATION_TYPES.values():
+        if notification_type.get('waffle_flag'):
+            notification_types_with_flags[notification_type['name']] = notification_type['waffle_flag']
+
+    return notification_types_with_flags
+
+
 def remove_preferences_with_no_access(preferences: dict, user) -> dict:
     """
     Filter out notifications visible to forum roles from user preferences.
@@ -128,15 +168,23 @@ def remove_preferences_with_no_access(preferences: dict, user) -> dict:
     user_preferences = preferences['notification_preference_config']
     user_forum_roles = get_user_forum_roles(user.id, preferences['course_id'])
     notifications_with_visibility_settings = get_notification_types_with_visibility_settings()
+    notifications_with_waffle_flag = get_notification_types_with_waffle_flag()
     user_course_roles = CourseAccessRole.objects.filter(
         user=user,
         course_id=preferences['course_id']
     ).values_list('role', flat=True)
-    preferences['notification_preference_config'] = filter_out_visible_notifications(
+
+    user_preferences = filter_out_visible_notifications(
         user_preferences,
         notifications_with_visibility_settings,
         user_forum_roles,
         user_course_roles
+    )
+
+    preferences['notification_preference_config'] = filter_out_flagged_notifications(
+        user_preferences,
+        notifications_with_waffle_flag,
+        course_id=preferences['course_id']
     )
     return preferences
 
@@ -280,3 +328,23 @@ def filter_out_visible_preferences_by_course_ids(user, preferences: Dict, course
         forum_roles,
         course_roles
     )
+
+
+def remove_disabled_flagged_notifications(preferences: Dict, course_keys: List[CourseKey]) -> Dict:
+    """
+    Remove notification types from preferences if their corresponding flag is disabled
+    for all given course_ids.
+    """
+    flagged_notifications = get_notification_types_with_waffle_flag()
+
+    for app_name, prefs in preferences.items():
+        notification_types = prefs.get('notification_types', {})
+
+        for notification_type in list(notification_types.keys()):
+            flag = flagged_notifications.get(notification_type)
+            if flag:
+                is_enabled_any = any(flag.is_enabled(course_key) for course_key in course_keys)
+                if not is_enabled_any:
+                    notification_types.pop(notification_type, None)
+
+    return preferences


### PR DESCRIPTION


## Description

This PR introduces a new notification type, new_instructor_all_learners_post, which enables course staff, course admins, discussion moderators, and discussion admins to create discussion or question posts that notify all learners. This functionality is controlled by the notifications.enable_post_notify_all_learners waffle flag, which must be enabled for the course. Web notifications are enabled by default for this notification type.

## Supporting ticket

https://2u-internal.atlassian.net/browse/INF-1917

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
