### PR TITLE
feat: added endpoint for priviledged roles to delete threads of a user

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -10,55 +10,23 @@ various user roles, input data, and edge cases, and that they return appropriate
 
 
 import json
-import random
 from datetime import datetime
 from unittest import mock
-from urllib.parse import parse_qs, urlencode, urlparse
 
 import ddt
+from forum.backends.mongodb.comments import Comment
+from forum.backends.mongodb.threads import CommentThread
 import httpretty
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
-from lms.djangoapps.discussion.django_comment_client.tests.mixins import (
-    MockForumApiMixin,
-)
-from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from rest_framework import status
 from rest_framework.parsers import JSONParser
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APIClient
 
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
-from lms.djangoapps.discussion.rest_api.utils import get_usernames_from_search_string
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import (
-    ModuleStoreTestCase,
-    SharedModuleStoreTestCase,
-)
-from xmodule.modulestore.tests.factories import (
-    CourseFactory,
-    BlockFactory,
-    check_mongo_calls,
-)
-
-from common.djangoapps.course_modes.models import CourseMode
-from common.djangoapps.course_modes.tests.factories import CourseModeFactory
-from common.djangoapps.student.models import (
-    get_retired_username_by_username,
-    CourseEnrollment,
-)
-from common.djangoapps.student.roles import (
-    CourseInstructorRole,
-    CourseStaffRole,
-    GlobalStaff,
-)
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 from common.djangoapps.student.tests.factories import (
-    AdminFactory,
     CourseEnrollmentFactory,
-    SuperuserFactory,
     UserFactory,
 )
 from common.djangoapps.util.testing import PatchMediaTypeMixin, UrlResetMixin
@@ -67,48 +35,18 @@ from lms.djangoapps.discussion.tests.utils import (
     make_minimal_cs_comment,
     make_minimal_cs_thread,
 )
-from lms.djangoapps.discussion.django_comment_client.tests.utils import (
-    ForumsEnableMixin,
-    config_course_discussions,
-    topic_name_to_id,
-)
+from lms.djangoapps.discussion.django_comment_client.tests.utils import ForumsEnableMixin
 from lms.djangoapps.discussion.rest_api import api
 from lms.djangoapps.discussion.rest_api.tests.utils import (
-    CommentsServiceMockMixin,
     ForumMockUtilsMixin,
     ProfileImageTestMixin,
     make_paginated_api_response,
-    parsed_body,
-)
-from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts
-from openedx.core.djangoapps.discussions.config.waffle import (
-    ENABLE_NEW_STRUCTURE_DISCUSSIONS,
-)
-from openedx.core.djangoapps.discussions.models import (
-    DiscussionsConfiguration,
-    DiscussionTopicLink,
-    Provider,
-)
-from openedx.core.djangoapps.discussions.tasks import (
-    update_discussions_settings_from_course_task,
 )
 from openedx.core.djangoapps.django_comment_common.models import (
-    CourseDiscussionSettings,
-    Role,
+    FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR, FORUM_ROLE_STUDENT,
+    assign_role
 )
-from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
-from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
-from openedx.core.djangoapps.oauth_dispatch.tests.factories import (
-    AccessTokenFactory,
-    ApplicationFactory,
-)
-from openedx.core.djangoapps.user_api.accounts.image_helpers import (
-    get_profile_image_storage,
-)
-from openedx.core.djangoapps.user_api.models import (
-    RetirementState,
-    UserRetirementStatus,
-)
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_storage
 
 
 class DiscussionAPIViewTestMixin(ForumsEnableMixin, ForumMockUtilsMixin, UrlResetMixin):
