### PR TITLE
feat!: Allow use of manage.py without specifying lms or cms

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1326,9 +1326,7 @@ WEBPACK_LOADER = {
 
 ############################ SERVICE_VARIANT ##################################
 
-# SERVICE_VARIANT specifies name of the variant used, which decides what JSON
-# configuration files are read during startup.
-SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', 'cms')
+SERVICE_VARIANT = "cms"
 
 # CONFIG_PREFIX specifies the prefix of the JSON configuration files,
 # based on the service variant. If no variant is use, don't use a

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2670,10 +2670,7 @@ CELERY_SEND_TASK_SENT_EVENT = True
 CELERY_DEFAULT_EXCHANGE = 'edx.core'
 CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
 
-
-# SERVICE_VARIANT specifies name of the variant used, which decides what JSON
-# configuration files are read during startup.
-SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', "lms")
+SERVICE_VARIANT = "lms"
 
 # CONFIG_PREFIX specifies the prefix of the JSON configuration files,
 # based on the service variant. If no variant is use, don't use a

--- a/lms/wsgi_apache_lms.py
+++ b/lms/wsgi_apache_lms.py
@@ -11,8 +11,7 @@ defuse_xml_libs()
 
 import os  # lint-amnesty, pylint: disable=wrong-import-order, wrong-import-position
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lms.envs.aws")
-os.environ.setdefault("SERVICE_VARIANT", "lms")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lms.envs.production")
 
 # This application object is used by the development server
 # as well as any WSGI server configured to use this file.

--- a/manage.py
+++ b/manage.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python
 """
-Usage: manage.py {lms|cms} [--settings env] ...
+Django administration utility.
 
-Run django management commands. Because edx-platform contains multiple django projects,
-the first argument specifies which project to run (cms [Studio] or lms [Learning Management System]).
+Standard idiomatic Django usage:
 
-By default, those systems run in with a settings file appropriate for development. However,
-by passing the --settings flag, you can specify what environment specific settings file to use.
+    DJANGO_SETTINGS_MODULE=lms.envs.production ./manage.py COMMAND ARGS...
+    DJANGO_SETTINGS_MODULE=cms.envs.production ./manage.py COMMAND ARGS...
 
-Any arguments not understood by this manage.py will be passed to django-admin.py
+Legacy usage:
+
+    ./manage.py lms [--settings=production] COMMAND ARGS...
+    ./manage.py cms [--settings=production] COMMAND ARGS...
 """
 # pylint: disable=wrong-import-order, wrong-import-position
 
@@ -24,76 +26,93 @@ import sys
 from argparse import ArgumentParser
 
 
-def parse_args():
-    """Parse edx specific arguments to manage.py"""
-    parser = ArgumentParser()
-    subparsers = parser.add_subparsers(title='system', description='edX service to run')
+def main():
+    """
+    Call the management command.
 
-    lms = subparsers.add_parser(
-        'lms',
-        help='Learning Management System',
-        add_help=False,
-        usage='%(prog)s [options] ...'
+    Convert from legacy style into standard idiomatic django style if necessary.
+    """
+
+    env_settings_module = os.environ.get("DJANGO_SETTINGS_MODULE")
+
+    # Final args and settings: We'll determine these based on whether we're using legacy usage or the new usage...
+    final_settings_module: str
+    final_args: list[str]
+
+    if len(sys.argv) > 1 and sys.argv[1] in ["lms", "cms"]:
+        # LEGACY USAGE:
+        # The first arg after 'manage.py' is the service_variant, either 'lms' or 'cms'.
+        # Additionally, the '--settings' flag may be provided, which points to module within {service_variant}.envs.
+        # We remove both service_variant and --settings, but use them to determine a DJANGO_SETTINGS_MODULE.
+        # For example:
+        #    ./manage.py cms migrate --foo bar --settings blah --baz quux
+        # Gets converted to:
+        #    DJANGO_SETTINGS_MODULE=cms.envs.blah ./manage.py migrate --foo bar --baz quux
+        manage_py = sys.argv[0]  # ./manage.py, manage.py, or path/to/manage.py
+        service_variant = sys.argv[1]  # lms or cms
+        settings_and_management_args = sys.argv[2:]  # everything else
+
+        # Parse --settings, if it's there.
+        parse_settings_module = ArgumentParser()
+        parse_settings_module.add_argument(
+            '--settings',
+            help=(
+                f"Which django settings module to use under {service_variant}.envs. "
+                f"If unspecified, will default to {service_variant}.envs.devstack."
+            ),
+        )
+        settings_arg, management_args = parse_settings_module.parse_known_args(settings_and_management_args)
+
+        # Compute final args and settings.
+        # Order of precedence: --settings, $DJANGO_SETTINGS_MODULE, $EDX_PLATFORM_SETTINGS, devstack
+        final_settings_module = (
+            f"{service_variant}.envs.{settings_arg.settings}"
+            if settings_arg.settings
+            else (
+                f"{service_variant}.envs.{env_settings_name}"
+                if (env_settings_name := os.environ.get("EDX_PLATFORM_SETTINGS")) and not env_settings_module
+                else (
+                    env_settings_module
+                    if env_settings_module
+                    else f"{service_variant}.envs.devstack"
+                )
+            )
+        )
+        final_args = [manage_py, *management_args]
+
+    else:
+        # STANDARD IDIOMATIC DJANGO USAGE (new):
+        # The first arg after 'manage.py' is a management command... anything other than 'lms' or 'cms'.
+        # The '--settings' flag is not accepted.
+        # Instead, operators can use the DJANGO_SETTINGS_MODULE variable, which default to LMS devstack settings.
+        # For example:
+        #    DJANGO_SETTINGS_MODULE=cms.envs.blah ./manage.py migrate --foo bar --baz quux
+        final_settings_module = env_settings_module or "lms.envs.devstack"
+        final_args = sys.argv
+
+    # The rest of this is just standard Django boilerplate.
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other exceptions.
+        try:
+            import django  # pylint: disable=unused-import, wrong-import-position
+        except ImportError as import_error:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            ) from import_error
+        raise
+
+    print(
+        f"{final_args[0]}: Effective DJANGO_SETTINGS_MODULE == \"{final_settings_module}\"",
+        file=sys.stderr
     )
