### PR TITLE
Hoist production settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -506,10 +506,6 @@ ENABLE_JASMINE = False
 
 MARKETING_EMAILS_OPT_IN = False
 
-# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
-# IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
-IDA_LOGOUT_URI_LIST = []
-
 ############################# MICROFRONTENDS ###################################
 COURSE_AUTHORING_MICROFRONTEND_URL = None
 DISCUSSIONS_MICROFRONTEND_URL = None
@@ -562,6 +558,7 @@ DJFS = {
     'directory_root': '/edx/var/edxapp/django-pyfs/static/django-pyfs',
     'url_root': '/static/django-pyfs',
 }
+
 ######################## BRANCH.IO ###########################
 BRANCH_IO_KEY = ''
 
@@ -650,14 +647,9 @@ TEMPLATES = [
 DEFAULT_TEMPLATE_ENGINE = TEMPLATES[0]
 
 #################################### AWS #######################################
-AWS_SES_REGION_NAME = 'us-east-1'
-AWS_SES_REGION_ENDPOINT = 'email.us-east-1.amazonaws.com'
 AWS_ACCESS_KEY_ID = None
 AWS_SECRET_ACCESS_KEY = None
 AWS_SECURITY_TOKEN = None
-AWS_QUERYSTRING_AUTH = False
-AWS_STORAGE_BUCKET_NAME = 'SET-ME-PLEASE (ex. bucket-name)'
-AWS_S3_CUSTOM_DOMAIN = 'SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)'
 
 ##############################################################################
 
@@ -672,17 +664,13 @@ AUTHENTICATION_BACKENDS = [
     'bridgekeeper.backends.RulePermissionBackend',
 ]
 
-STATIC_ROOT_BASE = '/edx/var/edxapp/staticfiles'
-
 # License for serving content in China
 ICP_LICENSE = None
 ICP_LICENSE_INFO = {}
 
 LOGGING_ENV = 'sandbox'
 
-LMS_BASE = 'localhost:18000'
-LMS_ROOT_URL = "https://localhost:18000"
-LMS_INTERNAL_ROOT_URL = LMS_ROOT_URL
+LMS_BASE = None
 
 # Use LMS SSO for login, once enabled by setting LOGIN_URL (see docs/guides/studio_oauth.rst)
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
@@ -694,22 +682,13 @@ FRONTEND_LOGIN_URL = LOGIN_URL
 FRONTEND_LOGOUT_URL = '/logout/'
 FRONTEND_REGISTER_URL = Derived(lambda settings: settings.LMS_ROOT_URL + '/register')
 
-LMS_ENROLLMENT_API_PATH = "/api/enrollment/v1/"
-ENTERPRISE_API_URL = LMS_INTERNAL_ROOT_URL + '/enterprise/api/v1/'
-ENTERPRISE_CONSENT_API_URL = LMS_INTERNAL_ROOT_URL + '/consent/api/v1/'
+ENTERPRISE_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/enterprise/api/v1/')
+ENTERPRISE_CONSENT_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/consent/api/v1/')
 ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS = {}
 
-# Setting for Open API key and prompts used by edx-enterprise.
-CHAT_COMPLETION_API = 'https://example.com/chat/completion'
-CHAT_COMPLETION_API_KEY = 'i am a key'
-LEARNER_ENGAGEMENT_PROMPT_FOR_ACTIVE_CONTRACT = ''
-LEARNER_ENGAGEMENT_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
-LEARNER_PROGRESS_PROMPT_FOR_ACTIVE_CONTRACT = ''
-LEARNER_PROGRESS_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
-
 # Public domain name of Studio (should be resolvable from the end-user's browser)
-CMS_BASE = 'localhost:18010'
-CMS_ROOT_URL = "https://localhost:18010"
+CMS_BASE = None
+CMS_ROOT_URL = None
 
 LOG_DIR = '/edx/var/log/edx'
 
@@ -720,9 +699,6 @@ MAINTENANCE_BANNER_TEXT = 'Sample banner message'
 WIKI_ENABLED = True
 
 CERT_QUEUE = 'certificates'
-# List of logout URIs for each IDA that the learner should be logged out of when they logout of
-# Studio. Only applies to IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
-IDA_LOGOUT_URI_LIST = []
 
 ELASTIC_SEARCH_CONFIG = [
     {
@@ -742,7 +718,6 @@ CSRF_COOKIE_SECURE = False
 
 CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = ''
 CROSS_DOMAIN_CSRF_COOKIE_NAME = ''
-CSRF_TRUSTED_ORIGINS = []
 
 #################### CAPA External Code Evaluation #############################
 XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds
@@ -1076,15 +1051,10 @@ CODE_JAIL_REST_SERVICE_READ_TIMEOUT = 3.5  # time in seconds
 
 ############################ DJANGO_BUILTINS ################################
 # Change DEBUG in your environment settings files, not here
-DEBUG = False
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
 SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
-SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
-
-# This is the domain that is used to set shared cookies between various sub-domains.
-SHARED_COOKIE_DOMAIN = ""
 
 # Site info
 SITE_NAME = "localhost"
@@ -1095,12 +1065,6 @@ COURSE_IMPORT_EXPORT_BUCKET = ''
 COURSE_METADATA_EXPORT_BUCKET = ''
 
 ALTERNATE_WORKER_QUEUES = 'lms'
-
-# .. setting_name: STATIC_URL_BASE
-# .. setting_default: "/static/"
-# .. setting_description: The CMS uses this to construct ``STATIC_URL`` by appending
-#   a slash (if needed) and then ``studio/``.
-STATIC_URL_BASE = '/static/'
 
 X_FRAME_OPTIONS = 'DENY'
 
@@ -1120,12 +1084,7 @@ GIT_EXPORT_DEFAULT_IDENT = {
 
 # Email
 TECH_SUPPORT_EMAIL = 'technical@example.com'
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'localhost'
-EMAIL_PORT = 25
-EMAIL_USE_TLS = False
-EMAIL_HOST_USER = ''
-EMAIL_HOST_PASSWORD = ''
+EMAIL_FILE_PATH = Derived(lambda settings: path(settings.DATA_DIR) / "emails" / "studio")
 DEFAULT_FROM_EMAIL = 'registration@example.com'
 DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
 TECH_SUPPORT_EMAIL = 'technical@example.com'
@@ -1427,13 +1386,11 @@ CELERY_QUEUE_HA_POLICY = 'all'
 
 CELERY_CREATE_MISSING_QUEUES = True
 
-CELERY_BROKER_TRANSPORT = 'amqp'
-CELERY_BROKER_HOSTNAME = 'localhost'
-CELERY_BROKER_USER = 'celery'
-CELERY_BROKER_PASSWORD = 'celery'
-CELERY_BROKER_VHOST = ''
-CELERY_BROKER_USE_SSL = False
-CELERY_EVENT_QUEUE_TTL = None
+CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = True
+
+BROKER_USE_SSL = Derived(lambda settings: settings.CELERY_BROKER_USE_SSL)
+
+CELERY_ALWAYS_EAGER = False
 
 ############################## HEARTBEAT ######################################
 
@@ -2055,18 +2012,6 @@ CREDIT_PROVIDER_SECRET_KEYS = {}
 #   separate paths.
 COMPREHENSIVE_THEME_DIRS = os.environ.get("COMPREHENSIVE_THEME_DIRS", "").split(":")
 
-# .. setting_name: COMPREHENSIVE_THEME_LOCALE_PATHS
-# .. setting_default: []
-# .. setting_description: See LMS annotation.
-#   "COMPREHENSIVE_THEME_LOCALE_PATHS" : ["/edx/src/edx-themes/conf/locale"].
-COMPREHENSIVE_THEME_LOCALE_PATHS = []
-
-# .. setting_name: PREPEND_LOCALE_PATHS
-# .. setting_default: []
-# .. setting_description: A list of the paths to locale directories to load first e.g.
-#   "PREPEND_LOCALE_PATHS" : ["/edx/my-locales/"].
-PREPEND_LOCALE_PATHS = []
-
 # .. setting_name: DEFAULT_SITE_THEME
 # .. setting_default: None
 # .. setting_description: See LMS annotation.
@@ -2201,10 +2146,8 @@ PARTNER_SUPPORT_EMAIL = ''
 AFFILIATE_COOKIE_NAME = 'dev_affiliate_id'
 
 # API access management
-API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
-API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
-AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 
 EDX_DRF_EXTENSIONS = {
     # Set this value to an empty dict in order to prevent automatically updating
@@ -2239,7 +2182,6 @@ USER_TASKS_MAX_AGE = timedelta(days=7)
 
 ############## Settings for the Enterprise App ######################
 
-ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + LMS_ENROLLMENT_API_PATH
 ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 # The default value of this needs to be a 16 character string
@@ -2268,22 +2210,10 @@ COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_exists'
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG = "both"
 DEFAULT_MOBILE_AVAILABLE = False
 
-
-# How long to cache OpenAPI schemas and UI, in seconds.
-OPENAPI_CACHE_TIMEOUT = 0
-
 ############################# Persistent Grades ####################################
 
 # Queue to use for updating persistent grades
 RECALCULATE_GRADES_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
-
-# Queue to use for updating grades due to grading policy change
-POLICY_CHANGE_GRADES_ROUTING_KEY = 'edx.lms.core.default'
-
-# Queue to use for individual learner course regrades
-SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY = 'edx.lms.core.default'
-
-SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = 'edx.lms.core.default'
 
 # Rate limit for regrading tasks that a grading policy change can kick off
 POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
@@ -2298,13 +2228,13 @@ POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
 DEFAULT_GRADE_DESIGNATIONS = ['A', 'B', 'C', 'D']
 
 ########## Settings for video transcript migration tasks ############
-VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = DEFAULT_PRIORITY_QUEUE
+VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 
 ########## Settings youtube thumbnails scraper tasks ############
-SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE = DEFAULT_PRIORITY_QUEUE
+SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 
 ########## Settings update search index task ############
-UPDATE_SEARCH_INDEX_JOB_QUEUE = DEFAULT_PRIORITY_QUEUE
+UPDATE_SEARCH_INDEX_JOB_QUEUE = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 
 ###################### VIDEO IMAGE STORAGE ######################
 
@@ -2539,6 +2469,7 @@ REGISTRATION_EXTRA_FIELDS = {
     'marketing_emails_opt_in': 'hidden',
 }
 EDXAPP_PARSE_KEYS = {}
+PARSE_KEYS = {}
 
 ############################ AI_TRANSLATIONS ##################################
 AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
@@ -2822,3 +2753,6 @@ SOCIAL_MEDIA_LOGO_URLS = {
 # .. setting_description: The default logo url for organizations that do not have a logo set.
 # .. setting_warning: This url is used as a placeholder for organizations that do not have a logo set.
 DEFAULT_ORG_LOGO_URL = Derived(lambda settings: settings.STATIC_URL + 'images/logo.png')
+
+# Misc
+AUTHORING_API_URL = ''

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -38,74 +38,6 @@ def get_env_setting(setting):
         error_msg = "Set the %s env variable" % setting
         raise ImproperlyConfigured(error_msg)  # lint-amnesty, pylint: disable=raise-missing-from
 
-
-#######################################################################################################################
-#### PRODUCTION DEFAULTS
-####
-#### Configure some defaults (beyond what has already been configured in common.py) before loading the YAML file.
-#### DO NOT ADD NEW DEFAULTS HERE! Put any new setting defaults in common.py instead, along with a setting annotation.
-#### TODO: Move all these defaults into common.py.
-####
-
-DEBUG = False
-
-# IMPORTANT: With this enabled, the server must always be behind a proxy that strips the header HTTP_X_FORWARDED_PROTO
-# from client requests. Otherwise, a user can fool our server into thinking it was an https connection. See
-# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header for other warnings.
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
-# Constant defaults (alphabetical)
-AUTHORING_API_URL = ''
-AWS_QUERYSTRING_AUTH = True
-AWS_S3_CUSTOM_DOMAIN = 'edxuploads.s3.amazonaws.com'
-AWS_STORAGE_BUCKET_NAME = 'edxuploads'
-BROKER_HEARTBEAT = 60.0
-BROKER_HEARTBEAT_CHECKRATE = 2
-CELERY_ALWAYS_EAGER = False
-CELERY_BROKER_HOSTNAME = ""
-CELERY_BROKER_PASSWORD = ""
-CELERY_BROKER_TRANSPORT = ""
-CELERY_BROKER_USER = ""
-CELERY_RESULT_BACKEND = 'django-cache'
-CHAT_COMPLETION_API = ''
-CHAT_COMPLETION_API_KEY = ''
-CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = True
-CMS_BASE = None
-CMS_ROOT_URL = None
-DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = False
-IDA_LOGOUT_URI_LIST = []
-LEARNER_ENGAGEMENT_PROMPT_FOR_ACTIVE_CONTRACT = ''
-LEARNER_ENGAGEMENT_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
-LEARNER_PROGRESS_PROMPT_FOR_ACTIVE_CONTRACT = ''
-LEARNER_PROGRESS_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
-LMS_BASE = None
-LMS_ROOT_URL = None
-OPENAPI_CACHE_TIMEOUT = 60 * 60
-PARSE_KEYS = {}
-REGISTRATION_EMAIL_PATTERNS_ALLOWED = None
-SESSION_COOKIE_DOMAIN = None
-SESSION_COOKIE_HTTPONLY = True
-SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = None
-STATIC_ROOT_BASE = None
-STATIC_URL_BASE = None
-VIDEO_CDN_URL = {}
-
-# Derived defaults (alphabetical)
-BROKER_USE_SSL = Derived(lambda settings: settings.CELERY_BROKER_USE_SSL)
-EMAIL_FILE_PATH = Derived(lambda settings: settings.DATA_DIR / "emails" / "studio")
-ENTERPRISE_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/enterprise/api/v1/')
-ENTERPRISE_CONSENT_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/consent/api/v1/')
-LMS_INTERNAL_ROOT_URL = Derived(lambda settings: settings.LMS_ROOT_URL)
-POLICY_CHANGE_GRADES_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-SHARED_COOKIE_DOMAIN = Derived(lambda settings: settings.SESSION_COOKIE_DOMAIN)
-SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = Derived(lambda settings: settings.HIGH_PRIORITY_QUEUE)
-UPDATE_SEARCH_INDEX_JOB_QUEUE = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-
-
 #######################################################################################################################
 #### YAML LOADING
 ####
@@ -223,7 +155,7 @@ if 'staticfiles' in CACHES:
 # Once we have migrated to service assets off S3, then we can convert this back to
 # managed by the yaml file contents
 STATICFILES_STORAGE = os.environ.get('STATICFILES_STORAGE', STATICFILES_STORAGE)
-CSRF_TRUSTED_ORIGINS = _YAML_TOKENS.get("CSRF_TRUSTED_ORIGINS", [])
+CSRF_TRUSTED_ORIGINS = _YAML_TOKENS.get('CSRF_TRUSTED_ORIGINS_WITH_SCHEME', [])
 
 MKTG_URL_LINK_MAP.update(_YAML_TOKENS.get('MKTG_URL_LINK_MAP', {}))
 

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -336,3 +336,37 @@ COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = {
 OPENEDX_LEARNING = {
     "MEDIA": {"BACKEND": "django.core.files.storage.InMemoryStorage", "OPTIONS": {"location": MEDIA_ROOT + "_private"}}
 }
+
+#### Override default production settings for testing purposes
+
+AWS_QUERYSTRING_AUTH = False
+AWS_S3_CUSTOM_DOMAIN = "SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)"
+AWS_STORAGE_BUCKET_NAME = "SET-ME-PLEASE (ex. bucket-name)"
+CELERY_BROKER_HOSTNAME = "localhost"
+CELERY_BROKER_PASSWORD = "celery"
+CELERY_BROKER_TRANSPORT = "amqp"
+CELERY_BROKER_USER = "celery"
+CHAT_COMPLETION_API = "https://example.com/chat/completion"
+CHAT_COMPLETION_API_KEY = "i am a key"
+del AUTHORING_API_URL
+del BROKER_HEARTBEAT
+del BROKER_HEARTBEAT_CHECKRATE
+del BROKER_USE_SSL
+del EMAIL_FILE_PATH
+del PARSE_KEYS
+del SESSION_INACTIVITY_TIMEOUT_IN_SECONDS
+ENTERPRISE_API_URL = "https://localhost:18000/enterprise/api/v1/"
+ENTERPRISE_CONSENT_API_URL = "https://localhost:18000/consent/api/v1/"
+ENTERPRISE_ENROLLMENT_API_URL = "https://localhost:18000/api/enrollment/v1/"
+INACTIVE_USER_URL = "http://localhost:18010"
+LMS_INTERNAL_ROOT_URL = "https://localhost:18000"
+OPENAPI_CACHE_TIMEOUT = 0
+POLICY_CHANGE_GRADES_ROUTING_KEY = "edx.lms.core.default"
+SECURE_PROXY_SSL_HEADER = None
+SESSION_COOKIE_DOMAIN = ""
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
+SHARED_COOKIE_DOMAIN = ""
+SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY = "edx.lms.core.default"
+SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = "edx.lms.core.default"
+STATIC_ROOT_BASE = "/edx/var/edxapp/staticfiles"
+STATIC_URL_BASE = "/static/"

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -77,20 +77,12 @@ from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 #     templates/emails/etc.
 PLATFORM_NAME = _('Your Platform Name Here')
 PLATFORM_DESCRIPTION = _('Your Platform Description Here')
-CC_MERCHANT_NAME = PLATFORM_NAME
+CC_MERCHANT_NAME = Derived(lambda settings: settings.PLATFORM_NAME)
 
 PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
 PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"
 
 ENABLE_JASMINE = False
-
-LMS_ROOT_URL = 'https://localhost:18000'
-LMS_INTERNAL_ROOT_URL = LMS_ROOT_URL
-LMS_ENROLLMENT_API_PATH = "/api/enrollment/v1/"
-
-# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
-# IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
-IDA_LOGOUT_URI_LIST = []
 
 # Features
 FEATURES = {
@@ -1075,6 +1067,16 @@ FEATURES = {
     'BADGES_ENABLED': False,
 }
 
+# .. toggle_name: ENABLE_REQUIRE_THIRD_PARTY_AUTH
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to prevent using username/password login and registration and only allow
+#   authentication with third party auth
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-09-16
+# .. toggle_warning: Requires configuration of third party auth
+ENABLE_REQUIRE_THIRD_PARTY_AUTH = False
+
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
 # Should be a list of tuples of (block_type, field_name), where block_type can also be "*" for all block types.
 # e.g. COURSE_BLOCKS_API_EXTRA_FIELDS = [  ('course', 'other_course_settings'), ("problem", "weight")  ]
@@ -1429,23 +1431,17 @@ SEARCH_COURSEWARE_CONTENT_LOG_PARAMS = False
 # .. setting_description: Specifies the prefix used when naming elasticsearch indexes related to edx-search.
 ELASTICSEARCH_INDEX_PREFIX = ""
 
-VIDEO_CDN_URL = {
-    'EXAMPLE_COUNTRY_CODE': "http://example.com/edx/video?s3_url="
-}
-
-STATIC_ROOT_BASE = '/edx/var/edxapp/staticfiles'
-
 LOGGING_ENV = 'sandbox'
 
 EDX_ROOT_URL = ''
-EDX_API_KEY = "PUT_YOUR_API_KEY_HERE"
+EDX_API_KEY = None
 
 LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/login'
 LOGIN_URL = EDX_ROOT_URL + '/login'
 
 PARTNER_SUPPORT_EMAIL = ''
 
-CERT_QUEUE = 'certificates'
+CERT_QUEUE = 'test-pull'
 
 ALTERNATE_WORKER_QUEUES = 'cms'
 
@@ -1456,11 +1452,11 @@ LOG_DIR = '/edx/var/log/edx'
 DATA_DIR = '/edx/var/edxapp/data'
 
 # .. setting_name: MAINTENANCE_BANNER_TEXT
-# .. setting_default: 'Sample banner message'
+# .. setting_default: None
 # .. setting_description: Specifies the text that is rendered on the maintenance banner.
 # .. setting_warning: Depends on the `open_edx_util.display_maintenance_warning` waffle switch.
 #   The banner is only rendered when the switch is activated.
-MAINTENANCE_BANNER_TEXT = 'Sample banner message'
+MAINTENANCE_BANNER_TEXT = None
 
 DJFS = {
     'type': 'osfs',
@@ -1565,13 +1561,13 @@ TRACKING_SEGMENTIO_SOURCE_MAP = {
 
 ######################## GOOGLE ANALYTICS ###########################
 GOOGLE_ANALYTICS_ACCOUNT = None
-GOOGLE_SITE_VERIFICATION_ID = ''
-GOOGLE_ANALYTICS_LINKEDIN = 'GOOGLE_ANALYTICS_LINKEDIN_DUMMY'
+GOOGLE_SITE_VERIFICATION_ID = None
+GOOGLE_ANALYTICS_LINKEDIN = None
 GOOGLE_ANALYTICS_TRACKING_ID = None
 GOOGLE_ANALYTICS_4_ID = None
 
 ######################## BRANCH.IO ###########################
-BRANCH_IO_KEY = ''
+BRANCH_IO_KEY = None
 
 ######################## OPTIMIZELY ###########################
 OPTIMIZELY_PROJECT_ID = None
@@ -1746,6 +1742,9 @@ DATABASES = {
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 DEFAULT_HASHING_ALGORITHM = 'sha256'
 
+HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = {}
+MONGODB_LOG = {}
+
 #################### Python sandbox ############################################
 
 CODE_JAIL = {
@@ -1805,28 +1804,29 @@ CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT = 0.5  # time in seconds
 #   codejail remote service endpoint.
 CODE_JAIL_REST_SERVICE_READ_TIMEOUT = 3.5  # time in seconds
 
+# .. setting_name: PYTHON_LIB_FILENAME
+# .. setting_default: python_lib.zip
+# .. setting_description: Name of the course file to make available to code in
+#   custom Python-graded problems. By default, this file will not be downloadable
+#   by learners.
+PYTHON_LIB_FILENAME = 'python_lib.zip'
 
 ############################### DJANGO BUILT-INS ###############################
 # Change DEBUG in your environment settings files, not here
-DEBUG = False
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
 SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
-SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 
 # django-session-cookie middleware
 DCS_SESSION_COOKIE_SAMESITE = 'None'
 DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 
-# This is the domain that is used to set shared cookies between various sub-domains.
-SHARED_COOKIE_DOMAIN = ""
-
-# CMS base
-CMS_BASE = 'localhost:18010'
-
 # LMS base
 LMS_BASE = 'localhost:18000'
+
+# CMS base
+CMS_BASE = 'studio.edx.org'
 
 # Studio name
 STUDIO_NAME = 'Studio'
@@ -1838,12 +1838,7 @@ HTTPS = 'on'
 ROOT_URLCONF = 'lms.urls'
 # NOTE: Please set ALLOWED_HOSTS to some sane value, as we do not allow the default '*'
 # Platform Email
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'localhost'
-EMAIL_PORT = 25
-EMAIL_USE_TLS = False
-EMAIL_HOST_USER = ''
-EMAIL_HOST_PASSWORD = ''
+EMAIL_FILE_PATH = Derived(lambda settings: path(settings.DATA_DIR) / "emails" / "lms")
 DEFAULT_FROM_EMAIL = 'registration@example.com'
 DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
 SERVER_EMAIL = 'devops@example.com'
@@ -1866,11 +1861,6 @@ MANAGERS = ADMINS
 # Static content
 STATIC_URL = '/static/'
 STATIC_ROOT = os.environ.get('STATIC_ROOT_LMS', ENV_ROOT / "staticfiles")
-# .. setting_name: STATIC_URL_BASE
-# .. setting_default: "/static/"
-# .. setting_description: The LMS uses this to construct ``STATIC_URL`` by appending
-#   a slash (if needed).
-STATIC_URL_BASE = '/static/'
 
 STATICFILES_DIRS = [
     COMMON_ROOT / "static",
@@ -1910,13 +1900,8 @@ TRANSLATORS_GUIDE = 'https://docs.openedx.org/en/latest/translators/index.html'
 #################################### AWS #######################################
 # The number of seconds that a generated URL is valid for.
 AWS_QUERYSTRING_EXPIRE = 10 * 365 * 24 * 60 * 60  # 10 years
-AWS_SES_REGION_NAME = 'us-east-1'
-AWS_SES_REGION_ENDPOINT = 'email.us-east-1.amazonaws.com'
 AWS_ACCESS_KEY_ID = None
 AWS_SECRET_ACCESS_KEY = None
-AWS_QUERYSTRING_AUTH = False
-AWS_STORAGE_BUCKET_NAME = "SET-ME-PLEASE (ex. bucket-name)"
-AWS_S3_CUSTOM_DOMAIN = "SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)"
 
 ################################# SIMPLEWIKI ###################################
 SIMPLE_WIKI_REQUIRE_LOGIN_EDIT = True
@@ -1972,8 +1957,8 @@ WIKI_LINK_DEFAULT_LEVEL = 2
 
 ##### Zendesk #####
 ZENDESK_URL = ''
-ZENDESK_USER = ''
-ZENDESK_API_KEY = ''
+ZENDESK_USER = None
+ZENDESK_API_KEY = None
 ZENDESK_CUSTOM_FIELDS = {}
 ZENDESK_OAUTH_ACCESS_TOKEN = ''
 # A mapping of string names to Zendesk Group IDs
@@ -2725,14 +2710,7 @@ CELERY_CREATE_MISSING_QUEUES = True
 # let logging work as configured:
 CELERYD_HIJACK_ROOT_LOGGER = False
 
-CELERY_BROKER_VHOST = ''
-CELERY_BROKER_USE_SSL = False
-CELERY_EVENT_QUEUE_TTL = None
-
-CELERY_BROKER_TRANSPORT = 'amqp'
-CELERY_BROKER_HOSTNAME = 'localhost'
-CELERY_BROKER_USER = 'celery'
-CELERY_BROKER_PASSWORD = 'celery'
+BROKER_USE_SSL = False
 
 ############################## HEARTBEAT ######################################
 
@@ -2795,11 +2773,11 @@ BULK_EMAIL_INFINITE_RETRY_CAP = 1000
 
 # We want Bulk Email running on the high-priority queue, so we define the
 # routing key that points to it.  At the moment, the name is the same.
-BULK_EMAIL_ROUTING_KEY = HIGH_PRIORITY_QUEUE
+BULK_EMAIL_ROUTING_KEY = Derived(lambda settings: settings.HIGH_PRIORITY_QUEUE)
 
 # We also define a queue for smaller jobs so that large courses don't block
 # smaller emails (see BULK_EMAIL_JOB_SIZE_THRESHOLD setting)
-BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = 'edx.lms.core.default'
+BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 
 # For emails with fewer than these number of recipients, send them through
 # a different queue to avoid large courses blocking emails that are meant to be
@@ -3196,7 +3174,6 @@ CSRF_COOKIE_AGE = 60 * 60 * 24 * 7 * 52
 # It is highly recommended that you override this in any environment accessed by
 # end users
 CSRF_COOKIE_SECURE = False
-CSRF_TRUSTED_ORIGINS = []
 
 # If setting a cross-domain cookie, it's really important to choose
 # a name for the cookie that is DIFFERENT than the cookies used
@@ -3250,9 +3227,6 @@ SWAGGER_SETTINGS = {
     'DEEP_LINKING': True,
 }
 
-# How long to cache OpenAPI schemas and UI, in seconds.
-OPENAPI_CACHE_TIMEOUT = 0
-
 ######################### MARKETING SITE ###############################
 EDXMKTG_LOGGED_IN_COOKIE_NAME = 'edxloggedin'
 EDXMKTG_USER_INFO_COOKIE_NAME = 'edx-user-info'
@@ -3282,11 +3256,11 @@ MKTG_URL_LINK_MAP = {
 STATIC_TEMPLATE_VIEW_DEFAULT_FILE_EXTENSION = 'html'
 
 SUPPORT_SITE_LINK = ''
-ID_VERIFICATION_SUPPORT_LINK = ''
-PASSWORD_RESET_SUPPORT_LINK = ''
-ACTIVATION_EMAIL_SUPPORT_LINK = ''
 SEND_ACTIVATION_EMAIL_URL = ''
-LOGIN_ISSUE_SUPPORT_LINK = ''
+ACTIVATION_EMAIL_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
+ID_VERIFICATION_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
+LOGIN_ISSUE_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
+PASSWORD_RESET_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
 
 # .. setting_name: SECURITY_PAGE_URL
 # .. setting_default: None
@@ -3542,6 +3516,8 @@ REGISTRATION_FIELD_ORDER = [
 # String length for the configurable part of the auto-generated username
 AUTO_GENERATED_USERNAME_RANDOM_STRING_LENGTH = 4
 
+REGISTRATION_CODE_LENGTH = 8
+
 ########################## CERTIFICATE NAME ########################
 CERT_NAME_SHORT = "Certificate"
 CERT_NAME_LONG = "Certificate of Achievement"
@@ -3549,15 +3525,9 @@ CERT_NAME_LONG = "Certificate of Achievement"
 ###################### Grade Downloads ######################
 # These keys are used for all of our asynchronous downloadable files, including
 # the ones that contain information other than grades.
-GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
-
-POLICY_CHANGE_GRADES_ROUTING_KEY = 'edx.lms.core.default'
-
-SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY = 'edx.lms.core.default'
+GRADES_DOWNLOAD_ROUTING_KEY = Derived(lambda settings: settings.HIGH_MEM_QUEUE)
 
 RECALCULATE_GRADES_ROUTING_KEY = 'edx.lms.core.default'
-
-SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = 'edx.lms.core.default'
 
 GRADES_DOWNLOAD = {
     'STORAGE_CLASS': 'django.core.files.storage.FileSystemStorage',
@@ -3939,8 +3909,8 @@ CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:8005'
 # time between scheduled runs, in seconds
 NOTIFY_CREDENTIALS_FREQUENCY = 14400
 
-COMMENTS_SERVICE_URL = 'http://localhost:18080'
-COMMENTS_SERVICE_KEY = 'password'
+COMMENTS_SERVICE_URL = ''
+COMMENTS_SERVICE_KEY = ''
 
 # Reverification checkpoint name pattern
 CHECKPOINT_PATTERN = r'(?P<checkpoint_name>[^/]+)'
@@ -4089,11 +4059,11 @@ STUDENTMODULEHISTORYEXTENDED_OFFSET = 10000
 ################################ Settings for Credentials Service ################################
 
 CREDENTIALS_SERVICE_USERNAME = 'credentials_service_user'
-CREDENTIALS_GENERATION_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
+CREDENTIALS_GENERATION_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 CREDENTIALS_COURSE_COMPLETION_STATE = 'awarded'
 
 # Queue to use for award program certificates
-PROGRAM_CERTIFICATES_ROUTING_KEY = 'edx.lms.core.default'
+PROGRAM_CERTIFICATES_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 
 # .. setting_name: COMPREHENSIVE_THEME_DIRS
 # .. setting_default: []
@@ -4102,19 +4072,6 @@ PROGRAM_CERTIFICATES_ROUTING_KEY = 'edx.lms.core.default'
 #   Instead, set the COMPREHENSIVE_THEME_DIRS environment variable, using colons (:) to
 #   separate paths.
 COMPREHENSIVE_THEME_DIRS = os.environ.get("COMPREHENSIVE_THEME_DIRS", "").split(":")
-
-# .. setting_name: COMPREHENSIVE_THEME_LOCALE_PATHS
-# .. setting_default: []
-# .. setting_description: A list of the paths to themes locale directories e.g.
-#   "COMPREHENSIVE_THEME_LOCALE_PATHS" : ["/edx/src/edx-themes/conf/locale"].
-COMPREHENSIVE_THEME_LOCALE_PATHS = []
-
-
-# .. setting_name: PREPEND_LOCALE_PATHS
-# .. setting_default: []
-# .. setting_description: A list of the paths to locale directories to load first e.g.
-#   "PREPEND_LOCALE_PATHS" : ["/edx/my-locales/"].
-PREPEND_LOCALE_PATHS = []
 
 # .. setting_name: DEFAULT_SITE_THEME
 # .. setting_default: None
@@ -4145,10 +4102,8 @@ ENABLE_COMPREHENSIVE_THEMING = False
 CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = None
 
 # API access management
-API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
-API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
-AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 
 # Affiliate cookie tracking
 AFFILIATE_COOKIE_NAME = 'dev_affiliate_id'
@@ -4171,8 +4126,9 @@ HELP_TOKENS_BOOKS = {
 #
 # Only used if FEATURES['ENABLE_ENTERPRISE_INTEGRATION'] == True.
 
-ENTERPRISE_ENROLLMENT_API_URL = LMS_INTERNAL_ROOT_URL + LMS_ENROLLMENT_API_PATH
-ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = LMS_ROOT_URL + LMS_ENROLLMENT_API_PATH
+ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = Derived(
+    lambda settings: (settings.LMS_ROOT_URL or '') + settings.LMS_ENROLLMENT_API_PATH
+)
 ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES = ['audit', 'honor']
 ENTERPRISE_SUPPORT_URL = ''
 ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = {}
@@ -4190,8 +4146,20 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT = {}
 # These default settings are utilized by the LMS when interacting with the service,
 # and are overridden by the configuration parameter accessors defined in production.py
 
-ENTERPRISE_API_URL = 'https://localhost:18000/enterprise/api/v1'
-ENTERPRISE_CONSENT_API_URL = LMS_INTERNAL_ROOT_URL + '/consent/api/v1/'
+DEFAULT_ENTERPRISE_API_URL = Derived(
+    lambda settings: (
+        None if settings.LMS_INTERNAL_ROOT_URL is None
+        else settings.LMS_INTERNAL_ROOT_URL + '/enterprise/api/v1/'
+    )
+)
+ENTERPRISE_API_URL = DEFAULT_ENTERPRISE_API_URL
+DEFAULT_ENTERPRISE_CONSENT_API_URL = Derived(
+    lambda settings: (
+        None if settings.LMS_INTERNAL_ROOT_URL is None
+        else settings.LMS_INTERNAL_ROOT_URL + '/consent/api/v1/'
+    )
+)
+ENTERPRISE_CONSENT_API_URL = DEFAULT_ENTERPRISE_CONSENT_API_URL
 ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = 512   # Enterprise logo image size limit in KB's
@@ -4206,14 +4174,6 @@ ENTERPRISE_ALL_SERVICE_USERNAMES = [
     'enterprise_access_worker',
     'enterprise_subsidy_worker',
 ]
-
-# Setting for Open API key and prompts used by edx-enterprise.
-CHAT_COMPLETION_API = 'https://example.com/chat/completion'
-CHAT_COMPLETION_API_KEY = 'i am a key'
-LEARNER_ENGAGEMENT_PROMPT_FOR_ACTIVE_CONTRACT = ''
-LEARNER_ENGAGEMENT_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
-LEARNER_PROGRESS_PROMPT_FOR_ACTIVE_CONTRACT = ''
-LEARNER_PROGRESS_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
 
 
 ############## ENTERPRISE SERVICE LMS CONFIGURATION ##################################
@@ -4606,9 +4566,9 @@ SWIFT_TEMP_URL_KEY = None
 SWIFT_TEMP_URL_DURATION = 1800  # seconds
 
 ############### Settings for facebook ##############################
-FACEBOOK_APP_ID = 'FACEBOOK_APP_ID'
-FACEBOOK_APP_SECRET = 'FACEBOOK_APP_SECRET'
-FACEBOOK_API_VERSION = 'v2.1'
+FACEBOOK_APP_ID = None
+FACEBOOK_APP_SECRET = None
+FACEBOOK_API_VERSION = None
 
 ############### Settings for django-fernet-fields ##################
 FERNET_KEYS = [
@@ -5026,3 +4986,16 @@ RECAPTCHA_SITE_KEYS = {
 #     and is required for the reCAPTCHA service to function correctly.
 #     The project ID should be obtained from the Google Cloud Console when creating a reCAPTCHA
 RECAPTCHA_PROJECT_ID = None
+
+############################## Miscellaneous ###############################
+
+# To limit the number of courses displayed on learner dashboard
+DASHBOARD_COURSE_LIMIT = None
+
+ENTITLEMENTS_EXPIRATION_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
+
+# TODO: We believe these were part of the DEPR'd sysadmin dashboard, and can likely be removed.
+SSL_AUTH_EMAIL_DOMAIN = "MIT.EDU"
+SSL_AUTH_DN_FORMAT_STRING = (
+    "/C=US/ST=Massachusetts/O=Massachusetts Institute of Technology/OU=Client CA v1/CN={0}/emailAddress={1}"
+)

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -26,7 +26,7 @@ from openedx_events.event_bus import merge_producer_configs
 from path import Path as path
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
-from openedx.core.lib.derived import Derived, derive_settings
+from openedx.core.lib.derived import derive_settings
 from openedx.core.lib.logsettings import get_logger_config
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -40,125 +40,6 @@ def get_env_setting(setting):
     except KeyError:
         error_msg = "Set the %s env variable" % setting
         raise ImproperlyConfigured(error_msg)  # lint-amnesty, pylint: disable=raise-missing-from
-
-
-#######################################################################################################################
-#### PRODUCTION DEFAULTS
-####
-#### Configure some defaults (beyond what has already been configured in common.py) before loading the YAML file.
-#### DO NOT ADD NEW DEFAULTS HERE! Put any new setting defaults in common.py instead, along with a setting annotation.
-#### TODO: Move all these defaults into common.py.
-####
-
-DEBUG = False
-
-# IMPORTANT: With this enabled, the server must always be behind a proxy that strips the header HTTP_X_FORWARDED_PROTO
-# from client requests. Otherwise, a user can fool our server into thinking it was an https connection. See
-# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header for other warnings.
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
-# TODO: We believe these were part of the DEPR'd sysadmin dashboard, and can likely be removed.
-SSL_AUTH_EMAIL_DOMAIN = "MIT.EDU"
-SSL_AUTH_DN_FORMAT_STRING = (
-    "/C=US/ST=Massachusetts/O=Massachusetts Institute of Technology/OU=Client CA v1/CN={0}/emailAddress={1}"
-)
-
-DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = False
-SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-CELERY_RESULT_BACKEND = 'django-cache'
-BROKER_HEARTBEAT = 60.0
-BROKER_HEARTBEAT_CHECKRATE = 2
-STATIC_ROOT_BASE = None
-STATIC_URL_BASE = None
-EMAIL_HOST = 'localhost'
-EMAIL_PORT = 25
-EMAIL_USE_TLS = False
-SESSION_COOKIE_DOMAIN = None
-SESSION_COOKIE_HTTPONLY = True
-AWS_SES_REGION_NAME = 'us-east-1'
-AWS_SES_REGION_ENDPOINT = 'email.us-east-1.amazonaws.com'
-REGISTRATION_EMAIL_PATTERNS_ALLOWED = None
-LMS_ROOT_URL = None
-CMS_BASE = 'studio.edx.org'
-CELERY_EVENT_QUEUE_TTL = None
-COMPREHENSIVE_THEME_LOCALE_PATHS = []
-PREPEND_LOCALE_PATHS = []
-COURSE_LISTINGS = {}
-COMMENTS_SERVICE_URL = ''
-COMMENTS_SERVICE_KEY = ''
-CERT_QUEUE = 'test-pull'
-PYTHON_LIB_FILENAME = 'python_lib.zip'
-VIDEO_CDN_URL = {}
-HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = {}
-AWS_STORAGE_BUCKET_NAME = 'edxuploads'
-AWS_QUERYSTRING_AUTH = True
-AWS_S3_CUSTOM_DOMAIN = 'edxuploads.s3.amazonaws.com'
-MONGODB_LOG = {}
-ZENDESK_USER = None
-ZENDESK_API_KEY = None
-EDX_API_KEY = None
-CELERY_BROKER_TRANSPORT = ""
-CELERY_BROKER_HOSTNAME = ""
-CELERY_BROKER_VHOST = ""
-CELERY_BROKER_USER = ""
-CELERY_BROKER_PASSWORD = ""
-BROKER_USE_SSL = False
-SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = None
-ENABLE_REQUIRE_THIRD_PARTY_AUTH = False
-GOOGLE_ANALYTICS_TRACKING_ID = None
-GOOGLE_ANALYTICS_LINKEDIN = None
-GOOGLE_SITE_VERIFICATION_ID = None
-BRANCH_IO_KEY = None
-REGISTRATION_CODE_LENGTH = 8
-FACEBOOK_API_VERSION = None
-FACEBOOK_APP_SECRET = None
-FACEBOOK_APP_ID = None
-API_ACCESS_MANAGER_EMAIL = None
-API_ACCESS_FROM_EMAIL = None
-CHAT_COMPLETION_API = ''
-CHAT_COMPLETION_API_KEY = ''
-OPENAPI_CACHE_TIMEOUT = 60 * 60
-MAINTENANCE_BANNER_TEXT = None
-DASHBOARD_COURSE_LIMIT = None
-
-# Derived defaults (alphabetical)
-ACTIVATION_EMAIL_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
-BULK_EMAIL_ROUTING_KEY = Derived(lambda settings: settings.HIGH_PRIORITY_QUEUE)
-BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-CC_MERCHANT_NAME = Derived(lambda settings: settings.PLATFORM_NAME)
-CREDENTIALS_GENERATION_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-CSRF_TRUSTED_ORIGINS = Derived(lambda settings: settings.CSRF_TRUSTED_ORIGINS)
-DEFAULT_ENTERPRISE_API_URL = Derived(
-    lambda settings: (
-        None if settings.LMS_INTERNAL_ROOT_URL is None
-        else settings.LMS_INTERNAL_ROOT_URL + '/enterprise/api/v1/'
-    )
-)
-DEFAULT_ENTERPRISE_CONSENT_API_URL = Derived(
-    lambda settings: (
-        None if settings.LMS_INTERNAL_ROOT_URL is None
-        else settings.LMS_INTERNAL_ROOT_URL + '/consent/api/v1/'
-    )
-)
-ENTERPRISE_API_URL = DEFAULT_ENTERPRISE_API_URL
-ENTERPRISE_CONSENT_API_URL = DEFAULT_ENTERPRISE_CONSENT_API_URL
-ENTERPRISE_ENROLLMENT_API_URL = Derived(
-    lambda settings: (settings.LMS_INTERNAL_ROOT_URL or '') + settings.LMS_ENROLLMENT_API_PATH
-)
-ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = Derived(
-    lambda settings: (settings.LMS_ROOT_URL or '') + settings.LMS_ENROLLMENT_API_PATH
-)
-EMAIL_FILE_PATH = Derived(lambda settings: settings.DATA_DIR / "emails" / "lms")
-ENTITLEMENTS_EXPIRATION_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-GRADES_DOWNLOAD_ROUTING_KEY = Derived(lambda settings: settings.HIGH_MEM_QUEUE)
-ID_VERIFICATION_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
-LMS_INTERNAL_ROOT_URL = Derived(lambda settings: settings.LMS_ROOT_URL)
-LOGIN_ISSUE_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
-PASSWORD_RESET_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
-PROGRAM_CERTIFICATES_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
-SHARED_COOKIE_DOMAIN = Derived(lambda settings: settings.SESSION_COOKIE_DOMAIN)
-SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = Derived(lambda settings: settings.HIGH_PRIORITY_QUEUE)
-
 
 #######################################################################################################################
 #### YAML LOADING

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -131,6 +131,8 @@ DJFS = {
     'url_root': '/static/django-pyfs',
 }
 
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
+
 ############################ STATIC FILES #############################
 
 # TODO (cpennington): We need to figure out how envs/test.py can inject things
@@ -689,3 +691,53 @@ TOKEN_SIGNING = {
         }
     """,  # noqa: E501
 }
+
+
+### Override default production settings for testing purposes
+
+API_ACCESS_FROM_EMAIL = "api-requests@example.com"
+AWS_QUERYSTRING_AUTH = False
+AWS_S3_CUSTOM_DOMAIN = "SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)"
+AWS_STORAGE_BUCKET_NAME = "SET-ME-PLEASE (ex. bucket-name)"
+BRANCH_IO_KEY = ""
+CC_MERCHANT_NAME = "Your Platform Name Here"
+CELERY_BROKER_HOSTNAME = "localhost"
+CELERY_BROKER_PASSWORD = "celery"
+CELERY_BROKER_TRANSPORT = "amqp"
+CELERY_BROKER_USER = "celery"
+CERT_QUEUE = "certificates"
+CHAT_COMPLETION_API = "https://example.com/chat/completion"
+CHAT_COMPLETION_API_KEY = "i am a key"
+CMS_BASE = "localhost:18010"
+COMMENTS_SERVICE_KEY = "password"
+del BROKER_HEARTBEAT
+del BROKER_HEARTBEAT_CHECKRATE
+del BROKER_USE_SSL
+del DEFAULT_ENTERPRISE_API_URL
+del DEFAULT_ENTERPRISE_CONSENT_API_URL
+del EMAIL_FILE_PATH
+del ENABLE_REQUIRE_THIRD_PARTY_AUTH
+del ENTITLEMENTS_EXPIRATION_ROUTING_KEY
+del PYTHON_LIB_FILENAME
+del REGISTRATION_CODE_LENGTH
+del SESSION_INACTIVITY_TIMEOUT_IN_SECONDS
+del SSL_AUTH_DN_FORMAT_STRING
+del SSL_AUTH_EMAIL_DOMAIN
+EDX_API_KEY = "PUT_YOUR_API_KEY_HERE"
+ENTERPRISE_ENROLLMENT_API_URL = "https://localhost:18000/api/enrollment/v1/"
+ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = "https://localhost:18000/api/enrollment/v1/"
+GOOGLE_ANALYTICS_LINKEDIN = "GOOGLE_ANALYTICS_LINKEDIN_DUMMY"
+GOOGLE_SITE_VERIFICATION_ID = ""
+ID_VERIFICATION_SUPPORT_LINK = ""
+LMS_INTERNAL_ROOT_URL = "https://localhost:18000"
+MAINTENANCE_BANNER_TEXT = "Sample banner message"
+OPENAPI_CACHE_TIMEOUT = 0
+SECURE_PROXY_SSL_HEADER = None
+SESSION_COOKIE_DOMAIN = ""
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
+SHARED_COOKIE_DOMAIN = ""
+SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = "edx.lms.core.default"
+STATIC_ROOT_BASE = "/edx/var/edxapp/staticfiles"
+STATIC_URL_BASE = "/static/"
+ZENDESK_API_KEY = ""
+ZENDESK_USER = ""

--- a/openedx/core/djangoapps/user_authn/toggles.py
+++ b/openedx/core/djangoapps/user_authn/toggles.py
@@ -8,15 +8,6 @@ from django.conf import settings
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
-# .. toggle_name: ENABLE_REQUIRE_THIRD_PARTY_AUTH
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to prevent using username/password login and registration and only allow
-#   authentication with third party auth
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-09-16
-# .. toggle_warning: Requires configuration of third party auth
-
 
 def is_require_third_party_auth_enabled():
     # TODO: Replace function with SettingToggle when it is available.

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -83,6 +83,8 @@ def _make_locale_paths(settings):
 
 ############################# Django Built-Ins #############################
 
+DEBUG = False
+
 USE_TZ = True
 
 # User-uploaded content
@@ -91,6 +93,15 @@ MEDIA_URL = '/media/'
 
 # Dummy secret key for dev/test
 SECRET_KEY = 'dev key'
+
+# IMPORTANT: With this enabled, the server must always be behind a proxy that strips the header HTTP_X_FORWARDED_PROTO
+# from client requests. Otherwise, a user can fool our server into thinking it was an https connection. See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header for other warnings.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+SESSION_COOKIE_DOMAIN = None
+SESSION_COOKIE_HTTPONLY = True
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 STATICI18N_OUTPUT_DIR = "js/i18n"
 
@@ -433,7 +444,19 @@ REST_FRAMEWORK = {
     },
 }
 
-################################ Heartbeat #################################
+################################## Celery ##################################
+
+BROKER_HEARTBEAT = 60.0
+BROKER_HEARTBEAT_CHECKRATE = 2
+
+CELERY_BROKER_USE_SSL = False
+CELERY_BROKER_HOSTNAME = ''
+CELERY_BROKER_PASSWORD = ''
+CELERY_BROKER_TRANSPORT = ''
+CELERY_BROKER_USER = ''
+CELERY_BROKER_VHOST = ''
+CELERY_RESULT_BACKEND = 'django-cache'
+CELERY_EVENT_QUEUE_TTL = None
 
 # Checks run in normal mode by the heartbeat djangoapp
 HEARTBEAT_CHECKS = [
@@ -752,6 +775,27 @@ USE_EXTRACTED_PROBLEM_BLOCK = False
 # .. toggle_target_removal_date: 2025-06-01
 USE_EXTRACTED_VIDEO_BLOCK = False
 
+################################# ChatGPT ##################################
+
+CHAT_COMPLETION_API = ''
+CHAT_COMPLETION_API_KEY = ''
+LEARNER_ENGAGEMENT_PROMPT_FOR_ACTIVE_CONTRACT = ''
+LEARNER_ENGAGEMENT_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
+LEARNER_PROGRESS_PROMPT_FOR_ACTIVE_CONTRACT = ''
+LEARNER_PROGRESS_PROMPT_FOR_NON_ACTIVE_CONTRACT = ''
+
+# How long to cache OpenAPI schemas and UI, in seconds.
+OPENAPI_CACHE_TIMEOUT = 60 * 60
+
+################################### AWS ####################################
+
+AWS_QUERYSTRING_AUTH = True
+AWS_STORAGE_BUCKET_NAME = 'edxuploads'
+AWS_S3_CUSTOM_DOMAIN = 'edxuploads.s3.amazonaws.com'
+
+AWS_SES_REGION_NAME = 'us-east-1'
+AWS_SES_REGION_ENDPOINT = 'email.us-east-1.amazonaws.com'
+
 ############################## Miscellaneous ###############################
 
 COURSE_MODE_DEFAULTS = {
@@ -783,3 +827,58 @@ USERNAME_PATTERN = fr'(?P<username>{USERNAME_REGEX_PARTIAL})'
 
 DISCUSSION_RATELIMIT = '100/m'
 SKIP_RATE_LIMIT_ON_ACCOUNT_AFTER_DAYS = 0
+
+LMS_ROOT_URL = None
+LMS_INTERNAL_ROOT_URL = Derived(lambda settings: settings.LMS_ROOT_URL)
+
+LMS_ENROLLMENT_API_PATH = "/api/enrollment/v1/"
+ENTERPRISE_ENROLLMENT_API_URL = Derived(
+    lambda settings: (settings.LMS_INTERNAL_ROOT_URL or '') + settings.LMS_ENROLLMENT_API_PATH
+)
+
+# This is the domain that is used to set shared cookies between various sub-domains.
+SHARED_COOKIE_DOMAIN = Derived(lambda settings: settings.SESSION_COOKIE_DOMAIN)
+
+SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = None
+
+STATIC_ROOT_BASE = None
+
+VIDEO_CDN_URL = {
+    # 'EXAMPLE_COUNTRY_CODE': "http://example.com/edx/video?s3_url="
+}
+
+# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS
+# or CMS. Only applies to IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
+IDA_LOGOUT_URI_LIST = []
+
+SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = Derived(lambda settings: settings.HIGH_PRIORITY_QUEUE)
+
+# Queue to use for updating grades due to grading policy change
+POLICY_CHANGE_GRADES_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
+
+# Queue to use for individual learner course regrades
+SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
+
+# .. setting_name: STATIC_URL_BASE
+# .. setting_default: "None"
+# .. setting_description: The LMS and CMS use this to construct ``STATIC_URL`` by appending
+#   a slash (if needed), and for the CMS, ``studio/`` afterwards.
+STATIC_URL_BASE = None
+
+# .. setting_name: COMPREHENSIVE_THEME_LOCALE_PATHS
+# .. setting_default: []
+# .. setting_description: A list of the paths to themes locale directories e.g.
+#   "COMPREHENSIVE_THEME_LOCALE_PATHS" : ["/edx/src/edx-themes/conf/locale"].
+COMPREHENSIVE_THEME_LOCALE_PATHS = []
+
+# .. setting_name: PREPEND_LOCALE_PATHS
+# .. setting_default: []
+# .. setting_description: A list of the paths to locale directories to load first e.g.
+#   "PREPEND_LOCALE_PATHS" : ["/edx/my-locales/"].
+PREPEND_LOCALE_PATHS = []
+
+# API access management
+API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
+AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+
+CSRF_TRUSTED_ORIGINS = []

--- a/xmodule/util/sandboxing.py
+++ b/xmodule/util/sandboxing.py
@@ -11,11 +11,6 @@ def course_code_library_asset_name():
     """
     Return the asset name to use for course code libraries, defaulting to python_lib.zip.
     """
-    # .. setting_name: PYTHON_LIB_FILENAME
-    # .. setting_default: python_lib.zip
-    # .. setting_description: Name of the course file to make available to code in
-    #   custom Python-graded problems. By default, this file will not be downloadable
-    #   by learners.
     return getattr(settings, 'PYTHON_LIB_FILENAME', DEFAULT_PYTHON_LIB_FILENAME)
 
 


### PR DESCRIPTION
## Description

In the effort to simplify settings in edx-platform, as discussed in [ADR 22 - Settings Simplification](https://github.com/openedx/edx-platform/blob/master/docs/decisions/0022-settings-simplification.rst), this PR brings some of the production defaults defined in `lms/envs/production.py` and `cms/envs/production.py` up to `openedx/envs/common.py` or `lms/envs/common.py` and `cms/envs/common.py` as appropriate.

Bringing these defaults up from the `production.py` settings modules caused changes in the rendered settings of the `test.py` modules, and so I have settings to the `test.py` modules to bring the rendered settings back in line with what is has been. I have not deeply looked at which settings are needed for tests to pass or not, but just the differences between the rendered settings between `master` and this branch.

## Supporting information

Fixes https://github.com/openedx/edx-platform/issues/36892.

## Testing instructions

### `diff_settings.py`

I've used the `diff_settings.sh` [script](https://github.com/openedx/edx-platform/pull/36306) as a foundation to create a `diff_settings.py` script that can be found [here](https://github.com/WGU-Open-edX/oex-utils/blob/main/settings_utils/diff_settings.py) (documentation [here](https://github.com/WGU-Open-edX/oex-utils/blob/main/settings_utils/README.md#diff_settingspy)). I've used this script to test the rendered settings for this branch against the rendered settings in the master branch.

### Modification to `cms/envs/production.py` required

To get all runs of `dump_settings` to work (specifically running the command with `DJANGO_SETTINGS_MODULE=cms.envs.production` and `CMS_CFG=cms/envs/mock.yml`) I needed to make a small patch to `cms/envs/production.py` in both `master` and my branch:

```diff
-CSRF_TRUSTED_ORIGINS = _YAML_TOKENS.get("CSRF_TRUSTED_ORIGINS", [])
+CSRF_TRUSTED_ORIGINS = _YAML_TOKENS.get('CSRF_TRUSTED_ORIGINS_WITH_SCHEME', [])
```

Without this, the command would fail and output this error:

> As of Django 4.0, the values in the CSRF_TRUSTED_ORIGINS setting must start with a scheme (usually http:// or https://) but found .localhost. See the release notes for details.

### Results from running `diff_settings.py`

Running `python diff_settings.py master hoist-production-settings` in a tutor dev environment, I get the following results:

```diff
python diff_settings.py master hoist-production-settings

diff main_settings_dump/cms.envs.production__cms_envs_mock.json feature_settings_dump/cms.envs.production__cms_envs_mock.json
2644c2644
<     "ENTERPRISE_ENROLLMENT_API_URL": "https://localhost:18000/api/enrollment/v1/",
---
>     "ENTERPRISE_ENROLLMENT_API_URL": "https://courses.localhost/api/enrollment/v1/",

diff main_settings_dump/cms.envs.tutor.development__openedx_config_cms.json feature_settings_dump/cms.envs.tutor.development__openedx_config_cms.json
1467c1467
<     "ENTERPRISE_ENROLLMENT_API_URL": "https://localhost:18000/api/enrollment/v1/",
---
>     "ENTERPRISE_ENROLLMENT_API_URL": "http://local.openedx.io/api/enrollment/v1/",

diff main_settings_dump/cms.envs.tutor.production__openedx_config_cms.json feature_settings_dump/cms.envs.tutor.production__openedx_config_cms.json
1442c1442
<     "ENTERPRISE_ENROLLMENT_API_URL": "https://localhost:18000/api/enrollment/v1/",
---
>     "ENTERPRISE_ENROLLMENT_API_URL": "http://local.openedx.io/api/enrollment/v1/",

diff main_settings_dump/cms.envs.tutor.test__openedx_config_cms.json feature_settings_dump/cms.envs.tutor.test__openedx_config_cms.json

diff main_settings_dump/lms.envs.production__lms_envs_minimal.json feature_settings_dump/lms.envs.production__lms_envs_minimal.json

diff main_settings_dump/lms.envs.production__lms_envs_mock.json feature_settings_dump/lms.envs.production__lms_envs_mock.json

diff main_settings_dump/lms.envs.tutor.development__openedx_config_lms.json feature_settings_dump/lms.envs.tutor.development__openedx_config_lms.json

diff main_settings_dump/lms.envs.tutor.production__openedx_config_lms.json feature_settings_dump/lms.envs.tutor.production__openedx_config_lms.json

diff main_settings_dump/lms.envs.tutor.test__openedx_config_lms.json feature_settings_dump/lms.envs.tutor.test__openedx_config_lms.json

Differences found between branches (shown above)


### Note: These are expected differences between the two branches, which have been removed
### from the diff output above:
4361c4361
<             "module": "lms.envs.common",
---
>             "module": "openedx.envs.common",
4890c4890
<                 "stream": "<colorama.ansitowin32.StreamWrapper object at 0xffffb4e72090>"
---
>                 "stream": "<colorama.ansitowin32.StreamWrapper object at 0xffff85baded0>"
5851a5852
>     "USAGE_ID_PATTERN": "(?P<usage_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))",
3282c3282
<     "THIS_UUID": "1db47",
---
>     "THIS_UUID": "2417d",
1257c1257
<         "db": "test_xmodule_1db47",
---
>         "db": "test_xmodule_2417d",
```

## Other information

This is built on the work done in https://github.com/openedx/edx-platform/pull/36941.

### Sandbox

the block below removes the tutor-discovery plugin, which seems to be having build issues

**Tutor Requirements**
```
git+https://github.com/overhangio/tutor.git@main
git+https://github.com/overhangio/tutor-mfe.git@main
git+https://github.com/overhangio/tutor-xqueue.git@main
git+https://github.com/overhangio/tutor-forum.git@main
git+https://gitlab.com/opencraft/dev/tutor-contrib-grove.git@main
git+https://github.com/open-craft/tutor-contrib-s3.git@kaustav/add_support_for_tutor_20
git+https://github.com/open-craft/openedx-k8s-harmony.git@kaustav/support_tutor_20#egg=tutor-contrib-harmony&subdirectory=tutor-contrib-harmony-plugin
```