### PR TITLE
feanil/remove unnecessary pin

### DIFF
--- a/openedx/core/djangoapps/agreements/serializers.py
+++ b/openedx/core/djangoapps/agreements/serializers.py
@@ -16,7 +16,7 @@ class IntegritySignatureSerializer(serializers.ModelSerializer):
     created_at = serializers.DateTimeField(source='created')
 
     class Meta:
-        model = IntegritySignature()
+        model = IntegritySignature
         fields = ('username', 'course_id', 'created_at')
 
 

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -233,7 +233,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
 
         # Preference is the same as the cookie, shouldn't write to the database
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             self.middleware.process_request(self.request)
 
         assert get_user_preference(self.user, LANGUAGE_KEY) == 'es'

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -443,7 +443,7 @@ class NotificationReadAPIViewTestCase(APITestCase):
         response = self.client.patch(self.url, data)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.data["detail"], 'Not found.')
+        self.assertEqual(response.data["detail"].code, 'not_found')
 
     def test_mark_notification_read_with_app_name_and_notification_id(self):
         # Create a PATCH request to mark notification as read for existing app e.g 'discussion' and notification_id: 2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -34,10 +34,6 @@ django-oauth-toolkit==1.7.1
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35276
 django-webpack-loader==0.7.0
 
-# Date: 2023-06-20
-# Adding pin to avoid any major upgrade
-djangorestframework<3.15.0
-
 # Date: 2024-07-19
 # Generally speaking, the major version of django-stubs must either match the major version
 # of django, or exceed it by 1. So, we will need to perpetually constrain django-stubs and

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -377,9 +377,8 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-config-models
     #   django-user-tasks
@@ -1010,7 +1009,6 @@ python3-saml==1.16.0
 pytz==2025.2
     # via
     #   -r requirements/edx/kernel.in
-    #   djangorestframework
     #   drf-yasg
     #   edx-completion
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -610,9 +610,8 @@ django-webpack-loader==0.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-config-models
@@ -1772,7 +1771,6 @@ pytz==2025.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   djangorestframework
     #   drf-yasg
     #   edx-completion
     #   edx-enterprise

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -449,9 +449,8 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   django-user-tasks
@@ -1238,7 +1237,6 @@ python3-saml==1.16.0
 pytz==2025.2
     # via
     #   -r requirements/edx/base.txt
-    #   djangorestframework
     #   drf-yasg
     #   edx-completion
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -475,9 +475,8 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-config-models
     #   django-user-tasks
@@ -1350,7 +1349,6 @@ python3-saml==1.16.0
 pytz==2025.2
     # via
     #   -r requirements/edx/base.txt
-    #   djangorestframework
     #   drf-yasg
     #   edx-completion
     #   edx-enterprise

--- a/scripts/user_retirement/requirements/base.in
+++ b/scripts/user_retirement/requirements/base.in
@@ -11,7 +11,3 @@ unicodecsv
 simplejson
 simple-salesforce
 google-api-python-client
-
-# urllib3 is needed for the user_retirement scripts 
-# constraint will be investigated and removed in a separate issue
-urllib3<2.0.0

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -152,9 +152,8 @@ unicodecsv==0.14.1
     # via -r scripts/user_retirement/requirements/base.in
 uritemplate==4.2.0
     # via google-api-python-client
-urllib3==1.26.20
+urllib3==2.5.0
     # via
-    #   -r scripts/user_retirement/requirements/base.in
     #   botocore
     #   requests
 zeep==4.3.1

--- a/scripts/user_retirement/requirements/testing.in
+++ b/scripts/user_retirement/requirements/testing.in
@@ -6,3 +6,4 @@ requests_mock
 responses
 mock
 ddt
+urllib3

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -264,9 +264,10 @@ uritemplate==4.2.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-urllib3==1.26.20
+urllib3==2.5.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
+    #   -r scripts/user_retirement/requirements/testing.in
     #   botocore
     #   requests
     #   responses


### PR DESCRIPTION
- **build: Unpin DRF.**
  There have been no breaking changes in the minor versions and there is
no ticket for unpinning this constraint. It doesn't make sense to keep.

- **build: urllib3 is only a testing direct requirement.**
  It's only used by botocore and requests in the actual retirement code
and those have been able to handle a newer version of the library for
quite some time.

  urllib3 is directly used in the testing code but not in a way where we
need to constrain it from being upgraded.
