### PR TITLE
fix: add generic headers to prevent false broken links in Course Optimizer page

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -98,6 +98,15 @@ FULL_COURSE_REINDEX_THRESHOLD = 1
 ALL_ALLOWED_XBLOCKS = frozenset(
     [entry_point.name for entry_point in entry_points(group="xblock.v1")]
 )
+DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/115.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Connection": "keep-alive",
+}
 
 
 class LinkState:
@@ -1255,7 +1264,7 @@ async def _validate_urls_access_in_batches(url_list, course_key, batch_size=100)
 
 async def _validate_batch(batch, course_key):
     """Validate a batch of URLs"""
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=DEFAULT_HEADERS) as session:
         tasks = [_validate_url_access(session, url_data, course_key) for url_data in batch]
         batch_results = await asyncio.gather(*tasks)
         return batch_results


### PR DESCRIPTION
## Description

This PR resolves an issue where valid external links were incorrectly marked as broken on the course optimizer page.
The problem was caused by missing HTTP headers in automated requests, which made some websites return a 400 error.

## Additional Information

- Added generic browser headers (User-Agent, Accept, Connection) to all link checker requests.
- Updated link checker to use these headers for all requests.
- Verified that valid links are no longer marked as broken.

## Jira Ticket

- [TNL2-250](https://2u-internal.atlassian.net/browse/TNL2-250)

## Screenshots

**Before**

<img width="1114" height="432" alt="image" src="https://github.com/user-attachments/assets/1a99d935-7ee5-4603-a823-83f853580b6a" />

**After**

<img width="1110" height="408" alt="image" src="https://github.com/user-attachments/assets/5766c117-fd90-43ba-95bb-3378ab05e5f9" />

