### PR TITLE
fix: make discovery service dependency optional for discussion notifications

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -709,6 +709,18 @@ DEFAULT_GROUPS = []
 # .. setting_description: Sets the number of days after which the gradebook will freeze following the course's end.
 GRADEBOOK_FREEZE_DAYS = 30
 
+# .. setting_name: COURSE_ACCESS_DURATION_MIN_WEEKS
+# .. setting_default: 4
+# .. setting_description: Minimum course duration in weeks when Discovery service data is unavailable or course has no
+# .. weeks_to_complete value. Used as fallback for course access duration calculations.
+COURSE_ACCESS_DURATION_MIN_WEEKS = 4
+
+# .. setting_name: COURSE_ACCESS_DURATION_MAX_WEEKS
+# .. setting_default: 18
+# .. setting_description: Maximum course duration in weeks. Course access duration is bounded by this upper limit
+# .. regardless of Discovery service data.
+COURSE_ACCESS_DURATION_MAX_WEEKS = 18
+
 RETRY_CALENDAR_SYNC_EMAIL_MAX_ATTEMPTS = 5
 
 ############################# SET PATH INFORMATION #############################

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -709,18 +709,6 @@ DEFAULT_GROUPS = []
 # .. setting_description: Sets the number of days after which the gradebook will freeze following the course's end.
 GRADEBOOK_FREEZE_DAYS = 30
 
-# .. setting_name: COURSE_ACCESS_DURATION_MIN_WEEKS
-# .. setting_default: 4
-# .. setting_description: Minimum course duration in weeks when Discovery service data is unavailable or course has no
-# .. weeks_to_complete value. Used as fallback for course access duration calculations.
-COURSE_ACCESS_DURATION_MIN_WEEKS = 4
-
-# .. setting_name: COURSE_ACCESS_DURATION_MAX_WEEKS
-# .. setting_default: 18
-# .. setting_description: Maximum course duration in weeks. Course access duration is bounded by this upper limit
-# .. regardless of Discovery service data.
-COURSE_ACCESS_DURATION_MAX_WEEKS = 18
-
 RETRY_CALENDAR_SYNC_EMAIL_MAX_ATTEMPTS = 5
 
 ############################# SET PATH INFORMATION #############################

--- a/openedx/core/djangoapps/course_date_signals/utils.py
+++ b/openedx/core/djangoapps/course_date_signals/utils.py
@@ -10,12 +10,8 @@ from django.conf import settings
 from openedx.core.djangoapps.catalog.utils import get_course_run_details
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 
-MIN_DURATION = timedelta(
-    weeks=getattr(settings, 'COURSE_ACCESS_DURATION_MIN_WEEKS', 4)
-)
-MAX_DURATION = timedelta(
-    weeks=getattr(settings, 'COURSE_ACCESS_DURATION_MAX_WEEKS', 18)
-)
+MIN_DURATION = timedelta(weeks=settings.COURSE_ACCESS_DURATION_MIN_WEEKS)
+MAX_DURATION = timedelta(weeks=settings.COURSE_ACCESS_DURATION_MAX_WEEKS)
 
 
 def catalog_integration_enabled():

--- a/openedx/core/djangoapps/course_date_signals/utils.py
+++ b/openedx/core/djangoapps/course_date_signals/utils.py
@@ -11,10 +11,10 @@ from openedx.core.djangoapps.catalog.utils import get_course_run_details
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 
 MIN_DURATION = timedelta(
-    weeks=getattr(settings, 'COURSE_DURATION_MIN_WEEKS', 4)
+    weeks=getattr(settings, 'COURSE_ACCESS_DURATION_MIN_WEEKS', 4)
 )
 MAX_DURATION = timedelta(
-    weeks=getattr(settings, 'COURSE_DURATION_MAX_WEEKS', 18)
+    weeks=getattr(settings, 'COURSE_ACCESS_DURATION_MAX_WEEKS', 18)
 )
 
 

--- a/openedx/core/djangoapps/course_date_signals/utils.py
+++ b/openedx/core/djangoapps/course_date_signals/utils.py
@@ -14,7 +14,7 @@ MIN_DURATION = timedelta(weeks=settings.COURSE_ACCESS_DURATION_MIN_WEEKS)
 MAX_DURATION = timedelta(weeks=settings.COURSE_ACCESS_DURATION_MAX_WEEKS)
 
 
-def catalog_integration_enabled():
+def _catalog_integration_enabled():
     """
     Check if catalog integration is enabled
     """
@@ -29,7 +29,7 @@ def get_expected_duration(course_id):
 
     access_duration = MIN_DURATION
 
