### PR TITLE
feat: [FC-0092] Optimize Course Info Blocks API

### DIFF
--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -140,7 +140,7 @@ def get_blocks(
 
     # store transformed blocks in the current request to be reused where possible for optimization
     if current_request := get_current_request():
-        setattr(current_request, "reusable_transformed_blocks", blocks)
+        setattr(current_request, "reusable_transformed_blocks", blocks)  # pylint: disable=literal-used-as-attribute
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -137,6 +137,12 @@ def get_blocks(
     request_cache = RequestCache("unfiltered_course_structure")
     request_cache.set("reusable_transformed_blocks", blocks.copy())
 
+    # Since we included blocks with future start dates in our block structure,
+    # we need to include the 'start' field to filter out such blocks before returning the response.
+    # If 'start' field is not requested, it will be removed from the response.
+    requested_fields = set(requested_fields)
+    requested_fields.add('start')
+
     # filter blocks by types
     if block_types_filter:
         block_keys_to_remove = []
@@ -148,14 +154,6 @@ def get_blocks(
             blocks.remove_block(block_key, keep_descendants=True)
 
     # serialize
-
-    # Since we included blocks with future start dates in our block structure,
-    # we need to include the 'start' field to filter out such blocks before returning the response.
-    # If 'start' field is not requested, it will be removed from the response.
-    requested_fields = requested_fields or set()
-    if 'start' not in requested_fields:
-        requested_fields.add('start')
-
     serializer_context = {
         'request': request,
         'block_structure': blocks,

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -128,6 +128,11 @@ def get_blocks(
         include_has_scheduled_content=include_has_scheduled_content
     )
 
+    # store a copy of the transformed, but still unfiltered, course blocks in RequestCache to be reused
+    # wherever possible for optimization
+    request_cache = RequestCache("unfiltered_course_structure")
+    request_cache.set("reusable_transformed_blocks", blocks.copy())
+
     # filter blocks by types
     if block_types_filter:
         block_keys_to_remove = []
@@ -137,10 +142,6 @@ def get_blocks(
                 block_keys_to_remove.append(block_key)
         for block_key in block_keys_to_remove:
             blocks.remove_block(block_key, keep_descendants=True)
-
-    # store transformed blocks in RequestCache to be reused where possible for optimization
-    request_cache = RequestCache("course_blocks")
-    request_cache.set("reusable_transformed_blocks", blocks)
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -139,7 +139,8 @@ def get_blocks(
             blocks.remove_block(block_key, keep_descendants=True)
 
     # store transformed blocks in the current request to be reused where possible for optimization
-    get_current_request().reusable_transformed_blocks = blocks
+    if current_request := get_current_request():
+        setattr(current_request, "reusable_transformed_blocks", blocks)
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -14,7 +14,7 @@ from .serializers import BlockDictSerializer, BlockSerializer
 from .toggles import HIDE_ACCESS_DENIALS_FLAG
 from .transformers.blocks_api import BlocksAPITransformer
 from .transformers.milestones import MilestonesAndSpecialExamsTransformer
-from .utils import UNFILTERED_STRUCTURE_CACHE_KEY, REUSABLE_BLOCKS_CACHE_KEY
+from .utils import COURSE_API_REQUEST_CACHE_NAMESPACE, REUSABLE_BLOCKS_CACHE_KEY
 
 
 def get_blocks(
@@ -139,7 +139,7 @@ def get_blocks(
         # Store a copy of the transformed, but still unfiltered, course blocks in RequestCache to be reused
         # wherever possible for optimization. Copying is required to make sure the cached structure is not mutated
         # by the filtering below.
-        request_cache = RequestCache(UNFILTERED_STRUCTURE_CACHE_KEY)
+        request_cache = RequestCache(COURSE_API_REQUEST_CACHE_NAMESPACE)
         request_cache.set(REUSABLE_BLOCKS_CACHE_KEY, blocks.copy())
 
         # Since we included blocks with future start dates in our block structure,

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -123,7 +123,7 @@ def get_blocks(
         user,
         usage_key,
         transformers,
-        allow_start_dates_in_future=allow_start_dates_in_future,
+        allow_start_dates_in_future=True,
         include_completion=include_completion,
         include_has_scheduled_content=include_has_scheduled_content
     )
@@ -145,10 +145,16 @@ def get_blocks(
             blocks.remove_block(block_key, keep_descendants=True)
 
     # serialize
+
+    # Include start field to be able to use it in filtering.
+    requested_fields = requested_fields or set()
+    if 'start' not in requested_fields:
+        requested_fields.add('start')
+
     serializer_context = {
         'request': request,
         'block_structure': blocks,
-        'requested_fields': requested_fields or [],
+        'requested_fields': requested_fields,
     }
 
     if return_type == 'dict':

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -118,12 +118,15 @@ def get_blocks(
         ),
     ]
 
+    # Include future dates such that get_course_assignments can reuse the block structure from RequestCache
+    allow_start_dates_in_future = True
+
     # transform
     blocks = course_blocks_api.get_course_blocks(
         user,
         usage_key,
         transformers,
-        allow_start_dates_in_future=True,
+        allow_start_dates_in_future=allow_start_dates_in_future,
         include_completion=include_completion,
         include_has_scheduled_content=include_has_scheduled_content
     )
@@ -146,7 +149,9 @@ def get_blocks(
 
     # serialize
 
-    # Include start field to be able to use it in filtering.
+    # Since we included blocks with future start dates in our block structure,
+    # we need to include the 'start' field to filter out such blocks before returning the response.
+    # If 'start' field is not requested, it will be removed from the response.
     requested_fields = requested_fields or set()
     if 'start' not in requested_fields:
         requested_fields.add('start')

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -128,8 +128,9 @@ def get_blocks(
         include_has_scheduled_content=include_has_scheduled_content
     )
 
-    # store a copy of the transformed, but still unfiltered, course blocks in RequestCache to be reused
-    # wherever possible for optimization
+    # Store a copy of the transformed, but still unfiltered, course blocks in RequestCache to be reused
+    # wherever possible for optimization. Copying is required to make sure the cached structure is not mutated
+    # by the filtering below.
     request_cache = RequestCache("unfiltered_course_structure")
     request_cache.set("reusable_transformed_blocks", blocks.copy())
 

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -1,7 +1,7 @@
 """
 API function for retrieving course blocks data
 """
-
+from crum import get_current_request
 
 import lms.djangoapps.course_blocks.api as course_blocks_api
 from lms.djangoapps.course_blocks.transformers.access_denied_filter import AccessDeniedMessageFilterTransformer
@@ -137,6 +137,9 @@ def get_blocks(
                 block_keys_to_remove.append(block_key)
         for block_key in block_keys_to_remove:
             blocks.remove_block(block_key, keep_descendants=True)
+
+    # store transformed blocks in the current request to be reused where possible for optimization
+    get_current_request()._reusable_transformed_blocks = blocks
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -139,7 +139,7 @@ def get_blocks(
             blocks.remove_block(block_key, keep_descendants=True)
 
     # store transformed blocks in the current request to be reused where possible for optimization
-    get_current_request()._reusable_transformed_blocks = blocks
+    get_current_request().reusable_transformed_blocks = blocks
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -1,7 +1,7 @@
 """
 API function for retrieving course blocks data
 """
-from crum import get_current_request
+from edx_django_utils.cache import RequestCache
 
 import lms.djangoapps.course_blocks.api as course_blocks_api
 from lms.djangoapps.course_blocks.transformers.access_denied_filter import AccessDeniedMessageFilterTransformer
@@ -138,9 +138,9 @@ def get_blocks(
         for block_key in block_keys_to_remove:
             blocks.remove_block(block_key, keep_descendants=True)
 
-    # store transformed blocks in the current request to be reused where possible for optimization
-    if current_request := get_current_request():
-        setattr(current_request, "reusable_transformed_blocks", blocks)  # pylint: disable=literal-used-as-attribute
+    # store transformed blocks in RequestCache to be reused where possible for optimization
+    request_cache = RequestCache("course_blocks")
+    request_cache.set("reusable_transformed_blocks", blocks)
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/utils.py
+++ b/lms/djangoapps/course_api/blocks/utils.py
@@ -10,7 +10,7 @@ from openedx.core.djangoapps.discussions.models import (
 )
 
 
-UNFILTERED_STRUCTURE_CACHE_KEY = "unfiltered_course_structure"
+COURSE_API_REQUEST_CACHE_NAMESPACE = "course_api"
 REUSABLE_BLOCKS_CACHE_KEY = "reusable_transformed_blocks"
 
 
@@ -75,8 +75,8 @@ def get_cached_transformed_blocks():
     Helper function to get an unfiltered course structure from RequestCache,
     including blocks with start dates in the future.
     """
-    request_cache = RequestCache(UNFILTERED_STRUCTURE_CACHE_KEY)
+    request_cache = RequestCache(COURSE_API_REQUEST_CACHE_NAMESPACE)
     cached_response = request_cache.get_cached_response(REUSABLE_BLOCKS_CACHE_KEY)
-    reusable_transformed_blocks = cached_response.value if cached_response.is_found else None
+    reusable_transformed_blocks = cached_response.value.copy() if cached_response.is_found else None
 
     return reusable_transformed_blocks

--- a/lms/djangoapps/course_api/blocks/utils.py
+++ b/lms/djangoapps/course_api/blocks/utils.py
@@ -74,9 +74,12 @@ def get_cached_transformed_blocks():
     """
     Helper function to get an unfiltered course structure from RequestCache,
     including blocks with start dates in the future.
+
+    Caution: For performance reasons, the function returns the structure object itself, not its copy.
+    This means the retrieved structure is supposed to be read-only and should not be mutated by consumers.
     """
     request_cache = RequestCache(COURSE_API_REQUEST_CACHE_NAMESPACE)
     cached_response = request_cache.get_cached_response(REUSABLE_BLOCKS_CACHE_KEY)
-    reusable_transformed_blocks = cached_response.value.copy() if cached_response.is_found else None
+    reusable_transformed_blocks = cached_response.value if cached_response.is_found else None
 
     return reusable_transformed_blocks

--- a/lms/djangoapps/course_api/blocks/utils.py
+++ b/lms/djangoapps/course_api/blocks/utils.py
@@ -1,12 +1,17 @@
 """
    Utils for Blocks
 """
+from edx_django_utils.cache import RequestCache
 from rest_framework.utils.serializer_helpers import ReturnList
 
 from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
     Provider,
 )
+
+
+UNFILTERED_STRUCTURE_CACHE_KEY = "unfiltered_course_structure"
+REUSABLE_BLOCKS_CACHE_KEY = "reusable_transformed_blocks"
 
 
 def filter_discussion_xblocks_from_response(response, course_key):
@@ -63,3 +68,15 @@ def filter_discussion_xblocks_from_response(response, course_key):
         response.data['blocks'] = filtered_blocks
 
     return response
+
+
+def get_cached_transformed_blocks():
+    """
+    Helper function to get an unfiltered course structure from RequestCache,
+    including blocks with start dates in the future.
+    """
+    request_cache = RequestCache(UNFILTERED_STRUCTURE_CACHE_KEY)
+    cached_response = request_cache.get_cached_response(REUSABLE_BLOCKS_CACHE_KEY)
+    reusable_transformed_blocks = cached_response.value if cached_response.is_found else None
+
+    return reusable_transformed_blocks

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -341,12 +341,11 @@ class BlocksInCourseView(BlocksView):
 
         # Earlier we included blocks with future start dates in the collected/cached block structure.
         # Now we need to emulate allow_start_dates_in_future=False by removing any such blocks.
-        include_start  = "start" in request.query_params['requested_fields']
+        include_start = "start" in request.query_params['requested_fields']
         self.remove_future_blocks(course_blocks, include_start)
 
         recurse_mark_complete(root, course_blocks)
         return response
-
 
     @staticmethod
     def remove_future_blocks(course_blocks, include_start: bool):

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -237,7 +237,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
                     params.cleaned_data['return_type'],
                     params.cleaned_data.get('block_types_filter', None),
                     hide_access_denials=hide_access_denials,
-                    for_blocks_view=True
+                    cache_with_future_dates=True
                 )
             )
             # If the username is an empty string, and not None, then we are requesting

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -339,8 +339,55 @@ class BlocksInCourseView(BlocksView):
         if not root:
             raise ValidationError(f"Unable to find course block in '{course_key_string}'")
 
+        include_start  = "start" in request.query_params['requested_fields']
+        self.remove_future_blocks(course_blocks, include_start)
+
         recurse_mark_complete(root, course_blocks)
         return response
+
+
+    @staticmethod
+    def remove_future_blocks(course_blocks, include_start: bool):
+        """
+        Mutates course_blocks in place:
+        - removes blocks whose 'start' is in the future
+        - also removes references to them from parents' 'children' lists
+        - removes 'start' key from all blocks if it wasn't requested
+        """
+        from datetime import datetime, timezone
+
+        # blocks = response_data.get("blocks", {})
+        if not course_blocks:
+            return course_blocks
+
+        now = datetime.now(timezone.utc)
+
+        # 1. Collect IDs of blocks to remove
+        to_remove = set()
+        for block_id, block in course_blocks.items():
+            start = block.get("start")
+            if start and start > now:
+                to_remove.add(block_id)
+
+        if not to_remove:
+            return course_blocks
+
+        # 2. Remove the blocks themselves
+        for block_id in to_remove:
+            course_blocks.pop(block_id, None)
+
+        # 3. Clean up children lists
+        for block in course_blocks.values():
+            children = block.get("children")
+            if children:
+                block["children"] = [cid for cid in children if cid not in to_remove]
+
+        # 4. Optionally remove 'start' key from visible blocks
+        if not include_start:
+            for block in course_blocks.values():
+                block.pop("start", None)
+
+        return course_blocks
 
 
 @method_decorator(transaction.non_atomic_requests, name='dispatch')

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -237,6 +237,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
                     params.cleaned_data['return_type'],
                     params.cleaned_data.get('block_types_filter', None),
                     hide_access_denials=hide_access_denials,
+                    for_blocks_view=True
                 )
             )
             # If the username is an empty string, and not None, then we are requesting

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -357,7 +357,6 @@ class BlocksInCourseView(BlocksView):
         """
         from datetime import datetime, timezone
 
-        # blocks = response_data.get("blocks", {})
         if not course_blocks:
             return course_blocks
 
@@ -366,7 +365,8 @@ class BlocksInCourseView(BlocksView):
         # 1. Collect IDs of blocks to remove
         to_remove = set()
         for block_id, block in course_blocks.items():
-            start = block.get("start")
+            get_field = block.get if include_start else block.pop
+            start = get_field("start")
             if start and start > now:
                 to_remove.add(block_id)
 
@@ -382,11 +382,6 @@ class BlocksInCourseView(BlocksView):
             children = block.get("children")
             if children:
                 block["children"] = [cid for cid in children if cid not in to_remove]
-
-        # 4. Optionally remove 'start' key from visible blocks
-        if not include_start:
-            for block in course_blocks.values():
-                block.pop("start", None)
 
         return course_blocks
 

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -2,6 +2,7 @@
 CourseBlocks API views
 """
 
+from datetime import datetime, timezone
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -356,8 +357,6 @@ class BlocksInCourseView(BlocksView):
         - also removes references to them from parents' 'children' lists
         - removes 'start' key from all blocks if it wasn't requested
         """
-        from datetime import datetime, timezone
-
         if not course_blocks:
             return course_blocks
 

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -339,6 +339,8 @@ class BlocksInCourseView(BlocksView):
         if not root:
             raise ValidationError(f"Unable to find course block in '{course_key_string}'")
 
+        # Earlier we included blocks with future start dates in the collected/cached block structure.
+        # Now we need to emulate allow_start_dates_in_future=False by removing any such blocks.
         include_start  = "start" in request.query_params['requested_fields']
         self.remove_future_blocks(course_blocks, include_start)
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -17,7 +17,6 @@ from django.core.cache import cache
 from django.http import Http404, QueryDict
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from edx_django_utils.cache import RequestCache
 from edx_django_utils.monitoring import function_trace, set_custom_attribute
 from fs.errors import ResourceNotFound
 from opaque_keys.edx.keys import UsageKey
@@ -27,6 +26,7 @@ from common.djangoapps.edxmako.shortcuts import render_to_string
 from common.djangoapps.static_replace import replace_static_urls
 from common.djangoapps.util.date_utils import strftime_localized
 from lms.djangoapps import branding
+from lms.djangoapps.course_api.blocks.utils import get_cached_transformed_blocks
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import (
@@ -634,10 +634,7 @@ def get_course_assignments(course_key, user, include_access=False, include_witho
     store = modulestore()
     course_usage_key = store.make_course_usage_key(course_key)
 
-    request_cache = RequestCache("unfiltered_course_structure")
-    cached_response = request_cache.get_cached_response("reusable_transformed_blocks")
-    reusable_transformed_blocks = cached_response.value if cached_response.is_found else None
-    block_data = reusable_transformed_blocks or get_course_blocks(
+    block_data = get_cached_transformed_blocks() or get_course_blocks(
         user, course_usage_key, allow_start_dates_in_future=True, include_completion=True
     )
 

--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -56,11 +56,10 @@ class CourseData:
     @property
     def structure(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         if self._structure is None:
-            """
-            The get_course_blocks function proved to be a major time sink during a request at "blocks/".
-            This caching logic helps improve the response time by getting the already transformed course blocks
-            from RequestCache and thus reducing the number of times that the get_course_blocks function is called.
-            """
+            # The get_course_blocks function proved to be a major time sink during a request at "blocks/".
+            # This caching logic helps improve the response time by getting the already transformed course blocks
+            # from RequestCache and thus reducing the number of times that the get_course_blocks function is called.
+
             request_cache = RequestCache("course_blocks")
             cached_response = request_cache.get_cached_response("reusable_transformed_blocks")
             reusable_transformed_blocks = cached_response.value if cached_response.is_found else None

--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -57,10 +57,11 @@ class CourseData:
     def structure(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         if self._structure is None:
             # The get_course_blocks function proved to be a major time sink during a request at "blocks/".
-            # This caching logic helps improve the response time by getting the already transformed course blocks
-            # from RequestCache and thus reducing the number of times that the get_course_blocks function is called.
+            # This caching logic helps improve the response time by getting a copy of the already transformed, but still
+            # unfiltered, course blocks from RequestCache and thus reducing the number of times that
+            # the get_course_blocks function is called.
 
-            request_cache = RequestCache("course_blocks")
+            request_cache = RequestCache("unfiltered_course_structure")
             cached_response = request_cache.get_cached_response("reusable_transformed_blocks")
             reusable_transformed_blocks = cached_response.value if cached_response.is_found else None
             self._structure = reusable_transformed_blocks or get_course_blocks(

--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -57,8 +57,8 @@ class CourseData:
     def structure(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         if self._structure is None:
             # reuse transformed blocks from request if available
-            _reusable_transformed_blocks = getattr(get_current_request(), "_reusable_transformed_blocks", None)
-            self._structure = _reusable_transformed_blocks or get_course_blocks(
+            reusable_transformed_blocks = getattr(get_current_request(), "reusable_transformed_blocks", None)
+            self._structure = reusable_transformed_blocks or get_course_blocks(
                 self.user,
                 self.location,
                 collected_block_structure=self._collected_block_structure,

--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -1,7 +1,7 @@
 """
 Code used to get and cache the requested course-data
 """
-
+from crum import get_current_request
 
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
@@ -56,7 +56,9 @@ class CourseData:
     @property
     def structure(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         if self._structure is None:
-            self._structure = get_course_blocks(
+            # reuse transformed blocks from request if available
+            _reusable_transformed_blocks = getattr(get_current_request(), "_reusable_transformed_blocks", None)
+            self._structure = _reusable_transformed_blocks or get_course_blocks(
                 self.user,
                 self.location,
                 collected_block_structure=self._collected_block_structure,

--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -1,13 +1,13 @@
 """
 Code used to get and cache the requested course-data
 """
-from edx_django_utils.cache import RequestCache
 
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .transformer import GradesTransformer
+from ..course_api.blocks.utils import get_cached_transformed_blocks
 
 
 class CourseData:
@@ -60,11 +60,7 @@ class CourseData:
             # This caching logic helps improve the response time by getting a copy of the already transformed, but still
             # unfiltered, course blocks from RequestCache and thus reducing the number of times that
             # the get_course_blocks function is called.
-
-            request_cache = RequestCache("unfiltered_course_structure")
-            cached_response = request_cache.get_cached_response("reusable_transformed_blocks")
-            reusable_transformed_blocks = cached_response.value if cached_response.is_found else None
-            self._structure = reusable_transformed_blocks or get_course_blocks(
+            self._structure = get_cached_transformed_blocks() or get_course_blocks(
                 self.user,
                 self.location,
                 collected_block_structure=self._collected_block_structure,

--- a/lms/djangoapps/mobile_api/tests/test_course_info_views.py
+++ b/lms/djangoapps/mobile_api/tests/test_course_info_views.py
@@ -432,6 +432,68 @@ class TestBlocksInfoInCourseView(TestBlocksInCourseView, MilestonesTestCaseMixin
         for block_info in response.data['blocks'].values():
             self.assertNotEqual('assignment_progress', block_info)
 
+    def test_response_keys(self):
+        response = self.verify_response(url=self.url)
+        data = response.data
+
+        expected_top_level_keys = {
+            'blocks',
+            'certificate',
+            'course_about',
+            'course_access_details',
+            'course_handouts',
+            'course_modes',
+            'course_progress',
+            'course_sharing_utm_parameters',
+            'course_updates',
+            'deprecate_youtube',
+            'discussion_url',
+            'end',
+            'enrollment_details',
+            'id',
+            'is_self_paced',
+            'media',
+            'name',
+            'number',
+            'org',
+            'org_logo',
+            'root',
+            'start',
+            'start_display',
+            'start_type'
+        }
+        expected_course_access_keys = {
+            "has_unmet_prerequisites",
+            "is_too_early",
+            "is_staff",
+            "audit_access_expires",
+            "courseware_access"
+        }
+        expected_courseware_access_keys = {
+            "has_access",
+            "error_code",
+            "developer_message",
+            "user_message",
+            "additional_context_user_message",
+            "user_fragment"
+        }
+        expected_enrollment_details_keys = {"created", "mode", "is_active", "upgrade_deadline"}
+        expected_media_keys = {"image"}
+        expected_image_keys = {"raw", "small", "large"}
+        expected_course_sharing_keys = {"facebook", "twitter"}
+        expected_course_modes_keys = {"slug", "sku", "android_sku", "ios_sku", "min_price"}
+        expected_course_progress_keys = {"total_assignments_count", "assignments_completed"}
+
+        self.assertSetEqual(set(data), expected_top_level_keys)
+        self.assertSetEqual(set(data["course_access_details"]), expected_course_access_keys)
+        self.assertSetEqual(set(data["course_access_details"]["courseware_access"]), expected_courseware_access_keys)
+        self.assertSetEqual(set(data["enrollment_details"]), expected_enrollment_details_keys)
+        self.assertSetEqual(set(data["media"]), expected_media_keys)
+        self.assertSetEqual(set(data["media"]["image"]), expected_image_keys)
+        self.assertSetEqual(set(data["course_sharing_utm_parameters"]), expected_course_sharing_keys)
+        self.assertSetEqual(set(data["course_modes"][0]), expected_course_modes_keys)
+        self.assertSetEqual(set(data["course_progress"]), expected_course_progress_keys)
+
 
 class TestCourseEnrollmentDetailsView(MobileAPITestCase, MilestonesTestCaseMixin):  # lint-amnesty, pylint: disable=test-inherits-tests
     """

--- a/lms/djangoapps/mobile_api/tests/test_course_info_views.py
+++ b/lms/djangoapps/mobile_api/tests/test_course_info_views.py
@@ -494,6 +494,16 @@ class TestBlocksInfoInCourseView(TestBlocksInCourseView, MilestonesTestCaseMixin
         self.assertSetEqual(set(data["course_modes"][0]), expected_course_modes_keys)
         self.assertSetEqual(set(data["course_progress"]), expected_course_progress_keys)
 
+    def test_block_count_depends_on_depth_in_request_params(self):
+        response_depth_zero = self.verify_response(url=self.url, params={'depth': 0})
+        response_depth_one = self.verify_response(url=self.url, params={'depth': 1})
+        blocks_depth_zero = [block for block in self.store.get_items(self.course_key) if block.category == "course"]
+        blocks_depth_one = [
+            block for block in self.store.get_items(self.course_key) if block.category in ("course", "chapter")
+        ]
+        self.assertEqual(len(response_depth_zero.data["blocks"]), len(blocks_depth_zero))
+        self.assertEqual(len(response_depth_one.data["blocks"]), len(blocks_depth_one))
+
 
 class TestCourseEnrollmentDetailsView(MobileAPITestCase, MilestonesTestCaseMixin):  # lint-amnesty, pylint: disable=test-inherits-tests
     """


### PR DESCRIPTION
### PR Rationale
The Course Info Blocks API endpoint has been known to be rather slow to return the response. Previous investigation showed that the major time sink was the `get_course_blocks` function, which is called three times in a single request. This PR aims to improve the response times by reducing the number of times that this function is called.

### Solution Summary
The first time the function `get_course_blocks` is called, the result (transformed course blocks) is stored in the current WSGI request object. Later in the same request, before the second `get_course_blocks` call is triggered, the already transformed course blocks are taken from the request object, and if they are available, `get_course_blocks` is not called (if not, it is called as a fallback). Later in the request, the function is called again as before (see Optimization Strategy and Difficulties).

### Optimization Strategy and Difficulties
The original idea was to fetch and transform the course blocks once and reuse them in all three cases, which would reduce `get_course_blocks` call count to 1. However, this did not turn out to be a viable solution because of the arguments passed to `get_course_blocks`. Notably, the `allow_start_dates_in_future` boolean flag affects the behavior of `StartDateTransformer`, which is a filtering transformer modifying the block structure returned.
The first two times `allow_start_dates_in_future` is `False`, the third time it is `True`. Setting it to `True` in all three cases would mean that some blocks would be incorrectly included in the response.

This left us with one option - optimize the first two calls. The difference between the first two calls is the non-filtering transformers, however the second call applies a subset of transformers from the first call, so it was safe to apply the superset of transformers in both cases. This allowed to reduce the number of function calls to 2. However, the cached structure may be further mutated by filters downstream, which means we need to cache a copy of the course structure (not the structure itself). The `copy` method itself is quite heavy (it calls `deepcopy` three times), making the benefits of this solution much less tangible. In fact, another potential optimization that was considered was to reuse the collected block structure (pre-transformation), but since calling `copy` on a collected structure proved to be more time-consuming than calling `get_collected`, this change was discarded, considering that the goal is to improve performance.

### UPD: Revised Solution

To achieve a more tangible performance improvement, it was decided to modify the previous strategy as follows:

- Pass a for_blocks_view parameter to the `get_blocks` function to make sure the new caching logic only affects the blocks view
- Collect and cache course blocks with future dates included
- Include `start` key in requested fields
- Reuse the cached blocks in the third call, which is in `get_course_assignments`
- Before returning the response, filter out any blocks with a future start date, and also remove the `start` key if it was not in requested fields

### Response Times Measured
Here is a sample of the response times (in seconds).
The measurements were taken on a course with ~3000 blocks.

**With the revised solution**
Current time: ~12 seconds
New time: ~ 8 seconds
Improvement: 4 seconds (~30%)

<img width="1903" height="805" alt="get_course_blocks_highlighted_big_course" src="https://github.com/user-attachments/assets/c2da15f0-5384-4126-8ada-17ab8f3d573d" />