### PR TITLE
fix: remove assertQuerysetEqual

### DIFF
--- a/openedx/core/djangoapps/enrollments/tests/test_services.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_services.py
@@ -171,7 +171,8 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
             {'username': 'user4', 'mode': 'professional'},
             {'username': 'user5', 'mode': 'verified'}
         ]
-        self.assertQuerysetEqual(enrollments, expected_values, self.enrollment_to_dict)
+        actual_values = [self.enrollment_to_dict(e) for e in enrollments]
+        self.assertEqual(actual_values, expected_values)
 
     def test_text_search_partial_return_some(self):
         enrollments = self.service.get_enrollments_can_take_proctored_exams(


### PR DESCRIPTION
## Description
Replace `assertQuerysetEqual` with assertEqual due to deprecation in Django 5.2

Reference [PR](https://github.com/openedx/edx-platform/pull/37182)

issue: [37150](https://github.com/openedx/edx-platform/issues/37150)