### PR TITLE
fix: fix bad serialization of courseware metadata

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -133,7 +133,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     allow_anonymous = serializers.BooleanField()
     ecommerce_checkout = serializers.BooleanField()
     single_paid_mode = serializers.DictField()
-    ecommerce_checkout_link = AbsoluteURLField()
+    ecommerce_checkout_link = AbsoluteURLField(allow_null=True)
     course_image_urls = serializers.ListField(
         child=serializers.CharField(),
         allow_empty=True,

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -454,7 +454,14 @@ class CoursewareMeta:
             else:
                 # have professional ignore other modes for historical reasons
                 single_paid_mode = modes.get(CourseMode.PROFESSIONAL)
-        return single_paid_mode
+        if single_paid_mode:
+            return {
+                "sku": single_paid_mode.sku if single_paid_mode else None,
+                "name": single_paid_mode.name if single_paid_mode else None,
+                "min_price": single_paid_mode.min_price if single_paid_mode else None,
+                "description": single_paid_mode.description if single_paid_mode else None,
+            }
+        return {}
 
     @property
     def ecommerce_checkout_link(self):
@@ -629,7 +636,6 @@ class CoursewareInformation(RetrieveAPIView):
             * name: (str) The name of the single paid mode
             * min_price: (str) The minimum price for the single paid mode, formatted with the currency symbol
             * description: (str) The description of the single paid mode
-            * is_discounted: (bool) Whether the single paid mode is discounted
         * ecommerce_checkout_link: The ecommerce checkout link for the course, if it exists
         * course_image_urls: A list of course image URLs
         * start_date_is_still_default: Whether the course start date is still the default value

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -456,10 +456,10 @@ class CoursewareMeta:
                 single_paid_mode = modes.get(CourseMode.PROFESSIONAL)
         if single_paid_mode:
             return {
-                "sku": single_paid_mode.sku if single_paid_mode else None,
-                "name": single_paid_mode.name if single_paid_mode else None,
-                "min_price": single_paid_mode.min_price if single_paid_mode else None,
-                "description": single_paid_mode.description if single_paid_mode else None,
+                "sku": single_paid_mode.sku,
+                "name": single_paid_mode.name,
+                "min_price": single_paid_mode.min_price,
+                "description": single_paid_mode.description,
             }
         return {}
 


### PR DESCRIPTION
## Description

Fixes serialization bugs introduced in #36845 

- Formats `single_paid_mode` as a dict, rather than named tuple which couldn't be serialized to `DictField`
- Allow `ecommerce_checkout_link` to be empty.

## Deadline

ASAP, this is actively causing outages in edX courses.
