### PR TITLE
Consolidate common settings to platform wide settings module

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -868,7 +868,7 @@ REQUIRE_BUILD_PROFILE = "cms/js/build.js"
 # The name of the require.js script used by your project, relative to REQUIRE_BASE_URL.
 REQUIRE_JS = "js/vendor/requiresjs/require.js"
 
-########################## Django Webpack Loader ###########################
+########################## DJANGO WEBPACK LOADER ##############################
 
 WEBPACK_LOADER = {
     'DEFAULT': {
@@ -1436,10 +1436,6 @@ DATABASE_ROUTERS = [
 
 # 5 minute expiration time for JWT id tokens issued for external API requests.
 OAUTH_ID_TOKEN_EXPIRATION = 5 * 60
-
-# API access management
-API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
-API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 
 EDX_DRF_EXTENSIONS = {
     # Set this value to an empty dict in order to prevent automatically updating

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -73,40 +73,12 @@ FEATURES = FeaturesProxy(globals())
 
 # pylint: enable=useless-suppression
 
-################ Enable credit eligibility feature ####################
-ENABLE_CREDIT_ELIGIBILITY = True
-
-################################ Block Structures ###################################
-BLOCK_STRUCTURES_SETTINGS = dict(
-    # Delay, in seconds, after a new edit of a course is published
-    # before updating the block structures cache.  This is needed
-    # for a better chance at getting the latest changes when there
-    # are secondary reads in sharded mongoDB clusters. See TNL-5041
-    # for more info.
-    COURSE_PUBLISH_TASK_DELAY=30,
-
-    # Delay, in seconds, between retry attempts if a task fails.
-    TASK_DEFAULT_RETRY_DELAY=30,
-
-    # Maximum number of retries per task.
-    TASK_MAX_RETRIES=5,
-)
-
 ############################ FEATURE CONFIGURATION #############################
-
-PLATFORM_NAME = _('Your Platform Name Here')
 
 CONTACT_MAILING_ADDRESS = _('Your Contact Mailing Address Here')
 
-PLATFORM_DESCRIPTION = _('Your Platform Description Here')
-
-PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
-PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"
-
 # Dummy secret key for dev/test
 SECRET_KEY = 'dev key'
-FAVICON_PATH = 'images/favicon.ico'
-
 
 # .. setting_name: STUDIO_NAME
 # .. setting_default: Your Platform Studio
@@ -119,31 +91,11 @@ STUDIO_SHORT_NAME = _("Studio")
 
 GITHUB_PUSH = False
 
-# See annotations in lms/envs/common.py for details.
-ENABLE_DISCUSSION_SERVICE = True
-# See annotations in lms/envs/common.py for details.
-ENABLE_TEXTBOOK = True
-
-# When True, all courses will be active, regardless of start date
-# DO NOT SET TO True IN THIS FILE
-# Doing so will cause all courses to be released on production
-DISABLE_START_DATES = False
-
 # email address for studio staff (eg to request course creation)
 STUDIO_REQUEST_EMAIL = ''
 
 # Segment - must explicitly turn it on for production
 CMS_SEGMENT_KEY = None
-
-# Enable URL that shows information about the status of various services
-ENABLE_SERVICE_STATUS = False
-
-# Don't autoplay videos for course authors
-AUTOPLAY_VIDEOS = False
-
-# Move the course author to next page when a video finishes. Set to True to
-# show an auto-advance button in videos. If False, videos never auto-advance.
-ENABLE_AUTOADVANCE_VIDEOS = False
 
 # If set to True, new Studio users won't be able to author courses unless
 # an Open edX admin has added them to the course creator group.
@@ -170,10 +122,6 @@ EDITABLE_SHORT_DESCRIPTION = True
 # Hide any Personally Identifiable Information from application logs
 SQUELCH_PII_IN_LOGS = False
 
-# Toggles the embargo functionality, which blocks users
-# based on their location.
-EMBARGO = False
-
 # Allow creating courses with non-ascii characters in the course id
 ALLOW_UNICODE_COURSE_ID = False
 
@@ -183,22 +131,9 @@ PREVENT_CONCURRENT_LOGINS = False
 # Turn off Video Upload Pipeline through Studio, by default
 ENABLE_VIDEO_UPLOAD_PIPELINE = False
 
-# See annotations in lms/envs/common.py for details.
-ENABLE_EDXNOTES = False
-
-# Toggle to enable coordination with the Publisher tool (keep in sync with lms/envs/common.py)
-ENABLE_PUBLISHER = False
-
 # Show a new field in "Advanced settings" that can store custom data about a
 # course and that can be read from themes
 ENABLE_OTHER_COURSE_SETTINGS = False
-
-# Write new CSM history to the extended table.
-# This will eventually default to True and may be
-# removed since all installs should have the separate
-# extended history table. This is needed in the LMS and CMS
-# for migration consistency.
-ENABLE_CSMH_EXTENDED = True
 
 # Enable support for content libraries. Note that content libraries are
 # only supported in courses using split mongo.
@@ -214,17 +149,8 @@ ENABLE_CONTENT_LIBRARIES = True
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/27411
 ENABLE_CONTENT_LIBRARIES_LTI_TOOL = False
 
-# Milestones application flag
-MILESTONES_APP = False
-
-# Prerequisite courses feature flag
-ENABLE_PREREQUISITE_COURSES = False
-
 # Toggle course entrance exams feature
 ENTRANCE_EXAMS = False
-
-# Toggle platform-wide course licensing
-LICENSING = False
 
 # Enable the courseware search functionality
 ENABLE_COURSEWARE_INDEX = False
@@ -243,113 +169,18 @@ ENABLE_LIBRARY_INDEX = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/6965
 ALLOW_COURSE_RERUNS = True
 
-# Certificates Web/HTML Views
-CERTIFICATES_HTML_VIEW = False
-
-# Teams feature
-ENABLE_TEAMS = True
-
-# Show video bumper in Studio
-ENABLE_VIDEO_BUMPER = False
-
-# How many seconds to show the bumper again, default is 7 days:
-SHOW_BUMPER_PERIODICITY = 7 * 24 * 3600
-
-# Special Exams, aka Timed and Proctored Exams
-ENABLE_SPECIAL_EXAMS = False
-
-# Show the language selector in the header
-SHOW_HEADER_LANGUAGE_SELECTOR = False
-
-# At edX it's safe to assume that English transcripts are always available
-# This is not the case for all installations.
-# The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
-FALLBACK_TO_ENGLISH_TRANSCRIPTS = True
-
-# Set this to False to facilitate cleaning up invalid xml from your modulestore.
-ENABLE_XBLOCK_XML_VALIDATION = True
-
-# Allow public account creation
-ALLOW_PUBLIC_ACCOUNT_CREATION = True
-
-# Allow showing the registration links
-SHOW_REGISTRATION_LINKS = True
-
-# Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
-ENABLE_ENROLLMENT_TRACK_USER_PARTITION = True
-
-ENABLE_PASSWORD_RESET_FAILURE_EMAIL = False
-
 # Whether archived courses (courses with end dates in the past) should be
 # shown in Studio in a separate list.
 ENABLE_SEPARATE_ARCHIVED_COURSES = True
 
-# For acceptance and load testing
-AUTOMATIC_AUTH_FOR_TESTING = False
-
-# Prevent auto auth from creating superusers or modifying existing users
-RESTRICT_AUTOMATIC_AUTH = True
-
 ENABLE_GRADE_DOWNLOADS = True
-ENABLE_MKTG_SITE = False
+
 ENABLE_DISCUSSION_HOME_PANEL = True
-ENABLE_CORS_HEADERS = False
-ENABLE_CROSS_DOMAIN_CSRF_COOKIE = False
+
 ENABLE_COUNTRY_ACCESS = False
 ENABLE_CREDIT_API = False
-ENABLE_OAUTH2_PROVIDER = False
-ENABLE_MOBILE_REST_API = False
-CUSTOM_COURSES_EDX = False
-ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES = True
-SHOW_FOOTER_LANGUAGE_SELECTOR = False
-ENABLE_ENROLLMENT_RESET = False
-# Settings for course import olx validation
-ENABLE_COURSE_OLX_VALIDATION = False
-# .. toggle_name: settings.DISABLE_MOBILE_COURSE_AVAILABLE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to remove Mobile Course Available UI Flag from Studio's Advanced Settings
-#   page else Mobile Course Available UI Flag will be available on Studio side.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-02-14
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/23073
-DISABLE_MOBILE_COURSE_AVAILABLE = False
-
-# .. toggle_name: settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by
-#   default because enabling allows a method to bypass password policy.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-02-21
-# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/21616'
-ENABLE_CHANGE_USER_PASSWORD_ADMIN = False
 
 ### ORA Feature Flags ###
-# .. toggle_name: settings.ENABLE_ORA_ALL_FILE_URLS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-#   discoverable. If enabled, will iterate through all possible file key suffixes up to the max for displaying file
-#   metadata in staff assessments.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2020-03-03
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-# .. toggle_warning: This temporary feature toggle does not have a target removal date.
-ENABLE_ORA_ALL_FILE_URLS = False
-
-# .. toggle_name: settings.ENABLE_ORA_USER_STATE_UPLOAD_DATA
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-#   discoverable. If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2020-03-03
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-# .. toggle_warning: This temporary feature toggle does not have a target removal date.
-ENABLE_ORA_USER_STATE_UPLOAD_DATA = False
 
 # .. toggle_name: settings.DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO
 # .. toggle_implementation: DjangoSetting
@@ -379,28 +210,6 @@ DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO = True
 # .. toggle_warning: Another toggle DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
 DISABLE_COURSE_CREATION = False
 
-# Can be turned off to disable the help link in the navbar
-# .. toggle_name: settings.ENABLE_HELP_LINK
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: When True, a help link is displayed on the main navbar. Set False to hide it.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-03-05
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/26106
-ENABLE_HELP_LINK = True
-
-# .. toggle_name: settings.ENABLE_INTEGRITY_SIGNATURE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Whether to replace ID verification course/certificate requirement
-# with an in-course Honor Code agreement
-# (https://github.com/edx/edx-name-affirmation)
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2022-02-15
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1348'
-ENABLE_INTEGRITY_SIGNATURE = False
-
 # .. toggle_name: settings.ENABLE_LTI_PII_ACKNOWLEDGEMENT
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
@@ -410,31 +219,6 @@ ENABLE_INTEGRITY_SIGNATURE = False
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: 'https://2u-internal.atlassian.net/browse/MST-2055'
 ENABLE_LTI_PII_ACKNOWLEDGEMENT = False
-
-# .. toggle_name: MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: If enabled, the Library Content Block is marked as complete when users view it.
-#   Otherwise (by default), all children of this block must be completed.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2022-03-22
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/28268
-# .. toggle_warning: For consistency in user-experience, keep the value in sync with the setting of the same name
-#   in the LMS and CMS.
-MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW = False
-
-# .. toggle_name: settings.DISABLE_UNENROLLMENT
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to disable self-unenrollments via REST API.
-#   This also hides the "Unenroll" button on the Learner Dashboard.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-10-11
-# .. toggle_warning: For consistency in user experience, keep the value in sync with the setting of the same name
-#   in the LMS and CMS.
-# .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
-DISABLE_UNENROLLMENT = False
 
 # .. toggle_name: settings.DISABLE_ADVANCED_SETTINGS
 # .. toggle_implementation: DjangoSetting
@@ -469,23 +253,6 @@ ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33952
 ENABLE_HIDE_FROM_TOC_UI = False
 
-# .. toggle_name: settings.ENABLE_GRADING_METHOD_IN_PROBLEMS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Enables the grading method feature in capa problems.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2024-03-22
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
-ENABLE_GRADING_METHOD_IN_PROBLEMS = False
-
-# .. toggle_name: settings.BADGES_ENABLED
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to enable the Badges feature.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2024-04-10
-BADGES_ENABLED = False
-
 # .. toggle_name: settings.IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: True
@@ -510,22 +277,6 @@ MARKETING_EMAILS_OPT_IN = False
 
 ############################# MICROFRONTENDS ###################################
 COURSE_AUTHORING_MICROFRONTEND_URL = None
-DISCUSSIONS_MICROFRONTEND_URL = None
-DISCUSSIONS_MFE_FEEDBACK_URL = None
-ACCOUNT_MICROFRONTEND_URL = None
-LEARNING_MICROFRONTEND_URL = None
-
-
-# .. toggle_name: ENABLE_DYNAMIC_REGISTRATION_FIELDS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When enabled, this toggle adds fields configured in
-# REGISTRATION_EXTRA_FIELDS to Authn MFE
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2022-04-21
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://openedx.atlassian.net/browse/VAN-838
-ENABLE_DYNAMIC_REGISTRATION_FIELDS = False
 
 ############################# SOCIAL MEDIA SHARING #############################
 SOCIAL_SHARING_SETTINGS = {
@@ -555,18 +306,8 @@ GEOIP_PATH = REPO_ROOT / "common/static/data/geoip/GeoLite2-Country.mmdb"
 
 DATA_DIR = COURSES_ROOT
 
-DJFS = {
-    'type': 'osfs',
-    'directory_root': '/edx/var/edxapp/django-pyfs/static/django-pyfs',
-    'url_root': '/static/django-pyfs',
-}
-
 ######################## BRANCH.IO ###########################
 BRANCH_IO_KEY = ''
-
-######################## OPTIMIZELY ###########################
-OPTIMIZELY_PROJECT_ID = None
-OPTIMIZELY_FULLSTACK_SDK_KEY = None
 
 ######################## GOOGLE ANALYTICS ###########################
 GOOGLE_ANALYTICS_ACCOUNT = None
@@ -649,13 +390,9 @@ TEMPLATES = [
 DEFAULT_TEMPLATE_ENGINE = TEMPLATES[0]
 
 #################################### AWS #######################################
-AWS_ACCESS_KEY_ID = None
-AWS_SECRET_ACCESS_KEY = None
 AWS_SECURITY_TOKEN = None
 
 ##############################################################################
-
-EDX_ROOT_URL = ''
 
 # use the ratelimit backend to prevent brute force attacks
 AUTHENTICATION_BACKENDS = [
@@ -665,12 +402,6 @@ AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.AllowAllUsersModelBackend',
     'bridgekeeper.backends.RulePermissionBackend',
 ]
-
-# License for serving content in China
-ICP_LICENSE = None
-ICP_LICENSE_INFO = {}
-
-LOGGING_ENV = 'sandbox'
 
 LMS_BASE = None
 
@@ -686,51 +417,16 @@ FRONTEND_REGISTER_URL = Derived(lambda settings: settings.LMS_ROOT_URL + '/regis
 
 ENTERPRISE_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/enterprise/api/v1/')
 ENTERPRISE_CONSENT_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/consent/api/v1/')
-ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS = {}
 
 # Public domain name of Studio (should be resolvable from the end-user's browser)
 CMS_BASE = None
 CMS_ROOT_URL = None
-
-LOG_DIR = '/edx/var/log/edx'
-
-LOCAL_LOGLEVEL = "INFO"
 
 MAINTENANCE_BANNER_TEXT = 'Sample banner message'
 
 WIKI_ENABLED = True
 
 CERT_QUEUE = 'certificates'
-
-ELASTIC_SEARCH_CONFIG = [
-    {
-        'use_ssl': False,
-        'host': 'localhost',
-        'port': 9200
-    }
-]
-
-######################### CSRF #########################################
-
-# Forwards-compatibility with Django 1.7
-CSRF_COOKIE_AGE = 60 * 60 * 24 * 7 * 52
-# It is highly recommended that you override this in any environment accessed by
-# end users
-CSRF_COOKIE_SECURE = False
-
-CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = ''
-CROSS_DOMAIN_CSRF_COOKIE_NAME = ''
-
-#################### CAPA External Code Evaluation #############################
-XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds
-XQUEUE_INTERFACE = {
-    'url': 'http://localhost:18040',
-    'basic_auth': ['edx', 'edx'],
-    'django_auth': {
-        'username': 'lms',
-        'password': 'password'
-    }
-}
 
 ################################# Middleware ###################################
 
@@ -820,12 +516,6 @@ MIDDLEWARE = [
 
 EXTRA_MIDDLEWARE_CLASSES = []
 
-# Clickjacking protection can be disabled by setting this to 'ALLOW'
-X_FRAME_OPTIONS = 'DENY'
-
-# Platform for Privacy Preferences header
-P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
-
 ############# XBlock Configuration ##########
 
 # Import after sys.path fixup
@@ -850,29 +540,10 @@ XBLOCK_MIXINS = (
     AuthoringMixin,
 )
 
-# .. setting_name: XBLOCK_EXTRA_MIXINS
-# .. setting_default: ()
-# .. setting_description: Custom mixins that will be dynamically added to every XBlock and XBlockAside instance.
-#     These can be classes or dotted-path references to classes.
-#     For example: `XBLOCK_EXTRA_MIXINS = ('my_custom_package.my_module.MyCustomMixin',)`
-XBLOCK_EXTRA_MIXINS = ()
-
-# Paths to wrapper methods which should be applied to every XBlock's FieldData.
-XBLOCK_FIELD_DATA_WRAPPERS = ()
-
-# .. setting_name: XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE
-# .. setting_default: default
-# .. setting_description: The django cache key of the cache to use for storing anonymous user state for XBlocks.
-XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
-
 ############################ ORA 2 ############################################
 
 # By default, don't use a file prefix
 ORA2_FILE_PREFIX = 'default_env-default_deployment/ora2'
-
-# Default File Upload Storage bucket and prefix. Used by the FileUpload Service.
-FILE_UPLOAD_STORAGE_BUCKET_NAME = 'SET-ME-PLEASE (ex. bucket-name)'
-FILE_UPLOAD_STORAGE_PREFIX = 'submissions_attachments'
 
 ############################ Modulestore Configuration ################################
 
@@ -951,43 +622,6 @@ MODULESTORE = {
 # require student context.
 MODULESTORE_FIELD_OVERRIDE_PROVIDERS = ()
 
-DATABASES = {
-    # edxapp's edxapp-migrate scripts and the edxapp_migrate play
-    # will ensure that any DB not named read_replica will be migrated
-    # for both the lms and cms.
-    'default': {
-        'ATOMIC_REQUESTS': True,
-        'CONN_MAX_AGE': 0,
-        'ENGINE': 'django.db.backends.mysql',
-        'HOST': '127.0.0.1',
-        'NAME': 'edxapp',
-        'OPTIONS': {},
-        'PASSWORD': 'password',
-        'PORT': '3306',
-        'USER': 'edxapp001'
-    },
-    'read_replica': {
-        'CONN_MAX_AGE': 0,
-        'ENGINE': 'django.db.backends.mysql',
-        'HOST': '127.0.0.1',
-        'NAME': 'edxapp',
-        'OPTIONS': {},
-        'PASSWORD': 'password',
-        'PORT': '3306',
-        'USER': 'edxapp001'
-    },
-    'student_module_history': {
-        'CONN_MAX_AGE': 0,
-        'ENGINE': 'django.db.backends.mysql',
-        'HOST': '127.0.0.1',
-        'NAME': 'edxapp_csmh',
-        'OPTIONS': {},
-        'PASSWORD': 'password',
-        'PORT': '3306',
-        'USER': 'edxapp001'
-    }
-}
-
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 DEFAULT_HASHING_ALGORITHM = 'sha256'
 
@@ -1019,57 +653,14 @@ CODE_JAIL = {
     "limit_overrides": {},
 }
 
-# Some courses are allowed to run unsafe code. This is a list of regexes, one
-# of them must match the course id for that course to run unsafe code.
-#
-# For example:
-#
-#   COURSES_WITH_UNSAFE_CODE = [
-#       r"Harvard/XY123.1/.*"
-#   ]
-
-COURSES_WITH_UNSAFE_CODE = []
-
-# Cojail REST service
-ENABLE_CODEJAIL_REST_SERVICE = False
-# .. setting_name: CODE_JAIL_REST_SERVICE_REMOTE_EXEC
-# .. setting_default: 'xmodule.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
-# .. setting_description: Set the python package.module.function that is reponsible of
-#   calling the remote service in charge of jailed code execution
-CODE_JAIL_REST_SERVICE_REMOTE_EXEC = 'xmodule.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
-# .. setting_name: CODE_JAIL_REST_SERVICE_HOST
-# .. setting_default: 'http://127.0.0.1:8550'
-# .. setting_description: Set the codejail remote service host
-CODE_JAIL_REST_SERVICE_HOST = 'http://127.0.0.1:8550'
-# .. setting_name: CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT
-# .. setting_default: 0.5
-# .. setting_description: Set the number of seconds CMS will wait to establish an internal
-#   connection to the codejail remote service.
-CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT = 0.5  # time in seconds
-# .. setting_name: CODE_JAIL_REST_SERVICE_READ_TIMEOUT
-# .. setting_default: 3.5
-# .. setting_description: Set the number of seconds CMS will wait for a response from the
-#   codejail remote service endpoint.
-CODE_JAIL_REST_SERVICE_READ_TIMEOUT = 3.5  # time in seconds
-
 ############################ DJANGO_BUILTINS ################################
-# Change DEBUG in your environment settings files, not here
-SESSION_COOKIE_SECURE = False
-SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
-SESSION_COOKIE_NAME = 'sessionid'
 
-# Site info
-SITE_NAME = "localhost"
-HTTPS = 'on'
 ROOT_URLCONF = 'cms.urls'
 
 COURSE_IMPORT_EXPORT_BUCKET = ''
 COURSE_METADATA_EXPORT_BUCKET = ''
 
 ALTERNATE_WORKER_QUEUES = 'lms'
-
-X_FRAME_OPTIONS = 'DENY'
 
 # .. setting_name: GIT_REPO_EXPORT_DIR
 # .. setting_default: '/edx/var/edxapp/export_course_repos'
@@ -1096,11 +687,6 @@ BUGS_EMAIL = 'bugs@example.com'
 SERVER_EMAIL = 'devops@example.com'
 UNIVERSITY_EMAIL = 'university@example.com'
 PRESS_EMAIL = 'press@example.com'
-ADMINS = []
-MANAGERS = ADMINS
-
-# Initialize to 'release', but read from JSON in production.py
-EDX_PLATFORM_REVISION = 'release'
 
 # Static content
 STATIC_URL = '/static/studio/'
@@ -1115,32 +701,10 @@ STATICFILES_DIRS = [
     XMODULE_ROOT / "static",
 ]
 
-# Locale/Internationalization
-CELERY_TIMEZONE = 'UTC'
-TIME_ZONE = 'UTC'
-LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
-
-# Languages supported for custom course certificate templates
-CERTIFICATE_TEMPLATE_LANGUAGES = {
-    'en': 'English',
-    'es': 'Español',
-}
-
-USE_I18N = True
-USE_L10N = True
-
-STATICI18N_FILENAME_FUNCTION = 'statici18n.utils.legacy_filename'
-STATICI18N_ROOT = PROJECT_ROOT / "static"
-
-# Messages
-MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
-
 COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 COURSE_METADATA_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
-
-##### EMBARGO #####
-EMBARGO_SITE_REDIRECT_URL = None
+STATICI18N_ROOT = PROJECT_ROOT / "static"
 
 ##### custom vendor plugin variables #####
 
@@ -1295,10 +859,6 @@ STATICFILES_IGNORE_PATTERNS = (
 
 ################################# DJANGO-REQUIRE ###############################
 
-
-# The baseUrl to pass to the r.js optimizer, relative to STATIC_ROOT.
-REQUIRE_BASE_URL = "./"
-
 # The name of a build profile to use for your project, relative to REQUIRE_BASE_URL.
 # A sensible value would be 'app.build.js'. Leave blank to use the built-in default build profile.
 # Set to False to disable running the default profile (e.g. if only using it to build Standalone
@@ -1308,10 +868,7 @@ REQUIRE_BUILD_PROFILE = "cms/js/build.js"
 # The name of the require.js script used by your project, relative to REQUIRE_BASE_URL.
 REQUIRE_JS = "js/vendor/requiresjs/require.js"
 
-# Whether to run django-require in debug mode.
-REQUIRE_DEBUG = False
-
-########################## DJANGO WEBPACK LOADER ##############################
+########################## Django Webpack Loader ###########################
 
 WEBPACK_LOADER = {
     'DEFAULT': {
@@ -1323,7 +880,6 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(STATIC_ROOT, 'webpack-worker-stats.json')
     }
 }
-
 
 ############################ SERVICE_VARIANT ##################################
 
@@ -1338,30 +894,6 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 
 
 ################################# CELERY ######################################
-
-# Message configuration
-
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-
-CELERY_MESSAGE_COMPRESSION = 'gzip'
-
-# Results configuration
-
-CELERY_IGNORE_RESULT = False
-CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
-
-# Events configuration
-
-CELERY_TRACK_STARTED = True
-
-CELERY_SEND_EVENTS = True
-CELERY_SEND_TASK_SENT_EVENT = True
-
-# Exchange configuration
-
-CELERY_DEFAULT_EXCHANGE = 'edx.core'
-CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
 
 # Name the exchange and queues for each variant
 
@@ -1384,10 +916,6 @@ CELERY_QUEUES = {
 
 # Queues configuration
 
-CELERY_QUEUE_HA_POLICY = 'all'
-
-CELERY_CREATE_MISSING_QUEUES = True
-
 CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = True
 
 BROKER_USE_SSL = Derived(lambda settings: settings.CELERY_BROKER_USE_SSL)
@@ -1399,27 +927,6 @@ CELERY_ALWAYS_EAGER = False
 HEARTBEAT_CELERY_ROUTING_KEY = HIGH_PRIORITY_QUEUE
 
 ############################## Video ##########################################
-
-YOUTUBE = {
-    # YouTube JavaScript API
-    'API': 'https://www.youtube.com/iframe_api',
-
-    'TEST_TIMEOUT': 1500,
-
-    # URL to get YouTube metadata
-    'METADATA_URL': 'https://www.googleapis.com/youtube/v3/videos',
-
-    # Web page mechanism for scraping transcript information from youtube video pages
-    'TRANSCRIPTS': {
-        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
-        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
-        'ALLOWED_LANGUAGE_CODES': ["en", "en-US", "en-GB"],
-    },
-
-    'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
-}
-
-YOUTUBE_API_KEY = 'PUT_YOUR_API_KEY_HERE'
 
 # Additional languages that should be supported for video transcripts, not included in ALL_LANGUAGES
 EXTENDED_VIDEO_TRANSCRIPT_LANGUAGES = []
@@ -1700,17 +1207,8 @@ INSTALLED_APPS = [
 
 ################# EDX MARKETING SITE ##################################
 
-EDXMKTG_LOGGED_IN_COOKIE_NAME = 'edxloggedin'
-EDXMKTG_USER_INFO_COOKIE_NAME = 'edx-user-info'
-EDXMKTG_USER_INFO_COOKIE_VERSION = 1
+MKTG_URL_LINK_MAP = {}
 
-MKTG_URLS = {}
-MKTG_URL_OVERRIDES = {}
-MKTG_URL_LINK_MAP = {
-
-}
-
-SUPPORT_SITE_LINK = ''
 ID_VERIFICATION_SUPPORT_LINK = ''
 PASSWORD_RESET_SUPPORT_LINK = ''
 ACTIVATION_EMAIL_SUPPORT_LINK = ''
@@ -1777,11 +1275,6 @@ EVENT_TRACKING_PROCESSORS = []
 
 EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST = []
 
-#### PASSWORD POLICY SETTINGS #####
-PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG = {
-    'ENFORCE_COMPLIANCE_ON_LOGIN': False
-}
-
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = 6
 MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 30 * 60
@@ -1836,15 +1329,6 @@ for app_name, insert_before in OPTIONAL_APPS:
     except (IndexError, ValueError):
         INSTALLED_APPS.append(app_name)
 
-
-### External auth usage -- prefixes for ENROLLMENT_DOMAIN
-SHIBBOLETH_DOMAIN_PREFIX = 'shib:'
-
-# Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)
-# Limits are currently disabled - but can be used for finer-grained denial-of-service protection.
-DATA_UPLOAD_MAX_MEMORY_SIZE = None
-DATA_UPLOAD_MAX_NUMBER_FIELDS = None
-
 ### Size of chunks into which asset uploads will be divided
 UPLOAD_CHUNK_SIZE_IN_MB = 10
 
@@ -1884,12 +1368,6 @@ LIBRARY_BLOCK_TYPES = [
 
 ############### Settings for Retirement #####################
 # See annotations in lms/envs/common.py for details.
-RETIRED_USERNAME_PREFIX = 'retired__user_'
-# See annotations in lms/envs/common.py for details.
-RETIRED_EMAIL_PREFIX = 'retired__user_'
-# See annotations in lms/envs/common.py for details.
-RETIRED_EMAIL_DOMAIN = 'retired.invalid'
-# See annotations in lms/envs/common.py for details.
 RETIRED_USERNAME_FMT = Derived(lambda settings: settings.RETIRED_USERNAME_PREFIX + '{}')
 # See annotations in lms/envs/common.py for details.
 RETIRED_EMAIL_FMT = Derived(lambda settings: settings.RETIRED_EMAIL_PREFIX + '{}@' + settings.RETIRED_EMAIL_DOMAIN)
@@ -1897,39 +1375,6 @@ RETIRED_EMAIL_FMT = Derived(lambda settings: settings.RETIRED_EMAIL_PREFIX + '{}
 RETIRED_USER_SALTS = ['abc', '123']
 # See annotations in lms/envs/common.py for details.
 RETIREMENT_SERVICE_WORKER_USERNAME = 'RETIREMENT_SERVICE_USER'
-
-# These states are the default, but are designed to be overridden in configuration.
-# See annotations in lms/envs/common.py for details.
-RETIREMENT_STATES = [
-    'PENDING',
-
-    'LOCKING_ACCOUNT',
-    'LOCKING_COMPLETE',
-
-    # Use these states only when ENABLE_DISCUSSION_SERVICE is True.
-    'RETIRING_FORUMS',
-    'FORUMS_COMPLETE',
-
-    # TODO - Change these states to be the LMS-only email opt-out - PLAT-2189
-    'RETIRING_EMAIL_LISTS',
-    'EMAIL_LISTS_COMPLETE',
-
-    'RETIRING_ENROLLMENTS',
-    'ENROLLMENTS_COMPLETE',
-
-    # Use these states only when ENABLE_STUDENT_NOTES is True.
-    'RETIRING_NOTES',
-    'NOTES_COMPLETE',
-
-    'RETIRING_LMS',
-    'LMS_COMPLETE',
-
-    'ERRORED',
-    'ABORTED',
-    'COMPLETE',
-]
-
-USERNAME_REPLACEMENT_WORKER = "REPLACE WITH VALID USERNAME"
 
 # Files and Uploads type filter values
 
@@ -1970,67 +1415,16 @@ FILES_AND_UPLOAD_TYPE_FILTERS = {
              'text/coffeescript', 'text/x-matlab', 'application/sql', 'text/php', ]
 }
 
-# Default to no Search Engine
-SEARCH_ENGINE = None
 ELASTIC_FIELD_MAPPINGS = {
     "start_date": {
         "type": "date"
     }
 }
 
-XBLOCK_SETTINGS = {}
 XBLOCK_FS_STORAGE_BUCKET = None
 XBLOCK_FS_STORAGE_PREFIX = None
 
 STUDIO_FRONTEND_CONTAINER_URL = None
-
-################################ Settings for Credit Course Requirements ################################
-# Initial delay used for retrying tasks.
-# Additional retries use longer delays.
-# Value is in seconds.
-CREDIT_TASK_DEFAULT_RETRY_DELAY = 30
-
-# Maximum number of retries per task for errors that are not related
-# to throttling.
-CREDIT_TASK_MAX_RETRIES = 5
-
-# Maximum age in seconds of timestamps we will accept
-# when a credit provider notifies us that a student has been approved
-# or denied for credit.
-CREDIT_PROVIDER_TIMESTAMP_EXPIRATION = 15 * 60
-
-CREDIT_PROVIDER_SECRET_KEYS = {}
-
-# .. setting_name: COMPREHENSIVE_THEME_DIRS
-# .. setting_default: []
-# .. setting_description: A list of paths to directories, each of which will
-#   be searched for comprehensive themes. Do not override this Django setting directly.
-#   Instead, set the COMPREHENSIVE_THEME_DIRS environment variable, using colons (:) to
-#   separate paths.
-COMPREHENSIVE_THEME_DIRS = os.environ.get("COMPREHENSIVE_THEME_DIRS", "").split(":")
-
-# .. setting_name: DEFAULT_SITE_THEME
-# .. setting_default: None
-# .. setting_description: See LMS annotation.
-DEFAULT_SITE_THEME = None
-
-# .. toggle_name: ENABLE_COMPREHENSIVE_THEMING
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: See LMS annotation.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2016-06-30
-ENABLE_COMPREHENSIVE_THEMING = False
-
-# .. setting_name: CUSTOM_RESOURCE_TEMPLATES_DIRECTORY
-# .. setting_default: None
-# .. setting_description: Path to an existing directory of YAML files containing
-#    html content to be used with the subclasses of xmodule.x_module.ResourceTemplates.
-#    Default example templates can be found in xmodule/templates/html.
-#    Note that the extension used is ".yaml" and not ".yml".
-#    See xmodule.x_module.ResourceTemplates for usage.
-#   "CUSTOM_RESOURCE_TEMPLATES_DIRECTORY" : null
-CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = None
 
 ############################ Global Database Configuration #####################
 
@@ -2038,109 +1432,10 @@ DATABASE_ROUTERS = [
     'openedx.core.lib.django_courseware_routers.StudentModuleHistoryExtendedRouter',
 ]
 
-############################ Cache Configuration ###############################
-
-CACHES = {
-    'course_structure_cache': {
-        'KEY_PREFIX': 'course_structure',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '604800',  # 1 week
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'celery': {
-        'KEY_PREFIX': 'celery',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '7200',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'mongo_metadata_inheritance': {
-        'KEY_PREFIX': 'mongo_metadata_inheritance',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'TIMEOUT': 300,
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'staticfiles': {
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'staticfiles_general',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'default': {
-        'VERSION': '1',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'default',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'configuration': {
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'configuration',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'general': {
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'general',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-}
-
 ############################ OAUTH2 Provider ###################################
 
 # 5 minute expiration time for JWT id tokens issued for external API requests.
 OAUTH_ID_TOKEN_EXPIRATION = 5 * 60
-
-# Partner support link for CMS footer
-PARTNER_SUPPORT_EMAIL = ''
-
-# Affiliate cookie tracking
-AFFILIATE_COOKIE_NAME = 'dev_affiliate_id'
 
 # API access management
 API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
@@ -2155,65 +1450,16 @@ EDX_DRF_EXTENSIONS = {
 ############## Settings for Studio Context Sensitive Help ##############
 
 HELP_TOKENS_INI_FILE = REPO_ROOT / "cms" / "envs" / "help_tokens.ini"
-HELP_TOKENS_LANGUAGE_CODE = Derived(lambda settings: settings.LANGUAGE_CODE)
-HELP_TOKENS_VERSION = Derived(lambda settings: doc_version())
-HELP_TOKENS_BOOKS = {
-    'learner': 'https://edx.readthedocs.io/projects/open-edx-learner-guide',
-    'course_author': 'https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course',
-}
-
-# Used with Email sending
-RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS = 5
-RETRY_ACTIVATION_EMAIL_TIMEOUT = 0.5
-
-# Software Secure request retry settings
-# Time in seconds before a retry of the task should be 60 mints.
-SOFTWARE_SECURE_REQUEST_RETRY_DELAY = 60 * 60
-# Maximum of 6 retries before giving up.
-SOFTWARE_SECURE_RETRY_MAX_ATTEMPTS = 6
 
 ############## DJANGO-USER-TASKS ##############
 
 # How long until database records about the outcome of a task and its artifacts get deleted?
 USER_TASKS_MAX_AGE = timedelta(days=7)
 
-############## Settings for the Enterprise App ######################
-
-ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
-ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
-# The default value of this needs to be a 16 character string
-ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = {}
-
-# The setting key maps to the channel code (e.g. 'SAP' for success factors), Channel code is defined as
-# part of django model of each integrated channel in edx-enterprise.
-# The absence of a key/value pair translates to NO LIMIT on the number of "chunks" transmitted per cycle.
-INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT = {}
-
-BASE_COOKIE_DOMAIN = 'localhost'
-
-############## Settings for the Discovery App ######################
-
-COURSE_CATALOG_URL_ROOT = 'http://localhost:8008'
-COURSE_CATALOG_API_URL = f'{COURSE_CATALOG_URL_ROOT}/api/v1'
-
-# which access.py permission name to check in order to determine if a course is visible in
-# the course catalog. We default this to the legacy permission 'see_exists'.
-COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_exists'
-
-# which access.py permission name to check in order to determine if a course about page is
-# visible. We default this to the legacy permission 'see_exists'.
-COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_exists'
-
-DEFAULT_COURSE_VISIBILITY_IN_CATALOG = "both"
-DEFAULT_MOBILE_AVAILABLE = False
-
 ############################# Persistent Grades ####################################
 
 # Queue to use for updating persistent grades
 RECALCULATE_GRADES_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
-
-# Rate limit for regrading tasks that a grading policy change can kick off
-POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
 
 # .. setting_name: DEFAULT_GRADE_DESIGNATIONS
 # .. setting_default: ['A', 'B', 'C', 'D']
@@ -2255,24 +1501,8 @@ VIDEO_IMAGE_ASPECT_RATIO_TEXT = '16:9'
 VIDEO_IMAGE_ASPECT_RATIO_ERROR_MARGIN = 0.1
 
 ###################### ZENDESK ######################
-ZENDESK_URL = ''
 ZENDESK_USER = ''
 ZENDESK_API_KEY = ''
-ZENDESK_CUSTOM_FIELDS = {}
-ZENDESK_OAUTH_ACCESS_TOKEN = ''
-# A mapping of string names to Zendesk Group IDs
-# To get the IDs of your groups you can go to
-# {zendesk_url}/api/v2/groups.json
-ZENDESK_GROUP_ID_MAPPING = {}
-
-############## Settings for Completion API #########################
-
-# Once a user has watched this percentage of a video, mark it as complete:
-# (0.0 = 0%, 1.0 = 100%)
-COMPLETION_VIDEO_COMPLETE_PERCENTAGE = 0.95
-
-############### Settings for edx-rbac  ###############
-SYSTEM_WIDE_ROLE_CLASSES = []
 
 ############## Installed Django Apps #########################
 
@@ -2287,38 +1517,13 @@ add_plugins(__name__, ProjectType.CMS, SettingsType.COMMON)
 # See: https://docs.python.org/2/library/wsgiref.html#wsgiref.util.FileWrapper
 COURSE_EXPORT_DOWNLOAD_CHUNK_SIZE = 8192
 
-# E-Commerce API Configuration
-ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:8002'
-ECOMMERCE_API_URL = 'http://localhost:8002/api/v2'
-ECOMMERCE_API_SIGNING_KEY = 'SET-ME-PLEASE'
-
-CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:8005'
-CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:8005'
-CREDENTIALS_SERVICE_USERNAME = 'credentials_service_user'
-# time between scheduled runs, in seconds
-NOTIFY_CREDENTIALS_FREQUENCY = 14400
-
-ANALYTICS_DASHBOARD_URL = 'http://localhost:18110/courses'
-ANALYTICS_DASHBOARD_NAME = 'Your Platform Name Here Insights'
-
 COMMENTS_SERVICE_URL = 'http://localhost:18080'
 COMMENTS_SERVICE_KEY = 'password'
 
 EXAMS_SERVICE_URL = 'http://localhost:18740/api/v1'
 EXAMS_SERVICE_USERNAME = 'edx_exams_worker'
 
-FINANCIAL_REPORTS = {
-    'STORAGE_TYPE': 'localfs',
-    'BUCKET': None,
-    'ROOT_PATH': 'sandbox',
-}
-
 ############# CORS headers for cross-domain requests #################
-if ENABLE_CORS_HEADERS:
-    CORS_ALLOW_CREDENTIALS = True
-    CORS_ORIGIN_WHITELIST = ()
-    CORS_ORIGIN_ALLOW_ALL = False
-    CORS_ALLOW_INSECURE = False
 
 # Set CORS_ALLOW_HEADERS regardless of whether we've enabled ENABLE_CORS_HEADERS
 # because that decision might happen in a later config file. (The headers to
@@ -2328,10 +1533,6 @@ CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'content-range',
     'content-disposition',
 )
-
-LOGIN_REDIRECT_WHITELIST = []
-
-DEPRECATED_ADVANCED_COMPONENT_TYPES = []
 
 ########################## VIDEO IMAGE STORAGE ############################
 
@@ -2351,19 +1552,6 @@ VIDEO_IMAGE_SETTINGS = dict(
 VIDEO_IMAGE_MAX_AGE = 31536000
 
 ########################## VIDEO TRANSCRIPTS STORAGE ############################
-VIDEO_TRANSCRIPTS_SETTINGS = dict(
-    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
-    # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
-    # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
-    STORAGE_KWARGS=dict(
-        location=MEDIA_ROOT,
-    ),
-    DIRECTORY_PREFIX='video-transcripts/',
-    BASE_URL=MEDIA_URL,
-)
-
-VIDEO_TRANSCRIPTS_MAX_AGE = 31536000
 TRANSCRIPT_LANG_CACHE_TIMEOUT = 60 * 60 * 24
 
 
@@ -2382,17 +1570,6 @@ BULK_EMAIL_DEFAULT_FROM_EMAIL = 'no-reply@example.com'
 # a bulk email message.
 BULK_EMAIL_LOG_SENT_EMAILS = False
 
-############### Settings for django file storage ##################
-STORAGES = {
-    'default': {
-        'BACKEND': 'django.core.files.storage.FileSystemStorage'
-    },
-    'staticfiles': {
-        'BACKEND': 'openedx.core.storage.ProductionStorage'
-    }
-}
-
-
 ###################### Grade Downloads ######################
 # These keys are used for all of our asynchronous downloadable files, including
 # the ones that contain information other than grades.
@@ -2407,59 +1584,21 @@ GRADES_DOWNLOAD = {
 }
 
 ############### Settings swift #####################################
-SWIFT_USERNAME = None
-SWIFT_KEY = None
-SWIFT_TENANT_ID = None
-SWIFT_TENANT_NAME = None
-SWIFT_AUTH_URL = None
-SWIFT_AUTH_VERSION = None
-SWIFT_REGION_NAME = None
 SWIFT_USE_TEMP_URLS = False
-SWIFT_TEMP_URL_KEY = None
-SWIFT_TEMP_URL_DURATION = 1800  # seconds
-
-############### The SAML private/public key values ################
-SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = ""
-SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = ""
-SOCIAL_AUTH_SAML_SP_PRIVATE_KEY_DICT = {}
-SOCIAL_AUTH_SAML_SP_PUBLIC_CERT_DICT = {}
 
 ############### Settings for facebook ##############################
 FACEBOOK_APP_ID = 'FACEBOOK_APP_ID'
 FACEBOOK_APP_SECRET = 'FACEBOOK_APP_SECRET'
 FACEBOOK_API_VERSION = 'v2.1'
 
-############### Settings for django-fernet-fields ##################
-FERNET_KEYS = [
-    'DUMMY KEY CHANGE BEFORE GOING TO PRODUCTION',
-]
-
-### Proctoring configuration (redirct URLs and keys shared between systems) ####
-PROCTORING_BACKENDS = {
-    'DEFAULT': 'null',
-    # The null key needs to be quoted because
-    # null is a language independent type in YAML
-    'null': {}
-}
-
+###################### PROCTORING SETTINGS ##########################
 PROCTORING_SETTINGS = {}
 
 ###################### LEARNER PORTAL ################################
 LEARNER_PORTAL_URL_ROOT = 'https://learner-portal-localhost:18000'
 
 ############################ JWT #################################
-JWT_ISSUER = 'http://127.0.0.1:8000/oauth2'
-DEFAULT_JWT_ISSUER = {
-    'ISSUER': 'http://127.0.0.1:8000/oauth2',
-    'AUDIENCE': 'SET-ME-PLEASE',
-    'SECRET_KEY': 'SET-ME-PLEASE'
-}
-JWT_EXPIRATION = 30
-JWT_PRIVATE_SIGNING_KEY = None
 
-
-SYSLOG_SERVER = ''
-FEEDBACK_SUBMISSION_EMAIL = ''
 REGISTRATION_EXTRA_FIELDS = {
     'confirm_email': 'hidden',
     'level_of_education': 'optional',
@@ -2475,9 +1614,6 @@ REGISTRATION_EXTRA_FIELDS = {
 }
 EDXAPP_PARSE_KEYS = {}
 PARSE_KEYS = {}
-
-############################ AI_TRANSLATIONS ##################################
-AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
 ###################### DEPRECATED URLS ##########################
 
@@ -2503,32 +1639,11 @@ DISABLE_DEPRECATED_SIGNIN_URL = False
 # .. toggle_tickets: ARCH-1253
 DISABLE_DEPRECATED_SIGNUP_URL = False
 
-##### LOGISTRATION RATE LIMIT SETTINGS #####
-LOGISTRATION_RATELIMIT_RATE = '100/5m'
-LOGISTRATION_PER_EMAIL_RATELIMIT_RATE = '30/5m'
-LOGISTRATION_API_RATELIMIT = '20/m'
-LOGIN_AND_REGISTER_FORM_RATELIMIT = '100/5m'
-RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = '30/7d'
-RESET_PASSWORD_API_RATELIMIT = '30/7d'
-
 ##### REGISTRATION RATE LIMIT SETTINGS #####
-REGISTRATION_VALIDATION_RATELIMIT = '30/7d'
-REGISTRATION_RATELIMIT = '60/7d'
 OPTIONAL_FIELD_API_RATELIMIT = '10/h'
-
-##### PASSWORD RESET RATE LIMIT SETTINGS #####
-PASSWORD_RESET_IP_RATE = '1/m'
-PASSWORD_RESET_EMAIL_RATE = '2/h'
 
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = 100_000
-
-################# Student Verification #################
-VERIFY_STUDENT = {
-    "DAYS_GOOD_FOR": 365,  # How many days is a verficiation good for?
-    # The variable represents the window within which a verification is considered to be "expiring soon."
-    "EXPIRING_SOON_WINDOW": 28,
-}
 
 ######################## Organizations ########################
 
@@ -2548,39 +1663,9 @@ VERIFY_STUDENT = {
 # .. toggle_tickets: https://github.com/openedx/edx-organizations/blob/master/docs/decisions/0001-phase-in-db-backed-organizations-to-all.rst
 ORGANIZATIONS_AUTOCREATE = True
 
-################# Settings for brand logos. #################
-LOGO_IMAGE_EXTRA_TEXT = ''
-LOGO_URL = None
-LOGO_URL_PNG = None
-LOGO_TRADEMARK_URL = None
-FAVICON_URL = None
-DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
-
-############## Settings for course import olx validation ############################
-COURSE_OLX_VALIDATION_STAGE = 1
-COURSE_OLX_VALIDATION_IGNORE_LIST = None
-
-################# show account activate cta after register ########################
-SHOW_ACTIVATE_CTA_POPUP_COOKIE_NAME = 'show-account-activation-popup'
-SHOW_ACCOUNT_ACTIVATION_CTA = False
-
 ################# Documentation links for course apps #################
 
-# pylint: disable=line-too-long
-CALCULATOR_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/add_calculator.html"
-DISCUSSIONS_HELP_URL = "https://docs.openedx.org/en/latest/educators/concepts/communication/about_course_discussions.html"
-EDXNOTES_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/enable_notes.html"
-PROGRESS_HELP_URL = "https://docs.openedx.org/en/latest/educators/references/data/progress_page.html"
-TEAMS_HELP_URL = "https://docs.openedx.org/en/latest/educators/navigation/advanced_features.html#use-teams-in-your-course"
-TEXTBOOKS_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/manage_textbooks.html"
-WIKI_HELP_URL = "https://docs.openedx.org/en/latest/educators/concepts/communication/about_course_wiki.html"
-CUSTOM_PAGES_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/manage_custom_page.html"
 COURSE_LIVE_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/add_course_live.html"
-ORA_SETTINGS_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/Manage_ORA_Assignment.html"
-# pylint: enable=line-too-long
-
-# keys for  big blue button live provider
-COURSE_LIVE_GLOBAL_CREDENTIALS = {}
 
 ######################## Registration ########################
 
@@ -2590,9 +1675,6 @@ INACTIVE_USER_LOGIN = True
 
 # Redirect URL for inactive user. If not set, user will be redirected to /login after the login itself (loop)
 INACTIVE_USER_URL = f'http://{CMS_BASE}'
-
-# String length for the configurable part of the auto-generated username
-AUTO_GENERATED_USERNAME_RANDOM_STRING_LENGTH = 4
 
 ######################## Discussion Forum settings ########################
 
@@ -2604,20 +1686,11 @@ DISCUSSIONS_INCONTEXT_FEEDBACK_URL = ''
 DISCUSSIONS_INCONTEXT_LEARNMORE_URL = "https://docs.openedx.org/en/latest/educators/concepts/communication/about_course_discussions.html"
 # pylint: enable=line-too-long
 
-#### django-simple-history##
-# disable indexing on date field its coming django-simple-history.
-SIMPLE_HISTORY_DATE_INDEX = False
-
 #### Event bus producing ####
 
 
 def _should_send_xblock_events(settings):
     return settings.ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS
-
-
-def _should_send_learning_badge_events(settings):
-    return settings.BADGES_ENABLED
-
 
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
 # .. setting_default: all events disabled
@@ -2671,13 +1744,13 @@ EVENT_BUS_PRODUCER_CONFIG = {
     "org.openedx.learning.course.passing.status.updated.v1": {
         "learning-badges-lifecycle": {
             "event_key_field": "course_passing_status.course.course_key",
-            "enabled": Derived(_should_send_learning_badge_events),
+            "enabled": Derived(should_send_learning_badge_events),
         },
     },
     "org.openedx.learning.ccx.course.passing.status.updated.v1": {
         "learning-badges-lifecycle": {
             "event_key_field": "course_passing_status.course.ccx_course_key",
-            "enabled": Derived(_should_send_learning_badge_events),
+            "enabled": Derived(should_send_learning_badge_events),
         },
     },
 }
@@ -2686,8 +1759,6 @@ EVENT_BUS_PRODUCER_CONFIG = {
 
 # This affects the Authoring API swagger docs but not the legacy swagger docs under /api-docs/.
 REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
-
-BEAMER_PRODUCT_ID = ""
 
 ################### Studio Search (beta), using Meilisearch ###################
 
@@ -2730,28 +1801,6 @@ LIBRARY_ENABLED_BLOCKS = [
     'survey',
     'word_cloud',
 ]
-
-############## NOTIFICATIONS EXPIRY ##############
-NOTIFICATIONS_EXPIRY = 60
-EXPIRED_NOTIFICATIONS_DELETE_BATCH_SIZE = 10000
-NOTIFICATION_CREATION_BATCH_SIZE = 76
-NOTIFICATIONS_DEFAULT_FROM_EMAIL = "no-reply@example.com"
-NOTIFICATION_DIGEST_LOGO = DEFAULT_EMAIL_LOGO_URL
-
-
-SOCIAL_MEDIA_FOOTER_ACE_URLS = {
-    'reddit': 'http://www.reddit.com/r/edx',
-    'twitter': 'https://twitter.com/edXOnline',
-    'linkedin': 'http://www.linkedin.com/company/edx',
-    'facebook': 'http://www.facebook.com/EdxOnline',
-}
-
-SOCIAL_MEDIA_LOGO_URLS = {
-    'reddit': 'http://email-media.s3.amazonaws.com/edX/2021/social_5_reddit.png',
-    'twitter': 'http://email-media.s3.amazonaws.com/edX/2021/social_2_twitter.png',
-    'linkedin': 'http://email-media.s3.amazonaws.com/edX/2021/social_3_linkedin.png',
-    'facebook': 'http://email-media.s3.amazonaws.com/edX/2021/social_1_fb.png',
-}
 
 # .. setting_name: DEFAULT_ORG_LOGO_URL
 # .. setting_default: Derived(lambda settings: settings.STATIC_URL + 'images/logo.png')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -98,7 +98,7 @@ DISPLAY_DEBUG_INFO_TO_STAFF = True
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2425
 DISPLAY_HISTOGRAMS_TO_STAFF = False  # For large courses this slows down courseware access for staff.
 
-REROUTE_ACTIVATION_EMAIL = False    # nonempty string = address for all activation emails
+REROUTE_ACTIVATION_EMAIL = False  # nonempty string = address for all activation emails
 
 # .. toggle_name: settings.ENABLE_DISCUSSION_HOME_PANEL
 # .. toggle_implementation: DjangoSetting
@@ -236,7 +236,7 @@ ENABLE_VERIFIED_CERTIFICATES = False
 # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
 DISABLE_HONOR_CERTIFICATES = False  # Toggle to disable honor certificates
 
-DISABLE_AUDIT_CERTIFICATES = False    # Toggle to disable audit certificates
+DISABLE_AUDIT_CERTIFICATES = False  # Toggle to disable audit certificates
 
 # .. toggle_name: settings.ENABLE_LOGIN_MICROFRONTEND
 # .. toggle_implementation: DjangoSetting
@@ -361,7 +361,7 @@ ENABLE_COURSE_SORTING_BY_START_DATE = True
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/19604
 ENABLE_COURSE_HOME_REDIRECT = True
 
-# .. toggle_name: ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
+# .. toggle_name: settings.ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Display the standard footer in the login page. This feature can be overridden by a site-

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -65,7 +65,6 @@ from enterprise.constants import (
 )
 
 from openedx.core.lib.derived import Derived
-from openedx.core.release import doc_version
 from openedx.envs.common import *  # pylint: disable=wildcard-import
 
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
@@ -75,20 +74,8 @@ from openedx.core.lib.features_setting_proxy import FeaturesProxy
 FEATURES = FeaturesProxy(globals())
 
 ################################### FEATURES ###################################
-# .. setting_name: PLATFORM_NAME
-# .. setting_default: Your Platform Name Here
-# .. setting_description: The display name of the platform to be used in
-#     templates/emails/etc.
-PLATFORM_NAME = _('Your Platform Name Here')
-PLATFORM_DESCRIPTION = _('Your Platform Description Here')
+
 CC_MERCHANT_NAME = Derived(lambda settings: settings.PLATFORM_NAME)
-
-PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
-PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"
-
-ENABLE_JASMINE = False
-
-# FEATURES
 
 # .. toggle_name: settings.DISPLAY_DEBUG_INFO_TO_STAFF
 # .. toggle_implementation: DjangoSetting
@@ -111,44 +98,7 @@ DISPLAY_DEBUG_INFO_TO_STAFF = True
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2425
 DISPLAY_HISTOGRAMS_TO_STAFF = False  # For large courses this slows down courseware access for staff.
 
-REROUTE_ACTIVATION_EMAIL = False  # nonempty string = address for all activation emails
-
-# .. toggle_name: settings.DISABLE_START_DATES
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When True, all courses will be active, regardless of start
-#   date.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2012-07-24
-# .. toggle_warning: This will cause ALL courses to be immediately visible.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/17913
-## DO NOT SET TO True IN THIS FILE
-## Doing so will cause all courses to be released on production
-DISABLE_START_DATES = False
-
-# .. toggle_name: settings.ENABLE_DISCUSSION_SERVICE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: When True, it will enable the Discussion tab in courseware for all courses. Setting this
-#   to False will not contain inline discussion components and discussion tab in any courses.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2012-08-14
-# .. toggle_warning: If the discussion panel is present in the course and the value for this flag is False then,
-#   attempting to expand those components will cause errors. So, this should only be set to False with an LMS that
-#   is running courses that do not contain discussion components.
-#   For consistency in user-experience, keep the value in sync with the setting of the same name in the CMS.
-ENABLE_DISCUSSION_SERVICE = True
-
-# .. toggle_name: settings.ENABLE_TEXTBOOK
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Add PDF and HTML textbook tabs to the courseware.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-03-27
-# .. toggle_warning: For consistency in user-experience, keep the value in sync with the setting of the same name
-#   in the CMS.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/3064
-ENABLE_TEXTBOOK = True
+REROUTE_ACTIVATION_EMAIL = False    # nonempty string = address for all activation emails
 
 # .. toggle_name: settings.ENABLE_DISCUSSION_HOME_PANEL
 # .. toggle_implementation: DjangoSetting
@@ -216,17 +166,6 @@ ENABLE_MASQUERADE = True
 # .. toggle_creation_date: 2013-12-03
 DISABLE_LOGIN_BUTTON = False
 
-# .. toggle_name: settings.ENABLE_OAUTH2_PROVIDER
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Enable this feature to allow this Open edX platform to be an OAuth2 authentication
-#   provider. This is necessary to enable some other features, such as the REST API for the mobile application.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2014-09-09
-# .. toggle_target_removal_date: None
-# .. toggle_warning: This temporary feature toggle does not have a target removal date.
-ENABLE_OAUTH2_PROVIDER = False
-
 # .. toggle_name: settings.ENABLE_XBLOCK_VIEW_ENDPOINT
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
@@ -237,10 +176,6 @@ ENABLE_OAUTH2_PROVIDER = False
 # .. toggle_creation_date: 2014-03-14
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2968
 ENABLE_XBLOCK_VIEW_ENDPOINT = False
-
-# Allows to configure the LMS to provide CORS headers to serve requests from other
-# domains
-ENABLE_CORS_HEADERS = False
 
 # Can be turned off if course lists need to be hidden. Effects views and templates.
 # .. toggle_name: settings.COURSES_ARE_BROWSABLE
@@ -253,16 +188,6 @@ ENABLE_CORS_HEADERS = False
 # .. toggle_warning: This Effects views and templates.
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/1073
 COURSES_ARE_BROWSABLE = True
-
-# Can be turned off to disable the help link in the navbar
-# .. toggle_name: settings.ENABLE_HELP_LINK
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: When True, a help link is displayed on the main navbar. Set False to hide it.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-03-05
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/26106
-ENABLE_HELP_LINK = True
 
 # .. toggle_name: settings.HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED
 # .. toggle_implementation: DjangoSetting
@@ -288,16 +213,6 @@ ENABLE_STUDENT_HISTORY_VIEW = True
 # sandbox, for testing whether it's enabled properly.
 ENABLE_DEBUG_RUN_PYTHON = False
 
-# Enable URL that shows information about the status of various services
-ENABLE_SERVICE_STATUS = False
-
-# Don't autoplay videos for students
-AUTOPLAY_VIDEOS = False
-
-# Move the student to next page when a video finishes. Set to True to show
-# an auto-advance button in videos. If False, videos never auto-advance.
-ENABLE_AUTOADVANCE_VIDEOS = False
-
 # Enable instructor dash to submit background tasks
 ENABLE_INSTRUCTOR_BACKGROUND_TASKS = True
 
@@ -308,23 +223,8 @@ ENABLE_INSTRUCTOR_BACKGROUND_TASKS = True
 # True.
 INDIVIDUAL_DUE_DATES = False
 
-# .. toggle_name: CUSTOM_COURSES_EDX
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to enable Custom Courses for edX, a feature that is more commonly known as
-#   CCX. Documentation for configuring and using this feature is available at
-#   https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/configuration/enable_ccx.html
-# .. toggle_warning: When set to true, 'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider' will
-#    be added to MODULESTORE_FIELD_OVERRIDE_PROVIDERS
-# .. toggle_use_cases: opt_in, circuit_breaker
-# .. toggle_creation_date: 2015-04-10
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/6636
-CUSTOM_COURSES_EDX = False
-
 # Toggle to enable certificates of courses on dashboard
 ENABLE_VERIFIED_CERTIFICATES = False
-# Settings for course import olx validation
-ENABLE_COURSE_OLX_VALIDATION = False
 
 # .. toggle_name: settings.DISABLE_HONOR_CERTIFICATES
 # .. toggle_implementation: DjangoSetting
@@ -336,31 +236,7 @@ ENABLE_COURSE_OLX_VALIDATION = False
 # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
 DISABLE_HONOR_CERTIFICATES = False  # Toggle to disable honor certificates
 
-DISABLE_AUDIT_CERTIFICATES = False  # Toggle to disable audit certificates
-
-# .. toggle_name: settings.AUTOMATIC_AUTH_FOR_TESTING
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to perform acceptance and load test. Auto auth view is responsible for load
-#    testing and is controlled by this feature flag. Session verification (of CacheBackedAuthenticationMiddleware)
-#    is a security feature, but it can be turned off by enabling this feature flag.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2013-07-25
-# .. toggle_warning: If this has been set to True then the account activation email will be skipped.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/417
-AUTOMATIC_AUTH_FOR_TESTING = False
-
-# .. toggle_name: settings.RESTRICT_AUTOMATIC_AUTH
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Prevent auto auth from creating superusers or modifying existing users. Auto auth is a
-#   mechanism where superusers can simply modify attributes of other users by accessing the "/auto_auth url" with
-#   the right
-#   querystring parameters.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2018-05-07
-# .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
-RESTRICT_AUTOMATIC_AUTH = True
+DISABLE_AUDIT_CERTIFICATES = False    # Toggle to disable audit certificates
 
 # .. toggle_name: settings.ENABLE_LOGIN_MICROFRONTEND
 # .. toggle_implementation: DjangoSetting
@@ -434,20 +310,6 @@ ENABLE_MAX_FAILED_LOGIN_ATTEMPTS = True
 # Hide any Personally Identifiable Information from application logs
 SQUELCH_PII_IN_LOGS = True
 
-# .. toggle_name: settings.EMBARGO
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Turns on embargo functionality, which blocks users from
-#   the site or courses based on their location. Embargo can restrict users by states
-#   and whitelist/blacklist (IP Addresses (ie. 10.0.0.0), Networks (ie. 10.0.0.0/24)), or the user profile country.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-02-27
-# .. toggle_target_removal_date: None
-# .. toggle_warning: reverse proxy should be configured appropriately for example Client IP address headers
-#   (e.g HTTP_X_FORWARDED_FOR) should be configured.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2749
-EMBARGO = False
-
 # Whether the Wiki subsystem should be accessible via the direct /wiki/ paths. Setting this to True means
 # that people can submit content and modify the Wiki in any arbitrary manner. We're leaving this as True in the
 # defaults, so that we maintain current behavior
@@ -463,16 +325,6 @@ ALLOW_WIKI_ROOT_ACCESS = True
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2014-09-15
 ENABLE_THIRD_PARTY_AUTH = False
-
-# .. toggle_name: settings.ENABLE_MKTG_SITE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Toggle to enable alternate urls for marketing links.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-03-24
-# .. toggle_warning: When this is enabled, the MKTG_URLS setting should be defined. The use case of this feature
-#   toggle is uncertain.
-ENABLE_MKTG_SITE = False
 
 # Prevent concurrent logins per user
 PREVENT_CONCURRENT_LOGINS = True
@@ -509,11 +361,7 @@ ENABLE_COURSE_SORTING_BY_START_DATE = True
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/19604
 ENABLE_COURSE_HOME_REDIRECT = True
 
-# Expose Mobile REST API. Note that if you use this, you must also set
-# ENABLE_OAUTH2_PROVIDER to True
-ENABLE_MOBILE_REST_API = False
-
-# .. toggle_name: settings.ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
+# .. toggle_name: ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Display the standard footer in the login page. This feature can be overridden by a site-
@@ -538,29 +386,6 @@ ENABLE_MKTG_EMAIL_OPT_IN = False
 #   want these links on your footer then you should use the edx.org theme.
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/6588
 ENABLE_FOOTER_MOBILE_APP_LINKS = False
-
-# Let students save and manage their annotations
-# .. toggle_name: settings.ENABLE_EDXNOTES
-# .. toggle_implementation: SettingToggle
-# .. toggle_default: False
-# .. toggle_description: This toggle enables the students to save and manage their annotations in the
-#   course using the notes service. The bulk of the actual work in storing the notes is done by
-#   a separate service (see the edx-notes-api repo).
-# .. toggle_warning: Requires the edx-notes-api service properly running and to have configured the django settings
-#   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API. If you update this setting, also update it in Studio.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2015-01-04
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/6321
-ENABLE_EDXNOTES = False
-
-# Toggle to enable coordination with the Publisher tool (keep in sync with cms/envs/common.py)
-ENABLE_PUBLISHER = False
-
-# Milestones application flag
-MILESTONES_APP = False
-
-# Prerequisite courses feature flag
-ENABLE_PREREQUISITE_COURSES = False
 
 # For easily adding modes to courses during acceptance testing
 MODE_CREATION_FOR_TESTING = False
@@ -609,29 +434,6 @@ ENABLE_DASHBOARD_SEARCH = False
 
 # log all information from cybersource callbacks
 LOG_POSTPAY_CALLBACKS = True
-
-# .. toggle_name: settings.LICENSING
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Toggle platform-wide course licensing. The course.license attribute is then used to append
-#   license information to the courseware.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2015-05-14
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/7315
-LICENSING = False
-
-# .. toggle_name: settings.CERTIFICATES_HTML_VIEW
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to enable course certificates on your instance of Open edX.
-# .. toggle_warning: You must enable this feature flag in both Studio and the LMS and complete the configuration tasks
-#   described here:
-#   https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/configuration/enable_certificates.html  pylint: disable=line-too-long,useless-suppression
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2015-03-13
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/7113
-CERTIFICATES_HTML_VIEW = False
 
 # .. toggle_name: settings.CUSTOM_CERTIFICATE_TEMPLATES_ENABLED
 # .. toggle_implementation: DjangoSetting
@@ -705,72 +507,6 @@ ENABLE_SPECIAL_EXAMS = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/7689
 ENABLE_LTI_PROVIDER = False
 
-# .. toggle_name: settings.SHOW_HEADER_LANGUAGE_SELECTOR
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When set to True, language selector will be visible in the header.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2017-05-25
-# .. toggle_warning: You should set the languages in the DarkLangConfig table to get this working. If you have
-#   not set any languages in the DarkLangConfig table then the language selector will not be visible in the header.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/15133
-SHOW_HEADER_LANGUAGE_SELECTOR = False
-
-# At edX it's safe to assume that English transcripts are always available
-# This is not the case for all installations.
-# The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
-FALLBACK_TO_ENGLISH_TRANSCRIPTS = True
-
-# .. toggle_name: settings.SHOW_FOOTER_LANGUAGE_SELECTOR
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When set to True, language selector will be visible in the footer.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2017-05-25
-# .. toggle_warning: LANGUAGE_COOKIE_NAME is required to use footer-language-selector, set it if it has not been set.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/15133
-SHOW_FOOTER_LANGUAGE_SELECTOR = False
-
-# .. toggle_name: settings.ENABLE_CSMH_EXTENDED
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Write Courseware Student Module History (CSMH) to the extended table: this logs all
-#   student activities to MySQL, in a separate database.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-11-05
-# .. toggle_warning: Even though most Open edX instances run with a separate CSMH database, it may not always be
-#   the case. When disabling this feature flag, remember to remove "lms.djangoapps.coursewarehistoryextended"
-#   from the INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
-ENABLE_CSMH_EXTENDED = True
-
-# Read from both the CSMH and CSMHE history tables.
-# This is the default, but can be disabled if all history
-# lives in the Extended table, saving the frontend from
-# making multiple queries.
-ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES = True
-
-# Set this to False to facilitate cleaning up invalid xml from your modulestore.
-ENABLE_XBLOCK_XML_VALIDATION = True
-
-# .. toggle_name: settings.ALLOW_PUBLIC_ACCOUNT_CREATION
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Allow public account creation. If this is disabled, users will no longer have access to
-#   the signup page.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2017-04-12
-# .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
-ALLOW_PUBLIC_ACCOUNT_CREATION = True
-
-# .. toggle_name: settings.SHOW_REGISTRATION_LINKS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Allow registration links. If this is disabled, users will no longer see buttons to the
-#   the signup page.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2023-03-27
-SHOW_REGISTRATION_LINKS = True
-
 # .. toggle_name: settings.ENABLE_COOKIE_CONSENT
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
@@ -780,9 +516,6 @@ SHOW_REGISTRATION_LINKS = True
 # .. toggle_creation_date: 2017-03-03
 # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1560
 ENABLE_COOKIE_CONSENT = False
-
-# Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
-ENABLE_ENROLLMENT_TRACK_USER_PARTITION = True
 
 # Enable one click program purchase
 # See LEARNER-493
@@ -823,18 +556,6 @@ ENABLE_ENTERPRISE_INTEGRATION = False
 # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1880
 ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA = False
 
-# .. toggle_name: settings.ENABLE_PASSWORD_RESET_FAILURE_EMAIL
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Whether to send an email for failed password reset attempts or not. This happens when a
-#   user asks for a password reset but they don't have an account associated to their email. This is useful for
-#   notifying users that they don't have an account associated with email addresses they believe they've registered
-#   with. This setting can be overridden by a site-specific configuration.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2017-07-20
-# .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
-ENABLE_PASSWORD_RESET_FAILURE_EMAIL = False
-
 # Sets the default browser support. For more information go to http://browser-update.org/customize.html
 UNSUPPORTED_BROWSER_ALERT_VERSIONS = "{i:10,f:-3,o:-3,s:-3,c:-3}"
 
@@ -847,20 +568,6 @@ UNSUPPORTED_BROWSER_ALERT_VERSIONS = "{i:10,f:-3,o:-3,s:-3,c:-3}"
 # .. toggle_creation_date: 2018-06-01
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/18298
 ENABLE_ACCOUNT_DELETION = True
-
-# Enable feature to remove enrollments and users. Used to reset state of master's integration environments
-ENABLE_ENROLLMENT_RESET = False
-DISABLE_MOBILE_COURSE_AVAILABLE = False
-
-# .. toggle_name: settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by
-#   default because enabling allows a method to bypass password policy.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-02-21
-# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/21616'
-ENABLE_CHANGE_USER_PASSWORD_ADMIN = False
 
 # .. toggle_name: settings.ENABLE_AUTHN_MICROFRONTEND
 # .. toggle_implementation: DjangoSetting
@@ -884,30 +591,6 @@ ENABLE_AUTHN_MICROFRONTEND = os.environ.get("EDXAPP_ENABLE_AUTHN_MFE", False)
 ENABLE_CATALOG_MICROFRONTEND = False
 
 ### ORA Feature Flags ###
-# .. toggle_name: settings.ENABLE_ORA_ALL_FILE_URLS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-#   discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
-#   file metadata in staff assessments.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2020-03-03
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-# .. toggle_warning: This temporary feature toggle does not have a target removal date.
-ENABLE_ORA_ALL_FILE_URLS = False
-
-# .. toggle_name: settings.ENABLE_ORA_USER_STATE_UPLOAD_DATA
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-#   discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2020-03-03
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-# .. toggle_warning: This temporary feature toggle does not have a target removal date.
-ENABLE_ORA_USER_STATE_UPLOAD_DATA = False
 
 # .. toggle_name: settings.ENABLE_ORA_USERNAMES_ON_DATA_EXPORT
 # .. toggle_implementation: DjangoSetting
@@ -953,27 +636,6 @@ ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION = False
 # .. toggle_tickets: 'https://openedx.atlassian.net/browse/OSPR-5290'
 ENABLE_BULK_USER_RETIREMENT = False
 
-# .. toggle_name: settings.ENABLE_INTEGRITY_SIGNATURE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Whether to display honor code agreement for learners before their first grade assignment
-# (https://github.com/edx/edx-name-affirmation)
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2022-02-15
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1348'
-ENABLE_INTEGRITY_SIGNATURE = False
-
-# .. toggle_name: settings.ENABLE_LTI_PII_ACKNOWLEDGEMENT
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Enables the lti pii acknowledgement feature for a course
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2023-10
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: 'https://2u-internal.atlassian.net/browse/MST-2055'
-ENABLE_LTI_PII_ACKNOWLEDGEMENT = False
-
 # .. toggle_name: settings.ENABLE_NEW_BULK_EMAIL_EXPERIENCE
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
@@ -985,31 +647,6 @@ ENABLE_LTI_PII_ACKNOWLEDGEMENT = False
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1758'
 ENABLE_NEW_BULK_EMAIL_EXPERIENCE = False
-
-# .. toggle_name: MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: If enabled, the Library Content Block is marked as complete when users view it.
-#   Otherwise (by default), all children of this block must be completed.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2022-03-22
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/28268
-# .. toggle_warning: For consistency in user-experience, keep the value in sync with the setting of the same name
-#   in the LMS and CMS.
-MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW = False
-
-# .. toggle_name: settings.DISABLE_UNENROLLMENT
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to disable self-unenrollments via REST API.
-#   This also hides the "Unenroll" button on the Learner Dashboard.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-10-11
-# .. toggle_warning: For consistency in user experience, keep the value in sync with the setting of the same name
-#   in the LMS and CMS.
-# .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
-DISABLE_UNENROLLMENT = False
 
 # .. toggle_name: settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT
 # .. toggle_implementation: DjangoSetting
@@ -1042,15 +679,6 @@ DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED = False
 # .. toggle_creation_date: 2023-10-10
 # .. toggle_tickets: https://github.com/openedx/openedx-events/issues/210
 SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS = False
-
-# .. toggle_name: settings.ENABLE_GRADING_METHOD_IN_PROBLEMS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Enables the grading method feature in capa problems.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2024-03-22
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
-ENABLE_GRADING_METHOD_IN_PROBLEMS = False
 
 # .. toggle_name: settings.ENABLE_COURSEWARE_SEARCH_VERIFIED_REQUIRED
 # .. toggle_implementation: DjangoSetting
@@ -1106,40 +734,7 @@ DEFAULT_GROUPS = []
 # .. setting_description: Sets the number of days after which the gradebook will freeze following the course's end.
 GRADEBOOK_FREEZE_DAYS = 30
 
-# Used with XQueue
-XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds
-XQUEUE_INTERFACE = {
-    'url': 'http://localhost:18040',
-    'basic_auth': ['edx', 'edx'],
-    'django_auth': {
-        'username': 'lms',
-        'password': 'password'
-    }
-}
-
-# Used with Email sending
-RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS = 5
-RETRY_ACTIVATION_EMAIL_TIMEOUT = 0.5
-
-# Software Secure request retry settings
-# Time in seconds before a retry of the task should be 60 mints.
-SOFTWARE_SECURE_REQUEST_RETRY_DELAY = 60 * 60
-# Maximum of 6 retries before giving up.
-SOFTWARE_SECURE_RETRY_MAX_ATTEMPTS = 6
-
 RETRY_CALENDAR_SYNC_EMAIL_MAX_ATTEMPTS = 5
-
-MARKETING_EMAILS_OPT_IN = False
-
-# .. toggle_name: ENABLE_COPPA_COMPLIANCE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When True, enforces COPPA compliance and removes YOB field from registration form and account
-# .. settings page. Also hide YOB banner from profile page.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-10-27
-# .. toggle_tickets: 'https://openedx.atlassian.net/browse/VAN-622'
-ENABLE_COPPA_COMPLIANCE = False
 
 ############################# SET PATH INFORMATION #############################
 PROJECT_ROOT = path(__file__).abspath().dirname().dirname()  # /edx-platform/lms
@@ -1164,103 +759,6 @@ DATABASE_ROUTERS = [
     'openedx.core.lib.django_courseware_routers.StudentModuleHistoryExtendedRouter',
     'edx_django_utils.db.read_replica.ReadReplicaRouter',
 ]
-
-############################ Cache Configuration ###############################
-
-CACHES = {
-    'course_structure_cache': {
-        'KEY_PREFIX': 'course_structure',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '604800',  # 1 week
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'celery': {
-        'KEY_PREFIX': 'celery',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '7200',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'mongo_metadata_inheritance': {
-        'KEY_PREFIX': 'mongo_metadata_inheritance',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'TIMEOUT': 300,
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'staticfiles': {
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'staticfiles_general',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'default': {
-        'VERSION': '1',
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'default',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'configuration': {
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'configuration',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-    'general': {
-        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'general',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'OPTIONS': {
-            'no_delay': True,
-            'ignore_exc': True,
-            'use_pooling': True,
-            'connect_timeout': 0.5
-        }
-    },
-}
-
-############################ OAUTH2 Provider ###################################
-OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS = 365
-OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS = 30
 
 ################################## DJANGO OAUTH TOOLKIT #######################################
 
@@ -1418,52 +916,25 @@ AUTHENTICATION_BACKENDS = [
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
-# Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)
-# Limits are currently disabled - but can be used for finer-grained denial-of-service protection.
-DATA_UPLOAD_MAX_MEMORY_SIZE = None
-DATA_UPLOAD_MAX_NUMBER_FIELDS = None
-
 # Configuration option for when we want to grab server error pages
 STATIC_GRAB = False
 DEV_CONTENT = True
 
-# License for serving content in China
-ICP_LICENSE = None
-ICP_LICENSE_INFO = {}
-
-ELASTIC_SEARCH_CONFIG = [
-    {
-        'use_ssl': False,
-        'host': 'localhost',
-        'port': 9200
-    }
-]
-
 SEARCH_COURSEWARE_CONTENT_LOG_PARAMS = False
-
 
 # .. setting_name: ELASTIC_SEARCH_INDEX_PREFIX
 # .. setting_default: ''
 # .. setting_description: Specifies the prefix used when naming elasticsearch indexes related to edx-search.
 ELASTICSEARCH_INDEX_PREFIX = ""
 
-LOGGING_ENV = 'sandbox'
-
-EDX_ROOT_URL = ''
 EDX_API_KEY = None
 
 LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/login'
 LOGIN_URL = EDX_ROOT_URL + '/login'
 
-PARTNER_SUPPORT_EMAIL = ''
-
 CERT_QUEUE = 'test-pull'
 
 ALTERNATE_WORKER_QUEUES = 'cms'
-
-LOCAL_LOGLEVEL = "INFO"
-
-LOG_DIR = '/edx/var/log/edx'
 
 DATA_DIR = '/edx/var/edxapp/data'
 
@@ -1473,12 +944,6 @@ DATA_DIR = '/edx/var/edxapp/data'
 # .. setting_warning: Depends on the `open_edx_util.display_maintenance_warning` waffle switch.
 #   The banner is only rendered when the switch is activated.
 MAINTENANCE_BANNER_TEXT = None
-
-DJFS = {
-    'type': 'osfs',
-    'directory_root': '/edx/var/edxapp/django-pyfs/static/django-pyfs',
-    'url_root': '/static/django-pyfs',
-}
 
 # Set certificate issued date format. It supports all formats supported by
 # `common.djangoapps.util.date_utils.strftime_localized`.
@@ -1585,10 +1050,6 @@ GOOGLE_ANALYTICS_4_ID = None
 ######################## BRANCH.IO ###########################
 BRANCH_IO_KEY = None
 
-######################## OPTIMIZELY ###########################
-OPTIMIZELY_PROJECT_ID = None
-OPTIMIZELY_FULLSTACK_SDK_KEY = None
-
 ######################## HOTJAR ###########################
 HOTJAR_SITE_ID = 00000
 
@@ -1616,34 +1077,6 @@ XBLOCK_MIXINS = (
     XModuleMixin,
     EditInfoMixin,
 )
-
-# .. setting_name: XBLOCK_EXTRA_MIXINS
-# .. setting_default: ()
-# .. setting_description: Custom mixins that will be dynamically added to every XBlock and XBlockAside instance.
-#     These can be classes or dotted-path references to classes.
-#     For example: `XBLOCK_EXTRA_MIXINS = ('my_custom_package.my_module.MyCustomMixin',)`
-XBLOCK_EXTRA_MIXINS = ()
-
-# .. setting_name: XBLOCK_FIELD_DATA_WRAPPERS
-# .. setting_default: ()
-# .. setting_description: Paths to wrapper methods which should be applied to every XBlock's FieldData.
-XBLOCK_FIELD_DATA_WRAPPERS = ()
-
-XBLOCK_FS_STORAGE_BUCKET = None
-XBLOCK_FS_STORAGE_PREFIX = None
-
-# .. setting_name: XBLOCK_SETTINGS
-# .. setting_default: {}
-# .. setting_description: Dictionary containing server-wide configuration of XBlocks on a per-type basis.
-#     By default, keys should match the XBlock `block_settings_key` attribute/property. If the attribute/property
-#     is not defined, use the XBlock class name. Check `xmodule.services.SettingsService`
-#     for more reference.
-XBLOCK_SETTINGS = {}
-
-# .. setting_name: XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE
-# .. setting_default: default
-# .. setting_description: The django cache key of the cache to use for storing anonymous user state for XBlocks.
-XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
 ############# ModuleStore Configuration ##########
 
@@ -1716,48 +1149,6 @@ MODULESTORE = {
     }
 }
 
-
-DATABASES = {
-    # edxapp's edxapp-migrate scripts and the edxapp_migrate play
-    # will ensure that any DB not named read_replica will be migrated
-    # for both the lms and cms.
-    'default': {
-        'ATOMIC_REQUESTS': True,
-        'CONN_MAX_AGE': 0,
-        'ENGINE': 'django.db.backends.mysql',
-        'HOST': '127.0.0.1',
-        'NAME': 'edxapp',
-        'OPTIONS': {},
-        'PASSWORD': 'password',
-        'PORT': '3306',
-        'USER': 'edxapp001'
-    },
-    'read_replica': {
-        'CONN_MAX_AGE': 0,
-        'ENGINE': 'django.db.backends.mysql',
-        'HOST': '127.0.0.1',
-        'NAME': 'edxapp',
-        'OPTIONS': {},
-        'PASSWORD': 'password',
-        'PORT': '3306',
-        'USER': 'edxapp001'
-    },
-    'student_module_history': {
-        'CONN_MAX_AGE': 0,
-        'ENGINE': 'django.db.backends.mysql',
-        'HOST': '127.0.0.1',
-        'NAME': 'edxapp_csmh',
-        'OPTIONS': {},
-        'PASSWORD': 'password',
-        'PORT': '3306',
-        'USER': 'edxapp001'
-    }
-}
-
-
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
-DEFAULT_HASHING_ALGORITHM = 'sha256'
-
 HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = {}
 MONGODB_LOG = {}
 
@@ -1788,38 +1179,6 @@ CODE_JAIL = {
     "limit_overrides": {},
 }
 
-# Some courses are allowed to run unsafe code. This is a list of regexes, one
-# of them must match the course id for that course to run unsafe code.
-#
-# For example:
-#
-#   COURSES_WITH_UNSAFE_CODE = [
-#       r"Harvard/XY123.1/.*"
-#   ]
-COURSES_WITH_UNSAFE_CODE = []
-
-# Code jail REST service
-ENABLE_CODEJAIL_REST_SERVICE = False
-# .. setting_name: CODE_JAIL_REST_SERVICE_REMOTE_EXEC
-# .. setting_default: 'xmodule.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
-# .. setting_description: Set the python package.module.function that is reponsible of
-#   calling the remote service in charge of jailed code execution
-CODE_JAIL_REST_SERVICE_REMOTE_EXEC = 'xmodule.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
-# .. setting_name: CODE_JAIL_REST_SERVICE_HOST
-# .. setting_default: 'http://127.0.0.1:8550'
-# .. setting_description: Set the codejail remote service host
-CODE_JAIL_REST_SERVICE_HOST = 'http://127.0.0.1:8550'
-# .. setting_name: CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT
-# .. setting_default: 0.5
-# .. setting_description: Set the number of seconds LMS will wait to establish an internal
-#   connection to the codejail remote service.
-CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT = 0.5  # time in seconds
-# .. setting_name: CODE_JAIL_REST_SERVICE_READ_TIMEOUT
-# .. setting_default: 3.5
-# .. setting_description: Set the number of seconds LMS will wait for a response from the
-#   codejail remote service endpoint.
-CODE_JAIL_REST_SERVICE_READ_TIMEOUT = 3.5  # time in seconds
-
 # .. setting_name: PYTHON_LIB_FILENAME
 # .. setting_default: python_lib.zip
 # .. setting_description: Name of the course file to make available to code in
@@ -1828,11 +1187,6 @@ CODE_JAIL_REST_SERVICE_READ_TIMEOUT = 3.5  # time in seconds
 PYTHON_LIB_FILENAME = 'python_lib.zip'
 
 ############################### DJANGO BUILT-INS ###############################
-# Change DEBUG in your environment settings files, not here
-SESSION_COOKIE_SECURE = False
-SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
-SESSION_COOKIE_NAME = 'sessionid'
 
 # django-session-cookie middleware
 DCS_SESSION_COOKIE_SAMESITE = 'None'
@@ -1849,8 +1203,6 @@ STUDIO_NAME = 'Studio'
 STUDIO_SHORT_NAME = 'Studio'
 
 # Site info
-SITE_NAME = "localhost"
-HTTPS = 'on'
 ROOT_URLCONF = 'lms.urls'
 # NOTE: Please set ALLOWED_HOSTS to some sane value, as we do not allow the default '*'
 # Platform Email
@@ -1871,9 +1223,6 @@ CONTACT_MAILING_ADDRESS = 'SET-ME-PLEASE'
 # Account activation email sender address
 ACTIVATION_EMAIL_FROM_ADDRESS = ''
 
-ADMINS = ()
-MANAGERS = ADMINS
-
 # Static content
 STATIC_URL = '/static/'
 STATIC_ROOT = os.environ.get('STATIC_ROOT_LMS', ENV_ROOT / "staticfiles")
@@ -1888,27 +1237,7 @@ STATICFILES_DIRS = [
     XMODULE_ROOT / "static",
 ]
 
-FAVICON_PATH = 'images/favicon.ico'
-
-# Locale/Internationalization
-CELERY_TIMEZONE = 'UTC'
-TIME_ZONE = 'UTC'
-LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
-
-# Languages supported for custom course certificate templates
-CERTIFICATE_TEMPLATE_LANGUAGES = {
-    'en': 'English',
-    'es': 'Español',
-}
-
-USE_I18N = True
-USE_L10N = True
-
-STATICI18N_FILENAME_FUNCTION = 'statici18n.utils.legacy_filename'
 STATICI18N_ROOT = PROJECT_ROOT / "static"
-
-# Messages
-MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
 # Guidelines for translators
 TRANSLATORS_GUIDE = 'https://docs.openedx.org/en/latest/translators/index.html'
@@ -1916,8 +1245,6 @@ TRANSLATORS_GUIDE = 'https://docs.openedx.org/en/latest/translators/index.html'
 #################################### AWS #######################################
 # The number of seconds that a generated URL is valid for.
 AWS_QUERYSTRING_EXPIRE = 10 * 365 * 24 * 60 * 60  # 10 years
-AWS_ACCESS_KEY_ID = None
-AWS_SECRET_ACCESS_KEY = None
 
 ################################# SIMPLEWIKI ###################################
 SIMPLE_WIKI_REQUIRE_LOGIN_EDIT = True
@@ -1972,21 +1299,8 @@ WIKI_LINK_LIVE_LOOKUPS = False
 WIKI_LINK_DEFAULT_LEVEL = 2
 
 ##### Zendesk #####
-ZENDESK_URL = ''
 ZENDESK_USER = None
 ZENDESK_API_KEY = None
-ZENDESK_CUSTOM_FIELDS = {}
-ZENDESK_OAUTH_ACCESS_TOKEN = ''
-# A mapping of string names to Zendesk Group IDs
-# To get the IDs of your groups you can go to
-# {zendesk_url}/api/v2/groups.json
-ZENDESK_GROUP_ID_MAPPING = {}
-
-##### EMBARGO #####
-EMBARGO_SITE_REDIRECT_URL = None
-
-##### shoppingcart Payment #####
-PAYMENT_SUPPORT_EMAIL = 'billing@example.com'
 
 # Setting for PAID_COURSE_REGISTRATION, DOES NOT AFFECT VERIFIED STUDENTS
 PAID_COURSE_REGISTRATION_CURRENCY = ['usd', '$']
@@ -2179,12 +1493,6 @@ MIDDLEWARE = [
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]
-
-# Clickjacking protection can be disbaled by setting this to 'ALLOW'
-X_FRAME_OPTIONS = 'DENY'
-
-# Platform for Privacy Preferences header
-P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
 
 ############################### PIPELINE #######################################
 
@@ -2590,9 +1898,6 @@ STATICFILES_IGNORE_PATTERNS = (
 
 ################################# DJANGO-REQUIRE ###############################
 
-# The baseUrl to pass to the r.js optimizer, relative to STATIC_ROOT.
-REQUIRE_BASE_URL = "./"
-
 # The name of a build profile to use for your project, relative to REQUIRE_BASE_URL.
 # A sensible value would be 'app.build.js'. Leave blank to use the built-in default build profile.
 # Set to False to disable running the default profile (e.g. if only using it to build Standalone
@@ -2601,9 +1906,6 @@ REQUIRE_BUILD_PROFILE = "lms/js/build.js"
 
 # The name of the require.js script used by your project, relative to REQUIRE_BASE_URL.
 REQUIRE_JS = "common/js/vendor/require.js"
-
-# Whether to run django-require in debug mode.
-REQUIRE_DEBUG = False
 
 # In production, the Django pipeline appends a file hash to JavaScript file names.
 # This makes it difficult for RequireJS to load its requirements, since module names
@@ -2661,31 +1963,6 @@ CELERY_IMPORTS = [
 #    These packages are added in addition to those added by CELERY_IMPORTS.
 CELERY_EXTRA_IMPORTS = []
 
-# Message configuration
-
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-
-CELERY_MESSAGE_COMPRESSION = 'gzip'
-
-# Results configuration
-
-CELERY_IGNORE_RESULT = False
-CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
-
-# Events configuration
-
-CELERY_TRACK_STARTED = True
-
-CELERY_SEND_EVENTS = True
-CELERY_SEND_TASK_SENT_EVENT = True
-
-# Exchange configuration
-
-CELERY_DEFAULT_EXCHANGE = 'edx.core'
-CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
-
-
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
 # configuration files are read during startup.
 SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', "lms")
@@ -2718,10 +1995,6 @@ CELERY_QUEUES = {
 CELERY_ROUTES = "openedx.core.lib.celery.routers.route_task"
 CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this dict
 
-CELERY_QUEUE_HA_POLICY = 'all'
-
-CELERY_CREATE_MISSING_QUEUES = True
-
 # let logging work as configured:
 CELERYD_HIJACK_ROOT_LOGGER = False
 
@@ -2731,48 +2004,7 @@ BROKER_USE_SSL = False
 
 HEARTBEAT_CELERY_ROUTING_KEY = HIGH_PRIORITY_QUEUE
 
-################################ Block Structures ###################################
-
-# .. setting_name: BLOCK_STRUCTURES_SETTINGS
-# .. setting_default: dict of settings
-# .. setting_description: Stores all the settings used by block structures and block structure
-#   related tasks. See BLOCK_STRUCTURES_SETTINGS[XXX] documentation for details of each setting.
-#   For more information, check https://github.com/openedx/edx-platform/pull/13388.
-BLOCK_STRUCTURES_SETTINGS = dict(
-    # .. setting_name: BLOCK_STRUCTURES_SETTINGS['COURSE_PUBLISH_TASK_DELAY']
-    # .. setting_default: 30
-    # .. setting_description: Delay, in seconds, after a new edit of a course is published before
-    #   updating the block structures cache. This is needed for a better chance at getting
-    #   the latest changes when there are secondary reads in sharded mongoDB clusters.
-    #   For more information, check https://github.com/openedx/edx-platform/pull/13388 and
-    #   https://github.com/openedx/edx-platform/pull/14571.
-    COURSE_PUBLISH_TASK_DELAY=30,
-
-    # .. setting_name: BLOCK_STRUCTURES_SETTINGS['TASK_DEFAULT_RETRY_DELAY']
-    # .. setting_default: 30
-    # .. setting_description: Delay, in seconds, between retry attempts if a block structure task
-    #   fails. For more information, check https://github.com/openedx/edx-platform/pull/13388 and
-    #   https://github.com/openedx/edx-platform/pull/14571.
-    TASK_DEFAULT_RETRY_DELAY=30,
-
-    # .. setting_name: BLOCK_STRUCTURES_SETTINGS['TASK_MAX_RETRIES']
-    # .. setting_default: 5
-    # .. setting_description: Maximum number of retries per block structure task.
-    #   If the maximum number of retries is exceeded, then you can attempt to either manually run
-    #   the celery task, or wait for it to be triggered again.
-    #   For more information, check https://github.com/openedx/edx-platform/pull/13388 and
-    #   https://github.com/openedx/edx-platform/pull/14571.
-    TASK_MAX_RETRIES=5,
-)
-
 ################################ Bulk Email ###################################
-
-# Suffix used to construct 'from' email address for bulk emails.
-# A course-specific identifier is prepended.
-BULK_EMAIL_DEFAULT_FROM_EMAIL = 'no-reply@example.com'
-
-# Parameters for breaking down course enrollment into subtasks.
-BULK_EMAIL_EMAILS_PER_TASK = 500
 
 # Initial delay used for retrying tasks.  Additional retries use
 # longer delays.  Value is in seconds.
@@ -2799,10 +2031,6 @@ BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = Derived(lambda settings: settings.DEFAULT_PR
 # sent to self and staff
 BULK_EMAIL_JOB_SIZE_THRESHOLD = 100
 
-# Flag to indicate if individual email addresses should be logged as they are sent
-# a bulk email message.
-BULK_EMAIL_LOG_SENT_EMAILS = False
-
 # Delay in seconds to sleep between individual mail messages being sent,
 # when a bulk email task is retried for rate-related reasons.  Choose this
 # value depending on the number of workers that might be sending email in
@@ -2813,28 +2041,6 @@ BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS = 0.02
 
 # Minimum age for organization-wide email opt in
 EMAIL_OPTIN_MINIMUM_AGE = PARENTAL_CONSENT_AGE_LIMIT
-
-############################## Video ##########################################
-
-YOUTUBE = {
-    # YouTube JavaScript API
-    'API': 'https://www.youtube.com/iframe_api',
-
-    'TEST_TIMEOUT': 1500,
-
-    # URL to get YouTube metadata
-    'METADATA_URL': 'https://www.googleapis.com/youtube/v3/videos/',
-
-    # Web page mechanism for scraping transcript information from youtube video pages
-    'TRANSCRIPTS': {
-        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
-        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
-        'ALLOWED_LANGUAGE_CODES': ["en", "en-US", "en-GB"],
-    },
-
-    'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
-}
-YOUTUBE_API_KEY = 'PUT_YOUR_API_KEY_HERE'
 
 ################################### APPS ######################################
 
@@ -3182,60 +2388,7 @@ INSTALLED_APPS = [
     "openedx_learning.apps.authoring.sections",
 ]
 
-######################### CSRF #########################################
-
-# Forwards-compatibility with Django 1.7
-CSRF_COOKIE_AGE = 60 * 60 * 24 * 7 * 52
-# It is highly recommended that you override this in any environment accessed by
-# end users
-CSRF_COOKIE_SECURE = False
-
-# If setting a cross-domain cookie, it's really important to choose
-# a name for the cookie that is DIFFERENT than the cookies used
-# by each subdomain.  For example, suppose the applications
-# at these subdomains are configured to use the following cookie names:
-#
-# 1) foo.example.com --> "csrftoken"
-# 2) baz.example.com --> "csrftoken"
-# 3) bar.example.com --> "csrftoken"
-#
-# For the cross-domain version of the CSRF cookie, you need to choose
-# a name DIFFERENT than "csrftoken"; otherwise, the new token configured
-# for ".example.com" could conflict with the other cookies,
-# non-deterministically causing 403 responses.
-CROSS_DOMAIN_CSRF_COOKIE_NAME = ''
-
-# When setting the domain for the "cross-domain" version of the CSRF
-# cookie, you should choose something like: ".example.com"
-# (note the leading dot), where both the referer and the host
-# are subdomains of "example.com".
-#
-# Browser security rules require that
-# the cookie domain matches the domain of the server; otherwise
-# the cookie won't get set.  And once the cookie gets set, the client
-# needs to be on a domain that matches the cookie domain, otherwise
-# the client won't be able to read the cookie.
-CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = ''
-
-
 ######################### Django Rest Framework ########################
-
-# .. setting_name: REGISTRATION_VALIDATION_RATELIMIT
-# .. setting_default: 30/7d
-# .. setting_description: Whenever a user tries to register on edx, the data entered during registration
-#    is validated via RegistrationValidationView.
-#    It's POST endpoint is rate-limited up to 30 requests per IP Address in a week by default.
-#    It was introduced because an attacker can guess or brute force a series of names to enumerate valid users.
-# .. setting_tickets: https://github.com/openedx/edx-platform/pull/24664
-REGISTRATION_VALIDATION_RATELIMIT = '30/7d'
-
-# .. setting_name: REGISTRATION_RATELIMIT
-# .. setting_default: 60/7d
-# .. setting_description: New users are registered on edx via RegistrationView.
-#    It's POST end-point is rate-limited up to 60 requests per IP Address in a week by default.
-#    Purpose of this setting is to restrict an attacker from registering numerous fake accounts.
-# .. setting_tickets: https://github.com/openedx/edx-platform/pull/27060
-REGISTRATION_RATELIMIT = '60/7d'
 
 SWAGGER_SETTINGS = {
     'DEFAULT_INFO': 'openedx.core.apidocs.api_info',
@@ -3243,12 +2396,7 @@ SWAGGER_SETTINGS = {
 }
 
 ######################### MARKETING SITE ###############################
-EDXMKTG_LOGGED_IN_COOKIE_NAME = 'edxloggedin'
-EDXMKTG_USER_INFO_COOKIE_NAME = 'edx-user-info'
-EDXMKTG_USER_INFO_COOKIE_VERSION = 1
 
-MKTG_URLS = {}
-MKTG_URL_OVERRIDES = {}
 MKTG_URL_LINK_MAP = {
     'ABOUT': 'about',
     'CONTACT': 'contact',
@@ -3270,7 +2418,6 @@ MKTG_URL_LINK_MAP = {
 
 STATIC_TEMPLATE_VIEW_DEFAULT_FILE_EXTENSION = 'html'
 
-SUPPORT_SITE_LINK = ''
 SEND_ACTIVATION_EMAIL_URL = ''
 ACTIVATION_EMAIL_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
 ID_VERIFICATION_SUPPORT_LINK = Derived(lambda settings: settings.SUPPORT_SITE_LINK)
@@ -3315,29 +2462,11 @@ SOCIAL_MEDIA_FOOTER_NAMES = [
     "reddit",
 ]
 
-# The footer URLs dictionary maps social footer names
-# to URLs defined in configuration.
-SOCIAL_MEDIA_FOOTER_ACE_URLS = {
-    'reddit': 'http://www.reddit.com/r/edx',
-    'twitter': 'https://twitter.com/edXOnline',
-    'linkedin': 'http://www.linkedin.com/company/edx',
-    'facebook': 'http://www.facebook.com/EdxOnline',
-}
-
 # The mobile store URLs dictionary maps mobile store names
 # to URLs defined in configuration.
 MOBILE_STORE_ACE_URLS = {
     'google': 'https://play.google.com/store/apps/details?id=org.edx.mobile',
     'apple': 'https://itunes.apple.com/us/app/edx/id945480667?mt=8',
-}
-
-# The social media logo urls dictionary maps social media names
-# to the respective icons
-SOCIAL_MEDIA_LOGO_URLS = {
-    'reddit': 'http://email-media.s3.amazonaws.com/edX/2021/social_5_reddit.png',
-    'twitter': 'http://email-media.s3.amazonaws.com/edX/2021/social_2_twitter.png',
-    'linkedin': 'http://email-media.s3.amazonaws.com/edX/2021/social_3_linkedin.png',
-    'facebook': 'http://email-media.s3.amazonaws.com/edX/2021/social_1_fb.png',
 }
 
 # The mobile store logo urls dictionary maps mobile store names
@@ -3422,13 +2551,6 @@ SOCIAL_MEDIA_FOOTER_DISPLAY = {
 #################SOCAIL AUTH OAUTH######################
 SOCIAL_AUTH_OAUTH_SECRETS = {}
 
-################# Student Verification #################
-VERIFY_STUDENT = {
-    "DAYS_GOOD_FOR": 365,  # How many days is a verficiation good for?
-    # The variable represents the window within which a verification is considered to be "expiring soon."
-    "EXPIRING_SOON_WINDOW": 28,
-}
-
 ################# Student Verification Expiry Email #################
 VERIFICATION_EXPIRY_EMAIL = {
     "RESEND_DAYS": 15,
@@ -3437,12 +2559,6 @@ VERIFICATION_EXPIRY_EMAIL = {
 }
 
 ############# Cross-domain requests #################
-
-if ENABLE_CORS_HEADERS:
-    CORS_ALLOW_CREDENTIALS = True
-    CORS_ORIGIN_WHITELIST = ()
-    CORS_ORIGIN_ALLOW_ALL = False
-    CORS_ALLOW_INSECURE = False
 
 # Set CORS_ALLOW_HEADERS regardless of whether we've enabled ENABLE_CORS_HEADERS
 # because that decision might happen in a later config file. (The headers to
@@ -3458,12 +2574,6 @@ CORS_ALLOW_HEADERS = corsheaders_default_headers + (
 # This is a static page that can be iframed into an external page
 # to simulate cross-domain requests.
 XDOMAIN_PROXY_CACHE_TIMEOUT = 60 * 15
-
-# .. setting_name: LOGIN_REDIRECT_WHITELIST
-# .. setting_default: empty list ([])
-# .. setting_description: While logout, if logout request has a redirect-url as query strings,
-#   then the redirect-url is validated through LOGIN_REDIRECT_WHITELIST.
-LOGIN_REDIRECT_WHITELIST = []
 
 ###################### Registration ##################################
 
@@ -3515,9 +2625,6 @@ REGISTRATION_FIELD_ORDER = [
     "terms_of_service",
 ]
 
-# String length for the configurable part of the auto-generated username
-AUTO_GENERATED_USERNAME_RANDOM_STRING_LENGTH = 4
-
 REGISTRATION_CODE_LENGTH = 8
 
 ########################## CERTIFICATE NAME ########################
@@ -3530,31 +2637,6 @@ CERT_NAME_LONG = "Certificate of Achievement"
 GRADES_DOWNLOAD_ROUTING_KEY = Derived(lambda settings: settings.HIGH_MEM_QUEUE)
 
 RECALCULATE_GRADES_ROUTING_KEY = 'edx.lms.core.default'
-
-GRADES_DOWNLOAD = {
-    'STORAGE_CLASS': 'django.core.files.storage.FileSystemStorage',
-    'STORAGE_KWARGS': {
-        'location': '/tmp/edx-s3/grades',
-    },
-    'STORAGE_TYPE': None,
-    'BUCKET': None,
-    'ROOT_PATH': None,
-}
-
-FINANCIAL_REPORTS = {
-    'STORAGE_TYPE': 'localfs',
-    'BUCKET': None,
-    'ROOT_PATH': 'sandbox',
-}
-
-#### Grading policy change-related settings #####
-# Rate limit for regrading tasks that a grading policy change can kick off
-POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
-
-#### PASSWORD POLICY SETTINGS #####
-PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG = {
-    'ENFORCE_COMPLIANCE_ON_LOGIN': False
-}
 
 ############################ ORA 2 ############################################
 ORA_WORKFLOW_UPDATE_ROUTING_KEY = "edx.lms.core.ora_workflow_update"
@@ -3572,65 +2654,10 @@ ORA_PEER_LEASE_EXPIRATION_HOURS = 8
 # .. setting_description: Amount of time before a lease on a staff submission expires
 ORA_STAFF_LEASE_EXPIRATION_HOURS = 8
 
-# Default File Upload Storage bucket and prefix. Used by the FileUpload Service.
-FILE_UPLOAD_STORAGE_BUCKET_NAME = 'SET-ME-PLEASE (ex. bucket-name)'
-FILE_UPLOAD_STORAGE_PREFIX = 'submissions_attachments'
-
-##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
-# .. setting_name: MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED
-# .. setting_default: 6
-# .. setting_description: Specifies the maximum failed login attempts allowed to users. Once the user reaches this
-#   failure threshold then the account will be locked for a configurable amount of seconds (30 minutes) which will
-#   prevent additional login attempts until this time period has passed. This setting is related with
-#   MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS and only used when ENABLE_MAX_FAILED_LOGIN_ATTEMPTS is enabled.
-MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = 6
-
-# .. setting_name: MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS
-# .. setting_default: 30 * 60
-# .. setting_description: Specifies the lockout period in seconds for consecutive failed login attempts. Once the user
-#   reaches the threshold of the login failure, then the account will be locked for the given amount of seconds
-#   (30 minutes) which will prevent additional login attempts until this time period has passed. This setting is
-#   related with MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED and only used when ENABLE_MAX_FAILED_LOGIN_ATTEMPTS is enabled.
-MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 30 * 60
-
-
 ##### LMS DEADLINE DISPLAY TIME_ZONE #######
 TIME_ZONE_DISPLAYED_FOR_DEADLINES = 'UTC'
 
-
-########################## VIDEO IMAGE STORAGE ############################
-
-VIDEO_IMAGE_SETTINGS = dict(
-    VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB
-    VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
-    # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
-    # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
-    STORAGE_KWARGS=dict(
-        location=MEDIA_ROOT,
-    ),
-    DIRECTORY_PREFIX='video-images/',
-    BASE_URL=MEDIA_URL,
-
-)
-
-VIDEO_IMAGE_MAX_AGE = 31536000
-
 ########################## VIDEO TRANSCRIPTS STORAGE ############################
-
-VIDEO_TRANSCRIPTS_SETTINGS = dict(
-    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
-    # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
-    # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
-    STORAGE_KWARGS=dict(
-        location=MEDIA_ROOT,
-    ),
-    DIRECTORY_PREFIX='video-transcripts/',
-    BASE_URL=MEDIA_URL,
-)
-
-VIDEO_TRANSCRIPTS_MAX_AGE = 31536000
 
 ### Apps only installed in some instances
 # The order of INSTALLED_APPS matters, so this tuple is the app name and the item in INSTALLED_APPS
@@ -3693,14 +2720,9 @@ for app_name, insert_before in OPTIONAL_APPS:
     except (IndexError, ValueError):
         INSTALLED_APPS.append(app_name)
 
-### External auth usage -- prefixes for ENROLLMENT_DOMAIN
-SHIBBOLETH_DOMAIN_PREFIX = 'shib:'
-
 ### Analytics API
 ANALYTICS_API_KEY = ""
 ANALYTICS_API_URL = "http://localhost:18100"
-ANALYTICS_DASHBOARD_URL = 'http://localhost:18110/courses'
-ANALYTICS_DASHBOARD_NAME = 'Your Platform Name Here Insights'
 
 # REGISTRATION CODES DISPLAY INFORMATION SUBTITUTIONS IN THE INVOICE ATTACHMENT
 INVOICE_CORP_ADDRESS = "Please place your corporate address\nin this configuration"
@@ -3713,27 +2735,6 @@ COUNTRIES_OVERRIDE = {
     "TW": "Taiwan",
     'XK': _('Kosovo'),
 }
-
-# which access.py permission name to check in order to determine if a course is visible in
-# the course catalog. We default this to the legacy permission 'see_exists'.
-COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_exists'
-
-# which access.py permission name to check in order to determine if a course about page is
-# visible. We default this to the legacy permission 'see_exists'.
-COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_exists'
-
-DEFAULT_COURSE_VISIBILITY_IN_CATALOG = "both"
-
-# .. toggle_name: DEFAULT_MOBILE_AVAILABLE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: This specifies if the courses are available for mobile by default. To make any individual
-#   course available for mobile one can set the value of Mobile Course Available to true in Advanced Settings from the
-#   studio when this is False.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-01-26
-# .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1985
-DEFAULT_MOBILE_AVAILABLE = False
 
 # Enrollment API Cache Timeout
 ENROLLMENT_COURSE_DETAILS_CACHE_TIMEOUT = 60
@@ -3755,8 +2756,6 @@ PDF_RECEIPT_COBRAND_LOGO_PATH = PROJECT_ROOT + '/static/images/logo.png'
 # Height of the Co-brand Logo in mm
 PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM = 12
 
-# Use None for the default search engine
-SEARCH_ENGINE = None
 # Use LMS specific search initializer
 SEARCH_INITIALIZER = "lms.lib.courseware_search.lms_search_initializer.LmsSearchInitializer"
 # Use the LMS specific result processor
@@ -3878,15 +2877,9 @@ FIRST_PURCHASE_DISCOUNT_OVERRIDE_CODE = ''
 FIRST_PURCHASE_DISCOUNT_OVERRIDE_PERCENTAGE = 15
 
 # E-Commerce API Configuration
-ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:8002'
-ECOMMERCE_API_URL = 'http://localhost:8002/api/v2'
 ECOMMERCE_API_TIMEOUT = 5
 ECOMMERCE_ORDERS_API_CACHE_TIMEOUT = 3600
 ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
-ECOMMERCE_API_SIGNING_KEY = 'SET-ME-PLEASE'
-
-# Exam Service
-EXAMS_SERVICE_URL = 'http://localhost:18740/api/v1'
 
 ############## Settings for JWT token handling ##############
 TOKEN_SIGNING = {
@@ -3902,14 +2895,6 @@ TOKEN_SIGNING = {
 # > python manage.py lms generate_jwt_signing_key
 # This will output asymmetric JWTs to use here. Read more on this on:
 # https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
-
-COURSE_CATALOG_URL_ROOT = 'http://localhost:8008'
-COURSE_CATALOG_API_URL = f'{COURSE_CATALOG_URL_ROOT}/api/v1'
-
-CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:8005'
-CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:8005'
-# time between scheduled runs, in seconds
-NOTIFY_CREDENTIALS_FREQUENCY = 14400
 
 COMMENTS_SERVICE_URL = ''
 COMMENTS_SERVICE_KEY = ''
@@ -3944,26 +2929,6 @@ HOMEPAGE_COURSE_MAX = None
 COURSE_MEMBER_API_ENROLLMENT_LIMIT = 1000
 
 ################################ Settings for Credit Courses ################################
-# Initial delay used for retrying tasks.
-# Additional retries use longer delays.
-# Value is in seconds.
-CREDIT_TASK_DEFAULT_RETRY_DELAY = 30
-
-# Maximum number of retries per task for errors that are not related
-# to throttling.
-CREDIT_TASK_MAX_RETRIES = 5
-
-# Secret keys shared with credit providers.
-# Used to digitally sign credit requests (us --> provider)
-# and validate responses (provider --> us).
-# Each key in the dictionary is a credit provider ID, and
-# the value is the 32-character key.
-CREDIT_PROVIDER_SECRET_KEYS = {}
-
-# Maximum age in seconds of timestamps we will accept
-# when a credit provider notifies us that a student has been approved
-# or denied for credit.
-CREDIT_PROVIDER_TIMESTAMP_EXPIRATION = 15 * 60
 
 # The Help link to the FAQ page about the credit
 CREDIT_HELP_LINK_URL = ""
@@ -4002,15 +2967,6 @@ NOTIFICATION_EMAIL_EDX_LOGO = "templates/credit_notifications/edx-logo-header.pn
 
 
 ################################ Settings for JWTs ################################
-
-JWT_ISSUER = 'http://127.0.0.1:8000/oauth2'
-DEFAULT_JWT_ISSUER = {
-    'ISSUER': 'http://127.0.0.1:8000/oauth2',
-    'AUDIENCE': 'change-me',
-    'SECRET_KEY': 'SET-ME-PLEASE'
-}
-JWT_EXPIRATION = 30
-JWT_PRIVATE_SIGNING_KEY = None
 
 EDX_DRF_EXTENSIONS = {
     # Set this value to an empty dict in order to prevent automatically updating
@@ -4070,65 +3026,15 @@ STUDENTMODULEHISTORYEXTENDED_OFFSET = 10000
 
 ################################ Settings for Credentials Service ################################
 
-CREDENTIALS_SERVICE_USERNAME = 'credentials_service_user'
 CREDENTIALS_GENERATION_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 CREDENTIALS_COURSE_COMPLETION_STATE = 'awarded'
 
 # Queue to use for award program certificates
 PROGRAM_CERTIFICATES_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 
-# .. setting_name: COMPREHENSIVE_THEME_DIRS
-# .. setting_default: []
-# .. setting_description: A list of paths to directories, each of which will
-#   be searched for comprehensive themes. Do not override this Django setting directly.
-#   Instead, set the COMPREHENSIVE_THEME_DIRS environment variable, using colons (:) to
-#   separate paths.
-COMPREHENSIVE_THEME_DIRS = os.environ.get("COMPREHENSIVE_THEME_DIRS", "").split(":")
-
-# .. setting_name: DEFAULT_SITE_THEME
-# .. setting_default: None
-# .. setting_description: Theme to use when no site or site theme is defined, for example
-#   "dark-theme". Set to None if you want to use openedx default theme.
-# .. setting_warning: The theme folder needs to be in 'edx-platform/themes' or define the path
-#   to the theme folder in COMPREHENSIVE_THEME_DIRS. To be effective, ENABLE_COMPREHENSIVE_THEMING
-#   has to be enabled.
-DEFAULT_SITE_THEME = None
-
-# .. toggle_name: ENABLE_COMPREHENSIVE_THEMING
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When enabled, this toggle activates the use of the custom theme
-#   defined by DEFAULT_SITE_THEME.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2016-06-30
-ENABLE_COMPREHENSIVE_THEMING = False
-
-# .. setting_name: CUSTOM_RESOURCE_TEMPLATES_DIRECTORY
-# .. setting_default: None
-# .. setting_description: Path to an existing directory of YAML files containing
-#    html content to be used with the subclasses of xmodule.x_module.ResourceTemplates.
-#    Default example templates can be found in xmodule/templates/html.
-#    Note that the extension used is ".yaml" and not ".yml".
-#    See xmodule.x_module.ResourceTemplates for usage.
-#   "CUSTOM_RESOURCE_TEMPLATES_DIRECTORY" : null
-CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = None
-
-# API access management
-API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
-API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
-
-# Affiliate cookie tracking
-AFFILIATE_COOKIE_NAME = 'dev_affiliate_id'
-
 ############## Settings for LMS Context Sensitive Help ##############
 
 HELP_TOKENS_INI_FILE = REPO_ROOT / "lms" / "envs" / "help_tokens.ini"
-HELP_TOKENS_LANGUAGE_CODE = Derived(lambda settings: settings.LANGUAGE_CODE)
-HELP_TOKENS_VERSION = Derived(lambda settings: doc_version())
-HELP_TOKENS_BOOKS = {
-    'learner': 'https://edx.readthedocs.io/projects/open-edx-learner-guide',
-    'course_author': 'https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course',
-}
 
 ############## OPEN EDX ENTERPRISE SERVICE CONFIGURATION ######################
 # The Open edX Enterprise service is currently hosted via the LMS container/process.
@@ -4143,15 +3049,8 @@ ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = Derived(
 )
 ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES = ['audit', 'honor']
 ENTERPRISE_SUPPORT_URL = ''
-ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = {}
 ENTERPRISE_CUSTOMER_SUCCESS_EMAIL = "customersuccess@edx.org"
 ENTERPRISE_INTEGRATIONS_EMAIL = "enterprise-integrations@edx.org"
-
-
-# The setting key maps to the channel code (e.g. 'SAP' for success factors), Channel code is defined as
-# part of django model of each integrated channel in edx-enterprise.
-# The absence of a key/value pair translates to NO LIMIT on the number of "chunks" transmitted per cycle.
-INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT = {}
 
 ############## ENTERPRISE SERVICE API CLIENT CONFIGURATION ######################
 # The LMS communicates with the Enterprise service via the requests.Session() client
@@ -4172,8 +3071,6 @@ DEFAULT_ENTERPRISE_CONSENT_API_URL = Derived(
     )
 )
 ENTERPRISE_CONSENT_API_URL = DEFAULT_ENTERPRISE_CONSENT_API_URL
-ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
-ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = 512   # Enterprise logo image size limit in KB's
 # Defines the usernames of service users who should be throttled
 # at a higher rate than normal users when making requests of enterprise endpoints.
@@ -4221,7 +3118,7 @@ ENTERPRISE_READONLY_ACCOUNT_FIELDS = [
     'country',
 ]
 ENTERPRISE_CUSTOMER_COOKIE_NAME = 'enterprise_customer_uuid'
-BASE_COOKIE_DOMAIN = 'localhost'
+
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     ENTERPRISE_LEARNER_ROLE: [
         DEFAULT_ENTERPRISE_ENROLLMENT_INTENTIONS_ROLE,
@@ -4250,8 +3147,6 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
 
 DATA_CONSENT_SHARE_CACHE_TIMEOUT = 8 * 60 * 60  # 8 hours
 
-ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS = {}
-ENTERPRISE_TAGLINE = ''
 TRANSCRIPT_LANG_CACHE_TIMEOUT = 60 * 60 * 24  # 24 hours
 
 
@@ -4259,15 +3154,8 @@ TRANSCRIPT_LANG_CACHE_TIMEOUT = 60 * 60 * 24  # 24 hours
 
 COURSES_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 
-
-# Initialize to 'unknown', but read from JSON in production.py
-EDX_PLATFORM_REVISION = 'release'
-
 ############## Settings for Completion API #########################
 
-# Once a user has watched this percentage of a video, mark it as complete:
-# (0.0 = 0%, 1.0 = 100%)
-COMPLETION_VIDEO_COMPLETE_PERCENTAGE = 0.95
 COMPLETION_BY_VIEWING_DELAY_MS = 5000
 
 ############### Settings for Django Rate limit #####################
@@ -4293,120 +3181,8 @@ RATELIMIT_ENABLE = True
 # .. setting_tickets: https://github.com/openedx/edx-platform/pull/16951
 RATELIMIT_RATE = '120/m'
 
-##### LOGISTRATION RATE LIMIT SETTINGS #####
-LOGISTRATION_RATELIMIT_RATE = '100/5m'
-LOGISTRATION_PER_EMAIL_RATELIMIT_RATE = '30/5m'
-LOGISTRATION_API_RATELIMIT = '20/m'
-LOGIN_AND_REGISTER_FORM_RATELIMIT = '100/5m'
-RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = '30/7d'
-RESET_PASSWORD_API_RATELIMIT = '30/7d'
-OPTIONAL_FIELD_API_RATELIMIT = '10/h'
-
-##### PASSWORD RESET RATE LIMIT SETTINGS #####
-PASSWORD_RESET_IP_RATE = '1/m'
-PASSWORD_RESET_EMAIL_RATE = '2/h'
-
 # Keeping this for back compatibility with learner dashboard api
 GENERAL_RECOMMENDATION = {}
-
-############### Settings for Retirement #####################
-# .. setting_name: RETIRED_USERNAME_PREFIX
-# .. setting_default: retired__user_
-# .. setting_description: Set the prefix part of hashed usernames for retired users. Used by the derived
-#     setting RETIRED_USERNAME_FMT.
-RETIRED_USERNAME_PREFIX = 'retired__user_'
-# .. setting_name: RETIRED_EMAIL_PREFIX
-# .. setting_default: retired__user_
-# .. setting_description: Set the prefix part of hashed emails for retired users. Used by the derived
-#     setting RETIRED_EMAIL_FMT.
-RETIRED_EMAIL_PREFIX = 'retired__user_'
-# .. setting_name: RETIRED_EMAIL_DOMAIN
-# .. setting_default: retired.invalid
-# .. setting_description: Set the domain part of hashed emails for retired users. Used by the derived
-#     setting RETIRED_EMAIL_FMT.
-RETIRED_EMAIL_DOMAIN = 'retired.invalid'
-# .. setting_name: RETIRED_USERNAME_FMT
-# .. setting_default: retired__user_{}
-# .. setting_description: Set the format a retired user username field gets transformed into, where {}
-#     is replaced with the hash of the original username. This is a derived setting that depends on
-#     RETIRED_USERNAME_PREFIX value.
-RETIRED_USERNAME_FMT = Derived(lambda settings: settings.RETIRED_USERNAME_PREFIX + '{}')
-# .. setting_name: RETIRED_EMAIL_FMT
-# .. setting_default: retired__user_{}@retired.invalid
-# .. setting_description: Set the format a retired user email field gets transformed into, where {} is
-#     replaced with the hash of the original email. This is a derived setting that depends on
-#     RETIRED_EMAIL_PREFIX and RETIRED_EMAIL_DOMAIN values.
-RETIRED_EMAIL_FMT = Derived(lambda settings: settings.RETIRED_EMAIL_PREFIX + '{}@' + settings.RETIRED_EMAIL_DOMAIN)
-# .. setting_name: RETIRED_USER_SALTS
-# .. setting_default: ['abc', '123']
-# .. setting_description: Set a list of salts used for hashing usernames and emails on users retirement.
-# .. setting_warning: Only the last item in this list is used as a salt for all new retirements, but
-#     historical salts are preserved in order to guarantee that all hashed usernames and emails can still
-#     be checked.
-RETIRED_USER_SALTS = ['abc', '123']
-# .. setting_name: RETIREMENT_SERVICE_WORKER_USERNAME
-# .. setting_default: RETIREMENT_SERVICE_USER
-# .. setting_description: Set the username of the retirement service worker user. Retirement scripts
-#     authenticate with LMS as this user with oauth client credentials.
-RETIREMENT_SERVICE_WORKER_USERNAME = 'RETIREMENT_SERVICE_USER'
-
-# These states are the default, but are designed to be overridden in configuration.
-# .. setting_name: RETIREMENT_STATES
-# .. setting_default:
-#     [
-#         'PENDING',
-#         'LOCKING_ACCOUNT',
-#         'LOCKING_COMPLETE',
-#         'RETIRING_FORUMS',
-#         'FORUMS_COMPLETE',
-#         'RETIRING_EMAIL_LISTS',
-#         'EMAIL_LISTS_COMPLETE',
-#         'RETIRING_ENROLLMENTS',
-#         'ENROLLMENTS_COMPLETE',
-#         'RETIRING_NOTES',
-#         'NOTES_COMPLETE',
-#         'RETIRING_LMS',
-#         'LMS_COMPLETE',
-#         'ERRORED',
-#         'ABORTED',
-#         'COMPLETE',
-#     ]
-# .. setting_description: Set a list that defines the name and order of states for the retirement
-#     workflow.
-# .. setting_warning: These states are stored in the database and it is the responsibility of the
-#     administrator to populate the state list since the states can vary across different installations.
-#     There must be, at minimum, a PENDING state at the beginning, and COMPLETED, ERRORED, and ABORTED
-#     states at the end of the list.
-RETIREMENT_STATES = [
-    'PENDING',
-
-    'LOCKING_ACCOUNT',
-    'LOCKING_COMPLETE',
-
-    # Use these states only when ENABLE_DISCUSSION_SERVICE is True.
-    'RETIRING_FORUMS',
-    'FORUMS_COMPLETE',
-
-    # TODO - Change these states to be the LMS-only email opt-out - PLAT-2189
-    'RETIRING_EMAIL_LISTS',
-    'EMAIL_LISTS_COMPLETE',
-
-    'RETIRING_ENROLLMENTS',
-    'ENROLLMENTS_COMPLETE',
-
-    # Use these states only when ENABLE_STUDENT_NOTES is True.
-    'RETIRING_NOTES',
-    'NOTES_COMPLETE',
-
-    'RETIRING_LMS',
-    'LMS_COMPLETE',
-
-    'ERRORED',
-    'ABORTED',
-    'COMPLETE',
-]
-
-USERNAME_REPLACEMENT_WORKER = "REPLACE WITH VALID USERNAME"
 
 ############## Settings for Microfrontends  #########################
 # If running a Gradebook container locally,
@@ -4419,19 +3195,10 @@ WRITABLE_GRADEBOOK_URL = None
 #     learner_profile.redirect_to_microfrontend waffle flag
 PROFILE_MICROFRONTEND_URL = None
 ORDER_HISTORY_MICROFRONTEND_URL = None
-# .. setting_name: ACCOUNT_MICROFRONTEND_URL
-# .. setting_default: None
-# .. setting_description: Base URL of the micro-frontend-based account settings page.
-# .. setting_warning: Also set site's ENABLE_ACCOUNT_MICROFRONTEND and
-#     account.redirect_to_microfrontend waffle flag
-ACCOUNT_MICROFRONTEND_URL = None
+
 AUTHN_MICROFRONTEND_URL = None
 AUTHN_MICROFRONTEND_DOMAIN = None
 PROGRAM_CONSOLE_MICROFRONTEND_URL = None
-# .. setting_name: LEARNING_MICROFRONTEND_URL
-# .. setting_default: None
-# .. setting_description: Base URL of the micro-frontend-based courseware page.
-LEARNING_MICROFRONTEND_URL = None
 # .. setting_name: ORA_GRADING_MICROFRONTEND_URL
 # .. setting_default: None
 # .. setting_description: Base URL of the micro-frontend-based openassessment grading page.
@@ -4446,15 +3213,6 @@ ORA_GRADING_MICROFRONTEND_URL = None
 # .. setting_warning: Also set site's openresponseassessment.mfe_views
 #     waffle flag.
 ORA_MICROFRONTEND_URL = None
-# .. setting_name: DISCUSSIONS_MICROFRONTEND_URL
-# .. setting_default: None
-# .. setting_description: Base URL of the micro-frontend-based discussions page.
-# .. setting_warning: Also set site's courseware.discussions_mfe waffle flag.
-DISCUSSIONS_MICROFRONTEND_URL = None
-# .. setting_name: DISCUSSIONS_MFE_FEEDBACK_URL
-# .. setting_default: None
-# .. setting_description: Base URL of the discussions micro-frontend google form based feedback.
-DISCUSSIONS_MFE_FEEDBACK_URL = None
 # .. setting_name: EXAMS_DASHBOARD_MICROFRONTEND_URL
 # .. setting_default: None
 # .. setting_description: Base URL of the exams dashboard micro-frontend for instructors.
@@ -4534,17 +3292,6 @@ ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY = False
 #   See ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY for more details.
 HIBP_LOGIN_BLOCK_PASSWORD_FREQUENCY_THRESHOLD = 5.0
 
-# .. toggle_name: ENABLE_DYNAMIC_REGISTRATION_FIELDS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When enabled, this toggle adds fields configured in
-# REGISTRATION_EXTRA_FIELDS to Authn MFE
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2022-04-21
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://openedx.atlassian.net/browse/VAN-838
-ENABLE_DYNAMIC_REGISTRATION_FIELDS = False
-
 ############## Settings for EmailChangeMiddleware ###############
 
 # .. toggle_name: ENFORCE_SESSION_EMAIL_MATCH
@@ -4566,33 +3313,16 @@ from openedx.core.djangoapps.ace_common.settings import common as ace_common_set
 ACE_ROUTING_KEY = ace_common_settings.ACE_ROUTING_KEY
 
 ############### Settings swift #####################################
-SWIFT_USERNAME = None
-SWIFT_KEY = None
-SWIFT_TENANT_ID = None
-SWIFT_TENANT_NAME = None
-SWIFT_AUTH_URL = None
-SWIFT_AUTH_VERSION = None
-SWIFT_REGION_NAME = None
 SWIFT_USE_TEMP_URLS = None
-SWIFT_TEMP_URL_KEY = None
-SWIFT_TEMP_URL_DURATION = 1800  # seconds
 
 ############### Settings for facebook ##############################
 FACEBOOK_APP_ID = None
 FACEBOOK_APP_SECRET = None
 FACEBOOK_API_VERSION = None
 
-############### Settings for django-fernet-fields ##################
-FERNET_KEYS = [
-    'DUMMY KEY CHANGE BEFORE GOING TO PRODUCTION',
-]
-
 ############### Settings for user-state-client ##################
 # Maximum number of rows to fetch in XBlockUserStateClient calls. Adjust for performance
 USER_STATE_BATCH_SIZE = 5000
-
-############### Settings for edx-rbac  ###############
-SYSTEM_WIDE_ROLE_CLASSES = []
 
 ############## Plugin Django Apps #########################
 
@@ -4601,23 +3331,11 @@ from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType 
 INSTALLED_APPS.extend(get_plugin_apps(ProjectType.LMS))
 add_plugins(__name__, ProjectType.LMS, SettingsType.COMMON)
 
-DEPRECATED_ADVANCED_COMPONENT_TYPES = []
-
 ############### Settings for video pipeline ##################
 VIDEO_UPLOAD_PIPELINE = {
     'VEM_S3_BUCKET': '',
     'BUCKET': '',
     'ROOT_PATH': '',
-}
-
-############### Settings for django file storage ##################
-STORAGES = {
-    'default': {
-        'BACKEND': 'django.core.files.storage.FileSystemStorage'
-    },
-    'staticfiles': {
-        'BACKEND': 'openedx.core.storage.ProductionStorage'
-    }
 }
 
 ### Proctoring configuration (redirct URLs and keys shared between systems) ####
@@ -4630,12 +3348,6 @@ PROCTORING_BACKENDS = {
 
 PROCTORED_EXAM_VIEWABLE_PAST_DUE = False
 
-############### The SAML private/public key values ################
-SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = ""
-SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = ""
-SOCIAL_AUTH_SAML_SP_PRIVATE_KEY_DICT = {}
-SOCIAL_AUTH_SAML_SP_PUBLIC_CERT_DICT = {}
-
 ######################### rate limit for yt_video_metadata api ##############
 
 RATE_LIMIT_FOR_VIDEO_METADATA_API = '10/minute'
@@ -4643,8 +3355,6 @@ RATE_LIMIT_FOR_VIDEO_METADATA_API = '10/minute'
 ########################## MAILCHIMP SETTINGS #################################
 MAILCHIMP_NEW_USER_LIST_ID = ""
 
-SYSLOG_SERVER = ''
-FEEDBACK_SUBMISSION_EMAIL = ''
 GITHUB_REPO_ROOT = '/edx/var/edxapp/data'
 
 ##################### SUPPORT URL ############################
@@ -4661,42 +3371,9 @@ MAX_BLOCKS_PER_CONTENT_LIBRARY = 1000
 # https://github.com/SmileyChris/django-countries#show-certain-countries-first
 COUNTRIES_FIRST = []
 
-################# Settings for brand logos. #################
-LOGO_IMAGE_EXTRA_TEXT = ''
-LOGO_URL = None
-LOGO_URL_PNG = None
-LOGO_TRADEMARK_URL = None
-FAVICON_URL = None
-DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
-
-################# Settings for olx validation. #################
-COURSE_OLX_VALIDATION_STAGE = 1
-COURSE_OLX_VALIDATION_IGNORE_LIST = None
-
-################# show account activate cta after register ########################
-SHOW_ACTIVATE_CTA_POPUP_COOKIE_NAME = 'show-account-activation-popup'
-# .. toggle_name: SOME_FEATURE_NAME
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Flag would be used to show account activation popup after the registration
-# .. toggle_use_cases: open_edx
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/27661
-# .. toggle_creation_date: 2021-06-10
-SHOW_ACCOUNT_ACTIVATION_CTA = False
-
 ################# Documentation links for course apps #################
 
-# pylint: disable=line-too-long
-CALCULATOR_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/add_calculator.html"
-DISCUSSIONS_HELP_URL = "https://docs.openedx.org/en/latest/educators/concepts/communication/about_course_discussions.html"
-EDXNOTES_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/enable_notes.html"
-PROGRESS_HELP_URL = "https://docs.openedx.org/en/latest/educators/references/data/progress_page.html"
-TEAMS_HELP_URL = "https://docs.openedx.org/en/latest/educators/navigation/advanced_features.html#use-teams-in-your-course"
-TEXTBOOKS_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/manage_textbooks.html"
-WIKI_HELP_URL = "https://docs.openedx.org/en/latest/educators/concepts/communication/about_course_wiki.html"
-CUSTOM_PAGES_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/manage_custom_page.html"
 COURSE_BULK_EMAIL_HELP_URL = "https://docs.openedx.org/en/latest/educators/references/communication/bulk_email.html"
-ORA_SETTINGS_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/Manage_ORA_Assignment.html"
 
 ################# Bulk Course Email Settings #################
 # If set, recipients of bulk course email messages will be filtered based on the last_login date of their User account.
@@ -4732,9 +3409,6 @@ DISCUSSION_MODERATION_CLOSE_REASON_CODES = {
 IS_ELIGIBLE_FOR_FINANCIAL_ASSISTANCE_URL = '/core/api/course_eligibility/'
 FINANCIAL_ASSISTANCE_APPLICATION_STATUS_URL = "/core/api/financial_assistance_application/status/"
 CREATE_FINANCIAL_ASSISTANCE_APPLICATION_URL = '/core/api/financial_assistance_applications'
-
-# keys for  big blue button live provider
-COURSE_LIVE_GLOBAL_CREDENTIALS = {}
 
 # .. toggle_name: ENABLE_MFE_CONFIG_API
 # .. toggle_implementation: DjangoSetting
@@ -4812,13 +3486,8 @@ ENTERPRISE_MANUAL_REPORTING_CUSTOMER_UUIDS = []
 AVAILABLE_DISCUSSION_TOURS = []
 
 ############## NOTIFICATIONS ##############
-NOTIFICATIONS_EXPIRY = 60
-EXPIRED_NOTIFICATIONS_DELETE_BATCH_SIZE = 10000
-NOTIFICATION_CREATION_BATCH_SIZE = 76
-NOTIFICATIONS_DEFAULT_FROM_EMAIL = "no-reply@example.com"
 NOTIFICATION_TYPE_ICONS = {}
 DEFAULT_NOTIFICATION_ICON_URL = ""
-NOTIFICATION_DIGEST_LOGO = DEFAULT_EMAIL_LOGO_URL
 
 ############## SELF PACED EMAIL ##############
 SELF_PACED_BANNER_URL = ""
@@ -4836,22 +3505,12 @@ GOAL_REMINDER_PROFILE_URL = ""
 # .. eg ['BTDx', 'MYTx']
 DISABLED_ORGS_FOR_PROGRAM_NUDGE = []
 
-############################ AI_TRANSLATIONS ##################################
-AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
-
-#### django-simple-history##
-# disable indexing on date field its coming from django-simple-history.
-SIMPLE_HISTORY_DATE_INDEX = False
-
 
 def _should_send_certificate_events(settings):
     return settings.SEND_LEARNING_CERTIFICATE_LIFECYCLE_EVENTS_TO_BUS
 
 
 #### Event bus producing ####
-
-def _should_send_learning_badge_events(settings):
-    return settings.BADGES_ENABLED
 
 # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
 # .. setting_default: all events disabled
@@ -4932,18 +3591,16 @@ EVENT_BUS_PRODUCER_CONFIG = {
     "org.openedx.learning.course.passing.status.updated.v1": {
         "learning-badges-lifecycle": {
             "event_key_field": "course_passing_status.course.course_key",
-            "enabled": Derived(_should_send_learning_badge_events),
+            "enabled": Derived(should_send_learning_badge_events),
         },
     },
     "org.openedx.learning.ccx.course.passing.status.updated.v1": {
         "learning-badges-lifecycle": {
             "event_key_field": "course_passing_status.course.ccx_course_key",
-            "enabled": Derived(_should_send_learning_badge_events),
+            "enabled": Derived(should_send_learning_badge_events),
         },
     },
 }
-
-BEAMER_PRODUCT_ID = ""
 
 #### Survey Report ####
 # .. toggle_name: SURVEY_REPORT_ENABLE

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -109,9 +109,61 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 SESSION_COOKIE_DOMAIN = None
 SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_NAME = 'sessionid'
+SESSION_COOKIE_SECURE = False
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+SESSION_SAVE_EVERY_REQUEST = False
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 
-STATICI18N_OUTPUT_DIR = "js/i18n"
+ADMINS = []
+MANAGERS = ADMINS
+
+DEFAULT_FROM_EMAIL = 'registration@example.com'
+SERVER_EMAIL = 'devops@example.com'
+
+# See https://github.com/openedx/edx-django-sites-extensions for more info.
+# Default site to use if site matching request headers does not exist.
+SITE_ID = 1
+
+# Clickjacking protection can be disbaled by setting this to 'ALLOW'
+X_FRAME_OPTIONS = 'DENY'
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "common.djangoapps.util.password_policy_validators.MinimumLengthValidator",
+        "OPTIONS": {
+            "min_length": 8
+        }
+    },
+    {
+        "NAME": "common.djangoapps.util.password_policy_validators.MaximumLengthValidator",
+        "OPTIONS": {
+            "max_length": 75
+        }
+    },
+]
+
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage'
+    },
+    'staticfiles': {
+        'BACKEND': 'openedx.core.storage.ProductionStorage'
+    }
+}
+
+# Messages
+MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
+
+# these languages display right to left
+LANGUAGES_BIDI = ("he", "ar", "fa", "ur", "fa-ir", "rtl")
+
+LANGUAGE_COOKIE_NAME = "openedx-language-preference"
+
+LOCALE_PATHS = Derived(_make_locale_paths)
 
 # Sourced from http://www.localeplanet.com/icu/ and wikipedia
 LANGUAGES = [
@@ -197,46 +249,18 @@ LANGUAGES = [
     ('zh-tw', '中文 (台灣)'),  # Chinese (Taiwan)
 ]
 
-# these languages display right to left
-LANGUAGES_BIDI = ("he", "ar", "fa", "ur", "fa-ir", "rtl")
+############################## Site Settings ###############################
 
-LANGUAGE_COOKIE_NAME = "openedx-language-preference"
+HTTPS = 'on'
+SITE_NAME = "localhost"
+FAVICON_PATH = 'images/favicon.ico'
 
-LOCALE_PATHS = Derived(_make_locale_paths)
-
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
-        "NAME": "common.djangoapps.util.password_policy_validators.MinimumLengthValidator",
-        "OPTIONS": {
-            "min_length": 8
-        }
-    },
-    {
-        "NAME": "common.djangoapps.util.password_policy_validators.MaximumLengthValidator",
-        "OPTIONS": {
-            "max_length": 75
-        }
-    },
-]
-
-# See https://github.com/openedx/edx-django-sites-extensions for more info.
-# Default site to use if site matching request headers does not exist.
-SITE_ID = 1
-
-# Clickjacking protection can be disbaled by setting this to 'ALLOW'
-X_FRAME_OPTIONS = 'DENY'
-
-STORAGES = {
-    'default': {
-        'BACKEND': 'django.core.files.storage.FileSystemStorage'
-    },
-    'staticfiles': {
-        'BACKEND': 'openedx.core.storage.ProductionStorage'
-    }
-}
+BUGS_EMAIL = 'bugs@example.com'
+CONTACT_EMAIL = 'info@example.com'
+DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
+PRESS_EMAIL = 'press@example.com'
+TECH_SUPPORT_EMAIL = 'technical@example.com'
+UNIVERSITY_EMAIL = 'university@example.com'
 
 ################################# Language #################################
 
@@ -1025,7 +1049,6 @@ BADGES_ENABLED = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/8550
 ENABLE_CREDIT_ELIGIBILITY = True
 
-### TODO non-feature toggles
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
@@ -1327,7 +1350,7 @@ VIDEO_TRANSCRIPTS_MAX_AGE = 31536000
 #   or ``None`` if parental consent is never required.
 PARENTAL_CONSENT_AGE_LIMIT = 13
 
-############################# Grade Downloads ##############################
+########################### Instructor Downloads ###########################
 
 # These keys are used for all of our asynchronous downloadable files, including
 # the ones that contain information other than grades.
@@ -1341,15 +1364,11 @@ GRADES_DOWNLOAD = {
     'ROOT_PATH': None,
 }
 
-# TODO correct section?
 FINANCIAL_REPORTS = {
     'STORAGE_TYPE': 'localfs',
     'BUCKET': None,
     'ROOT_PATH': 'sandbox',
 }
-
-# Rate limit for regrading tasks that a grading policy change can kick off
-POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
 
 ############################### Registration ###############################
 
@@ -1829,37 +1848,6 @@ CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT = 0.5  # time in seconds
 #   codejail remote service endpoint.
 CODE_JAIL_REST_SERVICE_READ_TIMEOUT = 3.5  # time in seconds
 
-############################# Django Built-Ins #############################
-
-# Change DEBUG in your environment settings files, not here
-SESSION_COOKIE_SECURE = False
-SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
-SESSION_COOKIE_NAME = 'sessionid'
-
-# Site info
-SITE_NAME = "localhost"
-HTTPS = 'on'
-
-BUGS_EMAIL = 'bugs@example.com'
-CONTACT_EMAIL = 'info@example.com'
-DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
-DEFAULT_FROM_EMAIL = 'registration@example.com'
-PRESS_EMAIL = 'press@example.com'
-SERVER_EMAIL = 'devops@example.com'
-TECH_SUPPORT_EMAIL = 'technical@example.com'
-UNIVERSITY_EMAIL = 'university@example.com'
-
-# TODO merge
-ADMINS = []
-ADMINS = ()
-MANAGERS = ADMINS
-
-FAVICON_PATH = 'images/favicon.ico'
-
-# Messages
-MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
-
 ####################### Locale/Internationalization ########################
 
 # Locale/Internationalization
@@ -1877,6 +1865,7 @@ USE_I18N = True
 USE_L10N = True
 
 STATICI18N_FILENAME_FUNCTION = 'statici18n.utils.legacy_filename'
+STATICI18N_OUTPUT_DIR = "js/i18n"
 
 ################################# Pipeline #################################
 
@@ -1938,9 +1927,6 @@ PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG = {
     'ENFORCE_COMPLIANCE_ON_LOGIN': False
 }
 
-# This is the domain that is used to set shared cookies between various sub-domains.
-SHARED_COOKIE_DOMAIN = Derived(lambda settings: settings.SESSION_COOKIE_DOMAIN)
-
 SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = None
 
 # List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS
@@ -1949,6 +1935,9 @@ IDA_LOGOUT_URI_LIST = []
 
 ### External auth usage -- prefixes for ENROLLMENT_DOMAIN
 SHIBBOLETH_DOMAIN_PREFIX = 'shib:'
+
+# This is the domain that is used to set shared cookies between various sub-domains.
+SHARED_COOKIE_DOMAIN = Derived(lambda settings: settings.SESSION_COOKIE_DOMAIN)
 
 ################################ Analytics #################################
 
@@ -2243,9 +2232,13 @@ WIKI_HELP_URL = "https://docs.openedx.org/en/latest/educators/concepts/communica
 CUSTOM_PAGES_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/manage_custom_page.html"
 ORA_SETTINGS_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/Manage_ORA_Assignment.html"
 
-# API access management
+########################## API Access Management ###########################
+
 API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
 AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+
+API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 
 ############################## Notifications ###############################
 
@@ -2309,8 +2302,6 @@ ENTERPRISE_ENROLLMENT_API_URL = Derived(
     lambda settings: (settings.LMS_INTERNAL_ROOT_URL or '') + settings.LMS_ENROLLMENT_API_PATH
 )
 
-STATIC_ROOT_BASE = None
-
 VIDEO_CDN_URL = {
     # 'EXAMPLE_COUNTRY_CODE': "http://example.com/edx/video?s3_url="
 }
@@ -2320,8 +2311,13 @@ SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = Derived(lambda settings: settings.HIG
 # Queue to use for updating grades due to grading policy change
 POLICY_CHANGE_GRADES_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
 
+# Rate limit for regrading tasks that a grading policy change can kick off
+POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
+
 # Queue to use for individual learner course regrades
 SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY = Derived(lambda settings: settings.DEFAULT_PRIORITY_QUEUE)
+
+STATIC_ROOT_BASE = None
 
 # .. setting_name: STATIC_URL_BASE
 # .. setting_default: "None"
@@ -2386,10 +2382,10 @@ DJFS = {
     'url_root': '/static/django-pyfs',
 }
 
-##### EMBARGO #####
+# Embargo
 EMBARGO_SITE_REDIRECT_URL = None
 
-##### shoppingcart Payment #####
+# shoppingcart Payment
 PAYMENT_SUPPORT_EMAIL = 'billing@example.com'
 
 # Platform for Privacy Preferences header
@@ -2405,12 +2401,6 @@ P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
 #   "CUSTOM_RESOURCE_TEMPLATES_DIRECTORY" : null
 CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = None
 
-# TODO - category? CMS - oauth2 provider, LMS - credentials service
-# API access management
-API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
-API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
-
-# TODO - category
 # Affiliate cookie tracking
 AFFILIATE_COOKIE_NAME = 'dev_affiliate_id'
 
@@ -2419,8 +2409,7 @@ ENTRANCE_EXAM_MIN_SCORE_PCT = 50
 # Initialize to 'release', but read from JSON in production.py
 EDX_PLATFORM_REVISION = 'release'
 
-# TODO - categorize storages?
-### Proctoring configuration (redirct URLs and keys shared between systems) ####
+# Proctoring configuration (redirct URLs and keys shared between systems)
 PROCTORING_BACKENDS = {
     'DEFAULT': 'null',
     # The null key needs to be quoted because

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -6,6 +6,14 @@ environments. It centralizes common settings in one place and reduces duplicatio
 
 Service-specific settings should import from this module and override as needed.
 
+WARNING: Mutable values defined in this file may be unintentionally modified
+downstream, if settings are shared across services. Some settings modules
+(cms/envs/common.py, cms/envs/test.py) import settings across services
+(the CMS imports settings from the LMS). In such cases, if an LMS settings
+module modifies a mutable value defined here, the final value of the corresponding
+CMS setting may also be affected. To avoid this risk, create a deep copy of the
+value in the module that modifies it.
+
 Note: More settings will be added to this file as the effort to simplify
 settings moves forward. See docs/decisions/0022-settings-simplification.rst for
 more details on the effort to simplify settings across Open edX services.
@@ -23,7 +31,7 @@ from path import Path as path
 from django.utils.translation import gettext_lazy as _
 
 from openedx.core.lib.derived import Derived
-
+from openedx.core.release import doc_version
 from openedx.core.djangoapps.theming.helpers_dirs import (
     get_themes_unchecked,
     get_theme_base_dirs_from_settings
@@ -217,6 +225,18 @@ AUTH_PASSWORD_VALIDATORS = [
 # See https://github.com/openedx/edx-django-sites-extensions for more info.
 # Default site to use if site matching request headers does not exist.
 SITE_ID = 1
+
+# Clickjacking protection can be disbaled by setting this to 'ALLOW'
+X_FRAME_OPTIONS = 'DENY'
+
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage'
+    },
+    'staticfiles': {
+        'BACKEND': 'openedx.core.storage.ProductionStorage'
+    }
+}
 
 ################################# Language #################################
 
@@ -444,6 +464,23 @@ REST_FRAMEWORK = {
     },
 }
 
+# .. setting_name: REGISTRATION_VALIDATION_RATELIMIT
+# .. setting_default: 30/7d
+# .. setting_description: Whenever a user tries to register on edx, the data entered during registration
+#    is validated via RegistrationValidationView.
+#    It's POST endpoint is rate-limited up to 30 requests per IP Address in a week by default.
+#    It was introduced because an attacker can guess or brute force a series of names to enumerate valid users.
+# .. setting_tickets: https://github.com/openedx/edx-platform/pull/24664
+REGISTRATION_VALIDATION_RATELIMIT = '30/7d'
+
+# .. setting_name: REGISTRATION_RATELIMIT
+# .. setting_default: 60/7d
+# .. setting_description: New users are registered on edx via RegistrationView.
+#    It's POST end-point is rate-limited up to 60 requests per IP Address in a week by default.
+#    Purpose of this setting is to restrict an attacker from registering numerous fake accounts.
+# .. setting_tickets: https://github.com/openedx/edx-platform/pull/27060
+REGISTRATION_RATELIMIT = '60/7d'
+
 ################################## Celery ##################################
 
 BROKER_HEARTBEAT = 60.0
@@ -457,6 +494,30 @@ CELERY_BROKER_USER = ''
 CELERY_BROKER_VHOST = ''
 CELERY_RESULT_BACKEND = 'django-cache'
 CELERY_EVENT_QUEUE_TTL = None
+
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+
+# Message configuration
+CELERY_MESSAGE_COMPRESSION = 'gzip'
+
+# Results configuration
+CELERY_IGNORE_RESULT = False
+CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
+
+# Events configuration
+CELERY_TRACK_STARTED = True
+
+CELERY_SEND_EVENTS = True
+CELERY_SEND_TASK_SENT_EVENT = True
+
+# Exchange configuration
+CELERY_DEFAULT_EXCHANGE = 'edx.core'
+CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
+
+# Queues configuration
+CELERY_QUEUE_HA_POLICY = 'all'
+CELERY_CREATE_MISSING_QUEUES = True
 
 # Checks run in normal mode by the heartbeat djangoapp
 HEARTBEAT_CHECKS = [
@@ -527,6 +588,737 @@ JWT_AUTH = {
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 }
 
+# These JWT settings appear to be vestigial. They are duplicates of settings
+# defined in JWT_AUTH above, and don't seem to be used anymore. See issue
+# https://github.com/openedx/edx-drf-extensions/issues/332.
+JWT_ISSUER = 'http://127.0.0.1:8000/oauth2'
+DEFAULT_JWT_ISSUER = {
+    'ISSUER': 'http://127.0.0.1:8000/oauth2',
+    'AUDIENCE': 'SET-ME-PLEASE',
+    'SECRET_KEY': 'SET-ME-PLEASE'
+}
+JWT_EXPIRATION = 30
+JWT_PRIVATE_SIGNING_KEY = None
+
+
+################################# Features #################################
+
+# .. setting_name: PLATFORM_NAME
+# .. setting_default: Your Platform Name Here
+# .. setting_description: The display name of the platform to be used in
+#     templates/emails/etc.
+PLATFORM_NAME = _('Your Platform Name Here')
+PLATFORM_DESCRIPTION = _('Your Platform Description Here')
+
+PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
+PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"
+
+ENABLE_JASMINE = False
+
+# .. toggle_name: DISABLE_START_DATES
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When True, all courses will be active, regardless of start
+#   date.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2012-07-24
+# .. toggle_warning: This will cause ALL courses to be immediately visible.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/17913
+## DO NOT SET TO True IN THIS FILE
+## Doing so will cause all courses to be released on production
+DISABLE_START_DATES = False
+
+# .. toggle_name: ENABLE_DISCUSSION_SERVICE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: When True, it will enable the Discussion tab in courseware for all courses. Setting this
+#   to False will not contain inline discussion components and discussion tab in any courses.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2012-08-14
+# .. toggle_warning: If the discussion panel is present in the course and the value for this flag is False then,
+#   attempting to expand those components will cause errors. So, this should only be set to False with an LMS that
+#   is running courses that do not contain discussion components.
+#   For consistency in user-experience, keep the value in sync with the setting of the same name in the CMS.
+ENABLE_DISCUSSION_SERVICE = True
+
+# .. toggle_name: ENABLE_TEXTBOOK
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Add PDF and HTML textbook tabs to the courseware.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-03-27
+# .. toggle_warning: For consistency in user-experience, keep the value in sync with the setting of the same name
+#   in the CMS.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/3064
+ENABLE_TEXTBOOK = True
+
+# .. toggle_name: ENABLE_OAUTH2_PROVIDER
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enable this feature to allow this Open edX platform to be an OAuth2 authentication
+#   provider. This is necessary to enable some other features, such as the REST API for the mobile application.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2014-09-09
+# .. toggle_target_removal_date: None
+# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+ENABLE_OAUTH2_PROVIDER = False
+
+# Allows to configure the LMS to provide CORS headers to serve requests from other
+# domains
+ENABLE_CORS_HEADERS = False
+
+# Can be turned off to disable the help link in the navbar
+# .. toggle_name: ENABLE_HELP_LINK
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: When True, a help link is displayed on the main navbar. Set False to hide it.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-03-05
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/26106
+ENABLE_HELP_LINK = True
+
+# Enable URL that shows information about the status of various services
+ENABLE_SERVICE_STATUS = False
+
+# Don't autoplay videos for students/course authors
+AUTOPLAY_VIDEOS = False
+
+# Move the student/course author to next page when a video finishes. Set to
+# True to show an auto-advance button in videos. If False, videos never
+# auto-advance.
+ENABLE_AUTOADVANCE_VIDEOS = False
+
+# .. toggle_name: CUSTOM_COURSES_EDX
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable Custom Courses for edX, a feature that is more commonly known as
+#   CCX. Documentation for configuring and using this feature is available at
+#   https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/configuration/enable_ccx.html
+# .. toggle_warning: When set to true, 'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider' will
+#    be added to MODULESTORE_FIELD_OVERRIDE_PROVIDERS
+# .. toggle_use_cases: opt_in, circuit_breaker
+# .. toggle_creation_date: 2015-04-10
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/6636
+CUSTOM_COURSES_EDX = False
+
+# Settings for course import olx validation
+ENABLE_COURSE_OLX_VALIDATION = False
+
+# .. toggle_name: AUTOMATIC_AUTH_FOR_TESTING
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to perform acceptance and load test. Auto auth view is responsible for load
+#    testing and is controlled by this feature flag. Session verification (of CacheBackedAuthenticationMiddleware)
+#    is a security feature, but it can be turned off by enabling this feature flag.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2013-07-25
+# .. toggle_warning: If this has been set to True then the account activation email will be skipped.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/417
+AUTOMATIC_AUTH_FOR_TESTING = False
+
+# .. toggle_name: RESTRICT_AUTOMATIC_AUTH
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Prevent auto auth from creating superusers or modifying existing users. Auto auth is a
+#   mechanism where superusers can simply modify attributes of other users by accessing the "/auto_auth url" with
+#   the right
+#   querystring parameters.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2018-05-07
+# .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
+RESTRICT_AUTOMATIC_AUTH = True
+
+# .. toggle_name: EMBARGO
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Turns on embargo functionality, which blocks users from
+#   the site or courses based on their location. Embargo can restrict users by states
+#   and whitelist/blacklist (IP Addresses (ie. 10.0.0.0), Networks (ie. 10.0.0.0/24)), or the user profile country.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-02-27
+# .. toggle_target_removal_date: None
+# .. toggle_warning: reverse proxy should be configured appropriately for example Client IP address headers
+#   (e.g HTTP_X_FORWARDED_FOR) should be configured.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2749
+EMBARGO = False
+
+# .. toggle_name: ENABLE_MKTG_SITE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Toggle to enable alternate urls for marketing links.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-03-24
+# .. toggle_warning: When this is enabled, the MKTG_URLS setting should be defined. The use case of this feature
+#   toggle is uncertain.
+ENABLE_MKTG_SITE = False
+
+# Expose Mobile REST API. Note that if you use this, you must also set
+# ENABLE_OAUTH2_PROVIDER to True
+ENABLE_MOBILE_REST_API = False
+
+# Let students save and manage their annotations
+# .. toggle_name: settings.ENABLE_EDXNOTES
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: This toggle enables the students to save and manage their annotations in the
+#   course using the notes service. The bulk of the actual work in storing the notes is done by
+#   a separate service (see the edx-notes-api repo).
+# .. toggle_warning: Requires the edx-notes-api service properly running and to have configured the django settings
+#   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API. If you update this setting, also update it in Studio.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-01-04
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/6321
+ENABLE_EDXNOTES = False
+
+# Toggle to enable coordination with the Publisher tool (keep in sync between the LMS and CMS)
+ENABLE_PUBLISHER = False
+
+# Milestones application flag
+MILESTONES_APP = False
+
+# Prerequisite courses feature flag
+ENABLE_PREREQUISITE_COURSES = False
+
+# .. toggle_name: LICENSING
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Toggle platform-wide course licensing. The course.license attribute is then used to append
+#   license information to the courseware.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-05-14
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/7315
+LICENSING = False
+
+# .. toggle_name: CERTIFICATES_HTML_VIEW
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable course certificates on your instance of Open edX.
+# .. toggle_warning: You must enable this feature flag in both Studio and the LMS and complete the configuration tasks
+#   described here:
+#   https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/configuration/enable_certificates.html  pylint: disable=line-too-long,useless-suppression
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-03-13
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/7113
+CERTIFICATES_HTML_VIEW = False
+
+# Teams feature
+ENABLE_TEAMS = True
+
+# Show video bumper
+ENABLE_VIDEO_BUMPER = False
+
+# How many seconds to show the bumper again, default is 7 days:
+SHOW_BUMPER_PERIODICITY = 7 * 24 * 3600
+
+# .. toggle_name: ENABLE_SPECIAL_EXAMS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enable to use special exams, aka timed and proctored exams.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-09-04
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/9744
+ENABLE_SPECIAL_EXAMS = False
+
+# .. toggle_name: SHOW_HEADER_LANGUAGE_SELECTOR
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When set to True, language selector will be visible in the header.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-05-25
+# .. toggle_warning: You should set the languages in the DarkLangConfig table to get this working. If you have
+#   not set any languages in the DarkLangConfig table then the language selector will not be visible in the header.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/15133
+SHOW_HEADER_LANGUAGE_SELECTOR = False
+
+# At edX it's safe to assume that English transcripts are always available
+# This is not the case for all installations.
+# The default value here and in xmodule/tests/test_video.py should be consistent.
+FALLBACK_TO_ENGLISH_TRANSCRIPTS = True
+
+# .. toggle_name: SHOW_FOOTER_LANGUAGE_SELECTOR
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When set to True, language selector will be visible in the footer.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-05-25
+# .. toggle_warning: LANGUAGE_COOKIE_NAME is required to use footer-language-selector, set it if it has not been set.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/15133
+SHOW_FOOTER_LANGUAGE_SELECTOR = False
+
+# .. toggle_name: ENABLE_CSMH_EXTENDED
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Write Courseware Student Module History (CSMH) to the extended table: this logs all
+#   student activities to MySQL, in a separate database.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-11-05
+# .. toggle_warning: Even though most Open edX instances run with a separate CSMH database, it may not always be
+#   the case. When disabling this feature flag, remember to remove "lms.djangoapps.coursewarehistoryextended"
+#   from the INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS. This is needed
+#   in the LMS and CMS for migration consistency.
+ENABLE_CSMH_EXTENDED = True
+
+# Read from both the CSMH and CSMHE history tables.
+# This is the default, but can be disabled if all history
+# lives in the Extended table, saving the frontend from
+# making multiple queries.
+ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES = True
+
+# Set this to False to facilitate cleaning up invalid xml from your modulestore.
+ENABLE_XBLOCK_XML_VALIDATION = True
+
+# .. toggle_name: ALLOW_PUBLIC_ACCOUNT_CREATION
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Allow public account creation. If this is disabled, users will no longer have access to
+#   the signup page.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-04-12
+# .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
+ALLOW_PUBLIC_ACCOUNT_CREATION = True
+
+# .. toggle_name: SHOW_REGISTRATION_LINKS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Allow registration links. If this is disabled, users will no longer see buttons to the
+#   the signup page.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-03-27
+SHOW_REGISTRATION_LINKS = True
+
+# Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
+ENABLE_ENROLLMENT_TRACK_USER_PARTITION = True
+
+# .. toggle_name: ENABLE_PASSWORD_RESET_FAILURE_EMAIL
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Whether to send an email for failed password reset attempts or not. This happens when a
+#   user asks for a password reset but they don't have an account associated to their email. This is useful for
+#   notifying users that they don't have an account associated with email addresses they believe they've registered
+#   with. This setting can be overridden by a site-specific configuration.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-07-20
+# .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
+ENABLE_PASSWORD_RESET_FAILURE_EMAIL = False
+
+# Enable feature to remove enrollments and users. Used to reset state of master's integration environments
+ENABLE_ENROLLMENT_RESET = False
+
+# .. toggle_name: settings.DISABLE_MOBILE_COURSE_AVAILABLE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to remove Mobile Course Available UI Flag from Studio's Advanced Settings
+#   page else Mobile Course Available UI Flag will be available on Studio side.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-02-14
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/23073
+DISABLE_MOBILE_COURSE_AVAILABLE = False
+
+# .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by
+#   default because enabling allows a method to bypass password policy.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-02-21
+# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/21616'
+ENABLE_CHANGE_USER_PASSWORD_ADMIN = False
+
+### ORA Feature Flags ###
+
+# .. toggle_name: ENABLE_ORA_ALL_FILE_URLS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
+#   discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
+#   file metadata in staff assessments.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2020-03-03
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
+# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+ENABLE_ORA_ALL_FILE_URLS = False
+
+# .. toggle_name: ENABLE_ORA_USER_STATE_UPLOAD_DATA
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
+#   discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2020-03-03
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
+# .. toggle_warning: This temporary feature toggle does not have a target removal date.
+ENABLE_ORA_USER_STATE_UPLOAD_DATA = False
+
+# .. toggle_name: ENABLE_INTEGRITY_SIGNATURE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Whether to display honor code agreement for learners before their first grade assignment.
+# The honor code agreement replaces the ID verification requirement (https://github.com/edx/edx-name-affirmation).
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-02-15
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1348'
+ENABLE_INTEGRITY_SIGNATURE = False
+
+# .. toggle_name: ENABLE_LTI_PII_ACKNOWLEDGEMENT
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enables the lti pii acknowledgement feature for a course
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-10
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: 'https://2u-internal.atlassian.net/browse/MST-2055'
+ENABLE_LTI_PII_ACKNOWLEDGEMENT = False
+
+# .. toggle_name: MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: If enabled, the Library Content Block is marked as complete when users view it.
+#   Otherwise (by default), all children of this block must be completed.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-03-22
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/28268
+# .. toggle_warning: For consistency in user-experience, keep the value in sync between the LMS and CMS
+MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW = False
+
+# .. toggle_name: DISABLE_UNENROLLMENT
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to disable self-unenrollments via REST API.
+#   This also hides the "Unenroll" button on the Learner Dashboard.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-10-11
+# .. toggle_warning: For consistency in user experience, keep the value in sync with the setting of the same name
+#   in the LMS and CMS.
+# .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
+DISABLE_UNENROLLMENT = False
+
+# .. toggle_name: ENABLE_GRADING_METHOD_IN_PROBLEMS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enables the grading method feature in capa problems.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-03-22
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33911
+ENABLE_GRADING_METHOD_IN_PROBLEMS = False
+
+# .. toggle_name: BADGES_ENABLED
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable badges functionality.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-04-02
+# .. toggle_target_removal_date: None
+BADGES_ENABLED = False
+
+# .. toggle_name: ENABLE_CREDIT_ELIGIBILITY
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: When enabled, it is possible to define a credit eligibility criteria in the CMS. A "Credit
+#   Eligibility" section then appears for those courses in the LMS.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-06-17
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/8550
+ENABLE_CREDIT_ELIGIBILITY = True
+
+### TODO non-feature toggles
+# .. toggle_name: ENABLE_COPPA_COMPLIANCE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When True, enforces COPPA compliance and removes YOB field from registration form and account
+# .. settings page. Also hide YOB banner from profile page.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-10-27
+# .. toggle_tickets: 'https://openedx.atlassian.net/browse/VAN-622'
+ENABLE_COPPA_COMPLIANCE = False
+
+###################### CAPA External Code Evaluation #######################
+
+# Used with XQueue
+XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds
+XQUEUE_INTERFACE = {
+    'url': 'http://localhost:18040',
+    'basic_auth': ['edx', 'edx'],
+    'django_auth': {
+        'username': 'lms',
+        'password': 'password'
+    }
+}
+
+########################### Cache Configuration ############################
+
+CACHES = {
+    'course_structure_cache': {
+        'KEY_PREFIX': 'course_structure',
+        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
+        'LOCATION': ['localhost:11211'],
+        'TIMEOUT': '604800',  # 1 week
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+            'connect_timeout': 0.5
+        }
+    },
+    'celery': {
+        'KEY_PREFIX': 'celery',
+        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
+        'LOCATION': ['localhost:11211'],
+        'TIMEOUT': '7200',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+            'connect_timeout': 0.5
+        }
+    },
+    'mongo_metadata_inheritance': {
+        'KEY_PREFIX': 'mongo_metadata_inheritance',
+        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
+        'LOCATION': ['localhost:11211'],
+        'TIMEOUT': 300,
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+            'connect_timeout': 0.5
+        }
+    },
+    'staticfiles': {
+        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
+        'LOCATION': ['localhost:11211'],
+        'KEY_PREFIX': 'staticfiles_general',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+            'connect_timeout': 0.5
+        }
+    },
+    'default': {
+        'VERSION': '1',
+        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
+        'LOCATION': ['localhost:11211'],
+        'KEY_PREFIX': 'default',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+            'connect_timeout': 0.5
+        }
+    },
+    'configuration': {
+        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
+        'LOCATION': ['localhost:11211'],
+        'KEY_PREFIX': 'configuration',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+            'connect_timeout': 0.5
+        }
+    },
+    'general': {
+        'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
+        'LOCATION': ['localhost:11211'],
+        'KEY_PREFIX': 'general',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'OPTIONS': {
+            'no_delay': True,
+            'ignore_exc': True,
+            'use_pooling': True,
+            'connect_timeout': 0.5
+        }
+    },
+}
+
+################################### CSRF ###################################
+
+CSRF_COOKIE_AGE = 60 * 60 * 24 * 7 * 52
+
+# It is highly recommended that you override this in any environment accessed by
+# end users
+CSRF_COOKIE_SECURE = False
+
+# If setting a cross-domain cookie, it's really important to choose
+# a name for the cookie that is DIFFERENT than the cookies used
+# by each subdomain.  For example, suppose the applications
+# at these subdomains are configured to use the following cookie names:
+#
+# 1) foo.example.com --> "csrftoken"
+# 2) baz.example.com --> "csrftoken"
+# 3) bar.example.com --> "csrftoken"
+#
+# For the cross-domain version of the CSRF cookie, you need to choose
+# a name DIFFERENT than "csrftoken"; otherwise, the new token configured
+# for ".example.com" could conflict with the other cookies,
+# non-deterministically causing 403 responses.
+CROSS_DOMAIN_CSRF_COOKIE_NAME = ''
+
+# When setting the domain for the "cross-domain" version of the CSRF
+# cookie, you should choose something like: ".example.com"
+# (note the leading dot), where both the referer and the host
+# are subdomains of "example.com".
+#
+# Browser security rules require that
+# the cookie domain matches the domain of the server; otherwise
+# the cookie won't get set.  And once the cookie gets set, the client
+# needs to be on a domain that matches the cookie domain, otherwise
+# the client won't be able to read the cookie.
+CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = ''
+
+CSRF_TRUSTED_ORIGINS = []
+
+ENABLE_CROSS_DOMAIN_CSRF_COOKIE = False
+
+########################## Cross-domain Requests ###########################
+
+if ENABLE_CORS_HEADERS:
+    CORS_ALLOW_CREDENTIALS = True
+    CORS_ORIGIN_WHITELIST = ()
+    CORS_ORIGIN_ALLOW_ALL = False
+    CORS_ALLOW_INSECURE = False
+
+# .. setting_name: LOGIN_REDIRECT_WHITELIST
+# .. setting_default: empty list ([])
+# .. setting_description: While logout, if logout request has a redirect-url as query strings,
+#   then the redirect-url is validated through LOGIN_REDIRECT_WHITELIST.
+LOGIN_REDIRECT_WHITELIST = []
+
+######################## Social Media Footer Links #########################
+
+# The footer URLs dictionary maps social footer names
+# to URLs defined in configuration.
+SOCIAL_MEDIA_FOOTER_ACE_URLS = {
+    'reddit': 'http://www.reddit.com/r/edx',
+    'twitter': 'https://twitter.com/edXOnline',
+    'linkedin': 'http://www.linkedin.com/company/edx',
+    'facebook': 'http://www.facebook.com/EdxOnline',
+}
+
+# The social media logo urls dictionary maps social media names
+# to the respective icons
+SOCIAL_MEDIA_LOGO_URLS = {
+    'reddit': 'http://email-media.s3.amazonaws.com/edX/2021/social_5_reddit.png',
+    'twitter': 'http://email-media.s3.amazonaws.com/edX/2021/social_2_twitter.png',
+    'linkedin': 'http://email-media.s3.amazonaws.com/edX/2021/social_3_linkedin.png',
+    'facebook': 'http://email-media.s3.amazonaws.com/edX/2021/social_1_fb.png',
+}
+
+############################# Block Structures #############################
+
+# .. setting_name: BLOCK_STRUCTURES_SETTINGS
+# .. setting_default: dict of settings
+# .. setting_description: Stores all the settings used by block structures and block structure
+#   related tasks. See BLOCK_STRUCTURES_SETTINGS[XXX] documentation for details of each setting.
+#   For more information, check https://github.com/openedx/edx-platform/pull/13388.
+BLOCK_STRUCTURES_SETTINGS = dict(
+    # .. setting_name: BLOCK_STRUCTURES_SETTINGS['COURSE_PUBLISH_TASK_DELAY']
+    # .. setting_default: 30
+    # .. setting_description: Delay, in seconds, after a new edit of a course is published before
+    #   updating the block structures cache. This is needed for a better chance at getting
+    #   the latest changes when there are secondary reads in sharded mongoDB clusters.
+    #   For more information, check https://github.com/openedx/edx-platform/pull/13388 and
+    #   https://github.com/openedx/edx-platform/pull/14571.
+    COURSE_PUBLISH_TASK_DELAY=30,
+
+    # .. setting_name: BLOCK_STRUCTURES_SETTINGS['TASK_DEFAULT_RETRY_DELAY']
+    # .. setting_default: 30
+    # .. setting_description: Delay, in seconds, between retry attempts if a block structure task
+    #   fails. For more information, check https://github.com/openedx/edx-platform/pull/13388 and
+    #   https://github.com/openedx/edx-platform/pull/14571.
+    TASK_DEFAULT_RETRY_DELAY=30,
+
+    # .. setting_name: BLOCK_STRUCTURES_SETTINGS['TASK_MAX_RETRIES']
+    # .. setting_default: 5
+    # .. setting_description: Maximum number of retries per block structure task.
+    #   If the maximum number of retries is exceeded, then you can attempt to either manually run
+    #   the celery task, or wait for it to be triggered again.
+    #   For more information, check https://github.com/openedx/edx-platform/pull/13388 and
+    #   https://github.com/openedx/edx-platform/pull/14571.
+    TASK_MAX_RETRIES=5,
+)
+
+################################ Bulk Email ################################
+
+# Suffix used to construct 'from' email address for bulk emails.
+# A course-specific identifier is prepended.
+BULK_EMAIL_DEFAULT_FROM_EMAIL = 'no-reply@example.com'
+
+# Parameters for breaking down course enrollment into subtasks.
+BULK_EMAIL_EMAILS_PER_TASK = 500
+
+# Flag to indicate if individual email addresses should be logged as they are sent
+# a bulk email message.
+BULK_EMAIL_LOG_SENT_EMAILS = False
+
+################################## Video ###################################
+
+YOUTUBE = {
+    # YouTube JavaScript API
+    'API': 'https://www.youtube.com/iframe_api',
+
+    'TEST_TIMEOUT': 1500,
+
+    # URL to get YouTube metadata
+    'METADATA_URL': 'https://www.googleapis.com/youtube/v3/videos/',
+
+    # Web page mechanism for scraping transcript information from youtube video pages
+    'TRANSCRIPTS': {
+        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
+        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+        'ALLOWED_LANGUAGE_CODES': ["en", "en-US", "en-GB"],
+    },
+
+    'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
+}
+
+YOUTUBE_API_KEY = 'PUT_YOUR_API_KEY_HERE'
+
+########################### Video Image Storage ############################
+
+VIDEO_IMAGE_SETTINGS = dict(
+    VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB
+    VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
+    # Backend storage
+    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
+    # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+    ),
+    DIRECTORY_PREFIX='video-images/',
+    BASE_URL=MEDIA_URL,
+
+)
+
+VIDEO_IMAGE_MAX_AGE = 31536000
+
+######################## Video Transcripts Storage #########################
+
+VIDEO_TRANSCRIPTS_SETTINGS = dict(
+    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
+    # Backend storage
+    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
+    # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+    ),
+    DIRECTORY_PREFIX='video-transcripts/',
+    BASE_URL=MEDIA_URL,
+)
+
+VIDEO_TRANSCRIPTS_MAX_AGE = 31536000
+
 ############################ Parental Controls #############################
 
 # .. setting_name: PARENTAL_CONSENT_AGE_LIMIT
@@ -535,6 +1327,30 @@ JWT_AUTH = {
 #   or ``None`` if parental consent is never required.
 PARENTAL_CONSENT_AGE_LIMIT = 13
 
+############################# Grade Downloads ##############################
+
+# These keys are used for all of our asynchronous downloadable files, including
+# the ones that contain information other than grades.
+GRADES_DOWNLOAD = {
+    'STORAGE_CLASS': 'django.core.files.storage.FileSystemStorage',
+    'STORAGE_KWARGS': {
+        'location': '/tmp/edx-s3/grades',
+    },
+    'STORAGE_TYPE': None,
+    'BUCKET': None,
+    'ROOT_PATH': None,
+}
+
+# TODO correct section?
+FINANCIAL_REPORTS = {
+    'STORAGE_TYPE': 'localfs',
+    'BUCKET': None,
+    'ROOT_PATH': 'sandbox',
+}
+
+# Rate limit for regrading tasks that a grading policy change can kick off
+POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
+
 ############################### Registration ###############################
 
 # .. setting_name: REGISTRATION_EMAIL_PATTERNS_ALLOWED
@@ -542,6 +1358,20 @@ PARENTAL_CONSENT_AGE_LIMIT = 13
 # .. setting_description: Optional setting to restrict registration / account creation
 #   to only emails that match a regex in this list. Set to ``None`` to allow any email (default).
 REGISTRATION_EMAIL_PATTERNS_ALLOWED = None
+
+# String length for the configurable part of the auto-generated username
+AUTO_GENERATED_USERNAME_RANDOM_STRING_LENGTH = 4
+
+SHOW_ACTIVATE_CTA_POPUP_COOKIE_NAME = 'show-account-activation-popup'
+
+# .. toggle_name: SOME_FEATURE_NAME
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Flag would be used to show account activation popup after the registration
+# .. toggle_use_cases: open_edx
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/27661
+# .. toggle_creation_date: 2021-06-10
+SHOW_ACCOUNT_ACTIVATION_CTA = False
 
 ######################### Course Enrollment Modes ##########################
 
@@ -642,6 +1472,113 @@ ENTERPRISE_BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://127.0.0.1:8000/oaut
 
 ASSET_IGNORE_REGEX = r"(^\._.*$)|(^\.DS_Store$)|(^.*~$)"
 
+DATABASES = {
+    # edxapp's edxapp-migrate scripts and the edxapp_migrate play
+    # will ensure that any DB not named read_replica will be migrated
+    # for both the lms and cms.
+    'default': {
+        'ATOMIC_REQUESTS': True,
+        'CONN_MAX_AGE': 0,
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': '127.0.0.1',
+        'NAME': 'edxapp',
+        'OPTIONS': {},
+        'PASSWORD': 'password',
+        'PORT': '3306',
+        'USER': 'edxapp001'
+    },
+    'read_replica': {
+        'CONN_MAX_AGE': 0,
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': '127.0.0.1',
+        'NAME': 'edxapp',
+        'OPTIONS': {},
+        'PASSWORD': 'password',
+        'PORT': '3306',
+        'USER': 'edxapp001'
+    },
+    'student_module_history': {
+        'CONN_MAX_AGE': 0,
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': '127.0.0.1',
+        'NAME': 'edxapp_csmh',
+        'OPTIONS': {},
+        'PASSWORD': 'password',
+        'PORT': '3306',
+        'USER': 'edxapp001'
+    }
+}
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+DEFAULT_HASHING_ALGORITHM = 'sha256'
+
+############################# Micro-frontends ##############################
+
+# .. setting_name: ACCOUNT_MICROFRONTEND_URL
+# .. setting_default: None
+# .. setting_description: Base URL of the micro-frontend-based account settings page.
+# .. setting_warning: Also set site's ENABLE_ACCOUNT_MICROFRONTEND and
+#     account.redirect_to_microfrontend waffle flag
+ACCOUNT_MICROFRONTEND_URL = None
+
+# .. setting_name: LEARNING_MICROFRONTEND_URL
+# .. setting_default: None
+# .. setting_description: Base URL of the micro-frontend-based courseware page.
+LEARNING_MICROFRONTEND_URL = None
+
+# .. setting_name: DISCUSSIONS_MICROFRONTEND_URL
+# .. setting_default: None
+# .. setting_description: Base URL of the micro-frontend-based discussions page.
+# .. setting_warning: Also set site's courseware.discussions_mfe waffle flag.
+DISCUSSIONS_MICROFRONTEND_URL = None
+
+# .. setting_name: DISCUSSIONS_MFE_FEEDBACK_URL
+# .. setting_default: None
+# .. setting_description: Base URL of the discussions micro-frontend google form based feedback.
+DISCUSSIONS_MFE_FEEDBACK_URL = None
+
+# .. toggle_name: ENABLE_DYNAMIC_REGISTRATION_FIELDS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When enabled, this toggle adds fields configured in
+# REGISTRATION_EXTRA_FIELDS to Authn MFE
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2022-04-21
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: https://openedx.atlassian.net/browse/VAN-838
+ENABLE_DYNAMIC_REGISTRATION_FIELDS = False
+
+################################## Swift ###################################
+
+SWIFT_USERNAME = None
+SWIFT_KEY = None
+SWIFT_TENANT_ID = None
+SWIFT_TENANT_NAME = None
+SWIFT_AUTH_URL = None
+SWIFT_AUTH_VERSION = None
+SWIFT_REGION_NAME = None
+SWIFT_USE_TEMP_URLS = None
+SWIFT_TEMP_URL_KEY = None
+SWIFT_TEMP_URL_DURATION = 1800  # seconds
+
+################################### SAML ###################################
+
+SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = ""
+SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = ""
+SOCIAL_AUTH_SAML_SP_PRIVATE_KEY_DICT = {}
+SOCIAL_AUTH_SAML_SP_PUBLIC_CERT_DICT = {}
+
+########################### django-fernet-fields ###########################
+
+FERNET_KEYS = [
+    'DUMMY KEY CHANGE BEFORE GOING TO PRODUCTION',
+]
+
+########################## django-simple-history ###########################
+
+# disable indexing on date field its coming from django-simple-history.
+SIMPLE_HISTORY_DATE_INDEX = False
+
 ########################### Django OAuth Toolkit ###########################
 
 # This is required for the migrations in oauth_dispatch.models
@@ -686,6 +1623,36 @@ PROFILE_IMAGE_SIZES_MAP = {
     'medium': 50,
     'small': 30
 }
+
+################################## XBlock ##################################
+
+# .. setting_name: XBLOCK_EXTRA_MIXINS
+# .. setting_default: ()
+# .. setting_description: Custom mixins that will be dynamically added to every XBlock and XBlockAside instance.
+#     These can be classes or dotted-path references to classes.
+#     For example: `XBLOCK_EXTRA_MIXINS = ('my_custom_package.my_module.MyCustomMixin',)`
+XBLOCK_EXTRA_MIXINS = ()
+
+# .. setting_name: XBLOCK_FIELD_DATA_WRAPPERS
+# .. setting_default: ()
+# .. setting_description: Paths to wrapper methods which should be applied to every XBlock's FieldData.
+XBLOCK_FIELD_DATA_WRAPPERS = ()
+
+XBLOCK_FS_STORAGE_BUCKET = None
+XBLOCK_FS_STORAGE_PREFIX = None
+
+# .. setting_name: XBLOCK_SETTINGS
+# .. setting_default: {}
+# .. setting_description: Dictionary containing server-wide configuration of XBlocks on a per-type basis.
+#     By default, keys should match the XBlock `block_settings_key` attribute/property. If the attribute/property
+#     is not defined, use the XBlock class name. Check `xmodule.services.SettingsService`
+#     for more reference.
+XBLOCK_SETTINGS = {}
+
+# .. setting_name: XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE
+# .. setting_default: default
+# .. setting_description: The django cache key of the cache to use for storing anonymous user state for XBlocks.
+XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
 ######################## Built-in Blocks Extraction ########################
 
@@ -775,6 +1742,17 @@ USE_EXTRACTED_PROBLEM_BLOCK = False
 # .. toggle_target_removal_date: 2025-06-01
 USE_EXTRACTED_VIDEO_BLOCK = False
 
+############################## Marketing Site ##############################
+
+EDXMKTG_LOGGED_IN_COOKIE_NAME = 'edxloggedin'
+EDXMKTG_USER_INFO_COOKIE_NAME = 'edx-user-info'
+EDXMKTG_USER_INFO_COOKIE_VERSION = 1
+
+MKTG_URLS = {}
+MKTG_URL_OVERRIDES = {}
+
+SUPPORT_SITE_LINK = ''
+
 ################################# ChatGPT ##################################
 
 CHAT_COMPLETION_API = ''
@@ -795,6 +1773,497 @@ AWS_S3_CUSTOM_DOMAIN = 'edxuploads.s3.amazonaws.com'
 
 AWS_SES_REGION_NAME = 'us-east-1'
 AWS_SES_REGION_ENDPOINT = 'email.us-east-1.amazonaws.com'
+
+AWS_ACCESS_KEY_ID = None
+AWS_SECRET_ACCESS_KEY = None
+
+################################ Optimizely ################################
+
+OPTIMIZELY_PROJECT_ID = None
+OPTIMIZELY_FULLSTACK_SDK_KEY = None
+
+################################# Zendesk ##################################
+ZENDESK_URL = ''
+ZENDESK_CUSTOM_FIELDS = {}
+ZENDESK_OAUTH_ACCESS_TOKEN = ''
+# A mapping of string names to Zendesk Group IDs
+# To get the IDs of your groups you can go to
+# {zendesk_url}/api/v2/groups.json
+ZENDESK_GROUP_ID_MAPPING = {}
+
+############################## Python sandbox ##############################
+
+# Some courses are allowed to run unsafe code. This is a list of regexes, one
+# of them must match the course id for that course to run unsafe code.
+#
+# For example:
+#
+#   COURSES_WITH_UNSAFE_CODE = [
+#       r"Harvard/XY123.1/.*"
+#   ]
+COURSES_WITH_UNSAFE_CODE = []
+
+# Code jail REST service
+ENABLE_CODEJAIL_REST_SERVICE = False
+
+# .. setting_name: CODE_JAIL_REST_SERVICE_REMOTE_EXEC
+# .. setting_default: 'xmodule.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
+# .. setting_description: Set the python package.module.function that is reponsible of
+#   calling the remote service in charge of jailed code execution
+CODE_JAIL_REST_SERVICE_REMOTE_EXEC = 'xmodule.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
+
+# .. setting_name: CODE_JAIL_REST_SERVICE_HOST
+# .. setting_default: 'http://127.0.0.1:8550'
+# .. setting_description: Set the codejail remote service host
+CODE_JAIL_REST_SERVICE_HOST = 'http://127.0.0.1:8550'
+
+# .. setting_name: CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT
+# .. setting_default: 0.5
+# .. setting_description: Set the number of seconds LMS will wait to establish an internal
+#   connection to the codejail remote service.
+CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT = 0.5  # time in seconds
+
+# .. setting_name: CODE_JAIL_REST_SERVICE_READ_TIMEOUT
+# .. setting_default: 3.5
+# .. setting_description: Set the number of seconds LMS/CMS will wait for a response from the
+#   codejail remote service endpoint.
+CODE_JAIL_REST_SERVICE_READ_TIMEOUT = 3.5  # time in seconds
+
+############################# Django Built-Ins #############################
+
+# Change DEBUG in your environment settings files, not here
+SESSION_COOKIE_SECURE = False
+SESSION_SAVE_EVERY_REQUEST = False
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
+SESSION_COOKIE_NAME = 'sessionid'
+
+# Site info
+SITE_NAME = "localhost"
+HTTPS = 'on'
+
+BUGS_EMAIL = 'bugs@example.com'
+CONTACT_EMAIL = 'info@example.com'
+DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
+DEFAULT_FROM_EMAIL = 'registration@example.com'
+PRESS_EMAIL = 'press@example.com'
+SERVER_EMAIL = 'devops@example.com'
+TECH_SUPPORT_EMAIL = 'technical@example.com'
+UNIVERSITY_EMAIL = 'university@example.com'
+
+# TODO merge
+ADMINS = []
+ADMINS = ()
+MANAGERS = ADMINS
+
+FAVICON_PATH = 'images/favicon.ico'
+
+# Messages
+MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
+
+####################### Locale/Internationalization ########################
+
+# Locale/Internationalization
+CELERY_TIMEZONE = 'UTC'
+TIME_ZONE = 'UTC'
+LANGUAGE_CODE = 'en'  # http://www.i18nguy.com/unicode/language-identifiers.html
+
+# Languages supported for custom course certificate templates
+CERTIFICATE_TEMPLATE_LANGUAGES = {
+    'en': 'English',
+    'es': 'Español',
+}
+
+USE_I18N = True
+USE_L10N = True
+
+STATICI18N_FILENAME_FUNCTION = 'statici18n.utils.legacy_filename'
+
+################################# Pipeline #################################
+
+STATICFILES_STORAGE_KWARGS = {}
+
+# List of finder classes that know how to find static files in various locations.
+# Note: the pipeline finder is included to be able to discover optimized files
+STATICFILES_FINDERS = [
+    'openedx.core.djangoapps.theming.finders.ThemeFilesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'openedx.core.lib.xblock_pipeline.finder.XBlockPipelineFinder',
+    'pipeline.finders.PipelineFinder',
+]
+
+############################## django-require ##############################
+
+# The baseUrl to pass to the r.js optimizer, relative to STATIC_ROOT.
+REQUIRE_BASE_URL = "./"
+
+# Whether to run django-require in debug mode.
+REQUIRE_DEBUG = False
+
+########################### Student Verification ###########################
+
+VERIFY_STUDENT = {
+    "DAYS_GOOD_FOR": 365,  # How many days is a verficiation good for?
+    # The variable represents the window within which a verification is considered to be "expiring soon."
+    "EXPIRING_SOON_WINDOW": 28,
+}
+
+################################## ORA 2 ###################################
+
+# Default File Upload Storage bucket and prefix. Used by the FileUpload Service.
+FILE_UPLOAD_STORAGE_BUCKET_NAME = 'SET-ME-PLEASE (ex. bucket-name)'
+FILE_UPLOAD_STORAGE_PREFIX = 'submissions_attachments'
+
+
+############################## Authentication ##############################
+
+##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
+# .. setting_name: MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED
+# .. setting_default: 6
+# .. setting_description: Specifies the maximum failed login attempts allowed to users. Once the user reaches this
+#   failure threshold then the account will be locked for a configurable amount of seconds (30 minutes) which will
+#   prevent additional login attempts until this time period has passed. This setting is related with
+#   MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS and only used when ENABLE_MAX_FAILED_LOGIN_ATTEMPTS is enabled.
+MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = 6
+
+# .. setting_name: MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS
+# .. setting_default: 30 * 60
+# .. setting_description: Specifies the lockout period in seconds for consecutive failed login attempts. Once the user
+#   reaches the threshold of the login failure, then the account will be locked for the given amount of seconds
+#   (30 minutes) which will prevent additional login attempts until this time period has passed. This setting is
+#   related with MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED and only used when ENABLE_MAX_FAILED_LOGIN_ATTEMPTS is enabled.
+MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 30 * 60
+
+PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG = {
+    'ENFORCE_COMPLIANCE_ON_LOGIN': False
+}
+
+# This is the domain that is used to set shared cookies between various sub-domains.
+SHARED_COOKIE_DOMAIN = Derived(lambda settings: settings.SESSION_COOKIE_DOMAIN)
+
+SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = None
+
+# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS
+# or CMS. Only applies to IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
+IDA_LOGOUT_URI_LIST = []
+
+### External auth usage -- prefixes for ENROLLMENT_DOMAIN
+SHIBBOLETH_DOMAIN_PREFIX = 'shib:'
+
+################################ Analytics #################################
+
+ANALYTICS_DASHBOARD_URL = 'http://localhost:18110/courses'
+ANALYTICS_DASHBOARD_NAME = 'Your Platform Name Here Insights'
+
+################################ Discovery #################################
+
+# which access.py permission name to check in order to determine if a course is visible in
+# the course catalog. We default this to the legacy permission 'see_exists'.
+COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_exists'
+
+# which access.py permission name to check in order to determine if a course about page is
+# visible. We default this to the legacy permission 'see_exists'.
+COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_exists'
+
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG = "both"
+
+# .. toggle_name: DEFAULT_MOBILE_AVAILABLE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: This specifies if the courses are available for mobile by default. To make any individual
+#   course available for mobile one can set the value of Mobile Course Available to true in Advanced Settings from the
+#   studio when this is False.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-01-26
+# .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1985
+DEFAULT_MOBILE_AVAILABLE = False
+
+COURSE_CATALOG_URL_ROOT = 'http://localhost:8008'
+COURSE_CATALOG_API_URL = f'{COURSE_CATALOG_URL_ROOT}/api/v1'
+
+################################## Search ##################################
+
+# Use None for the default search engine
+SEARCH_ENGINE = None
+
+############################### Credentials ################################
+
+CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:8005'
+CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:8005'
+
+# time between scheduled runs, in seconds
+NOTIFY_CREDENTIALS_FREQUENCY = 14400
+
+CREDENTIALS_SERVICE_USERNAME = 'credentials_service_user'
+
+################################## Themes ##################################
+
+# .. setting_name: COMPREHENSIVE_THEME_DIRS
+# .. setting_default: []
+# .. setting_description: A list of paths to directories, each of which will
+#   be searched for comprehensive themes. Do not override this Django setting directly.
+#   Instead, set the COMPREHENSIVE_THEME_DIRS environment variable, using colons (:) to
+#   separate paths.
+COMPREHENSIVE_THEME_DIRS = os.environ.get("COMPREHENSIVE_THEME_DIRS", "").split(":")
+
+# .. setting_name: DEFAULT_SITE_THEME
+# .. setting_default: None
+# .. setting_description: Theme to use when no site or site theme is defined, for example
+#   "dark-theme". Set to None if you want to use openedx default theme.
+# .. setting_warning: The theme folder needs to be in 'edx-platform/themes' or define the path
+#   to the theme folder in COMPREHENSIVE_THEME_DIRS. To be effective, ENABLE_COMPREHENSIVE_THEMING
+#   has to be enabled.
+DEFAULT_SITE_THEME = None
+
+# .. toggle_name: ENABLE_COMPREHENSIVE_THEMING
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When enabled, this toggle activates the use of the custom theme
+#   defined by DEFAULT_SITE_THEME.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2016-06-30
+ENABLE_COMPREHENSIVE_THEMING = False
+
+
+################################ Ecommerce #################################
+
+ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:8002'
+ECOMMERCE_API_URL = 'http://localhost:8002/api/v2'
+ECOMMERCE_API_SIGNING_KEY = 'SET-ME-PLEASE'
+
+################################ Enterprise ################################
+
+# The default value of this needs to be a 16 character string
+ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = {}
+
+# The setting key maps to the channel code (e.g. 'SAP' for success factors), Channel code is defined as
+# part of django model of each integrated channel in edx-enterprise.
+# The absence of a key/value pair translates to NO LIMIT on the number of "chunks" transmitted per cycle.
+INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT = {}
+
+ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
+ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
+
+BASE_COOKIE_DOMAIN = 'localhost'
+
+ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS = {}
+
+################################## Exams ###################################
+
+EXAMS_SERVICE_URL = 'http://localhost:18740/api/v1'
+
+############################## Credit Courses ##############################
+
+# Initial delay used for retrying tasks.
+# Additional retries use longer delays.
+# Value is in seconds.
+CREDIT_TASK_DEFAULT_RETRY_DELAY = 30
+
+# Maximum number of retries per task for errors that are not related
+# to throttling.
+CREDIT_TASK_MAX_RETRIES = 5
+
+# Secret keys shared with credit providers.
+# Used to digitally sign credit requests (us --> provider)
+# and validate responses (provider --> us).
+# Each key in the dictionary is a credit provider ID, and
+# the value is the 32-character key.
+CREDIT_PROVIDER_SECRET_KEYS = {}
+
+# Maximum age in seconds of timestamps we will accept
+# when a credit provider notifies us that a student has been approved
+# or denied for credit.
+CREDIT_PROVIDER_TIMESTAMP_EXPIRATION = 15 * 60
+
+################################ Completion ################################
+
+# Once a user has watched this percentage of a video, mark it as complete:
+# (0.0 = 0%, 1.0 = 100%)
+COMPLETION_VIDEO_COMPLETE_PERCENTAGE = 0.95
+
+############################### Rate Limits ################################
+
+##### LOGISTRATION RATE LIMIT SETTINGS #####
+LOGISTRATION_RATELIMIT_RATE = '100/5m'
+LOGISTRATION_PER_EMAIL_RATELIMIT_RATE = '30/5m'
+LOGISTRATION_API_RATELIMIT = '20/m'
+LOGIN_AND_REGISTER_FORM_RATELIMIT = '100/5m'
+RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = '30/7d'
+RESET_PASSWORD_API_RATELIMIT = '30/7d'
+OPTIONAL_FIELD_API_RATELIMIT = '10/h'
+
+##### PASSWORD RESET RATE LIMIT SETTINGS #####
+PASSWORD_RESET_IP_RATE = '1/m'
+PASSWORD_RESET_EMAIL_RATE = '2/h'
+
+################################### Help ###################################
+
+HELP_TOKENS_LANGUAGE_CODE = Derived(lambda settings: settings.LANGUAGE_CODE)
+HELP_TOKENS_VERSION = Derived(lambda settings: doc_version())
+
+HELP_TOKENS_BOOKS = {
+    'learner': 'https://edx.readthedocs.io/projects/open-edx-learner-guide',
+    'course_author': 'https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course',
+}
+
+################################ Retirement ################################
+
+# .. setting_name: RETIRED_USERNAME_PREFIX
+# .. setting_default: retired__user_
+# .. setting_description: Set the prefix part of hashed usernames for retired users. Used by the derived
+#     setting RETIRED_USERNAME_FMT.
+RETIRED_USERNAME_PREFIX = 'retired__user_'
+
+# .. setting_name: RETIRED_EMAIL_PREFIX
+# .. setting_default: retired__user_
+# .. setting_description: Set the prefix part of hashed emails for retired users. Used by the derived
+#     setting RETIRED_EMAIL_FMT.
+RETIRED_EMAIL_PREFIX = 'retired__user_'
+
+# .. setting_name: RETIRED_EMAIL_DOMAIN
+# .. setting_default: retired.invalid
+# .. setting_description: Set the domain part of hashed emails for retired users. Used by the derived
+#     setting RETIRED_EMAIL_FMT.
+RETIRED_EMAIL_DOMAIN = 'retired.invalid'
+
+# .. setting_name: RETIRED_USERNAME_FMT
+# .. setting_default: retired__user_{}
+# .. setting_description: Set the format a retired user username field gets transformed into, where {}
+#     is replaced with the hash of the original username. This is a derived setting that depends on
+#     RETIRED_USERNAME_PREFIX value.
+RETIRED_USERNAME_FMT = Derived(lambda settings: settings.RETIRED_USERNAME_PREFIX + '{}')
+
+# .. setting_name: RETIRED_EMAIL_FMT
+# .. setting_default: retired__user_{}@retired.invalid
+# .. setting_description: Set the format a retired user email field gets transformed into, where {} is
+#     replaced with the hash of the original email. This is a derived setting that depends on
+#     RETIRED_EMAIL_PREFIX and RETIRED_EMAIL_DOMAIN values.
+RETIRED_EMAIL_FMT = Derived(lambda settings: settings.RETIRED_EMAIL_PREFIX + '{}@' + settings.RETIRED_EMAIL_DOMAIN)
+
+# .. setting_name: RETIRED_USER_SALTS
+# .. setting_default: ['abc', '123']
+# .. setting_description: Set a list of salts used for hashing usernames and emails on users retirement.
+# .. setting_warning: Only the last item in this list is used as a salt for all new retirements, but
+#     historical salts are preserved in order to guarantee that all hashed usernames and emails can still
+#     be checked.
+RETIRED_USER_SALTS = ['abc', '123']
+
+# .. setting_name: RETIREMENT_SERVICE_WORKER_USERNAME
+# .. setting_default: RETIREMENT_SERVICE_USER
+# .. setting_description: Set the username of the retirement service worker user. Retirement scripts
+#     authenticate with LMS as this user with oauth client credentials.
+RETIREMENT_SERVICE_WORKER_USERNAME = 'RETIREMENT_SERVICE_USER'
+
+# These states are the default, but are designed to be overridden in configuration.
+# .. setting_name: RETIREMENT_STATES
+# .. setting_default:
+#     [
+#         'PENDING',
+#         'LOCKING_ACCOUNT',
+#         'LOCKING_COMPLETE',
+#         'RETIRING_FORUMS',
+#         'FORUMS_COMPLETE',
+#         'RETIRING_EMAIL_LISTS',
+#         'EMAIL_LISTS_COMPLETE',
+#         'RETIRING_ENROLLMENTS',
+#         'ENROLLMENTS_COMPLETE',
+#         'RETIRING_NOTES',
+#         'NOTES_COMPLETE',
+#         'RETIRING_LMS',
+#         'LMS_COMPLETE',
+#         'ERRORED',
+#         'ABORTED',
+#         'COMPLETE',
+#     ]
+# .. setting_description: Set a list that defines the name and order of states for the retirement
+#     workflow.
+# .. setting_warning: These states are stored in the database and it is the responsibility of the
+#     administrator to populate the state list since the states can vary across different installations.
+#     There must be, at minimum, a PENDING state at the beginning, and COMPLETED, ERRORED, and ABORTED
+#     states at the end of the list.
+RETIREMENT_STATES = [
+    'PENDING',
+
+    'LOCKING_ACCOUNT',
+    'LOCKING_COMPLETE',
+
+    # Use these states only when ENABLE_DISCUSSION_SERVICE is True.
+    'RETIRING_FORUMS',
+    'FORUMS_COMPLETE',
+
+    # TODO - Change these states to be the LMS-only email opt-out - PLAT-2189
+    'RETIRING_EMAIL_LISTS',
+    'EMAIL_LISTS_COMPLETE',
+
+    'RETIRING_ENROLLMENTS',
+    'ENROLLMENTS_COMPLETE',
+
+    # Use these states only when ENABLE_STUDENT_NOTES is True.
+    'RETIRING_NOTES',
+    'NOTES_COMPLETE',
+
+    'RETIRING_LMS',
+    'LMS_COMPLETE',
+
+    'ERRORED',
+    'ABORTED',
+    'COMPLETE',
+]
+
+USERNAME_REPLACEMENT_WORKER = "REPLACE WITH VALID USERNAME"
+
+################################# edx-rbac #################################
+
+SYSTEM_WIDE_ROLE_CLASSES = []
+
+############################### Brand Logos ################################
+
+LOGO_IMAGE_EXTRA_TEXT = ''
+LOGO_URL = None
+LOGO_URL_PNG = None
+LOGO_TRADEMARK_URL = None
+FAVICON_URL = None
+DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
+
+############################## Course Import ###############################
+
+COURSE_OLX_VALIDATION_STAGE = 1
+COURSE_OLX_VALIDATION_IGNORE_LIST = None
+
+
+############################## Documentation ###############################
+
+CALCULATOR_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/add_calculator.html"
+DISCUSSIONS_HELP_URL = "https://docs.openedx.org/en/latest/educators/concepts/communication/about_course_discussions.html"
+EDXNOTES_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/enable_notes.html"
+PROGRESS_HELP_URL = "https://docs.openedx.org/en/latest/educators/references/data/progress_page.html"
+TEAMS_HELP_URL = "https://docs.openedx.org/en/latest/educators/navigation/advanced_features.html#use-teams-in-your-course"
+TEXTBOOKS_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/manage_textbooks.html"
+WIKI_HELP_URL = "https://docs.openedx.org/en/latest/educators/concepts/communication/about_course_wiki.html"
+CUSTOM_PAGES_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/manage_custom_page.html"
+ORA_SETTINGS_HELP_URL = "https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/Manage_ORA_Assignment.html"
+
+# API access management
+API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
+AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+
+############################## Notifications ###############################
+
+NOTIFICATIONS_EXPIRY = 60
+EXPIRED_NOTIFICATIONS_DELETE_BATCH_SIZE = 10000
+NOTIFICATION_CREATION_BATCH_SIZE = 76
+NOTIFICATIONS_DEFAULT_FROM_EMAIL = "no-reply@example.com"
+NOTIFICATION_DIGEST_LOGO = DEFAULT_EMAIL_LOGO_URL
+
+############################# AI Translations ##############################
+
+AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
+
+################################ Event Bus #################################
+
+
+def should_send_learning_badge_events(settings):
+    return settings.BADGES_ENABLED
 
 ############################## Miscellaneous ###############################
 
@@ -840,20 +2309,11 @@ ENTERPRISE_ENROLLMENT_API_URL = Derived(
     lambda settings: (settings.LMS_INTERNAL_ROOT_URL or '') + settings.LMS_ENROLLMENT_API_PATH
 )
 
-# This is the domain that is used to set shared cookies between various sub-domains.
-SHARED_COOKIE_DOMAIN = Derived(lambda settings: settings.SESSION_COOKIE_DOMAIN)
-
-SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = None
-
 STATIC_ROOT_BASE = None
 
 VIDEO_CDN_URL = {
     # 'EXAMPLE_COUNTRY_CODE': "http://example.com/edx/video?s3_url="
 }
-
-# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS
-# or CMS. Only applies to IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
-IDA_LOGOUT_URI_LIST = []
 
 SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = Derived(lambda settings: settings.HIGH_PRIORITY_QUEUE)
 
@@ -881,10 +2341,99 @@ COMPREHENSIVE_THEME_LOCALE_PATHS = []
 #   "PREPEND_LOCALE_PATHS" : ["/edx/my-locales/"].
 PREPEND_LOCALE_PATHS = []
 
-# API access management
-API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
-AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+# Used with Email sending
+RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS = 5
+RETRY_ACTIVATION_EMAIL_TIMEOUT = 0.5
 
-CSRF_TRUSTED_ORIGINS = []
+# Software Secure request retry settings
+# Time in seconds before a retry of the task should be 60 mints.
+SOFTWARE_SECURE_REQUEST_RETRY_DELAY = 60 * 60
+# Maximum of 6 retries before giving up.
+SOFTWARE_SECURE_RETRY_MAX_ATTEMPTS = 6
+
+MARKETING_EMAILS_OPT_IN = False
+
+# Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)
+# Limits are currently disabled - but can be used for finer-grained denial-of-service protection.
+DATA_UPLOAD_MAX_MEMORY_SIZE = None
+DATA_UPLOAD_MAX_NUMBER_FIELDS = None
+
+# License for serving content in China
+ICP_LICENSE = None
+ICP_LICENSE_INFO = {}
+
+ELASTIC_SEARCH_CONFIG = [
+    {
+        'use_ssl': False,
+        'host': 'localhost',
+        'port': 9200
+    }
+]
+
+LOGGING_ENV = 'sandbox'
+
+EDX_ROOT_URL = ''
+
+PARTNER_SUPPORT_EMAIL = ''
+
+LOCAL_LOGLEVEL = "INFO"
+
+LOG_DIR = '/edx/var/log/edx'
+
+DJFS = {
+    'type': 'osfs',
+    'directory_root': '/edx/var/edxapp/django-pyfs/static/django-pyfs',
+    'url_root': '/static/django-pyfs',
+}
+
+##### EMBARGO #####
+EMBARGO_SITE_REDIRECT_URL = None
+
+##### shoppingcart Payment #####
+PAYMENT_SUPPORT_EMAIL = 'billing@example.com'
+
+# Platform for Privacy Preferences header
+P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
+
+# .. setting_name: CUSTOM_RESOURCE_TEMPLATES_DIRECTORY
+# .. setting_default: None
+# .. setting_description: Path to an existing directory of YAML files containing
+#    html content to be used with the subclasses of xmodule.x_module.ResourceTemplates.
+#    Default example templates can be found in xmodule/templates/html.
+#    Note that the extension used is ".yaml" and not ".yml".
+#    See xmodule.x_module.ResourceTemplates for usage.
+#   "CUSTOM_RESOURCE_TEMPLATES_DIRECTORY" : null
+CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = None
+
+# TODO - category? CMS - oauth2 provider, LMS - credentials service
+# API access management
+API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
+API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
+
+# TODO - category
+# Affiliate cookie tracking
+AFFILIATE_COOKIE_NAME = 'dev_affiliate_id'
 
 ENTRANCE_EXAM_MIN_SCORE_PCT = 50
+
+# Initialize to 'release', but read from JSON in production.py
+EDX_PLATFORM_REVISION = 'release'
+
+# TODO - categorize storages?
+### Proctoring configuration (redirct URLs and keys shared between systems) ####
+PROCTORING_BACKENDS = {
+    'DEFAULT': 'null',
+    # The null key needs to be quoted because
+    # null is a language independent type in YAML
+    'null': {}
+}
+
+DEPRECATED_ADVANCED_COMPONENT_TYPES = []
+
+SYSLOG_SERVER = ''
+FEEDBACK_SUBMISSION_EMAIL = ''
+
+# keys for  big blue button live provider
+COURSE_LIVE_GLOBAL_CREDENTIALS = {}
+
+BEAMER_PRODUCT_ID = ""


### PR DESCRIPTION
## Description

These changes are a part of the effort to [simplify the edx-platform settings](https://github.com/openedx/edx-platform/blob/master/docs/decisions/0022-settings-simplification.rst). Previously a platform-wide settings module was introduced, `openedx/envs/common.py`, and settings that were explicitly shared between `lms/envs/common.py` and `cms/envs/common.py` were brought into this new module. This PR continues the effort to bring up shared settings, but the settings raised up in the PR are independently declared in both the LMS and CMS, rather than explicitly imported.

## Supporting information

Resolves https://github.com/openedx/edx-platform/issues/37107.
[Simplify Settings ADR](https://github.com/openedx/edx-platform/blob/master/docs/decisions/0022-settings-simplification.rst).

This PR builds on the work done in https://github.com/openedx/edx-platform/pull/37067, and so contains the changes in that branch as well. You can see the unique changes [here in this diff](https://github.com/WGU-Open-edX/edx-platform/compare/collapse-features-dictionary...WGU-Open-edX:edx-platform:tpayne/consolidate-common-settings).

## Testing instructions

In a Tutor dev environment, run [diff_settings.py](https://github.com/WGU-Open-edX/oex-utils/blob/main/settings_utils/diff_settings.py) passing in `master` and `tpayne/consolidate-common-settings`. Since `master` still has the `FEATURES` dictionary, run [flatten_json_features.py](https://github.com/WGU-Open-edX/oex-utils/blob/main/settings_utils/flatten_json_features.py), and then a `diff` can be run to compare the rendered settings of `master` and this branch. To put the diff in a more compact format, you can then run [table_diff.py](https://github.com/WGU-Open-edX/oex-utils/blob/main/settings_utils/table_diff.py).

The diff output, and the "table diff", can be found in [this gist](https://gist.github.com/wgu-taylor-payne/ed47703403368f5c7056f0adedbf02c9).

`table_diff.py` was run with these settings being ignored, and thus not showing up in the output.

```python
IGNORED_SETTINGS = {
    "LOGGING", # handlers.console.stream displays memory address
    "CONTENTSTORE", # DOC_STORE_CONFIG.db value has random characters at end
    "MODULESTORE", # default.OPTIONS.stores[0].DOC_STORE_CONFIG.db has random characters at end
    "DOC_STORE_CONFIG", # db has random characters at end
    "THIS_UUID", # value is random

    # FEATURES specific
    "FEATURES", # dict vs proxy
    "CMS_SEGMENT_KEY", # was declared in FEATURES and outside of FEATURES in cms common.py
    "test_django_plugin", # in master, this key is in FEATURES, so is not ignored when dumping settings
    "ENTRANCE_EXAM_MIN_SCORE_PCT", # recently hoisted as part of collapse-features-dictionary
    "ENABLE_CROSS_DOMAIN_CSRF_COOKIE", # Referenced in LMS, but wasn't present upstream...added upstream to openedx/envs/common.py
}
```

### Pertinent changes to rendered settings
```diff
6009c6010
<         "METADATA_URL": "https://www.googleapis.com/youtube/v3/videos",
---
>         "METADATA_URL": "https://www.googleapis.com/youtube/v3/videos/",
3322c3323,3327
<         "EXPIRING_SOON_WINDOW": 28
---
>         "EXPIRING_SOON_WINDOW": 28,
>         "SOFTWARE_SECURE": {
>             "API_ACCESS_KEY": "BBBBBBBBBBBBBBBBBBBB",
>             "API_SECRET_KEY": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
>         }
1485c1485
<         "AUDIENCE": "change-me",
---
>         "AUDIENCE": "SET-ME-PLEASE",
```

### Justification

- `YOUTUBE["METADATA_URL"]` - The only difference between the LMS and CMS values is a trailing slash. In `edx-platform`, the only reference to this key is in `lms/djangoapps/courseware/views/views.py`, and then the value is only used to call the YouTube `videos` endpoint.
- `VERIFY_STUDENT["SOFTWARE_SECURE"]` - This key (and its value) is actually added in `lms/envs/test.py`. `cms/envs/test.py` imports settings from `lms/envs/test.py`, and in so doing, top level code in `lms/envs/test.py` is executed and `VERIFY_STUDENT` gets mutated. For now, I have added a warning at the top of `openedx/envs/common.py` that this can happen. I'm not sure if we want to take further action to prevent this from happening.
- `DEFAULT_JWT_ISSUER["AUDIENCE"]` - Both values were placeholders, but with different text, so I thought that these could be merged together. (After digging a little deeper, we might want to remove `DEFAULT_JWT_ISSUER` as it is only declared, never referenced in the code base. The setting appears to be brought in https://github.com/openedx/edx-platform/pull/21859/ and https://github.com/openedx/edx-platform/pull/21951/. It was slated to be potentially be removed [here](https://github.com/openedx/edx-drf-extensions/issues/332)).