### PR TITLE
chore: Remove notification app waffle flags

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -378,7 +378,7 @@ def get_course(request, course_key, check_tab=True):
         ],
         'show_discussions': bool(discussion_tab and discussion_tab.is_enabled(course, request.user)),
         'is_notify_all_learners_enabled': can_user_notify_all_learners(
-            course_key, user_roles, is_course_staff, is_course_admin
+            user_roles, is_course_staff, is_course_admin
         ),
         'captcha_settings': {
             'enabled': is_captcha_enabled(course_key),

--- a/lms/djangoapps/discussion/rest_api/tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tasks.py
@@ -40,7 +40,7 @@ def send_thread_created_notification(thread_id, course_key_str, user_id, notify_
         is_course_staff = CourseStaffRole(course_key).has_user(user)
         is_course_admin = CourseInstructorRole(course_key).has_user(user)
         user_roles = get_user_role_names(user, course_key)
-        if not can_user_notify_all_learners(course_key, user_roles, is_course_staff, is_course_admin):
+        if not can_user_notify_all_learners(user_roles, is_course_staff, is_course_admin):
             return
 
     course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks.py
@@ -29,7 +29,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_STUDENT,
     CourseDiscussionSettings
 )
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS, ENABLE_NOTIFY_ALL_LEARNERS
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -190,14 +190,14 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
         """
 
     @ddt.data(
-        ('new_question_post', False, False),
-        ('new_discussion_post', False, False),
-        ('new_discussion_post', True, True),
-        ('new_discussion_post', True, False),
+        ('new_question_post', False),
+        ('new_discussion_post', False),
+        ('new_discussion_post', True),
+        ('new_discussion_post', True),
     )
     @ddt.unpack
     def test_notification_is_send_to_all_enrollments(
-        self, notification_type, notify_all_learners, waffle_flag_enabled
+        self, notification_type, notify_all_learners
     ):
         """
         Tests notification is sent to all users if course is not cohorted
@@ -207,29 +207,27 @@ class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTe
             "discussion" if notification_type == "new_discussion_post" else "question"
         )
 
-        with override_waffle_flag(ENABLE_NOTIFY_ALL_LEARNERS, active=waffle_flag_enabled):
-            thread = self._create_thread(thread_type=thread_type)
-            handler = mock.Mock()
-            COURSE_NOTIFICATION_REQUESTED.connect(handler)
+        thread = self._create_thread(thread_type=thread_type)
+        handler = mock.Mock()
+        COURSE_NOTIFICATION_REQUESTED.connect(handler)
 
