### PR TITLE
Unify Certificate Generation and Regeneration APIs into a Single Endpoint

### DIFF
--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -381,7 +381,35 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         assert (res_json['message'] ==
                 'Please select certificate statuses from the list only.')
 
-    def test_certificate_task_api_with_generation(self):
+    def test_certificate_task_api_without_action(self):
+        """
+        Test certificates task api endpoint returns success status when called with
+        valid course key and mode.
+        """
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
+        url = reverse('certificate_task', kwargs={'course_id': str(self.course.id)})
+        response = self.client.post(url)
+
+        assert response.status_code == 400
+        res_json = json.loads(response.content.decode('utf-8'))
+        assert res_json['message'] is not None
+        assert res_json['message']['api_action'][0] == "The 'api_action' field is required."
+
+    def test_certificate_task_api_with_invalid_action(self):
+        """
+        Test certificates task api endpoint returns success status when called with
+        valid course key and mode.
+        """
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
+        url = reverse('certificate_task', kwargs={'course_id': str(self.course.id)})
+        response = self.client.post(url, data={'api_action': 'invalid'})
+
+        assert response.status_code == 400
+        res_json = json.loads(response.content.decode('utf-8'))
+        assert res_json['message'] is not None
+        assert res_json['message']['api_action'][0] == "The 'api_action' must be either 'generate' or 'regenerate'."
+
+    def test_certificate_task_api_with_generate_action(self):
         """
         Test certificates task api endpoint returns success status when called with
         valid course key and mode.
@@ -395,7 +423,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         assert res_json['message'] is not None
         assert res_json['task_id'] is not None
 
-    def test_certificate_task_api_with_regeneration(self):
+    def test_certificate_task_api_with_regenerate_action(self):
         """
         Test certificate task api is successful when accessed with 'certificate_statuses'
         present in GeneratedCertificate table.

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -381,6 +381,51 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         assert (res_json['message'] ==
                 'Please select certificate statuses from the list only.')
 
