### PR TITLE
[TNL-11998] fix: bson obj size error due to mongo aggregate func

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -25,6 +25,7 @@ from common.djangoapps.util.date_utils import get_default_time_display
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx_filters.content_authoring.filters import LMSPageURLRequested
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -194,7 +195,9 @@ def _assets_json(request, course_key):
     '''
     request_options = _parse_request_to_dictionary(request)
 
-    filter_parameters = {}
+    filter_parameters = {
+        'user_language': UserPreference.get_value(request.user, 'pref-lang') or 'en',
+    }
 
     if request_options['requested_asset_type']:
         filters_are_invalid_error = _get_error_if_invalid_parameters(request_options['requested_asset_type'])

--- a/xmodule/contentstore/mongo.py
+++ b/xmodule/contentstore/mongo.py
@@ -311,7 +311,9 @@ class MongoContentStore(ContentStore):
             md5: An md5 hash of the asset content
         '''
         query = query_for_course(course_key, 'asset' if not get_thumbnails else 'thumbnail')
+        user_language = 'en'
         if filter_params:
+            user_language = filter_params.pop('user_language', 'en')
             query.update(filter_params)
 
         # Count total matching documents
@@ -335,7 +337,9 @@ class MongoContentStore(ContentStore):
                     'thumbnail_location': 1,
                     'md5': 1
                 })
-                cursor = cursor.sort('displayname', sort['displayname']).collation({'locale': 'en', 'strength': 2})
+                cursor = cursor.sort('displayname', sort['displayname']).collation(
+                    {'locale': user_language, 'strength': 2}
+                )
             else:
                 # Apply simple sorting
                 sort_list = list(sort.items())

