### PR TITLE
fix: strip whitespace from URL causing broken link on Course Optimizer page

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1280,6 +1280,7 @@ async def _validate_url_access(session, url_data, course_key):
         }
     """
     block_id, url = url_data
+    url = url.strip()  # Trim leading/trailing whitespace
     result = {'block_id': block_id, 'url': url}
     standardized_url = _convert_to_standard_url(url, course_key)
     try:


### PR DESCRIPTION
## Description
This PR fixes a broken link that appeared on the **Course Optimizer page** due to leading or trailing whitespace in a URL string.  

## Additional Information
- Stripped whitespace from the affected URL using `.strip()`.

## Jira Tickets
- [TNL2-236](https://2u-internal.atlassian.net/browse/TNL2-236)
- [TNL2-261](https://2u-internal.atlassian.net/browse/TNL2-261)
- [TNL2-254](https://2u-internal.atlassian.net/browse/TNL2-254)
- [TNL2-250](https://2u-internal.atlassian.net/browse/TNL2-250)

## Screenshots

**Before**

<img width="1415" height="416" alt="image" src="https://github.com/user-attachments/assets/2a229d6a-7f9c-4b3c-ba58-d71815787f0b" />

**After**

<img width="800" height="199" alt="image" src="https://github.com/user-attachments/assets/42f2e629-b371-45c2-93f6-982be201bee5" />
