### PR TITLE
feat: automatically follow post when creating comments/responses

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1543,6 +1543,7 @@ def create_comment(request, comment_data):
         raise PermissionDenied
 
     _check_initializable_comment_fields(comment_data, context)
+    comment_data["following"] = True
     serializer = CommentSerializer(data=comment_data, context=context)
     actions_form = CommentActionsForm(comment_data)
     if not (serializer.is_valid() and actions_form.is_valid()):
@@ -1552,7 +1553,6 @@ def create_comment(request, comment_data):
     comment_created.send(sender=None, user=request.user, post=cc_comment)
     api_comment = serializer.data
     _do_extra_actions(api_comment, cc_comment, list(comment_data.keys()), actions_form, context, request)
-
     track_comment_created_event(request, course, cc_comment, cc_thread["commentable_id"], followed=False,
                                 from_mfe_sidebar=from_mfe_sidebar)
     return api_comment

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1543,11 +1543,11 @@ def create_comment(request, comment_data):
         raise PermissionDenied
 
     _check_initializable_comment_fields(comment_data, context)
-    comment_data["following"] = True
     serializer = CommentSerializer(data=comment_data, context=context)
     actions_form = CommentActionsForm(comment_data)
     if not (serializer.is_valid() and actions_form.is_valid()):
         raise ValidationError(dict(list(serializer.errors.items()) + list(actions_form.errors.items())))
+    context["cc_requester"].follow(cc_thread)
     serializer.save()
     cc_comment = serializer.instance
     comment_created.send(sender=None, user=request.user, post=cc_comment)


### PR DESCRIPTION
[INF-2112](https://2u-internal.atlassian.net/browse/INF-2112)
Description

As of today, if i respond or comment on a post, i don’t get notifications for future activity on that post.

This is counter-intuitive when we consider other platforms like Slack, Facebook, Linkedin etc.

Therefore, to make the experience intuitive and to improve engagement, i propose that:

right arrow  Whenever someone creates a response or comment on a post, that user automatically follows that post. 

