### PR TITLE
feanil/unpin urllib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ compile-requirements: pre-requirements $(COMMON_CONSTRAINTS_TXT) ## Re-compile *
 	@# time someone tries to use the outputs.
 	sed '/^django-simple-history==/d' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
-	sed 's/Django<4.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	sed 's/Django<5.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
-	sed 's/event-tracking<2.4.1//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	sed 's/urllib3<2.3.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	pip-compile -v --allow-unsafe ${COMPILE_OPTS} -o requirements/pip.txt requirements/pip.in
 	pip install -r requirements/pip.txt

--- a/openedx/core/djangoapps/content_staging/serializers.py
+++ b/openedx/core/djangoapps/content_staging/serializers.py
@@ -66,7 +66,7 @@ class UserClipboardSerializer(serializers.Serializer):
         except ItemNotFoundError:
             return ""
         edit_url = xblock_studio_url(block, find_parent=True)
-        if edit_url:
+        if edit_url and request:
             return request.build_absolute_uri(edit_url)
         return ""
 

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
@@ -201,7 +201,7 @@ class ObjectTagExportView(APIView):
             def write(self, value):
                 return value
 
-        object_id: str = kwargs.get('context_id', None)
+        object_id: str | None = kwargs.get('context_id', None)
         pseudo_buffer = Echo()
 
         if not has_view_object_tags_access(self.request.user, object_id):

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -16,7 +16,7 @@
 #  this file from Github directly. It does not require packaging in edx-lint.
 
 # using LTS django version
-Django<5.0
+
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
@@ -31,4 +31,4 @@ pip<24.3
 
 # Cause: https://github.com/openedx/edx-lint/issues/475
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0
+

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -10,15 +10,15 @@ chem==2.0.0
     # via -r requirements/edx-sandbox/base.in
 click==8.2.1
     # via nltk
-codejail-includes==1.0.0
+codejail-includes==2.0.0
     # via -r requirements/edx-sandbox/base.in
-contourpy==1.3.2
+contourpy==1.3.3
     # via matplotlib
-cryptography==45.0.3
+cryptography==45.0.5
     # via -r requirements/edx-sandbox/base.in
 cycler==0.12.1
     # via matplotlib
-fonttools==4.58.1
+fonttools==4.59.0
     # via matplotlib
 joblib==1.5.1
     # via nltk
@@ -58,7 +58,7 @@ openedx-calc==4.0.2
     # via -r requirements/edx-sandbox/base.in
 packaging==25.0
     # via matplotlib
-pillow==11.2.1
+pillow==11.3.0
     # via matplotlib
 pycparser==2.22
     # via cffi
@@ -74,14 +74,12 @@ random2==1.0.2
     # via -r requirements/edx-sandbox/base.in
 regex==2024.11.6
     # via nltk
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
 six==1.17.0
-    # via
-    #   codejail-includes
-    #   python-dateutil
+    # via python-dateutil
 sympy==1.14.0
     # via
     #   -r requirements/edx-sandbox/base.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,11 +10,11 @@ acid-xblock==0.4.1
     # via -r requirements/edx/kernel.in
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.8
+aiohttp==3.12.14
     # via
     #   geoip2
     #   openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
 amqp==5.3.1
     # via kombu
@@ -24,9 +24,11 @@ aniso8601==10.0.1
     # via edx-tincan-py35
 annotated-types==0.7.0
     # via pydantic
+anyio==4.9.0
+    # via httpx
 appdirs==1.4.4
     # via fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   django
     #   django-cors-headers
@@ -68,14 +70,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.38.29
+boto3==1.39.14
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.38.29
+botocore==1.39.14
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -102,9 +104,11 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.4.26
+certifi==2025.7.14
     # via
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
@@ -132,7 +136,7 @@ click==8.2.1
     #   user-util
 click-didyoumean==0.3.1
     # via celery
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
@@ -140,11 +144,11 @@ code-annotations==2.3.0
     # via
     #   edx-enterprise
     #   edx-toggles
-codejail-includes==1.0.0
+codejail-includes==2.0.0
     # via -r requirements/edx/kernel.in
 crowdsourcehinter-xblock==0.8
     # via -r requirements/edx/bundled.in
-cryptography==45.0.3
+cryptography==45.0.5
     # via
     #   -r requirements/edx/kernel.in
     #   django-fernet-fields-v2
@@ -165,9 +169,8 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.22
+django==4.2.23
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-appconf
@@ -188,7 +191,6 @@ django==4.2.22
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
-    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
@@ -339,7 +341,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/bundled.in
-django-simple-history==3.8.0
+django-simple-history==3.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -359,9 +361,9 @@ django-storages==1.14.6
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
-django-user-tasks==3.4.1
+django-user-tasks==3.4.2
     # via -r requirements/edx/kernel.in
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-django-utils
@@ -415,7 +417,7 @@ edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
-edx-auth-backends==4.5.0
+edx-auth-backends==4.6.0
     # via -r requirements/edx/kernel.in
 edx-bulk-grades==1.2.0
     # via
@@ -447,6 +449,7 @@ edx-django-utils==8.0.0
     #   -r requirements/edx/kernel.in
     #   django-config-models
     #   edx-ace
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -508,7 +511,7 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==6.13.0
+edx-organizations==7.1.0
     # via -r requirements/edx/kernel.in
 edx-proctoring==5.2.0
     # via
@@ -541,6 +544,7 @@ edx-tincan-py35==2.0.0
 edx-toggles==5.3.0
     # via
     #   -r requirements/edx/kernel.in
+    #   edx-auth-backends
     #   edx-completion
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -578,9 +582,9 @@ fastavro==1.11.1
     # via openedx-events
 filelock==3.18.0
     # via snowflake-connector-python
-firebase-admin==6.8.0
+firebase-admin==7.0.0
     # via edx-ace
-frozenlist==1.6.2
+frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
@@ -600,32 +604,25 @@ geoip2==5.1.0
     # via -r requirements/edx/kernel.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
-google-api-core[grpc]==2.25.0
+google-api-core[grpc]==2.25.1
     # via
     #   firebase-admin
-    #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.171.0
-    # via firebase-admin
-google-auth==2.40.2
+google-auth==2.40.3
     # via
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth-httplib2==0.2.0
-    # via google-api-python-client
 google-cloud-core==2.4.3
     # via
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-firestore==2.21.0
     # via firebase-admin
