### PR TITLE
fix: studio swagger api-docs crashes with 500 error

### DIFF
--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -138,7 +138,8 @@ class LibraryContainerChildrenView(GenericAPIView):
     @convert_exceptions
     @swagger_auto_schema(
         responses={
-            200: serializers.LibraryXBlockMetadataSerializer(many=True) | serializers.LibraryContainerMetadataSerializer
+            200: serializers.LibraryXBlockMetadataSerializer(many=True)
+                 | serializers.LibraryContainerMetadataSerializer(many=True)
         }
     )
     def get(self, request, container_key: LibraryContainerLocator):

--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -137,7 +137,9 @@ class LibraryContainerChildrenView(GenericAPIView):
 
     @convert_exceptions
     @swagger_auto_schema(
-        responses={200: serializers.LibraryXBlockMetadataSerializer(many=True)}
+        responses={
+            200: serializers.LibraryXBlockMetadataSerializer(many=True) | serializers.LibraryContainerMetadataSerializer
+        }
     )
     def get(self, request, container_key: LibraryContainerLocator):
         """
@@ -280,7 +282,8 @@ class LibraryContainerRestore(GenericAPIView):
     """
     View to restore soft-deleted library containers.
     """
-    serializer_class = serializers.DummySerializer
+    # serializer_class = serializers.DummySerializer
+    swagger_schema = None
 
     @convert_exceptions
     def post(self, request, container_key: LibraryContainerLocator) -> Response:
@@ -302,7 +305,8 @@ class LibraryContainerCollectionsView(GenericAPIView):
     """
     View to set collections for a container.
     """
-    serializer_class = serializers.DummySerializer
+    # serializer_class = serializers.DummySerializer
+    swagger_schema = None
 
     @convert_exceptions
     def patch(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
@@ -337,7 +341,8 @@ class LibraryContainerPublishView(GenericAPIView):
     """
     View to publish a container, or revert to last published.
     """
-    serializer_class = serializers.DummySerializer
+    # serializer_class = serializers.DummySerializer
+    swagger_schema = None
 
     @convert_exceptions
     def post(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:

--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -9,12 +9,13 @@ from django.contrib.auth import get_user_model
 from django.db.transaction import non_atomic_requests
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 from opaque_keys.edx.locator import LibraryLocatorV2, LibraryContainerLocator
 from openedx_learning.api import authoring as authoring_api
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
-from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.status import HTTP_204_NO_CONTENT, HTTP_200_OK
 
 from openedx.core.djangoapps.content_libraries import api, permissions
 from openedx.core.lib.api.view_utils import view_auth_classes
@@ -138,8 +139,7 @@ class LibraryContainerChildrenView(GenericAPIView):
     @convert_exceptions
     @swagger_auto_schema(
         responses={
-            200: serializers.LibraryXBlockMetadataSerializer(many=True),
-            200: serializers.LibraryContainerMetadataSerializer(many=True)
+            HTTP_200_OK: serializers.UnionLibraryMetadataSerializer()
         }
     )
     def get(self, request, container_key: LibraryContainerLocator):
@@ -283,10 +283,16 @@ class LibraryContainerRestore(GenericAPIView):
     """
     View to restore soft-deleted library containers.
     """
-    # serializer_class = serializers.DummySerializer
-    swagger_schema = None
 
     @convert_exceptions
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+        ),
+        responses={
+            HTTP_204_NO_CONTENT: "No content"
+        }
+    )
     def post(self, request, container_key: LibraryContainerLocator) -> Response:
         """
         Restores a soft-deleted library container
@@ -306,10 +312,21 @@ class LibraryContainerCollectionsView(GenericAPIView):
     """
     View to set collections for a container.
     """
