### PR TITLE
feat: migrate show_unit_extensions to DRF APIView.

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -112,6 +112,7 @@ from lms.djangoapps.instructor.views.serializer import (
     ModifyAccessSerializer,
     RoleNameSerializer,
     SendEmailSerializer,
+    ShowUnitExtensionsSerializer,
     ShowStudentExtensionSerializer,
     StudentAttemptsSerializer,
     UserSerializer,
@@ -139,11 +140,11 @@ from openedx.core.lib.courses import get_course_by_id
 from openedx.core.lib.api.serializers import CourseKeyField
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
 from .tools import (
+    DashboardError,
     dump_block_extensions,
     dump_student_extensions,
     find_unit,
     get_student_from_identifier,
-    handle_dashboard_error,
     keep_field_private,
     parse_datetime,
     set_due_date_extension,
@@ -3220,19 +3221,38 @@ class ResetDueDate(APIView):
             return JsonResponse({'error': str(error)}, status=400)
 
 
-@handle_dashboard_error
-@require_POST
-@ensure_csrf_cookie
-@cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.GIVE_STUDENT_EXTENSION)
-@require_post_params('url')
-def show_unit_extensions(request, course_id):
+@method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
+class ShowUnitExtensionsView(APIView):
     """
-    Shows all of the students which have due date extensions for the given unit.
+    API view to retrieve a list of students who have due date extensions
+    for a specific unit in a course.
     """
-    course = get_course_by_id(CourseKey.from_string(course_id))
-    unit = find_unit(course, request.POST.get('url'))
-    return JsonResponse(dump_block_extensions(course, unit))
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    serializer_class = ShowUnitExtensionsSerializer
+    permission_name = permissions.GIVE_STUDENT_EXTENSION
+
+    @method_decorator(ensure_csrf_cookie)
+    def post(self, request, course_id):
+        """
+        Shows all of the students which have due date extensions for the given unit.
+        """
+        try:
+            serializer = self.serializer_class(data=request.data)
+            serializer.is_valid(raise_exception=True)
+
+            url = serializer.validated_data['url']
+            course_key = CourseKey.from_string(course_id)
+            course = get_course_by_id(course_key)
+
+            self.check_object_permissions(request, course)
+
+            unit = find_unit(course, url)
+            data = dump_block_extensions(course, unit)
+
+            return Response(data)
+
+        except DashboardError as error:
+            return error.response()
 
 
 @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3236,19 +3236,16 @@ class ShowUnitExtensionsView(APIView):
         """
         Shows all of the students which have due date extensions for the given unit.
         """
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        url = serializer.validated_data['url']
+        course_key = CourseKey.from_string(course_id)
+        course = get_course_by_id(course_key)
+
         try:
-            serializer = self.serializer_class(data=request.data)
-            serializer.is_valid(raise_exception=True)
-
-            url = serializer.validated_data['url']
-            course_key = CourseKey.from_string(course_id)
-            course = get_course_by_id(course_key)
-
-            self.check_object_permissions(request, course)
-
             unit = find_unit(course, url)
             data = dump_block_extensions(course, unit)
-
             return Response(data)
 
         except DashboardError as error:

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -53,7 +53,7 @@ urlpatterns = [
     path('change_due_date', api.ChangeDueDate.as_view(), name='change_due_date'),
     path('send_email', api.SendEmail.as_view(), name='send_email'),
     path('reset_due_date', api.ResetDueDate.as_view(), name='reset_due_date'),
-    path('show_unit_extensions', api.show_unit_extensions, name='show_unit_extensions'),
+    path('show_unit_extensions', api.ShowUnitExtensionsView.as_view(), name='show_unit_extensions'),
     path('show_student_extensions', api.ShowStudentExtensions.as_view(), name='show_student_extensions'),
 
     # proctored exam downloads...

--- a/lms/djangoapps/instructor/views/serializer.py
+++ b/lms/djangoapps/instructor/views/serializer.py
@@ -125,6 +125,21 @@ class ShowStudentExtensionSerializer(serializers.Serializer):
         return user
 
 
+class ShowUnitExtensionsSerializer(serializers.Serializer):
+    """
+    Serializer for showing all students who have due date extensions
+    for a specific unit (block).
+
+    Fields:
+        url (str): The URL (block ID) of the unit for which student extensions should be retrieved.
+    """
+    url = serializers.CharField(
+        required=True,
+        max_length=2048,
+        help_text="The unit URL (block ID) to retrieve student extensions for."
+    )
+
+
 class StudentAttemptsSerializer(serializers.Serializer):
     """
     Serializer for resetting a students attempts counter or starts a task to reset all students


### PR DESCRIPTION
Resolves: https://github.com/openedx/edx-platform/issues/35359
## Testing Instructions

### **1. Testing Using Instructor Dashboard**

1. Go to this [URL](http://localhost:18000/courses/course-v1:ola+a1+2025/instructor#view-extensions)

   ![Instructor Dashboard](https://github.com/user-attachments/assets/5e1ae853-aa17-43e9-b95f-64a157ccb0f7)

2. Grant users an extension.

3. Under **"Viewing granted extensions"**, select the **subgraded section**.

   ![Subgraded Section](https://github.com/user-attachments/assets/7a541e79-3b05-49d1-8d73-5610fa9e5199)

4. Click **“List all students with due date extensions.”**

---

### **2. Testing Using Django REST Framework Web**

1. Go to this [URL](http://localhost:18000/courses/course-v1:ola+a1+2025/instructor/api/show_unit_extensions)

2. Use a unit URL identifier, for example:
`url = block-v1:edx+cs222+23111+type@sequential+block@14a256f0a4e44466978ec41fca103710
`

2. **Expected Results:**

   ![Expected Result 1](https://github.com/user-attachments/assets/19dd6877-e519-4305-8e0e-fd2197394d10)

   ![Expected Result 2](https://github.com/user-attachments/assets/478ddc4e-fbc4-49e4-8925-87078a22c494)

