### PR TITLE
feat: disallow adding children to containers imported from library [FC-0097]

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1304,7 +1304,11 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
         # Update with gating info
         xblock_info.update(_get_gating_info(course, xblock))
         # Also add upstream info
-        xblock_info["upstream_info"] = UpstreamLink.try_get_for_block(xblock, log_error=False).to_json()
+        upstream_info = UpstreamLink.try_get_for_block(xblock, log_error=False).to_json()
+        xblock_info["upstream_info"] = upstream_info
+        # Disable adding or removing children component if xblock is imported from library
+        if upstream_info["upstream_ref"]:
+            xblock_actions["childAddable"] = False
         if is_xblock_unit:
             # if xblock is a Unit we add the discussion_enabled option
             xblock_info["discussion_enabled"] = xblock.discussion_enabled


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Updates `childAddable` action in xblocks that have upstream link to stop users from updating imported sections and subsections.

## Supporting information

* https://github.com/openedx/frontend-app-authoring/pull/2311
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4226

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/2311 for test instructions

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
