### PR TITLE
build: Unpin pip and pip-tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,8 @@ compile-requirements: pre-requirements $(COMMON_CONSTRAINTS_TXT) ## Re-compile *
 	@# time someone tries to use the outputs.
 	sed 's/Django<5.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/pip<24.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	pip-compile -v --allow-unsafe ${COMPILE_OPTS} -o requirements/pip.txt requirements/pip.in
 	pip install -r requirements/pip.txt
 

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -25,4 +25,4 @@ elasticsearch<7.14.0
 
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
-pip<24.3
+

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -79,11 +79,6 @@ openai<=0.28.1
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35267
 path<16.12.0
 
-# Date: 2025-05-11
-# Broke lxml[html_clean] extra dependency declaration
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/37168
-pip-tools<7.5.0
-
 # Date: 2022-08-03
 # pycodestyle==2.9.0 generates false positive error E275.
 # Constraint can be removed once the issue https://github.com/PyCQA/pycodestyle/issues/1090 is fixed.

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -24,9 +24,9 @@ joblib==1.5.2
     # via nltk
 kiwisolver==1.4.9
     # via matplotlib
-lxml[html-clean,html_clean]==5.3.2
+lxml[html-clean]==5.3.2
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx-sandbox/base.in
     #   lxml-html-clean
     #   openedx-calc
@@ -48,7 +48,7 @@ nltk==3.9.1
     #   chem
 numpy==1.26.4
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
+    #   -c requirements/constraints.txt
     #   chem
     #   contourpy
     #   matplotlib

--- a/requirements/edx/assets.txt
+++ b/requirements/edx/assets.txt
@@ -8,7 +8,7 @@ click==8.2.1
     # via -r requirements/edx/assets.in
 libsass==0.10.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.in
 nodeenv==1.9.1
     # via -r requirements/edx/assets.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -95,7 +95,7 @@ camel-converter[pydantic]==4.0.1
     # via meilisearch
 celery==5.5.3
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-celery-results
     #   django-user-tasks
@@ -171,7 +171,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==4.2.23
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-appconf
     #   django-autocomplete-light
@@ -322,7 +322,7 @@ django-mysql==4.17.0
     # via -r requirements/edx/kernel.in
 django-oauth-toolkit==1.7.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   enterprise-integrated-channels
@@ -374,7 +374,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==0.7.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
 djangorestframework==3.16.1
@@ -478,7 +478,7 @@ edx-drf-extensions==10.6.0
     #   openedx-learning
 edx-enterprise==6.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
 edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/kernel.in
@@ -562,8 +562,8 @@ edxval==3.0.0
     # via -r requirements/edx/kernel.in
 elasticsearch==7.9.1
     # via
-    #   -c requirements/edx/../common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   edx-search
     #   openedx-forum
 enmerkar==0.7.1
@@ -726,9 +726,9 @@ loremipsum==1.0.5
     # via ora2
 lti-consumer-xblock==9.14.2
     # via -r requirements/edx/kernel.in
-lxml[html-clean,html_clean]==5.3.2
+lxml[html-clean]==5.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   edxval
@@ -774,7 +774,7 @@ mongoengine==0.29.1
     # via -r requirements/edx/kernel.in
 monotonic==1.6
     # via analytics-python
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via cssutils
 mpmath==1.3.0
     # via sympy
@@ -798,7 +798,7 @@ nodeenv==1.9.1
     # via -r requirements/edx/kernel.in
 numpy==1.26.4
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   chem
     #   openedx-calc
     #   scipy
@@ -815,7 +815,7 @@ olxcleaner==0.3.0
     # via -r requirements/edx/kernel.in
 openai==0.28.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   edx-enterprise
 openedx-atlas==0.7.0
     # via
@@ -851,7 +851,7 @@ openedx-forum==0.3.4
     # via -r requirements/edx/kernel.in
 openedx-learning==0.27.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
 optimizely-sdk==5.2.0
     # via -r requirements/edx/bundled.in
