### PR TITLE
test: Disable the Django Debug Toolbar by default.

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -22,6 +22,8 @@ ORA2_FILEUPLOAD_BACKEND = 'django'
 
 
 DEBUG = True
+INTERNAL_IPS = ('127.0.0.1',)
+
 USE_I18N = True
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = True
 LMS_BASE = 'localhost:18000'
@@ -81,13 +83,14 @@ DJFS = {
 
 ################################ DEBUG TOOLBAR ################################
 
-INSTALLED_APPS += ['debug_toolbar']
-MIDDLEWARE += [
-    'lms.djangoapps.discussion.django_comment_client.utils.QueryCountDebugMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-]
-
-INTERNAL_IPS = ('127.0.0.1',)
+# The Django Debug Toolbar is disabled by default, if you need to enable it for
+# debugging.  Simply uncomment the INSTALLED_APPS and MIDDLEWARE section below.
+#
+# INSTALLED_APPS += ['debug_toolbar']
+# MIDDLEWARE += [
+#     'lms.djangoapps.discussion.django_comment_client.utils.QueryCountDebugMiddleware',
+#     'debug_toolbar.middleware.DebugToolbarMiddleware',
+# ]
 
 DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.versions.VersionsPanel',


### PR DESCRIPTION
Disable the toolbar by default but make it easy to turn back on as
needed.  This is in response to the discussion here:
    https://discuss.openedx.org/t/lets-remove-django-debug-toolbar/16847
