### PR TITLE
Fix: When clicking "Download Handout", the handout (image) overlays the video area, and the download does not start automatically.

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -144,7 +144,7 @@
                 {% if handout %}
             <div class="wrapper-handouts">
                         <h4 class="hd hd-5">{% trans 'Handouts' as tmsg %}{{tmsg|force_escape}}</h4>
-                        <a class="btn-link" href="{{ handout|escape }}">{% trans 'Download Handout' as tmsg %}{{tmsg|force_escape}}</a>
+                        <a class="btn-link" href="{{ handout|escape }}" download>{% trans 'Download Handout' as tmsg %}{{tmsg|force_escape}}</a>
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description
This pull request will enable learners to be able to click "Download Handout" link available in a video component and initiate a direct download on image attachments(image handouts). The "download" attribute is added in the anchor element to perform a direct download.


Learners exploring courses with video component and an image handout attached to it will be able to click the "Download Handout" link to initiate a direct download.

## Supporting information

- [Issue Link](https://github.com/openedx/edx-platform/issues/37081)

- [a: The Anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#download)

## Testing instructions

- [You can follow instructions available here to reproduce the issue](https://github.com/openedx/edx-platform/issues/37081)

## Deadline

None

## Other information

None