### PR TITLE
chore: remove outdated JWT auth related settings

### DIFF
--- a/cms/envs/mock.yml
+++ b/cms/envs/mock.yml
@@ -298,10 +298,6 @@ STORAGES:
       BACKEND: openedx.core.storage.ProductionStorage
 DEFAULT_FROM_EMAIL: no-reply@registration.localhost
 DEFAULT_HASHING_ALGORITHM: sha256
-DEFAULT_JWT_ISSUER:
-  AUDIENCE: test_password
-  ISSUER: https://courses.localhost/oauth2
-  SECRET_KEY: test_secret_key
 DEFAULT_SITE_THEME: localhost
 DISABLED_COUNTRIES:
 - US
@@ -513,7 +509,6 @@ JWT_AUTH:
     "kid": "lms001"}]}'
   JWT_SECRET_KEY: test_JWT_SECRET_KEY
   JWT_SIGNING_ALGORITHM: RS512
-JWT_ISSUER: https://courses.localhost/oauth2
 LANGUAGE_COOKIE: language-preference
 LEARNER_PORTAL_URL_ROOT: https://masters.localhost
 LEARNER_RECORD_MICROFRONTEND_URL: https://records.localhost

--- a/lms/envs/mock.yml
+++ b/lms/envs/mock.yml
@@ -383,10 +383,6 @@ STORAGES:
       BACKEND: openedx.core.storage.ProductionStorage
 DEFAULT_FROM_EMAIL: sandbox-notifications@example.com
 DEFAULT_HASHING_ALGORITHM: sha256
-DEFAULT_JWT_ISSUER:
-  AUDIENCE: SET-ME-PLEASE
-  ISSUER: https://deploy_host/oauth2
-  SECRET_KEY: SET-ME-PLEASE
 DEFAULT_MOBILE_AVAILABLE: true
 DEFAULT_NOTIFICATION_ICON_URL: https://notifications-static.localhost/icons/post_outline.png
 DEFAULT_SITE_THEME: localhost
@@ -725,9 +721,6 @@ JWT_AUTH:
   JWT_SECRET_KEY: SET-ME-PLEASE
   JWT_SIGNING_ALGORITHM: null
 JWT_AUTH_ADD_KID_HEADER: true
-JWT_EXPIRATION: 30
-JWT_ISSUER: https://deploy_host/oauth2
-JWT_PRIVATE_SIGNING_KEY: null
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: openedx-language-preference
 LEARNER_DASHBOARD_AMPLITUDE_MODEL_ID: hello

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -612,19 +612,6 @@ JWT_AUTH = {
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 }
 
-# These JWT settings appear to be vestigial. They are duplicates of settings
-# defined in JWT_AUTH above, and don't seem to be used anymore. See issue
-# https://github.com/openedx/edx-drf-extensions/issues/332.
-JWT_ISSUER = 'http://127.0.0.1:8000/oauth2'
-DEFAULT_JWT_ISSUER = {
-    'ISSUER': 'http://127.0.0.1:8000/oauth2',
-    'AUDIENCE': 'SET-ME-PLEASE',
-    'SECRET_KEY': 'SET-ME-PLEASE'
-}
-JWT_EXPIRATION = 30
-JWT_PRIVATE_SIGNING_KEY = None
-
-
 ################################# Features #################################
 
 # .. setting_name: PLATFORM_NAME


### PR DESCRIPTION
## Description

This PR removes unused settings relating to JWT authentication. These settings were originally added [here](https://github.com/openedx/edx-platform/pull/21859) and [here](https://github.com/openedx/edx-platform/pull/21951).

I originally thought the removal of these settings was related to the effort in [this issue](https://github.com/openedx/edx-drf-extensions/issues/332), but a closer reading revealed that issue is talking about the settings in the `JWT_AUTH` setting.

The settings removed in this PR appear to be redundant, unused duplicates of settings in the [JWT_AUTH dictionary](https://github.com/openedx/edx-platform/blob/87eb6718c43cb4449b03bb6e65308f0f948e1fa7/openedx/envs/common.py#L576). I was unable to find any references in edx-platform, [edx-drf-extensions](https://github.com/openedx/edx-drf-extensions/blob/1311a63c3e0d1e93be8bf46a05ec01fb98e29cd4/edx_rest_framework_extensions/settings.py#L63), or [drf-jwt](https://github.com/Styria-Digital/django-rest-framework-jwt/blob/4e8550e15902399df277aac97e6f300a0610697f/src/rest_framework_jwt/settings.py#L11) where these settings were access at the top level (not through `JWT_AUTH`). [Searching the openedx org](https://github.com/search?q=org%3Aopenedx+JWT_ISSUER&type=code&p=3) on GitHub didn't turn up anything that used these.

## Testing instructions

Remove these settings and unit tests still pass. Search these settings in relevant repos to verify they are not used.

## Other considerations

Is there anywhere else that needs to be searched? Would this removal need to be categorized as a breaking change?
