### PR TITLE
fix: upgrade django-simple-history

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -141,3 +141,6 @@ xmlsec==1.3.14
 # https://github.com/django-commons/django-debug-toolbar/issues/2172
 # Pin this back to the previous version until that bug is fixed.
 django-debug-toolbar<6.0.0
+
+# incremental upgrade plan.
+django-simple-history>=3.10.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -342,7 +342,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/bundled.in
-django-simple-history==3.8.0
+django-simple-history==3.10.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -563,7 +563,7 @@ django-ses==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-django-simple-history==3.8.0
+django-simple-history==3.10.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -414,7 +414,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.8.0
+django-simple-history==3.10.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -440,7 +440,7 @@ django-sekizai==4.1.0
     #   openedx-django-wiki
 django-ses==4.4.0
     # via -r requirements/edx/base.txt
-django-simple-history==3.8.0
+django-simple-history==3.10.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION


## Description

Upgrade django-simple-history to the latest version to fix `django.db.utils.IntegrityError`

[37146](https://github.com/openedx/edx-platform/issues/37146)
