### PR TITLE
feat!: update finder method to work with django 42 and 52

### DIFF
--- a/openedx/core/djangoapps/theming/finders.py
+++ b/openedx/core/djangoapps/theming/finders.py
@@ -65,10 +65,21 @@ class ThemeFilesFinder(BaseFinder):  # lint-amnesty, pylint: disable=abstract-me
                 for path in utils.get_files(storage, ignore_patterns):
                     yield path, storage
 
-    def find(self, path, all=False):  # pylint: disable=redefined-builtin
+    def find(self, path, *args, **kwargs):  # pylint: disable=redefined-builtin
         """
         Looks for files in the theme directories.
         """
+        if 'all' in kwargs:
+            # Note this method signature where we accept all and find_all is being used so that we can be
+            # compatible with both Django 4.2 and Django 5.2 at the same time.  After we have fully
+            # dropped Django 4.2 support, the method signature can be updated to just consume the
+            # `find_all` paramater.
+            find_all = kwargs.get('all', False)
+        elif 'find_all' in kwargs:
+            find_all = kwargs.get('find_all', False)
+        else:
+            find_all = args[0] if args else False
+
         matches = []
         theme_dir_name = path.split("/", 1)[0]
 
@@ -79,7 +90,7 @@ class ThemeFilesFinder(BaseFinder):  # lint-amnesty, pylint: disable=abstract-me
             path = "/".join(path.split("/")[1:])
             match = self.find_in_theme(theme.theme_dir_name, path)
             if match:
-                if not all:
+                if not find_all:
                     return match
                 matches.append(match)
         return matches

--- a/openedx/core/djangoapps/theming/tests/test_finders.py
+++ b/openedx/core/djangoapps/theming/tests/test_finders.py
@@ -35,14 +35,24 @@ class TestThemeFinders(TestCase):
         Verify Theme Finder returns themed assets
         """
         themes_dir = settings.COMPREHENSIVE_THEME_DIRS[1]
+        expected_path = (((((themes_dir / 'test-theme') / 'lms') / 'static') / 'images') / 'logo.png')
 
         asset = "test-theme/images/logo.png"
-        matches = self.finder.find(asset, all=True)
+        matches_test_1 = self.finder.find(asset, True)
+        matches_test_2 = self.finder.find(asset, all=True)
+        matches_test_3 = self.finder.find(asset, find_all=True)
 
-        # Make sure only first match was returned
-        assert 1 == len(matches)
+        # 1 Make sure only first match was returned
+        assert 1 == len(matches_test_1)
+        assert matches_test_1[0] == expected_path
 
-        assert matches[0] == (((((themes_dir / 'test-theme') / 'lms') / 'static') / 'images') / 'logo.png')
+        # 2 Make sure only first match was returned
+        assert 1 == len(matches_test_2)
+        assert matches_test_2[0] == expected_path
+
+        # 3 Make sure only first match was returned
+        assert 1 == len(matches_test_3)
+        assert matches_test_3[0] == expected_path
 
     def test_find_in_theme(self):
         """

--- a/openedx/core/lib/xblock_pipeline/finder.py
+++ b/openedx/core/lib/xblock_pipeline/finder.py
@@ -144,15 +144,25 @@ class XBlockPipelineFinder(BaseFinder):  # lint-amnesty, pylint: disable=abstrac
                 for path in utils.get_files(storage, ignore_patterns):
                     yield path, storage
 
-    def find(self, path, all=False):  # pylint: disable=redefined-builtin
+    def find(self, path, *args, **kwargs):  # pylint: disable=redefined-builtin
         """
         Looks for files in the xblock package directories.
         """
+        if 'all' in kwargs:
+            # Note this method signature where we accept all and find_all is being used so that we can be
+            # compatible with both Django 4.2 and Django 5.2 at the same time.  After we have fully
+            # dropped Django 4.2 support, the method signature can be updated to just consume the
+            # `find_all` paramater.
+            find_all = kwargs.get('all', False)
+        elif 'find_all' in kwargs:
+            find_all = kwargs.get('find_all', False)
+        else:
+            find_all = args[0] if args else False
         matches = []
         for storage in self.package_storages:
             if storage.exists(path):
                 match = storage.path(path)
-                if not all:
+                if not find_all:
                     return match
                 matches.append(match)
         return matches


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

In Django 5.2, the BaseFinder.find() method signature has changed from:

def find(self, path, all=False):
to:
def find(self, path, find_all=False, **kwargs):

However, in [ThemeFilesFinder](https://github.com/openedx/edx-platform/blob/b6cec3c67ede90270af8e18ffe92ca0c1c7d0e72/openedx/core/djangoapps/theming/finders.py#L68), the find() method still uses the old signature:

def find(self, path, all=False):

This causes compatibility issues when running collectstatic or when Django attempts to use the finder, resulting in a TypeError or warning about method signature mismatch.


## Supporting information

https://github.com/openedx/edx-platform/issues/36862

## Testing instructions

`pytest openedx/core/djangoapps/theming/tests/test_finders.py::TestThemeFinders::test_find_all_themed_asset`

<img width="1440" alt="Screenshot 2025-06-16 at 4 43 11 PM" src="https://github.com/user-attachments/assets/bd183953-0657-4bf5-a1de-9c9122d2993b" />

