### PR TITLE
fix: remove enrollment notification until functionality is live

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -248,26 +248,6 @@ COURSE_NOTIFICATION_TYPES = {
         'email_template': '',
         'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE]
     },
-    'audit_access_expiring_soon': {
-        'notification_app': 'enrollments',
-        'name': 'audit_access_expiring_soon',
-        'is_core': False,
-        'info': '',
-        'web': True,
-        'email': False,
-        'email_cadence': EmailCadence.DAILY,
-        'push': False,
-        'non_editable': [],
-        'content_template': _('<{p}>Your audit access for <{strong}>{course_name}</{strong}> is expiring on '
-                              '<{strong}>{audit_access_expiry}</{strong}>. '
-                              'Upgrade now to extend access and get a certificate!.</{p}>'),
-        'content_context': {
-            'course_name': 'Course name',
-            'audit_access_expiry': 'Audit access expiry date',
-        },
-        'email_template': '',
-        'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE],
-    },
 }
 
 COURSE_NOTIFICATION_APPS = {
@@ -299,15 +279,6 @@ COURSE_NOTIFICATION_APPS = {
         'core_email_cadence': EmailCadence.DAILY,
         'non_editable': []
     },
-    'enrollments': {
-        'enabled': True,
-        'core_info': _('Notifications for enrollments.'),
-        'core_web': True,
-        'core_email': True,
-        'core_push': True,
-        'core_email_cadence': EmailCadence.DAILY,
-        'non_editable': []
-    }
 }
 
 

--- a/openedx/core/djangoapps/notifications/models.py
+++ b/openedx/core/djangoapps/notifications/models.py
@@ -26,7 +26,7 @@ NOTIFICATION_CHANNELS = ['web', 'push', 'email']
 ADDITIONAL_NOTIFICATION_CHANNEL_SETTINGS = ['email_cadence']
 
 # Update this version when there is a change to any course specific notification type or app.
-COURSE_NOTIFICATION_CONFIG_VERSION = 15
+COURSE_NOTIFICATION_CONFIG_VERSION = 16
 
 
 def get_course_notification_preference_config():

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -293,7 +293,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         self.assertEqual(response.data['count'], 4)
         self.assertEqual(response.data['count_by_app_name'], {
             'App Name 1': 2, 'App Name 2': 1, 'App Name 3': 1, 'discussion': 0,
-            'updates': 0, 'grading': 0, 'enrollments': 0})
+            'updates': 0, 'grading': 0})
         self.assertEqual(response.data['show_notifications_tray'], True)
 
     def test_get_unseen_notifications_count_for_unauthenticated_user(self):
@@ -315,7 +315,7 @@ class NotificationCountViewSetTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['count'], 0)
         self.assertEqual(response.data['count_by_app_name'], {'discussion': 0, 'updates': 0,
-                                                              'grading': 0, 'enrollments': 0})
+                                                              'grading': 0})
 
     def test_get_expiry_days_in_count_view(self):
         """
@@ -658,25 +658,6 @@ class TestNotificationPreferencesView(ModuleStoreTestCase):
                         "ora_staff_notifications": ["push"]
                     }
                 },
-                "enrollments": {
-                    "enabled": True,
-                    "core_notification_types": [],
-                    "notification_types": {
-                        "audit_access_expiring_soon": {
-                            "web": True,
-                            "email": False,
-                            "push": False,
-                            "email_cadence": "Daily"
-                        },
-                        "core": {
-                            "web": True,
-                            "email": True,
-                            "push": True,
-                            "email_cadence": "Daily"
-                        }
-                    },
-                    "non_editable": {}
-                }
             }
         }
         self.TEST_PASSWORD = 'testpass'
@@ -846,25 +827,6 @@ class TestNotificationPreferencesView(ModuleStoreTestCase):
                         "ora_grade_assigned": ["push"]
                     }
                 },
-                "enrollments": {
-                    "enabled": True,
-                    "core_notification_types": [],
-                    "notification_types": {
-                        "audit_access_expiring_soon": {
-                            "web": False,
-                            "email": False,
-                            "push": False,
-                            "email_cadence": "Daily"
-                        },
-                        "core": {
-                            "web": True,
-                            "email": True,
-                            "push": True,
-                            "email_cadence": "Daily"
-                        }
-                    },
-                    "non_editable": {}
-                }
             }
         }
         self.assertEqual(response.data, data)


### PR DESCRIPTION

## Description

Enrollment notification implementation is not live yet. Therefore enrollment tab in notification tray can be misleading. I'll put these settings back once enrollment notifications are live. 


## Deadline

ASAP.

