### PR TITLE
feanil/unpin fs s3fs

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -588,13 +588,13 @@ frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
-fs==2.0.27
+fs==2.4.16
     # via
     #   -r requirements/edx/kernel.in
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
-fs-s3fs==0.1.8
+fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-pyfs
@@ -1017,7 +1017,6 @@ pytz==2025.2
     #   edx-tincan-py35
     #   enterprise-integrated-channels
     #   event-tracking
-    #   fs
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -932,14 +932,14 @@ frozenlist==1.7.0
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   aiosignal
-fs==2.0.27
+fs==2.4.16
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
-fs-s3fs==0.1.8
+fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1781,7 +1781,6 @@ pytz==2025.2
     #   edx-tincan-py35
     #   enterprise-integrated-channels
     #   event-tracking
-    #   fs
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -684,13 +684,13 @@ frozenlist==1.7.0
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   aiosignal
-fs==2.0.27
+fs==2.4.16
     # via
     #   -r requirements/edx/base.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
-fs-s3fs==0.1.8
+fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-pyfs
@@ -1245,7 +1245,6 @@ pytz==2025.2
     #   edx-tincan-py35
     #   enterprise-integrated-channels
     #   event-tracking
-    #   fs
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -91,7 +91,7 @@ edxval
 event-tracking
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
 fs
-fs-s3fs==0.1.8
+fs-s3fs
 geoip2                              # Python API for the GeoIP web services and databases
 glob2                               # Enhanced glob module, used in openedx.core.lib.rooted_paths
 gunicorn

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -719,13 +719,13 @@ frozenlist==1.7.0
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   aiosignal
-fs==2.0.27
+fs==2.4.16
     # via
     #   -r requirements/edx/base.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
-fs-s3fs==0.1.8
+fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-pyfs
@@ -1357,7 +1357,6 @@ pytz==2025.2
     #   edx-tincan-py35
     #   enterprise-integrated-channels
     #   event-tracking
-    #   fs
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python


### PR DESCRIPTION
- **fix: Don't pin fs-s3fs in kernel.index**
  It's unclear why this is pinned here in the first place.  The only
changes since this version that the fs-s3fs package has had is that the
API has become stable and the underlying dependencies have been upgraded
to newer versions.

  Among other benefits, this resolves a bunch of warnings that come up when we start up the platform.
- **chore: Run `make upgrade`**
