### PR TITLE
feat: added captcha validation in discussion thread/comment creation api

### DIFF
--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -3,6 +3,10 @@ Discussion settings.
 """
 from django.conf import settings
 
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+WAFFLE_NAMESPACE = 'discussion'
+
 # .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
@@ -17,3 +21,13 @@ ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""
     return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST', False)
+
+# .. toggle_name: discussion.enable_captcha
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable account level preferences for notifications
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2025-07-12
+# .. toggle_target_removal_date: 2025-07-29
+# .. toggle_warning: When the flag is ON, users will be able to see captcha for discussion.
+ENABLE_CAPTCHA_IN_DISCUSSION = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_captcha', __name__)

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -128,7 +128,7 @@ from .utils import (
     get_usernames_from_search_string,
     set_attribute,
     is_posting_allowed,
-    can_user_notify_all_learners
+    can_user_notify_all_learners, is_captcha_enabled
 )
 
 User = get_user_model()
@@ -378,6 +378,11 @@ def get_course(request, course_key, check_tab=True):
         'is_notify_all_learners_enabled': can_user_notify_all_learners(
             course_key, user_roles, is_course_staff, is_course_admin
         ),
+        'captcha_settings': {
+            'enabled': is_captcha_enabled(course_key),
+            'site_key': settings.RECAPTCHA_SITE_KEY,
+        }
+
     }
 
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -214,7 +214,11 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
             'edit_reasons': [{'code': 'test-edit-reason', 'label': 'Test Edit Reason'}],
             'post_close_reasons': [{'code': 'test-close-reason', 'label': 'Test Close Reason'}],
             'show_discussions': True,
-            'is_notify_all_learners_enabled': False
+            'is_notify_all_learners_enabled': False,
+            'captcha_settings': {
+                'enabled': False,
+                'site_key': '',
+            },
         }
 
     @ddt.data(

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -557,7 +557,11 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "edit_reasons": [{"code": "test-edit-reason", "label": "Test Edit Reason"}],
                 "post_close_reasons": [{"code": "test-close-reason", "label": "Test Close Reason"}],
                 'show_discussions': True,
-                'is_notify_all_learners_enabled': False
+                'is_notify_all_learners_enabled': False,
+                'captcha_settings': {
+                    'enabled': False,
+                    'site_key': '',
+                },
             }
         )
 

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -427,11 +427,11 @@ def verify_recaptcha_token(token):
         return False
 
 
-def is_captcha_enabled(course_id):
+def is_captcha_enabled(course_id) -> bool:
     """
     Check if reCAPTCHA is enabled for discussion posts in the given course.
     """
-    return ENABLE_CAPTCHA_IN_DISCUSSION.is_enabled(course_id) and settings.RECAPTCHA_PRIVATE_KEY
+    return bool(ENABLE_CAPTCHA_IN_DISCUSSION.is_enabled(course_id) and settings.RECAPTCHA_PRIVATE_KEY)
 
 
 def get_course_id_from_thread_id(thread_id: str) -> str:

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -673,7 +673,9 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
 
             if not verify_recaptcha_token(captcha_token):
                 return Response({'error': 'CAPTCHA verification failed.'}, status=400)
-        return Response(create_thread(request, request.data))
+        data = request.data.copy()
+        data.pop('captcha_token', None)
+        return Response(create_thread(request, data))
 
     def partial_update(self, request, thread_id):
         """
@@ -1038,6 +1040,8 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
 
             if not verify_recaptcha_token(captcha_token):
                 return Response({'error': 'CAPTCHA verification failed.'}, status=400)
+        data = request.data.copy()
+        data.pop('captcha_token', None)
         return Response(create_comment(request, request.data))
 
     def destroy(self, request, comment_id):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3378,7 +3378,6 @@ INSTALLED_APPS = [
     "openedx_learning.apps.authoring.sections",
 ]
 
-
 ######################### CSRF #########################################
 
 # Forwards-compatibility with Django 1.7
@@ -5674,3 +5673,13 @@ USE_EXTRACTED_PROBLEM_BLOCK = False
 # .. toggle_creation_date: 2024-11-10
 # .. toggle_target_removal_date: 2025-06-01
 USE_EXTRACTED_VIDEO_BLOCK = False
+
+# .. setting_name: RECAPTCHA_PRIVATE_KEY
+# .. setting_default: empty string
+# .. setting_description: Add recaptcha private key to use captcha feature in discussion app.
+RECAPTCHA_PRIVATE_KEY = ""
+
+# .. setting_name: RECAPTCHA_VERIFY_URL
+# .. setting_default: empty string
+# .. setting_description: Add recaptcha verification api url to verify capthca tokens.
+RECAPTCHA_VERIFY_URL = ""

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5683,3 +5683,8 @@ RECAPTCHA_PRIVATE_KEY = ""
 # .. setting_default: empty string
 # .. setting_description: Add recaptcha verification api url to verify capthca tokens.
 RECAPTCHA_VERIFY_URL = ""
+
+# .. setting_name: RECAPTCHA_SITE_KEY
+# .. setting_default: empty string
+# .. setting_description: Add recaptcha site key to use captcha feature in discussion MFE.
+RECAPTCHA_SITE_KEY = ""


### PR DESCRIPTION

This pull request introduces a reCAPTCHA feature in the discussion app to enhance security by verifying user actions, such as creating threads or comments. It includes changes to enable and configure reCAPTCHA, validate tokens, and enforce CAPTCHA checks for specific endpoints. 

Below are the most important changes grouped by theme:

### Feature Implementation: reCAPTCHA Support
* Added a new `CourseWaffleFlag` named `ENABLE_CAPTCHA_IN_DISCUSSION` in `lms/djangoapps/discussion/config/settings.py` to toggle reCAPTCHA functionality for discussion posts.
* Introduced helper functions `verify_recaptcha_token`, `is_captcha_enabled`, and `get_course_id_from_thread_id` in `lms/djangoapps/discussion/rest_api/utils.py` to handle token verification and course-specific CAPTCHA checks.
* Updated the `create` method in Thread and Comment views to validate the captcha if the waffle flag is enabled.

### Configuration Changes
Added new settings `RECAPTCHA_PRIVATE_KEY` and `RECAPTCHA_VERIFY_URL` in lms settings to configure the captcha service.

