### PR TITLE
fix: use import_string instead of get_storage_class to import classes

### DIFF
--- a/xmodule/tabs.py
+++ b/xmodule/tabs.py
@@ -6,7 +6,7 @@ Implement CourseTab
 import logging
 from abc import ABCMeta
 
-from django.core.files.storage import get_storage_class
+from django.utils.module_loading import import_string
 from xblock.fields import List
 
 from edx_django_utils.plugins import PluginError
@@ -281,7 +281,7 @@ class TabFragmentViewMixin:
         Returns the view that will be used to render the fragment.
         """
         if not self._fragment_view:
-            self._fragment_view = get_storage_class(self.fragment_view_name)()
+            self._fragment_view = import_string(self.fragment_view_name)()
         return self._fragment_view
 
     def render_to_fragment(self, request, course, **kwargs):


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes: https://github.com/openedx/edx-platform/issues/36737

Originally, the intention of this fix was to deprecate `get_storage_class` and ensure backward compatibility between Django 4.2 and Django 5. However, I noticed that `get_storage_class` was being used to import a view class, which I believe is incorrect. Therefore, I replaced `get_storage_class` with a more appropriate function, `import_string`, which both addresses the issue and allows us to deprecate `get_storage_class`.