-    lms.add_argument('-h', '--help', action='store_true', help='show this help message and exit')
-    lms.add_argument(
-        '--settings',
-        help="Which django settings module to use under lms.envs. If not provided, the DJANGO_SETTINGS_MODULE "
-             "environment variable will be used if it is set, otherwise it will default to lms.envs.devstack")
-    lms.add_argument(
-        '--service-variant',
-        choices=['lms', 'lms-xml', 'lms-preview'],
-        default='lms',
-        help='Which service variant to run, when using the production environment')
-    lms.set_defaults(
-        help_string=lms.format_help(),
-        settings_base='lms/envs',
-        default_settings='lms.envs.devstack',
-    )
-
-    cms = subparsers.add_parser(
-        'cms',
-        help='Studio',
-        add_help=False,
-        usage='%(prog)s [options] ...'
-    )
-    cms.add_argument(
-        '--settings',
-        help="Which django settings module to use under cms.envs. If not provided, the DJANGO_SETTINGS_MODULE "
-             "environment variable will be used if it is set, otherwise it will default to cms.envs.devstack")
-    cms.add_argument('-h', '--help', action='store_true', help='show this help message and exit')
-    cms.set_defaults(
-        help_string=cms.format_help(),
-        settings_base='cms/envs',
-        default_settings='cms.envs.devstack',
-        service_variant='cms',
-    )
-
-    edx_args, django_args = parser.parse_known_args()
-
-    if edx_args.help:
-        print("edX:")
-        print(edx_args.help_string)
-
-    return edx_args, django_args
+    os.environ["DJANGO_SETTINGS_MODULE"] = final_settings_module
+    execute_from_command_line(final_args)
 
 
 if __name__ == "__main__":
-    edx_args, django_args = parse_args()
-
-    edx_args_base = edx_args.settings_base.replace('/', '.') + '.'
-    if edx_args.settings:
-        os.environ["DJANGO_SETTINGS_MODULE"] = edx_args_base + edx_args.settings
-    elif os.environ.get("EDX_PLATFORM_SETTINGS") and not os.environ.get("DJANGO_SETTINGS_MODULE"):
-        os.environ["DJANGO_SETTINGS_MODULE"] = edx_args_base + os.environ["EDX_PLATFORM_SETTINGS"]
-
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", edx_args.default_settings)
-    os.environ.setdefault("SERVICE_VARIANT", edx_args.service_variant)
-
-    if edx_args.help:
-        print("Django:")
-        # This will trigger django-admin.py to print out its help
-        django_args.append('--help')
-
-    from django.core.management import execute_from_command_line
-    execute_from_command_line([sys.argv[0]] + django_args)
+    main()

--- a/openedx/core/djangoapps/content/course_overviews/management/commands/simulate_publish.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/simulate_publish.py
@@ -15,11 +15,11 @@ behavior to trigger the necessary data updates.
 
 import copy
 import logging
-import os
 import sys
 import textwrap
 import time
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -38,13 +38,13 @@ class Command(BaseCommand):
     # seconds between courses. We might use a delay like this to make sure we
     # don't flood the queue and unnecessarily delay normal publishing via
     # Studio.
-    $ ./manage.py lms --settings=devstack_docker simulate_publish --delay 10
+    $ ./manage.py lms --settings=devstack simulate_publish --delay 10
 
     # Find all available listeners
-    $ ./manage.py lms --settings=devstack_docker simulate_publish --show_receivers
+    $ ./manage.py lms --settings=devstack simulate_publish --show_receivers
 
     # Send the publish signal to two courses and two listeners