-google-cloud-storage==3.1.0
+google-cloud-storage==3.2.0
     # via firebase-admin
 google-crc32c==1.7.1
     # via
@@ -637,28 +634,38 @@ googleapis-common-protos==1.70.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.72.1
+grpcio==1.74.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.72.1
+grpcio-status==1.74.0
     # via google-api-core
 gunicorn==23.0.0
     # via -r requirements/edx/kernel.in
+h11==0.16.0
+    # via httpcore
+h2==4.2.0
+    # via httpx
 help-tokens==3.2.0
     # via -r requirements/edx/kernel.in
+hpack==4.1.0
+    # via h2
 html5lib==1.1
     # via
     #   -r requirements/edx/kernel.in
     #   ora2
-httplib2==0.22.0
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
+httpcore==1.0.9
+    # via httpx
+httpx[http2]==0.28.1
+    # via firebase-admin
+hyperframe==6.1.0
+    # via h2
 icalendar==6.3.1
     # via -r requirements/edx/kernel.in
 idna==3.10
     # via
+    #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
     #   snowflake-connector-python
@@ -683,7 +690,7 @@ joblib==1.5.1
     # via nltk
 jsondiff==2.2.1
     # via edx-enterprise
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-celeryutils
@@ -693,7 +700,7 @@ jsonfield==3.1.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   drf-spectacular
     #   optimizely-sdk
@@ -742,7 +749,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.8
+markdown==3.8.2
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
@@ -755,9 +762,9 @@ markupsafe==3.0.2
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.7.0
+maxminddb==2.8.2
     # via geoip2
-meilisearch==0.34.1
+meilisearch==0.36.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-search
@@ -769,9 +776,9 @@ more-itertools==10.7.0
     # via cssutils
 mpmath==1.3.0
     # via sympy
-msgpack==1.1.0
+msgpack==1.1.1
     # via cachecontrol
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl
@@ -779,7 +786,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum
-nh3==0.2.21
+nh3==0.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   xblocks-contrib
@@ -794,7 +801,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   -r requirements/edx/kernel.in
     #   django-oauth-toolkit
@@ -820,11 +827,11 @@ openedx-django-pyfs==3.8.0
     #   lti-consumer-xblock
     #   xblock
     #   xblocks-contrib
-openedx-django-require==2.1.0
+openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/kernel.in
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -838,7 +845,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.0
+openedx-forum==0.3.1
     # via -r requirements/edx/kernel.in
 openedx-learning==0.27.0
     # via
@@ -846,7 +853,7 @@ openedx-learning==0.27.0
     #   -r requirements/edx/kernel.in
 optimizely-sdk==5.2.0
     # via -r requirements/edx/bundled.in
-ora2==6.16.3
+ora2==6.16.4
     # via -r requirements/edx/bundled.in
 packaging==25.0
     # via
@@ -873,7 +880,7 @@ pgpy==0.6.0
     # via edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/kernel.in
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -885,7 +892,7 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.51
     # via click-repl
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
@@ -921,7 +928,7 @@ pycryptodomex==3.23.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.11.5
+pydantic==2.11.7
     # via camel-converter
 pydantic-core==2.33.2
     # via pydantic
@@ -967,7 +974,6 @@ pyopenssl==25.1.0
 pyparsing==3.2.3
     # via
     #   chem
-    #   httplib2
     #   openedx-calc
 pyrsistent==0.20.0
     # via optimizely-sdk
@@ -1043,7 +1049,7 @@ referencing==0.36.2
     #   jsonschema-specifications
 regex==2024.11.6
     # via nltk
-requests==2.32.3
+requests==2.32.4
     # via
     #   analytics-python
     #   cachecontrol
@@ -1074,7 +1080,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   social-auth-core
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
@@ -1086,11 +1092,11 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
-scipy==1.15.3
+scipy==1.16.1
     # via chem
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -1107,7 +1113,6 @@ six==1.17.0
     # via
     #   -r requirements/edx/kernel.in
     #   analytics-python
-    #   codejail-includes
     #   crowdsourcehinter-xblock
     #   edx-ace
     #   edx-auth-backends
@@ -1128,7 +1133,9 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-snowflake-connector-python==3.15.0
+sniffio==1.3.1
+    # via anyio
+snowflake-connector-python==3.16.0
     # via edx-enterprise
 social-auth-app-django==5.4.1
     # via
@@ -1167,13 +1174,13 @@ super-csv==4.1.0
     # via edx-bulk-grades
 sympy==1.14.0
     # via openedx-calc
-testfixtures==8.3.0
+testfixtures==9.1.0
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify
 tinycss2==1.4.0
     # via bleach
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
     #   openedx-learning
     #   snowflake-connector-python
@@ -1181,8 +1188,10 @@ tqdm==4.67.1
     # via
     #   nltk
     #   openai
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
+    #   aiosignal
+    #   anyio
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -1211,10 +1220,8 @@ uritemplate==4.2.0
     # via
     #   drf-spectacular
     #   drf-yasg
-    #   google-api-python-client
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   botocore
     #   elasticsearch
     #   requests
@@ -1227,7 +1234,7 @@ vine==5.1.0
     #   kombu
 voluptuous==0.15.2
     # via ora2
-walrus==0.9.4
+walrus==0.9.5
     # via edx-event-bus-redis
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -1268,7 +1275,7 @@ xblock[django]==5.2.0
     #   xblock-google-drive
     #   xblock-utils
     #   xblocks-contrib
-xblock-drag-and-drop-v2==5.0.2
+xblock-drag-and-drop-v2==5.0.3
     # via -r requirements/edx/bundled.in
 xblock-google-drive==0.8.1
     # via -r requirements/edx/bundled.in
@@ -1286,9 +1293,9 @@ xmlsec==1.3.14
     #   python3-saml
 xss-utils==0.8.0
     # via -r requirements/edx/kernel.in
-yarl==1.20.0
+yarl==1.20.1
     # via aiohttp
-zipp==3.22.0
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,9 +6,9 @@
 #
 chardet==5.2.0
     # via diff-cover
-coverage==7.8.2
+coverage==7.10.1
     # via -r requirements/edx/coverage.in
-diff-cover==9.3.2
+diff-cover==9.6.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.6
     # via diff-cover
@@ -16,5 +16,5 @@ markupsafe==3.0.2
     # via jinja2
 pluggy==1.6.0
     # via diff-cover
