### PR TITLE
feat: showing captcha only for learners and not other roles

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -60,7 +60,6 @@ from openedx.core.djangoapps.discussions.tasks import update_discussions_setting
 from openedx.core.djangoapps.django_comment_common.models import (
     CourseDiscussionSettings,
     Role,
-    FORUM_ROLE_STUDENT,
     FORUM_ROLE_ADMINISTRATOR,
     FORUM_ROLE_MODERATOR,
     FORUM_ROLE_GROUP_MODERATOR,

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -2384,7 +2384,6 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             )
             assert response.status_code == response_status
 
-
     def test_captcha_enabled_privileged_user(self):
         """Test that CAPTCHA is skipped for users with privileged roles when CAPTCHA is enabled."""
         self.mock_is_captcha_enabled.side_effect = lambda course_key: True

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -458,7 +458,7 @@ def is_only_student(course_key, user) -> bool:
         Check if the user is only a user and doesn't hold any other roles the given course.
     """
     is_course_staff_or_admin = (CourseAccessRole.objects.filter
-                                (user=user, course_id__in=course_key, role__in=["instructor", "staff"]).exists())
+                                (user=user, course_id__in=[course_key], role__in=["instructor", "staff"]).exists())
     is_user_admin = user.is_staff
     user_roles = get_user_role_names(user, course_key)
     return user_roles == {FORUM_ROLE_STUDENT} and not (is_course_staff_or_admin or is_user_admin)

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -452,7 +452,11 @@ def get_course_id_from_thread_id(thread_id: str) -> str:
     })
     return thread["course_id"]
 
+
 def is_only_student(course_key, user) -> bool:
+    """
+        Check if the user is only a user and doesn't hold any other roles the given course.
+    """
     is_course_staff_or_admin = (CourseAccessRole.objects.filter
                                 (user=user, course_id__in=course_key, role__in=["instructor", "staff"]).exists())
     is_user_admin = user.is_staff

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -23,6 +23,10 @@ from rest_framework.viewsets import ViewSet
 
 from xmodule.modulestore.django import modulestore
 
+from common.djangoapps.student.roles import (
+    CourseInstructorRole,
+    CourseStaffRole,
+)
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.file import store_uploaded_file
 from lms.djangoapps.course_api.blocks.api import get_blocks
@@ -37,7 +41,7 @@ from openedx.core.djangoapps.discussions.config.waffle import ENABLE_NEW_STRUCTU
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangoapps.discussions.serializers import DiscussionSettingsSerializer
 from openedx.core.djangoapps.django_comment_common import comment_client
-from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings, Role
+from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings, Role, FORUM_ROLE_STUDENT
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
 from openedx.core.djangoapps.user_api.accounts.permissions import CanReplaceUsername, CanRetireUser
@@ -88,6 +92,8 @@ from .utils import (
     create_blocks_params,
     create_topics_v3_structure, is_captcha_enabled, verify_recaptcha_token, get_course_id_from_thread_id,
 )
+
+from ..django_comment_client.utils import get_user_role_names
 
 log = logging.getLogger(__name__)
 
@@ -674,7 +680,15 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
             raise ValidationError({"course_id": ["This field is required."]})
         course_key_str = request.data.get("course_id")
         course_key = CourseKey.from_string(course_key_str)
-        if is_captcha_enabled(course_key):
+
+        is_course_staff = CourseStaffRole(course_key).has_user(request.user)
+        is_course_admin = CourseInstructorRole(course_key).has_user(request.user)
+        is_user_admin = request.user.is_staff
+        user_roles = get_user_role_names(request.user, course_key)
+        is_only_student = (user_roles == {FORUM_ROLE_STUDENT}
+                           and not (is_course_staff and is_course_admin and is_user_admin))
+
+        if is_captcha_enabled(course_key) and is_only_student:
             captcha_token = request.data.get('captcha_token')
             if not captcha_token:
                 raise ValidationError({'captcha_token': 'This field is required.'})
@@ -1047,7 +1061,14 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
         course_key_str = get_course_id_from_thread_id(request.data["thread_id"])
         course_key = CourseKey.from_string(course_key_str)
 
-        if is_captcha_enabled(course_key):
+        is_course_staff = CourseStaffRole(course_key).has_user(request.user)
+        is_course_admin = CourseInstructorRole(course_key).has_user(request.user)
+        is_user_admin = request.user.is_staff
+        user_roles = get_user_role_names(request.user, course_key)
+        is_only_student = (user_roles == {FORUM_ROLE_STUDENT}
+                           and not (is_course_staff and is_course_admin and is_user_admin))
+
+        if is_captcha_enabled(course_key) and is_only_student:
             captcha_token = request.data.get('captcha_token')
             if not captcha_token:
                 raise ValidationError({'captcha_token': 'This field is required.'})

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -686,7 +686,7 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
         is_user_admin = request.user.is_staff
         user_roles = get_user_role_names(request.user, course_key)
         is_only_student = (user_roles == {FORUM_ROLE_STUDENT}
-                           and not (is_course_staff and is_course_admin and is_user_admin))
+                           and not (is_course_staff or is_course_admin or is_user_admin))
 
         if is_captcha_enabled(course_key) and is_only_student:
             captcha_token = request.data.get('captcha_token')

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -1066,7 +1066,7 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
         is_user_admin = request.user.is_staff
         user_roles = get_user_role_names(request.user, course_key)
         is_only_student = (user_roles == {FORUM_ROLE_STUDENT}
-                           and not (is_course_staff and is_course_admin and is_user_admin))
+                           and not (is_course_staff or is_course_admin or is_user_admin))
 
         if is_captcha_enabled(course_key) and is_only_student:
             captcha_token = request.data.get('captcha_token')


### PR DESCRIPTION
Ticket: [INF-2042](https://2u-internal.atlassian.net/browse/INF-2042)

To avoid inconvenience for instructors, we need to skip showing captcha to a user that holds at least 1 course role i.e. they are NOT a learner.