-    $ ./manage.py lms --settings=devstack_docker simulate_publish --receivers \
+    $ ./manage.py lms --settings=devstack simulate_publish --receivers \
     openedx.core.djangoapps.content.course_overviews.signals._listen_for_course_publish \
     openedx.core.djangoapps.bookmarks.signals.trigger_update_xblocks_cache_task \
     --courses course-v1:edX+DemoX+Demo_Course edX/MODULESTORE_100/2018
@@ -189,14 +189,13 @@ class Command(BaseCommand):
             options['delay']
         )
 
-        if os.environ.get('SERVICE_VARIANT', 'cms').startswith('lms'):
+        if settings.SERVICE_VARIANT == "lms":
             if options['force_lms']:
                 log.info("Forcing simulate_publish to run in LMS process.")
             else:
                 log.fatal(  # lint-amnesty, pylint: disable=logging-not-lazy
                     "simulate_publish should be run as a CMS (Studio) " +
-                    "command, not %s (override with --force-lms).",
-                    os.environ.get('SERVICE_VARIANT')
+                    "command, not LMS (override with --force-lms).",
                 )
                 sys.exit(1)
 

--- a/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_simulate_publish.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_simulate_publish.py
@@ -9,6 +9,7 @@ import lms.djangoapps.ccx.tasks
 import openedx.core.djangoapps.content.course_overviews.signals
 from openedx.core.djangoapps.content.course_overviews.management.commands.simulate_publish import Command, name_from_fn
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview, SimulateCoursePublishConfig
+from openedx.core.djangolib.testing.utils import skip_unless_cms
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import SwitchedSignal  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
@@ -17,6 +18,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 LOGGER_NAME = 'simulate_publish'
 
 
+@skip_unless_cms
 class TestSimulatePublish(SharedModuleStoreTestCase):
     """Test simulate_publish, our fake course-publish signal command."""
 


### PR DESCRIPTION
## Description

The lms or cms argument is redundant because operators should always set the DJANGO_SETTINGS_MODULE, and this settings module module should always set SERVICE_VARIANT to "lms" or "cms". So, we can just omit lms/cms, and allow operators to call manage.py like they would in any other idiomatic django project.

For backwards compatibility, it is still supported to specify lms or cms explicitly.

New style:

    DJANGO_SETTINGS_MODULE=cms.envs.blah ./manage.py migrate --foo=bar --baz=quux

Old style (still supported):

    ./manage.py cms  --foo=bar --settings=blah migrate --baz=quux

BREAKING CHANGE: Reading from or writing to the SERVICE_VARIANT environment variable is no longer supported. To determine the service variant, look at the SERVICE_VARIANT django setting. To specify the service variant, point Django to a DJANGO_SETTINGS_MODULE which defines SERVICE_VARIANT as "lms" or "cms".


## Testing instructions

I tested this by calling `./manage.py ...` with a variety of arguments and `DJANGO_SETTINGS_MODULE` values and observing the what the logged "Effective DJANGO_SETTINGS_MODULE" is.

```bash
# New style, specifying custom LMS dev settings
DJANGO_SETTINGS_MODULE=lms.envs.tutor.development ./manage.py ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "lms.envs.tutor.development"
...

# New style, specifying custom CMS prod settings
DJANGO_SETTINGS_MODULE=cms.envs.tutor.production ./manage.py ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "cms.envs.tutor.production"
...

# New style, no settings specified, so LMS devstack settings are used
unset DJANGO_SETTINGS_MODULE && ./manage.py ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "lms.envs.devstack"
...

# Old style with cms, no settings specified, so CMS test settings are used
unset DJANGO_SETTINGS_MODULE && ./manage.py cms ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "cms.envs.test"
...

# Old style with lms, built-in devstack settings specified
unset DJANGO_SETTINGS_MODULE && ./manage.py lms --settings devstack ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "lms.envs.devstack"
...

# Old style with lms, built-in production settings specified using env var
unset DJANGO_SETTINGS_MODULE && EDX_PLATFORM_SETTINGS=production ./manage.py lms ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "lms.envs.devstack"
...

# Old style with lms, built-in devstack settings specified, which takes precedence over DJANGO_SETTINGS_MODULE
DJANGO_SETTINGS_MODULE=cms.envs.tutor.production ./manage.py lms --settings devstack ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "lms.envs..devstack"
...

# Old style with lms, but DJANGO_SETTINGS_MODULE takes precedence over EDX_PLATFORM_SETTINGS 
DJANGO_SETTINGS_MODULE=cms.envs.tutor.production  EDX_PLATFORM_SETTINGS=production ./manage.py lms ...
./manage.py: Effective DJANGO_SETTINGS_MODULE == "cms.envs.tutor.production"
...

```

## Deadline

No urgency

## Other information

This is tangentially related to [the effort to simplify edx-platform settings](https://github.com/openedx/edx-platform/issues/36215).

In the future, it would be reasonable to update the default DJANGO_SETTINGS_MODULE to something other than lms.envs.devstack. It seems that the default django manage.py defaults to test settings, so maybe lms.envs.test. I decided to keep that change separate from this PR.