### PR TITLE
feat: includes location as the usage_key in child ancestor block

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -28,6 +28,7 @@ class ChildAncestorSerializer(serializers.Serializer):
 
     url = serializers.SerializerMethodField()
     display_name = serializers.CharField(source="display_name_with_default")
+    usage_key = serializers.CharField(source="location")  # need it for frontend authoring app
 
     def get_url(self, obj):
         """

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -127,6 +127,59 @@ class ContainerHandlerViewTest(BaseXBlockContainer):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_ancestor_xblocks_response(self):
+        """
+        Check if the ancestor_xblocks are returned as expected.
+        """
+        expected_ancestor_xblocks = [
+            {
+                'children': [
+                    {
+                        'url': (
+                            '/course/course-v1:org.552+course_552+Run_552'
+                            '?show=block-v1%3Aorg.552%2Bcourse_552%2BRun_552'
+                            '%2Btype%40chapter%2Bblock%40Week_1'
+                        ),
+                        'display_name': 'Week 1',
+                        'usage_key': (
+                            'block-v1:org.552+course_552+Run_552+type@chapter+block@Week_1'
+                        ),
+                    }
+                ],
+                'title': 'Week 1',
+                'is_last': False,
+            },
+            {
+                'children': [
+                    {
+                        'url': (
+                            '/course/course-v1:org.552+course_552+Run_552'
+                            '?show=block-v1%3Aorg.552%2Bcourse_552%2BRun_552'
+                            '%2Btype%40sequential%2Bblock%40Lesson_1'
+                        ),
+                        'display_name': 'Lesson 1',
+                        'usage_key': (
+                            'block-v1:org.552+course_552+Run_552+type@sequential+block@Lesson_1'
+                        ),
+                    }
+                ],
+                'title': 'Lesson 1',
+                'is_last': True,
+            }
+        ]
+
+        url = self.get_reverse_url(self.vertical.location)
+        response = self.client.get(url)
+        response_ancestor_xblocks = response.json().get("ancestor_xblocks", [])
+
+        def sort_key(block):
+            return block.get("title", "")
+
+        self.assertEqual(
+            sorted(response_ancestor_xblocks, key=sort_key),
+            sorted(expected_ancestor_xblocks, key=sort_key)
+        )
+
     def test_not_valid_usage_key_string(self):
         """
         Check that invalid 'usage_key_string' raises Http404.

--- a/cms/djangoapps/contentstore/rest_api/v1/views/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/vertical_block.py
@@ -89,7 +89,8 @@ class ContainerHandlerView(APIView, ContainerHandlerMixin):
                 "children": [
                     {
                     "url": "/course/course-v1:edX+DemoX+Demo_Course?show=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%",
-                    "display_name": "Introduction"
+                    "display_name": "Introduction",
+                    "usage_key": "subsection_id"
                     },
                     ...
                 ],


### PR DESCRIPTION
- Includes location along with the child ancestor block as it is required in the frontend authoring app for unit scrolling purpose in the breadcrumbs.
Required for
https://github.com/openedx/frontend-app-authoring/issues/1924

## Description:

- As per the above issue raised there is a need to navigate to the first unit if available, of the subsection via the breadcrumbs. 
- Inside the breadcrumbs the url which was set for navigation was sent from the backend api.
- This ancestorXblocks section from the api was missing the info about the subsection id which would be required for navigation to the first unit of the subsection.