-    # serializer_class = serializers.DummySerializer
-    swagger_schema = None
 
     @convert_exceptions
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+        ),
+        responses={
+            HTTP_200_OK: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    'count': openapi.Schema(type=openapi.TYPE_INTEGER)
+                }
+            )
+        }
+    )
     def patch(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
         """
         Sets Collections for a Component.
@@ -342,10 +359,18 @@ class LibraryContainerPublishView(GenericAPIView):
     """
     View to publish a container, or revert to last published.
     """
-    # serializer_class = serializers.DummySerializer
-    swagger_schema = None
 
     @convert_exceptions
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+        ),
+        responses={
+            HTTP_200_OK: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+            )
+        }
+    )
     def post(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
         """
         Publish the container and its children

--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -138,8 +138,8 @@ class LibraryContainerChildrenView(GenericAPIView):
     @convert_exceptions
     @swagger_auto_schema(
         responses={
-            200: serializers.LibraryXBlockMetadataSerializer(many=True)
-                 | serializers.LibraryContainerMetadataSerializer(many=True)
+            200: serializers.LibraryXBlockMetadataSerializer(many=True),
+            200: serializers.LibraryContainerMetadataSerializer(many=True)
         }
     )
     def get(self, request, container_key: LibraryContainerLocator):

--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -137,10 +137,7 @@ class LibraryContainerChildrenView(GenericAPIView):
 
     @convert_exceptions
     @swagger_auto_schema(
-        responses={
-            200: list[serializers.LibraryXBlockMetadataSerializer]
-            | list[serializers.LibraryContainerMetadataSerializer]
-        }
+        responses={200: serializers.LibraryXBlockMetadataSerializer(many=True)}
     )
     def get(self, request, container_key: LibraryContainerLocator):
         """
@@ -283,6 +280,8 @@ class LibraryContainerRestore(GenericAPIView):
     """
     View to restore soft-deleted library containers.
     """
+    serializer_class = serializers.DummySerializer
+
     @convert_exceptions
     def post(self, request, container_key: LibraryContainerLocator) -> Response:
         """
@@ -303,6 +302,8 @@ class LibraryContainerCollectionsView(GenericAPIView):
     """
     View to set collections for a container.
     """
+    serializer_class = serializers.DummySerializer
+
     @convert_exceptions
     def patch(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
         """
@@ -336,6 +337,8 @@ class LibraryContainerPublishView(GenericAPIView):
     """
     View to publish a container, or revert to last published.
     """
+    serializer_class = serializers.DummySerializer
+
     @convert_exceptions
     def post(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
         """

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -386,3 +386,11 @@ class ContentLibraryItemCollectionsUpdateSerializer(serializers.Serializer):
     """
 
     collection_keys = serializers.ListField(child=serializers.CharField(), allow_empty=True)
+
+
+class DummySerializer(serializers.Serializer):
+    """
+    Serializer for swagger to fake views.
+    """
+
+    pass

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -388,9 +388,10 @@ class ContentLibraryItemCollectionsUpdateSerializer(serializers.Serializer):
     collection_keys = serializers.ListField(child=serializers.CharField(), allow_empty=True)
 
 
-class DummySerializer(serializers.Serializer):
+class UnionLibraryMetadataSerializer(serializers.Serializer):
     """
-    Serializer for swagger to fake views.
+    Union serializer for swagger api response.
     """
 
-    pass
+    type_a = LibraryXBlockMetadataSerializer(many=True, required=False)
+    type_b = LibraryContainerMetadataSerializer(many=True, required=False)


### PR DESCRIPTION
## Description

Attempting to view the openapi (swagger) api docs for the cms fails. The Swagger web UI loads successfully, but displays a message "Failed to load API definition.".


## Supporting information

https://github.com/openedx/edx-platform/issues/37084


## Testing instructions

CMS API docs should load properly and no error logged on the backend.


## Other information

<img width="1552" height="987" alt="Screenshot 2025-07-31 at 9 20 11 PM" src="https://github.com/user-attachments/assets/e7d75fd7-d914-4d5f-9d70-8e60a2d9ec99" />
