### PR TITLE
feat: enhance Course Optimizer to update previous course links via API

### DIFF
--- a/cms/djangoapps/contentstore/core/course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/course_optimizer_provider.py
@@ -13,7 +13,7 @@ from cms.djangoapps.contentstore.tasks import (
     LinkState,
     extract_content_URLs_from_course
 )
-from cms.djangoapps.contentstore.utils import create_course_info_usage_key
+from cms.djangoapps.contentstore.utils import create_course_info_usage_key, get_previous_run_course_key
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import get_xblock
 from cms.djangoapps.contentstore.xblock_storage_handlers.xblock_helpers import usage_key_with_run
 from openedx.core.lib.xblock_utils import get_course_update_items
@@ -123,7 +123,13 @@ def generate_broken_links_descriptor(json_content, request_user, course_key):
                                         'url': 'url/to/block',
                                         'brokenLinks: [],
                                         'lockedLinks: [],
-                                        'previousRunLinks: []
+                                        'previousRunLinks: [
+                                            {
+                                                'originalLink': 'http://...',
+                                                'isUpdated': true,
+                                                'updatedLink': 'http://...'
+                                            }
+                                        ]
                                     },
                                     ...,
                                 ]
@@ -143,7 +149,13 @@ def generate_broken_links_descriptor(json_content, request_user, course_key):
                 'brokenLinks': [],
                 'lockedLinks': [],
                 'externalForbiddenLinks': [],
-                'previousRunLinks': []
+                'previousRunLinks': [
+                    {
+                        'originalLink': 'http://...',
+                        'isUpdated': true,
+                        'updatedLink': 'http://...'
+                    }
+                ]
             },
             ...
             {
@@ -152,7 +164,13 @@ def generate_broken_links_descriptor(json_content, request_user, course_key):
                 'brokenLinks': [],
                 'lockedLinks': [],
                 'externalForbiddenLinks': [],
-                'previousRunLinks': []
+                'previousRunLinks': [
+                    {
+                        'originalLink': 'http://...',
+                        'isUpdated': true,
+                        'updatedLink': 'http://...'
+                    }
+                ]
             }
         ],
         'custom_pages': [
@@ -162,7 +180,13 @@ def generate_broken_links_descriptor(json_content, request_user, course_key):
                 'brokenLinks': [],
                 'lockedLinks': [],
                 'externalForbiddenLinks': [],
-                'previousRunLinks': []
+                'previousRunLinks': [
+                    {
+                        'originalLink': 'http://...',
+                        'isUpdated': true,
+                        'updatedLink': 'http://...'
+                    }
+                ]
             },
             ...
         ]
@@ -171,7 +195,7 @@ def generate_broken_links_descriptor(json_content, request_user, course_key):
     return _generate_enhanced_links_descriptor(json_content, request_user, course_key)
 
 
-def _update_node_tree_and_dictionary(block, link, link_state, node_tree, dictionary):
+def _update_node_tree_and_dictionary(block, link, link_state, node_tree, dictionary, course_key=None):
     """
     Inserts a block into the node tree and add its attributes to the dictionary.
 
@@ -245,7 +269,7 @@ def _update_node_tree_and_dictionary(block, link, link_state, node_tree, diction
     elif link_state == LinkState.EXTERNAL_FORBIDDEN:
         updated_dictionary[xblock_id].setdefault('external_forbidden_links', []).append(link)
     elif link_state == LinkState.PREVIOUS_RUN:
-        updated_dictionary[xblock_id].setdefault('previous_run_links', []).append(link)
+        _add_previous_run_link(updated_dictionary, xblock_id, link, course_key)
     else:
         updated_dictionary[xblock_id].setdefault('broken_links', []).append(link)
 
@@ -345,7 +369,7 @@ def sort_course_sections(course_key, data):
     return data
 
 
-def _generate_links_descriptor_for_content(json_content, request_user):
+def _generate_links_descriptor_for_content(json_content, request_user, course_key=None):
     """
     Creates a content tree of all links in a course and their states
     Returns a structure containing all broken links and locked links for a course.
@@ -368,6 +392,7 @@ def _generate_links_descriptor_for_content(json_content, request_user):
             link_state=link_state,
             node_tree=xblock_node_tree,
             dictionary=xblock_dictionary,
+            course_key=course_key,
         )
 
     result = _create_dto_recursive(xblock_node_tree, xblock_dictionary)
@@ -391,7 +416,7 @@ def _generate_enhanced_links_descriptor(json_content, request_user, course_key):
 
     for item in json_content:
         block_id, link, *rest = item
-        if "course_info" in block_id and "updates" in block_id:
+        if isinstance(block_id, int):
             course_updates_links.append(item)
         elif "course_info" in block_id and "handouts" in block_id:
             handouts_links.append(item)
@@ -401,22 +426,22 @@ def _generate_enhanced_links_descriptor(json_content, request_user, course_key):
             content_links.append(item)
 
     try:
-        main_content = _generate_links_descriptor_for_content(content_links, request_user)
+        main_content = _generate_links_descriptor_for_content(content_links, request_user, course_key)
     except Exception:   # pylint: disable=broad-exception-caught
         main_content = {"sections": []}
 
     course_updates_data = (
-        _generate_course_updates_structure(course, course_updates_links)
+        _generate_enhanced_content_structure(course, course_updates_links, "updates", course_key)
         if course_updates_links and course else []
     )
 
     handouts_data = (
-        _generate_handouts_structure(course, handouts_links)
+        _generate_enhanced_content_structure(course, handouts_links, "handouts", course_key)
         if handouts_links and course else []
     )
 
     custom_pages_data = (
-        _generate_custom_pages_structure(course, custom_pages_links)
+        _generate_enhanced_content_structure(course, custom_pages_links, "custom_pages", course_key)
         if custom_pages_links and course else []
     )
 
@@ -426,7 +451,7 @@ def _generate_enhanced_links_descriptor(json_content, request_user, course_key):
     return result
 
 
-def _generate_enhanced_content_structure(course, content_links, content_type):
+def _generate_enhanced_content_structure(course, content_links, content_type, course_key=None):
     """
     Unified function to generate structure for enhanced content (updates, handouts, custom pages).
 
@@ -434,24 +459,25 @@ def _generate_enhanced_content_structure(course, content_links, content_type):
         course: Course object
         content_links: List of link items for this content type
         content_type: 'updates', 'handouts', or 'custom_pages'
+        course_key: Course key to check for link updates (optional)
 
     Returns:
         List of content items with categorized links
     """
