### PR TITLE
feat: Add DOI-specific headers for link validation

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -12,6 +12,7 @@ import tarfile
 from datetime import datetime, timezone
 from importlib.metadata import entry_points
 from tempfile import NamedTemporaryFile, mkdtemp
+from urllib.parse import urlparse
 
 import aiohttp
 import olxcleaner
@@ -34,7 +35,7 @@ from olxcleaner.exceptions import ErrorLevel
 from olxcleaner.reporting import report_error_summary, report_errors
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryContainerLocator, LibraryLocator, BlockUsageLocator
+from opaque_keys.edx.locator import BlockUsageLocator, LibraryContainerLocator, LibraryLocator
 from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 from organizations.models import Organization
@@ -54,16 +55,16 @@ from cms.djangoapps.contentstore.toggles import enable_course_optimizer_check_pr
 from cms.djangoapps.contentstore.utils import (
     IMPORTABLE_FILE_TYPES,
     contains_previous_course_reference,
-    get_previous_run_course_key,
+    create_course_info_usage_key,
     create_or_update_xblock_upstream_link,
     delete_course,
+    get_previous_run_course_key,
     initialize_permissions,
     reverse_usage_url,
     translation_language
 )
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import get_block_info
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
-from cms.djangoapps.contentstore.utils import create_course_info_usage_key
 from common.djangoapps.course_action_state.models import CourseRerunState
 from common.djangoapps.static_replace import replace_static_urls
 from common.djangoapps.student.auth import has_course_author_access
@@ -112,6 +113,18 @@ DEFAULT_HEADERS = {
     ),
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     "Connection": "keep-alive",
+}
+
+# DOI-specific headers
+DOI_HEADERS = {
+    "User-Agent": DEFAULT_HEADERS["User-Agent"],
+    "Accept": "application/vnd.citationstyles.csl+json",
+    "Connection": "keep-alive",
+}
+
+# Domain-specific header mapping
+DOMAIN_HEADERS = {
+    "doi.org": DOI_HEADERS,
 }
 
 
@@ -1426,7 +1439,7 @@ async def _validate_urls_access_in_batches(url_list, course_key, batch_size=100)
 
 async def _validate_batch(batch, course_key):
     """Validate a batch of URLs"""
-    async with aiohttp.ClientSession(headers=DEFAULT_HEADERS) as session:
+    async with aiohttp.ClientSession() as session:
         tasks = [_validate_url_access(session, url_data, course_key) for url_data in batch]
         batch_results = await asyncio.gather(*tasks)
         return batch_results
@@ -1454,8 +1467,17 @@ async def _validate_url_access(session, url_data, course_key):
     url = url.strip()  # Trim leading/trailing whitespace
     result = {'block_id': block_id, 'url': url}
     standardized_url = _convert_to_standard_url(url, course_key)
+
     try:
-        async with session.get(standardized_url, timeout=5) as response:
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower()
+        headers = DOMAIN_HEADERS.get(domain, DEFAULT_HEADERS)
+    except Exception as e:  # lint-amnesty, pylint: disable=broad-except
+        LOGGER.debug(f'[Link Check] Error parsing URL {url}: {str(e)}')
+        headers = DEFAULT_HEADERS
+
+    try:
+        async with session.get(standardized_url, headers=headers, timeout=5) as response:
             result.update({'status': response.status})
     except Exception as e:  # lint-amnesty, pylint: disable=broad-except
         result.update({'status': None})


### PR DESCRIPTION
### Description

This PR enhances the course link validation system to properly handle DOI (Digital Object Identifier) links by implementing domain-specific HTTP headers. DOI links require specific Accept headers to return proper citation metadata instead of HTML redirects.

---

### Supporting information

- **Added DOI-specific headers**: Implemented `DOI_HEADERS` with `application/vnd.citationstyles.csl+json` Accept header for proper citation resolution
- **Domain-specific header mapping**: Created `DOMAIN_HEADERS` dictionary to map domains to their required headers
- **Enhanced URL validation**: Updated `_validate_url_access()` to detect DOI domains and use appropriate headers

---

### Testing instructions

1. Go to **Studio → Course → Content**.
2. Add an **HTML block** and include the following DOI links:
   - `https://doi.org/10.1000/182` *(valid DOI)*
   - `https://doi.org/invalid-doi-12345` *(invalid DOI)*
3. Navigate to the **Course Optimizer** page.
4. Run the **Broken Link Check** task from the Optimizer page.
5. After the task completes, verify that:
   - The valid DOI is marked as accessible.
   - The invalid DOI is flagged as a broken link.

---

### Jira

- https://2u-internal.atlassian.net/browse/TNL2-327