### PR TITLE
chore: added email verified in course view api

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -106,6 +106,7 @@ from .forms import CommentActionsForm, ThreadActionsForm, UserOrdering
 from .pagination import DiscussionAPIPagination
 from .permissions import (
     can_delete,
+    can_take_action_on_spam,
     get_editable_fields,
     get_initializable_comment_fields,
     get_initializable_thread_fields
@@ -354,6 +355,7 @@ def get_course(request, course_key, check_tab=True):
         "allow_anonymous": course.allow_anonymous,
         "allow_anonymous_to_peers": course.allow_anonymous_to_peers,
         "user_roles": user_roles,
+        "has_bulk_delete_privileges": can_take_action_on_spam(request.user, course_key),
         "has_moderation_privileges": bool(user_roles & {
             FORUM_ROLE_ADMINISTRATOR,
             FORUM_ROLE_MODERATOR,
@@ -381,8 +383,9 @@ def get_course(request, course_key, check_tab=True):
         'captcha_settings': {
             'enabled': is_captcha_enabled(course_key),
             'site_key': settings.RECAPTCHA_SITE_KEY,
-        }
-
+        },
+        "is_email_verified": request.user.is_active,
+        "only_verified_users_can_post": False,
     }
 
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -205,6 +205,7 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
             'enable_in_context': True,
             'group_at_subsection': False,
             'provider': 'legacy',
+            "has_bulk_delete_privileges": False,
             'has_moderation_privileges': False,
             "is_course_staff": False,
             "is_course_admin": False,
@@ -219,6 +220,8 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
                 'enabled': False,
                 'site_key': '',
             },
+            "is_email_verified": True,
+            "only_verified_users_can_post": False
         }
 
     @ddt.data(

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -548,6 +548,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "provider": "legacy",
                 "allow_anonymous": True,
                 "allow_anonymous_to_peers": False,
+                "has_bulk_delete_privileges": False,
                 "has_moderation_privileges": False,
                 'is_course_admin': False,
                 'is_course_staff': False,
@@ -562,6 +563,8 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                     'enabled': False,
                     'site_key': '',
                 },
+                "is_email_verified": True,
+                "only_verified_users_can_post": False
             }
         )
 


### PR DESCRIPTION
Added following attributes in course view API
- `is_email_verified` User has verified their email
- `only_verified_users_can_post` Returns that only verified users are allowed to post or unverified users can post as well. TODO: This will be added behind a waffle flag
- `has_bulk_delete_privileges` Returns that user has access to bulk delete posts or not
