### PR TITLE
chore: remove django-webpack-loader constraint to allow newer versions

### DIFF
--- a/cms/conftest.py
+++ b/cms/conftest.py
@@ -50,7 +50,7 @@ def no_webpack_loader(monkeypatch):
     """
     monkeypatch.setattr(
         "webpack_loader.templatetags.webpack_loader.render_bundle",
-        lambda entry, extension=None, config='DEFAULT', attrs='': ''
+        lambda context, entry, extension=None, config='DEFAULT', attrs='': ''
     )
     monkeypatch.setattr(
         "webpack_loader.utils.get_as_tags",

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -66,7 +66,7 @@ TEST_ROOT = path("test_root")
 
 # Want static files in the same dir for running on jenkins.
 STATIC_ROOT = TEST_ROOT / "staticfiles"
-WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
+WEBPACK_LOADER['DEFAULT']['LOADER_CLASS'] = 'webpack_loader.loaders.FakeWebpackLoader'
 
 GITHUB_REPO_ROOT = TEST_ROOT / "data"
 DATA_DIR = TEST_ROOT / "data"

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -147,7 +147,7 @@ if not source:
     <%
         body = capture(caller.body)
     %>
-    ${HTML(render_bundle(entry, extension=None, config='DEFAULT', attrs=attrs))}
+    ${HTML(render_bundle({'request': request}, entry, extension=None, config='DEFAULT', attrs=attrs))}
     % if body:
       <script type="text/javascript">
         ${body | n, decode.utf8}
@@ -166,8 +166,8 @@ if not source:
         component as props.
     </%doc>
 
-    ${HTML(render_bundle(component))}
-    ${HTML(render_bundle('ReactRenderer'))}
+    ${HTML(render_bundle({"request": request}, component))}
+    ${HTML(render_bundle({"request": request}, 'ReactRenderer'))}
 
     <div id="${id}"></div>
     <script type="text/javascript">

--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,7 @@ TestCase.maxDiff = None
 def no_webpack_loader(monkeypatch):  # lint-amnesty, pylint: disable=missing-function-docstring
     monkeypatch.setattr(
         "webpack_loader.templatetags.webpack_loader.render_bundle",
-        lambda entry, extension=None, config='DEFAULT', attrs='': ''
+        lambda context, entry, extension=None, config='DEFAULT', attrs='': ''
     )
     monkeypatch.setattr(
         "webpack_loader.utils.get_as_tags",

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -95,7 +95,7 @@ PARENTAL_CONSENT_AGE_LIMIT = 13
 TEST_ROOT = path("test_root")
 # Want static files in the same dir for running on jenkins.
 STATIC_ROOT = TEST_ROOT / "staticfiles"
-WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = STATIC_ROOT / "webpack-stats.json"
+WEBPACK_LOADER['DEFAULT']['LOADER_CLASS'] = 'webpack_loader.loaders.FakeWebpackLoader'
 
 STATUS_MESSAGE_PATH = TEST_ROOT / "status_message.json"
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -29,11 +29,6 @@ Django<5.0
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35277
 django-oauth-toolkit==1.7.1
 
-# Date: 2021-05-17
-# greater version has breaking changes and requires some migration steps.
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35276
-django-webpack-loader==0.7.0
-
 # Date: 2023-06-20
 # Adding pin to avoid any major upgrade
 djangorestframework<3.15.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -369,9 +369,8 @@ django-waffle==4.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==0.7.0
+django-webpack-loader==3.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
 djangorestframework==3.14.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -604,9 +604,8 @@ django-waffle==4.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==0.7.0
+django-webpack-loader==3.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -439,9 +439,8 @@ django-waffle==4.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==0.7.0
+django-webpack-loader==3.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
 djangorestframework==3.14.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -469,9 +469,8 @@ django-waffle==4.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   edx-toggles
-django-webpack-loader==0.7.0
+django-webpack-loader==3.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
 djangorestframework==3.14.0


### PR DESCRIPTION
Fixes: #35276

### Description

This PR upgrades the `django-webpack-loader` library from **v0.7.0 to v3.2.1**, which introduces several **breaking changes** that required adjustments in both runtime logic and test configurations.

### Key Changes

* **Upgraded `django-webpack-loader`** from `0.7.0` → `3.2.1`.

  * The `render_bundle` template tag now **requires `context` as the first argument**, due to `@simple_tag(takes_context=True)`.
  * The context **must include an `HttpRequest` object**, so updates were made in Mako templates and views to ensure this.
  
![image](https://github.com/user-attachments/assets/0f8196b6-64fa-495c-a21f-9305285b06d5)

* **Updated frontend build setup**:

  * Installed `webpack-bundle-tracker` via `npm install --save-dev webpack-bundle-tracker`.
  * Rebuilt Webpack bundles using `npm run webpack`.
* **Updated `webpack-stats.json` format**:

  * Older versions accepted chunks like:

    ```json
    [{ "name": "commons.js", "path": "/..." }]
    ```
  * New format (required by `django-webpack-loader >= 1.x`) expects:

    ```json
    {
      "chunks": {
        "commons": ["commons.abc123.js"]
      }
    }
    ```
  * This change is now reflected in the Webpack config and build artifacts.
* **Fixed test compatibility**:

  * Introduced a `FakeWebpackLoader` for test environments to simulate a valid `webpack-stats.json` file and bypass strict validation.
  * Monkeypatched `render_bundle` in test contexts to support legacy test rendering.
