### PR TITLE
fix: include error_code in PreventRegistration exception response

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -600,7 +600,7 @@ class RegistrationView(APIView):
             errors = {
                 "error_message": [{"user_message": str(exc)}],
             }
-            return self._create_response(request, errors, status_code=exc.status_code)
+            return self._create_response(request, errors, status_code=exc.status_code, error_code=exc.error_code)
 
         response = self._handle_duplicate_email_username(request, data)
         if response:

--- a/openedx/core/djangoapps/user_authn/views/tests/test_filters.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_filters.py
@@ -50,7 +50,11 @@ class TestStopRegisterPipelineStep(PipelineStep):
 
     def run_filter(self, form_data):  # pylint: disable=arguments-differ
         """Pipeline steps that stops the user's registration process."""
-        raise StudentRegistrationRequested.PreventRegistration("You can't register on this site.", status_code=403)
+        raise StudentRegistrationRequested.PreventRegistration(
+            "You can't register on this site.",
+            status_code=403,
+            error_code="registration_not_allowed"
+        )
 
 
 class TestLoginPipelineStep(PipelineStep):


### PR DESCRIPTION
## Description

This pull request updates the `StudentRegistrationRequested` filter to include the `error_code` in API responses when a `PreventRegistration` exception is raised.

The Authn MFE relies on the presence of `error_code` in API responses to display appropriate error messages to users. While the `PreventRegistration` exception class already supports `error_code`, it was previously not returned in the API response payload. Due to this there was no sound way to show error message on frontend based on api response.

This change aligns the behavior of `StudentRegistrationRequested` with `StudentLoginRequested`, which already includes `error_code` in its exception handling:

```python
try:
    possibly_authenticated_user = StudentLoginRequested.run_filter(user=possibly_authenticated_user)
except StudentLoginRequested.PreventLogin as exc:
    raise AuthFailedError(
        str(exc), redirect_url=exc.redirect_to, error_code=exc.error_code, context=exc.context,
    ) from exc
```

By ensuring `error_code` is returned when a registration is prevented, the frontend (Authn MFE) can now provide more precise and user-friendly error feedback during registration.

### Impacted roles:

* **Learners**: Better error messages during registration.
* **Developers**: More consistent API behavior between login and registration paths.

## Supporting information
* Aligns with behavior in `StudentLoginRequested`

## Testing instructions

1. Run the LMS locally with Authn MFE enabled.
2. Simulate a registration request that triggers a `PreventRegistration` exception (e.g., disallowed domain or blocked IP).
3. Verify that the API response includes an `error_code` field.
4. Check that the Authn MFE displays the appropriate error message on the frontend.

## Deadline

None

## Other information

* No migrations or DB changes involved.
* No deprecations or security implications.
* No impact on existing users.
