### PR TITLE
[DRAFT] Unit Prerequisites Lost During Course Export/Import

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -117,6 +117,8 @@ from xmodule.services import ConfigurationService, SettingsService, TeamsConfigu
 
 from .models import ComponentLink, ContainerLink
 
+from openedx.core.lib.gating.services import GatingService
+
 IMPORTABLE_FILE_TYPES = ('.tar.gz', '.zip')
 log = logging.getLogger(__name__)
 
@@ -1311,7 +1313,8 @@ def load_services_for_studio(runtime, user):
         "settings": SettingsService(),
         "lti-configuration": ConfigurationService(CourseAllowPIISharingInLTIFlag),
         "teams_configuration": TeamsConfigurationService(),
-        "library_tools": LegacyLibraryToolsService(modulestore(), user.id)
+        "library_tools": LegacyLibraryToolsService(modulestore(), user.id),
+        'gating': GatingService(),
     }
 
     runtime._services.update(services)  # lint-amnesty, pylint: disable=protected-access

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -154,7 +154,7 @@ from openedx.core.djangolib.js_utils import (
             % if handout:
             <div class="wrapper-handouts">
                 <h4 class="hd hd-5">${_('Handouts')}</h4>
-                <a class="btn-link" href="${handout}">${_('Download Handout')}</a>
+                <a class="btn-link" href="${handout}" download>${_('Download Handout')}</a>
             </div>
             % endif
             % if branding_info:

--- a/openedx/core/lib/gating/services.py
+++ b/openedx/core/lib/gating/services.py
@@ -54,3 +54,16 @@ class GatingService:
             Returns False otherwise
         """
         return gating_api.is_gate_fulfilled(course_key, gating_content_key, user_id)
+
+    def get_required_prereq_metadata(course_key, gated_content_key):
+        """
+        Returns the prerequisite information of the provided subsection
+
+        Arguments:
+            course_key (str|CourseKey): The course key
+            content_key (str|UsageKey): The content usage key
+
+        Returns:
+            dict or None: The gating milestone dict or None
+        """
+        return gating_api.get_required_content(course_key, gated_content_key)

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -41,7 +41,6 @@ from .progress import Progress
 from .x_module import AUTHOR_VIEW, PUBLIC_VIEW
 from .xml_block import XmlMixin
 
-
 log = logging.getLogger(__name__)
 
 # HACK: This shouldn't be hard-coded to two types
@@ -374,6 +373,26 @@ class SequenceBlock(
         meta['is_hidden_after_due'] = is_hidden_after_due
         meta['navigation_disabled'] = self.is_sequence_navigation_disabled()
         return meta
+
+    def get_prereq_metadata(self, course_key, gated_content_key):
+        """
+        Returns the prerequisite of this sequence if there is one.
+
+        Arguments:
+            course_key (str|CourseKey): The course key
+            content_key (str|UsageKey): The content usage key
+
+        Returns:
+            dict or None: The gating milestone dict or None
+        """
+        logging.warning(f'INSPECTING-LOG get_prereq_metadata type is = %s', type(self))
+        logging.warning(f'INSPECTING-LOG get_prereq_metadata vars is = %s', vars(self))
+            
+        gating_service = self.runtime.service(self, 'gating')
+        if gating_service:
+            return gating_service.get_required_prereq_metadata(course_key, gated_content_key)
+        else:
+            return None
 
     def is_sequence_navigation_disabled(self):
         """

--- a/xmodule/xml_block.py
+++ b/xmodule/xml_block.py
@@ -12,11 +12,11 @@ from xblock.fields import Dict, Scope, ScopeIds
 from xblock.runtime import KvsFieldData
 from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.inheritance import InheritanceKeyValueStore, own_metadata
-
 log = logging.getLogger(__name__)
 
 # assume all XML files are persisted as utf-8.
 EDX_XML_PARSER = XMLParser(dtd_validation=False, load_dtd=False, remove_blank_text=True, encoding='utf-8')
+
 
 
 def name_to_pathname(name):
@@ -455,6 +455,28 @@ class XmlMixin:
         xml_object.tag = self.category
         node.tag = self.category
 
+        # Populate Prerequisite information of a sequential object
+        if self.category == 'sequential':
+            course_id = self.scope_ids.usage_id.context_key
+            content_id = self.location
+            logging.warning(f'INSPECTING-LOG self type is = %s', type(self))
+            logging.warning(f'INSPECTING-LOG self vars is = %s', vars(self))
+
+            logging.warning(f'INSPECTING-LOG course_id is = %s', course_id)
+            logging.warning(f'INSPECTING-LOG content_id is = %s', content_id)
+            
+            milestone =   self.get_prereq_metadata(course_id, content_id)
+            if milestone :
+                logging.warning(f'INSPECTING-LOG milestone type is = %s', type(milestone))
+                logging.warning(f'INSPECTING-LOG milestone vars is = %s', vars(milestone))
+                # xml_object.set('is_prereq', '')
+                # xml_object.set('prereq', '')
+                # xml_object.set('prereq_min_score', '')
+                # xml_object.set('prereq_min_completion', '')
+            else :
+                logging.warning(f'INSPECTING-LOG milestone is None= %s', (milestone))
+                
+        
         # Add the non-inherited metadata
         for attr in sorted(own_metadata(self)):
             # don't want e.g. data_dir


### PR DESCRIPTION
This PR introduces support for subsection (sequential) prerequisites in the OLX course format. Course authors can now define prerequisite relationships between subsections with configurable completion criteria including minimum score and completion percentage requirements.

## Problem Statement
Currently, Open edX lacks the ability to define prerequisite relationships between subsections at the OLX level. This prevents course authors from enforcing learning pathways where students must complete certain subsections before accessing others, which is crucial for structured learning experiences.

Proposed Solution
- Extend the <sequential> element in OLX to support prerequisite definitions
- Add a new <prerequisite> child element with configurable requirements
- Maintain full backward compatibility with existing OLX courses

```
<sequential display_name="..." ...>
  <prerequisite 
    url_name="SEQUENTIAL-ID"
    min_score="MIN-SCORE-VALUE"
    min_completion="MIN-COMPLETION-SCORE"
  />
  <vertical url_name="..."/>
</sequential>

```

## Supporting information
1. https://github.com/openedx/edx-platform/issues/36995
2. https://discuss.openedx.org/t/request-for-comments-course-export-import-and-re-run/16508?u=haftamu.kebede 