### PR TITLE
fix: show Order History link only when MFE is configured

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -23,7 +23,7 @@ displayname = get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.
-should_show_order_history = not enterprise_customer_portal
+should_show_order_history = not enterprise_customer_portal and settings.ORDER_HISTORY_MICROFRONTEND_URL
 %>
 
 <div class="nav-item hidden-mobile">


### PR DESCRIPTION
### Description

This PR updates the logic that controls the visibility of the Order History link in the LMS user dropdown menu.

Previously, the link was shown whenever the user was not associated with an enterprise portal:

```
should_show_order_history = not enterprise_customer_portal
```

With this change, the link is only shown if:

- The user is not associated with an enterprise portal, and
- `settings.ORDER_HISTORY_MICROFRONTEND_URL` is configured.

This ensures that the Order History link only appears when the new Order History MFE is enabled and available, avoiding broken links.