### PR TITLE
fix: support the pointer tag OLX parsing of XBlocks residing outside the edx-platform

### DIFF
--- a/xmodule/conditional_block.py
+++ b/xmodule/conditional_block.py
@@ -20,7 +20,7 @@ from xmodule.seq_block import SequenceMixin
 from xmodule.studio_editable import StudioEditableBlock
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment
 from xmodule.validation import StudioValidation, StudioValidationMessage
-from xmodule.xml_block import XmlMixin
+from xmodule.xml_block import XmlMixin, is_pointer_tag
 from xmodule.x_module import (
     ResourceTemplates,
     shim_xmodule_js,
@@ -335,7 +335,19 @@ class ConditionalBlock(
                     show_tag_list.append(location)
             else:
                 try:
-                    block = system.process_xml(etree.tostring(child, encoding='unicode'))
+                    def_id = None
+                    def_loaded = False
+
+                    if is_pointer_tag(child):
+                        def_id = system.id_generator.create_definition(child.tag, child.get('url_name'))
+                        child, _ = cls.load_definition_xml(child, system, def_id)
+                        def_loaded = True
+
+                    block = system.process_xml(
+                        etree.tostring(child, encoding='unicode'),
+                        def_id,
+                        def_loaded=def_loaded,
+                    )
                     children.append(block.scope_ids.usage_id)
                 except:  # lint-amnesty, pylint: disable=bare-except
                     msg = "Unable to load child when parsing Conditional."

--- a/xmodule/modulestore/xml.py
+++ b/xmodule/modulestore/xml.py
@@ -65,9 +65,21 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):  # lint-amnesty, pyl
         self.load_error_blocks = load_error_blocks
         self.modulestore = xmlstore
 
-        def process_xml(xml):  # lint-amnesty, pylint: disable=too-many-statements
-            """Takes an xml string, and returns a XBlock created from
+        def process_xml(xml, def_id=None, def_loaded=False):  # lint-amnesty, pylint: disable=too-many-statements
+            """
+            Takes an xml string, and returns an XBlock created from
             that xml.
+
+            Args:
+                xml (string): A string containing xml.
+                def_id (BlockUsageLocator): The :class:`BlockUsageLocator` to use as the
+                    definition_id for the block.
+                def_loaded (bool): Indicates if the pointer tag definition is loaded from
+                    from the pointed-to file.
+
+            Returns:
+                XBlock: The fully instantiated :class:`~xblock.core.XBlock`.
+
             """
 
             def make_name_unique(xml_data):
@@ -159,11 +171,13 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):  # lint-amnesty, pyl
 
             try:
                 xml_data = etree.fromstring(xml)
-                make_name_unique(xml_data)
+                if not def_loaded:
+                    make_name_unique(xml_data)
                 block = self.xblock_from_node(
                     xml_data,
                     None,  # parent_id
                     id_manager,
+                    def_id,
                 )
             except Exception as err:  # pylint: disable=broad-except
                 if not self.load_error_blocks:

--- a/xmodule/tests/xml/__init__.py
+++ b/xmodule/tests/xml/__init__.py
@@ -42,13 +42,14 @@ class InMemorySystem(XMLParsingSystem, MakoDescriptorSystem):  # pylint: disable
         )
         self.id_generator = Mock()
 
-    def process_xml(self, xml):  # pylint: disable=method-hidden
+    def process_xml(self, xml, def_id=None, def_loaded=False):  # pylint: disable=method-hidden
         """Parse `xml` as an XBlock, and add it to `self._blocks`"""
         self.get_asides = Mock(return_value=[])
         block = self.xblock_from_node(
             etree.fromstring(xml),
             None,
             CourseLocationManager(self.course_id),
+            def_id,
         )
         self._blocks[str(block.location)] = block
         return block
@@ -61,7 +62,7 @@ class InMemorySystem(XMLParsingSystem, MakoDescriptorSystem):  # pylint: disable
 class XModuleXmlImportTest(TestCase):
     """Base class for tests that use basic XML parsing"""
     @classmethod
-    def process_xml(cls, xml_import_data):
+    def process_xml(cls, xml_import_data, def_id=None, def_loaded=False):
         """Use the `xml_import_data` to import an :class:`XBlock` from XML."""
         system = InMemorySystem(xml_import_data)
-        return system.process_xml(xml_import_data.xml_string)
+        return system.process_xml(xml_import_data.xml_string, def_id)

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1543,16 +1543,20 @@ class XMLParsingSystem(DescriptorSystem):  # lint-amnesty, pylint: disable=abstr
         """
         return self.xblock_from_node(node, parent_id, self.id_generator).scope_ids.usage_id
 
-    def xblock_from_node(self, node, parent_id, id_generator=None):
+    def xblock_from_node(self, node, parent_id, id_generator=None, def_id=None):
         """
         Create an XBlock instance from XML data.
 
         Args:
-            xml_data (string): A string containing valid xml.
+            node (RestrictedElement): The :class:`openedx.core.lib.safe_lxml.xmlparser.RestrictedElement`
+                containing the XML data to parse.
             system (XMLParsingSystem): The :class:`.XMLParsingSystem` used to connect the block
                 to the outside world.
             id_generator (IdGenerator): An :class:`~xblock.runtime.IdGenerator` that
-                will be used to construct the usage_id and definition_id for the block.
+                will be used to construct the usage_id and definition_id for the block
+                if `def_id` is None.
+            def_id (BlockUsageLocator): The :class:`BlockUsageLocator` to use as the
+                definition_id for the block. If None, a new definition_id will be generated.
 
         Returns:
             XBlock: The fully instantiated :class:`~xblock.core.XBlock`.
@@ -1567,7 +1571,10 @@ class XMLParsingSystem(DescriptorSystem):  # lint-amnesty, pylint: disable=abstr
         node.attrib.pop('xblock-family', None)
 
         url_name = node.get('url_name')  # difference from XBlock.runtime
-        def_id = id_generator.create_definition(block_type, url_name)
+
+        if not def_id:
+            def_id = id_generator.create_definition(block_type, url_name)
+
         usage_id = id_generator.create_usage(def_id)
 
         keys = ScopeIds(None, block_type, def_id, usage_id)


### PR DESCRIPTION
The Pointer tag OLX format of the XBlocks residing outside the edx-platform isn't supported.

- resolves: https://github.com/openedx/XBlock/issues/823

## Description
This issue was identified [here](https://github.com/openedx/XBlock/issues/823). It was decided that we don't want to add the pointer tag support to the XBlock core parsing methods instead it should be handled by the edx-platform runtime.

Let me briefly describe what this issue is all about. The XBlocks that reside outside the edx-platform are exported in the inline OLX format while the BuiltIn XBlocks (WordCloud, Annotatable, LTI etc.) are exported in the pointer tag format. 
Here are the examples of the inline VS the pointer tag OLX format:

### Inline format
```
<vertical display_name="LTI">
  <lti url_name="lti_789b78a45ec7" button_text="Launch third-party stuff" display_name="LTI Testing " has_score="true" weight="20.0"/>
</vertical>
```

### Pointer tag format
```
<vertical display_name="LTI">
  <lti url_name="e73666f5807e47cbbd161d0d3aa5132b"/>
</vertical>
```
Here the `<lti/>` tag is a pointer tag because it's definition (or you can say, configurations) isn't defined inline as above. The definition is present at `lti/e73666f5807e47cbbd161d0d3aa5132b.xml` as follows:
```
<lti button_text="Launch third-party stuff" display_name="LTI Testing " has_score="true" weight="20.0"/>
```

This issue was discovered during the [LTI XBlock extraction](https://github.com/openedx/xblocks-contrib/pull/13) when one of its test cases on edx-platform was failing. It was later identified that it's pointer tag format is parsed correctly by the edx-platform's XmlMixin [`parse_xml`](https://github.com/openedx/edx-platform/blob/master/xmodule/xml_block.py#L292) method and it doesn't get parsed correctly by the xblock.core [`parse_xml`](https://github.com/openedx/XBlock/blob/master/xblock/core.py#L737) method.

## Approach
Following this [comment](https://github.com/openedx/XBlock/issues/823#issuecomment-2881707131) of @bradenmacdonald 
> have the vertical block in this case realize that the child is a pointer node and load the full definition before telling the LTI block to parse it.

I am now loading the full definition of the Vertical block's children before it calls the [`system.process_xml()`](https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L253) inside the `definition_from_xml()` method which in turn calls the `xblock_from_node` and then `parse_xml` method is called . This way we have the full definition of the child block (LTI, for example) before calling the `parse_xml` method. Followed the same approach for the `ItemBankBlock`'s `definition_from_xml()` method.
Here's the call stack captured during the course import.

```
-> definition, children = cls.load_definition(definition_xml, runtime, keys.def_id, runtime.id_generator)
  /openedx/edx-platform/xmodule/xml_block.py(247)load_definition()
-> definition, children = cls.definition_from_xml(definition_xml, system)
  /openedx/edx-platform/xmodule/vertical_block.py(256)definition_from_xml()
-> child_block = system.process_xml(etree.tostring(child, encoding='unicode'))
  /openedx/edx-platform/xmodule/modulestore/xml.py(163)process_xml()
-> block = self.xblock_from_node(
  /openedx/edx-platform/xmodule/x_module.py(1579)xblock_from_node()
-> block = block_class.parse_xml(node, self, keys)
> /openedx/edx-platform/xmodule/xml_block.py(307)parse_xml()
-> from xmodule.modulestore.xml import ImportSystem  # done here to avoid circular import
```

---

**Tutor requirements**
```txt
git+https://github.com/overhangio/tutor.git@main
git+https://github.com/overhangio/tutor-mfe.git@main
git+https://github.com/overhangio/tutor-forum.git@main
git+https://gitlab.com/opencraft/dev/tutor-contrib-grove.git@main
git+https://github.com/open-craft/tutor-contrib-s3.git@kaustav/remove_storage_settings
git+https://github.com/openedx/openedx-k8s-harmony.git@main#egg=tutor-contrib-harmony&subdirectory=tutor-contrib-harmony-plugin
```