### PR TITLE
chore: Update openedx-forum version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -847,7 +847,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.4
+openedx-forum==0.3.6
     # via -r requirements/edx/kernel.in
 openedx-learning==0.27.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1402,7 +1402,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.4
+openedx-forum==0.3.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1023,7 +1023,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.4
+openedx-forum==0.3.6
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1068,7 +1068,7 @@ openedx-filters==2.1.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.4
+openedx-forum==0.3.6
     # via -r requirements/edx/base.txt
 openedx-learning==0.27.1
     # via


### PR DESCRIPTION
## Description

This PR updated the package version of openedx-forum to get the [fixes](https://github.com/openedx/forum/issues/211) for migration command failure

## Supporting information

https://2u-internal.atlassian.net/browse/INF-2157

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