-pygments==2.19.1
+pygments==2.19.2
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -21,13 +21,13 @@ aiohappyeyeballs==2.6.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
-aiohttp==3.12.8
+aiohttp==3.12.14
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   geoip2
     #   openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -57,28 +57,28 @@ annotated-types==0.7.0
     #   pydantic
 anyio==4.9.0
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   httpcore
+    #   httpx
     #   starlette
 appdirs==1.4.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django
     #   django-cors-headers
     #   django-countries
-    #   django-stubs
 asn1crypto==1.5.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-astroid==3.3.10
+astroid==3.3.11
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -140,7 +140,7 @@ boto==2.49.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.38.29
+boto3==1.39.14
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -148,7 +148,7 @@ boto3==1.38.29
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.38.29
+botocore==1.39.14
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -192,7 +192,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.4.26
+certifi==2025.7.14
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -206,6 +206,7 @@ cffi==1.17.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cryptography
+    #   pact-python
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
@@ -255,7 +256,7 @@ click-log==0.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -272,7 +273,7 @@ code-annotations==2.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
-codejail-includes==1.0.0
+codejail-includes==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -280,7 +281,7 @@ colorama==0.4.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-coverage[toml]==7.8.2
+coverage[toml]==7.10.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -288,7 +289,7 @@ crowdsourcehinter-xblock==0.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-cryptography==45.0.3
+cryptography==45.0.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -324,19 +325,18 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-diff-cover==9.3.2
+diff-cover==9.6.0
     # via -r requirements/edx/testing.txt
 dill==0.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==4.2.22
+django==4.2.23
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -359,7 +359,6 @@ django==4.2.22
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
-    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-stubs
@@ -463,7 +462,7 @@ django-crum==0.7.9
     #   edx-rbac
     #   edx-toggles
     #   super-csv
-django-debug-toolbar==5.2.0
+django-debug-toolbar==6.0.0
     # via -r requirements/edx/development.in
 django-fernet-fields-v2==0.9
     # via
@@ -561,7 +560,7 @@ django-ses==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-simple-history==3.8.0
+django-simple-history==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -584,18 +583,18 @@ django-storages==1.14.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-django-stubs[compatible-mypy]==5.2.0
+django-stubs[compatible-mypy]==5.2.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
     #   djangorestframework-stubs
-django-stubs-ext==5.2.0
+django-stubs-ext==5.2.2
     # via django-stubs
-django-user-tasks==3.4.1
+django-user-tasks==3.4.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -632,7 +631,7 @@ djangorestframework==3.14.0
     #   openedx-learning
     #   ora2
     #   super-csv
-djangorestframework-stubs==3.16.0
+djangorestframework-stubs==3.16.1
     # via -r requirements/edx/development.in
 djangorestframework-xml==2.0.0
     # via
@@ -678,7 +677,7 @@ edx-api-doc-tools==2.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
-edx-auth-backends==4.5.0
+edx-auth-backends==4.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -723,6 +722,7 @@ edx-django-utils==8.0.0
     #   -r requirements/edx/testing.txt
     #   django-config-models
     #   edx-ace
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -798,7 +798,7 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==6.13.0
+edx-organizations==7.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -844,6 +844,7 @@ edx-toggles==5.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   edx-auth-backends
     #   edx-completion
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -896,11 +897,11 @@ execnet==2.1.1
     #   pytest-xdist
 factory-boy==3.3.3
     # via -r requirements/edx/testing.txt
-faker==37.3.0
+faker==37.4.2
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.115.12
+fastapi==0.116.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -916,14 +917,14 @@ filelock==3.18.0
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==6.8.0
+firebase-admin==7.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-ace
-freezegun==1.5.2
+freezegun==1.5.3
     # via -r requirements/edx/testing.txt
-frozenlist==1.6.2
+frozenlist==1.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -954,41 +955,28 @@ gitdb==4.0.12
     # via
     #   -r requirements/edx/doc.txt
     #   gitpython
-gitpython==3.1.44
+gitpython==3.1.45
     # via -r requirements/edx/doc.txt
 glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-google-api-core[grpc]==2.25.0
+google-api-core[grpc]==2.25.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
-    #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.171.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   firebase-admin
-google-auth==2.40.2
+google-auth==2.40.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth-httplib2==0.2.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   google-api-python-client
 google-cloud-core==2.4.3
     # via
     #   -r requirements/edx/doc.txt
@@ -1000,7 +988,7 @@ google-cloud-firestore==2.21.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
-google-cloud-storage==3.1.0
+google-cloud-storage==3.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1026,13 +1014,13 @@ grimp==3.9
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
-grpcio==1.72.1
+grpcio==1.74.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.72.1
+grpcio-status==1.74.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1041,36 +1029,48 @@ gunicorn==23.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-h11==0.14.0
+h11==0.16.0
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   httpx
 help-tokens==3.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+hpack==4.1.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   h2
 html5lib==1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   ora2
-httpcore==0.16.3
-    # via
-    #   -r requirements/edx/testing.txt
-    #   httpx
-httplib2==0.22.0
+httpcore==1.0.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   google-api-python-client
-    #   google-auth-httplib2
+    #   httpx
 httpretty==1.1.4
     # via -r requirements/edx/testing.txt
-httpx==0.23.3
+httpx[http2]==0.28.1
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   pact-python
+    #   firebase-admin
+hyperframe==6.1.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   h2
 icalendar==6.3.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1080,9 +1080,9 @@ idna==3.10
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
-    #   rfc3986
     #   snowflake-connector-python
     #   yarl
 imagesize==1.4.1
@@ -1143,7 +1143,7 @@ jsondiff==2.2.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1154,7 +1154,7 @@ jsonfield==3.1.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1235,7 +1235,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.8
+markdown==3.8.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1251,7 +1251,7 @@ markupsafe==3.0.2
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.7.0
+maxminddb==2.8.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1260,7 +1260,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-meilisearch==0.34.1
+meilisearch==0.36.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1290,18 +1290,18 @@ mpmath==1.3.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   sympy
-msgpack==1.1.0
+msgpack==1.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cachecontrol
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.15.0
+mypy==1.17.0
     # via
     #   -r requirements/edx/development.in
     #   django-stubs
@@ -1312,7 +1312,7 @@ mysqlclient==2.2.7
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
-nh3==0.2.21
+nh3==0.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1336,7 +1336,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1372,7 +1372,7 @@ openedx-django-pyfs==3.8.0
     #   lti-consumer-xblock
     #   xblock
     #   xblocks-contrib
