### PR TITLE
feat: add data report for enrolled & inactive user

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1600,6 +1600,46 @@ class GetStudentsWhoMayEnroll(DeveloperErrorViewMixin, APIView):
         raise MethodNotAllowed('GET')
 
 
+@method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
+class GetInactiveEnrolledStudents(DeveloperErrorViewMixin, APIView):
+    """
+    Initiate generation of a CSV file containing information about
+    students who are enrolled in a course but have inactive account.
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.CAN_RESEARCH
+
+    @method_decorator(ensure_csrf_cookie)
+    @method_decorator(transaction.non_atomic_requests)
+    def post(self, request, course_id):
+        """
+        Initiate generation of a CSV file containing information about
+        students who are enrolled in a course but have inactive account.
+
+        Responds with JSON
+            {"status": "... status message ..."}
+        """
+        course_key = CourseKey.from_string(course_id)
+        query_features = ["email"]
+        report_type = _("inactive enrollment")
+        try:
+            task_api.submit_calculate_inactive_enrolled_students_csv(
+                request, course_key, query_features
+            )
+            success_status = SUCCESS_MESSAGE_TEMPLATE.format(report_type=report_type)
+        except Exception as e:
+            raise self.api_error(
+                status.HTTP_400_BAD_REQUEST, str(e), "Requested task is already running"
+            )
+
+        return JsonResponse({"status": success_status})
+
+    def get(self, request, *args, **kwargs):
+        raise MethodNotAllowed("GET")
+
+
 def _cohorts_csv_validator(file_storage, file_to_validate):
     """
     Verifies that the expected columns are present in the CSV used to add users to cohorts.

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -31,6 +31,8 @@ urlpatterns = [
     re_path(r'^get_students_features(?P<csv>/csv)?$', api.GetStudentsFeatures.as_view(), name='get_students_features'),
     path('get_grading_config', api.GetGradingConfig.as_view(), name='get_grading_config'),
     path('get_students_who_may_enroll', api.GetStudentsWhoMayEnroll.as_view(), name='get_students_who_may_enroll'),
+    path('get_enrolled_students_with_inactive_account', api.GetInactiveEnrolledStudents.as_view(),
+         name='get_enrolled_students_with_inactive_account'),
     path('get_anon_ids', api.GetAnonIds.as_view(), name='get_anon_ids'),
     path('get_student_enrollment_status', api.GetStudentEnrollmentStatus.as_view(),
          name="get_student_enrollment_status"),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -650,6 +650,9 @@ def _section_data_download(course, access):
         'get_students_who_may_enroll_url': reverse(
             'get_students_who_may_enroll', kwargs={'course_id': str(course_key)}
         ),
+        'get_inactive_enrolled_students_url': reverse(
+            'get_enrolled_students_with_inactive_account', kwargs={'course_id': str(course_key)}
+        ),
         'get_anon_ids_url': reverse('get_anon_ids', kwargs={'course_id': str(course_key)}),
         'list_proctored_results_url': reverse(
             'get_proctored_exam_results', kwargs={'course_id': str(course_key)}

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -32,6 +32,7 @@ from lms.djangoapps.instructor_task.data import InstructorTaskTypes
 from lms.djangoapps.instructor_task.models import InstructorTask, InstructorTaskSchedule, SCHEDULED
 from lms.djangoapps.instructor_task.tasks import (
     calculate_grades_csv,
+    calculate_inactive_enrolled_students_info_csv,
     calculate_may_enroll_csv,
     calculate_problem_grade_report,
     calculate_problem_responses_csv,
@@ -403,6 +404,21 @@ def submit_calculate_may_enroll_csv(request, course_key, features):
     """
     task_type = InstructorTaskTypes.MAY_ENROLL_INFO_CSV
     task_class = calculate_may_enroll_csv
+    task_input = {'features': features}
+    task_key = ""
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_calculate_inactive_enrolled_students_csv(request, course_key, features):
+    """
+    Submits a task to generate a CSV file containing information about
+    enrolled students in a course who have not activated their account yet.
+
+    Raises AlreadyRunningError if said file is already being updated.
+    """
+    task_type = InstructorTaskTypes.INACTIVE_ENROLLED_STUDENTS_INFO_CSV
+    task_class = calculate_inactive_enrolled_students_info_csv
     task_input = {'features': features}
     task_key = ""
 

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -114,7 +114,7 @@ def generate_already_running_error_message(task_type):
         'proctored_exam_results_report': _('proctored exam results'),
         'export_ora2_data': _('ORA data'),
         'grade_course': _('grade'),
-
+        'inactive_enrolled_students_info_csv': _('inactive enrollment')
     }
 
     if report_types.get(task_type):

--- a/lms/djangoapps/instructor_task/data.py
+++ b/lms/djangoapps/instructor_task/data.py
@@ -24,6 +24,7 @@ class InstructorTaskTypes(str, Enum):
     GRADE_COURSE = "grade_course"
     GRADE_PROBLEMS = "grade_problems"
     MAY_ENROLL_INFO_CSV = "may_enroll_info_csv"
+    INACTIVE_ENROLLED_STUDENTS_INFO_CSV = "inactive_enrolled_students_info_csv"
     OVERRIDE_PROBLEM_SCORE = "override_problem_score"
     PROBLEM_RESPONSES_CSV = "problem_responses_csv"
     PROCTORED_EXAM_RESULTS_REPORT = "proctored_exam_results_report"

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -30,7 +30,11 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 from lms.djangoapps.bulk_email.tasks import perform_delegate_email_batches
 from lms.djangoapps.instructor_task.tasks_base import BaseInstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.certs import generate_students_certificates
-from lms.djangoapps.instructor_task.tasks_helper.enrollments import upload_may_enroll_csv, upload_students_csv
+from lms.djangoapps.instructor_task.tasks_helper.enrollments import (
+    upload_inactive_enrolled_students_info_csv,
+    upload_may_enroll_csv,
+    upload_students_csv
+)
 from lms.djangoapps.instructor_task.tasks_helper.grades import CourseGradeReport, ProblemGradeReport, ProblemResponses
 from lms.djangoapps.instructor_task.tasks_helper.misc import (
     cohort_students_and_upload,
@@ -264,6 +268,20 @@ def calculate_may_enroll_csv(entry_id, xblock_instance_args):
     # Translators: This is a past-tense verb that is inserted into task progress messages as {action}.
     action_name = gettext_noop('generated')
     task_fn = partial(upload_may_enroll_csv, xblock_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@shared_task(base=BaseInstructorTask)
+@set_code_owner_attribute
+def calculate_inactive_enrolled_students_info_csv(entry_id, xblock_instance_args):
+    """
+    Compute information about invited students who have not enrolled
+    in a given course yet and upload the CSV to an S3 bucket for
+    download.
+    """
+    # Translators: This is a past-tense verb that is inserted into task progress messages as {action}.
+    action_name = gettext_noop('generated')
+    task_fn = partial(upload_inactive_enrolled_students_info_csv, xblock_instance_args)
     return run_main_task(entry_id, task_fn, action_name)
 
 

--- a/lms/static/js/instructor_dashboard/data_download.js
+++ b/lms/static/js/instructor_dashboard/data_download.js
@@ -101,6 +101,7 @@
             this.$proctored_exam_csv_btn = this.$section.find("input[name='proctored-exam-results-report']");
             this.$survey_results_csv_btn = this.$section.find("input[name='survey-results-report']");
             this.$list_may_enroll_csv_btn = this.$section.find("input[name='list-may-enroll-csv']");
+            this.$list_learners_not_activated_csv_btn = this.$section.find("input[name='list-learners-not-activated-csv']");
             this.$list_problem_responses_csv_input = this.$section.find("input[name='problem-location']");
             this.$list_problem_responses_csv_btn = this.$section.find("input[name='list-problem-responses-csv']");
             this.$list_anon_btn = this.$section.find("input[name='list-anon-ids']");
@@ -299,6 +300,31 @@
             this.$list_may_enroll_csv_btn.click(function() {
                 var url = dataDownloadObj.$list_may_enroll_csv_btn.data('endpoint');
                 var errorMessage = gettext('Error generating list of students who may enroll. Please try again.');
+                dataDownloadObj.clear_display();
+                return $.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    url: url,
+                    error: function(error) {
+                        if (error.responseText) {
+                            errorMessage = JSON.parse(error.responseText);
+                        }
+                        dataDownloadObj.$reports_request_response_error.text(errorMessage);
+                        return dataDownloadObj.$reports_request_response_error.css({
+                            display: 'block'
+                        });
+                    },
+                    success: function(data) {
+                        dataDownloadObj.$reports_request_response.text(data.status);
+                        return $('.msg-confirm').css({
+                            display: 'block'
+                        });
+                    }
+                });
+            });
+            this.$list_learners_not_activated_csv_btn.click(function() {
+                var url = dataDownloadObj.$list_learners_not_activated_csv_btn.data('endpoint');
+                var errorMessage = gettext('Error generating list of inactive students who are enrolled in a course. Please try again.');
                 dataDownloadObj.clear_display();
                 return $.ajax({
                     type: 'POST',

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -37,6 +37,10 @@ from openedx.core.djangolib.markup import HTML, Text
 
     <p><input type="button" name="list-may-enroll-csv" value="${_("Download a CSV of learners who can enroll")}" data-endpoint="${ section_data['get_students_who_may_enroll_url'] }" data-csv="true"></p>
 
+    <p>${_("Click to generate a CSV file that lists learners who are enrolled in the course but have not yet activated their account.")}</p>
+
+    <p><input type="button" name="list-learners-not-activated-csv" value="${_("Download a CSV of learners who have not activated their account")}" data-endpoint="${ section_data['get_inactive_enrolled_students_url'] }" data-csv="true"></p>
+
     <p>${_("Click to download a CSV of anonymized student IDs:")}</p>
     <p><input type="button" name="list-anon-ids" value="${_("Get Student Anonymized IDs CSV")}" data-csv="true" class="csv" data-endpoint="${ section_data['get_anon_ids_url'] }" class="${'is-disabled' if disable_buttons else ''}" aria-disabled="${'true' if disable_buttons else 'false'}" ></p>
 

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/reports.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/reports.html
@@ -34,6 +34,10 @@ from openedx.core.djangolib.markup import HTML, Text
                         Learner
                         who can enroll
                     </option>
+                    <option value="inactiveEnrolledlearners"
+                            data-endpoint="${ section_data['get_inactive_enrolled_students_url'] }" data-csv="true">
+                        Enrolled Learner who has an inactive account
+                    </option>
                     <option value="listEnrolledPeople"
                             data-endpoint="${ section_data['get_students_features_url'] }"
                             data-datatable="true">
@@ -94,6 +98,9 @@ from openedx.core.djangolib.markup import HTML, Text
 
             <p hidden="hidden" class="selectionInfo reports learnerWhoCanEnroll">${_("Click to generate a CSV file \
                 that lists learners who can enroll in the course but have not yet done so.")}</p>
+
+            <p hidden="hidden" class="selectionInfo reports inactiveEnrolledlearners">${_("Click to generate a CSV file \
+                that lists learners who are enrolled in the course but have not yet activated their account.")}</p>
 
             <p hidden="hidden" class="selectionInfo reports proctoredExamResults">${_("Click to generate a CSV file \
                 of all proctored exam results in this course.")}</p>


### PR DESCRIPTION
Ticket: [TNL2-107](https://2u-internal.atlassian.net/browse/TNL2-107)
Add new data report for learners who are enrolled in a course and have not activated their account.

**Before:**
<img width="1792" height="1030" alt="Screenshot 2025-07-16 at 2 22 57 PM" src="https://github.com/user-attachments/assets/08cc1431-fe44-4db3-a756-ecd797746f05" />

**After:**
![after](https://github.com/user-attachments/assets/92fb9782-45da-46fb-b88e-69fc33405be8)
