### PR TITLE
WIP: fix: allow JWT auth for views used in Authoring MFE

### DIFF
--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -13,6 +13,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_http_methods
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
+from rest_framework.decorators import api_view
 
 from cms.djangoapps.contentstore.utils import load_services_for_studio
 from cms.lib.xblock.authoring_mixin import VISIBILITY_VIEW
@@ -28,6 +29,7 @@ from openedx.core.lib.xblock_utils import (
     wrap_xblock,
     wrap_xblock_aside,
 )
+from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.modulestore.django import (
     modulestore,
 )  # lint-amnesty, pylint: disable=wrong-import-order
@@ -84,9 +86,10 @@ ALWAYS = lambda x: True
 # ends, which end up reading from an outdated state of the database. For more information see the discussion in the
 # following PR: https://github.com/openedx/edx-platform/pull/34020
 @transaction.non_atomic_requests
-@require_http_methods(("DELETE", "GET", "PUT", "POST", "PATCH"))
-@login_required
+# @require_http_methods(("DELETE", "GET", "PUT", "POST", "PATCH"))
+@view_auth_classes()
 @expect_json
+@api_view(http_method_names=["DELETE", "GET", "PUT", "POST", "PATCH"])
 def xblock_handler(request, usage_key_string=None):
     """
     The restful handler for xblock requests.
@@ -145,9 +148,9 @@ def xblock_handler(request, usage_key_string=None):
     return handle_xblock(request, usage_key_string)
 
 
-@require_http_methods("GET")
-@login_required
+@view_auth_classes()
 @expect_json
+@api_view(http_method_names=["GET"])
 def xblock_view_handler(request, usage_key_string, view_name):
     """
     The restful handler for requests for rendered xblock views.
@@ -306,8 +309,9 @@ def xblock_view_handler(request, usage_key_string, view_name):
 
 
 @xframe_options_exempt
-@require_http_methods(["GET"])
-@login_required
+@view_auth_classes()
+@expect_json
+@api_view(http_method_names=["GET"])
 def xblock_edit_view(request, usage_key_string):
     """
     Return rendered xblock edit view.
@@ -338,9 +342,9 @@ def xblock_edit_view(request, usage_key_string):
         return render_to_response('container_editor.html', container_handler_context)
 
 
-@require_http_methods("GET")
-@login_required
+@view_auth_classes()
 @expect_json
+@api_view(http_method_names=["GET"])
 def xblock_outline_handler(request, usage_key_string):
     """
     The restful handler for requests for XBlock information about the block and its children.
@@ -371,9 +375,9 @@ def xblock_outline_handler(request, usage_key_string):
         raise Http404
 
 
-@require_http_methods("GET")
-@login_required
+@view_auth_classes()
 @expect_json
+@api_view(http_method_names=["GET"])
 def xblock_container_handler(request, usage_key_string):
     """
     The restful handler for requests for XBlock information about the block and its children.
@@ -400,8 +404,9 @@ def xblock_container_handler(request, usage_key_string):
         raise Http404
 
 
-@login_required
-@require_http_methods(("GET", "DELETE"))
+@view_auth_classes()
+@expect_json
+@api_view(http_method_names=["GET", "DELETE"])
 def orphan_handler(request, course_key_string):
     """
     View for handling orphan related requests. GET gets all of the current orphans.


### PR DESCRIPTION
## Description

Avoid authentication errors from MFEs (specifically the Authoring MFE here) in the case where the LMS is logged in, but Studio is not yet authenticated.

Fixes: [#1080](https://github.com/openedx/frontend-app-authoring/issues/1080)

### TODO:

- [ ] check for backwards incompatibilities
- [ ] check for security issues (are the permissions the same, is it fine opening these endpoints up to jwt authentication?)
- [ ] check for other endpoints that are used by the Authoring MFE that could be updated
- [ ] add/update tests

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9549

## Testing instructions

1. Log in to the LMS as an admin.
1. Navigate to a course, and open the course in Studio, and navigate to the course outline page. Ensure you're on this Authoring MFE, not the Studio views.
1. Copy or bookmark the direct url to the course outline in Authoring.
1. Log out of the LMS.
1. Log back in to the LMS. Do not visit Studio / CMS. (This results in you being logged in to the LMS, but not directly logged into the CMS; this CMS login only happens on first visit to a CMS web page where you are redirected through the lms oauth process)
1. Directly navigate to the Authoring url from step 3. You may notice the page redirect briefly; this is expected, as it's logging you in to the CMS.
1. Try to perform one of the following actions: click the "New unit" button, click the "New subsection" button, click the "New section" button.
1. Verify the action succeeds.
1. Reload the page.
1. Verify the page loads successfully.
1. Try to perform one of the actions (New unit/subsection/section) again.
1. Verify the action succeeds.


## Other information

See also https://github.com/openedx/frontend-app-authoring/issues/1080#issuecomment-3134921254 and https://github.com/openedx/frontend-app-authoring/pull/2335 . There may be alternate or better methods of implementing this.