### PR TITLE
Fixed jwt scope issue

### DIFF
--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -57,7 +57,7 @@ class ThirdPartyOAuthTestMixin(ThirdPartyAuthTestMixin):
             client_type=Application.CLIENT_PUBLIC,
         )
 
-    def _setup_provider_response(self, success=False, email=''):
+    def _setup_provider_response(self, success=False, email='', profile_data=None):
         """
         Register a mock response for the third party user information endpoint;
         success indicates whether the response status code should be 200 or 400
@@ -67,6 +67,10 @@ class ThirdPartyOAuthTestMixin(ThirdPartyAuthTestMixin):
             response = {self.UID_FIELD: self.social_uid}
             if email:
                 response.update({'email': email})
+
+            if profile_data:
+                response.update(profile_data)
+
             body = json.dumps(response)
         else:
             status = 400

--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -80,7 +80,7 @@ def create_jwt_token_dict(token_dict, oauth_adapter, use_asymmetric_key=None):
     # .. custom_attribute_name: create_jwt_grant_type
     # .. custom_attribute_description: The grant type of the newly created JWT.
     set_custom_attribute('create_jwt_grant_type', grant_type)
-    scopes = _get_updated_scopes(token_dict['scope'].split(' '), grant_type)
+    scopes = _get_updated_scopes(token_dict['scope'].split(), grant_type)
 
     jwt_access_token = _create_jwt(
         access_token.user,

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -422,7 +422,8 @@ class TestAccessTokenExchangeView(ThirdPartyOAuthTestMixinGoogle, ThirdPartyOAut
         """
         client = getattr(self, client_attr)
         self.oauth_client = client
-        self._setup_provider_response(success=True)
+        profile_data = {'given_name': self.user.first_name, 'family_name': self.user.last_name}
+        self._setup_provider_response(success=True, profile_data=profile_data)
         response = self._post_request(self.user, client, token_type=token_type,
                                       headers=headers or {}, asymmetric_jwt=asymmetric_jwt)
         assert response.status_code == 200
@@ -451,7 +452,8 @@ class TestAccessTokenExchangeView(ThirdPartyOAuthTestMixinGoogle, ThirdPartyOAut
     def test_jwt_access_token_exchange_calls_dispatched_view(self, client_attr):
         client = getattr(self, client_attr)
         self.oauth_client = client
-        self._setup_provider_response(success=True)
+        profile_data = {'given_name': self.user.first_name, 'family_name': self.user.last_name}
+        self._setup_provider_response(success=True, profile_data=profile_data)
         response = self._post_request(self.user, client, token_type='jwt')
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))
@@ -470,7 +472,8 @@ class TestAccessTokenExchangeView(ThirdPartyOAuthTestMixinGoogle, ThirdPartyOAut
     def test_asymmetric_jwt_access_token_exchange_calls_dispatched_view(self, client_attr):
         client = getattr(self, client_attr)
         self.oauth_client = client
-        self._setup_provider_response(success=True)
+        profile_data = {'given_name': self.user.first_name, 'family_name': self.user.last_name}
+        self._setup_provider_response(success=True, profile_data=profile_data)
         response = self._post_request(self.user, client, token_type='jwt', asymmetric_jwt=True)
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))


### PR DESCRIPTION


## Description

Mobile clients are using AccessTokenExchangeView for third-party authentication (e.g., "Sign in with Google").

Previously, when the scope parameter was set to "none" or an empty string, using .split(" ") resulted in [''] — a list containing an empty string — instead of an empty list. This caused the default scopes (['email', 'profile', 'user_id']) not to be applied as expected.

This PR fixes scope parsing to ensure that if the provided scope is empty or invalid, an empty list is returned instead of [''].

Useful information to include:

- This will effect all mobile clients and any client using `AccessTokenExchangeView` for third party authentication.

## Supporting information

This issue was raised by the Commerce Coordinator team after mobile payments were migrated to use their flow. Specifically, when users signed in via third-party SSO (e.g., Google), the email field was not getting set correctly, which caused the payment flow to break.


## Deadline

ASAP.