-    if catalog_integration_enabled():
+    if _catalog_integration_enabled():
         discovery_course_details = get_course_run_details(
             course_id, ['weeks_to_complete']
         )

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -743,6 +743,19 @@ ALL_LANGUAGES = [
 
 LANGUAGE_DICT = dict(LANGUAGES)
 
+# .. setting_name: COURSE_ACCESS_DURATION_MIN_WEEKS
+# .. setting_default: 4
+# .. setting_description: Minimum course duration in weeks when Discovery service data is unavailable or course has no
+# .. weeks_to_complete value. Used as fallback for course access duration calculations (e.g., audit access expiration
+# .. and discussion notification filtering).
+COURSE_ACCESS_DURATION_MIN_WEEKS = 4
+
+# .. setting_name: COURSE_ACCESS_DURATION_MAX_WEEKS
+# .. setting_default: 18
+# .. setting_description: Maximum course duration in weeks. Course access duration is bounded by this upper limit
+# .. regardless of Discovery service data.
+COURSE_ACCESS_DURATION_MAX_WEEKS = 18
+
 ############################## Optional Apps ###############################
 
 OPTIONAL_APPS = [

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -4,6 +4,7 @@ Contains tests to verify correctness of course expiration functionality
 
 from datetime import timedelta
 from unittest import mock
+from unittest.mock import patch
 
 import ddt
 from django.conf import settings
@@ -46,6 +47,11 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
     """Tests to verify the get_user_course_expiration_date function is working correctly"""
     def setUp(self):
         super().setUp()  # lint-amnesty, pylint: disable=super-with-arguments
+        self.catalog_patch = patch(
+            'openedx.core.djangoapps.catalog.models.CatalogIntegration.is_enabled',
+            return_value=True
+        )
+        self.catalog_patch.start()
         self.course = CourseFactory(
             start=now() - timedelta(weeks=10),
         )
@@ -72,6 +78,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
         add_course_mode(self.course)
 
     def tearDown(self):
+        self.catalog_patch.stop()
         CourseEnrollment.unenroll(self.user, self.course.id)
         super().tearDown()  # lint-amnesty, pylint: disable=super-with-arguments
 


### PR DESCRIPTION
### What are the relevant tickets?
[#6471](https://github.com/mitodl/hq/issues/6471), [#6650](https://github.com/mitodl/hq/issues/6650)

### Description (What does it do?)
When the Discussions MFE is enabled via the discussions.enable_discussions_mfe Waffle flag, users encounter noisy error logs like:

```
Unable to retrieve details about Data for course_run course-v1:MITxT+21A.819.2x+3T2022 because Catalog Integration is not enabled
```

This error occurs in deployments where the Discovery service (Catalog Integration) is not configured, but the system still attempts to fetch course duration data for notification filtering.

The discussion notification system uses `filter_audit_expired_users_with_no_role` to exclude audit learners whose access has expired. This filtering logic calls:

- `get_expected_duration()` to determine course duration
- `get_course_run_details()` to fetch weeks_to_complete from Discovery
- `check_catalog_integration_and_get_user()` which logs an error when Catalog Integration is disabled

This PR modifies `get_expected_duration()` in [course_date_signals/utils.py](https://github.com/openedx/edx-platform/blob/22167dd88b12be395f130f9f3a4c48f823408f58/openedx/core/djangoapps/course_date_signals/utils.py#L16) to:

1. Check if Catalog Integration is enabled before attempting to call Discovery
2. Use the default minimum duration (4 weeks) when Discovery is unavailable
3. Maintain existing behavior when Discovery is enabled

#### Additional Changes

This PR also adds configurable Django settings `COURSE_DURATION_MIN_WEEKS` (default: 4) and `COURSE_DURATION_MAX_WEEKS` (default: 18) to allow deployments to customize course duration bounds without code changes.

Current State - The course duration bounds are currently hard-coded as constants:

MIN_DURATION = timedelta(weeks=4)(4 weeks minimum)
MAX_DURATION = timedelta(weeks=18)(18 weeks maximum)

This PR makes these durations configurable through Django settings to allow deployments to customize course duration bounds without code changes:

`COURSE_DURATION_MIN_WEEKS` (default: 4) - replaces the hard-coded MIN_DURATION
`COURSE_DURATION_MAX_WEEKS` (default: 18) - replaces the hard-coded MAX_DURATION

This change enables deployments to adjust the audit access duration policy to better suit their needs without requiring code modifications.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Verify the fix eliminates error logs when CatalogIntegration.is_enabled() returns False
- Confirm existing functionality works when Discovery is enabled