### PR TITLE
fix: use data instead of request.data in comment view set

### DIFF
--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1042,7 +1042,7 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
                 return Response({'error': 'CAPTCHA verification failed.'}, status=400)
         data = request.data.copy()
         data.pop('captcha_token', None)
-        return Response(create_comment(request, request.data))
+        return Response(create_comment(request, data))
 
     def destroy(self, request, comment_id):
         """


### PR DESCRIPTION
This pull request includes a small but important bug fix in the `lms/djangoapps/discussion/rest_api/views.py` file. The change ensures that the modified `data` object, with the `captcha_token` removed, is passed to the `create_comment` function instead of the original `request.data`. 

This prevents the `captcha_token` from being inadvertently included in the comment creation process.