### PR TITLE
fix: Invalid read param in forum thread api

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -215,7 +215,6 @@ class ThreadViewSetPartialUpdateTest(
             "anonymous_to_peers": False,
             "closed": False,
             "pinned": False,
-            "read": True,
             "editing_user_id": str(self.user.id),
         }
         self.check_mock_called_with("update_thread", -1, **params)

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -287,7 +287,6 @@ class Model:
             "close_reason_code": request_params.get("close_reason_code"),
             "closing_user_id": request_params.get("closing_user_id"),
             "endorsed": request_params.get("endorsed"),
-            "read": request_params.get("read"),
         }
         request_data = {k: v for k, v in request_data.items() if v is not None}
         response = forum_api.update_thread(**request_data)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR fixes the invalid read parameter being passed in forum update_thread api. 

This was somehow introduced in this commit https://github.com/openedx/edx-platform/commit/6f522f3992101707ba7df03dfa49a34af154a6e1#diff-b9d08209a02c673887f6ca72b0018758174e95508539adbcb6885f22c7844eb8L292

This fix should fix the following issues: https://github.com/openedx/forum/issues/216 and https://github.com/openedx/forum/issues/215