### PR TITLE
feat: tpa automatic logout with a single redirect

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -8,7 +8,6 @@ from urllib.parse import parse_qs, urlsplit, urlunsplit  # pylint: disable=impor
 import nh3
 from django.conf import settings
 from django.contrib.auth import logout
-from django.shortcuts import redirect
 from django.utils.http import urlencode
 from django.views.generic import TemplateView
 from oauth2_provider.models import Application
@@ -47,7 +46,13 @@ class LogoutView(TemplateView):
         If a redirect_url is specified in the querystring for this request, and the value is a safe
         url for redirect, the view will redirect to this page after rendering the template.
         If it is not specified, we will use the default target url.
+        Redirect to tpa_logout_url if TPA_AUTOMATIC_LOGOUT_ENABLED is set to True and if
+        tpa_logout_url is configured.
         """
+
+        if getattr(settings, 'TPA_AUTOMATIC_LOGOUT_ENABLED', False) and self.tpa_logout_url:
+            return self.tpa_logout_url
+
         target_url = self.request.GET.get('redirect_url') or self.request.GET.get('next')
 
         #  Some third party apps do not build URLs correctly and send next query param without URL-encoding, resulting
@@ -84,16 +89,6 @@ class LogoutView(TemplateView):
         delete_logged_in_cookies(response)
 
         mark_user_change_as_expected(None)
-
-        # Redirect to tpa_logout_url if TPA_AUTOMATIC_LOGOUT_ENABLED is set to True and if
-        # tpa_logout_url is configured.
-        #
-        # NOTE: This step skips rendering logout.html, which is used to log the user out from the
-        # different IDAs. To ensure the user is logged out of all the IDAs be sure to redirect
-        # back to <LMS>/logout after logging out of the TPA.
-        if getattr(settings, 'TPA_AUTOMATIC_LOGOUT_ENABLED', False):
-            if self.tpa_logout_url:
-                return redirect(self.tpa_logout_url)
 
         return response
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -211,8 +211,10 @@ class LogoutTests(TestCase):
             mock_idp_logout_url.return_value = idp_logout_url
             self._authenticate_with_oauth(client)
             response = self.client.get(reverse('logout'))
-            assert response.status_code == 302
-            assert response.url == idp_logout_url
+            expected = {
+                'target': idp_logout_url,
+            }
+            self.assertDictContainsSubset(expected, response.context_data)
 
     @mock.patch('django.conf.settings.TPA_AUTOMATIC_LOGOUT_ENABLED', True)
     def test_no_automatic_tpa_logout_without_logout_url(self):


### PR DESCRIPTION
## Description

Current Third Party Authentication logout requires a redirect from the SSO IDP to the LMS to handle IDAs logout, i.e. we need to visit the `<LMS>/logout` twice. This PR attempts to handle the TPA logout with only one visit to `<LMS>/logout`.
## Testing instructions

1. Add `TPA_AUTOMATIC_LOGOUT_ENABLED = True` to `edx-platform/lms/envs/devstack.py`
2. Replace `self.tpa_logout_url = tpa_pipeline.get_idp_logout_url_from_running_pipeline(request)` in `edx-platform/openedx/core/djangoapps/user_authn/views/logout.py` with  `self.tpa_logout_url = "https://example.com/logout"` (to simplify testing)
3. Launch LMS  and Studio e.g. `make dev.up.lms+cms`
4. Check the network tab and ensure that the user is logged out from both the LMS and Studio before being redirected to `https://example.com/logout` (fake IDP logout URL)


## Supporting information

Private ref BB-8759
## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.