-            send_thread_created_notification(
-                thread['id'],
-                str(self.course.id),
-                self.author.id,
-                notify_all_learners
+        send_thread_created_notification(
+            thread['id'],
+            str(self.course.id),
+            self.author.id,
+            notify_all_learners
+        )
+        self.assertEqual(handler.call_count, 1)
+
+        if handler.call_count:
+            course_notification_data = handler.call_args[1]['course_notification_data']
+            expected_type = (
+                'new_instructor_all_learners_post'
+                if notify_all_learners
+                else notification_type
             )
-            expected_handler_calls = 0 if notify_all_learners and not waffle_flag_enabled else 1
-            self.assertEqual(handler.call_count, expected_handler_calls)
-
-            if handler.call_count:
-                course_notification_data = handler.call_args[1]['course_notification_data']
-                expected_type = (
-                    'new_instructor_all_learners_post'
-                    if notify_all_learners and waffle_flag_enabled
-                    else notification_type
-                )
-                self.assertEqual(course_notification_data.notification_type, expected_type)
-                self.assertEqual(course_notification_data.audience_filters, {})
+            self.assertEqual(course_notification_data.notification_type, expected_type)
+            self.assertEqual(course_notification_data.audience_filters, {})
 
     @ddt.data(
         ('cohort_1', 'new_question_post'),

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -17,7 +17,6 @@ from openedx.core.djangoapps.django_comment_common.comment_client.thread import 
 
 from lms.djangoapps.discussion.config.settings import ENABLE_CAPTCHA_IN_DISCUSSION
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFY_ALL_LEARNERS
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, PostingRestriction
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -390,12 +389,11 @@ def is_posting_allowed(posting_restrictions: str, blackout_schedules: List):
         return False
 
 
-def can_user_notify_all_learners(course_key, user_roles, is_course_staff, is_course_admin):
+def can_user_notify_all_learners(user_roles, is_course_staff, is_course_admin):
     """
     Check if user posting is allowed to notify all learners based on the given restrictions
 
     Args:
-        course_key (CourseKey): CourseKey for which user creating any discussion post.
         user_roles (Dict): Roles of the posting user
         is_course_staff (Boolean): Whether the user has a course staff access.
         is_course_admin (Boolean): Whether the user has a course admin access.
@@ -409,7 +407,7 @@ def can_user_notify_all_learners(course_key, user_roles, is_course_staff, is_cou
         is_course_admin,
     ])
 
-    return is_staff_or_instructor and ENABLE_NOTIFY_ALL_LEARNERS.is_enabled(course_key)
+    return is_staff_or_instructor
 
 
 def verify_recaptcha_token(token):

--- a/openedx/core/djangoapps/notifications/config/waffle.py
+++ b/openedx/core/djangoapps/notifications/config/waffle.py
@@ -29,37 +29,6 @@ ENABLE_NOTIFICATIONS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_notification
 # .. toggle_tickets: INF-1259
 ENABLE_EMAIL_NOTIFICATIONS = WaffleFlag(f'{WAFFLE_NAMESPACE}.enable_email_notifications', __name__)
 
-# .. toggle_name: notifications.enable_ora_grade_notifications
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable ORA grade notifications
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2024-09-10
-# .. toggle_target_removal_date: 2024-10-10
-# .. toggle_tickets: INF-1304
-ENABLE_ORA_GRADE_NOTIFICATION = CourseWaffleFlag(f"{WAFFLE_NAMESPACE}.enable_ora_grade_notifications", __name__)
-
-# .. toggle_name: notifications.enable_notification_grouping
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable the Notifications Grouping feature
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2024-07-22
-# .. toggle_target_removal_date: 2025-06-01
-# .. toggle_warning: When the flag is ON, Notifications Grouping feature is enabled.
-# .. toggle_tickets: INF-1472
-ENABLE_NOTIFICATION_GROUPING = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_notification_grouping', __name__)
-
-# .. toggle_name: notifications.post_enable_notify_all_learners
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable the notify all learners on discussion post
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2025-06-11
-# .. toggle_warning: When the flag is ON, notification to all learners feature is enabled on discussion post.
-# .. toggle_tickets: INF-1917
-ENABLE_NOTIFY_ALL_LEARNERS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_post_notify_all_learners', __name__)
-
 # .. toggle_name: notifications.enable_push_notifications
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
@@ -69,14 +38,3 @@ ENABLE_NOTIFY_ALL_LEARNERS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_post_n
 # .. toggle_target_removal_date: 2026-05-27
 # .. toggle_warning: When the flag is ON, Notifications will go through ace push channels.
 ENABLE_PUSH_NOTIFICATIONS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_push_notifications', __name__)
-
-# .. toggle_name: notifications.enable_account_level_preferences
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable account level preferences for notifications
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2025-04-29
-# .. toggle_target_removal_date: 2025-07-29
-# .. toggle_warning: When the flag is ON, account level preferences for notifications are enabled.
-# .. toggle_tickets: INF-1472
-ENABLE_ACCOUNT_LEVEL_PREFERENCES = WaffleFlag(f'{WAFFLE_NAMESPACE}.enable_account_level_preferences', __name__)

--- a/openedx/core/djangoapps/notifications/email/tasks.py
+++ b/openedx/core/djangoapps/notifications/email/tasks.py
@@ -10,7 +10,6 @@ from edx_ace import ace
 from edx_ace.recipient import Recipient
 from edx_django_utils.monitoring import set_code_owner_attribute
 
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_ACCOUNT_LEVEL_PREFERENCES
 from openedx.core.djangoapps.notifications.email_notifications import EmailCadence
 from openedx.core.djangoapps.notifications.models import (
     CourseNotificationPreference,
@@ -26,12 +25,10 @@ from .utils import (
     create_email_digest_context,
     create_email_template_context,
     filter_email_enabled_notifications,
-    filter_notification_with_email_enabled_preferences,
     get_course_info,
     get_language_preference_for_users,
     get_start_end_date,
     get_text_for_notification_type,
-    get_unique_course_ids,
     is_email_notification_flag_enabled,
 )
 
@@ -102,14 +99,9 @@ def send_digest_email_to_user(user, cadence_type, start_date, end_date, user_lan
         return
 
     with translation_override(user_language):
-        if ENABLE_ACCOUNT_LEVEL_PREFERENCES.is_enabled():
-            preferences = NotificationPreference.objects.filter(user=user)
-            notifications = filter_email_enabled_notifications(notifications, preferences, user,
-                                                               cadence_type=cadence_type)
-        else:
-            course_ids = get_unique_course_ids(notifications)
-            preferences = get_user_preferences_for_courses(course_ids, user)
-            notifications = filter_notification_with_email_enabled_preferences(notifications, preferences, cadence_type)
+        preferences = NotificationPreference.objects.filter(user=user)
+        notifications = filter_email_enabled_notifications(notifications, preferences, user,
+                                                           cadence_type=cadence_type)
 
         if not notifications:
             logger.info(f'<Email Cadence> No filtered notification for {user.username} ==Temp Log==')

--- a/openedx/core/djangoapps/notifications/handlers.py
+++ b/openedx/core/djangoapps/notifications/handlers.py
@@ -24,7 +24,7 @@ from openedx.core.djangoapps.notifications.audience_filters import (
     TeamAudienceFilter
 )
 from openedx.core.djangoapps.notifications.base_notification import NotificationAppManager, COURSE_NOTIFICATION_TYPES
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS, ENABLE_ORA_GRADE_NOTIFICATION
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
 from openedx.core.djangoapps.notifications.email import ONE_CLICK_EMAIL_UNSUB_KEY
 from openedx.core.djangoapps.notifications.models import CourseNotificationPreference, NotificationPreference
 from openedx.core.djangoapps.notifications.tasks import create_notification_preference
@@ -107,11 +107,6 @@ def generate_user_notifications(signal, sender, notification_data, metadata, **k
     """
     Watches for USER_NOTIFICATION_REQUESTED signal and calls send_web_notifications task
     """
-    if (
-        notification_data.notification_type == 'ora_grade_assigned'
-        and not ENABLE_ORA_GRADE_NOTIFICATION.is_enabled(notification_data.course_key)
-    ):
-        return
 
     from openedx.core.djangoapps.notifications.tasks import send_notifications
     notification_data = notification_data.__dict__

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -341,10 +341,18 @@ class UserNotificationPreferenceAPITest(ModuleStoreTestCase):
                             'info': '',
                             'email_cadence': 'Daily',
                         },
+                        'new_instructor_all_learners_post': {
+                            'web': True,
+                            'email': False,
+                            'push': False,
+                            'email_cadence': 'Daily',
+                            'info': ''
+                        },
                     },
                     'non_editable': {
                         'new_discussion_post': ['push'],
                         'new_question_post': ['push'],
+                        'new_instructor_all_learners_post': ['push'],
                     }
                 },
                 'updates': {
@@ -1450,6 +1458,7 @@ class GetAggregateNotificationPreferencesTest(APITestCase):
         self.assertDictEqual(prefs['discussion']['non_editable'], {
             'new_discussion_post': ['push'],
             'new_question_post': ['push'],
+            'new_instructor_all_learners_post': ['push'],
             'core': ['web']
         })
 

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -4,11 +4,9 @@ Utils function for notifications app
 import copy
 from typing import Dict, List, Set
 
-from opaque_keys.edx.keys import CourseKey
-
 from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment
 from openedx.core.djangoapps.django_comment_common.models import Role
-from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS, ENABLE_NOTIFY_ALL_LEARNERS
+from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
 from openedx.core.djangoapps.notifications.email_notifications import EmailCadence
 from openedx.core.lib.cache_utils import request_cached
 
@@ -142,13 +140,6 @@ def remove_preferences_with_no_access(preferences: dict, user) -> dict:
         user_forum_roles,
         user_course_roles
     )
-
-    course_key = CourseKey.from_string(preferences['course_id'])
-    discussion_config = user_preferences.get('discussion', {})
-    notification_types = discussion_config.get('notification_types', {})
-
-    if notification_types and not ENABLE_NOTIFY_ALL_LEARNERS.is_enabled(course_key):
-        notification_types.pop('new_instructor_all_learners_post', None)
 
     return preferences
 

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -28,7 +28,7 @@ from openedx.core.djangoapps.user_api.models import UserPreference
 
 from .base_notification import COURSE_NOTIFICATION_APPS, NotificationAppManager, COURSE_NOTIFICATION_TYPES, \
     NotificationTypeManager
-from .config.waffle import ENABLE_NOTIFICATIONS, ENABLE_NOTIFY_ALL_LEARNERS
+from .config.waffle import ENABLE_NOTIFICATIONS
 from .events import (
     notification_preference_update_event,
     notification_preferences_viewed_event,
@@ -618,12 +618,6 @@ class AggregatedNotificationPreferences(APIView):
 
         notification_preferences_viewed_event(request)
         notification_configs = add_info_to_notification_config(notification_configs)
-
-        discussion_config = notification_configs.get('discussion', {})
-        notification_types = discussion_config.get('notification_types', {})
-
-        if not any(ENABLE_NOTIFY_ALL_LEARNERS.is_enabled(course_key) for course_key in course_ids):
-            notification_types.pop('new_instructor_all_learners_post', None)
 
         return Response({
             'status': 'success',


### PR DESCRIPTION
## Description

This PR removes the following obsolete flags from the notifications app:

- enable_post_notify_all_learners
- enable_notification_grouping
- enable_account_level_preferences
- enable_ora_grade_notifications


## Supporting information

https://2u-internal.atlassian.net/browse/INF-2010

## Testing instructions

Confirmed that no active logic depends on these flags. Also tested the creation of "notify all" notifications, grouped notifications, and ORA grading notifications after disabling the flags to ensure functionality remains unaffected.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
