### PR TITLE
fix: Update vertical block test to use dynamic course id

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -2,6 +2,8 @@
 Unit tests for the vertical block.
 """
 
+from urllib.parse import quote
+
 from django.urls import reverse
 from rest_framework import status
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -131,19 +133,21 @@ class ContainerHandlerViewTest(BaseXBlockContainer):
         """
         Check if the ancestor_xblocks are returned as expected.
         """
+        course_key_str = str(self.course.id)
+        chapter_usage_key = str(self.chapter.location)
+        sequential_usage_key = str(self.sequential.location)
+
+        # URL encode the usage keys for the URLs
+        chapter_encoded = quote(chapter_usage_key, safe='')
+        sequential_encoded = quote(sequential_usage_key, safe='')
+
         expected_ancestor_xblocks = [
             {
                 'children': [
                     {
-                        'url': (
-                            '/course/course-v1:org.552+course_552+Run_552'
-                            '?show=block-v1%3Aorg.552%2Bcourse_552%2BRun_552'
-                            '%2Btype%40chapter%2Bblock%40Week_1'
-                        ),
+                        'url': f'/course/{course_key_str}?show={chapter_encoded}',
                         'display_name': 'Week 1',
-                        'usage_key': (
-                            'block-v1:org.552+course_552+Run_552+type@chapter+block@Week_1'
-                        ),
+                        'usage_key': chapter_usage_key,
                     }
                 ],
                 'title': 'Week 1',
@@ -152,15 +156,9 @@ class ContainerHandlerViewTest(BaseXBlockContainer):
             {
                 'children': [
                     {
-                        'url': (
-                            '/course/course-v1:org.552+course_552+Run_552'
-                            '?show=block-v1%3Aorg.552%2Bcourse_552%2BRun_552'
-                            '%2Btype%40sequential%2Bblock%40Lesson_1'
-                        ),
+                        'url': f'/course/{course_key_str}?show={sequential_encoded}',
                         'display_name': 'Lesson 1',
-                        'usage_key': (
-                            'block-v1:org.552+course_552+Run_552+type@sequential+block@Lesson_1'
-                        ),
+                        'usage_key': sequential_usage_key,
                     }
                 ],
                 'title': 'Lesson 1',


### PR DESCRIPTION
## Description

The [test_ancestor_xblocks_response ](https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py#L130) test is failing due to hardcoded course IDs that don't match dynamically generated ones from `CourseFactory`.

Failing test Job:  https://github.com/openedx/edx-platform/actions/runs/16717228209/job/47330749265?pr=37104#step:12:4783

Test becomes flaky when:
- New test cases are added before this test.
- Test execution order changes.
- Other tests create courses using `CourseFactory`.
- Different test suites run in different orders.


**Root Cause:**
- `CourseFactory` uses auto-incrementing sequences for org, number and run.
- Each test run creates multiple courses, incrementing these values.
- Test expects static values (e.g.,`org.552+course_552+Run_552`)
- Actual values differ based on test execution order (e.g., `org.555+course_555+Run_555`)


**Solution:**

Update the test to use dynamic course keys from `CourseFactory` instead of hardcoded values, making it resilient to:

- Changes in test execution order.
- Addition of new test cases.
- Changes in CourseFactory sequence generation.

## JIRA

- [TNL2-330](https://2u-internal.atlassian.net/browse/TNL2-330)

## Testing Instructions

- Run CMS tests.
- Verify test passes with dynamic course IDs.
- Check test isolation.