### PR TITLE
feat: removed spaces check for spam urls

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -155,13 +155,6 @@ def filter_spam_urls_from_html(html_string):
         escaped = domain.replace(".", r"\.")
         domain_pattern = rf"(\w+\.)*{escaped}(?:/\S*)*"
         patterns.append(re.compile(rf"(https?://)?{domain_pattern}", re.IGNORECASE))
-        spaced_parts = list(domain)
-        spaced_pattern = "".join(
-            rf"{re.escape(char)}(?:\s|&nbsp;|\u00A0)*" if char != "." else r"\.(?:\s|&nbsp;|\u00A0)*"
-            for char in spaced_parts
-        )
-        spaced_pattern += r"(?:\/(?:\s|&nbsp;|\u00A0|\w)*)*"
-        patterns.append(re.compile(spaced_pattern, re.IGNORECASE))
 
     for a_tag in soup.find_all("a", href=True):
         href = a_tag.get('href')

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -1130,7 +1130,3 @@ class FilterSpamTest(SharedModuleStoreTestCase):
             filter_spam_urls_from_html('<div>example.com/abc/def</div>')[0],
             '<div></div>'
         )
-        self.assertEqual(
-            filter_spam_urls_from_html('<div>e x a m p l e . c o m / a b c / d e f</div>')[0],
-            '<div></div>'
-        )


### PR DESCRIPTION
Discussion content will be marked as spam for exact url match. If url contains spaces, it will not be marked as spam

for `example.com` as spam domain

### Old behavior:
`example.com/dasdas`
`e x a m p l e . c o m`
These were both spam

### New behavior:
`example.com/dasdas` will be marked as spam whereas `e x a m p l e . c o m / d a s d a s` will not be marked as spam