-openedx-django-require==2.1.0
+openedx-django-require==3.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1380,7 +1380,7 @@ openedx-django-wiki==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1396,7 +1396,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.0
+openedx-forum==0.3.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1409,7 +1409,7 @@ optimizely-sdk==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.16.3
+ora2==6.16.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1428,7 +1428,7 @@ packaging==25.0
     #   snowflake-connector-python
     #   sphinx
     #   tox
-pact-python==2.0.1
+pact-python==2.3.3
     # via -r requirements/edx/testing.txt
 paramiko==3.5.1
     # via
@@ -1449,6 +1449,8 @@ path-py==12.5.0
     #   edx-enterprise
     #   ora2
     #   staff-graded-xblock
+pathspec==0.12.1
+    # via mypy
 pbr==6.1.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1467,7 +1469,7 @@ piexif==1.1.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1489,6 +1491,7 @@ pluggy==1.6.0
     #   -r requirements/edx/testing.txt
     #   diff-cover
     #   pytest
+    #   pytest-cov
     #   tox
 polib==1.2.0
     # via
@@ -1500,7 +1503,7 @@ prompt-toolkit==3.0.51
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   click-repl
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1562,7 +1565,7 @@ pycryptodomex==3.23.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.11.5
+pydantic==2.11.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1577,7 +1580,7 @@ pydata-sphinx-theme==0.15.4
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx-book-theme
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1626,7 +1629,7 @@ pylint-django==2.6.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint-celery
@@ -1670,7 +1673,6 @@ pyparsing==3.2.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   chem
-    #   httplib2
     #   openedx-calc
 pyproject-api==1.9.1
     # via
@@ -1706,7 +1708,7 @@ pytest==8.2.0
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
-pytest-cov==6.1.1
+pytest-cov==6.2.1
     # via -r requirements/edx/testing.txt
 pytest-django==4.11.1
     # via -r requirements/edx/testing.txt
@@ -1718,7 +1720,7 @@ pytest-metadata==3.1.1
     #   pytest-json-report
 pytest-randomly==3.16.0
     # via -r requirements/edx/testing.txt
-pytest-xdist[psutil]==3.7.0
+pytest-xdist[psutil]==3.8.0
     # via -r requirements/edx/testing.txt
 python-dateutil==2.9.0.post0
     # via
@@ -1820,7 +1822,7 @@ regex==2024.11.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   nltk
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1857,15 +1859,11 @@ requests-oauthlib==2.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   social-auth-core
-rfc3986[idna2008]==1.5.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   httpx
 roman-numerals-py==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1883,7 +1881,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1893,7 +1891,7 @@ sailthru-client==2.2.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-ace
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1923,7 +1921,6 @@ six==1.17.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
-    #   codejail-includes
     #   crowdsourcehinter-xblock
     #   edx-ace
     #   edx-auth-backends
@@ -1955,15 +1952,14 @@ smmap==5.0.2
     #   gitdb
 sniffio==1.3.1
     # via
+    #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   anyio
-    #   httpcore
-    #   httpx
 snowballstemmer==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==3.15.0
+snowflake-connector-python==3.16.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2062,7 +2058,7 @@ staff-graded-xblock==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-starlette==0.46.2
+starlette==0.47.2
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
@@ -2085,7 +2081,7 @@ sympy==1.14.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-calc
-testfixtures==8.3.0
+testfixtures==9.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2100,14 +2096,14 @@ tinycss2==1.4.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   bleach
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-learning
     #   pylint
     #   snowflake-connector-python
-tox==4.26.0
+tox==4.27.0
     # via -r requirements/edx/testing.txt
 tqdm==4.67.1
     # via
@@ -2119,12 +2115,13 @@ types-pyyaml==6.0.12.20250516
     # via
     #   django-stubs
     #   djangorestframework-stubs
-types-requests==2.32.0.20250602
+types-requests==2.32.4.20250611
     # via djangorestframework-stubs
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   django-countries
@@ -2144,6 +2141,7 @@ typing-extensions==4.14.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.1
     # via
@@ -2175,22 +2173,19 @@ uritemplate==4.2.0
     #   -r requirements/edx/testing.txt
     #   drf-spectacular
     #   drf-yasg
-    #   google-api-python-client
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   elasticsearch
-    #   pact-python
     #   requests
     #   types-requests
 user-util==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-uvicorn==0.34.3
+uvicorn==0.35.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -2201,7 +2196,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.31.2
+virtualenv==20.32.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -2212,7 +2207,7 @@ voluptuous==0.15.2
     #   ora2
 vulture==2.14
     # via -r requirements/edx/development.in
-walrus==0.9.4
+walrus==0.9.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2273,7 +2268,7 @@ xblock[django]==5.2.0
     #   xblock-google-drive
     #   xblock-utils
     #   xblocks-contrib
-xblock-drag-and-drop-v2==5.0.2
+xblock-drag-and-drop-v2==5.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2305,12 +2300,13 @@ xss-utils==0.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-yarl==1.20.0
+yarl==1.20.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
-zipp==3.22.0
+    #   pact-python
+zipp==3.23.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -14,12 +14,12 @@ aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.12.8
+aiohttp==3.12.14
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
     #   openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -39,11 +39,15 @@ annotated-types==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
+anyio==4.9.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpx
 appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -53,7 +57,7 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==3.3.10
+astroid==3.3.11
     # via sphinx-autoapi
 attrs==25.3.0
     # via
@@ -101,14 +105,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.38.29
+boto3==1.39.14
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.38.29
+botocore==1.39.14
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -140,10 +144,12 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.4.26
+certifi==2025.7.14
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
@@ -178,7 +184,7 @@ click-didyoumean==0.3.1
     # via
     #   -r requirements/edx/base.txt
     #   celery
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -192,11 +198,11 @@ code-annotations==2.3.0
     #   -r requirements/edx/doc.in
     #   edx-enterprise
     #   edx-toggles
-codejail-includes==1.0.0
+codejail-includes==2.0.0
     # via -r requirements/edx/base.txt
 crowdsourcehinter-xblock==0.8
     # via -r requirements/edx/base.txt
