### PR TITLE
chore: Track 'notify all learners' option in event data

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -161,7 +161,7 @@ def add_truncated_title_to_event_data(event_data, full_title):
     event_data['title'] = full_title[:TRACKING_MAX_FORUM_TITLE]
 
 
-def track_thread_created_event(request, course, thread, followed, from_mfe_sidebar=False):
+def track_thread_created_event(request, course, thread, followed, from_mfe_sidebar=False, notify_all_learners=False):
     """
     Send analytics event for a newly created thread.
     """
@@ -172,7 +172,10 @@ def track_thread_created_event(request, course, thread, followed, from_mfe_sideb
         'thread_type': thread.thread_type,
         'anonymous': thread.anonymous,
         'anonymous_to_peers': thread.anonymous_to_peers,
-        'options': {'followed': followed},
+        'options': {
+            'followed': followed,
+            'notify_all_learners': notify_all_learners
+        },
         'from_mfe_sidebar': from_mfe_sidebar,
         # There is a stated desire for an 'origin' property that will state
         # whether this thread was created via courseware or the forum.

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1497,7 +1497,7 @@ def create_thread(request, thread_data):
     _do_extra_actions(api_thread, cc_thread, list(thread_data.keys()), actions_form, context, request)
 
     track_thread_created_event(request, course, cc_thread, actions_form.cleaned_data["following"],
-                               from_mfe_sidebar)
+                               from_mfe_sidebar, notify_all_learners)
 
     return api_thread
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -1411,7 +1411,10 @@ class CreateThreadTest(
             'title_truncated': False,
             'anonymous': False,
             'anonymous_to_peers': False,
-            'options': {'followed': False},
+            'options': {
+                'followed': False,
+                'notify_all_learners': False
+            },
             'id': 'test_id',
             'truncated': False,
             'body': 'Test body',
@@ -1500,7 +1503,10 @@ class CreateThreadTest(
                 "title_truncated": False,
                 "anonymous": False,
                 "anonymous_to_peers": False,
-                "options": {"followed": False},
+                "options": {
+                    "followed": False,
+                    "notify_all_learners": False
+                },
                 "id": "test_id",
                 "truncated": False,
                 "body": "Test body",
@@ -1536,7 +1542,10 @@ class CreateThreadTest(
             'title_truncated': True,
             'anonymous': False,
             'anonymous_to_peers': False,
-            'options': {'followed': False},
+            'options': {
+                'followed': False,
+                'notify_all_learners': False
+            },
             'id': 'test_id',
             'truncated': False,
             'body': 'Test body',


### PR DESCRIPTION

## Description

This PR enhances tracking events by including a flag that indicates whether the "Notify All Learners" option was selected when creating a discussion/question post.

## Supporting ticket

https://2u-internal.atlassian.net/browse/INF-1929

## Testing instructions

Verified that the flag is correctly recorded in the event stream when "Notify All Learners" is enabled when creating discussion/question post using snowflake.