@@ -867,7 +867,7 @@ paramiko==4.0.0
     # via edx-enterprise
 path==16.11.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-i18n-tools
     #   path-py
@@ -955,7 +955,7 @@ pymemcache==4.0.0
     # via -r requirements/edx/kernel.in
 pymongo==4.4.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-opaque-keys
     #   event-tracking
@@ -1135,7 +1135,7 @@ snowflake-connector-python==3.17.2
     # via edx-enterprise
 social-auth-app-django==5.4.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
 social-auth-core==4.7.0
@@ -1284,7 +1284,7 @@ xblocks-contrib==0.6.0
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   python3-saml
 xss-utils==0.8.0
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -161,7 +161,7 @@ bridgekeeper==0.9
     #   -r requirements/edx/testing.txt
 build==1.3.0
     # via
-    #   -r requirements/edx/../pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
 cachecontrol==0.14.3
     # via
@@ -182,7 +182,7 @@ camel-converter[pydantic]==4.0.1
     #   meilisearch
 celery==5.5.3
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-celery-results
@@ -228,11 +228,11 @@ chem==2.0.0
     #   -r requirements/edx/testing.txt
 click==8.2.1
     # via
-    #   -r requirements/edx/../pip-tools.txt
     #   -r requirements/edx/assets.txt
     #   -r requirements/edx/development.in
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   -r requirements/pip-tools.txt
     #   celery
     #   click-didyoumean
     #   click-log
@@ -337,7 +337,7 @@ distlib==0.4.0
     #   virtualenv
 django==4.2.23
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
@@ -465,7 +465,7 @@ django-crum==0.7.9
     #   super-csv
 django-debug-toolbar==5.2.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/development.in
 django-fernet-fields-v2==0.9
     # via
@@ -530,7 +530,7 @@ django-mysql==4.17.0
     #   -r requirements/edx/testing.txt
 django-oauth-toolkit==1.7.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -588,7 +588,7 @@ django-storages==1.14.6
     #   edxval
 django-stubs[compatible-mypy]==5.2.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/development.in
     #   djangorestframework-stubs
 django-stubs-ext==5.2.2
@@ -608,7 +608,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==0.7.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
@@ -754,7 +754,7 @@ edx-drf-extensions==10.6.0
     #   openedx-learning
 edx-enterprise==6.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 edx-event-bus-kafka==6.1.0
@@ -867,8 +867,8 @@ edxval==3.0.0
     #   -r requirements/edx/testing.txt
 elasticsearch==7.9.1
     # via
-    #   -c requirements/edx/../common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-search
@@ -1197,7 +1197,7 @@ lazy==1.6
     #   xblock
 libsass==0.10.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.txt
 loremipsum==1.0.5
     # via
@@ -1210,7 +1210,7 @@ lti-consumer-xblock==9.14.2
     #   -r requirements/edx/testing.txt
 lxml[html-clean]==5.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
@@ -1286,7 +1286,7 @@ monotonic==1.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1335,7 +1335,7 @@ nodeenv==1.9.1
     #   -r requirements/edx/testing.txt
 numpy==1.26.4
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   chem
@@ -1357,7 +1357,7 @@ olxcleaner==0.3.0
     #   -r requirements/edx/testing.txt
 openai==0.28.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1408,7 +1408,7 @@ openedx-forum==0.3.4
     #   -r requirements/edx/testing.txt
 openedx-learning==0.27.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 optimizely-sdk==5.2.0
@@ -1421,9 +1421,9 @@ ora2==6.16.4
     #   -r requirements/edx/testing.txt
 packaging==25.0
     # via
-    #   -r requirements/edx/../pip-tools.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   -r requirements/pip-tools.txt
     #   build
     #   drf-yasg
     #   gunicorn
@@ -1443,7 +1443,7 @@ paramiko==4.0.0
     #   edx-enterprise
 path==16.11.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
