### PR TITLE
fix: course detail page error

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -10,10 +10,13 @@ from openedx.core.lib.api.serializers import CourseKeyField
 class InstructorInfoSerializer(serializers.Serializer):
     """ Serializer for instructor info """
     name = serializers.CharField(allow_blank=True, required=False)
-    title = serializers.CharField(allow_blank=True, required=False)
+    title = serializers.SerializerMethodField()
     organization = serializers.CharField(allow_blank=True, required=False)
     image = serializers.CharField(allow_blank=True, required=False)
     bio = serializers.CharField(allow_blank=True, required=False)
+
+    def get_title(self, obj):
+        return obj.title() if isinstance(obj, str) else ""
 
 
 class InstructorsSerializer(serializers.Serializer):


### PR DESCRIPTION
Ticket: [TNL2-333](https://2u-internal.atlassian.net/browse/TNL2-333)

Course detail page was failing to load due to below error.
`rest_framework.fields.BuiltinSignatureError: Field source for `InstructorInfoSerializer.title` maps to a built-in function type and is invalid. Define a property or method on the `str` instance that wraps the call to the built-in function.`