### PR TITLE
chore: change release line from 'master' to 'teak'

### DIFF
--- a/openedx/core/release.py
+++ b/openedx/core/release.py
@@ -8,7 +8,7 @@ import unittest
 # The release line: an Open edX release name ("ficus"), or "master".
 # This should always be "master" on the master branch, and will be changed
 # manually when we start release-line branches, like open-release/ficus.master.
-RELEASE_LINE = "master"
+RELEASE_LINE = "teak"
 
 
 def doc_version():


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

I noticed that teak releases where showing up as 'master' in an automated check I was doing and then I found we never changed this line for teak.


## Supporting information

This line should have been changed during the branch cut.


## Deadline

I think this should be merged soon and specially before we publish teak.3