@@ -1477,10 +1477,8 @@ pillow==11.3.0
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-pip-tools==7.4.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/../pip-tools.txt
+pip-tools==7.5.0
+    # via -r requirements/pip-tools.txt
 platformdirs==4.4.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1550,7 +1548,7 @@ pyasn1-modules==0.4.2
     #   google-auth
 pycodestyle==2.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.txt
 pycountry==24.6.1
     # via
@@ -1648,7 +1646,7 @@ pymemcache==4.0.0
     #   -r requirements/edx/testing.txt
 pymongo==4.4.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-opaque-keys
@@ -1682,7 +1680,7 @@ pyproject-api==1.9.1
     #   tox
 pyproject-hooks==1.2.0
     # via
-    #   -r requirements/edx/../pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
 pyquery==2.0.1
@@ -1966,7 +1964,7 @@ snowflake-connector-python==3.17.2
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
@@ -2241,9 +2239,9 @@ webob==1.8.9
     #   xblock
 wheel==0.45.1
     # via
-    #   -r requirements/edx/../pip-tools.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   -r requirements/pip-tools.txt
     #   django-pipeline
     #   pip-tools
 wrapt==1.17.3
@@ -2291,7 +2289,7 @@ xblocks-contrib==0.6.0
     #   -r requirements/edx/testing.txt
 xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -135,7 +135,7 @@ camel-converter[pydantic]==4.0.1
     #   meilisearch
 celery==5.5.3
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-celery-results
     #   django-user-tasks
@@ -229,7 +229,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==4.2.23
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
     #   django-autocomplete-light
@@ -391,7 +391,7 @@ django-mysql==4.17.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
@@ -446,7 +446,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==0.7.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
 djangorestframework==3.16.1
@@ -562,7 +562,7 @@ edx-drf-extensions==10.6.0
     #   openedx-learning
 edx-enterprise==6.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
 edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/base.txt
@@ -648,8 +648,8 @@ edxval==3.0.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.9.1
     # via
-    #   -c requirements/edx/../common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-search
     #   openedx-forum
@@ -883,7 +883,7 @@ lti-consumer-xblock==9.14.2
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
@@ -938,7 +938,7 @@ monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r requirements/edx/base.txt
     #   cssutils
@@ -971,7 +971,7 @@ nodeenv==1.9.1
     # via -r requirements/edx/base.txt
 numpy==1.26.4
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc
@@ -989,7 +989,7 @@ olxcleaner==0.3.0
     # via -r requirements/edx/base.txt
 openai==0.28.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 openedx-atlas==0.7.0
@@ -1027,7 +1027,7 @@ openedx-forum==0.3.4
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.2.0
     # via -r requirements/edx/base.txt
@@ -1048,7 +1048,7 @@ paramiko==4.0.0
     #   edx-enterprise
 path==16.11.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   path-py
@@ -1169,7 +1169,7 @@ pymemcache==4.0.0
     # via -r requirements/edx/base.txt
 pymongo==4.4.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-opaque-keys
     #   event-tracking
@@ -1390,7 +1390,7 @@ snowflake-connector-python==3.17.2
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
 social-auth-core==4.7.0
@@ -1613,7 +1613,7 @@ xblocks-contrib==0.6.0
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.8.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -133,7 +133,7 @@ camel-converter[pydantic]==4.0.1
     #   meilisearch
 celery==5.5.3
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-celery-results
     #   django-user-tasks
@@ -255,7 +255,7 @@ distlib==0.4.0
     # via virtualenv
 django==4.2.23
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
     #   django-autocomplete-light
@@ -417,7 +417,7 @@ django-mysql==4.17.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.7.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
@@ -472,7 +472,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==0.7.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
 djangorestframework==3.16.1
@@ -583,7 +583,7 @@ edx-drf-extensions==10.6.0
     #   openedx-learning
 edx-enterprise==6.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
 edx-event-bus-kafka==6.1.0
     # via -r requirements/edx/base.txt
@@ -671,8 +671,8 @@ edxval==3.0.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.9.1
     # via
