### PR TITLE
Revert "chore: update @edx/brand dependency to new package @openedx/brand-openedx"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-object-assign": "^7.18.6",
         "@babel/preset-env": "^7.19.0",
         "@babel/preset-react": "7.26.3",
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+        "@edx/brand-edx.org": "^2.0.7",
         "@edx/edx-bootstrap": "1.0.4",
         "@edx/edx-proctoring": "^4.18.1",
         "@edx/frontend-component-cookie-policy-banner": "2.2.0",
@@ -1974,11 +1974,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/@edx/brand": {
-      "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
+    "node_modules/@edx/brand-edx.org": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.3.tgz",
+      "integrity": "sha512-1TwUwW7YVgvhh7aO1ql1poAosUCA0zd7/DNuqeSO0wXui0oCHL+WQW8b9tXS2tRJ5BMRKjG8t22fcOcKX3ljbg==",
+      "license": "UNLICENSED"
     },
     "node_modules/@edx/edx-bootstrap": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/plugin-transform-object-assign": "^7.18.6",
     "@babel/preset-env": "^7.19.0",
     "@babel/preset-react": "7.26.3",
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+    "@edx/brand-edx.org": "^2.0.7",
     "@edx/edx-bootstrap": "1.0.4",
     "@edx/edx-proctoring": "^4.18.1",
     "@edx/frontend-component-cookie-policy-banner": "2.2.0",


### PR DESCRIPTION
Reverts openedx/edx-platform#37105

Faced the issue on stage build which needs to be resolved 

```
npm notice
npm notice New major version of npm available! 10.7.0 -> 11.5.2
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.5.2
npm notice To update run: npm install -g npm@11.5.2
npm notice
rtlcss: Warning! No config present, using defaults.
rtlcss: Warning! No config present, using defaults.
rtlcss: Warning! No config present, using defaults.
rtlcss: Warning! No config present, using defaults.
rtlcss: Warning! No config present, using defaults.
rtlcss: Warning! No config present, using defaults.
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/scripts/compile_sass.py", line 451, in <module>
    main(prog_name="npm run compile-sass --")
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/scripts/compile_sass.py", line 373, in main
    compile_sass_dir(
  File "/edx/app/edxapp/edx-platform/scripts/compile_sass.py", line 252, in compile_sass_dir
    raise Exception(f"Failed to compile {source}: {output_text}")
Exception: Failed to compile lms/static/sass/lms-mobile-rtl.scss: Error: File to import not found or unreadable: brand-edx.org/paragon/fonts
       Parent style sheet: /edx/var/edx-themes/edx-themes/edx-platform/edx.org-next/lms/static/sass/partials/lms/theme/_variables.scss
        on line 4 of ../../../var/edx-themes/edx-themes/edx-platform/edx.org-next/lms/static/sass/partials/lms/theme/_variables.scss
>> @import 'brand-edx.org/paragon/fonts';
   ^
```