### PR TITLE
fix: generate IDV URL only if ACCOUNT_MICROFRONTEND_URL is available (#36898)

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -188,7 +188,7 @@ class Command(BaseCommand):
             return True
 
         site = Site.objects.get_current()
-        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -251,7 +251,7 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
         location = f'{account_base_url}/id-verification'
         if course_id:
             location += f'?course_id={quote(str(course_id))}'

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1128,7 +1128,7 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
         log.info("[COSMO-184] Denied verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
 
         attempt.deny(json.dumps(reason), error_code=error_code)
-        account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
         reverify_url = f'{account_base_url}/id-verification'
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -94,7 +94,7 @@ def create_email_template_context(username):
         'channel': 'email',
         'value': False
     }
-    account_base_url = settings.ACCOUNT_MICROFRONTEND_URL.rstrip('/')
+    account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
     return {
         "platform_name": settings.PLATFORM_NAME,
         "mailing_address": settings.CONTACT_MAILING_ADDRESS,


### PR DESCRIPTION

**Backport** of https://github.com/openedx/edx-platform/pull/36898

## Description
Fixes an issue with the identity verification URL when a user is enrolled in a verified course mode. More details can be seen in https://github.com/openedx/edx-platform/pull/36898