-cryptography==45.0.3
+cryptography==45.0.5
     # via
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
@@ -221,9 +227,8 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-django==4.2.22
+django==4.2.23
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -244,7 +249,6 @@ django==4.2.22
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
-    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
@@ -409,7 +413,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.8.0
+django-simple-history==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -429,9 +433,9 @@ django-storages==1.14.6
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.4.1
+django-user-tasks==3.4.2
     # via -r requirements/edx/base.txt
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -497,7 +501,7 @@ edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
-edx-auth-backends==4.5.0
+edx-auth-backends==4.6.0
     # via -r requirements/edx/base.txt
 edx-bulk-grades==1.2.0
     # via
@@ -529,6 +533,7 @@ edx-django-utils==8.0.0
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   edx-ace
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -590,7 +595,7 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==6.13.0
+edx-organizations==7.1.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.2.0
     # via
@@ -625,6 +630,7 @@ edx-tincan-py35==2.0.0
 edx-toggles==5.3.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-auth-backends
     #   edx-completion
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -669,11 +675,11 @@ filelock==3.18.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-firebase-admin==6.8.0
+firebase-admin==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-frozenlist==1.6.2
+frozenlist==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -696,35 +702,24 @@ geoip2==5.1.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.44
+gitpython==3.1.45
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.25.0
+google-api-core[grpc]==2.25.1
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-    #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.171.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   firebase-admin
-google-auth==2.40.2
+google-auth==2.40.3
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth-httplib2==0.2.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   google-api-python-client
 google-cloud-core==2.4.3
     # via
     #   -r requirements/edx/base.txt
@@ -734,7 +729,7 @@ google-cloud-firestore==2.21.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-cloud-storage==3.1.0
+google-cloud-storage==3.2.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -752,33 +747,54 @@ googleapis-common-protos==1.70.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.72.1
+grpcio==1.74.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.72.1
+grpcio-status==1.74.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
 gunicorn==23.0.0
     # via -r requirements/edx/base.txt
+h11==0.16.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpcore
+h2==4.2.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpx
 help-tokens==3.2.0
     # via -r requirements/edx/base.txt
+hpack==4.1.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   h2
 html5lib==1.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-httplib2==0.22.0
+httpcore==1.0.9
     # via
     #   -r requirements/edx/base.txt
-    #   google-api-python-client
-    #   google-auth-httplib2
+    #   httpx
+httpx[http2]==0.28.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   firebase-admin
+hyperframe==6.1.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   h2
 icalendar==6.3.1
     # via -r requirements/edx/base.txt
 idna==3.10
     # via
     #   -r requirements/edx/base.txt
+    #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
     #   snowflake-connector-python
@@ -817,7 +833,7 @@ jsondiff==2.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-celeryutils
@@ -827,7 +843,7 @@ jsonfield==3.1.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
@@ -888,7 +904,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.8
+markdown==3.8.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -902,11 +918,11 @@ markupsafe==3.0.2
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.7.0
+maxminddb==2.8.2
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
-meilisearch==0.34.1
+meilisearch==0.36.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-search
@@ -926,11 +942,11 @@ mpmath==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   sympy
-msgpack==1.1.0
+msgpack==1.1.1
     # via
     #   -r requirements/edx/base.txt
     #   cachecontrol
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -939,7 +955,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-nh3==0.2.21
+nh3==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
@@ -957,7 +973,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
@@ -985,11 +1001,11 @@ openedx-django-pyfs==3.8.0
     #   lti-consumer-xblock
     #   xblock
     #   xblocks-contrib
-openedx-django-require==2.1.0
+openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1003,7 +1019,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.0
+openedx-forum==0.3.1
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.0
     # via
@@ -1011,7 +1027,7 @@ openedx-learning==0.27.0
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.2.0
     # via -r requirements/edx/base.txt
-ora2==6.16.3
+ora2==6.16.4
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via
@@ -1050,7 +1066,7 @@ picobox==4.0.0
     # via sphinxcontrib-openapi
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1068,7 +1084,7 @@ prompt-toolkit==3.0.51
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -1112,7 +1128,7 @@ pycryptodomex==3.23.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.11.5
+pydantic==2.11.7
     # via
     #   -r requirements/edx/base.txt
     #   camel-converter
@@ -1122,7 +1138,7 @@ pydantic-core==2.33.2
     #   pydantic
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
@@ -1176,7 +1192,6 @@ pyparsing==3.2.3
     # via
     #   -r requirements/edx/base.txt
     #   chem
-    #   httplib2
     #   openedx-calc
 pyrsistent==0.20.0
     # via
@@ -1265,7 +1280,7 @@ regex==2024.11.6
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
@@ -1300,7 +1315,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 roman-numerals-py==3.1.0
     # via sphinx
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -1315,7 +1330,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1323,7 +1338,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1344,7 +1359,6 @@ six==1.17.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-    #   codejail-includes
     #   crowdsourcehinter-xblock
     #   edx-ace
     #   edx-auth-backends
@@ -1368,9 +1382,13 @@ slumber==0.7.1
     #   enterprise-integrated-channels
 smmap==5.0.2
     # via gitdb
+sniffio==1.3.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   anyio
 snowballstemmer==3.0.1
     # via sphinx
-snowflake-connector-python==3.15.0
+snowflake-connector-python==3.16.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1459,7 +1477,7 @@ sympy==1.14.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==8.3.0
+testfixtures==9.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1471,7 +1489,7 @@ tinycss2==1.4.0
     # via
     #   -r requirements/edx/base.txt
     #   bleach
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
     #   -r requirements/edx/base.txt
     #   openedx-learning
@@ -1481,9 +1499,11 @@ tqdm==4.67.1
     #   -r requirements/edx/base.txt
     #   nltk
     #   openai
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/edx/base.txt
+    #   aiosignal
+    #   anyio
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -1517,10 +1537,8 @@ uritemplate==4.2.0
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-    #   google-api-python-client
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
     #   elasticsearch
@@ -1537,7 +1555,7 @@ voluptuous==0.15.2
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-walrus==0.9.4
+walrus==0.9.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
@@ -1585,7 +1603,7 @@ xblock[django]==5.2.0
     #   xblock-google-drive
     #   xblock-utils
     #   xblocks-contrib
-xblock-drag-and-drop-v2==5.0.2
+xblock-drag-and-drop-v2==5.0.3
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.8.1
     # via -r requirements/edx/base.txt
@@ -1605,11 +1623,11 @@ xmlsec==1.3.14
     #   python3-saml
 xss-utils==0.8.0
     # via -r requirements/edx/base.txt
