### PR TITLE
fix: test failure in test_all_languages

### DIFF
--- a/openedx/core/djangoapps/lang_pref/tests/test_api.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_api.py
@@ -95,7 +95,7 @@ class LanguageApiTest(CacheIsolationTestCase):
         assert all_languages[0][1] < all_languages[1][1]
         assert 'nl' == all_languages[0][0]
         assert 'cs' == all_languages[1][0]
-        assert 'Néerlandais' == all_languages[0][1]
+        assert all_languages[0][1] in ('Hollandais', 'Néerlandais')
         assert 'Tchèque' == all_languages[1][1]
 
     def test_beta_languages(self):

--- a/openedx/core/djangoapps/lang_pref/tests/test_api.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_api.py
@@ -95,7 +95,7 @@ class LanguageApiTest(CacheIsolationTestCase):
         assert all_languages[0][1] < all_languages[1][1]
         assert 'nl' == all_languages[0][0]
         assert 'cs' == all_languages[1][0]
-        assert 'Hollandais' == all_languages[0][1]
+        assert 'Néerlandais' == all_languages[0][1]
         assert 'Tchèque' == all_languages[1][1]
 
     def test_beta_languages(self):


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

https://github.com/openedx/edx-platform/issues/37143

## Testing instructions

Following test was failing:
openedx/core/djangoapps/lang_pref/tests/test_api.py::LanguageApiTest::test_all_languages