### PR TITLE
fix: model instances passed to related filters must be save

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -517,6 +517,10 @@ def get_group_info_for_cohort(cohort, use_cached=False):
 
     If the cohort has not been linked to any group/partition, both values in the
     tuple will be None.
+
+    The partition group info is cached for the duration of a request. Pass
+    use_cached=True to use the cached value instead of fetching from the
+    database.
     """
     cohort_id = getattr(cohort, "id", None) if not isinstance(cohort, int) else cohort
     cache = RequestCache("cohorts.get_group_info_for_cohort").data

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -40,8 +40,8 @@ class CohortFactory(DjangoModelFactory):
                     user.save()
                 saved_users.append(user)
 
-            self.users.add(*saved_users) # lint-amnesty, pylint: disable=no-member
-            for user in saved_users: # lint-amnesty, pylint: disable=no-member
+            self.users.add(*saved_users)  # lint-amnesty, pylint: disable=no-member
+            for user in saved_users:  # lint-amnesty, pylint: disable=no-member
                 CohortMembership.objects.create(
                     user=user,
                     course_user_group=self,

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -34,13 +34,18 @@ class CohortFactory(DjangoModelFactory):
         Returns the users associated with the cohort.
         """
         if extracted:
-            self.users.add(*extracted)  # lint-amnesty, pylint: disable=no-member
-            for user in self.users.all():  # lint-amnesty, pylint: disable=no-member
+            saved_users = []
+            for user in extracted:
+                if user.pk is None:  # unsaved
+                    user.save()
+                saved_users.append(user)
+
+            self.users.add(*saved_users)
+            for user in saved_users:
                 CohortMembership.objects.create(
                     user=user,
                     course_user_group=self,
                 )
-
 
 class CourseCohortFactory(DjangoModelFactory):
     """

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -40,12 +40,13 @@ class CohortFactory(DjangoModelFactory):
                     user.save()
                 saved_users.append(user)
 
-            self.users.add(*saved_users)
-            for user in saved_users:
+            self.users.add(*saved_users) # lint-amnesty, pylint: disable=no-member
+            for user in saved_users: # lint-amnesty, pylint: disable=no-member
                 CohortMembership.objects.create(
                     user=user,
                     course_user_group=self,
                 )
+
 
 class CourseCohortFactory(DjangoModelFactory):
     """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

openedx/core/djangoapps/course_groups/tests/test_cohorts.py::TestCohortsAndPartitionGroups::test_delete_cascade - ValueError: Model instances passed to related filters must be saved


## Supporting information

Ticket: https://github.com/openedx/edx-platform/issues/37202

## Testing instructions

`pytest openedx/core/djangoapps/course_groups/tests/test_cohorts.py::TestCohortsAndPartitionGroups::test_delete_cascade`