### PR TITLE
feat: Make `USERNAME_MIN_LENGTH` customizable

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -14,7 +14,7 @@ NAME_MIN_LENGTH = 1
 NAME_MAX_LENGTH = 255
 
 # The minimum and maximum length for the username account field
-USERNAME_MIN_LENGTH = 2
+USERNAME_MIN_LENGTH = getattr(settings, 'USERNAME_MIN_LENGTH', 2)
 # Note: 30 chars is the default for historical reasons. Django uses 150 as the username length since 1.10
 USERNAME_MAX_LENGTH = getattr(settings, 'USERNAME_MAX_LENGTH', 30)
 


### PR DESCRIPTION
## Description

This PR introduces new setting `USERNAME_MIN_LENGTH`. It can be used to persuade users to choose more descriptive usernames. It affects some new users experience if they would want to choose some short username, but the min length is higher on the particular platform. The default value has not been changed.

## Testing instructions

There is no additional testing required.

## Deadline

None.