### PR TITLE
feat: Upgrade Python dependency edx-toggles

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -23,12 +23,6 @@
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -541,7 +541,7 @@ edx-tincan-py35==2.0.0
     # via
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -840,7 +840,7 @@ edx-tincan-py35==2.0.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -627,7 +627,7 @@ edx-tincan-py35==2.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -650,7 +650,7 @@ edx-tincan-py35==2.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends


### PR DESCRIPTION
### Description

Toggle state reports were missing `ex: EVENT_BUS_PRODUCER_CONFIG` entries due to inadequate nested dictionary processing in edx-toggles library.

### Solution

Upgraded edx-toggles dependency from 5.3.0 to 5.4.1 which includes enhanced nested dictionary extraction logic.

### JIRA ticket

[BOMS-24](https://2u-internal.atlassian.net/browse/BOMS-24)

### Reference

[PR](https://github.com/openedx/edx-toggles/pull/433)