### PR TITLE
feat: add ability to override middlewares for recurring nudges

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -29,11 +29,27 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
             '--override-recipient-email',
             help='Send all emails to this address instead of the actual recipient'
         )
-        parser.add_argument('site_domain_name')
+        parser.add_argument(
+            'site_domain_name',
+            nargs='?',
+            default=None,
+            help=(
+                'Domain name for the site to use. '
+                'Do not provide a domain if you wish to run this for all sites'
+            )
+        )
         parser.add_argument(
             '--weeks',
             type=int,
             help='Number of weekly emails to be sent',
+        )
+        parser.add_argument(
+            '--override-middlewares',
+            action='append',
+            help=(
+                'Use this middleware when emulating http requests. '
+                'To use multiple middlewares, provide this argument multiple times'
+            )
         )
 
     def handle(self, *args, **options):
@@ -49,19 +65,26 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
             tzinfo=pytz.UTC
         )
         self.log_debug('Current date = %s', current_date.isoformat())
-
-        site = Site.objects.get(domain__iexact=options['site_domain_name'])
-        self.log_debug('Running for site %s', site.domain)
-
         override_recipient_email = options.get('override_recipient_email')
-        self.send_emails(site, current_date, override_recipient_email)
+        override_middlewares = options.get('override_middlewares')
 
-    def enqueue(self, day_offset, site, current_date, override_recipient_email=None):
+        site_domain_name = options['site_domain_name']
+        sites = Site.objects.filter(domain__iexact=site_domain_name) if site_domain_name else Site.objects.all()
+
+        if sites:
+            for site in sites:
+                self.log_debug('Running for site %s', site.domain)
+                self.send_emails(site, current_date, override_recipient_email, override_middlewares)
+        else:
+            self.log_info("No matching site found")
+
+    def enqueue(self, day_offset, site, current_date, override_recipient_email=None, override_middlewares=None):
         self.async_send_task.enqueue(
             site,
             current_date,
             day_offset,
             override_recipient_email,
+            override_middlewares,
         )
 
     def send_emails(self, *args, **kwargs):

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -10,6 +10,7 @@ from unittest.mock import DEFAULT, Mock, patch
 import ddt
 import pytz
 from django.conf import settings
+from django.contrib.sites.models import Site
 
 from openedx.core.djangoapps.schedules.management.commands import SendEmailBaseCommand
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
@@ -33,8 +34,22 @@ class TestSendEmailBaseCommand(CacheIsolationTestCase):  # lint-amnesty, pylint:
             send_emails.assert_called_once_with(
                 self.site,
                 datetime.datetime(2017, 9, 29, tzinfo=pytz.UTC),
+                None,
                 None
             )
+
+    def test_handle_all_sites(self):
+        with patch.object(self.command, 'send_emails') as send_emails:
+            self.command.handle(site_domain_name=None, date='2017-09-29')
+            expected_sites = Site.objects.all()
+            for expected_site in expected_sites:
+                send_emails.assert_any_call(
+                    expected_site,
+                    datetime.datetime(2017, 9, 29, tzinfo=pytz.UTC),
+                    None,
+                    None
+                )
+            assert send_emails.call_count == len(expected_sites)
 
     def test_weeks_option(self):
         with patch.object(self.command, 'enqueue') as enqueue:

--- a/openedx/core/lib/celery/task_utils.py
+++ b/openedx/core/lib/celery/task_utils.py
@@ -45,7 +45,7 @@ def emulate_http_request(site=None, user=None, middleware_classes=None):
         _run_method_if_implemented(middleware, 'process_request', request)
 
     try:
-        yield
+        yield request
     except Exception as exc:
         for middleware in reversed(middleware_instances):
             _run_method_if_implemented(middleware, 'process_exception', request, exc)


### PR DESCRIPTION
## Description

This PR brings two changes to all the management commands based on [SendEmailBaseCommand](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/djangoapps/schedules/management/commands/__init__.py#L15):

1. Adds the ability to pass a list of middlewares to override the [default list of middlewares](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/lib/celery/task_utils.py#L37-L40) used to emulate HTTP requests in the [async message tasks](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/djangoapps/schedules/tasks.py#L135) - This would be very helpful for instances running custom middlewares that they want to apply to recurring messages.
2. Adds the ability to run the management commands for all sites by not passing any site domain. This would be helpful for instances running lots of sites that would otherwise need to run the same command individually for each site.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Set up this branch in a sandbox.
2. Set up two or more sites with course_org_filter setup for each site to map it to a unique org.
3. Create courses for each site/org and enroll in them.
4. Make sure [date conditions](https://docs.openedx.org/en/open-release-redwood.master/educators/migration_wip/16_manage_live_course/automatic_email.html) for recurring nudges are satisfied for the enrollments and run the [send_recurring_nudge](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/djangoapps/schedules/management/commands/send_recurring_nudge.py#L12) command without passing any site domain name.
5. Make sure emails from each site/org are triggered.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Private Ref : [BB-9883](https://tasks.opencraft.com/browse/BB-9883)