-    #   -c requirements/edx/../common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-search
     #   openedx-forum
@@ -924,7 +924,7 @@ lti-consumer-xblock==9.14.2
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   edxval
@@ -983,7 +983,7 @@ monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r requirements/edx/base.txt
     #   cssutils
@@ -1016,7 +1016,7 @@ nodeenv==1.9.1
     # via -r requirements/edx/base.txt
 numpy==1.26.4
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   chem
     #   openedx-calc
@@ -1034,7 +1034,7 @@ olxcleaner==0.3.0
     # via -r requirements/edx/base.txt
 openai==0.28.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 openedx-atlas==0.7.0
@@ -1072,7 +1072,7 @@ openedx-forum==0.3.4
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.2.0
     # via -r requirements/edx/base.txt
@@ -1096,7 +1096,7 @@ paramiko==4.0.0
     #   edx-enterprise
 path==16.11.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
     #   path-py
@@ -1179,7 +1179,7 @@ pyasn1-modules==0.4.2
     #   google-auth
 pycodestyle==2.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.in
 pycountry==24.6.1
     # via -r requirements/edx/base.txt
@@ -1248,7 +1248,7 @@ pymemcache==4.0.0
     # via -r requirements/edx/base.txt
 pymongo==4.4.0
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-opaque-keys
     #   event-tracking
@@ -1496,7 +1496,7 @@ snowflake-connector-python==3.17.2
     #   edx-enterprise
 social-auth-app-django==5.4.1
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
 social-auth-core==4.7.0
@@ -1695,7 +1695,7 @@ xblocks-contrib==0.6.0
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via
-    #   -c requirements/edx/../constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   python3-saml
 xss-utils==0.8.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,10 +10,8 @@ click==8.2.1
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.4.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/pip-tools.in
+pip-tools==7.5.0
+    # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,9 +8,7 @@ wheel==0.45.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+pip==25.2
+    # via -r requirements/pip.in
 setuptools==80.9.0
     # via -r requirements/pip.in

--- a/scripts/structures_pruning/requirements/base.txt
+++ b/scripts/structures_pruning/requirements/base.txt
@@ -16,7 +16,7 @@ edx-opaque-keys==3.0.0
     # via -r scripts/structures_pruning/requirements/base.in
 pymongo==4.4.0
     # via
-    #   -c scripts/structures_pruning/requirements/../../../requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r scripts/structures_pruning/requirements/base.in
     #   edx-opaque-keys
 stevedore==5.5.0

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -34,7 +34,7 @@ cryptography==45.0.7
     # via pyjwt
 django==4.2.23
     # via
-    #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
@@ -48,7 +48,7 @@ edx-rest-api-client==6.2.0
     # via -r scripts/user_retirement/requirements/base.in
 google-api-core==2.25.1
     # via google-api-python-client
-google-api-python-client==2.179.0
+google-api-python-client==2.181.0
     # via -r scripts/user_retirement/requirements/base.in
 google-auth==2.40.3
     # via
@@ -75,9 +75,9 @@ jmespath==1.0.1
     #   botocore
 lxml==5.3.2
     # via
-    #   -c scripts/user_retirement/requirements/../../../requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   zeep
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via simple-salesforce
 platformdirs==4.4.0
     # via zeep

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -76,7 +76,7 @@ google-api-core==2.25.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.179.0
+google-api-python-client==2.181.0
     # via -r scripts/user_retirement/requirements/base.txt
 google-auth==2.40.3
     # via
@@ -126,7 +126,7 @@ markupsafe==3.0.2
     #   werkzeug
 mock==5.2.0
     # via -r scripts/user_retirement/requirements/testing.in
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce


### PR DESCRIPTION
Test with unpinning both pip and pip-tools. The latest versions have
fixed the pathing issues with `make upgrade` and the dependency
resolution issues reported in https://github.com/openedx/edx-lint/issues/458

This is prep for unpinning pip in common-constraints.txt