### PR TITLE
chore: remove assertQuerysetEqual to use assertEqual

### DIFF
--- a/common/djangoapps/student/tests/test_api.py
+++ b/common/djangoapps/student/tests/test_api.py
@@ -88,7 +88,7 @@ class TestStudentApi(SharedModuleStoreTestCase):
 
         result = get_course_enrollments(self.user)
 
-        self.assertQuerySetEqual(expected, result)
+        self.assertEqual(list(expected), list(result))
 
     def test_get_filtered_course_enrollments(self):
         """Verify a filtered subset of enrollments can be retrieved"""
@@ -99,4 +99,4 @@ class TestStudentApi(SharedModuleStoreTestCase):
 
         result = get_course_enrollments(self.user, True, course_ids=[course_2.id])
 
-        self.assertQuerySetEqual(expected, result)
+        self.assertEqual(list(expected), list(result))

--- a/lms/djangoapps/verify_student/management/commands/tests/test_manual_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_manual_verify_student.py
@@ -77,7 +77,7 @@ class TestVerifyStudentCommand(TestCase):
             created_at__gte=earliest_allowed_verification_date()
         )
 
-        self.assertQuerysetEqual(verification1, [repr(r) for r in verification2], transform=repr)
+        self.assertEqual(list(map(repr, verification1)), list(map(repr, verification2)))
 
     def test_user_doesnot_exist_log(self):
         """

--- a/openedx/core/djangoapps/enrollments/tests/test_services.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_services.py
@@ -97,7 +97,8 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
             {'username': 'user4', 'mode': 'professional'},
             {'username': 'user5', 'mode': 'verified'}
         ]
-        self.assertQuerysetEqual(enrollments, expected_values, self.enrollment_to_dict)
+        actual_values = [self.enrollment_to_dict(e) for e in enrollments]
+        self.assertEqual(actual_values, expected_values)
 
     def test_get_enrollments_can_take_proctored_exams_by_course_ignore_inactive(self):
         """
@@ -141,7 +142,8 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
             {'username': 'user5', 'mode': 'verified'}
 
         ]
-        self.assertQuerysetEqual(enrollments, expected_values, self.enrollment_to_dict)
+        actual_values = [self.enrollment_to_dict(e) for e in enrollments]
+        self.assertEqual(actual_values, expected_values)
 
     def test_get_enrollments_can_take_proctored_exams_not_enable_proctored_exams(self):
         self.course.enable_proctored_exams = False
@@ -180,7 +182,8 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
         expected_values = [
             {'username': 'user3', 'mode': 'masters'}
         ]
-        self.assertQuerysetEqual(enrollments, expected_values, self.enrollment_to_dict)
+        actual_values = [self.enrollment_to_dict(e) for e in enrollments]
+        self.assertEqual(actual_values, expected_values)
 
     @ddt.data('user1', 'USER1', 'LEARNER1@example.com', 'lEarNer1@eXAMPLE.com')
     def test_text_search_exact_return_one(self, text_search):
@@ -192,7 +195,8 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
         expected_values = [
             {'username': 'user1', 'mode': 'executive-education'}
         ]
-        self.assertQuerysetEqual(enrollments, expected_values, self.enrollment_to_dict)
+        actual_values = [self.enrollment_to_dict(e) for e in enrollments]
+        self.assertEqual(actual_values, expected_values)
 
     def test_text_search_return_none(self):
         enrollments = self.service.get_enrollments_can_take_proctored_exams(


### PR DESCRIPTION
## Description
`assertQuerysetEqual` was deprecated in Django 4.2 in favor of the CamelCase `assertQuerySetEqual`, and removed entirely in Django 5.1.
In Django 5.2 we can use `assertEqual` with list values equivalent to `assertQuerySetEqual`

[Reference](https://docs.djangoproject.com/en/5.2/releases/5.1/#features-removed-in-5-1)

Issue: [37150](https://github.com/openedx/edx-platform/issues/37150)
