### PR TITLE
feat: Extend MFE Config API for `frontend-app-catalog` [FC-0086] 

### DIFF
--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -19,7 +19,6 @@ default_base_config = {
     "HOMEPAGE_COURSE_MAX": None,
     "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": "your-youtube-id",
     "IS_COSMETIC_PRICE_ENABLED": False,
-    "SHOW_HOMEPAGE_PROMO_VIDEO": False,
     "ENABLE_COURSE_DISCOVERY": False,
 }
 
@@ -214,8 +213,6 @@ class MFEConfigTestCase(APITestCase):
                 return mfe_config_overrides
             if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
                 return True
-            if key == "show_homepage_promo_video":
-                return True
             if key == "homepage_promo_video_youtube_id":
                 return "test-youtube-id"
             if key == "HOMEPAGE_COURSE_MAX":
@@ -231,7 +228,6 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
         self.assertEqual(data["SOME_SETTING"], "catalog_value")
         self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], True)
-        self.assertEqual(data["SHOW_HOMEPAGE_PROMO_VIDEO"], True)
         self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "test-youtube-id")
         self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
         self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -17,7 +17,6 @@ default_base_config = {
     'courses_are_browsable': True,
     'enable_course_sorting_by_start_date': True,
     'homepage_course_max': None,
-    'homepage_overlay_html': None,
     'homepage_promo_video_youtube_id': 'your-youtube-id',
     'is_cosmetic_price_enabled': False,
     'show_homepage_promo_video': False
@@ -214,8 +213,6 @@ class MFEConfigTestCase(APITestCase):
                 return mfe_config_overrides
             if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
                 return True
-            if key == "homepage_overlay_html":
-                return "<h1>Welcome</h1>"
             if key == "show_homepage_promo_video":
                 return True
             if key == "homepage_promo_video_youtube_id":
@@ -233,7 +230,6 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
         self.assertEqual(data["SOME_SETTING"], "catalog_value")
         self.assertEqual(data["enable_course_sorting_by_start_date"], True)
-        self.assertEqual(data["homepage_overlay_html"], "<h1>Welcome</h1>")
         self.assertEqual(data["show_homepage_promo_video"], True)
         self.assertEqual(data["homepage_promo_video_youtube_id"], "test-youtube-id")
         self.assertEqual(data["homepage_course_max"], 8)

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -20,6 +20,7 @@ default_base_config = {
     'HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID': 'your-youtube-id',
     'IS_COSMETIC_PRICE_ENABLED': False,
     'SHOW_HOMEPAGE_PROMO_VIDEO': False,
+    'ENABLE_COURSE_DISCOVERY': False,
 }
 
 
@@ -236,6 +237,7 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
         self.assertEqual(data["IS_COSMETIC_PRICE_ENABLED"], True)
         self.assertEqual(data["COURSES_ARE_BROWSABLE"], False)
+        self.assertEqual(data["ENABLE_COURSE_DISCOVERY"], False)
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_config_order_of_precedence(self, configuration_helpers_mock):
@@ -276,7 +278,10 @@ class MFEConfigTestCase(APITestCase):
 
         with override_settings(
             HOMEPAGE_COURSE_MAX=3,  # Plain settings (lowest precedence)
-            FEATURES={'ENABLE_COURSE_SORTING_BY_START_DATE': True}  # Settings FEATURES
+            FEATURES={              # Settings FEATURES
+                "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+                "ENABLE_COURSE_DISCOVERY": True,
+            }
         ):
             response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
 

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-# Based config values, used in tests to build a correct expected response
+# Base configuration values, used in tests to build a correct expected response
 default_base_config = {
     'course_about_twitter_account': '@YourPlatformTwitterAccount',
     'courses_are_browsable': True,

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -23,6 +23,7 @@ default_base_config = {
     'show_homepage_promo_video': False
 }
 
+
 @ddt.ddt
 class MFEConfigTestCase(APITestCase):
     """

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -51,7 +51,7 @@ class MFEConfigTestCase(APITestCase):
 
         response = self.client.get(self.mfe_config_api_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"EXAMPLE_VAR": "value", **default_base_config})
+        self.assertEqual(response.json(), {**default_base_config, "EXAMPLE_VAR": "value"})
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_get_mfe_config_with_queryparam(self, configuration_helpers_mock):
@@ -77,7 +77,7 @@ class MFEConfigTestCase(APITestCase):
                  call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
         configuration_helpers_mock.get_value.assert_has_calls(calls)
         self.assertEqual(
-            response.json(), {"EXAMPLE_VAR": "mymfe_value", "OTHER": "other", **default_base_config}
+            response.json(), {**default_base_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
         )
 
     @ddt.unpack
@@ -90,27 +90,27 @@ class MFEConfigTestCase(APITestCase):
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={},
-            expected_response={"EXAMPLE_VAR": "value", **default_base_config},
+            expected_response={**default_base_config, "EXAMPLE_VAR": "value"},
         ),
         dict(
             mfe_config={},
             mfe_config_overrides={"mymfe": {"EXAMPLE_VAR": "mymfe_value"}},
-            expected_response={"EXAMPLE_VAR": "mymfe_value", **default_base_config},
+            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={"mymfe": {"EXAMPLE_VAR": "mymfe_value"}},
-            expected_response={"EXAMPLE_VAR": "mymfe_value", **default_base_config},
+            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value", "OTHER": "other"},
             mfe_config_overrides={"mymfe": {"EXAMPLE_VAR": "mymfe_value"}},
-            expected_response={"EXAMPLE_VAR": "mymfe_value", "OTHER": "other", **default_base_config},
+            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={"yourmfe": {"EXAMPLE_VAR": "yourmfe_value"}},
-            expected_response={"EXAMPLE_VAR": "value", **default_base_config},
+            expected_response={**default_base_config, "EXAMPLE_VAR": "value"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
@@ -118,7 +118,7 @@ class MFEConfigTestCase(APITestCase):
                 "yourmfe": {"EXAMPLE_VAR": "yourmfe_value"},
                 "mymfe": {"EXAMPLE_VAR": "mymfe_value"},
             },
-            expected_response={"EXAMPLE_VAR": "mymfe_value", **default_base_config},
+            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
     )
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
@@ -162,7 +162,7 @@ class MFEConfigTestCase(APITestCase):
         - The json response is equal to MFE_CONFIG in lms/envs/test.py"""
         response = self.client.get(self.mfe_config_api_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), settings.MFE_CONFIG | default_base_config)
+        self.assertEqual(response.json(), default_base_config | settings.MFE_CONFIG)
 
     def test_get_mfe_config_with_queryparam_from_django_settings(self):
         """Test that when there is no site configuration, the API with queryparam takes the django settings.
@@ -173,7 +173,7 @@ class MFEConfigTestCase(APITestCase):
         """
         response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected = settings.MFE_CONFIG | settings.MFE_CONFIG_OVERRIDES["mymfe"] | default_base_config
+        expected = default_base_config | settings.MFE_CONFIG | settings.MFE_CONFIG_OVERRIDES["mymfe"]
         self.assertEqual(response.json(), expected)
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -13,14 +13,14 @@ from rest_framework.test import APITestCase
 
 # Base configuration values, used in tests to build a correct expected response
 default_base_config = {
-    'COURSE_ABOUT_TWITTER_ACCOUNT': '@YourPlatformTwitterAccount',
-    'COURSES_ARE_BROWSABLE': True,
-    'ENABLE_COURSE_SORTING_BY_START_DATE': True,
-    'HOMEPAGE_COURSE_MAX': None,
-    'HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID': 'your-youtube-id',
-    'IS_COSMETIC_PRICE_ENABLED': False,
-    'SHOW_HOMEPAGE_PROMO_VIDEO': False,
-    'ENABLE_COURSE_DISCOVERY': False,
+    "COURSE_ABOUT_TWITTER_ACCOUNT": "@YourPlatformTwitterAccount",
+    "NON_BROWSABLE_COURSES": False,
+    "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+    "HOMEPAGE_COURSE_MAX": None,
+    "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": "your-youtube-id",
+    "IS_COSMETIC_PRICE_ENABLED": False,
+    "SHOW_HOMEPAGE_PROMO_VIDEO": False,
+    "ENABLE_COURSE_DISCOVERY": False,
 }
 
 
@@ -203,7 +203,7 @@ class MFEConfigTestCase(APITestCase):
             "catalog": {
                 "SOME_SETTING": "catalog_value",
                 "IS_COSMETIC_PRICE_ENABLED": True,
-                "COURSES_ARE_BROWSABLE": False,
+                "NON_BROWSABLE_COURSES": True,
             }
         }
 
