### PR TITLE
feat: add course url to course team management GET API response

### DIFF
--- a/lms/djangoapps/support/rest_api/serializers.py
+++ b/lms/djangoapps/support/rest_api/serializers.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import pytz
 from rest_framework import serializers
 
+from lms.djangoapps.courseware.courses import get_cms_course_link
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 
@@ -15,10 +16,11 @@ class CourseTeamManageSerializer(serializers.ModelSerializer):
 
     role = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
+    course_url = serializers.SerializerMethodField()
 
     class Meta:
         model = CourseOverview
-        fields = ("id", "display_name", "role", "status")
+        fields = ("id", "display_name", "role", "status", "course_url")
 
     def get_role(self, obj):
         course_role_map = self.context.get("course_role_map", {})
@@ -33,12 +35,19 @@ class CourseTeamManageSerializer(serializers.ModelSerializer):
             return "active"
         return "archived"
 
+    def get_course_url(self, obj):
+        """
+        Construct the course URL for CMS using get_cms_course_link.
+        """
+        return get_cms_course_link(obj, "course")
+
     def to_representation(self, instance):
         data = super().to_representation(instance)
         course_key = instance.id
         return {
             "course_id": str(course_key),
             "course_name": data["display_name"],
+            "course_url": data["course_url"],
             "role": data["role"],
             "status": data["status"],
             "org": course_key.org,

--- a/lms/djangoapps/support/rest_api/serializers.py
+++ b/lms/djangoapps/support/rest_api/serializers.py
@@ -5,9 +5,9 @@ Serializers for use in the support app.
 from datetime import datetime
 
 import pytz
+from django.conf import settings
 from rest_framework import serializers
 
-from lms.djangoapps.courseware.courses import get_cms_course_link
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 
@@ -37,9 +37,11 @@ class CourseTeamManageSerializer(serializers.ModelSerializer):
 
     def get_course_url(self, obj):
         """
-        Construct the course URL for CMS using get_cms_course_link.
+        Construct the course URL for CMS with proper scheme and host.
         """
-        return get_cms_course_link(obj, "course")
+        scheme = "https" if settings.HTTPS == "on" else "http"
+        course_url = f"{scheme}://{settings.CMS_BASE}/course/{str(obj.id)}"
+        return course_url
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/lms/djangoapps/support/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/support/rest_api/v1/tests/test_views.py
@@ -114,6 +114,7 @@ class CourseTeamManageAPIViewTest(SupportViewTestCase):
                     self.assertIn("run", course)
                     self.assertIn("number", course)
                     self.assertIn("course_name", course)
+                    self.assertIn("course_url", course)
                 course_found = True
         self.assertTrue(course_found, "Expected course not found in response.")
 

--- a/lms/djangoapps/support/rest_api/v1/views.py
+++ b/lms/djangoapps/support/rest_api/v1/views.py
@@ -197,7 +197,7 @@ class CourseTeamManageAPIView(GenericAPIView):
                     {
                         "course_id": "course-v1:edX+DemoX+2025_T1",
                         "course_name": "edX Demonstration Course",
-                        "course_url": "//localhost:18010/course/course-v1:edX+DemoX+2025_T1",
+                        "course_url": "https://studio.example.com/course/course-v1:edX+DemoX+2025_T1",
                         "role": "instructor",
                         "status": "active",
                         "org": "edX",
@@ -207,7 +207,7 @@ class CourseTeamManageAPIView(GenericAPIView):
                     {
                         "course_id": "course-v1:MITx+6.00x+2024_Fall",
                         "course_name": "Introduction to Computer Science",
-                        "course_url": "//localhost:18010/course/course-v1:MITx+6.00x+2024_Fall",
+                        "course_url": "https://studio.example.com/course/course-v1:MITx+6.00x+2024_Fall",
                         "role": "staff",
                         "status": "archived",
                         "org": "MITx",

--- a/lms/djangoapps/support/rest_api/v1/views.py
+++ b/lms/djangoapps/support/rest_api/v1/views.py
@@ -201,7 +201,8 @@ class CourseTeamManageAPIView(GenericAPIView):
                         "status": "active",
                         "org": "edX",
                         "run": "2025_T1",
-                        "number": "DemoX"
+                        "number": "DemoX",
+                        "url": "//localhost:18010/course/course-v1:edX+DemoX+2025_T1"
                     },
                     {
                         "course_id": "course-v1:MITx+6.00x+2024_Fall",
@@ -210,7 +211,8 @@ class CourseTeamManageAPIView(GenericAPIView):
                         "status": "archived",
                         "org": "MITx",
                         "run": "2024_Fall",
-                        "number": "6.00x"
+                        "number": "6.00x",
+                        "url": "//localhost:18010/course/course-v1:MITx+6.00x+2024_Fall"
                     }
                 ]
             }

--- a/lms/djangoapps/support/rest_api/v1/views.py
+++ b/lms/djangoapps/support/rest_api/v1/views.py
@@ -197,22 +197,22 @@ class CourseTeamManageAPIView(GenericAPIView):
                     {
                         "course_id": "course-v1:edX+DemoX+2025_T1",
                         "course_name": "edX Demonstration Course",
+                        "course_url": "//localhost:18010/course/course-v1:edX+DemoX+2025_T1",
                         "role": "instructor",
                         "status": "active",
                         "org": "edX",
                         "run": "2025_T1",
-                        "number": "DemoX",
-                        "url": "//localhost:18010/course/course-v1:edX+DemoX+2025_T1"
+                        "number": "DemoX"
                     },
                     {
                         "course_id": "course-v1:MITx+6.00x+2024_Fall",
                         "course_name": "Introduction to Computer Science",
+                        "course_url": "//localhost:18010/course/course-v1:MITx+6.00x+2024_Fall",
                         "role": "staff",
                         "status": "archived",
                         "org": "MITx",
                         "run": "2024_Fall",
-                        "number": "6.00x",
-                        "url": "//localhost:18010/course/course-v1:MITx+6.00x+2024_Fall"
+                        "number": "6.00x"
                     }
                 ]
             }


### PR DESCRIPTION
## Description

This pull request enhances the course team management GET API by adding a `course_url` field to the response. This provides direct links to course page in CMS, improving the user experience for course team management workflows.

## Jira

- [TNL2-229](https://2u-internal.atlassian.net/browse/TNL2-229)

## Technical Implementation

- Constructs the course URL.
- Follows established patterns for adding fields to DRF serializers.
- Maintains backward compatibility while enhancing the API response.

## Testing
- Updated existing test cases to verify the new `course_url` field.
- All existing functionality remains unchanged.
- No breaking changes to API contract.

## Related PR

- https://github.com/openedx/edx-platform/pull/36990

## Screenshot

<img width="732" height="463" alt="image" src="https://github.com/user-attachments/assets/d69972d3-2c82-4e1e-9f92-30c61d4b3370" />



