### PR TITLE
feat: added api for mobile configs

### DIFF
--- a/lms/djangoapps/mobile_api/tests/test_views.py
+++ b/lms/djangoapps/mobile_api/tests/test_views.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for MobileConfigurationView API endpoint.
+"""
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from lms.djangoapps.mobile_api.models import MobileConfig
+
+
+class MobileConfigurationViewTest(APITestCase):
+    """
+    Test cases for MobileConfigurationView API endpoint.
+    """
+
+    def setUp(self):
+        """
+        Set up test data and common test utilities.
+        """
+        self.url = reverse('mobile-configurations', kwargs={'api_version': 'v1'})
+
+    def test_get_mobile_configurations_empty_database(self):
+        """
+        Test API response when no configurations exist in database.
+        """
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = {"iap_configs": {}}
+        self.assertEqual(response.data, expected_data)
+
+    def test_get_mobile_configurations_with_regular_configs(self):
+        """
+        Test API response with regular (non-IAP) configurations.
+        """
+        # Arrange
+        MobileConfig.objects.create(name='app_version', value='2.1.0')
+        MobileConfig.objects.create(name='enable_dark_mode', value='true')
+        MobileConfig.objects.create(name='api_timeout', value='30')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = {
+            "iap_configs": {},
+            "app_version": "2.1.0",
+            "enable_dark_mode": "true",
+            "api_timeout": "30"
+        }
+        self.assertEqual(response.data, expected_data)

--- a/lms/djangoapps/mobile_api/urls.py
+++ b/lms/djangoapps/mobile_api/urls.py
@@ -2,14 +2,15 @@
 URLs for mobile API
 """
 
-
 from django.urls import include, path
 
 from .users.views import my_user_info
+from .views import MobileConfigurationView
 
 urlpatterns = [
     path('users/', include('lms.djangoapps.mobile_api.users.urls')),
     path('my_user_info', my_user_info, name='user-info'),
     path('notifications/', include('lms.djangoapps.mobile_api.notifications.urls')),
     path('course_info/', include('lms.djangoapps.mobile_api.course_info.urls')),
+    path('configurations/', MobileConfigurationView.as_view(), name='mobile-configurations')
 ]

--- a/lms/djangoapps/mobile_api/views.py
+++ b/lms/djangoapps/mobile_api/views.py
@@ -1,0 +1,20 @@
+"""
+Views for the mobile API.
+"""
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from lms.djangoapps.mobile_api.models import MobileConfig
+
+
+class MobileConfigurationView(APIView):
+    """
+    API endpoint that returns mobile configuration data.
+    """
+
+    def get(self, request, *args, **kwargs):
+        """
+        Get all mobile configurations.
+        """
+        return Response(MobileConfig.get_structured_configs())


### PR DESCRIPTION
This pull request introduces a new API endpoint to serve mobile configuration data and adds corresponding unit tests to ensure correct behavior. The changes include implementing the `MobileConfigurationView`, registering its URL, and adding comprehensive tests for its responses.

**New API endpoint for mobile configurations:**

* Added `MobileConfigurationView` in `views.py` to provide all mobile configuration data via a GET request, returning structured configurations from the `MobileConfig` model.
* Registered the new endpoint at `/configurations/` in `urls.py`, making it accessible as `mobile-configurations`.

**Testing:**

* Added unit tests in `test_views.py` to verify the API's responses for both empty and populated mobile configuration scenarios.