### PR TITLE
feature: Added disable/enable discussion endpoint to swagger

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -22,6 +22,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiRequest, OpenApiResponse
 from edx_django_utils.monitoring import function_trace
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -1712,6 +1713,37 @@ def group_configurations_detail_handler(request, course_key_string, group_config
             )
 
 
+@extend_schema(
+    summary="Bulk enable/disable discussions for all units in a course.",
+    description="Enable or disable discussions for all verticals in the specified course.",
+    request=OpenApiRequest(
+        request={
+            "type": "object",
+            "properties": {"discussion_enabled": {"type": "boolean"}},
+            "required": ["discussion_enabled"],
+        }
+    ),
+    responses={
+        200: OpenApiResponse(
+            response={
+                "type": "object",
+                "properties": {"units_updated_and_republished": {"type": "integer"}},
+            }
+        ),
+        400: OpenApiResponse(description="Bad request"),
+        403: OpenApiResponse(description="Permission denied"),
+    },
+    methods=["PUT"],
+    parameters=[
+        OpenApiParameter(
+            name="course_key_string",
+            description="Course key string",
+            required=True,
+            type=str,
+            location=OpenApiParameter.PATH,
+        )
+    ],
+)
 @api_view(['PUT'])
 @view_auth_classes()
 @expect_json

--- a/cms/lib/spectacular.py
+++ b/cms/lib/spectacular.py
@@ -16,7 +16,8 @@ def cms_api_filter(endpoints):
             path.startswith("/api/contentstore/v0/videos") or
             path.startswith("/api/contentstore/v0/video_transcripts") or
             path.startswith("/api/contentstore/v0/file_assets") or
-            path.startswith("/api/contentstore/v0/youtube_transcripts")
+            path.startswith("/api/contentstore/v0/youtube_transcripts") or
+            path.startswith("/api/courses/") and "bulk_enable_disable_discussions" in path
         ):
             filtered.append((path, path_regex, method, callback))
     return filtered

--- a/cms/lib/spectacular.py
+++ b/cms/lib/spectacular.py
@@ -1,4 +1,6 @@
-""" Helper functions for drf-spectacular """
+"""Helper functions for drf-spectacular"""
+
+import re
 
 
 def cms_api_filter(endpoints):
@@ -7,17 +9,15 @@ def cms_api_filter(endpoints):
     Filter out endpoints that are not part of the CMS API.
     """
     filtered = []
-    for (path, path_regex, method, callback) in endpoints:
-        # Add only paths to the list that are part of the CMS API
-        if (
-            # Don't just replace this with /v1 when switching to a later version of the CMS API.
-            # That would include some unintended endpoints.
-            path.startswith("/api/contentstore/v0/xblock") or
-            path.startswith("/api/contentstore/v0/videos") or
-            path.startswith("/api/contentstore/v0/video_transcripts") or
-            path.startswith("/api/contentstore/v0/file_assets") or
-            path.startswith("/api/contentstore/v0/youtube_transcripts") or
-            path.startswith("/api/courses/") and "bulk_enable_disable_discussions" in path
+    CMS_PATH_PATTERN = re.compile(
+        r"^/api/contentstore/v0/(xblock|videos|video_transcripts|file_assets|youtube_transcripts)"
+    )
+
+    for path, path_regex, method, callback in endpoints:
+        if CMS_PATH_PATTERN.match(path) or (
+            path.startswith("/api/courses/")
+            and "bulk_enable_disable_discussions" in path
         ):
             filtered.append((path, path_regex, method, callback))
+
     return filtered


### PR DESCRIPTION
## Description
This pull request focuses on improving API visibility and developer experience by:

- Adding the `bulk_enable_disable_discussions` API endpoint to the Swagger (OpenAPI) documentation

- Creating internal documentation on how to add new endpoints to the CMS Swagger UI

## Documentation

**Confluence Page:**[ TNL-12056:  Add a New API to Swagger UI Using drf-spectacular](https://2u-internal.atlassian.net/wiki/spaces/TNL/pages/2139685025/TNL-12056+Add+a+New+API+to+Swagger+UI+Using+drf-spectacular)

A new Confluence page will be created to document the steps for:

- Registering new API endpoints with Swagger/OpenAPI

- Using `@extend_schema` from `drf-spectacular`

 
**CMS Swagger-UI** - `/authoring-api/ui/`


## Additional Information 

2U internal ticket : [TNL-12056](https://2u-internal.atlassian.net/browse/TNL-12056)