### PR TITLE
chore: Added logs in notification send function

### DIFF
--- a/openedx/core/djangoapps/notifications/push/tasks.py
+++ b/openedx/core/djangoapps/notifications/push/tasks.py
@@ -10,7 +10,7 @@ User = get_user_model()
 logger = get_task_logger(__name__)
 
 
-def send_ace_msg_to_push_channel(audience_ids, notification_object, sender_id):
+def send_ace_msg_to_push_channel(audience_ids, notification_object):
     """
     Send mobile notifications using ace to push channels.
     """

--- a/openedx/core/djangoapps/notifications/push/tests/test_tasks.py
+++ b/openedx/core/djangoapps/notifications/push/tests/test_tasks.py
@@ -36,11 +36,7 @@ class SendNotificationsTest(ModuleStoreTestCase):
     @mock.patch('openedx.core.djangoapps.notifications.push.tasks.ace.send')
     def test_send_ace_msg_success(self, mock_ace_send):
         """ Test send_ace_msg_success """
-        send_ace_msg_to_push_channel(
-            [self.user_1.id, self.user_2.id],
-            self.notification,
-            sender_id=self.user_1.id
-        )
+        send_ace_msg_to_push_channel([self.user_1.id, self.user_2.id], self.notification)
 
         mock_ace_send.assert_called_once()
         message_sent = mock_ace_send.call_args[0][0]
@@ -50,18 +46,14 @@ class SendNotificationsTest(ModuleStoreTestCase):
     @mock.patch('openedx.core.djangoapps.notifications.push.tasks.ace.send')
     def test_send_ace_msg_no_sender(self, mock_ace_send):
         """ Test when sender is not valid """
-        send_ace_msg_to_push_channel(
-            [self.user_1.id, self.user_2.id],
-            self.notification,
-            sender_id=999
-        )
+        send_ace_msg_to_push_channel([self.user_1.id, self.user_2.id], self.notification)
 
         mock_ace_send.assert_called_once()
 
     @mock.patch('openedx.core.djangoapps.notifications.push.tasks.ace.send')
     def test_send_ace_msg_empty_audience(self, mock_ace_send):
         """ Test send_ace_msg_success with empty audience """
-        send_ace_msg_to_push_channel([], self.notification, sender_id=self.user_1.id)
+        send_ace_msg_to_push_channel([], self.notification)
         mock_ace_send.assert_not_called()
 
     @mock.patch('openedx.core.djangoapps.notifications.push.tasks.ace.send')
@@ -69,5 +61,5 @@ class SendNotificationsTest(ModuleStoreTestCase):
         """ Test send_ace_msg_success with non-discussion app """
         self.notification.app_name = 'ecommerce'
         self.notification.save()
-        send_ace_msg_to_push_channel([1], self.notification, sender_id=self.user_1.id)
+        send_ace_msg_to_push_channel([1], self.notification)
         mock_ace_send.assert_not_called()


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR add logs and simplify a condition to make it easily readable. 

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
