### PR TITLE
fix: ensure _get_user returns saved user (with id)

### DIFF
--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -1190,9 +1190,10 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
             self.user, blocks_dict['not_graded_1'], course['course'].id
         ) is None
 
-    @patch.object(ContentTypeGatingService, '_get_user', return_value=UserFactory.build())
-    def test_check_children_for_content_type_gating_paywall(self, mocked_user):  # pylint: disable=unused-argument
+    @patch.object(ContentTypeGatingService, "_get_user")
+    def test_check_children_for_content_type_gating_paywall(self, mocked_get_user):
         ''' Verify that the method returns a content type gate when appropriate '''
+        mocked_get_user.return_value = UserFactory.create()  # saved user object with id
         course = self._create_course()
         blocks_dict = course['blocks']
         CourseEnrollmentFactory.create(


### PR DESCRIPTION
https://github.com/openedx/edx-platform/issues/37287

Django 5.2 tightened model handling: unsaved User objects (no primary key) no longer pass through in some checks.