### PR TITLE
fix: Passing unsaved model instances to related filters is no longer …

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -523,7 +523,7 @@ def get_group_info_for_cohort(cohort, use_cached=False):
     database.
     """
     if cohort.pk is None:
-        # Object not saved yet, skip caching
+        # Cohort not saved yet, so no PartitionGroup can be linked to it.
         return (None, None)
 
     cache = RequestCache("cohorts.get_group_info_for_cohort").data

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -522,6 +522,10 @@ def get_group_info_for_cohort(cohort, use_cached=False):
     use_cached=True to use the cached value instead of fetching from the
     database.
     """
+    if cohort.pk is None:
+        # Object not saved yet, skip caching
+        return (None, None)
+
     cache = RequestCache("cohorts.get_group_info_for_cohort").data
     cache_key = str(cohort.id)
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.0/releases/5.0/

Passing unsaved model instances to related filters is no longer allowed.

issue = https://github.com/openedx/edx-platform/issues/37202


```
(Pdb) cache_key = str(cohort.id)
(Pdb) cache_key
'None'
-> try:
> /edx/app/edxapp/edx-platform/openedx/core/djangoapps/course_groups/cohorts.py(535)get_group_info_for_cohort()
-> partition_group = CourseUserGroupPartitionGroup.objects.get(course_user_group=cohort)
ValueError: Model instances passed to related filters must be saved.
```

On django42 it returns does not found exception.