### PR TITLE
feat: Upgrade openedx-learning to get better Container admin pages

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -70,7 +70,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.26.0
+openedx-learning==0.27.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1177,7 +1177,9 @@ text-unidecode==1.3
 tinycss2==1.4.0
     # via bleach
 tomlkit==0.13.2
-    # via snowflake-connector-python
+    # via
+    #   openedx-learning
+    #   snowflake-connector-python
 tqdm==4.67.1
     # via
     #   nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -840,7 +840,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.0
     # via -r requirements/edx/kernel.in
-openedx-learning==0.26.0
+openedx-learning==0.27.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2109,6 +2109,7 @@ tomlkit==0.13.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   openedx-learning
     #   pylint
     #   snowflake-connector-python
 tox==4.26.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1400,7 +1400,7 @@ openedx-forum==0.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.26.0
+openedx-learning==0.27.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1477,6 +1477,7 @@ tinycss2==1.4.0
 tomlkit==0.13.2
     # via
     #   -r requirements/edx/base.txt
+    #   openedx-learning
     #   snowflake-connector-python
 tqdm==4.67.1
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1005,7 +1005,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.26.0
+openedx-learning==0.27.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1566,6 +1566,7 @@ tinycss2==1.4.0
 tomlkit==0.13.2
     # via
     #   -r requirements/edx/base.txt
+    #   openedx-learning
     #   pylint
     #   snowflake-connector-python
 tox==4.26.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1064,7 +1064,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.0
     # via -r requirements/edx/base.txt
-openedx-learning==0.26.0
+openedx-learning==0.27.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Upgrades openedx-learning from 0.26.0 to 0.27.0

Change information: https://github.com/openedx/openedx-learning/releases/tag/v0.27.0

See those PRs for information on what is being added and how it was tested.