### PR TITLE
feat: Allow adding custom LTI parameters via LTI_CUSTOM_PARAMS django setting

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3984,6 +3984,16 @@ LTI_USER_EMAIL_DOMAIN = 'lti.example.com'
 # The time value is in seconds.
 LTI_AGGREGATE_SCORE_PASSBACK_DELAY = 15 * 60
 
+
+# .. setting_name: LTI_CUSTOM_PARAMS
+# .. setting_default: []
+# .. setting_description: This expands the list of optional LTI parameters that the
+#    platform accepts. These parameters are not used by the platform, but can then
+#    be used by other plugins.
+# .. setting_creation_date: 2025-08-22
+# .. setting_tickets:
+LTI_CUSTOM_PARAMS = []
+
 # Credit notifications settings
 NOTIFICATION_EMAIL_CSS = "templates/credit_notifications/credit_notification.css"
 NOTIFICATION_EMAIL_EDX_LOGO = "templates/credit_notifications/edx-logo-header.png"


### PR DESCRIPTION
## Description

Adds a new Django setting called `LTI_CUSTOM_PARAMS` that allows extending the list of optional LTI parameters processed by the platform. These parameters can be used by plugins for deeper platform integration.

## Testing instructions

NA

## Deadline

None

## Other information

This can particularly be used by https://github.com/openedx/edx-platform/pull/36756 to provide additional params to the event.