### PR TITLE
fix: Improve error for missing (Translate)CustomTagBlock template #35829

### DIFF
--- a/xmodule/template_block.py
+++ b/xmodule/template_block.py
@@ -8,7 +8,6 @@ from lxml import etree
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 
-from openedx.core.djangolib.markup import Text
 from xmodule.editing_block import EditingMixin
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.raw_block import RawMixin

--- a/xmodule/template_block.py
+++ b/xmodule/template_block.py
@@ -17,6 +17,7 @@ from xmodule.xml_block import XmlMixin
 
 log = logging.getLogger(__name__)
 
+
 class CustomTagTemplateBlock(  # pylint: disable=abstract-method
     RawMixin,
     XmlMixin,
@@ -94,8 +95,8 @@ class CustomTagBlock(CustomTagTemplateBlock):  # pylint: disable=abstract-method
             template_block = system.get_block(template_loc)
             template_block_data = template_block.data
         except ItemNotFoundError as ex:
-            log.exception(f"Could not find template block for custom tag with Id {template_name}", )
-            template_block_data= f"Could not find template block for custom tag with Id {template_name}. Error: {ex}"
+            log.exception(f"Could not find template block for custom tag with Id {template_name}")
+            template_block_data = f"Could not find template block for custom tag with Id {template_name}. Error: {ex}"
 
         template = Template(template_block_data)
         return template.safe_substitute(params)

--- a/xmodule/template_block.py
+++ b/xmodule/template_block.py
@@ -76,7 +76,7 @@ class CustomTagBlock(CustomTagTemplateBlock):  # pylint: disable=abstract-method
         if not xml_data:
             return "Please set the template for this custom tag."
         xmltree = etree.fromstring(xml_data)
-        if 'impl' in xmltree.attrib:
+        if 'impl' in xmltree.attrib and xmltree.attrib['impl']:
             template_name = xmltree.attrib['impl']
         else:
             # VS[compat]  backwards compatibility with old nested customtag structure

--- a/xmodule/template_block.py
+++ b/xmodule/template_block.py
@@ -95,8 +95,8 @@ class CustomTagBlock(CustomTagTemplateBlock):  # pylint: disable=abstract-method
             template_block = system.get_block(template_loc)
             template_block_data = template_block.data
         except ItemNotFoundError as ex:
-            log.exception(f"Could not find template block for custom tag with Id {template_name}")
-            template_block_data = f"Could not find template block for custom tag with Id {template_name}. Error: {ex}"
+            template_block_data = f"Could not find template block for custom tag with Id {template_name}"
+            log.info(template_block_data)
 
         template = Template(template_block_data)
         return template.safe_substitute(params)


### PR DESCRIPTION
## Description

Under this PR I have fixed a open issue [35829](https://github.com/openedx/edx-platform/issues/35829). I have placed checks and exception handlers to gracefully inform the users.

## Supporting information

https://tasks.opencraft.com/browse/BB-9666

## Testing instructions

1. Check out [master/main](qasimgulzar:qasim/35829) on edx-platform allow CMS and LMS to reload.
2. Goto authering frontend.
3. Add new unit
4. click on `Advanced`
5. Select customtag/book (currently in master after adding empty customtag xblock it will show you error/500)
6. Verify you should be able to update customtag xml, you should also be able to remove this problem.
7. Screenshots and recording is attached for your reference

**Note**

I have used course attach to the [GITHUB ISSUE](https://github.com/openedx/edx-platform/issues/35829#issuecomment-2471198229) for testing.


<img width="1281" height="1247" alt="image" src="https://github.com/user-attachments/assets/b84fa0fd-19ea-4dcf-81b3-a4ddf60da34a" />

**Customtag with missing template.**
<img width="1528" height="812" alt="image" src="https://github.com/user-attachments/assets/142f9d52-bca7-4776-a54e-c7be16510427" />
