### PR TITLE
feat: Top-level parent logic in `UpstreamLink.ready_to_sync` [FC-0097]

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v2/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/urls.py
@@ -13,23 +13,10 @@ urlpatterns = [
         home.HomePageCoursesViewV2.as_view(),
         name="courses",
     ),
-    # TODO: Rename this to `downstreams/` after full deprecate `DownstreamComponentsListView`
-    re_path(
-        r'^downstreams-all/$',
-        downstreams.DownstreamListView.as_view(),
-        name="downstreams_list_all",
-    ),
-    # [DEPRECATED], use `downstreams-all/` instead.
     re_path(
         r'^downstreams/$',
-        downstreams.DownstreamComponentsListView.as_view(),
+        downstreams.DownstreamListView.as_view(),
         name="downstreams_list",
-    ),
-    # [DEPRECATED], use `downstreams-all/` instead.
-    re_path(
-        r'^downstream-containers/$',
-        downstreams.DownstreamContainerListView.as_view(),
-        name="container_downstreams_list",
     ),
     re_path(
         fr'^downstreams/{settings.USAGE_KEY_PATTERN}$',

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -43,10 +43,12 @@ def _get_upstream_link_good_and_syncable(downstream):
     return UpstreamLink(
         upstream_ref=downstream.upstream,
         upstream_key=UsageKey.from_string(downstream.upstream),
+        downstream_key=str(downstream.usage_key),
         version_synced=downstream.upstream_version,
         version_available=(downstream.upstream_version or 0) + 1,
         version_declined=downstream.upstream_version_declined,
         error_message=None,
+        has_top_level_parent=False,
     )
 
 
@@ -582,7 +584,7 @@ class GetUpstreamViewTest(
             data["item_type"] = str(item_type)
         if use_top_level_parents is not None:
             data["use_top_level_parents"] = str(use_top_level_parents)
-        return self.client.get("/api/contentstore/v2/downstreams-all/", data=data)
+        return self.client.get("/api/contentstore/v2/downstreams/", data=data)
 
     def test_200_all_downstreams_for_a_course(self):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- Updates `UpstreamLink.ready_to_sync` with the top-level parent logic: In a container, `ready_to_sync` is `True` if the container or any children have changes.
- Updates `decline_sync` to decline children recursively.
- Which edX user roles will this change impact? "Course Author",
"Developer".

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2166
- Used in https://github.com/openedx/frontend-app-authoring/pull/2324
- Internal ticket: [FAL-4228](https://tasks.opencraft.com/browse/FAL-4228)

## Testing instructions

Follow the testing instructions in https://github.com/openedx/frontend-app-authoring/pull/2324

## Deadline

None

## Other information

N/A