### PR TITLE
feat: reindex course and recreate upstream links post import and course re-run

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -23,6 +23,7 @@ from openedx_events.content_authoring.data import (
 from openedx_events.content_authoring.signals import (
     COURSE_CATALOG_INFO_CHANGED,
     COURSE_IMPORT_COMPLETED,
+    COURSE_RERUN_COMPLETED,
     LIBRARY_BLOCK_DELETED,
     LIBRARY_CONTAINER_DELETED,
     XBLOCK_CREATED,
@@ -304,10 +305,10 @@ def delete_upstream_downstream_link_handler(**kwargs):
     ).delete()
 
 
-@receiver(COURSE_IMPORT_COMPLETED)
-def handle_new_course_import(**kwargs):
+@receiver([COURSE_IMPORT_COMPLETED, COURSE_RERUN_COMPLETED])
+def handle_upstream_links_on_signal(**kwargs):
     """
-    Automatically create upstream->downstream links for course in database on new import.
+    Automatically create upstream->downstream links for course in database on new import or rerun.
     """
     course_data = kwargs.get("course", None)
     if not course_data or not isinstance(course_data, CourseData):

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -18,7 +18,7 @@ from meilisearch import Client as MeilisearchClient
 from meilisearch.errors import MeilisearchApiError, MeilisearchError
 from meilisearch.models.task import TaskInfo
 from opaque_keys import OpaqueKey
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import (
     LibraryCollectionLocator,
     LibraryContainerLocator,
@@ -397,6 +397,32 @@ def init_index(status_cb: Callable[[str], None] | None = None, warn_cb: Callable
     reset_index(status_cb)
 
 
+def index_course(course_key: CourseKey) -> list:
+    """
+    Rebuilds the index for a given course.
+    """
+    store = modulestore()
+    client = _get_meilisearch_client()
+    docs = []
+    # Pre-fetch the course with all of its children:
+    course = store.get_course(course_key, depth=None)
+
+    def add_with_children(block):
+        """ Recursively index the given XBlock/component """
+        doc = searchable_doc_for_course_block(block)
+        doc.update(searchable_doc_tags(block.usage_key))
+        docs.append(doc)  # pylint: disable=cell-var-from-loop
+        _recurse_children(block, add_with_children)  # pylint: disable=cell-var-from-loop
+
+    # Index course children
+    _recurse_children(course, add_with_children)
+
+    if docs:
+        # Add all the docs in this course at once (usually faster than adding one at a time):
+        _wait_for_meili_task(client.index(STUDIO_INDEX_NAME).add_documents(docs))
+    return docs
+
+
 def rebuild_index(status_cb: Callable[[str], None] | None = None, incremental=False) -> None:  # lint-amnesty, pylint: disable=too-many-statements
     """
     Rebuild the Meilisearch index from scratch
@@ -405,7 +431,6 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None, incremental=Fa
         status_cb = log.info
 
     client = _get_meilisearch_client()
-    store = modulestore()
 
     # Get the lists of libraries
     status_cb("Counting libraries...")
@@ -559,26 +584,6 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None, incremental=Fa
         status_cb("Indexing courses...")
         # To reduce memory usage on large instances, split up the CourseOverviews into pages of 1,000 courses:
 
-        def index_course(course: CourseOverview) -> list:
-            docs = []
-            # Pre-fetch the course with all of its children:
-            course = store.get_course(course.id, depth=None)
-
-            def add_with_children(block):
-                """ Recursively index the given XBlock/component """
-                doc = searchable_doc_for_course_block(block)
-                doc.update(searchable_doc_tags(block.usage_key))
-                docs.append(doc)  # pylint: disable=cell-var-from-loop
-                _recurse_children(block, add_with_children)  # pylint: disable=cell-var-from-loop
-
-            # Index course children
-            _recurse_children(course, add_with_children)
-
-            if docs:
-                # Add all the docs in this course at once (usually faster than adding one at a time):
-                _wait_for_meili_task(client.index(index_name).add_documents(docs))
-            return docs
-
         paginator = Paginator(CourseOverview.objects.only('id', 'display_name'), 1000)
         for p in paginator.page_range:
             for course in paginator.page(p).object_list:
@@ -588,7 +593,7 @@ def rebuild_index(status_cb: Callable[[str], None] | None = None, incremental=Fa
                 if course.id in keys_indexed:
                     num_contexts_done += 1
                     continue
-                course_docs = index_course(course)
+                course_docs = index_course(course.id)
                 if incremental:
                     IncrementalIndexCompleted.objects.get_or_create(context_key=course.id)
                 num_contexts_done += 1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -833,7 +833,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/kernel.in
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1387,7 +1387,7 @@ openedx-django-wiki==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1009,7 +1009,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1055,7 +1055,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Index the newly created course after import and course re-run. Also recreate upstream links after course re-run.

We make use of newly created `COURSE_RERUN_COMPLETED` signal to run post re-run processes.

*We were already creating upstream links after course imports but the course was not being properly indexed in meilisearch, specifically the index was missing section info.*

Useful information to include:

- Which edX user roles will this change impact? : "Learner" and "Course Author".

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2361
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4245
* **Depends on:** https://github.com/openedx/openedx-events/pull/521

## Testing instructions

* Checkout https://github.com/openedx/openedx-events/pull/521 if openedx-events is locally checked out and mounted in tutor, else just run `tutor images build openedx-dev && tutor dev launch -I --skip-build`.
* Create a library with some components and containers.
* Create a course, import some components from the library.
* Update imported component in library and publish.
* Verify that you can see update in `Library Updates` page in the course.
* Now export this course and import it in another course. Verify that you can see the same update in `Library Updates` page.
* Also verify that the course is indexed in meilisearch, you can use course search option here.
* Now Go to studio home page and click on three dots button of the first course and click on `Re-run course`.
* Verify the upstream links and course index for this newly created re-run course.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