-yarl==1.20.0
+yarl==1.20.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==3.22.0
+zipp==3.23.0
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -15,9 +15,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-bracex==2.5.post1
+bracex==2.6
     # via wcmatch
-certifi==2025.4.26
+certifi==2025.7.14
     # via requests
 charset-normalizer==3.4.2
     # via requests
@@ -47,7 +47,7 @@ idna==3.10
     # via requests
 importlib-metadata==7.1.0
     # via opentelemetry-api
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via semgrep
 jsonschema-specifications==2025.4.1
     # via jsonschema
@@ -87,44 +87,43 @@ opentelemetry-util-http==0.46b0
     # via opentelemetry-instrumentation-requests
 packaging==25.0
     # via semgrep
-peewee==3.18.1
+peewee==3.18.2
     # via semgrep
 protobuf==4.25.8
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-pygments==2.19.1
+pygments==2.19.2
     # via rich
 referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.3
+requests==2.32.4
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   semgrep
 rich==13.5.3
     # via semgrep
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.12
+ruamel-yaml==0.18.14
     # via semgrep
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-semgrep==1.123.0
+semgrep==1.130.0
     # via -r requirements/edx/semgrep.in
 tomli==2.0.2
     # via semgrep
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   opentelemetry-sdk
     #   referencing
     #   semgrep
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   requests
     #   semgrep
 wcmatch==8.5.2
@@ -133,7 +132,7 @@ wrapt==1.17.2
     # via
     #   deprecated
     #   opentelemetry-instrumentation
-zipp==3.22.0
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -12,12 +12,12 @@ aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-aiohttp==3.12.8
+aiohttp==3.12.14
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
     #   openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -37,13 +37,14 @@ annotated-types==0.7.0
     #   pydantic
 anyio==4.9.0
     # via
-    #   httpcore
+    #   -r requirements/edx/base.txt
+    #   httpx
     #   starlette
 appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -53,7 +54,7 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==3.3.10
+astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
@@ -101,14 +102,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.38.29
+boto3==1.39.14
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.38.29
+botocore==1.39.14
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -141,7 +142,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.4.26
+certifi==2025.7.14
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -153,6 +154,7 @@ cffi==1.17.1
     # via
     #   -r requirements/edx/base.txt
     #   cryptography
+    #   pact-python
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
@@ -191,7 +193,7 @@ click-didyoumean==0.3.1
     #   celery
 click-log==0.4.0
     # via edx-lint
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -206,17 +208,17 @@ code-annotations==2.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
-codejail-includes==1.0.0
+codejail-includes==2.0.0
     # via -r requirements/edx/base.txt
 colorama==0.4.6
     # via tox
-coverage[toml]==7.8.2
+coverage[toml]==7.10.1
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
 crowdsourcehinter-xblock==0.8
     # via -r requirements/edx/base.txt
-cryptography==45.0.3
+cryptography==45.0.5
     # via
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
@@ -245,15 +247,14 @@ defusedxml==0.7.1
     #   ora2
     #   python3-openid
     #   social-auth-core
-diff-cover==9.3.2
+diff-cover==9.6.0
     # via -r requirements/edx/coverage.txt
 dill==0.4.0
     # via pylint
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-django==4.2.22
+django==4.2.23
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -274,7 +275,6 @@ django==4.2.22
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
-    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
@@ -439,7 +439,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.8.0
+django-simple-history==3.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -459,9 +459,9 @@ django-storages==1.14.6
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-django-user-tasks==3.4.1
+django-user-tasks==3.4.2
     # via -r requirements/edx/base.txt
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -522,7 +522,7 @@ edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
-edx-auth-backends==4.5.0
+edx-auth-backends==4.6.0
     # via -r requirements/edx/base.txt
 edx-bulk-grades==1.2.0
     # via
@@ -554,6 +554,7 @@ edx-django-utils==8.0.0
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   edx-ace
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -617,7 +618,7 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==6.13.0
+edx-organizations==7.1.0
     # via -r requirements/edx/base.txt
 edx-proctoring==5.2.0
     # via
@@ -652,6 +653,7 @@ edx-tincan-py35==2.0.0
 edx-toggles==5.3.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-auth-backends
     #   edx-completion
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -692,9 +694,9 @@ execnet==2.1.1
     # via pytest-xdist
 factory-boy==3.3.3
     # via -r requirements/edx/testing.in
-faker==37.3.0
+faker==37.4.2
     # via factory-boy
-fastapi==0.115.12
+fastapi==0.116.1
     # via pact-python
 fastavro==1.11.1
     # via
@@ -706,13 +708,13 @@ filelock==3.18.0
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==6.8.0
+firebase-admin==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-freezegun==1.5.2
+freezegun==1.5.3
     # via -r requirements/edx/testing.in
-frozenlist==1.6.2
+frozenlist==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -735,31 +737,20 @@ geoip2==5.1.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.25.0
+google-api-core[grpc]==2.25.1
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-    #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.171.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   firebase-admin
-google-auth==2.40.2
+google-auth==2.40.3
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth-httplib2==0.2.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   google-api-python-client
 google-cloud-core==2.4.3
     # via
     #   -r requirements/edx/base.txt
@@ -769,7 +760,7 @@ google-cloud-firestore==2.21.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-cloud-storage==3.1.0
+google-cloud-storage==3.2.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -789,47 +780,59 @@ googleapis-common-protos==1.70.0
     #   grpcio-status
 grimp==3.9
     # via import-linter
-grpcio==1.72.1
+grpcio==1.74.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.72.1
+grpcio-status==1.74.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
 gunicorn==23.0.0
     # via -r requirements/edx/base.txt
-h11==0.14.0
+h11==0.16.0
     # via
+    #   -r requirements/edx/base.txt
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   httpx
 help-tokens==3.2.0
     # via -r requirements/edx/base.txt
+hpack==4.1.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   h2
 html5lib==1.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-httpcore==0.16.3
-    # via httpx
-httplib2==0.22.0
+httpcore==1.0.9
     # via
     #   -r requirements/edx/base.txt
-    #   google-api-python-client
-    #   google-auth-httplib2
+    #   httpx
 httpretty==1.1.4
     # via -r requirements/edx/testing.in
