### PR TITLE
feat: add CMS base domain to enable session-based API access

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -350,6 +350,7 @@ SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX_TRIM': '/api/contentstore',
     'SERVERS': [
         {'url': AUTHORING_API_URL, 'description': 'Public'},
-        {'url': f'http://{CMS_BASE}/api/contentstore', 'description': 'Local'}
+        {'url': f'http://{CMS_BASE}', 'description': 'Local'},
+        {'url': f'http://{CMS_BASE}/api/contentstore', 'description': 'CMS-contentstore'}
     ],
 }

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -481,7 +481,8 @@ SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX_TRIM': '/api/contentstore',
     'SERVERS': [
         {'url': AUTHORING_API_URL, 'description': 'Public'},
-        {'url': f'https://{CMS_BASE}/api/contentstore', 'description': 'Local'},
+        {'url': f'https://{CMS_BASE}', 'description': 'Local'},
+        {'url': f'https://{CMS_BASE}/api/contentstore', 'description': 'CMS-contentstore'}
     ],
 }
 


### PR DESCRIPTION
 
## Description  

This pull request enhances API usability and improves the developer experience by:
 
- Introducing a new CMS base domain in the Swagger UI dropdown, allowing API access using Django sessions instead of requiring tokens.

---
 
## Documentation  

**Confluence Page:** [TNL-12056 – Add a New API to Swagger UI Using `drf-spectacular`](https://2u-internal.atlassian.net/wiki/spaces/TNL/pages/2139685025/TNL-12056+Add+a+New+API+to+Swagger+UI+Using+drf-spectacular)
 
---
 
## CMS Swagger UI Path  

`/authoring-api/ui/`
 
---
 
## Additional Information  

**2u Internal Ticket:**  
[TNL2-191](https://2u-internal.atlassian.net/browse/TNL2-191)
 