### PR TITLE
feat: updated management command to use default preferences

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -130,7 +130,7 @@ COURSE_NOTIFICATION_TYPES = {
         'web': True,
         'email': True,
         'email_cadence': EmailCadence.DAILY,
-        'push': True,
+        'push': False,
         'non_editable': [],
         'content_template': _('<p><strong>{username}’s </strong> {content_type} has been reported <strong> {'
                               'content}</strong></p>'),
@@ -179,7 +179,7 @@ COURSE_NOTIFICATION_TYPES = {
         'info': '',
         'web': True,
         'email': False,
-        'push': True,
+        'push': False,
         'email_cadence': EmailCadence.DAILY,
         'non_editable': [],
         'content_template': _('<{p}><{strong}>{course_update_content}</{strong}></{p}>'),

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -338,7 +338,7 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                         'content_reported': {
                             'web': True,
                             'email': True,
-                            'push': True,
+                            'push': False,
                             'info': '',
                             'email_cadence': 'Daily',
                         },
@@ -352,7 +352,7 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                         'course_updates': {
                             'web': True,
                             'email': False,
-                            'push': True,
+                            'push': False,
                             'email_cadence': 'Daily',
                             'info': ''
                         },
@@ -1455,7 +1455,7 @@ class TestNotificationPreferencesView(APITestCase):
                         "content_reported": {
                             "web": True,
                             "email": True,
-                            "push": True,
+                            "push": False,
                             "email_cadence": "Daily"
                         },
                         "new_instructor_all_learners_post": {
@@ -1480,7 +1480,7 @@ class TestNotificationPreferencesView(APITestCase):
                         "course_updates": {
                             "web": True,
                             "email": False,
-                            "push": True,
+                            "push": False,
                             "email_cadence": "Daily"
                         },
                         "core": {


### PR DESCRIPTION
## Description
This pull request introduces changes to the notification system to enhance flexibility and control over notification preferences during the migration process. The most significant updates include disabling push notifications by default, adding support for specifying default notification channels during migration, and expanding test coverage for these new features.

### Notification Defaults:
* Disabled push notifications by default in the `base_notification.py` configuration for both daily and course update notifications. 

### Migration Command Enhancements:
* Added a new `--use-default` argument to the `migrate_preferences_to_account_level_model` management command, enabling users to specify which notification channels (e.g., `web`, `push`, `email`) should use default values during migration. 
