### PR TITLE
chore: Upgrading django-pipeline

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -330,7 +330,7 @@ django-object-actions==5.0.0
     # via
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-pipeline==4.0.0
+django-pipeline==4.1.0
     # via -r requirements/edx/kernel.in
 django-push-notifications==3.2.1
     # via edx-ace

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -541,7 +541,7 @@ django-object-actions==5.0.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-pipeline==4.0.0
+django-pipeline==4.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -400,7 +400,7 @@ django-object-actions==5.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-pipeline==4.0.0
+django-pipeline==4.1.0
     # via -r requirements/edx/base.txt
 django-push-notifications==3.2.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -426,7 +426,7 @@ django-object-actions==5.0.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   enterprise-integrated-channels
-django-pipeline==4.0.0
+django-pipeline==4.1.0
     # via -r requirements/edx/base.txt
 django-push-notifications==3.2.1
     # via


### PR DESCRIPTION
Upgrding to latest version it has `django52` compatbility.  After this PR we are in position to run `django52` tests

https://pypi.org/project/django-pipeline/