### PR TITLE
fix: prevent None entrance_exam_minimum_score_pct from breaking CourseOverview sync

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -499,7 +499,11 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         course = modulestore().get_course(self.course.id)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(course.entrance_exam_enabled)
-        self.assertEqual(course.entrance_exam_minimum_score_pct, None)
+        entrance_exam_minimum_score_pct = float(settings.ENTRANCE_EXAM_MIN_SCORE_PCT)
+        if entrance_exam_minimum_score_pct.is_integer():
+            entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct / 100
+
+        self.assertEqual(course.entrance_exam_minimum_score_pct, entrance_exam_minimum_score_pct)
 
         self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
                          msg='The entrance exam should not be required anymore')

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -224,7 +224,7 @@ def _delete_entrance_exam(request, course_key):
     if course.entrance_exam_id:
         metadata = {
             'entrance_exam_enabled': False,
-            'entrance_exam_minimum_score_pct': None,
+            'entrance_exam_minimum_score_pct': _get_default_entrance_exam_minimum_pct(),
             'entrance_exam_id': None,
         }
         CourseMetadata.update_from_dict(metadata, course, request.user)

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -272,6 +272,15 @@ class CourseOverview(TimeStampedModel):
             course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
 
         course_overview.force_on_flexible_peer_openassessments = course.force_on_flexible_peer_openassessments
+        if course.entrance_exam_minimum_score_pct is None:
+            entrance_exam_minimum_score_pct = float(settings.ENTRANCE_EXAM_MIN_SCORE_PCT)
+            if entrance_exam_minimum_score_pct.is_integer():
+                entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct / 100
+            course_overview.entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct
+        elif isinstance(course.entrance_exam_minimum_score_pct, int):
+            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct / 100
+        else:
+            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
 
         if not CatalogIntegration.is_enabled():
             course_overview.language = course.language

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -266,21 +266,22 @@ class CourseOverview(TimeStampedModel):
         course_overview.entrance_exam_id = course.entrance_exam_id or ''
         # Despite it being a float, the course object defaults to an int. So we will detect that case and update
         # it to be a float like everything else.
-        if isinstance(course.entrance_exam_minimum_score_pct, int):
-            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct / 100
-        else:
-            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
-
-        course_overview.force_on_flexible_peer_openassessments = course.force_on_flexible_peer_openassessments
+        # Extra handling: entrance_exam_minimum_score_pct can be None (e.g. when exams are disabled in Studio),
+        # so we fall back to settings.ENTRANCE_EXAM_MIN_SCORE_PCT to prevent CourseOverview save failures.
         if course.entrance_exam_minimum_score_pct is None:
             entrance_exam_minimum_score_pct = float(settings.ENTRANCE_EXAM_MIN_SCORE_PCT)
-            if entrance_exam_minimum_score_pct.is_integer():
-                entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct / 100
-            course_overview.entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct
-        elif isinstance(course.entrance_exam_minimum_score_pct, int):
-            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct / 100
         else:
-            course_overview.entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
+            entrance_exam_minimum_score_pct = course.entrance_exam_minimum_score_pct
+
+        if (
+            isinstance(entrance_exam_minimum_score_pct, int)
+            or (isinstance(entrance_exam_minimum_score_pct, float) and entrance_exam_minimum_score_pct.is_integer())
+        ):
+            entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct / 100
+
+        course_overview.entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct
+
+        course_overview.force_on_flexible_peer_openassessments = course.force_on_flexible_peer_openassessments
 
         if not CatalogIntegration.is_enabled():
             course_overview.language = course.language


### PR DESCRIPTION
When entrance exams are disabled in Studio, the field `entrance_exam_minimum_score_pct` was set to `None`. This caused silent failures when saving `CourseOverview` because the database column requires a float (NOT NULL).

This patch ensures that:
- CourseOverview sanitizes None values by falling back to `settings.ENTRANCE_EXAM_MIN_SCORE_PCT` (default=50).
- Studio avoids writing `None` and instead applies the configured default.

Impact:
- Prevents IntegrityErrors and silent failures when updating course settings.
- Restores proper syncing between modulestore (Mongo) and CourseOverview (MySQL).
- Fixes reported issues such as display name changes not persisting and course start dates not syncing.

Closes: https://github.com/openedx/edx-platform/issues/37319#

