### PR TITLE
fix: [FC-86] use CMS common settings for default org logo static url

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -42,6 +42,7 @@ import importlib.util
 import json
 import os
 import sys
+from importlib import import_module
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from datetime import timedelta
@@ -2833,7 +2834,7 @@ SOCIAL_MEDIA_LOGO_URLS = {
 }
 
 # .. setting_name: DEFAULT_ORG_LOGO_URL
-# .. setting_default: Derived(lambda settings: settings.STATIC_URL + 'images/logo.png')
+# .. setting_default: import_module('lms.envs.common').STATIC_URL + 'images/logo.png'
 # .. setting_description: The default logo url for organizations that do not have a logo set.
 # .. setting_warning: This url is used as a placeholder for organizations that do not have a logo set.
-DEFAULT_ORG_LOGO_URL = Derived(lambda settings: settings.STATIC_URL + 'images/logo.png')
+DEFAULT_ORG_LOGO_URL = import_module('lms.envs.common').STATIC_URL + 'images/logo.png'

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2834,7 +2834,7 @@ SOCIAL_MEDIA_LOGO_URLS = {
 }
 
 # .. setting_name: DEFAULT_ORG_LOGO_URL
-# .. setting_default: import_module('lms.envs.common').STATIC_URL + 'images/logo.png'
+# .. setting_default: import_module('cms.envs.common').STATIC_URL_BASE + 'images/logo.png'
 # .. setting_description: The default logo url for organizations that do not have a logo set.
 # .. setting_warning: This url is used as a placeholder for organizations that do not have a logo set.
-DEFAULT_ORG_LOGO_URL = import_module('lms.envs.common').STATIC_URL + 'images/logo.png'
+DEFAULT_ORG_LOGO_URL = import_module('cms.envs.common').STATIC_URL_BASE + 'images/logo.png'

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -42,7 +42,6 @@ import importlib.util
 import json
 import os
 import sys
-from importlib import import_module
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from datetime import timedelta
@@ -2834,7 +2833,7 @@ SOCIAL_MEDIA_LOGO_URLS = {
 }
 
 # .. setting_name: DEFAULT_ORG_LOGO_URL
-# .. setting_default: import_module('cms.envs.common').STATIC_URL_BASE + 'images/logo.png'
+# .. setting_default: STATIC_URL_BASE + 'images/logo.png'
 # .. setting_description: The default logo url for organizations that do not have a logo set.
 # .. setting_warning: This url is used as a placeholder for organizations that do not have a logo set.
-DEFAULT_ORG_LOGO_URL = import_module('cms.envs.common').STATIC_URL_BASE + 'images/logo.png'
+DEFAULT_ORG_LOGO_URL = STATIC_URL_BASE + 'images/logo.png'


### PR DESCRIPTION
**Summary**
This PR fixes a bug that causes an incorrect image URL being returned by the `course_discovery/` endpoint for the default organization logo.

**Current behavior**
`DEFAULT_ORG_LOGO_URL` uses `STATIC_URL` (`/static/studio/`) from CMS settings.
**Fixed behavior**
`DEFAULT_ORG_LOGO_URL` uses `STATIC_URL_BASE` (`/static/`) from `cms.envs.common` module.

**Commands to run**
To see the changes, courses need to be reindexed. To do this, use Reindex button in Studio UI, or run:
`tutor dev run cms ./manage.py cms reindex_course --all`