### PR TITLE
fix: Sort the output of dump_settings

### DIFF
--- a/openedx/core/djangoapps/util/management/commands/dump_settings.py
+++ b/openedx/core/djangoapps/util/management/commands/dump_settings.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
             for name in dir(settings)
             if SETTING_NAME_REGEX.match(name)
         }
-        print(json.dumps(settings_json, indent=4))
+        print(json.dumps(settings_json, indent=4, sort_keys=True))
 
 
 def _to_json_friendly_repr(value: object) -> object:


### PR DESCRIPTION
## Description

The dump_settings management command is
used for debugging changes to Django settings.
When comparing settings between two branches or
modules side-by-side, it is very useful to have the keys
print out in a deterministic order.

Affects developers only. This has no end-user impact. 

## Testing instructions

I've been using this locally to debug https://github.com/openedx/edx-platform/pull/37067.

You can test it yourself just by running `./manage.py lms dump_settings` and noting that JSON keys (both top-level and nested) are now sorted alphabetically.

## Deadline

No rush