+    def test_certificate_task_api_with_generation(self):
+        """
+        Test certificates task api endpoint returns success status when called with
+        valid course key and mode.
+        """
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
+        url = reverse('certificate_task', kwargs={'course_id': str(self.course.id)})
+        response = self.client.post(url, data={'mode': 'generate'})
+
+        assert response.status_code == 200
+        res_json = json.loads(response.content.decode('utf-8'))
+        assert res_json['message'] is not None
+        assert res_json['task_id'] is not None
+
+    def test_certificate_task_api_with_regeneration(self):
+        """
+        Test certificate task api is successful when accessed with 'certificate_statuses'
+        present in GeneratedCertificate table.
+        """
+
+        # Create a generated Certificate of some user with status 'downloadable'
+        GeneratedCertificateFactory.create(
+            user=self.user,
+            course_id=self.course.id,
+            status=CertificateStatuses.downloadable,
+            mode='honor'
+        )
+
+        # Login the client and access the url with 'certificate_statuses'
+        self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
+        url = reverse('certificate_task', kwargs={'course_id': str(self.course.id)})
+        response = self.client.post(url, data={'mode': 'regenerate', 'certificate_statuses': [CertificateStatuses.downloadable]})
+
+        # Assert 200 status code in response
+        assert response.status_code == 200
+        res_json = json.loads(response.content.decode('utf-8'))
+
+        # Assert request is successful
+        assert res_json['success']
+
+        # Assert success message
+        assert res_json['message'] ==\
+               'Certificate regeneration task has been started.' \
+               ' You can view the status of the generation task in the "Pending Tasks" section.'
+
 
 @override_settings(CERT_QUEUE='certificates')
 @ddt.ddt

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -388,7 +388,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         """
         self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         url = reverse('certificate_task', kwargs={'course_id': str(self.course.id)})
-        response = self.client.post(url, data={'mode': 'generate'})
+        response = self.client.post(url, data={'api_action': 'generate'})
 
         assert response.status_code == 200
         res_json = json.loads(response.content.decode('utf-8'))
@@ -412,7 +412,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         # Login the client and access the url with 'certificate_statuses'
         self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         url = reverse('certificate_task', kwargs={'course_id': str(self.course.id)})
-        response = self.client.post(url, data={'mode': 'regenerate', 'certificate_statuses': [CertificateStatuses.downloadable]})
+        response = self.client.post(url, data={'api_action': 'regenerate', 'certificate_statuses': [CertificateStatuses.downloadable]})
 
         # Assert 200 status code in response
         assert response.status_code == 200

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3387,8 +3387,10 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
         response_payload = {}
         certificate_task = CertificateTaskSerializer(data=request.data)
 
-        if (certificate_task.is_valid() and
-            certificate_task.validated_data['api_action'] == 'generate'):
+        if not certificate_task.is_valid():
+            return JsonResponse({'message': certificate_task.errors}, status=400)
+
+        if certificate_task.validated_data['api_action'] == 'generate':
             """
              Generating certificates for all students enrolled in given course.
             """
@@ -3402,8 +3404,7 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
                 'task_id': task.task_id
             }
 
-        elif (certificate_task.is_valid() and
-              certificate_task.validated_data['api_action'] == 'regenerate'):
+        elif certificate_task.validated_data['api_action'] == 'regenerate':
             """
             certificate_statuses 'certificate_statuses' in POST data.
             """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3385,7 +3385,7 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
     def post(self, request, course_id):
         response_payload = {}
 
-        if request.POST.get('mode') == 'generate':
+        if request.POST.get('api_action') == 'generate':
             """
              Generating certificates for all students enrolled in given course.
             """
@@ -3399,7 +3399,7 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
                 'task_id': task.task_id
             }
 
-        if request.POST.get('mode') == 'regenerate':
+        elif request.POST.get('api_action') == 'regenerate':
             """
             certificate_statuses 'certificate_statuses' in POST data.
             """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3377,9 +3377,7 @@ class MarkStudentCanSkipEntranceExam(APIView):
 @method_decorator(transaction.non_atomic_requests, name='dispatch')
 class CertificateTask(DeveloperErrorViewMixin, APIView):
     permission_classes = (IsAuthenticated, permissions.InstructorPermission)
-    permission_name = None
-    statuses_serializer = CertificateStatusesSerializer
-    http_method_names = ['post']
+    permission_name = permissions.START_CERTIFICATE_GENERATION
 
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(transaction.non_atomic_requests)
@@ -3388,7 +3386,7 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
         certificate_task = CertificateTaskSerializer(data=request.data)
 
         if not certificate_task.is_valid():
-            return JsonResponse({'message': certificate_task.errors}, status=400)
+            return JsonResponse({'message': certificate_task.errors}, status=status.HTTP_400_BAD_REQUEST)
 
         if certificate_task.validated_data['api_action'] == 'generate':
             """
