### PR TITLE
Revert "chore: Upgrade Python requirements"

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -24,7 +24,7 @@ joblib==1.5.1
     # via nltk
 kiwisolver==1.4.8
     # via matplotlib
-lxml[html-clean]==5.3.2
+lxml[html-clean,html_clean]==5.3.2
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/base.in
@@ -36,7 +36,7 @@ markupsafe==3.0.2
     # via
     #   chem
     #   openedx-calc
-matplotlib==3.10.5
+matplotlib==3.10.3
     # via -r requirements/edx-sandbox/base.in
 mpmath==1.3.0
     # via sympy
@@ -72,7 +72,7 @@ python-dateutil==2.9.0.post0
     # via matplotlib
 random2==1.0.2
     # via -r requirements/edx-sandbox/base.in
-regex==2025.7.34
+regex==2025.7.31
     # via nltk
 scipy==1.16.1
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -24,7 +24,7 @@ aniso8601==10.0.1
     # via edx-tincan-py35
 annotated-types==0.7.0
     # via pydantic
-anyio==4.10.0
+anyio==4.9.0
     # via httpx
 appdirs==1.4.4
     # via fs
@@ -70,14 +70,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.40.2
+boto3==1.39.16
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.2
+botocore==1.39.16
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -104,7 +104,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.8.3
+certifi==2025.7.14
     # via
     #   elasticsearch
     #   httpcore
@@ -578,11 +578,11 @@ event-tracking==3.3.0
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-fastavro==1.12.0
+fastavro==1.11.1
     # via openedx-events
 filelock==3.18.0
     # via snowflake-connector-python
-firebase-admin==7.1.0
+firebase-admin==7.0.0
     # via edx-ace
 frozenlist==1.7.0
     # via
@@ -676,8 +676,6 @@ inflection==0.5.1
     # via
     #   drf-spectacular
     #   drf-yasg
-invoke==2.2.0
-    # via paramiko
 ipaddress==1.0.23
     # via -r requirements/edx/kernel.in
 isodate==0.7.2
@@ -726,7 +724,7 @@ loremipsum==1.0.5
     # via ora2
 lti-consumer-xblock==9.14.0
     # via -r requirements/edx/kernel.in
-lxml[html-clean]==5.3.2
+lxml[html-clean,html_clean]==5.3.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -863,7 +861,7 @@ packaging==25.0
     #   gunicorn
     #   kombu
     #   snowflake-connector-python
-paramiko==4.0.0
+paramiko==3.5.1
     # via edx-enterprise
 path==16.11.0
     # via
@@ -1049,7 +1047,7 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.7.34
+regex==2025.7.31
     # via nltk
 requests==2.32.4
     # via

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 chardet==5.2.0
     # via diff-cover
-coverage==7.10.2
+coverage==7.10.1
     # via -r requirements/edx/coverage.in
 diff-cover==9.6.0
     # via -r requirements/edx/coverage.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -55,7 +55,7 @@ annotated-types==0.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pydantic
-anyio==4.10.0
+anyio==4.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -140,7 +140,7 @@ boto==2.49.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-boto3==1.40.2
+boto3==1.39.16
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -148,7 +148,7 @@ boto3==1.40.2
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.2
+botocore==1.39.16
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -159,7 +159,7 @@ bridgekeeper==0.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-build==1.3.0
+build==1.2.2.post1
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   pip-tools
@@ -192,7 +192,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.8.3
+certifi==2025.7.14
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -281,7 +281,7 @@ colorama==0.4.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-coverage[toml]==7.10.2
+coverage[toml]==7.10.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -905,7 +905,7 @@ fastapi==0.116.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-fastavro==1.12.0
+fastavro==1.11.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -917,12 +917,12 @@ filelock==3.18.0
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==7.1.0
+firebase-admin==7.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-ace
-freezegun==1.5.4
+freezegun==1.5.3
     # via -r requirements/edx/testing.txt
 frozenlist==1.7.0
     # via
@@ -1105,11 +1105,6 @@ iniconfig==2.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest
-invoke==2.2.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   paramiko
 ipaddress==1.0.23
     # via
     #   -r requirements/edx/doc.txt
@@ -1306,7 +1301,7 @@ multidict==6.6.3
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.17.1
+mypy==1.17.0
     # via
     #   -r requirements/edx/development.in
     #   django-stubs
@@ -1435,7 +1430,7 @@ packaging==25.0
     #   tox
 pact-python==2.3.3
     # via -r requirements/edx/testing.txt
-paramiko==4.0.0
+paramiko==3.5.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1481,7 +1476,7 @@ pillow==11.3.0
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-pip-tools==7.5.0
+pip-tools==7.4.1
     # via -r requirements/edx/../pip-tools.txt
 platformdirs==4.3.8
     # via
@@ -1822,7 +1817,7 @@ referencing==0.36.2
     #   -r requirements/edx/testing.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.7.34
