### PR TITLE
chore: Bumped xblocks-contrib version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1285,7 +1285,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.4.0
+xblocks-contrib==0.5.0
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2286,7 +2286,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.4.0
+xblocks-contrib==0.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1614,7 +1614,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.4.0
+xblocks-contrib==0.5.0
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1697,7 +1697,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.4.0
+xblocks-contrib==0.5.0
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via


### PR DESCRIPTION
This pull request updates the xblocks-contrib dependency across multiple requirement files to version 0.4.0, ensuring consistency and incorporating the latest changes or fixes from the updated version.

Dependency updates:

- Updated xblocks-contrib from 0.4.0 to 0.5.0 in requirements/edx/base.txt.
- Updated xblocks-contrib from 0.4.0 to 0.5.0 in requirements/edx/development.txt.
- Updated xblocks-contrib from 0.4.0 to 0.5.0 in requirements/edx/doc.txt.
- Updated xblocks-contrib from 0.4.0 to 0.5.0 in requirements/edx/testing.txt.