-httpx==0.23.3
-    # via pact-python
+httpx[http2]==0.28.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   firebase-admin
+hyperframe==6.1.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   h2
 icalendar==6.3.1
     # via -r requirements/edx/base.txt
 idna==3.10
     # via
     #   -r requirements/edx/base.txt
     #   anyio
+    #   httpx
     #   optimizely-sdk
     #   requests
-    #   rfc3986
     #   snowflake-connector-python
     #   yarl
 import-linter==2.3
@@ -873,7 +876,7 @@ jsondiff==2.2.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-celeryutils
@@ -883,7 +886,7 @@ jsonfield==3.1.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-spectacular
@@ -944,7 +947,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.8
+markdown==3.8.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -959,13 +962,13 @@ markupsafe==3.0.2
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==2.7.0
+maxminddb==2.8.2
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
 mccabe==0.7.0
     # via pylint
-meilisearch==0.34.1
+meilisearch==0.36.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-search
@@ -985,11 +988,11 @@ mpmath==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   sympy
-msgpack==1.1.0
+msgpack==1.1.1
     # via
     #   -r requirements/edx/base.txt
     #   cachecontrol
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -998,7 +1001,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-nh3==0.2.21
+nh3==0.3.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
@@ -1016,7 +1019,7 @@ numpy==1.26.4
     #   openedx-calc
     #   scipy
     #   shapely
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   -r requirements/edx/base.txt
     #   django-oauth-toolkit
@@ -1044,11 +1047,11 @@ openedx-django-pyfs==3.8.0
     #   lti-consumer-xblock
     #   xblock
     #   xblocks-contrib
-openedx-django-require==2.1.0
+openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1062,7 +1065,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.0
+openedx-forum==0.3.1
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.0
     # via
@@ -1070,7 +1073,7 @@ openedx-learning==0.27.0
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.2.0
     # via -r requirements/edx/base.txt
-ora2==6.16.3
+ora2==6.16.4
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via
@@ -1082,7 +1085,7 @@ packaging==25.0
     #   pytest
     #   snowflake-connector-python
     #   tox
-pact-python==2.0.1
+pact-python==2.3.3
     # via -r requirements/edx/testing.in
 paramiko==3.5.1
     # via
@@ -1110,7 +1113,7 @@ pgpy==0.6.0
     #   edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1128,6 +1131,7 @@ pluggy==1.6.0
     #   -r requirements/edx/coverage.txt
     #   diff-cover
     #   pytest
+    #   pytest-cov
     #   tox
 polib==1.2.0
     # via
@@ -1138,7 +1142,7 @@ prompt-toolkit==3.0.51
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -1190,7 +1194,7 @@ pycryptodomex==3.23.0
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pydantic==2.11.5
+pydantic==2.11.7
     # via
     #   -r requirements/edx/base.txt
     #   camel-converter
@@ -1199,7 +1203,7 @@ pydantic-core==2.33.2
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   -r requirements/edx/coverage.txt
     #   diff-cover
@@ -1235,7 +1239,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.6.1
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
@@ -1268,7 +1272,6 @@ pyparsing==3.2.3
     # via
     #   -r requirements/edx/base.txt
     #   chem
-    #   httplib2
     #   openedx-calc
 pyproject-api==1.9.1
     # via tox
@@ -1295,7 +1298,7 @@ pytest==8.2.0
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
-pytest-cov==6.1.1
+pytest-cov==6.2.1
     # via -r requirements/edx/testing.in
 pytest-django==4.11.1
     # via -r requirements/edx/testing.in
@@ -1307,7 +1310,7 @@ pytest-metadata==3.1.1
     #   pytest-json-report
 pytest-randomly==3.16.0
     # via -r requirements/edx/testing.in
-pytest-xdist[psutil]==3.7.0
+pytest-xdist[psutil]==3.8.0
     # via -r requirements/edx/testing.in
 python-dateutil==2.9.0.post0
     # via
@@ -1387,7 +1390,7 @@ regex==2024.11.6
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
@@ -1420,9 +1423,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-rfc3986[idna2008]==1.5.0
-    # via httpx
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -1437,7 +1438,7 @@ rules==3.5
     #   edx-enterprise
     #   edx-proctoring
     #   openedx-learning
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -1445,7 +1446,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1468,7 +1469,6 @@ six==1.17.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-    #   codejail-includes
     #   crowdsourcehinter-xblock
     #   edx-ace
     #   edx-auth-backends
@@ -1493,10 +1493,9 @@ slumber==0.7.1
     #   enterprise-integrated-channels
 sniffio==1.3.1
     # via
+    #   -r requirements/edx/base.txt
     #   anyio
-    #   httpcore
-    #   httpx
-snowflake-connector-python==3.15.0
+snowflake-connector-python==3.16.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1529,7 +1528,7 @@ sqlparse==0.5.3
     #   django
 staff-graded-xblock==3.1.0
     # via -r requirements/edx/base.txt
-starlette==0.46.2
+starlette==0.47.2
     # via fastapi
 stevedore==5.4.1
     # via
@@ -1547,7 +1546,7 @@ sympy==1.14.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-testfixtures==8.3.0
+testfixtures==9.1.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1560,22 +1559,23 @@ tinycss2==1.4.0
     # via
     #   -r requirements/edx/base.txt
     #   bleach
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
     #   -r requirements/edx/base.txt
     #   openedx-learning
     #   pylint
     #   snowflake-connector-python
-tox==4.26.0
+tox==4.27.0
     # via -r requirements/edx/testing.in
 tqdm==4.67.1
     # via
     #   -r requirements/edx/base.txt
     #   nltk
     #   openai
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/edx/base.txt
+    #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   django-countries
@@ -1590,6 +1590,7 @@ typing-extensions==4.14.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.1
     # via
@@ -1615,18 +1616,15 @@ uritemplate==4.2.0
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-    #   google-api-python-client
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
     #   elasticsearch
-    #   pact-python
     #   requests
 user-util==2.0.0
     # via -r requirements/edx/base.txt
-uvicorn==0.34.3
+uvicorn==0.35.0
     # via pact-python
 vine==5.1.0
     # via
@@ -1634,13 +1632,13 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.31.2
+virtualenv==20.32.0
     # via tox
 voluptuous==0.15.2
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-walrus==0.9.4
+walrus==0.9.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
@@ -1688,7 +1686,7 @@ xblock[django]==5.2.0
     #   xblock-google-drive
     #   xblock-utils
     #   xblocks-contrib
