### PR TITLE
feat!: Make MFE scroll content instead of iFrame when scrollToXblock is called

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -175,7 +175,10 @@ function($, _, Backbone, gettext, BasePage,
                         this.createComponent(this, xblockElement, data);
                         break;
                     case 'scrollToXBlock':
-                        document.getElementById(data.payload.locator)?.scrollIntoView({behavior: "smooth"});
+                        window.parent.postMessage({
+                            type: 'xblock-scroll',
+                            offset: document.getElementById(data.payload.locator).offsetTop
+                        }, document.referrer);
                         break;
                     default:
                         console.warn('Unhandled message type:', data.type);


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description
Fixes https://github.com/openedx/openedx-aspects/issues/316 by scrolling window to the xblock location instead of scrolling within the iFrame

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Test with https://github.com/openedx/frontend-app-authoring/pull/2363
Need to enable Aspects in-context metrics (https://github.com/openedx/frontend-plugin-aspects)

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
