### PR TITLE
fix: prevent None entrance_exam_minimum_score_pct from breaking CourseOverview

### DIFF
--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -224,7 +224,7 @@ def _delete_entrance_exam(request, course_key):
     if course.entrance_exam_id:
         metadata = {
             'entrance_exam_enabled': False,
-            'entrance_exam_minimum_score_pct': None,
+            'entrance_exam_minimum_score_pct': settings.ENTRANCE_EXAM_MIN_SCORE_PCT,
             'entrance_exam_id': None,
         }
         CourseMetadata.update_from_dict(metadata, course, request.user)

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -266,7 +266,9 @@ class CourseOverview(TimeStampedModel):
         course_overview.entrance_exam_id = course.entrance_exam_id or ''
         # Despite it being a float, the course object defaults to an int. So we will detect that case and update
         # it to be a float like everything else.
-        if isinstance(course.entrance_exam_minimum_score_pct, int):
+        if course.entrance_exam_minimum_score_pct is None:
+            course_overview.entrance_exam_minimum_score_pct = float(settings.ENTRANCE_EXAM_MIN_SCORE_PCT) / 100
+        elif isinstance(course.entrance_exam_minimum_score_pct, int):
             course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct / 100
         else:
             course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct


### PR DESCRIPTION
When entrance exams are disabled in Studio, the field `entrance_exam_minimum_score_pct` was set to `None`. This caused silent failures when saving `CourseOverview` because the database column requires a float (NOT NULL).

This patch ensures that:
- CourseOverview sanitizes None values by falling back to `settings.ENTRANCE_EXAM_MIN_SCORE_PCT` (default=50).
- Studio avoids writing `None` and instead applies the configured default.

Impact:
- Prevents IntegrityErrors and silent failures when updating course settings.
- Restores proper syncing between modulestore (Mongo) and CourseOverview (MySQL).
- Fixes reported issues such as display name changes not persisting and course start dates not syncing.

Closes: https://github.com/openedx/edx-platform/issues/37319