-    result = []
-    try:
-        if content_type == "custom_pages":
-            result = _generate_custom_pages_content(course, content_links)
-        elif content_type == "updates":
-            result = _generate_course_updates_content(course, content_links)
-        elif content_type == "handouts":
-            result = _generate_handouts_content(course, content_links)
-        return result
-    except Exception as e:   # pylint: disable=broad-exception-caught
-        return result
+    generators = {
+        "custom_pages": _generate_custom_pages_content,
+        "updates": _generate_course_updates_content,
+        "handouts": _generate_handouts_content,
+    }
+
+    generator = generators.get(content_type)
+    if generator:
+        return generator(course, content_links, course_key)
+
+    return []
 
 
-def _generate_course_updates_content(course, updates_links):
+def _generate_course_updates_content(course, updates_links, course_key=None):
     """Generate course updates content with categorized links."""
     store = modulestore()
     usage_key = create_course_info_usage_key(course, "updates")
@@ -465,23 +491,10 @@ def _generate_course_updates_content(course, updates_links):
     if not update_items:
         return course_updates
 
-    # Create link state mapping
-    link_state_map = {
-        item[1]: item[2] if len(item) >= 3 else LinkState.BROKEN
-        for item in updates_links if len(item) >= 2
-    }
-
     for update in update_items:
         if update.get("status") != "deleted":
             update_content = update.get("content", "")