@@ -3410,12 +3408,12 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
             """
             self.permission_name = permissions.START_CERTIFICATE_REGENERATION
             course_key = CourseKey.from_string(course_id)
-            serializer = self.statuses_serializer(data=request.data)
+            serializer = CertificateStatusesSerializer(data=request.data)
 
             if not serializer.is_valid():
                 return JsonResponse(
                     {'message': _('Please select certificate statuses from the list only.')},
-                    status=400
+                    status=status.HTTP_400_BAD_REQUEST
                 )
 
             certificates_statuses = serializer.validated_data['certificate_statuses']

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3387,7 +3387,8 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
         response_payload = {}
         certificate_task = CertificateTaskSerializer(data=request.data)
 
-        if request.POST.get('api_action') == 'generate' and certificate_task.is_valid():
+        if (certificate_task.is_valid() and
+            certificate_task.validated_data['api_action'] == 'generate'):
             """
              Generating certificates for all students enrolled in given course.
             """
@@ -3401,7 +3402,8 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
                 'task_id': task.task_id
             }
 
-        elif request.POST.get('api_action') == 'regenerate' and certificate_task.is_valid():
+        elif (certificate_task.is_valid() and
+              certificate_task.validated_data['api_action'] == 'regenerate'):
             """
             certificate_statuses 'certificate_statuses' in POST data.
             """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -117,7 +117,8 @@ from lms.djangoapps.instructor.views.serializer import (
     UserSerializer,
     UniqueStudentIdentifierSerializer,
     ProblemResetSerializer,
-    RescoreEntranceExamSerializer
+    RescoreEntranceExamSerializer,
+    CertificateTaskSerializer
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort, is_course_cohorted
@@ -3384,8 +3385,9 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
     @method_decorator(transaction.non_atomic_requests)
     def post(self, request, course_id):
         response_payload = {}
+        certificate_task = CertificateTaskSerializer(data=request.data)
 
-        if request.POST.get('api_action') == 'generate':
+        if request.POST.get('api_action') == 'generate' and certificate_task.is_valid():
             """
              Generating certificates for all students enrolled in given course.
             """
@@ -3399,7 +3401,7 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
                 'task_id': task.task_id
             }
 
-        elif request.POST.get('api_action') == 'regenerate':
+        elif request.POST.get('api_action') == 'regenerate' and certificate_task.is_valid():
             """
             certificate_statuses 'certificate_statuses' in POST data.
             """
@@ -3422,6 +3424,7 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
             }
 
         return JsonResponse(response_payload)
+
 
 @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
 @method_decorator(transaction.non_atomic_requests, name='dispatch')

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3383,12 +3383,12 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
     @method_decorator(transaction.non_atomic_requests)
     def post(self, request, course_id):
         response_payload = {}
-        certificate_task = CertificateTaskSerializer(data=request.data)
+        task_serializer = CertificateTaskSerializer(data=request.data)
 
-        if not certificate_task.is_valid():
-            return JsonResponse({'message': certificate_task.errors}, status=status.HTTP_400_BAD_REQUEST)
+        if not task_serializer.is_valid():
+            return JsonResponse({'message': task_serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
-        if certificate_task.validated_data['api_action'] == 'generate':
+        if task_serializer.validated_data['api_action'] == 'generate':
             """
              Generating certificates for all students enrolled in given course.
             """
@@ -3402,21 +3402,21 @@ class CertificateTask(DeveloperErrorViewMixin, APIView):
                 'task_id': task.task_id
             }
 
-        elif certificate_task.validated_data['api_action'] == 'regenerate':
+        elif task_serializer.validated_data['api_action'] == 'regenerate':
             """
             certificate_statuses 'certificate_statuses' in POST data.
             """
             self.permission_name = permissions.START_CERTIFICATE_REGENERATION
             course_key = CourseKey.from_string(course_id)
-            serializer = CertificateStatusesSerializer(data=request.data)
+            status_serializer = CertificateStatusesSerializer(data=request.data)
 
-            if not serializer.is_valid():
+            if not status_serializer.is_valid():
                 return JsonResponse(
                     {'message': _('Please select certificate statuses from the list only.')},
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
-            certificates_statuses = serializer.validated_data['certificate_statuses']
+            certificates_statuses = status_serializer.validated_data['certificate_statuses']
             task_api.regenerate_certificates(request, course_key, certificates_statuses)
             response_payload = {
                 'message': _('Certificate regeneration task has been started. '

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -85,6 +85,7 @@ urlpatterns = [
     path('start_certificate_generation', api.StartCertificateGeneration.as_view(), name='start_certificate_generation'),
     path('start_certificate_regeneration', api.StartCertificateRegeneration.as_view(),
          name='start_certificate_regeneration'),
+    path('certificate_task/<course_id>', api.CertificateTask.as_view(), name='certificate_task'),
     path('certificate_exception_view/', api.CertificateExceptionView.as_view(), name='certificate_exception_view'),
     re_path(r'^generate_certificate_exceptions/(?P<generate_for>[^/]*)', api.GenerateCertificateExceptions.as_view(),
             name='generate_certificate_exceptions'),

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -85,7 +85,7 @@ urlpatterns = [
     path('start_certificate_generation', api.StartCertificateGeneration.as_view(), name='start_certificate_generation'),
     path('start_certificate_regeneration', api.StartCertificateRegeneration.as_view(),
          name='start_certificate_regeneration'),
-    path('certificate_task/<course_id>', api.CertificateTask.as_view(), name='certificate_task'),
+    re_path('certificate_task/<course_id>', api.CertificateTask.as_view(), name='certificate_task'),
     path('certificate_exception_view/', api.CertificateExceptionView.as_view(), name='certificate_exception_view'),
     re_path(r'^generate_certificate_exceptions/(?P<generate_for>[^/]*)', api.GenerateCertificateExceptions.as_view(),
             name='generate_certificate_exceptions'),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -400,6 +400,10 @@ def _section_certificates(course):
                 'list_instructor_tasks',
                 kwargs={'course_id': course.id}
             ),
+            'certificate_task': reverse(
+                'certificate_task',
+                kwargs={'course_id': course.id}
+            ),
         }
     }
 

--- a/lms/djangoapps/instructor/views/serializer.py
+++ b/lms/djangoapps/instructor/views/serializer.py
@@ -386,7 +386,9 @@ class CertificateTaskSerializer(serializers.Serializer):
     """
     Serializer for validating and serializing api_action
     """
-    api_action = serializers.ChoiceField(choices=[
-        'generate',
-        'regenerate'
-    ]),
+    api_action = serializers.ChoiceField(
+        choices=[
+            'generate',
+            'regenerate'
+        ]
+    ),

--- a/lms/djangoapps/instructor/views/serializer.py
+++ b/lms/djangoapps/instructor/views/serializer.py
@@ -387,8 +387,10 @@ class CertificateTaskSerializer(serializers.Serializer):
     Serializer for validating and serializing api_action
     """
     api_action = serializers.ChoiceField(
-        choices=[
-            'generate',
-            'regenerate'
-        ]
-    ),
+        choices=["generate", "regenerate"],
+        required=True,
+        error_messages={
+            "required": "The 'api_action' field is required.",
+            "invalid_choice": "The 'api_action' must be either 'generate' or 'regenerate'."
+        }
+    )

