### PR TITLE
refactor: load learning mfe ports from env

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -6,6 +6,7 @@ Specific overrides to the base prod settings to make development easier.
 # Silence noisy logs
 import logging
 from os.path import abspath, dirname, join
+from urllib.parse import urlparse
 
 # pylint: enable=unicode-format-string  # lint-amnesty, pylint: disable=bad-option-value
 #####################################################################
@@ -283,6 +284,10 @@ ORA_MICROFRONTEND_URL = 'http://localhost:1992'
 ########################## LEARNER HOME APP ##############################
 LEARNER_HOME_MICROFRONTEND_URL = 'http://localhost:1996'
 
+########################## LEARNING MFE ##############################
+LEARNING_MICROFRONTEND_URL = os.environ.get("LEARNING_MICROFRONTEND_URL", "http://localhost:2000"),
+LEARNING_MICROFRONTEND_NETLOC = os.environ.get("LEARNING_MICROFRONTEND_NETLOC", urlparse(LEARNING_MICROFRONTEND_URL).netloc)
+
 ###################### Cross-domain requests ######################
 FEATURES['ENABLE_CORS_HEADERS'] = True
 CORS_ALLOW_CREDENTIALS = True
@@ -302,7 +307,7 @@ LOGIN_REDIRECT_WHITELIST.extend([
     'localhost:1997',  # frontend-app-account
     'localhost:1976',  # frontend-app-program-console
     'localhost:1994',  # frontend-app-gradebook
-    'localhost:2000',  # frontend-app-learning
+    LEARNING_MICROFRONTEND_NETLOC,  # frontend-app-learning
     'localhost:2001',  # frontend-app-course-authoring
     'localhost:3001',  # frontend-app-library-authoring
     'localhost:18400',  # frontend-app-publisher
@@ -540,7 +545,7 @@ AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
 # MFEs that will call this service in devstack
 CSRF_TRUSTED_ORIGINS = [
-    'http://localhost:2000',  # frontend-app-learning
+    LEARNING_MICROFRONTEND_URL,  # frontend-app-learning
     'http://localhost:2001',  # frontend-app-course-authoring
     'http://localhost:1997',  # frontend-app-account
     'http://localhost:1995',  # frontend-app-profile

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -285,7 +285,7 @@ ORA_MICROFRONTEND_URL = 'http://localhost:1992'
 LEARNER_HOME_MICROFRONTEND_URL = 'http://localhost:1996'
 
 ########################## LEARNING MFE ##############################
-LEARNING_MICROFRONTEND_URL = os.environ.get("LEARNING_MICROFRONTEND_URL", "http://localhost:2000"),
+LEARNING_MICROFRONTEND_URL = os.environ.get("LEARNING_MICROFRONTEND_URL", "http://localhost:2000")
 LEARNING_MICROFRONTEND_NETLOC = os.environ.get("LEARNING_MICROFRONTEND_NETLOC", urlparse(LEARNING_MICROFRONTEND_URL).netloc)
 
 ###################### Cross-domain requests ######################

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -285,6 +285,7 @@ ORA_MICROFRONTEND_URL = 'http://localhost:1992'
 LEARNER_HOME_MICROFRONTEND_URL = 'http://localhost:1996'
 
 ########################## LEARNING MFE ##############################
+# pylint: disable=line-too-long
 LEARNING_MICROFRONTEND_URL = os.environ.get("LEARNING_MICROFRONTEND_URL", "http://localhost:2000")
 LEARNING_MICROFRONTEND_NETLOC = os.environ.get("LEARNING_MICROFRONTEND_NETLOC", urlparse(LEARNING_MICROFRONTEND_URL).netloc)
 

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -160,7 +160,7 @@ def make_learning_mfe_courseware_url(
 
     We're building a URL like this:
 
-    {LEARNING_MICROFRONTEND_URL}/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@19a30717eff543078a5d94ae9d6c18a5/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4a1bba2a403f40bca5ec245e945b0d76
+    {LEARNING_MICROFRONTEND_URL}/course/{course_id}/{sequence_id}/{veritcal_id}
 
     `course_key`, `sequence_key`, and `unit_key` can be either OpaqueKeys or
     strings. They're only ever used to concatenate a URL string.

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -160,7 +160,7 @@ def make_learning_mfe_courseware_url(
 
     We're building a URL like this:
 
-    http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@19a30717eff543078a5d94ae9d6c18a5/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4a1bba2a403f40bca5ec245e945b0d76
+    {LEARNING_MICROFRONTEND_URL}/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@19a30717eff543078a5d94ae9d6c18a5/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4a1bba2a403f40bca5ec245e945b0d76
 
     `course_key`, `sequence_key`, and `unit_key` can be either OpaqueKeys or
     strings. They're only ever used to concatenate a URL string.
@@ -200,7 +200,7 @@ def get_learning_mfe_home_url(
 
     We're building a URL like this:
 
-    http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/dates
+    {LEARNING_MICROFRONTEND_URL}/course/course-v1:edX+DemoX+Demo_Course/dates
 
     `course_key` can be either an OpaqueKey or a string.
     `url_fragment` is an optional string.


### PR DESCRIPTION
## Description

Make it possible for devstack configuration to load Learning MFE port values from environment, rather than hard coding.

## Testing instructions

Add overrides for any of the following in Devstack configuration, they should be inherited for development.

- LEARNING_MICROFRONTEND_URL
- LEARNING_MICROFRONTEND_NETLOC

Removing them should fall back to old default values.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