-            update_links = extract_content_URLs_from_course(update_content) if update_content else []
-
-            # Match links with their states
-            update_link_data = _create_empty_links_data()
-            for link in update_links:
-                link_state = link_state_map.get(link)
-                if link_state is not None:
-                    _categorize_link_by_state(link, link_state, update_link_data)
+            update_link_data = _process_content_links(update_content, updates_links, course_key)
 
             course_updates.append(
                 {
@@ -495,7 +508,7 @@ def _generate_course_updates_content(course, updates_links):
     return course_updates
 
 
-def _generate_handouts_content(course, handouts_links):
+def _generate_handouts_content(course, handouts_links, course_key=None):
     """Generate handouts content with categorized links."""
     store = modulestore()
     usage_key = create_course_info_usage_key(course, "handouts")
@@ -509,15 +522,7 @@ def _generate_handouts_content(course, handouts_links):
     ):
         return course_handouts
 
-    # Create link state mapping for handouts
-    link_state_map = {
-        item[1]: item[2] if len(item) >= 3 else LinkState.BROKEN
-        for item in handouts_links if len(item) >= 2
-    }
-
-    links_data = _create_empty_links_data()
-    for link, link_state in link_state_map.items():
-        _categorize_link_by_state(link, link_state, links_data)
+    links_data = _process_content_links(handouts_block.data, handouts_links, course_key)
 
     course_handouts = [
         {
@@ -530,7 +535,7 @@ def _generate_handouts_content(course, handouts_links):
     return course_handouts
 
 
-def _generate_custom_pages_content(course, custom_pages_links):
+def _generate_custom_pages_content(course, custom_pages_links, course_key=None):
     """Generate custom pages content with categorized links."""
     custom_pages = []
 
@@ -544,7 +549,7 @@ def _generate_custom_pages_content(course, custom_pages_links):
             block_id, link = item[0], item[1]
             link_state = item[2] if len(item) >= 3 else LinkState.BROKEN
             links_by_page.setdefault(block_id, _create_empty_links_data())
-            _categorize_link_by_state(link, link_state, links_by_page[block_id])
+            _categorize_link_by_state(link, link_state, links_by_page[block_id], course_key)
 
     # Process static tabs and add their pages
     for tab in course.tabs:
@@ -560,24 +565,7 @@ def _generate_custom_pages_content(course, custom_pages_links):
     return custom_pages
 
 
-def _generate_course_updates_structure(course, updates_links):
-    """Generate structure for course updates."""
-    return _generate_enhanced_content_structure(course, updates_links, "updates")
-
-
-def _generate_handouts_structure(course, handouts_links):
-    """Generate structure for course handouts."""
-    return _generate_enhanced_content_structure(course, handouts_links, "handouts")
-
-
-def _generate_custom_pages_structure(course, custom_pages_links):
-    """Generate structure for custom pages (static tabs)."""
-    return _generate_enhanced_content_structure(
-        course, custom_pages_links, "custom_pages"
-    )
-
-
-def _categorize_link_by_state(link, link_state, links_data):
+def _categorize_link_by_state(link, link_state, links_data, course_key=None):
     """
     Helper function to categorize a link into the appropriate list based on its state.
 
@@ -585,6 +573,7 @@ def _categorize_link_by_state(link, link_state, links_data):
         link (str): The URL link to categorize
         link_state (str): The state of the link (broken, locked, external-forbidden, previous-run)
         links_data (dict): Dictionary containing the categorized link lists
+        course_key: Course key to check for link updates (optional)
     """
     state_to_key = {
         LinkState.BROKEN: "brokenLinks",
@@ -595,7 +584,11 @@ def _categorize_link_by_state(link, link_state, links_data):
 
     key = state_to_key.get(link_state)
     if key:
-        links_data[key].append(link)
+        if key == "previousRunLinks":
+            data = _generate_link_update_info(link, course_key)
+            links_data[key].append(data)
+        else:
+            links_data[key].append(link)
 
 
 def _create_empty_links_data():
@@ -624,15 +617,7 @@ def get_course_link_update_data(request, course_id):
     if task_status is None:
         status = "uninitiated"
     else:
-        status_mapping = {
-            UserTaskStatus.PENDING: "pending",
-            UserTaskStatus.IN_PROGRESS: "in_progress",
-            UserTaskStatus.SUCCEEDED: "completed",
-            UserTaskStatus.FAILED: "failed",
-            UserTaskStatus.CANCELED: "failed",
-            UserTaskStatus.RETRYING: "in_progress",
-        }
-        status = status_mapping.get(task_status.state, task_status.state.lower())
+        status = task_status.state
 
         if task_status.state == UserTaskStatus.SUCCEEDED:
             try:
@@ -653,14 +638,233 @@ def get_course_link_update_data(request, course_id):
     return data
 
 
-def _latest_course_link_update_task_status(request, course_key_string, view_func=None):
+def _latest_course_link_update_task_status(request, course_id, view_func=None):
     """
     Get the most recent course link update status for the specified course key.
     """
 
-    args = {"course_key_string": course_key_string}
+    args = {"course_id": course_id}
     name = CourseLinkUpdateTask.generate_name(args)
     task_status = UserTaskStatus.objects.filter(name=name)
     for status_filter in STATUS_FILTERS:
         task_status = status_filter().filter_queryset(request, task_status, view_func)
     return task_status.order_by("-created").first()
+
+
+def _get_link_update_status(original_url, course_key):
+    """
+    Check whether a given link has been updated based on the latest link update results.
+
+    Args:
+        original_url (str): The original URL to check
+        course_key: The course key
+
+    Returns:
+        dict: Dictionary with 'originalLink', 'isUpdated', and 'updatedLink' keys
+    """
+    def _create_response(original_link, is_updated, updated_link=None):
+        """Helper to create consistent response format."""
+        return {
+            "originalLink": original_link,
+            "isUpdated": is_updated,
+            "updatedLink": updated_link,
+        }
+
+    try:
+        # Check if URL contains current course key (indicates it's been updated)
+        current_course_str = str(course_key)
+        if current_course_str in original_url:
+            prev_run_key = get_previous_run_course_key(course_key)
+            if prev_run_key:
+                reconstructed_original = original_url.replace(current_course_str, str(prev_run_key))
+                return _create_response(reconstructed_original, True, original_url)
+            return _create_response(original_url, True, original_url)
+
+        update_results = _get_update_results(course_key)
+        if not update_results:
+            return _create_response(original_url, False, None)
+
+        for result in update_results:
+            if not result.get("success", False):
+                continue
+
+            result_original = result.get("original_url", "")
+            result_new = result.get("new_url", "")
+
+            # Direct match with original URL
+            if result_original == original_url:
+                return _create_response(original_url, True, result_new)
+
+            # Check if current URL is an updated URL
+            if result_new == original_url:
+                return _create_response(result_original, True, original_url)
+
+            # Check if URLs match through reconstruction
+            if _urls_match_through_reconstruction(original_url, result_new, course_key):
+                return _create_response(original_url, True, result_new)
+
+        return _create_response(original_url, False, None)
+
+    except Exception:  # pylint: disable=broad-except
+        return _create_response(original_url, False, None)
+
+
+def _get_update_results(course_key):
+    """
+    Helper function to get update results from the latest link update task.
+
+    Returns:
+        list: Update results or empty list if not found
+    """
+    try:
+        task_status = _latest_course_link_update_task_status(None, str(course_key))
+
+        if not task_status or task_status.state != UserTaskStatus.SUCCEEDED:
+            return []
+
+        artifact = UserTaskArtifact.objects.get(
+            status=task_status, name="LinkUpdateResults"
+        )
+        with artifact.file as file:
+            content = file.read()
+            return json.loads(content)
+
+    except (UserTaskArtifact.DoesNotExist, ValueError, json.JSONDecodeError):
+        return []
+
+
+def _is_previous_run_link(link, course_key):
+    """
+    Check if a link is a previous run link by checking if it contains a previous course key
+    or if it has update results indicating it was updated.
+
+    Args:
+        link: The URL to check
+        course_key: The current course key
+
+    Returns:
+        bool: True if the link appears to be a previous run link
+    """
+    try:
+        if str(course_key) in link:
+            return True
+
+        prev_run_key = get_previous_run_course_key(course_key)
+        if prev_run_key and str(prev_run_key) in link:
+            return True
+
+        update_results = _get_update_results(course_key)
+        for result in update_results:
+            if not result.get("success", False):
+                continue
+            if link in [result.get("original_url", ""), result.get("new_url", "")]:
+                return True
+
+        return False
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+def _urls_match_through_reconstruction(original_url, new_url, course_key):
+    """
+    Check if an original URL matches a new URL through course key reconstruction.
+
+    Args:
+        original_url (str): The original URL from broken links
+        new_url (str): The new URL from update results
+        course_key: The current course key
+
+    Returns:
+        bool: True if they match through reconstruction
+    """
+    try:
+        prev_run_key = get_previous_run_course_key(course_key)
+        if not prev_run_key:
+            return False
+
+        # Reconstruct what the original URL would have been
+        reconstructed_original = new_url.replace(str(course_key), str(prev_run_key))
+        return reconstructed_original == original_url
+
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+def _process_content_links(content_text, all_links, course_key=None):
+    """
+    Helper function to process links in content and categorize them by state.
+
+    Args:
+        content_text: The text content to extract links from
+        all_links: List of tuples containing (url, state) or (url, state, extra_info)
+        course_key: Course key to check for link updates (optional)
+
+    Returns:
+        dict: Categorized link data
+    """
+    if not content_text:
+        return _create_empty_links_data()
+
+    content_links = extract_content_URLs_from_course(content_text)
+    if not content_links:
+        return _create_empty_links_data()
+
+    # Create link state mapping
+    link_state_map = {
+        item[1]: item[2] if len(item) >= 3 else LinkState.BROKEN
+        for item in all_links if len(item) >= 2
+    }
+
+    # Categorize links by state
+    link_data = _create_empty_links_data()
+    for link in content_links:
+        link_state = link_state_map.get(link)
+        if link_state is not None:
+            _categorize_link_by_state(link, link_state, link_data, course_key)
+        else:
+            # Check if this link is a previous run link that might have been updated
+            if course_key and _is_previous_run_link(link, course_key):
+                _categorize_link_by_state(link, LinkState.PREVIOUS_RUN, link_data, course_key)
+
+    return link_data
+
+
+def _generate_link_update_info(link, course_key=None):
+    """
+    Create a previous run link data with appropriate update status.
+
+    Args:
+        link: The link URL
+        course_key: Course key to check for updates (optional)
+
+    Returns:
+        dict: Previous run link data with originalLink, isUpdated, and updatedLink
+    """
+    if course_key:
+        updated_info = _get_link_update_status(link, course_key)
+        if updated_info:
+            return {
+                'originalLink': updated_info['originalLink'],
+                'isUpdated': updated_info['isUpdated'],
+                'updatedLink': updated_info['updatedLink']
+            }
+
+    return {
+        'originalLink': link,
+        'isUpdated': False,
+        'updatedLink': None
+    }
+
+
+def _add_previous_run_link(dictionary, xblock_id, link, course_key):
+    """
+    Helper function to add a previous run link with appropriate update status.
+
+    Args:
+        dictionary: The xblock dictionary to update
+        xblock_id: The ID of the xblock
+        link: The link URL
+        course_key: Course key to check for updates (optional)
+    """
+    data = _generate_link_update_info(link, course_key)
+    dictionary[xblock_id].setdefault('previous_run_links', []).append(data)

--- a/cms/djangoapps/contentstore/core/tests/test_course_optimizer_provider.py
+++ b/cms/djangoapps/contentstore/core/tests/test_course_optimizer_provider.py
@@ -61,10 +61,10 @@ class TestLinkCheckProvider(CourseTestCase):
         when passed a block level xblock.
         """
         expected_tree = {
-            'chapter_1': {
-                'sequential_1': {
-                    'vertical_1': {
-                        'block_1': {}
+            self.mock_section.location: {
+                self.mock_subsection.location: {
+                    self.mock_unit.location: {
+                        self.mock_block.location: {}
                     }
                 }
             }
@@ -81,19 +81,19 @@ class TestLinkCheckProvider(CourseTestCase):
         when passed a block level xblock.
         """
         expected_dictionary = {
-            'chapter_1': {
+            self.mock_section.location: {
                 'display_name': 'Section Name',
                 'category': 'chapter'
             },
-            'sequential_1': {
+            self.mock_subsection.location: {
                 'display_name': 'Subsection Name',
                 'category': 'sequential'
             },
-            'vertical_1': {
+            self.mock_unit.location: {
                 'display_name': 'Unit Name',
                 'category': 'vertical'
             },
-            'block_1': {
+            self.mock_block.location: {
                 'display_name': 'Block Name',
                 'category': 'html',
                 'url': f'/course/{self.course.id}/editor/html/{self.mock_block.location}',
@@ -274,11 +274,16 @@ class TestLinkCheckProvider(CourseTestCase):
     def test_sorts_sections_correctly(self, mock_modulestore):
         """Test that the function correctly sorts sections based on published course structure."""
 
+        # Create mock location objects that will match the section IDs in data
+        mock_location2 = "section2"
+        mock_location3 = "section3"
+        mock_location1 = "section1"
+
         mock_course_block = Mock()
         mock_course_block.get_children.return_value = [
-            Mock(location=Mock(block_id="section2")),
-            Mock(location=Mock(block_id="section3")),
-            Mock(location=Mock(block_id="section1")),
+            Mock(location=mock_location2),
+            Mock(location=mock_location3),
+            Mock(location=mock_location1),
         ]
 
         mock_modulestore_instance = Mock()
@@ -301,8 +306,7 @@ class TestLinkCheckProvider(CourseTestCase):
             {"id": "section3", "name": "Bonus"},
             {"id": "section1", "name": "Intro"},
         ]
-
-        assert result["LinkCheckOutput"]["sections"] == expected_sections
+        self.assertEqual(result["LinkCheckOutput"]["sections"], expected_sections)
 
     def test_prev_run_link_detection(self):
         """Test the core logic of separating previous run links from regular links."""

--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
@@ -50,3 +50,54 @@ class LinkCheckSerializer(serializers.Serializer):
     LinkCheckCreatedAt = serializers.DateTimeField(required=False)
     LinkCheckOutput = LinkCheckOutputSerializer(required=False)
     LinkCheckError = serializers.CharField(required=False)
+
+
+class CourseRerunLinkDataSerializer(serializers.Serializer):
+    """ Serializer for individual course rerun link data """
+    url = serializers.CharField(required=True, allow_null=False, allow_blank=False)
+    type = serializers.CharField(required=True, allow_null=False, allow_blank=False)
+    id = serializers.CharField(required=True, allow_null=False, allow_blank=False)
+
+
+class CourseRerunLinkUpdateRequestSerializer(serializers.Serializer):
+    """ Serializer for course rerun link update request """
+    action = serializers.ChoiceField(choices=['all', 'specific'], required=True)
+    data = CourseRerunLinkDataSerializer(many=True, required=False)
+
+    def validate(self, attrs):
+        """
+        Validate that data is provided when action is 'specific'
+        """
+        if attrs.get('action') == 'specific' and not attrs.get('data'):
+            raise serializers.ValidationError(
+                "Field 'data' is required when action is 'specific'"
+            )
+        return attrs
+
+
+class CourseRerunLinkUpdateResultSerializer(serializers.Serializer):
+    """ Serializer for individual course rerun link update result """
+    new_url = serializers.CharField(required=True, allow_null=False, allow_blank=False)
+    type = serializers.CharField(required=True, allow_null=False, allow_blank=False)
+    id = serializers.CharField(required=True, allow_null=False, allow_blank=False)
+    success = serializers.BooleanField(required=True)
+    error_message = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+
+    def to_representation(self, instance):
+        """
+        Override to exclude error_message field when success is True or error_message is null/empty
+        """
+        data = super().to_representation(instance)
+        if data.get('success') is True or not data.get('error_message'):
+            data.pop('error_message', None)
+
+        return data
+
+
+class CourseRerunLinkUpdateStatusSerializer(serializers.Serializer):
+    """ Serializer for course rerun link update status """
+    status = serializers.ChoiceField(
+        choices=['pending', 'in_progress', 'completed', 'failed', 'uninitiated'],
+        required=True
+    )
+    results = CourseRerunLinkUpdateResultSerializer(many=True, required=False)

--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/course_optimizer.py
@@ -60,25 +60,33 @@ class CourseRerunLinkDataSerializer(serializers.Serializer):
 
 
 class CourseRerunLinkUpdateRequestSerializer(serializers.Serializer):
-    """ Serializer for course rerun link update request """
-    action = serializers.ChoiceField(choices=['all', 'specific'], required=True)
+    """Serializer for course rerun link update request."""
+
+    ACTION_CHOICES = ("all", "single")
+
+    action = serializers.ChoiceField(choices=ACTION_CHOICES, required=True)
     data = CourseRerunLinkDataSerializer(many=True, required=False)
 
     def validate(self, attrs):
         """
-        Validate that data is provided when action is 'specific'
+        Validate that 'data' is provided when action is 'single'.
         """
-        if attrs.get('action') == 'specific' and not attrs.get('data'):
+        action = attrs.get("action")
+        data = attrs.get("data")
+
+        if action == "single" and not data:
             raise serializers.ValidationError(
-                "Field 'data' is required when action is 'specific'"
+                {"data": "This field is required when action is 'single'."}
             )
+
         return attrs
 
 
 class CourseRerunLinkUpdateResultSerializer(serializers.Serializer):
     """ Serializer for individual course rerun link update result """
     new_url = serializers.CharField(required=True, allow_null=False, allow_blank=False)
-    type = serializers.CharField(required=True, allow_null=False, allow_blank=False)
+    original_url = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    type = serializers.CharField(required=True, allow_null=False, allow_blank=True)
     id = serializers.CharField(required=True, allow_null=False, allow_blank=False)
     success = serializers.BooleanField(required=True)
     error_message = serializers.CharField(required=False, allow_null=True, allow_blank=True)

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_course_rerun_link_update.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_course_rerun_link_update.py
@@ -90,14 +90,14 @@ class TestCourseLinkUpdateAPI(CourseTestCase):
                 self.assertIn("status", response.json())
                 mock_task.delay.assert_called_once()
 
-    def test_post_update_specific_links_success(self):
-        """Test successful request to update specific links"""
+    def test_post_update_single_links_success(self):
+        """Test successful request to update single links"""
         with patch(self.enable_optimizer_patch, return_value=True):
             with patch(self.update_links_patch) as mock_task:
                 mock_task.delay.return_value = Mock()
 
                 data = {
-                    "action": "specific",
+                    "action": "single",
                     "data": [
                         {
                             "url": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course/course",
@@ -156,5 +156,5 @@ class TestCourseLinkUpdateAPI(CourseTestCase):
 
                         self.assertEqual(status_response.status_code, 200)
                         status_data = status_response.json()
-                        self.assertEqual(status_data["status"], "failed")
+                        self.assertEqual(status_data["status"], "Failed")
                         self.assertEqual(status_data["results"], [])

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_course_rerun_link_update.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_course_rerun_link_update.py
@@ -1,0 +1,160 @@
+"""
+Unit tests for Course Rerun Link Update API
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+from django.urls import reverse
+from user_tasks.models import UserTaskStatus
+
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+
+
+class TestCourseLinkUpdateAPI(CourseTestCase):
+    """
+    Tests for the Course Rerun Link Update API endpoints
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.sample_links_data = [
+            {
+                "url": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course_2023/course",
+                "type": "course_content",
+                "id": "block-v1:edX+DemoX+Demo_Course+type@html+block@intro",
+            },
+            {
+                "url": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course_2023/progress",
+                "type": "course_updates",
+                "id": "1",
+            },
+            {
+                "url": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course_2023/handouts",
+                "type": "handouts",
+                "id": "block-v1:edX+DemoX+Demo_Course+type@course_info+block@handouts",
+            },
+        ]
+
+        self.enable_optimizer_patch = (
+            "cms.djangoapps.contentstore.rest_api.v0.views.course_optimizer."
+            "enable_course_optimizer_check_prev_run_links"
+        )
+        self.update_links_patch = (
+            "cms.djangoapps.contentstore.rest_api.v0.views.course_optimizer."
+            "update_course_rerun_links"
+        )
+        self.task_status_patch = (
+            "cms.djangoapps.contentstore.core.course_optimizer_provider."
+            "_latest_course_link_update_task_status"
+        )
+        self.user_task_artifact_patch = (
+            "cms.djangoapps.contentstore.core.course_optimizer_provider."
+            "UserTaskArtifact"
+        )
+
+    def make_post_request(self, course_id=None, data=None, **kwargs):
+        """Helper method to make POST requests to the link update endpoint"""
+        url = self.get_update_url(course_id or self.course.id)
+        response = self.client.post(
+            url,
+            data=json.dumps(data) if data else None,
+            content_type="application/json",
+        )
+        return response
+
+    def get_update_url(self, course_key):
+        """Get the update endpoint URL"""
+        return reverse(
+            "cms.djangoapps.contentstore:v0:rerun_link_update",
+            kwargs={"course_id": str(course_key)},
+        )
+
+    def get_status_url(self, course_key):
+        """Get the status endpoint URL"""
+        return reverse(
+            "cms.djangoapps.contentstore:v0:rerun_link_update_status",
+            kwargs={"course_id": str(course_key)},
+        )
+
+    def test_post_update_all_links_success(self):
+        """Test successful request to update all links"""
+        with patch(self.enable_optimizer_patch, return_value=True):
+            with patch(self.update_links_patch) as mock_task:
+                mock_task.delay.return_value = Mock()
+
+                data = {"action": "all"}
+                response = self.make_post_request(data=data)
+
+                self.assertEqual(response.status_code, 200)
+                self.assertIn("status", response.json())
+                mock_task.delay.assert_called_once()
+
+    def test_post_update_specific_links_success(self):
+        """Test successful request to update specific links"""
+        with patch(self.enable_optimizer_patch, return_value=True):
+            with patch(self.update_links_patch) as mock_task:
+                mock_task.delay.return_value = Mock()
+
+                data = {
+                    "action": "specific",
+                    "data": [
+                        {
+                            "url": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course/course",
+                            "type": "course_content",
+                            "id": "block-v1:edX+DemoX+Demo_Course+type@html+block@abc123",
+                        },
+                        {
+                            "url": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course/progress",
+                            "type": "course_updates",
+                            "id": "1",
+                        },
+                    ],
+                }
+                response = self.make_post_request(data=data)
+
+                self.assertEqual(response.status_code, 200)
+                self.assertIn("status", response.json())
+                mock_task.delay.assert_called_once()
+
+    def test_post_update_missing_action_returns_400(self):
+        """Test that missing action parameter returns 400"""
+        with patch(
+            self.enable_optimizer_patch,
+            return_value=True,
+        ):
+            data = {}
+            response = self.make_post_request(data=data)
+
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("error", response.json())
+            self.assertIn("action", response.json()["error"])
+
+    def test_error_handling_workflow(self):
+        """Test error handling in the complete workflow"""
+        with patch(
+            self.enable_optimizer_patch,
+            return_value=True,
+        ):
+            with patch(self.update_links_patch) as mock_task:
+                # Step 1: Start task
+                mock_task.delay.return_value = Mock()
+
+                data = {"action": "all"}
+                response = self.make_post_request(data=data)
+                self.assertEqual(response.status_code, 200)
+
+                # Step 2: Check failed status
+                with patch(self.task_status_patch) as mock_status:
+                    with patch(self.user_task_artifact_patch) as mock_artifact:
+                        mock_task_status = Mock()
+                        mock_task_status.state = UserTaskStatus.FAILED
+                        mock_status.return_value = mock_task_status
+
+                        status_url = self.get_status_url(self.course.id)
+                        status_response = self.client.get(status_url)
+
+                        self.assertEqual(status_response.status_code, 200)
+                        status_data = status_response.json()
+                        self.assertEqual(status_data["status"], "failed")
+                        self.assertEqual(status_data["results"], [])

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -9,11 +9,13 @@ from .views import (
     AdvancedCourseSettingsView,
     APIHeartBeatView,
     AuthoringGradingView,
-    CourseTabSettingsView,
     CourseTabListView,
     CourseTabReorderView,
-    LinkCheckView,
+    CourseTabSettingsView,
     LinkCheckStatusView,
+    LinkCheckView,
+    RerunLinkUpdateStatusView,
+    RerunLinkUpdateView,
     TranscriptView,
     YoutubeTranscriptCheckView,
     YoutubeTranscriptUploadView,
@@ -113,5 +115,14 @@ urlpatterns = [
     re_path(
         fr'^link_check_status/{settings.COURSE_ID_PATTERN}$',
         LinkCheckStatusView.as_view(), name='link_check_status'
+    ),
+
+    re_path(
+        fr'^rerun_link_update/{settings.COURSE_ID_PATTERN}$',
+        RerunLinkUpdateView.as_view(), name='rerun_link_update'
+    ),
+    re_path(
+        fr'^rerun_link_update_status/{settings.COURSE_ID_PATTERN}$',
+        RerunLinkUpdateStatusView.as_view(), name='rerun_link_update_status'
     ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
@@ -4,6 +4,6 @@ Views for v0 contentstore API.
 from .advanced_settings import AdvancedCourseSettingsView
 from .api_heartbeat import APIHeartBeatView
 from .authoring_grading import AuthoringGradingView
-from .course_optimizer import LinkCheckView, LinkCheckStatusView
-from .tabs import CourseTabSettingsView, CourseTabListView, CourseTabReorderView
+from .course_optimizer import LinkCheckStatusView, LinkCheckView, RerunLinkUpdateStatusView, RerunLinkUpdateView
+from .tabs import CourseTabListView, CourseTabReorderView, CourseTabSettingsView
 from .transcripts import TranscriptView, YoutubeTranscriptCheckView, YoutubeTranscriptUploadView

--- a/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/course_optimizer.py
@@ -1,17 +1,32 @@
-""" API Views for Course Optimizer. """
+"""API Views for Course Optimizer."""
+
 import edx_api_doc_tools as apidocs
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from rest_framework.views import APIView
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from user_tasks.models import UserTaskStatus
 
-from cms.djangoapps.contentstore.core.course_optimizer_provider import get_link_check_data, sort_course_sections
-from cms.djangoapps.contentstore.rest_api.v0.serializers.course_optimizer import LinkCheckSerializer
-from cms.djangoapps.contentstore.tasks import check_broken_links
+from cms.djangoapps.contentstore.core.course_optimizer_provider import (
+    get_course_link_update_data,
+    get_link_check_data,
+    sort_course_sections,
+)
+from cms.djangoapps.contentstore.rest_api.v0.serializers.course_optimizer import (
+    CourseRerunLinkUpdateStatusSerializer,
+    LinkCheckSerializer,
+    CourseRerunLinkUpdateRequestSerializer,
+)
+from cms.djangoapps.contentstore.tasks import check_broken_links, update_course_rerun_links
+from cms.djangoapps.contentstore.toggles import enable_course_optimizer_check_prev_run_links
 from common.djangoapps.student.auth import has_course_author_access, has_studio_read_access
 from common.djangoapps.util.json_request import JsonResponse
-from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
+from openedx.core.lib.api.view_utils import (
+    DeveloperErrorViewMixin,
+    verify_course_exists,
+    view_auth_classes,
+)
 
 
 @view_auth_classes(is_authenticated=True)
@@ -167,11 +182,213 @@ class LinkCheckStatusView(DeveloperErrorViewMixin, APIView):
         """
         course_key = CourseKey.from_string(course_id)
         if not has_course_author_access(request.user, course_key):
-            print('missing course author access')
             self.permission_denied(request)
 
         data = get_link_check_data(request, course_id)
         data = sort_course_sections(course_key, data)
 
         serializer = LinkCheckSerializer(data)
+        return Response(serializer.data)
+
+
+@view_auth_classes(is_authenticated=True)
+class RerunLinkUpdateView(DeveloperErrorViewMixin, APIView):
+    """
+    View for queueing a celery task to update course links to the latest re-run.
+    """
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                "course_id", apidocs.ParameterLocation.PATH, description="Course ID"
+            )
+        ],
+        body=CourseRerunLinkUpdateRequestSerializer,
+        responses={
+            200: "Celery task queued.",
+            400: "Bad request - invalid action or missing data.",
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    @verify_course_exists()
+    def post(self, request: Request, course_id: str):
+        """
+        Queue celery task to update course links to the latest re-run.
+
+        **Example Request - Update All Links**
+            POST /api/contentstore/v0/rerun_link_update/{course_id}
+            ```json
+            {
+                "action": "all"
+            }
+            ```
+
+        **Example Request - Update Specific Links**
+            POST /api/contentstore/v0/rerun_link_update/{course_id}
+            ```json
+            {
+                "action": "specific",
+                "data": [
+                    {
+                        "url": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course/course",
+                        "type": "course_updates",
+                        "id": "block_id_123"
+                    }
+                ]
+            }
+            ```
+
+        **Response Values**
+        ```json
+        {
+            "status": "pending"
+        }
+        ```
+        """
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except (InvalidKeyError, IndexError):
+            return JsonResponse(
+                {"error": "Invalid course ID format."},
+                status=400,
+            )
+
+        # Check course author permissions
+        if not has_course_author_access(request.user, course_key):
+            self.permission_denied(request)
+
+        if not enable_course_optimizer_check_prev_run_links(course_key):
+            return JsonResponse(
+                {
+                    "error": "Course optimizer check for previous run links is not enabled."
+                },
+                status=400,
+            )
+
+        # Validate request data
+        action = request.data.get("action")
+        if not action or action not in ["all", "specific"]:
+            return JsonResponse(
+                {"error": 'Invalid or missing action. Must be "all" or "specific".'},
+                status=400,
+            )
+
+        if action == "specific":
+            data = request.data.get("data")
+            if not data or not isinstance(data, list):
+                return JsonResponse(
+                    {
+                        "error": 'Missing or invalid data. Required when action is "specific".'
+                    },
+                    status=400,
+                )
+
+        update_course_rerun_links.delay(
+            request.user.id,
+            course_id,
+            action,
+            request.data.get("data", []),
+            request.LANGUAGE_CODE,
+        )
+
+        return JsonResponse({"status": UserTaskStatus.PENDING})
+
+
+@view_auth_classes()
+class RerunLinkUpdateStatusView(DeveloperErrorViewMixin, APIView):
+    """
+    View for checking the status of the course link update task and returning the results.
+    """
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                "course_id", apidocs.ParameterLocation.PATH, description="Course ID"
+            ),
+        ],
+        responses={
+            200: "OK",
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    def get(self, request: Request, course_id: str):
+        """
+        **Use Case**
+
+            GET handler to return the status of the course link update task from UserTaskStatus.
+            If no task has been started for the course, return 'uninitiated'.
+            If the task was successful, the updated links results are also returned.
+
+            Possible statuses:
+                'pending', 'in_progress', 'completed', 'failed', 'uninitiated'
+
+        **Example Request**
+
+            GET /api/contentstore/v0/rerun_link_update_status/{course_id}
+
+        **Example Response - Task In Progress**
+
+        ```json
+        {
+            "status": "pending"
+        }
+        ```
+
+        **Example Response - Task Completed**
+
+        ```json
+        {
+            "status": "completed",
+            "results": [
+                {
+                    "id": "block_id_123",
+                    "type": "course_updates",
+                    "new_url": "http://localhost:18000/course/course-v1:edX+DemoX+2024_Q2/course",
+                    "success": true
+                },
+                {
+                    "id": "block_id_456",
+                    "type": "course_updates",
+                    "new_url": "http://localhost:18000/course/course-v1:edX+DemoX+2024_Q2/progress",
+                    "success": true
+                }
+            ]
+        }
+        ```
+
+        **Example Response - Task Failed**
+
+        ```json
+        {
+            "status": "failed",
+            "error": "Target course run not found or inaccessible"
+        }
+        ```
+        """
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except (InvalidKeyError, IndexError):
+            return JsonResponse(
+                {"error": "Invalid course ID format."},
+                status=400,
+            )
+
+        # Check course author permissions
+        if not has_course_author_access(request.user, course_key):
+            self.permission_denied(request)
+
+        if not enable_course_optimizer_check_prev_run_links(course_key):
+            return JsonResponse(
+                {
+                    "error": "Course optimizer check for previous run links is not enabled."
+                },
+                status=400,
+            )
+
+        data = get_course_link_update_data(request, course_id)
+        serializer = CourseRerunLinkUpdateStatusSerializer(data)
         return Response(serializer.data)

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1342,7 +1342,7 @@ def _scan_course_updates_for_links(course):
                     course_updates.append(
                         {
                             "displayName": update.get("date", "Unknown"),
-                            "block_id": str(usage_key),
+                            "block_id": update.get("id", str(usage_key)),
                             "urls": url_list,
                         }
                     )
@@ -1782,25 +1782,25 @@ class CourseLinkUpdateTask(UserTask):  # pylint: disable=abstract-method
         Returns:
             str: The generated name
         """
-        key = arguments_dict["course_key_string"]
+        key = arguments_dict["course_id"]
         return f"Course link update of {key}"
 
 
 @shared_task(base=CourseLinkUpdateTask, bind=True)
 def update_course_rerun_links(
-    self, user_id, course_key_string, action, data=None, language=None
+    self, user_id, course_id, action, data=None, language=None
 ):
     """
     Updates course links to point to the latest re-run.
     """
     set_code_owner_attribute_from_module(__name__)
     return _update_course_rerun_links(
-        self, user_id, course_key_string, action, data, language
+        self, user_id, course_id, action, data, language
     )
 
 
 def _update_course_rerun_links(
-    task_instance, user_id, course_key_string, action, data, language
+    task_instance, user_id, course_id, action, data, language
 ):
     """
     Updates course links to point to the latest re-run.
@@ -1808,9 +1808,9 @@ def _update_course_rerun_links(
     Args:
         task_instance: The Celery task instance
         user_id: ID of the user requesting the update
-        course_key_string: String representation of the course key
-        action: 'all' or 'specific'
-        data: List of specific links to update (when action='specific')
+        course_id: String representation of the course key
+        action: 'all' or 'single'
+        data: List of specific links to update (when action='single')
         language: Language code for translations
     """
     user = _validate_user(task_instance, user_id, language)
@@ -1818,9 +1818,8 @@ def _update_course_rerun_links(
         return
 
     task_instance.status.set_state(UserTaskStatus.IN_PROGRESS)
-    course_key = CourseKey.from_string(course_key_string)
+    course_key = CourseKey.from_string(course_id)
     prev_run_course_key = get_previous_run_course_key(course_key)
-
     try:
         task_instance.status.set_state("Scanning")
 
@@ -1839,7 +1838,7 @@ def _update_course_rerun_links(
                         }
                     )
         else:
-            # Process only specific course link updates
+            # Process only single link updates
             links_to_update = data or []
 
         task_instance.status.increment_completed_steps()
@@ -1854,6 +1853,7 @@ def _update_course_rerun_links(
                 )
                 updated_links.append(
                     {
+                        "original_url": link_data.get("url", ""),
                         "new_url": new_url,
                         "type": link_data.get("type", "unknown"),
                         "id": link_data.get("id", ""),
@@ -1866,6 +1866,7 @@ def _update_course_rerun_links(
                 )
                 updated_links.append(
                     {
+                        "original_url": link_data.get("url", ""),
                         "new_url": link_data.get("url", ""),
                         "type": link_data.get("type", "unknown"),
                         "id": link_data.get("id", ""),
@@ -1889,6 +1890,9 @@ def _update_course_rerun_links(
             name=os.path.basename(results_file.name), content=File(results_file)
         )
         artifact.save()
+
+        # Update the existing broken links file to reflect the updated links
+        _update_broken_links_file_with_updated_links(course_key, updated_links)
 
         task_instance.status.succeed()
 
@@ -1945,11 +1949,11 @@ def _determine_link_type(block_id):
 
     block_id_str = str(block_id)
 
-    if "course_info" in block_id_str:
-        if "updates" in block_id_str:
-            return "course_updates"
-        elif "handouts" in block_id_str:
-            return "handouts"
+    if isinstance(block_id, int):
+        return "course_updates"
+
+    if "course_info" in block_id_str and "handouts" in block_id_str:
+        return "handouts"
 
     if "static_tab" in block_id_str:
         return "custom_pages"
@@ -1993,6 +1997,10 @@ def _update_link_to_latest_rerun(link_data, course_key, prev_run_course_key, use
         return original_url
 
     new_url = original_url.replace(str(prev_run_course_key), str(course_key))
+
+    # condition because we're showing handouts as updates
+    if link_type == "course_updates" and "handouts" in str(block_id):
+        link_type = "handouts"
 
     _update_block_content_with_new_url(
         block_id, original_url, new_url, link_type, course_key, user
@@ -2092,7 +2100,6 @@ def _update_course_content_link(block_id, old_url, new_url, course_key, user):
     try:
         usage_key = UsageKey.from_string(block_id)
         block = store.get_item(usage_key)
-
         if hasattr(block, "data") and old_url in block.data:
             block.data = block.data.replace(old_url, new_url)
             store.update_item(block, user.id)
@@ -2125,3 +2132,154 @@ def _update_block_content_with_new_url(block_id, old_url, new_url, link_type, co
         _update_custom_pages_link(block_id, old_url, new_url, course_key, user)
     else:
         _update_course_content_link(block_id, old_url, new_url, course_key, user)
+
+
+def _update_broken_links_file_with_updated_links(course_key, updated_links):
+    """
+    Updates the existing broken links file to reflect the status of updated links.
+
+    This function finds the latest broken links file for the course and updates it
+    to remove successfully updated links or update their status.
+
+    Args:
+        course_key: The current course key
+        updated_links: List of updated link results from the link update task
+    """
+    try:
+        # Find the latest broken links task artifact for this course
+        latest_artifact = UserTaskArtifact.objects.filter(
+            name="BrokenLinks", status__name__contains=str(course_key)
+        ).order_by("-created").first()
+
+        if not latest_artifact or not latest_artifact.file:
+            LOGGER.debug(f"No broken links file found for course {course_key}")
+            return
+
+        # Read the existing broken links file
+        try:
+            with latest_artifact.file.open("r") as file:
+                existing_broken_links = json.load(file)
+        except (json.JSONDecodeError, IOError) as e:
+            LOGGER.error(
+                f"Failed to read broken links file for course {course_key}: {e}"
+            )
+            return
+
+        successful_results = []
+        for result in updated_links:
+            if not result.get("success"):
+                continue
+            original_url = result.get("original_url") or _get_original_url_from_updated_result(result, course_key)
+            if not original_url:
+                continue
+            successful_results.append(
+                {
+                    "original_url": original_url,
+                    "new_url": result.get("new_url"),
+                    "type": result.get("type"),
+                    "id": str(result.get("id")) if result.get("id") is not None else None,
+                }
+            )
+
+        updated_broken_links = []
+        for link in existing_broken_links:
+            if len(link) >= 3:
+                block_id, url, link_state = link[0], link[1], link[2]
+
+                applied = False
+                for res in successful_results:
+                    if res["original_url"] != url:
+                        continue
+
+                    if _update_result_applies_to_block(res, block_id) and res.get('id') == str(block_id):
+                        new_url = res["new_url"]
+                        updated_broken_links.append([block_id, new_url, link_state])
+                        applied = True
+                        break
+
+                if not applied:
+                    updated_broken_links.append(link)
+            else:
+                updated_broken_links.append(link)
+
+        # Create a new temporary file with updated data
+        file_name = f"{course_key}_updated"
+        updated_file = NamedTemporaryFile(prefix=file_name + ".", suffix=".json")
+
+        with open(updated_file.name, "w") as file:
+            json.dump(updated_broken_links, file, indent=4)
+
+        # Update the existing artifact with the new file
+        latest_artifact.file.save(
+            name=os.path.basename(updated_file.name), content=File(updated_file)
+        )
+        latest_artifact.save()
+
+        LOGGER.info(f"Successfully updated broken links file for course {course_key}")
+
+    except Exception as e:  # pylint: disable=broad-except
+        LOGGER.error(f"Failed to update broken links file for course {course_key}: {e}")
+
+
+def _get_original_url_from_updated_result(update_result, course_key):
+    """
+    Reconstruct the original URL from an update result.
+
+    Args:
+        update_result: The update result containing new_url and other info
+        course_key: The current course key
+
+    Returns:
+        str: The original URL before update, or None if it cannot be determined
+    """
+    try:
+        new_url = update_result.get("new_url", "")
+        if not new_url or str(course_key) not in new_url:
+            return None
+
+        prev_run_course_key = get_previous_run_course_key(course_key)
+        if not prev_run_course_key:
+            return None
+
+        return new_url.replace(str(course_key), str(prev_run_course_key))
+
+    except Exception as e:  # pylint: disable=broad-except
+        LOGGER.debug(
+            f"Failed to reconstruct original URL from update result: {e}"
+        )
+        return None
+
+
+def _update_result_applies_to_block(result_entry, block_id):
+    """
+    Determine if a given update result applies to a specific broken-link block id.
+
+    The task update results contain a 'type' and an 'id' indicating where the
+    replacement was applied. A single URL may appear in multiple places (course
+    content, course_updates, handouts, custom pages). We should only apply the
+    replacement to broken-link entries that match the same target area.
+    """
+    try:
+        result_type = (result_entry.get("type") or "course_content").lower()
+        result_id = result_entry.get("id")
+        block_id_str = str(block_id) if block_id is not None else ""
+        result_id_str = str(result_id) if result_id is not None else None
+
+        if result_id_str and block_id_str == result_id_str:
+            return True
+
+        is_course_info = "course_info" in block_id_str
+        is_updates_section = "updates" in block_id_str
+        is_handouts_section = "handouts" in block_id_str
+        is_static_tab = "static_tab" in block_id_str
+
+        block_category = (
+            "course_updates" if is_course_info and is_updates_section else
+            "handouts" if is_course_info and is_handouts_section else
+            "custom_pages" if is_static_tab else
+            "course_content"
+        )
+
+        return block_category == result_type
+    except Exception:  # pylint: disable=broad-except
+        return False

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -669,7 +669,7 @@ def use_legacy_logged_out_home():
 #   after creating a course rerun.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2025-07-21
-# .. toggle_target_removal_date: None
+# .. toggle_target_removal_date: 2026-02-25
 ENABLE_COURSE_OPTIMIZER_CHECK_PREV_RUN_LINKS = CourseWaffleFlag(
     f'{CONTENTSTORE_NAMESPACE}.enable_course_optimizer_check_prev_run_links',
     __name__,


### PR DESCRIPTION
## Description

This update introduces new functionality to the **Course Optimizer** page and enhances the **Previous Run Link** feature.  
It includes new API endpoints for updating and checking the status of previous course links.

---

## API Endpoints

#### 1. Update Previous Course Link (Celery Task)

**Endpoint:**  `POST /api/contentstore/v0/rerun_link_update/{course_id}`

- Updates previous course link(s) to the new course link(s)
- Accepts a POST request with `action` and `data`.
- Returns the update status in the response.

---

#### 2. Check Status of Update Previous Course Link Task
**Endpoint:**  `GET /api/contentstore/v0/rerun_link_update_status/{course_id}`

- Checks and returns the status of the update for the previous course link(s).
- If status is `"Succeeded"`, returns the updated course link(s).
- If an error occurs, returns an error message.

---

## Jira

- https://2u-internal.atlassian.net/browse/TNL2-139
- https://2u-internal.atlassian.net/browse/TNL2-142
---

## Related PR

- [37104](https://github.com/openedx/edx-platform/pull/37104)
---

## Testing Instructions

- Create a course re-run and verify a `CourseRerunState` record is created.
- Add links pointing to the original course in content, updates, handouts, and custom pages.
- Run the Course Optimizer and ensure these links are marked as previous-run.
- Use the "Update All" or specific update option via Studio UI or directly call the API.
- After calling the POST API, verify the GET API returns updated links or relevant errors.
- Run the optimizer again and confirm the updated links are no longer detected.