### PR TITLE
fix: make ALLOWED_HOSTS configurable through YAML

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -89,6 +89,7 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
             'EVENT_BUS_PRODUCER_CONFIG',
             'DEFAULT_FILE_STORAGE',
             'STATICFILES_STORAGE',
+            'ALLOWED_HOSTS',
         ]
     })
 
@@ -139,11 +140,19 @@ if STATIC_ROOT_BASE:
 
 DATA_DIR = path(DATA_DIR)
 
-ALLOWED_HOSTS = [
-    # TODO: bbeggs remove this before prod, temp fix to get load testing running
-    "*",
-    CMS_BASE,
-]
+# Configure ALLOWED_HOSTS based on YAML configuration
+# If ALLOWED_HOSTS is explicitly set in YAML, use that; otherwise include "*" as fallback
+if 'ALLOWED_HOSTS' in _YAML_TOKENS:
+    # User has explicitly configured ALLOWED_HOSTS in YAML
+    ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
+else:
+    # Default behavior: include wildcard and CMS_BASE
+    ALLOWED_HOSTS = [
+        "*",
+    ]
+
+if CMS_BASE and CMS_BASE not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append(CMS_BASE)
 
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -140,19 +140,9 @@ if STATIC_ROOT_BASE:
 
 DATA_DIR = path(DATA_DIR)
 
-# Configure ALLOWED_HOSTS based on YAML configuration
-# If ALLOWED_HOSTS is explicitly set in YAML, use that; otherwise include "*" as fallback
+# If ALLOWED_HOSTS is explicitly set in YAML, use it as the base; otherwise use default from common.py
 if 'ALLOWED_HOSTS' in _YAML_TOKENS:
-    # User has explicitly configured ALLOWED_HOSTS in YAML
-    ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
-else:
-    # Default behavior: include wildcard and CMS_BASE
-    ALLOWED_HOSTS = [
-        "*",
-    ]
-
-if CMS_BASE and CMS_BASE not in ALLOWED_HOSTS:
-    ALLOWED_HOSTS.append(CMS_BASE)
+    _BASE_ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
 
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -89,7 +89,6 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
             'EVENT_BUS_PRODUCER_CONFIG',
             'DEFAULT_FILE_STORAGE',
             'STATICFILES_STORAGE',
-            'ALLOWED_HOSTS',
         ]
     })
 
@@ -139,10 +138,6 @@ if STATIC_ROOT_BASE:
     WEBPACK_LOADER['WORKERS']['STATS_FILE'] = STATIC_ROOT / "webpack-worker-stats.json"
 
 DATA_DIR = path(DATA_DIR)
-
-# If ALLOWED_HOSTS is explicitly set in YAML, use it as the base; otherwise use default from common.py
-if 'ALLOWED_HOSTS' in _YAML_TOKENS:
-    _BASE_ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
 
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -84,7 +84,6 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
             'EVENT_BUS_PRODUCER_CONFIG',
             'DEFAULT_FILE_STORAGE',
             'STATICFILES_STORAGE',
-            'ALLOWED_HOSTS',
         ]
     })
 
@@ -141,10 +140,6 @@ SESSION_COOKIE_SAMESITE = DCS_SESSION_COOKIE_SAMESITE
 
 for feature, value in _YAML_TOKENS.get('FEATURES', {}).items():
     FEATURES[feature] = value
-
-# If ALLOWED_HOSTS is explicitly set in YAML, use it as the base; otherwise use default from common.py
-if 'ALLOWED_HOSTS' in _YAML_TOKENS:
-    _BASE_ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
 
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -84,6 +84,7 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
             'EVENT_BUS_PRODUCER_CONFIG',
             'DEFAULT_FILE_STORAGE',
             'STATICFILES_STORAGE',
+            'ALLOWED_HOSTS',
         ]
     })
 
@@ -141,10 +142,20 @@ SESSION_COOKIE_SAMESITE = DCS_SESSION_COOKIE_SAMESITE
 for feature, value in _YAML_TOKENS.get('FEATURES', {}).items():
     FEATURES[feature] = value
 
-ALLOWED_HOSTS = [
-    "*",
-    _YAML_TOKENS.get('LMS_BASE'),
-]
+# Configure ALLOWED_HOSTS based on YAML configuration
+# If ALLOWED_HOSTS is explicitly set in YAML, use that; otherwise include "*" as fallback
+if 'ALLOWED_HOSTS' in _YAML_TOKENS:
+    # User has explicitly configured ALLOWED_HOSTS in YAML
+    ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
+else:
+    # Default behavior: include wildcard and LMS_BASE
+    ALLOWED_HOSTS = [
+        "*",
+    ]
+
+LMS_BASE = _YAML_TOKENS.get('LMS_BASE')
+if LMS_BASE and LMS_BASE not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append(LMS_BASE)
 
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -142,20 +142,9 @@ SESSION_COOKIE_SAMESITE = DCS_SESSION_COOKIE_SAMESITE
 for feature, value in _YAML_TOKENS.get('FEATURES', {}).items():
     FEATURES[feature] = value
 
-# Configure ALLOWED_HOSTS based on YAML configuration
-# If ALLOWED_HOSTS is explicitly set in YAML, use that; otherwise include "*" as fallback
+# If ALLOWED_HOSTS is explicitly set in YAML, use it as the base; otherwise use default from common.py
 if 'ALLOWED_HOSTS' in _YAML_TOKENS:
-    # User has explicitly configured ALLOWED_HOSTS in YAML
-    ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
-else:
-    # Default behavior: include wildcard and LMS_BASE
-    ALLOWED_HOSTS = [
-        "*",
-    ]
-
-LMS_BASE = _YAML_TOKENS.get('LMS_BASE')
-if LMS_BASE and LMS_BASE not in ALLOWED_HOSTS:
-    ALLOWED_HOSTS.append(LMS_BASE)
+    _BASE_ALLOWED_HOSTS = _YAML_TOKENS['ALLOWED_HOSTS']
 
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2258,6 +2258,10 @@ AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 def should_send_learning_badge_events(settings):
     return settings.BADGES_ENABLED
 
+############################## ALLOWED_HOSTS ###############################
+
+ALLOWED_HOSTS = ['*']
+
 ############################## Miscellaneous ###############################
 
 COURSE_MODE_DEFAULTS = {


### PR DESCRIPTION
## Related Ticket (internal)
https://github.com/mitodl/hq/issues/6604

## Description
[ALLOWED_HOSTS](https://github.com/openedx/edx-platform/blob/master/lms/envs/production.py#L139) is not truly configurable through YAML file. We have `*` in any case and can't remove/override it.

**Problem:** With anyone accessing our website through any means (IP of the server) and as the site is configured through domain we don't get any backend and [error is thrown](https://github.com/openedx/edx-platform/blob/master/common/djangoapps/third_party_auth/strategy.py#L34)  

**This PR:**
1. Allow `ALLOWED_HOSTS` to be configured through YAML file

## Testing instructions
1. Checkout to master branch and check the `ALLOWED_HOSTS` setting value by either printing it for test purposes or by going into shell: 
     - tutor dev exec lms bash
     - from django.conf import settings
     - settings.ALLOWED_HOSTS
2. Observe the values
3. Checkout to this branch and updated yaml file, either CMS or LMS and add `ALLOWED_HOSTS: ["*", "abc"]`
4. Check the ALLOWED_HOSTS value by following step 1, you should see `['*', 'abc', ...]`
