### PR TITLE
fix: always generate block structure from "published-only" branch

### DIFF
--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -88,7 +88,7 @@ class CoursesTest(ModuleStoreTestCase):
         assert not error.value.access_response.has_access
 
     @ddt.data(
-        (GET_COURSE_WITH_ACCESS, 2),
+        (GET_COURSE_WITH_ACCESS, 1),
         (GET_COURSE_OVERVIEW_WITH_ACCESS, 0),
     )
     @ddt.unpack

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -156,8 +156,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert mock_block_structure_create.call_count == 1
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, 42, True),
-        (ModuleStoreEnum.Type.split, 2, 42, False),
+        (ModuleStoreEnum.Type.split, 1, 42, True),
+        (ModuleStoreEnum.Type.split, 1, 42, False),
     )
     @ddt.unpack
     def test_query_counts(self, default_store, num_mongo_calls, num_sql_calls, create_multiple_subsections):
@@ -168,7 +168,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                     self._apply_recalculate_subsection_grade()
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, 42),
+        (ModuleStoreEnum.Type.split, 1, 42),
     )
     @ddt.unpack
     def test_query_counts_dont_change_with_more_content(self, default_store, num_mongo_calls, num_sql_calls):
@@ -200,16 +200,17 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
                 self.store.update_item(sequential, self.user.id)
 
-        # Make sure the signal is sent for only the 2 accessible sequentials.
+        # Make sure the signal is sent for only the 1 accessible sequentials.
+        # Update: draft branch content shouldn't be accessible
         self._apply_recalculate_subsection_grade()
-        assert mock_subsection_signal.call_count == 2
+        assert mock_subsection_signal.call_count == 1
         sequentials_signalled = {
             args[1]['subsection_grade'].location
             for args in mock_subsection_signal.call_args_list
         }
         self.assertSetEqual(
             sequentials_signalled,
-            {self.sequential.location, accessible_seq.location},
+            {self.sequential.location},
         )
 
     @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send')
@@ -255,7 +256,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         UserPartition.scheme_extensions = None
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 2, 42),
+        (ModuleStoreEnum.Type.split, 1, 42),
     )
     @ddt.unpack
     def test_persistent_grades_on_course(self, default_store, num_mongo_queries, num_sql_queries):

--- a/openedx/core/djangoapps/content/block_structure/tests/helpers.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/helpers.py
@@ -110,6 +110,13 @@ class MockModulestore:
         """
         yield
 
+    @contextmanager
+    def branch_setting(self, branch_settings, course_id=None):  # pylint: disable=unused-argument
+        """
+        A context manager for temporarily setting a store's branch value on the current thread.
+        """
+        yield
+
 
 class MockCache:
     """

--- a/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
@@ -4,7 +4,7 @@ Tests for manager.py
 
 import pytest
 import ddt
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 from django.test import TestCase
 
 from xmodule.modulestore import ModuleStoreEnum
@@ -16,7 +16,6 @@ from ..transformers import BlockStructureTransformers
 from .helpers import (
     ChildrenMapTestMixin,
     MockCache,
-    MockModulestore,
     MockModulestoreFactory,
     MockTransformer,
     UsageKeyFactoryMixin,
@@ -220,26 +219,6 @@ class TestBlockStructureManager(UsageKeyFactoryMixin, ChildrenMapTestMixin, Test
         self.bs_manager.clear()
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
         assert TestTransformer1.collect_call_count == 2
-
-    @patch.object(MockModulestore, 'branch_setting')
-    def test_update_collected_uses_published_only_branch(self, mock_branch_setting):
-        """
-        Test that _update_collected always uses published-only branch.
-        """
-        # Set up the mock to return a proper context manager
-        mock_context_manager = MagicMock()
-        mock_context_manager.__enter__ = MagicMock(return_value=None)
-        mock_context_manager.__exit__ = MagicMock(return_value=None)
-        mock_branch_setting.return_value = mock_context_manager
-
-        with mock_registered_transformers(self.registered_transformers):
-            self.bs_manager.get_collected()
-
-        # Verify branch_setting was called with published_only
-        mock_branch_setting.assert_called_once_with(
-            ModuleStoreEnum.Branch.published_only,
-            self.block_key_factory(0).course_key
-        )
 
     def test_update_collected_branch_context_integration(self):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR:
- Fixes the logic around caching the block structure to only get and cache from `published-only` branch

Please Refer to this [PR](https://github.com/openedx/edx-platform/pull/37247) for better context

When, for any reason, the block structure is cached in CMS it cache the content from `draft-preferred` branch which messes with learner progress calculation
 

## Supporting information
https://github.com/openedx/edx-platform/pull/37247

## Testing instructions

1. Stay on `master` branch
2. Don't run celery or Keep [CELERY_ALWAYS_EAGER](https://github.com/openedx/edx-platform/blob/master/cms/envs/devstack.py#L80) as True to run tasks in CMS env.
3. Create a course -- Add minimum number of component to complete
4. Complete that course as learner
5. Go to home page and check that the section is marked as complete (all green)
6. Add two text components with any dummy data and delete one of them -- fast way to cache immediately without publishing OR use [simulate_publish](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/content/course_overviews/management/commands/simulate_publish.py) management command
8. Now refresh the learner home page -- Completed section should be greyed out now (not completed)
9. Switch to this branch
10. Refresh the block structure by adding and removing a text unit OR by running [simulate_publish](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/content/course_overviews/management/commands/simulate_publish.py) management command
11. Refresh the page, it should be fixed now.