@@ -236,7 +236,7 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
         self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
         self.assertEqual(data["IS_COSMETIC_PRICE_ENABLED"], True)
-        self.assertEqual(data["COURSES_ARE_BROWSABLE"], False)
+        self.assertEqual(data["NON_BROWSABLE_COURSES"], True)
         self.assertEqual(data["ENABLE_COURSE_DISCOVERY"], False)
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -11,8 +11,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-# Base configuration values, used in tests to build a correct expected response
-default_base_config = {
+# Default legacy configuration values, used in tests to build a correct expected response
+default_legacy_config = {
     "COURSE_ABOUT_TWITTER_ACCOUNT": "@YourPlatformTwitterAccount",
     "NON_BROWSABLE_COURSES": False,
     "ENABLE_COURSE_SORTING_BY_START_DATE": True,
@@ -51,7 +51,7 @@ class MFEConfigTestCase(APITestCase):
 
         response = self.client.get(self.mfe_config_api_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {**default_base_config, "EXAMPLE_VAR": "value"})
+        self.assertEqual(response.json(), {**default_legacy_config, "EXAMPLE_VAR": "value"})
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_get_mfe_config_with_queryparam(self, configuration_helpers_mock):
@@ -77,7 +77,7 @@ class MFEConfigTestCase(APITestCase):
                  call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
         configuration_helpers_mock.get_value.assert_has_calls(calls)
         self.assertEqual(
-            response.json(), {**default_base_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
+            response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
         )
 
     @ddt.unpack
@@ -85,32 +85,32 @@ class MFEConfigTestCase(APITestCase):
         dict(
             mfe_config={},
             mfe_config_overrides={},
-            expected_response={**default_base_config},
+            expected_response={**default_legacy_config},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={},
-            expected_response={**default_base_config, "EXAMPLE_VAR": "value"},
+            expected_response={**default_legacy_config, "EXAMPLE_VAR": "value"},
         ),
         dict(
             mfe_config={},
             mfe_config_overrides={"mymfe": {"EXAMPLE_VAR": "mymfe_value"}},
-            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value"},
+            expected_response={**default_legacy_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={"mymfe": {"EXAMPLE_VAR": "mymfe_value"}},
-            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value"},
+            expected_response={**default_legacy_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value", "OTHER": "other"},
             mfe_config_overrides={"mymfe": {"EXAMPLE_VAR": "mymfe_value"}},
-            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"},
+            expected_response={**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={"yourmfe": {"EXAMPLE_VAR": "yourmfe_value"}},
-            expected_response={**default_base_config, "EXAMPLE_VAR": "value"},
+            expected_response={**default_legacy_config, "EXAMPLE_VAR": "value"},
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
@@ -118,7 +118,7 @@ class MFEConfigTestCase(APITestCase):
                 "yourmfe": {"EXAMPLE_VAR": "yourmfe_value"},
                 "mymfe": {"EXAMPLE_VAR": "mymfe_value"},
             },
-            expected_response={**default_base_config, "EXAMPLE_VAR": "mymfe_value"},
+            expected_response={**default_legacy_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
     )
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
@@ -162,7 +162,7 @@ class MFEConfigTestCase(APITestCase):
         - The json response is equal to MFE_CONFIG in lms/envs/test.py"""
         response = self.client.get(self.mfe_config_api_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), default_base_config | settings.MFE_CONFIG)
+        self.assertEqual(response.json(), default_legacy_config | settings.MFE_CONFIG)
 
     def test_get_mfe_config_with_queryparam_from_django_settings(self):
         """Test that when there is no site configuration, the API with queryparam takes the django settings.
@@ -173,7 +173,7 @@ class MFEConfigTestCase(APITestCase):
         """
         response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected = default_base_config | settings.MFE_CONFIG | settings.MFE_CONFIG_OVERRIDES["mymfe"]
+        expected = default_legacy_config | settings.MFE_CONFIG | settings.MFE_CONFIG_OVERRIDES["mymfe"]
         self.assertEqual(response.json(), expected)
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -13,13 +13,13 @@ from rest_framework.test import APITestCase
 
 # Base configuration values, used in tests to build a correct expected response
 default_base_config = {
-    'course_about_twitter_account': '@YourPlatformTwitterAccount',
-    'courses_are_browsable': True,
-    'enable_course_sorting_by_start_date': True,
-    'homepage_course_max': None,
-    'homepage_promo_video_youtube_id': 'your-youtube-id',
-    'is_cosmetic_price_enabled': False,
-    'show_homepage_promo_video': False
+    'COURSE_ABOUT_TWITTER_ACCOUNT': '@YourPlatformTwitterAccount',
+    'COURSES_ARE_BROWSABLE': True,
+    'ENABLE_COURSE_SORTING_BY_START_DATE': True,
+    'HOMEPAGE_COURSE_MAX': None,
+    'HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID': 'your-youtube-id',
+    'IS_COSMETIC_PRICE_ENABLED': False,
+    'SHOW_HOMEPAGE_PROMO_VIDEO': False,
 }
 
 
@@ -197,12 +197,12 @@ class MFEConfigTestCase(APITestCase):
         - The configuration_helpers get_value is called for each catalog-specific configuration.
         - The catalog-specific values are included in the response.
         """
-        mfe_config = {"BASE_URL": "https://catalog.example.com", "course_about_twitter_account": "@TestAccount"}
+        mfe_config = {"BASE_URL": "https://catalog.example.com", "COURSE_ABOUT_TWITTER_ACCOUNT": "@TestAccount"}
         mfe_config_overrides = {
             "catalog": {
                 "SOME_SETTING": "catalog_value",
-                "is_cosmetic_price_enabled": True,
-                "courses_are_browsable": False,
+                "IS_COSMETIC_PRICE_ENABLED": True,
+                "COURSES_ARE_BROWSABLE": False,
             }
         }
 
@@ -229,13 +229,13 @@ class MFEConfigTestCase(APITestCase):
         data = response.json()
         self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
         self.assertEqual(data["SOME_SETTING"], "catalog_value")
-        self.assertEqual(data["enable_course_sorting_by_start_date"], True)
-        self.assertEqual(data["show_homepage_promo_video"], True)
-        self.assertEqual(data["homepage_promo_video_youtube_id"], "test-youtube-id")
-        self.assertEqual(data["homepage_course_max"], 8)
-        self.assertEqual(data["course_about_twitter_account"], "@TestAccount")
-        self.assertEqual(data["is_cosmetic_price_enabled"], True)
-        self.assertEqual(data["courses_are_browsable"], False)
+        self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], True)
+        self.assertEqual(data["SHOW_HOMEPAGE_PROMO_VIDEO"], True)
+        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "test-youtube-id")
+        self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
+        self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
+        self.assertEqual(data["IS_COSMETIC_PRICE_ENABLED"], True)
+        self.assertEqual(data["COURSES_ARE_BROWSABLE"], False)
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_config_order_of_precedence(self, configuration_helpers_mock):
@@ -251,13 +251,13 @@ class MFEConfigTestCase(APITestCase):
             6. Plain settings
         """
         mfe_config = {
-            "homepage_course_max": 10,
-            "enable_course_sorting_by_start_date": False,
-            "preserved_setting": "preserved"
+            "HOMEPAGE_COURSE_MAX": 10,
+            "ENABLE_COURSE_SORTING_BY_START_DATE": False,
+            "PRESERVED_SETTING": "preserved"
         }
         mfe_config_overrides = {
             "catalog": {
-                "homepage_course_max": 15,
+                "HOMEPAGE_COURSE_MAX": 15,
             }
         }
 
@@ -284,13 +284,13 @@ class MFEConfigTestCase(APITestCase):
         data = response.json()
 
         # MFE_CONFIG_OVERRIDES from site conf (highest precedence)
-        self.assertEqual(data["homepage_course_max"], 15)
+        self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 15)
 
         # MFE_CONFIG from site conf takes precedence over plain site configuration and settings
-        self.assertEqual(data["enable_course_sorting_by_start_date"], False)
+        self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], False)
 
         # Plain site configuration takes precedence over plain settings
-        self.assertEqual(data["homepage_promo_video_youtube_id"], "site-conf-youtube-id")
+        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "site-conf-youtube-id")
 
         # Value in original MFE_CONFIG not overridden by catalog config should be preserved
-        self.assertEqual(data["preserved_setting"], "preserved")
+        self.assertEqual(data["PRESERVED_SETTING"], "preserved")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -18,7 +18,6 @@ default_legacy_config = {
     "ENABLE_COURSE_SORTING_BY_START_DATE": True,
     "HOMEPAGE_COURSE_MAX": None,
     "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": None,
-    "IS_COSMETIC_PRICE_ENABLED": False,
     "ENABLE_COURSE_DISCOVERY": False,
 }
 
@@ -201,7 +200,6 @@ class MFEConfigTestCase(APITestCase):
         mfe_config_overrides = {
             "catalog": {
                 "SOME_SETTING": "catalog_value",
-                "IS_COSMETIC_PRICE_ENABLED": True,
                 "NON_BROWSABLE_COURSES": True,
             }
         }
@@ -231,7 +229,6 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], None)
         self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
         self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
-        self.assertEqual(data["IS_COSMETIC_PRICE_ENABLED"], True)
         self.assertEqual(data["NON_BROWSABLE_COURSES"], True)
         self.assertEqual(data["ENABLE_COURSE_DISCOVERY"], False)
 

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -17,7 +17,7 @@ default_base_config = {
     "NON_BROWSABLE_COURSES": False,
     "ENABLE_COURSE_SORTING_BY_START_DATE": True,
     "HOMEPAGE_COURSE_MAX": None,
-    "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": "your-youtube-id",
+    "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": None,
     "IS_COSMETIC_PRICE_ENABLED": False,
     "ENABLE_COURSE_DISCOVERY": False,
 }
@@ -214,7 +214,7 @@ class MFEConfigTestCase(APITestCase):
             if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
                 return True
             if key == "homepage_promo_video_youtube_id":
-                return "test-youtube-id"
+                return None
             if key == "HOMEPAGE_COURSE_MAX":
                 return 8
             return default
@@ -228,7 +228,7 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
         self.assertEqual(data["SOME_SETTING"], "catalog_value")
         self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], True)
-        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "test-youtube-id")
+        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], None)
         self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
         self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
         self.assertEqual(data["IS_COSMETIC_PRICE_ENABLED"], True)

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -59,8 +59,8 @@ class MFEConfigView(APIView):
             "LOGOUT_URL": "https://courses.example.com/logout",
             "STUDIO_BASE_URL": "https://studio.example.com",
             "LOGO_URL": "https://courses.example.com/logo.png",
-            "enable_course_sorting_by_start_date": True,
-            "homepage_course_max": 10,
+            "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+            "HOMEPAGE_COURSE_MAX": 10,
             ... and so on
         }
         ```
@@ -96,26 +96,26 @@ class MFEConfigView(APIView):
         Return configuration values available in either site configuration or django settings.
         """
         return {
-            "enable_course_sorting_by_start_date": configuration_helpers.get_value(
+            "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
                 settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
             ),
-            "show_homepage_promo_video": configuration_helpers.get_value(
+            "SHOW_HOMEPAGE_PROMO_VIDEO": configuration_helpers.get_value(
                 "show_homepage_promo_video",
                 False
             ),
-            "homepage_promo_video_youtube_id": configuration_helpers.get_value(
+            "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
                 "your-youtube-id"
             ),
-            "homepage_course_max": configuration_helpers.get_value(
+            "HOMEPAGE_COURSE_MAX": configuration_helpers.get_value(
                 "HOMEPAGE_COURSE_MAX",
                 settings.HOMEPAGE_COURSE_MAX
             ),
-            "course_about_twitter_account": configuration_helpers.get_value(
+            "COURSE_ABOUT_TWITTER_ACCOUNT": configuration_helpers.get_value(
                 "course_about_twitter_account",
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
-            "is_cosmetic_price_enabled": settings.FEATURES.get("ENABLE_COSMETIC_DISPLAY_PRICE"),
-            "courses_are_browsable": settings.FEATURES.get("COURSES_ARE_BROWSABLE")
+            "IS_COSMETIC_PRICE_ENABLED": settings.FEATURES.get("ENABLE_COSMETIC_DISPLAY_PRICE"),
+            "COURSES_ARE_BROWSABLE": settings.FEATURES.get("COURSES_ARE_BROWSABLE")
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -102,7 +102,7 @@ class MFEConfigView(APIView):
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
-                "your-youtube-id"
+                None
             ),
             "HOMEPAGE_COURSE_MAX": configuration_helpers.get_value(
                 "HOMEPAGE_COURSE_MAX",

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -117,6 +117,6 @@ class MFEConfigView(APIView):
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
             "IS_COSMETIC_PRICE_ENABLED": settings.FEATURES.get("ENABLE_COSMETIC_DISPLAY_PRICE"),
-            "COURSES_ARE_BROWSABLE": settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
+            "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
             "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -117,5 +117,6 @@ class MFEConfigView(APIView):
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
             "IS_COSMETIC_PRICE_ENABLED": settings.FEATURES.get("ENABLE_COSMETIC_DISPLAY_PRICE"),
-            "COURSES_ARE_BROWSABLE": settings.FEATURES.get("COURSES_ARE_BROWSABLE")
+            "COURSES_ARE_BROWSABLE": settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
+            "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -100,10 +100,6 @@ class MFEConfigView(APIView):
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
                 settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
             ),
-            "SHOW_HOMEPAGE_PROMO_VIDEO": configuration_helpers.get_value(
-                "show_homepage_promo_video",
-                False
-            ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
                 "your-youtube-id"

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -115,7 +115,6 @@ class MFEConfigView(APIView):
                 "course_about_twitter_account",
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
-            "IS_COSMETIC_PRICE_ENABLED": settings.FEATURES.get("ENABLE_COSMETIC_DISPLAY_PRICE"),
             "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
             "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -100,7 +100,6 @@ class MFEConfigView(APIView):
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
                 settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
             ),
-            "homepage_overlay_html": configuration_helpers.get_value("homepage_overlay_html"),
             "show_homepage_promo_video": configuration_helpers.get_value(
                 "show_homepage_promo_video",
                 False


### PR DESCRIPTION
**Summary**
This PR extends the MFE Config API in order to return MFE configuration values using the following hierarchy, in the order from most specific to least specific:

1. site configuration MFE_CONFIG_OVERRIDES
2. settings MFE_CONFIG_OVERRIDES
3. site configuration MFE_CONFIG
4. settings MFE_CONFIG
5. site configuration plain value
6. settings plain value

The following fields have been added to the configuration being returned:

- ENABLE_COURSE_SORTING_BY_START_DATE
- HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID
- HOMEPAGE_COURSE_MAX
- COURSE_ABOUT_TWITTER_ACCOUNT
- NON_BROWSABLE_COURSES
- ENABLE_COURSE_DISCOVERY

**Usage**
Usage remains exactly as before:
Get common config:
`GET /api/mfe_config/v1`

Get app config (common + mfe-specific overrides):
`GET /api/mfe_config/v1?mfe=name_of_mfe`

**Example of a GET response**
(abbreviated)
```
{
  "ENABLE_COURSE_SORTING_BY_START_DATE": true,
  "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": "your-youtube-id",
  "HOMEPAGE_COURSE_MAX": 9,
  "BASE_URL": "apps.local.openedx.io",
  "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
  "CREDENTIALS_BASE_URL": "",
  ...
}
```

**Dependent PRs:**
[feat: [FC-86] Home page banner section](https://github.com/openedx/frontend-app-catalog/pull/7)
[feat: [FC-86] Added Home page courses list](https://github.com/raccoongang/frontend-app-catalog/pull/16)
[feat: [FC-86] Created Intro section for Course About page](https://github.com/raccoongang/frontend-app-catalog/pull/19)
[feat: [FC-86] Added Course About sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/20)
[feat: [FC-86] Added course overview and updated sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/21)
[feat: [FC-86] Updated Header links](https://github.com/raccoongang/frontend-app-catalog/pull/18)
[feat: [FC-86] Added DataTable for Catalog page](https://github.com/raccoongang/frontend-app-catalog/pull/22)
[feat: [FC-86] Added filtration for Catalog page](https://github.com/raccoongang/frontend-app-catalog/pull/23)
[feat: [FC-86] Added course search for DataTable](https://github.com/raccoongang/frontend-app-catalog/pull/24)