### PR TITLE
fix: Fix signal test failures in Django 5.2.

### DIFF
--- a/common/test/utils.py
+++ b/common/test/utils.py
@@ -85,10 +85,11 @@ class MockSignalHandlerMixin:
 
         """
         with patch.object(module, signal, new=Signal()) as mock_signal:
-            def handler(*args, **kwargs):  # pylint: disable=unused-argument
+            mock_handler = Mock()
+            # Wrap the mock in a real callable so inspect.iscoroutinefunction() works
+            def handler(*h_args, **h_kwargs):  # pylint: disable=unused-argument
                 """No-op signal handler."""
-                pass  # lint-amnesty, pylint: disable=unnecessary-pass
-            mock_handler = Mock(spec=handler)
+                return mock_handler(*h_args, **h_kwargs)
             mock_signal.connect(mock_handler)
             yield
             assert mock_handler.called

--- a/common/test/utils.py
+++ b/common/test/utils.py
@@ -87,9 +87,11 @@ class MockSignalHandlerMixin:
         with patch.object(module, signal, new=Signal()) as mock_signal:
             mock_handler = Mock()
             # Wrap the mock in a real callable so inspect.iscoroutinefunction() works
+
             def handler(*h_args, **h_kwargs):  # pylint: disable=unused-argument
                 """No-op signal handler."""
                 return mock_handler(*h_args, **h_kwargs)
+
             mock_signal.connect(mock_handler)
             yield
             assert mock_handler.called

--- a/common/test/utils.py
+++ b/common/test/utils.py
@@ -88,11 +88,11 @@ class MockSignalHandlerMixin:
             mock_handler = Mock()
             # Wrap the mock in a real callable so inspect.iscoroutinefunction() works
 
-            def handler(*h_args, **h_kwargs):  # pylint: disable=unused-argument
+            def handler(*h_args, **h_kwargs):
                 """No-op signal handler."""
                 return mock_handler(*h_args, **h_kwargs)
 
-            mock_signal.connect(mock_handler)
+            mock_signal.connect(handler)
             yield
             assert mock_handler.called
             mock_args, mock_kwargs = mock_handler.call_args


### PR DESCRIPTION
https://github.com/openedx/edx-platform/issues/37194

Lots of tests failing with this error `TypeError: unsupported operand type(s) for &: 'Mock' and 'int'`

Reproduct steps:
`pytest lms/djangoapps/discussion/rest_api/tests/test_api.py`


**Root cause:**
in Django 4.2 + older Python because the coroutine check was less strict and didn’t reach into mocks’ __code__. The Django 5.2 upgrade surfaces it because the connect-time coroutine check now always runs.