### PR TITLE
fix: refresh-saml-metadata beat task path fixed

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -411,7 +411,7 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
         # If we didn't override the value in YAML, OR we overrode it to a truthy value,
         # then update CELERYBEAT_SCHEDULE.
         CELERYBEAT_SCHEDULE['refresh-saml-metadata'] = {
-            'task': 'common.djangoapps.third_party_auth.fetch_saml_metadata',
+            'task': 'common.djangoapps.third_party_auth.tasks.fetch_saml_metadata',
             'schedule': datetime.timedelta(hours=hours),
         }
 


### PR DESCRIPTION
## Description

This PR fixes the task path in the Celery beat settings for the `refresh-saml-metadata` scheduled task.

We had previously added the `fetch_saml_metadata` task to the [Celery beat schedule](https://github.com/openedx/edx-platform/blob/master/lms/envs/production.py#L414) to run periodically (default: every 24 hours). However, due to a typo in the task path, Celery workers were throwing errors. This fix corrects the task path so the schedule can run as intended.


## Supporting information

https://github.com/mitodl/hq/issues/6702