--- a/lms/djangoapps/instructor/views/serializer.py
+++ b/lms/djangoapps/instructor/views/serializer.py
@@ -380,3 +380,13 @@ class RescoreEntranceExamSerializer(serializers.Serializer):
     unique_student_identifier = serializers.CharField(required=False, allow_null=True)
     all_students = serializers.BooleanField(required=False)
     only_if_higher = serializers.BooleanField(required=False, allow_null=True)
+
+
+class CertificateTaskSerializer(serializers.Serializer):
+    """
+    Serializer for validating and serializing api_action
+    """
+    api_action = serializers.ChoiceField(choices=[
+        'generate',
+        'regenerate'
+    ]),

--- a/lms/static/js/instructor_dashboard/certificates.js
+++ b/lms/static/js/instructor_dashboard/certificates.js
@@ -52,6 +52,7 @@ var onCertificatesReady = null;
             var url = $btn_generating_certs.data('endpoint');
             $.ajax({
                 type: 'POST',
+                data: $('#certificates-generating-form').serializeArray(),
                 url: url,
                 success: function(data) {
                     $btn_generating_certs.attr('disabled', 'disabled');

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -85,6 +85,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
     <div class="start-certificate-generation">
         <h3 class="hd hd-3">${_("Generate Certificates")}</h3>
         <form id="certificates-generating-form" method="post" action="${section_data['urls']['certificate_task']}">
+            <input type="hidden" name="api_action" value="generate" />
             % if section_data['html_cert_enabled'] and section_data['active_certificate'] is None:
                 <p>${_("Course certificate generation requires an activated web certificate configuration.")}</p>
                 <input type="button" id="disabled-btn-start-generating-certificates" class="is-disabled" aria-disabled="true" value="${_('Generate Certificates')}"/>
@@ -116,6 +117,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
     <div class="start-certificate-regeneration">
         <h3 class="hd hd-3">${_("Regenerate Certificates")}</h3>
         <form id="certificate-regenerating-form" method="post" action="${section_data['urls']['certificate_task']}">
+            <input type="hidden" name="api_action" value="regenerate" />
             <p class="under-heading">
                 ${_('To regenerate certificates for your course, choose the learners who will receive regenerated certificates and click Regenerate Certificates.')}
             </p>

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -84,7 +84,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 
     <div class="start-certificate-generation">
         <h3 class="hd hd-3">${_("Generate Certificates")}</h3>
-        <form id="certificates-generating-form" method="post" action="${section_data['urls']['start_certificate_generation']}">
+        <form id="certificates-generating-form" method="post" action="${section_data['urls']['certificate_task']}">
             % if section_data['html_cert_enabled'] and section_data['active_certificate'] is None:
                 <p>${_("Course certificate generation requires an activated web certificate configuration.")}</p>
                 <input type="button" id="disabled-btn-start-generating-certificates" class="is-disabled" aria-disabled="true" value="${_('Generate Certificates')}"/>
@@ -92,7 +92,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                 <p class="under-heading">
                     ${_("When you are ready to generate certificates for your course, click Generate Certificates. You do not need to do this if you have set the certificate mode to on-demand generation.")}
                 </p>
-                <input type="button" class="btn-blue" id="btn-start-generating-certificates" value="${_('Generate Certificates')}" data-endpoint="${section_data['urls']['start_certificate_generation']}"/>
+                <input type="button" class="btn-blue" id="btn-start-generating-certificates" value="${_('Generate Certificates')}" data-endpoint="${section_data['urls']['certificate_task']}"/>
             %endif
         </form>
         <div class="certificate-generation-status"></div>
@@ -115,7 +115,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
     <hr>
     <div class="start-certificate-regeneration">
         <h3 class="hd hd-3">${_("Regenerate Certificates")}</h3>
-        <form id="certificate-regenerating-form" method="post" action="${section_data['urls']['start_certificate_regeneration']}">
+        <form id="certificate-regenerating-form" method="post" action="${section_data['urls']['certificate_task']}">
             <p class="under-heading">
                 ${_('To regenerate certificates for your course, choose the learners who will receive regenerated certificates and click Regenerate Certificates.')}
             </p>
@@ -152,7 +152,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                     </label>
                 </div>
             </fieldset>
-            <input type="button" class="btn-blue" id="btn-start-regenerating-certificates" value="${_('Regenerate Certificates')}" data-endpoint="${section_data['urls']['start_certificate_regeneration']}"/>
+            <input type="button" class="btn-blue" id="btn-start-regenerating-certificates" value="${_('Regenerate Certificates')}" data-endpoint="${section_data['urls']['certificate_task']}"/>
         </form>
         <div class="certificate-regeneration-status"></div>
     </div>


### PR DESCRIPTION
## Description

Introduce a unified API endpoint:
/certificate_task/<course_id>

Use a mode parameter in POST data to determine the action:

generate
regenerate
toggle

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

#36961 

## Testing instructions

Following test cases executed:

`pytest lms/djangoapps/instructor/tests/test_certificates.py::CertificatesInstructorApiTest::test_certificate_task_api_without_action`
`pytest lms/djangoapps/instructor/tests/test_certificates.py::CertificatesInstructorApiTest::test_certificate_task_api_with_invalid_action`
`pytest lms/djangoapps/instructor/tests/test_certificates.py::CertificatesInstructorApiTest::test_certificate_task_api_with_generate_action
`
`pytest lms/djangoapps/instructor/tests/test_certificates.py::CertificatesInstructorApiTest::test_certificate_task_api_with_regenerate_action
`