### PR TITLE
[POC] feat: implement content restriction based on new user groups

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -909,6 +909,9 @@ def get_visibility_partition_info(xblock, course=None):
     team_user_partitions = get_user_partition_info(xblock, schemes=["team"], course=course)
     selectable_partitions += team_user_partitions
 
+    user_groups_partitions = get_user_partition_info(xblock, schemes=["user_group"], course=course)
+    selectable_partitions += user_groups_partitions
+
     course_key = xblock.scope_ids.usage_id.course_key
     is_library = isinstance(course_key, LibraryLocator)
     if not is_library and ContentTypeGatingConfig.current(course_key=course_key).studio_override_enabled:

--- a/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
@@ -19,6 +19,8 @@ from openedx.core import types
 from openedx.core.djangoapps.content.learning_sequences.api.processors.team_partition_groups \
     import TeamPartitionGroupsOutlineProcessor
 
+from openedx_user_groups.processors.user_group_partition_groups import UserGroupPartitionGroupsOutlineProcessor
+
 from ..data import (
     ContentErrorData,
     CourseLearningSequenceData,
@@ -333,6 +335,7 @@ def _get_user_course_outline_and_processors(course_key: CourseKey,  # lint-amnes
         ('enrollment_track_partitions', EnrollmentTrackPartitionGroupsOutlineProcessor),
         ('cohorts_partitions', CohortPartitionGroupsOutlineProcessor),
         ('teams_partitions', TeamPartitionGroupsOutlineProcessor),
+        ('user_groups_partitions', UserGroupPartitionGroupsOutlineProcessor),
     ]
 
     # Run each OutlineProcessor in order to figure out what items we have to


### PR DESCRIPTION
## Description

This is a Proof of Concept (POC) for the following Architectural Decision Records (ADR's):
- https://github.com/openedx/openedx-user-groups/pull/4
- https://github.com/openedx/openedx-user-groups/pull/5

This implementation adds support for the content restriction functionality currently available with **Cohorts, Teams, and Enrollment Track Groups**.

This implementation is based on the team's connection implemented in [this PR](https://github.com/openedx/edx-platform/pull/33788/).

## Related PRs

- https://github.com/openedx/openedx-user-groups/pull/8

## Supporting information

[User Groups Confluence Page](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4901404678/User+Groups)

## Testing instructions

1. Use the changes in the related PRs.
2. After creating your course, you'll need to turn on a course-level flag that enables user groups. Go to  `/admin/waffle_utils/waffleflagcourseoverridemodel`. Add a new flag using your new course ID and this Waffle flag: `user_groups.enable_user_groups`
3. Create user groups and add users to each one.
4. As course staff from Studio > [Your Course] > Course Outline > + New unit.
5. Configure the unit to restrict access using **User Groups**. Select the user groups for which you want to display the unit.
6. As a student from LMS > [Your Course] > Course Outline.
7. If you belong to any of the user groups that have access to the content, you will be able to see it.
8. If you don't belong to any of the user groups that have access to the content, you will not be able to view it.

https://github.com/user-attachments/assets/1640678d-4d1f-4c9b-9639-23c96fae5860

## Deadline

None