+regex==2025.7.31
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2201,7 +2196,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.33.0
+virtualenv==20.32.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -39,7 +39,7 @@ annotated-types==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-anyio==4.10.0
+anyio==4.9.0
     # via
     #   -r requirements/edx/base.txt
     #   httpx
@@ -105,14 +105,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.40.2
+boto3==1.39.16
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.2
+botocore==1.39.16
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -144,7 +144,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.8.3
+certifi==2025.7.14
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -667,7 +667,7 @@ event-tracking==3.3.0
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-fastavro==1.12.0
+fastavro==1.11.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
@@ -675,7 +675,7 @@ filelock==3.18.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-firebase-admin==7.1.0
+firebase-admin==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -808,10 +808,6 @@ inflection==0.5.1
     #   -r requirements/edx/base.txt
     #   drf-spectacular
     #   drf-yasg
-invoke==2.2.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   paramiko
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
 isodate==0.7.2
@@ -1042,7 +1038,7 @@ packaging==25.0
     #   pydata-sphinx-theme
     #   snowflake-connector-python
     #   sphinx
-paramiko==4.0.0
+paramiko==3.5.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1280,7 +1276,7 @@ referencing==0.36.2
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.7.34
+regex==2025.7.31
     # via
     #   -r requirements/edx/base.txt
     #   nltk

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -17,7 +17,7 @@ boltons==21.0.0
     #   semgrep
 bracex==2.6
     # via wcmatch
-certifi==2025.8.3
+certifi==2025.7.14
     # via requests
 charset-normalizer==3.4.2
     # via requests
@@ -113,7 +113,7 @@ ruamel-yaml==0.18.14
     # via semgrep
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-semgrep==1.131.0
+semgrep==1.130.0
     # via -r requirements/edx/semgrep.in
 tomli==2.0.2
     # via semgrep

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -35,7 +35,7 @@ annotated-types==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   pydantic
-anyio==4.10.0
+anyio==4.9.0
     # via
     #   -r requirements/edx/base.txt
     #   httpx
@@ -102,14 +102,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/base.txt
-boto3==1.40.2
+boto3==1.39.16
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.40.2
+botocore==1.39.16
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -142,7 +142,7 @@ celery==5.5.3
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.8.3
+certifi==2025.7.14
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -212,7 +212,7 @@ codejail-includes==2.0.0
     # via -r requirements/edx/base.txt
 colorama==0.4.6
     # via tox
-coverage[toml]==7.10.2
+coverage[toml]==7.10.1
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -698,7 +698,7 @@ faker==37.5.3
     # via factory-boy
 fastapi==0.116.1
     # via pact-python
-fastavro==1.12.0
+fastavro==1.11.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
@@ -708,11 +708,11 @@ filelock==3.18.0
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==7.1.0
+firebase-admin==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-freezegun==1.5.4
+freezegun==1.5.3
     # via -r requirements/edx/testing.in
 frozenlist==1.7.0
     # via
@@ -846,10 +846,6 @@ inflection==0.5.1
     #   drf-yasg
 iniconfig==2.1.0
     # via pytest
-invoke==2.2.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   paramiko
 ipaddress==1.0.23
     # via -r requirements/edx/base.txt
 isodate==0.7.2
@@ -1091,7 +1087,7 @@ packaging==25.0
     #   tox
 pact-python==2.3.3
     # via -r requirements/edx/testing.in
-paramiko==4.0.0
+paramiko==3.5.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1390,7 +1386,7 @@ referencing==0.36.2
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.7.34
+regex==2025.7.31
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1636,7 +1632,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.33.0
+virtualenv==20.32.0
     # via tox
 voluptuous==0.15.2
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-build==1.3.0
+build==1.2.2.post1
     # via pip-tools
 click==8.2.1
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.5.0
+pip-tools==7.4.1
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -10,15 +10,15 @@ attrs==25.3.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-boto3==1.40.2
+boto3==1.39.16
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.40.2
+botocore==1.39.16
     # via
     #   boto3
     #   s3transfer
 cachetools==5.5.2
     # via google-auth
-certifi==2025.8.3
+certifi==2025.7.14
     # via requests
 cffi==1.17.1
     # via

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -14,11 +14,11 @@ attrs==25.3.0
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-boto3==1.40.2
+boto3==1.39.16
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.40.2
+botocore==1.39.16
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -28,7 +28,7 @@ cachetools==5.5.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-certifi==2025.8.3
+certifi==2025.7.14
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2025.8.3
+certifi==2025.7.14
     # via requests
 charset-normalizer==3.4.2
     # via requests


### PR DESCRIPTION
2U pipeline is running into issues with 
```
AssertionError: Internal issue: Candidate is not for this requirement lxml[html-clean,html-clean] vs lxml[html-clean]
```
This seems to be due to the recent Upgrade python requirements changes that address `lxml`.

Reverts openedx/edx-platform#37121