### PR TITLE
feat: look up remote_id by remote_id_field_name

### DIFF
--- a/common/djangoapps/third_party_auth/api/serializers.py
+++ b/common/djangoapps/third_party_auth/api/serializers.py
@@ -20,4 +20,7 @@ class UserMappingSerializer(serializers.Serializer):  # pylint: disable=abstract
 
     def get_remote_id(self, social_user):
         """ Gets remote id from social user based on provider """
+        remote_id_field_name = self.context.get('remote_id_field_name', None)
+        if remote_id_field_name:
+            return self.provider.get_remote_id_from_field_name(social_user, remote_id_field_name)
         return self.provider.get_remote_id_from_social_auth(social_user)

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -323,6 +323,9 @@ class UserMappingView(ListAPIView):
 
           GET /api/third_party_auth/v0/providers/{provider_id}/users?username={username1},{username2}
 
+          GET /api/third_party_auth/v0/providers/{provider_id}/users?username={username1}&
+            remote_id_field_name={external_id_field_name}
+
           GET /api/third_party_auth/v0/providers/{provider_id}/users?username={username1}&usernames={username2}
 
           GET /api/third_party_auth/v0/providers/{provider_id}/users?remote_id={remote_id1},{remote_id2}
@@ -345,6 +348,9 @@ class UserMappingView(ListAPIView):
 
         * usernames: Optional. List of comma separated edX usernames to filter the result set.
           e.g. ?usernames=bob123,jane456
+
+        * remote_id_field_name: Optional. The field name to use for the remote id lookup.
+          Useful when learners are coming from external LMS. e.g. ?remote_id_field_name=ext_userid_sf
 
         * page, page_size: Optional. Used for paging the result set, especially when getting
           an unfiltered list.
@@ -415,6 +421,7 @@ class UserMappingView(ListAPIView):
         remove idp_slug from the remote_id if there is any
         """
         context = super().get_serializer_context()
+        context['remote_id_field_name'] = self.request.query_params.get('remote_id_field_name', None)
         context['provider'] = self.provider
 
         return context

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -810,6 +810,17 @@ class SAMLProviderConfig(ProviderConfig):
         prefix = self.slug + ":"
         return self.backend_name == social_auth.provider and social_auth.uid.startswith(prefix)
 
+    def get_remote_id_from_field_name(self, social_auth, field_name):
+        """ Given a UserSocialAuth object, return the user remote ID against the field name provided. """
+        if not self.match_social_auth(social_auth):
+            raise ValueError(
+                f"UserSocialAuth record does not match given provider {self.provider_id}"
+            )
+        field_value = social_auth.extra_data.get(field_name, None)
+        if field_value and isinstance(field_value, list):
+            return field_value[0]
+        return field_value
+
     def get_remote_id_from_social_auth(self, social_auth):
         """ Given a UserSocialAuth object, return the remote ID used by this provider. """
         assert self.match_social_auth(social_auth)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR is about adding the ability for the third_party_auth endpoint `/api/third_party_auth/v0/providers/{provider_id}/users` to accept a new query param `remote_id_field_name` and use it for external user id lookup. This is essential for users coming from third party LMS to edX and provides flexibility to look up external User ID based on the field name provided. 

Follow-up PR: https://github.com/openedx/edx-enterprise/pull/2442

Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.
**JIRA**: https://2u-internal.atlassian.net/browse/ENT-10804

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
