### PR TITLE
fix: optimizer error due to duplicate ids at sections and subsections level

### DIFF
--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -251,7 +251,7 @@ CATEGORY_TO_LEVEL_MAP = {
 }
 
 
-def _create_dto_recursive(xblock_node, xblock_dictionary):
+def _create_dto_recursive(xblock_node, xblock_dictionary, parent_id=None):
     """
     Recursively build the Data Transfer Object by using
     the structure from the node tree and data from the dictionary.
@@ -264,7 +264,7 @@ def _create_dto_recursive(xblock_node, xblock_dictionary):
     xblock_children = []
 
     for xblock_id, node in xblock_node.items():
-        child_blocks = _create_dto_recursive(node, xblock_dictionary)
+        child_blocks = _create_dto_recursive(node, xblock_dictionary, parent_id=xblock_id)
         xblock_data = xblock_dictionary.get(xblock_id, {})
 
         xblock_entry = {
@@ -281,6 +281,13 @@ def _create_dto_recursive(xblock_node, xblock_dictionary):
             })
         else:   # Non-leaf node
             category = xblock_data.get('category', None)
+            # If parent and child has same IDs and level is 'sections', change it to 'subsections'
+            # And if parent and child has same IDs and level is 'subsections', change it to 'units'
+            if xblock_id == parent_id:
+                if category == "chapter":
+                    category = "sequential"
+                elif category == "sequential":
+                    category = "vertical"
             level = CATEGORY_TO_LEVEL_MAP.get(category, None)
             xblock_entry.update(child_blocks)
 


### PR DESCRIPTION
Ticket: [TNL-12034](https://2u-internal.atlassian.net/browse/TNL-12034)
In this PR, fix optimizer error due to duplicate ids at sections and subsections level.
If Section has only 1 subsection with same ID and it has broken links, then this error will occur.

**Before:**
![before](https://github.com/user-attachments/assets/602611d5-7509-4f7d-a4a1-62c5816a43ae)

**After:**
<img width="1792" alt="Screenshot 2025-07-07 at 3 24 45 PM" src="https://github.com/user-attachments/assets/02ca0e89-ca13-4b9f-beee-c4877d8c15ec" />

error log:
```
File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/serializers.py", line 687, in <listcomp>
    self.child.to_representation(item) for item in iterable
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/serializers.py", line 509, in to_representation
    attribute = field.get_attribute(instance)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/fields.py", line 479, in get_attribute
    raise type(exc)(msg)
KeyError: "Got KeyError when attempting to get a value for field `subsections` on serializer `LinkCheckSectionSerializer`.
The serializer field might be named incorrectly and not match any attribute or key on the `dict` instance.
Original exception text was: 'subsections'."
```