### PR TITLE
Backport "fix: intermittent "utils attribute not found" issue in webpack_loader (#37109)" in Teak

### DIFF
--- a/xmodule/util/builtin_assets.py
+++ b/xmodule/util/builtin_assets.py
@@ -5,7 +5,6 @@ These should not be used to support any XBlocks outside of edx-platform.
 """
 from pathlib import Path
 
-import webpack_loader
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -44,6 +43,11 @@ def add_webpack_js_to_fragment(fragment, bundle_name):
     """
     Add all JS webpack chunks to the supplied fragment.
     """
-    for chunk in webpack_loader.utils.get_files(bundle_name, None, 'DEFAULT'):
+    # Importing webpack_loader.utils at the top of the module causes an exception:
+    #   OSError: Error reading webpack-stats.json.
+    #   Are you sure webpack has generated the file and the path is correct?
+    # We are not quite sure why.
+    from webpack_loader.utils import get_files
+    for chunk in get_files(bundle_name, None, 'DEFAULT'):
         if chunk['name'].endswith(('.js', '.js.gz')):
             fragment.add_javascript_url(chunk['url'])


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR is a backport of https://github.com/openedx/edx-platform/pull/37109 in teak. Please refer to the original PR description for more details.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

- https://github.com/openedx/edx-platform/pull/37109

## Testing instructions

- Verify that the unit pages load without any issues in both LMS and CMS

## Deadline

"None" 

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
