### PR TITLE
fix: use correct studio resource url call

### DIFF
--- a/cms/lib/xblock/authoring_mixin.py
+++ b/cms/lib/xblock/authoring_mixin.py
@@ -43,7 +43,7 @@ class AuthoringMixin(XBlockMixin):
             'xblock': self,
             'manage_groups_url': reverse_course_url('group_configurations_list_handler', self.location.course_key),
         }))
-        fragment.add_javascript_url(self._get_studio_resource_url('/js/xblock/authoring.js'))
+        fragment.add_javascript_url(self._get_studio_resource_url('js/xblock/authoring.js'))
         fragment.initialize_js('VisibilityEditorInit')
         return fragment
 

--- a/cms/lib/xblock/tagging/tagging.py
+++ b/cms/lib/xblock/tagging/tagging.py
@@ -66,7 +66,7 @@ class StructuredTagsAside(XBlockAside):
             fragment = Fragment(render_to_string('structured_tags_block.html', {'tags': tags,
                                                                                 'tags_count': len(tags),
                                                                                 'block_location': block.location}))
-            fragment.add_javascript_url(self._get_studio_resource_url('/js/xblock_asides/structured_tags.js'))
+            fragment.add_javascript_url(self._get_studio_resource_url('js/xblock_asides/structured_tags.js'))
             fragment.initialize_js('StructuredTagsInit')
             return fragment
         else:


### PR DESCRIPTION
## Description

`authoring.js` was not loading in legacy studio unit page because it was being requested with `/static/studio//js/xblock/authoring.js` instead of `/static/studio/js/xblock/authoring.js`. This causes the visibility setting modal on the unit page to open without a save/cancel button. The modal could not be closed and visibility settings not be saved.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-12026

## Testing instructions

Local testing doesn't completely work because `/static/studio//js/xblock/authoring.js` is accessible locally for some reason. However, you can view the network tab while opening the visibility settings on the unit page and look for a call to `/static/studio//js/xblock/authoring.js`. Make sure the waffle flag: `legacy_studio.unit_editor` is turned on so you can access this unit page.

This can be tested on stage by opening the visibility settings on a unit page.

