### PR TITLE
feat: added update api for account level preferences

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -1671,7 +1671,7 @@ class TestNotificationPreferencesView(APITestCase):
             "email_cadence": "Weekly"
         }
         __, core_types, __ = NotificationTypeManager().get_notification_app_preference('discussion')
-
+        self.client.get(self.url)
         response = self.client.put(self.url, update_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'success')
@@ -1689,7 +1689,7 @@ class TestNotificationPreferencesView(APITestCase):
             "notification_channel": "web",
             "value": True
         }
-
+        self.client.get(self.url)
         response = self.client.put(self.url, update_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'success')
@@ -1709,7 +1709,7 @@ class TestNotificationPreferencesView(APITestCase):
             "notification_channel": "email_cadence",
             "email_cadence": 'Weekly'
         }
-
+        self.client.get(self.url)
         response = self.client.put(self.url, update_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'success')

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -1676,8 +1676,8 @@ class TestNotificationPreferencesView(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'success')
         cadence_set = NotificationPreference.objects.filter(type__in=core_types).values_list('email_cadence', flat=True)
-        self.assertEqual(len(set(cadence_set)),1)
-        self.assertTrue('Weekly' in set(cadence_set))
+        self.assertEqual(len(set(cadence_set)), 1)
+        self.assertIn('Weekly', set(cadence_set))
 
     def test_update_preferences(self):
         """
@@ -1695,10 +1695,9 @@ class TestNotificationPreferencesView(APITestCase):
         self.assertEqual(response.data['status'], 'success')
         preference = NotificationPreference.objects.get(
             type='new_discussion_post',
-            user__id= self.user.id
+            user__id=self.user.id
         )
         self.assertEqual(preference.web, True)
-
 
     def test_update_preferences_non_core_email(self):
         """

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -44,7 +44,8 @@ from openedx.core.djangoapps.notifications.email.utils import update_user_prefer
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from ..base_notification import COURSE_NOTIFICATION_APPS, COURSE_NOTIFICATION_TYPES, NotificationAppManager
+from ..base_notification import COURSE_NOTIFICATION_APPS, COURSE_NOTIFICATION_TYPES, NotificationAppManager, \
+    NotificationTypeManager
 from ..utils import get_notification_types_with_visibility_settings
 
 User = get_user_model()
@@ -1658,3 +1659,63 @@ class TestNotificationPreferencesView(APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_preferences_core(self):
+        """
+        Test case: Update notification preferences for the authenticated user
+        """
+        update_data = {
+            "notification_app": "discussion",
+            "notification_type": "core",
+            "notification_channel": "email_cadence",
+            "email_cadence": "Weekly"
+        }
+        __, core_types, __ = NotificationTypeManager().get_notification_app_preference('discussion')
+
+        response = self.client.put(self.url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'success')
+        cadence_set = NotificationPreference.objects.filter(type__in=core_types).values_list('email_cadence', flat=True)
+        self.assertEqual(len(set(cadence_set)),1)
+        self.assertTrue('Weekly' in set(cadence_set))
+
+    def test_update_preferences(self):
+        """
+        Test case: Update notification preferences for the authenticated user
+        """
+        update_data = {
+            "notification_app": "discussion",
+            "notification_type": "new_discussion_post",
+            "notification_channel": "web",
+            "value": True
+        }
+
+        response = self.client.put(self.url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'success')
+        preference = NotificationPreference.objects.get(
+            type='new_discussion_post',
+            user__id= self.user.id
+        )
+        self.assertEqual(preference.web, True)
+
+
+    def test_update_preferences_non_core_email(self):
+        """
+        Test case: Update notification preferences for the authenticated user
+        """
+        update_data = {
+            "notification_app": "discussion",
+            "notification_type": "new_discussion_post",
+            "notification_channel": "email_cadence",
+            "email_cadence": 'Weekly'
+        }
+
+        response = self.client.put(self.url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'success')
+        preference = NotificationPreference.objects.get(
+            type='new_discussion_post',
+            user__id=self.user.id
+        )
+        self.assertEqual(preference.email_cadence, 'Weekly')

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -9,11 +9,9 @@ from django.db import transaction
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
-from rest_framework import generics, status, permissions
+from rest_framework import generics, status
 from rest_framework.decorators import api_view
 from rest_framework.generics import UpdateAPIView
 from rest_framework.response import Response
@@ -53,7 +51,6 @@ from .utils import (
     filter_out_visible_preferences_by_course_ids,
     get_show_notifications_tray
 )
-from ...lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 
 @allow_any_authenticated_user()
@@ -718,17 +715,12 @@ class NotificationPreferencesView(APIView):
         }, status=status.HTTP_200_OK)
 
 
+@allow_any_authenticated_user()
 class NotificationPreferencesView(APIView):
     """
     API view to retrieve and structure the notification preferences for the
     authenticated user.
     """
-    authentication_classes = (
-        JwtAuthentication,
-        BearerAuthenticationAllowInactiveUser,
-        SessionAuthenticationAllowInactiveUser,
-    )
-    permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request):
         """


### PR DESCRIPTION


This pull request introduces functionality to update user notification preferences via a new `PUT` API endpoint, along with corresponding test cases. The changes also include the addition of the `NotificationTypeManager` class to manage notification types more effectively.

### API Enhancements:
* Added a new `put` method in `openedx/core/djangoapps/notifications/views.py` to handle updates to user notification preferences. The method validates input, updates preferences based on the notification type and channel, and triggers the `notification_preference_update_event`.

### Test Coverage:
* Introduced three new test cases in `test_views.py` to verify the functionality of updating notification preferences:
  - [`test_update_preferences_core`](diffhunk://#diff-b4fa003e14372e818c8da4d9093f4039567c9399771374bd7b2008914db1e643R1631-R1690): Tests updating preferences for core notification types.
  - [`test_update_preferences`](diffhunk://#diff-b4fa003e14372e818c8da4d9093f4039567c9399771374bd7b2008914db1e643R1631-R1690): Tests updating preferences for non-core notification types.
  - [`test_update_preferences_non_core_email`](diffhunk://#diff-b4fa003e14372e818c8da4d9093f4039567c9399771374bd7b2008914db1e643R1631-R1690): Tests updating email cadence for non-core notification types.
