### PR TITLE
fix: intermittent "utils attribute not found" issue in webpack_loader

### DIFF
--- a/xmodule/util/builtin_assets.py
+++ b/xmodule/util/builtin_assets.py
@@ -5,7 +5,6 @@ These should not be used to support any XBlocks outside of edx-platform.
 """
 from pathlib import Path
 
-import webpack_loader
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -44,6 +43,7 @@ def add_webpack_js_to_fragment(fragment, bundle_name):
     """
     Add all JS webpack chunks to the supplied fragment.
     """
-    for chunk in webpack_loader.utils.get_files(bundle_name, None, 'DEFAULT'):
+    from webpack_loader.utils import get_files
+    for chunk in get_files(bundle_name, None, 'DEFAULT'):
         if chunk['name'].endswith(('.js', '.js.gz')):
             fragment.add_javascript_url(chunk['url'])

--- a/xmodule/util/builtin_assets.py
+++ b/xmodule/util/builtin_assets.py
@@ -43,6 +43,10 @@ def add_webpack_js_to_fragment(fragment, bundle_name):
     """
     Add all JS webpack chunks to the supplied fragment.
     """
+    # Importing webpack_loader.utils at the top of the module causes an exception:
+    #   OSError: Error reading webpack-stats.json.
+    #   Are you sure webpack has generated the file and the path is correct?
+    # We are not quite sure why.
     from webpack_loader.utils import get_files
     for chunk in get_files(bundle_name, None, 'DEFAULT'):
         if chunk['name'].endswith(('.js', '.js.gz')):


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Since the merge of https://github.com/openedx/edx-platform/pull/32592, we have been facing this issue in our deployments. 

```
AttributeError: module 'webpack_loader' has no attribute 'utils'
(1 additional frame(s) were not displayed)
...
  File "lms/djangoapps/courseware/courses.py", line 457, in get_course_info_section
    html = info_block.render(STUDENT_VIEW).content.strip()
  File "xmodule/x_module.py", line 994, in render
    return super().render(block, view_name, context=context)
  File "xmodule/html_block.py", line 94, in student_view
    add_webpack_js_to_fragment(fragment, 'HtmlBlockDisplay')
  File "xmodule/util/builtin_assets.py", line 52, in add_webpack_js_to_fragment
    for chunk in webpack_loader.utils.get_files(bundle_name, None, 'DEFAULT'):

Error rendering course_id=course-v1:MITx+5.111r_20+2024_Fall, section_key=handouts
```

This issue occurs intermittently in both LMS and CMS, and we have been unable to reproduce it locally. To resolve this issue, we applied the changes in this PR to one of our deployments and, after extensive testing, confirmed that they successfully addressed the problem. 

<img width="1156" height="858" alt="Screenshot 2025-08-02 at 12 27 57 PM" src="https://github.com/user-attachments/assets/bd11e039-2a8e-4c0f-a3b7-39dde9e1eb63" />

<img width="2574" height="1146" alt="image" src="https://github.com/user-attachments/assets/fd725a8f-443d-438a-8b98-75c3f0dc91c1" />

Useful information to include:

- Which edX user roles will this change impact?  "Learner", "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

- Verify that the unit pages load without any issues in both LMS and CMS

## Deadline

"None"

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