-xblock-drag-and-drop-v2==5.0.2
+xblock-drag-and-drop-v2==5.0.3
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.8.1
     # via -r requirements/edx/base.txt
@@ -1708,11 +1706,12 @@ xmlsec==1.3.14
     #   python3-saml
 xss-utils==0.8.0
     # via -r requirements/edx/base.txt
-yarl==1.20.0
+yarl==1.20.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==3.22.0
+    #   pact-python
+zipp==3.23.0
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata

--- a/scripts/structures_pruning/requirements/base.txt
+++ b/scripts/structures_pruning/requirements/base.txt
@@ -23,7 +23,7 @@ pymongo==4.4.0
     #   edx-opaque-keys
 stevedore==5.4.1
     # via edx-opaque-keys
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via edx-opaque-keys
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/scripts/structures_pruning/requirements/testing.txt
+++ b/scripts/structures_pruning/requirements/testing.txt
@@ -28,19 +28,19 @@ pbr==6.1.1
     #   stevedore
 pluggy==1.6.0
     # via pytest
-pygments==2.19.1
+pygments==2.19.2
     # via pytest
 pymongo==4.4.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys
-pytest==8.4.0
+pytest==8.4.1
     # via -r scripts/structures_pruning/requirements/testing.in
 stevedore==5.4.1
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -4,21 +4,21 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+asgiref==3.9.1
     # via django
 attrs==25.3.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-boto3==1.38.29
+boto3==1.39.14
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.38.29
+botocore==1.39.14
     # via
     #   boto3
     #   s3transfer
 cachetools==5.5.2
     # via google-auth
-certifi==2025.4.26
+certifi==2025.7.14
     # via requests
 cffi==1.17.1
     # via
@@ -30,28 +30,27 @@ click==8.2.1
     # via
     #   -r scripts/user_retirement/requirements/base.in
     #   edx-django-utils
-cryptography==45.0.3
+cryptography==45.0.5
     # via pyjwt
-django==4.2.22
+django==4.2.23
     # via
-    #   -c scripts/user_retirement/requirements/../../../requirements/common_constraints.txt
     #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via edx-django-utils
 edx-django-utils==8.0.0
     # via edx-rest-api-client
 edx-rest-api-client==6.2.0
     # via -r scripts/user_retirement/requirements/base.in
-google-api-core==2.25.0
+google-api-core==2.25.1
     # via google-api-python-client
-google-api-python-client==2.171.0
+google-api-python-client==2.177.0
     # via -r scripts/user_retirement/requirements/base.in
-google-auth==2.40.2
+google-auth==2.40.3
     # via
     #   google-api-core
     #   google-api-python-client
@@ -117,7 +116,7 @@ pytz==2025.2
     #   zeep
 pyyaml==6.0.2
     # via -r scripts/user_retirement/requirements/base.in
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r scripts/user_retirement/requirements/base.in
     #   edx-rest-api-client
@@ -133,7 +132,7 @@ requests-toolbelt==1.0.0
     # via zeep
 rsa==4.9.1
     # via google-auth
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 simple-salesforce==1.12.6
     # via -r scripts/user_retirement/requirements/base.in
@@ -147,7 +146,7 @@ sqlparse==0.5.3
     # via django
 stevedore==5.4.1
     # via edx-django-utils
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via simple-salesforce
 unicodecsv==0.14.1
     # via -r scripts/user_retirement/requirements/base.in
@@ -155,7 +154,6 @@ uritemplate==4.2.0
     # via google-api-python-client
 urllib3==1.26.20
     # via
-    #   -c scripts/user_retirement/requirements/../../../requirements/common_constraints.txt
     #   -r scripts/user_retirement/requirements/base.in
     #   botocore
     #   requests

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
@@ -14,11 +14,11 @@ attrs==25.3.0
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-boto3==1.38.29
+boto3==1.39.14
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.38.29
+botocore==1.39.14
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -28,7 +28,7 @@ cachetools==5.5.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-certifi==2025.4.26
+certifi==2025.7.14
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
@@ -45,14 +45,14 @@ click==8.2.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-cryptography==45.0.3
+cryptography==45.0.5
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
     #   pyjwt
 ddt==1.7.2
     # via -r scripts/user_retirement/requirements/testing.in
-django==4.2.22
+django==4.2.23
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django-crum
@@ -62,7 +62,7 @@ django-crum==0.7.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
@@ -72,13 +72,13 @@ edx-django-utils==8.0.0
     #   edx-rest-api-client
 edx-rest-api-client==6.2.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-api-core==2.25.0
+google-api-core==2.25.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.171.0
+google-api-python-client==2.177.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-auth==2.40.2
+google-auth==2.40.3
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
@@ -130,7 +130,7 @@ more-itertools==10.7.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce
-moto==5.1.5
+moto==5.1.8
     # via -r scripts/user_retirement/requirements/testing.in
 packaging==25.0
     # via pytest
@@ -171,7 +171,7 @@ pycparser==2.22
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   cffi
-pygments==2.19.1
+pygments==2.19.2
     # via pytest
 pyjwt[crypto]==2.10.1
     # via
@@ -186,7 +186,7 @@ pyparsing==3.2.3
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   httplib2
-pytest==8.4.0
+pytest==8.4.1
     # via -r scripts/user_retirement/requirements/testing.in
 python-dateutil==2.9.0.post0
     # via
@@ -202,7 +202,7 @@ pyyaml==6.0.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
@@ -233,7 +233,7 @@ rsa==4.9.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -254,7 +254,7 @@ stevedore==5.4.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,15 +4,13 @@
 #
 #    make upgrade
 #
-certifi==2025.4.26
+certifi==2025.7.14
     # via requests
 charset-normalizer==3.4.2
     # via requests
 idna==3.10
     # via requests
-requests==2.32.3
+requests==2.32.4
     # via -r scripts/xblock/requirements.in
-urllib3==2.2.3
-    # via
-    #   -c scripts/xblock/../../requirements/common_constraints.txt
-    #   requests
+urllib3==2.5.0
+    # via requests


### PR DESCRIPTION
The urllib library is pinned in common constraints but it's unclear if that's still needed in this repo.  Drop that constraint and upgrade the requirements.  The ticket related to that constraint had no info on it so I think the best option is to try an do the upgrade. 

- **build: Drop urllib requirement so we can try to upgrade it.**
- **chore: Run `make upgrade`**
