### PR TITLE
feat: Show disabled edit button and tooltip to component in units from libraries

### DIFF
--- a/cms/static/sass/course-unit-mfe-iframe-bundle.scss
+++ b/cms/static/sass/course-unit-mfe-iframe-bundle.scss
@@ -618,6 +618,42 @@ body,
   }
 }
 
+.tooltipbox {
+  .tooltiptext {
+    visibility: hidden;
+    position: absolute;
+    width: 200px;
+    background-color: $black;
+    color: $white;
+    text-align: center;
+    padding: 5px;
+    border-radius: 6px;
+    z-index: 1;
+    top: 50%;
+    right: 100%;
+    margin-right: 10px;
+    transform: translateY(-50%);
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+
+  .tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    transform: translateY(-50%);
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent transparent $black;
+  }
+
+  &:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+
 .action-edit {
   .action-button-text {
     display: none;
@@ -630,6 +666,13 @@ body,
 
     .fa-pencil {
       display: none;
+    }
+
+    &.disabled-button {
+      pointer-events: all;
+      opacity: .5;
+      cursor: default;
+      border-color: $transparent
     }
 
     &::before {

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -152,11 +152,7 @@ upstream_info = UpstreamLink.try_get_for_block(xblock, log_error=False)
                         % endif
                         % if not show_inline:
                             <li class="action-item action-edit">
-                                <button
-                                    class="btn-default edit-button action-button"
-                                    data-usage-id=${xblock.scope_ids.usage_id}
-                                    data-tooltip="${_("Edit")}"
-                                >
+                                <button class="btn-default edit-button action-button" data-usage-id=${xblock.scope_ids.usage_id} data-tooltip="${_("Edit")}">
                                     <span class="icon fa fa-pencil" aria-hidden="true"></span>
                                     <span class="action-button-text">${_("Edit")}</span>
                                 </button>

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -152,7 +152,11 @@ upstream_info = UpstreamLink.try_get_for_block(xblock, log_error=False)
                         % endif
                         % if not show_inline:
                             <li class="action-item action-edit">
-                                <button class="btn-default edit-button action-button" data-usage-id=${xblock.scope_ids.usage_id}>
+                                <button
+                                    class="btn-default edit-button action-button"
+                                    data-usage-id=${xblock.scope_ids.usage_id}
+                                    data-tooltip="${_("Edit")}"
+                                >
                                     <span class="icon fa fa-pencil" aria-hidden="true"></span>
                                     <span class="action-button-text">${_("Edit")}</span>
                                 </button>
@@ -209,6 +213,18 @@ upstream_info = UpstreamLink.try_get_for_block(xblock, log_error=False)
                         % if is_reorderable:
                             <li class="action-item action-drag">
                                 <span data-tooltip="${_('Drag to reorder')}" class="drag-handle action"></span>
+                            </li>
+                        % endif
+                    % else:
+                        % if not show_inline:
+                            <li class="action-item action-edit">
+                                <div class="tooltipbox">
+                                    <button class="btn-default edit-button action-button disabled-button" data-usage-id=${xblock.scope_ids.usage_id} disabled>
+                                        <span class="icon fa fa-pencil" aria-hidden="true"></span>
+                                        <span class="action-button-text">${_("Edit")}</span>
+                                    </button>
+                                    <span class="tooltiptext">${_('Components within a library referenced object cannot be edited')}</span>
+                                </div>
                             </li>
                         % endif
                     % endif


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description


- Show disabled edit button and tooltip to component in units from libraries
- Which edX user roles will this change impact? "Course Author".

<img width="1097" height="402" alt="image" src="https://github.com/user-attachments/assets/7ce1cd1d-d547-4a5a-b301-9af00cadbb79" />

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/pull/2319#issuecomment-3185886865
- Backport: https://github.com/openedx/edx-platform/pull/37282
- Internal ticket: [FAL-4240](https://tasks.opencraft.com/browse/FAL-4240)

## Testing instructions

- Run `tutor dev exec cms npm run build-dev`
- Go to the library home of a library
- Create a unit on a library and add a component. Publish the unit
- Go to the course outline. Add the unit from the library.
- Go to the unit outline and verify that the edit button of the component is disabled.
- Verify the new tooltip on the edit button.

## Deadline

None

## Other information

N/A