--- a/xmodule/contentstore/mongo.py
+++ b/xmodule/contentstore/mongo.py
@@ -310,71 +310,47 @@ class MongoContentStore(ContentStore):
             contentType: The mimetype string of the asset
             md5: An md5 hash of the asset content
         '''
-        # TODO: Using an aggregate() instead of a find() here is a hack to get around the fact that Mongo 3.2 does not
-        # support sorting case-insensitively.
-        # If a sort on displayname is requested, the aggregation pipeline creates a new field:
-        # `insensitive_displayname`, a lowercase version of `displayname` that is sorted on instead.
-        # Mongo 3.4 does not require this hack. When upgraded, change this aggregation back to a find and specifiy
-        # a collation based on user's language locale instead.
-        # See: https://openedx.atlassian.net/browse/EDUCATOR-2221
-        pipeline_stages = []
         query = query_for_course(course_key, 'asset' if not get_thumbnails else 'thumbnail')
         if filter_params:
             query.update(filter_params)
-        pipeline_stages.append({'$match': query})
 
+        # Count total matching documents
+        count = self.fs_files.count_documents(query)
+
+        sort_list = []
         if sort:
             sort = dict(sort)
             if 'displayname' in sort:
-                pipeline_stages.append({
-                    '$project': {
-                        'contentType': 1,
-                        'locked': 1,
-                        'chunkSize': 1,
-                        'content_son': 1,
-                        'displayname': 1,
-                        'filename': 1,
-                        'length': 1,
-                        'import_path': 1,
-                        'uploadDate': 1,
-                        'thumbnail_location': 1,
-                        'md5': 1,
-                        'insensitive_displayname': {
-                            '$toLower': '$displayname'
-                        }
-                    }
+                # Apply case-insensitive sorting
+                cursor = self.fs_files.find(query, {
+                    'contentType': 1,
+                    'locked': 1,
+                    'chunkSize': 1,
+                    'content_son': 1,
+                    'displayname': 1,
+                    'filename': 1,
+                    'length': 1,
+                    'import_path': 1,
+                    'uploadDate': 1,
+                    'thumbnail_location': 1,
+                    'md5': 1
                 })
-                sort = {'insensitive_displayname': sort['displayname']}
-            pipeline_stages.append({'$sort': sort})
+                cursor = cursor.sort('displayname', sort['displayname']).collation({'locale': 'en', 'strength': 2})
+            else:
+                # Apply simple sorting
+                sort_list = list(sort.items())
+                cursor = self.fs_files.find(query).sort(sort_list)
+        else:
+            cursor = self.fs_files.find(query)
 
-        # This is another hack to get the total query result count, but only the Nth page of actual documents
-        # See: https://stackoverflow.com/a/39784851/6620612
-        pipeline_stages.append({'$group': {'_id': None, 'count': {'$sum': 1}, 'results': {'$push': '$$ROOT'}}})
+        # Apply pagination
+        if start > 0:
+            cursor = cursor.skip(start)
         if maxresults > 0:
-            pipeline_stages.append({
-                '$project': {
-                    'count': 1,
-                    'results': {
-                        '$slice': ['$results', start, maxresults]
-                    }
-                }
-            })
+            cursor = cursor.limit(maxresults)
 
-        cursor = self.fs_files.aggregate(pipeline_stages)
-        # Set values if result of query is empty
-        count = 0
-        assets = []
-        try:
-            result = cursor.next()
-            if result:
-                count = result['count']
-                assets = list(result['results'])
-        except StopIteration:
-            # Skip if no assets were returned
-            pass
-
-        # We're constructing the asset key immediately after retrieval from the database so that
-        # callers are insulated from knowing how our identifiers are stored.
+        assets = list(cursor)
+        # Construct asset keys
         for asset in assets:
             asset_id = asset.get('content_son', asset['_id'])
             asset['asset_key'] = course_key.make_asset_key(asset_id['category'], asset_id['name'])


### PR DESCRIPTION
Ticket: [TNL-11998](https://2u-internal.atlassian.net/browse/TNL-11998)
fix below bson_obj document size error due to mongo aggregate function by calculating the count and using find instead of aggregate. Size seemed to be increasing more than 16mb for the single document that aggregate function was creating.

This PR also resolves the #TODO that is mentioned in the removed changes.

```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/trace_utils.py", line 294, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 336, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapper_view
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/utils/decorators.py", line 134, in _wrapper_view
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/assets.py", line 54, in assets_handler
    return handle_assets(request, course_key_string, asset_key_string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/asset_storage_handlers.py", line 83, in handle_assets
    return _assets_json(request, course_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/asset_storage_handlers.py", line 226, in _assets_json
    assets, total_count = _get_assets_for_page(course_key, query_options)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/asset_storage_handlers.py", line 436, in _get_assets_for_page
    return contentstore().get_all_content_for_course(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/xmodule/contentstore/mongo.py", line 271, in get_all_content_for_course
    return self._get_all_content_for_course(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/mongodb_proxy.py", line 56, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/xmodule/contentstore/mongo.py", line 363, in _get_all_content_for_course
    cursor = self.fs_files.aggregate(pipeline_stages)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/collection.py", line 2448, in aggregate
    return self._aggregate(
           ^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/_csot.py", line 106, in csot_wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/collection.py", line 2355, in _aggregate
    return self.__database.client._retryable_read(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/_csot.py", line 106, in csot_wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/mongo_client.py", line 1465, in _retryable_read
    return func(session, server, sock_info, read_pref)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/aggregation.py", line 142, in get_cursor
    result = sock_info.command(
             ^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/helpers.py", line 275, in inner
    no_reauth = kwargs.pop("no_reauth", False)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/pymongo/client.py", line 236, in _trace_socket_command
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/helpers.py", line 279, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/pool.py", line 879, in command
    return command(
           ^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/network.py", line 166, in command
    helpers._check_command_response(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/pymongo/helpers.py", line 194, in _check_command_response
    raise OperationFailure(errmsg, code, response, max_wire_version)
pymongo.errors.OperationFailure: BSONObj size: 19117457 (0x123B591) is invalid. Size must be between 0 and 16793600(16MB) First element: _id: null, full error: {'ok': 0.0, 'errmsg': 'BSONObj size: 19117457 (0x123B591) is invalid. Size must be between 0 and 16793600(16MB) First element: _id: null', 'code': 10334, 'codeName': 'BSONObjectTooLarge', '$clusterTime': {'clusterTime': Timestamp(1750073176, 2), 'signature': {'hash': b'\xd7\xdd\xf4\x7f\xe4\xcea\xa1\xa7P\xba\xab\xcb\x12\x7f1A$(\xb4', 'keyId': 7471973240714297345}}, 'operationTime': Timestamp(1750073176, 2)}
```
