### PR TITLE
chore: Update notification preferences for non-editable push notifications

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -61,7 +61,7 @@ COURSE_NOTIFICATION_TYPES = {
         'email': False,
         'email_cadence': EmailCadence.DAILY,
         'push': False,
-        'non_editable': [],
+        'non_editable': ['push'],
         'content_template': _('<{p}><{strong}>{username}</{strong}> posted <{strong}>{post_title}</{strong}></{p}>'),
         'grouped_content_template': _('<{p}><{strong}>{replier_name}</{strong}> and others started new discussions'
                                       '</{p}>'),
@@ -81,7 +81,7 @@ COURSE_NOTIFICATION_TYPES = {
         'email': False,
         'email_cadence': EmailCadence.DAILY,
         'push': False,
-        'non_editable': [],
+        'non_editable': ['push'],
         'content_template': _('<{p}><{strong}>{username}</{strong}> asked <{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',
@@ -131,7 +131,7 @@ COURSE_NOTIFICATION_TYPES = {
         'email': True,
         'email_cadence': EmailCadence.DAILY,
         'push': False,
-        'non_editable': [],
+        'non_editable': ['push'],
         'content_template': _('<p><strong>{username}’s </strong> {content_type} has been reported <strong> {'
                               'content}</strong></p>'),
 
@@ -181,7 +181,7 @@ COURSE_NOTIFICATION_TYPES = {
         'email': False,
         'push': False,
         'email_cadence': EmailCadence.DAILY,
-        'non_editable': [],
+        'non_editable': ['push'],
         'content_template': _('<{p}><{strong}>{course_update_content}</{strong}></{p}>'),
         'content_context': {
             'course_update_content': 'Course update',
@@ -198,7 +198,7 @@ COURSE_NOTIFICATION_TYPES = {
         'email': False,
         'push': False,
         'email_cadence': EmailCadence.DAILY,
-        'non_editable': [],
+        'non_editable': ['push'],
         'content_template': _('<{p}>You have a new open response submission awaiting review for '
                               '<{strong}>{ora_name}</{strong}></{p}>'),
         'grouped_content_template': _('<{p}>You have multiple submissions awaiting review for '
@@ -219,7 +219,7 @@ COURSE_NOTIFICATION_TYPES = {
         'email': True,
         'push': False,
         'email_cadence': EmailCadence.DAILY,
-        'non_editable': [],
+        'non_editable': ['push'],
         'content_template': _('<{p}>You have received {points_earned} out of {points_possible} on your assessment: '
                               '<{strong}>{ora_name}</{strong}></{p}>'),
         'content_context': {
@@ -239,7 +239,7 @@ COURSE_NOTIFICATION_TYPES = {
         'email': False,
         'email_cadence': EmailCadence.DAILY,
         'push': False,
-        'non_editable': [],
+        'non_editable': ['push'],
         'content_template': _('<{p}>Your instructor posted <{strong}>{post_title}</{strong}></{p}>'),
         'grouped_content_template': '',
         'content_context': {

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -290,12 +290,10 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
             enrollment=enrollment_data
         )
 
-    def _expected_api_response(self, course=None):
+    def _expected_api_response(self, is_staff=False):
         """
         Helper method to return expected API response.
         """
-        if course is None:
-            course = self.course
         response = {
             'id': 1,
             'course_name': 'course-v1:testorg+testcourse+testrun Course',
@@ -343,7 +341,10 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'email_cadence': 'Daily',
                         },
                     },
-                    'non_editable': {}
+                    'non_editable': {
+                        'new_discussion_post': ['push'],
+                        'new_question_post': ['push'],
+                    }
                 },
                 'updates': {
                     'enabled': True,
@@ -364,7 +365,9 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'info': 'Notifications for new announcements and updates from the course team.'
                         }
                     },
-                    'non_editable': {}
+                    'non_editable': {
+                        'course_updates': ['push']
+                    }
                 },
                 'grading': {
                     'enabled': True,
@@ -393,10 +396,17 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'info': ''
                         },
                     },
-                    'non_editable': {}
+                    'non_editable': {
+                        'ora_grade_assigned': ['push']
+                    }
                 }
             }
         }
+        if is_staff:
+            response['notification_preference_config']['grading']['non_editable'] = {
+                'ora_staff_notifications': ['push'],
+                'ora_grade_assigned': ['push']
+            }
         return response
 
     def test_get_user_notification_preference_without_login(self):
@@ -452,11 +462,10 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        expected_response = self._expected_api_response()
+        expected_response = self._expected_api_response(is_staff=bool(role))
 
         if not role:
             expected_response = remove_notifications_with_visibility_settings(expected_response)
-
         self.assertEqual(response.data, expected_response)
         event_name, event_data = mock_emit.call_args[0]
         self.assertEqual(event_name, 'edx.notifications.preferences.viewed')
@@ -1191,13 +1200,12 @@ class UpdateAllNotificationPreferencesViewTests(APITestCase):
         """
         data = {
             'notification_app': 'discussion',
-            'notification_type': 'content_reported',
-            'notification_channel': 'push',
+            'notification_type': 'core',
+            'notification_channel': 'web',
             'value': False
         }
 
         response = self.client.post(self.url, data, format='json')
-
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'success')
         self.assertEqual(response.data['data']['total_updated'], 3)
@@ -1205,7 +1213,8 @@ class UpdateAllNotificationPreferencesViewTests(APITestCase):
         # Verify database updates
         for pref in CourseNotificationPreference.objects.filter(is_active=True):
             self.assertFalse(
-                pref.notification_preference_config['discussion']['notification_types']['content_reported']['push']
+                pref.notification_preference_config['discussion'][
+                    'notification_types']['core']['web']
             )
 
     def test_update_non_editable_field(self):
@@ -1414,7 +1423,11 @@ class GetAggregateNotificationPreferencesTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         prefs = response.data['data']
         self.assertDictEqual(prefs['updates']['non_editable'], {'course_updates': ['email']})
-        self.assertDictEqual(prefs['discussion']['non_editable'], {'core': ['web']})
+        self.assertDictEqual(prefs['discussion']['non_editable'], {
+            'new_discussion_post': ['push'],
+            'new_question_post': ['push'],
+            'core': ['web']
+        })
 
 
 class TestNotificationPreferencesView(APITestCase):
@@ -1471,7 +1484,12 @@ class TestNotificationPreferencesView(APITestCase):
                             "email_cadence": "Daily"
                         }
                     },
-                    "non_editable": {}
+                    "non_editable": {
+                        "new_discussion_post": ["push"],
+                        "new_question_post": ["push"],
+                        "content_reported": ["push"],
+                        "new_instructor_all_learners_post": ["push"]
+                    }
                 },
                 "updates": {
                     "enabled": True,
@@ -1490,7 +1508,9 @@ class TestNotificationPreferencesView(APITestCase):
                             "email_cadence": "Daily"
                         }
                     },
-                    "non_editable": {}
+                    "non_editable": {
+                        "course_updates": ["push"],
+                    }
                 },
                 "grading": {
                     "enabled": True,
@@ -1515,7 +1535,10 @@ class TestNotificationPreferencesView(APITestCase):
                             "email_cadence": "Daily"
                         }
                     },
-                    "non_editable": {}
+                    "non_editable": {
+                        "ora_grade_assigned": ["push"],
+                        "ora_staff_notifications": ["push"]
+                    }
                 }
             }
         }
@@ -1596,7 +1619,12 @@ class TestNotificationPreferencesView(APITestCase):
                             "email_cadence": "Daily"
                         }
                     },
-                    "non_editable": {}
+                    "non_editable": {
+                        "new_discussion_post": ["push"],
+                        "new_question_post": ["push"],
+                        "content_reported": ["push"],
+                        "new_instructor_all_learners_post": ["push"]
+                    }
                 },
                 "updates": {
                     "enabled": True,
@@ -1615,7 +1643,9 @@ class TestNotificationPreferencesView(APITestCase):
                             "email_cadence": "Daily"
                         }
                     },
-                    "non_editable": {}
+                    "non_editable": {
+                        "course_updates": ["push"],
+                    }
                 },
                 "grading": {
                     "enabled": True,
@@ -1640,7 +1670,10 @@ class TestNotificationPreferencesView(APITestCase):
                             "email_cadence": "Daily"
                         }
                     },
-                    "non_editable": {}
+                    "non_editable": {
+                        "ora_grade_assigned": ["push"],
+                        "ora_staff_notifications": ["push"]
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR updates the notification preferences for notification types where the push notification channel should be non-editable.


## Supporting ticket

https://2u-internal.atlassian.net/browse/INF-2019


