### PR TITLE
feat: add video duration value

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -50,6 +50,7 @@ from ..models import ComponentLink, ContainerLink
 from ..tasks import (
     create_or_update_upstream_links,
     handle_create_or_update_xblock_upstream_link,
+    handle_create_or_update_xblock_video_duration,
     handle_unlink_upstream_block,
     handle_unlink_upstream_container,
 )
@@ -269,6 +270,7 @@ def create_or_update_upstream_downstream_link_handler(**kwargs):
         return
 
     handle_create_or_update_xblock_upstream_link.delay(str(xblock_info.usage_key))
+    handle_create_or_update_xblock_video_duration.delay(str(xblock_info.usage_key))
 
 
 @receiver(XBLOCK_DELETED)

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -89,6 +89,7 @@ from .outlines import update_outline_from_modulestore
 from .outlines_regenerate import CourseOutlineRegenerate
 from .toggles import bypass_olx_failure_enabled
 from .utils import course_import_olx_validation_is_enabled
+from .video_utils import process_video_duration
 
 User = get_user_model()
 
@@ -1440,6 +1441,22 @@ def handle_create_or_update_xblock_upstream_link(usage_key):
     if not xblock.upstream or not xblock.upstream_version:
         return
     create_or_update_xblock_upstream_link(xblock, xblock.course_id)
+
+
+@shared_task
+@set_code_owner_attribute
+def handle_create_or_update_xblock_video_duration(usage_key):
+    """
+    Create or update upstream link for a single xblock.
+    """
+    ensure_cms("handle_create_or_update_xblock_upstream_link may only be executed in a CMS context")
+    store = modulestore()
+    try:
+        xblock = store.get_item(UsageKey.from_string(usage_key))
+    except (ItemNotFoundError, InvalidKeyError):
+        LOGGER.exception(f'Could not find item for given usage_key: {usage_key}')
+        return
+    process_video_duration(xblock)
 
 
 @shared_task

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3253,6 +3253,11 @@ class TestXBlockInfo(ItemTest):
 
     def setUp(self):
         super().setUp()
+        handle_create_or_update_xblock_video_duration = patch(
+            'cms.djangoapps.contentstore.signals.handlers.handle_create_or_update_xblock_video_duration'
+        )
+        handle_create_or_update_xblock_video_duration.start()
+        self.addCleanup(handle_create_or_update_xblock_video_duration.stop)
         user_id = self.user.id
         self.chapter = BlockFactory.create(
             parent_location=self.course.location,

--- a/xmodule/modulestore/mixed.py
+++ b/xmodule/modulestore/mixed.py
@@ -843,10 +843,13 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         course_key = xblock.location.course_key
         store = self._verify_modulestore_support(course_key, 'update_item')
         xblock = store.update_item(xblock, user_id, allow_not_found, **kwargs)
+        silence_update = kwargs.get("silence_update")
 
         def send_updated_event():
             # .. event_implemented_name: XBLOCK_UPDATED
             # .. event_type: org.openedx.content_authoring.xblock.updated.v1
+            if silence_update:
+                return
             XBLOCK_UPDATED.send_event(
                 time=datetime.now(timezone.utc),
                 xblock_info=XBlockData(

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -172,6 +172,11 @@ class CommonMixedModuleStoreSetup(CourseComparisonTest, OpenEdxEventsTestMixin):
             )
             create_or_update_xblock_upstream_link_patch.start()
             self.addCleanup(create_or_update_xblock_upstream_link_patch.stop)
+            handle_create_or_update_xblock_video_duration = patch(
+                'cms.djangoapps.contentstore.signals.handlers.handle_create_or_update_xblock_video_duration'
+            )
+            handle_create_or_update_xblock_video_duration.start()
+            self.addCleanup(handle_create_or_update_xblock_video_duration.stop)
             component_link_patch = patch(
                 'cms.djangoapps.contentstore.signals.handlers.ComponentLink'
             )

--- a/xmodule/video_block/video_xfields.py
+++ b/xmodule/video_block/video_xfields.py
@@ -154,6 +154,11 @@ class VideoFields:
         help=_("The last speed that the user specified for the video."),
         scope=Scope.user_state
     )
+    duration = Float(
+        help=_("Duration of the video in seconds."),
+        scope=Scope.settings,
+        default=0
+    )
     global_speed = Float(
         help=_("The default speed for the video."),
         scope=Scope.preferences,


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes: https://github.com/openedx/edx-platform/issues/36988

To collect the duration of all videos in a course, we can start by retrieving this information for YouTube-hosted videos. The process should be asynchronous to avoid negatively impacting the user experience, especially due to the latency of external API requests.

### Acceptance Criteria

- [x] Retrieve video duration using the Google (YouTube) API  
- [x] Trigger an asynchronous task via Celery when `XBLOCK_UPDATED` is received  
- [x] Store the duration value in the module store  

**Settings**

```yaml
TUTOR_GROVE_CMS_ENV: |
  YOUTUBE_API_KEY: "AIzaSyAIEDfEXOJ9OLrKWLvCs9KCW6nvwsHCOGU"
```