@@ -923,3 +861,89 @@ class ThreadViewSetListTest(
         response_thread = json.loads(response.content.decode("utf-8"))["results"][0]
         assert response_thread["author"] is None
         assert {} == response_thread["users"]
+
+
+@ddt.ddt
+class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
+    """
+    Tests for the BulkDeleteUserPostsViewSet
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("bulk_delete_user_posts", kwargs={"course_id": str(self.course.id)})
+        self.user2 = UserFactory.create(password=self.password)
+        CourseEnrollmentFactory.create(user=self.user2, course_id=self.course.id)
+
+    def test_basic(self):
+        """
+        Intentionally left empty because this test case is inherited from parent
+        """
+
+    def mock_comment_and_thread_count(self, comment_count=1, thread_count=1):
+        """
+        Patches count_documents() for Comment and CommentThread._collection.
+        """
+        thread_collection = mock.MagicMock()
+        thread_collection.count_documents.return_value = thread_count
+        patch_thread = mock.patch.object(
+            CommentThread, "_collection", new_callable=mock.PropertyMock, return_value=thread_collection
+        )
+
+        comment_collection = mock.MagicMock()
+        comment_collection.count_documents.return_value = comment_count
+        patch_comment = mock.patch.object(
+            Comment, "_collection", new_callable=mock.PropertyMock, return_value=comment_collection
+        )
+
+        thread_mock = patch_thread.start()
+        comment_mock = patch_comment.start()
+
+        self.addCleanup(patch_comment.stop)
+        self.addCleanup(patch_thread.stop)
+        return thread_mock, comment_mock
+
+    @ddt.data(FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_STUDENT)
+    def test_bulk_delete_denied_for_discussion_roles(self, role):
+        """
+        Test bulk delete user posts denied with discussion roles.
+        """
+        thread_mock, comment_mock = self.mock_comment_and_thread_count(comment_count=1, thread_count=1)
+        assign_role(self.course.id, self.user, role)
+        response = self.client.post(
+            f"{self.url}?username={self.user2.username}",
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        thread_mock.count_documents.assert_not_called()
+        comment_mock.count_documents.assert_not_called()
+
+    @ddt.data(FORUM_ROLE_MODERATOR, FORUM_ROLE_ADMINISTRATOR)
+    def test_bulk_delete_allowed_for_discussion_roles(self, role):
+        """
+        Test bulk delete user posts passed with discussion roles.
+        """
+        self.mock_comment_and_thread_count(comment_count=1, thread_count=1)
+        assign_role(self.course.id, self.user, role)
+        response = self.client.post(
+            f"{self.url}?username={self.user2.username}",
+            format="json",
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json() == {"comment_count": 1, "thread_count": 1}
+
+    @mock.patch('lms.djangoapps.discussion.rest_api.views.delete_course_post_for_user.apply_async')
+    @ddt.data(True, False)
+    def test_task_only_runs_if_execute_param_is_true(self, execute, task_mock):
+        """
+        Test bulk delete user posts task runs only if execute parameter is set to true.
+        """
+        assign_role(self.course.id, self.user, FORUM_ROLE_MODERATOR)
+        self.mock_comment_and_thread_count(comment_count=1, thread_count=1)
+        response = self.client.post(
+            f"{self.url}?username={self.user2.username}&execute={str(execute).lower()}",
+            format="json",
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json() == {"comment_count": 1, "thread_count": 1}
+        assert task_mock.called is execute

--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -8,6 +8,7 @@ from django.urls import include, path, re_path
 from rest_framework.routers import SimpleRouter
 
 from lms.djangoapps.discussion.rest_api.views import (
+    BulkDeleteUserPosts,
     CommentViewSet,
     CourseActivityStatsView,
     CourseDiscussionRolesAPIView,
@@ -86,6 +87,11 @@ urlpatterns = [
         fr"^v3/course_topics/{settings.COURSE_ID_PATTERN}",
         CourseTopicsViewV3.as_view(),
         name="course_topics_v3"
+    ),
+    re_path(
+        fr"^v1/bulk_delete_user_posts/{settings.COURSE_ID_PATTERN}",
+        BulkDeleteUserPosts.as_view(),
+        name="bulk_delete_user_posts"
     ),
     path('v1/', include(ROUTER.urls)),
 ]

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -9,6 +9,8 @@ from eventtracking import tracker
 from . import models, settings, utils
 from forum import api as forum_api
 from openedx.core.djangoapps.discussions.config.waffle import is_forum_v2_enabled, is_forum_v2_disabled_globally
+from forum.backends.mongodb.threads import CommentThread
+
 
 log = logging.getLogger(__name__)
 
@@ -228,6 +230,37 @@ class Thread(models.Model):
             course_id=str(course_key)
         )
         self._update_from_response(response)
+
+    @classmethod
+    def get_user_threads_count(cls, user_id, course_ids):
+        """
+        Returns threads and responses count of user in the given course_ids.
+        TODO: Add support for MySQL backend as well
+        """
+        query_params = {
+            "course_id": {"$in": course_ids},
+            "author_id": str(user_id),
+            "_type": "CommentThread"
+        }
+        return CommentThread()._collection.count_documents(query_params)  # pylint: disable=protected-access
+
+    @classmethod
+    def delete_user_threads(cls, user_id, course_ids):
+        """
+        Deletes threads of user in the given course_ids.
+        TODO: Add support for MySQL backend as well
+        """
+        query_params = {
+            "course_id": {"$in": course_ids},
+            "author_id": str(user_id),
+        }
+        threads_deleted = 0
+        threads = CommentThread().get_list(**query_params)
+        for thread in threads:
+            thread_id = thread.get("_id")
+            if thread_id:
+                threads_deleted += CommentThread().delete(thread_id)
+        return threads_deleted
 
 
 def _url_for_flag_abuse_thread(thread_id):


### PR DESCRIPTION
Added an API to allow priviledged users to bulk delete posts of a user
Following roles are allowed to perform this action
- Discussion Moderator
- Discussion Admin
- Course Staff
- Course Instructor
- Global Staff

Purpose of this endpoint is to allow instructors and privileged users to delete all spam posts of a single user in one action.

Ticket: [INF-2026](https://2u-internal.atlassian.net/browse/INF-2026)