### PR TITLE
feat!: Drop edx-name-affirmation as a dependency.

### DIFF
--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -32,6 +32,5 @@ jobs:
           find_python_dependencies \
             --req-file requirements/edx/base.txt \
             --req-file requirements/edx/testing.txt \
-            --ignore https://github.com/edx/edx-name-affirmation \
             --ignore https://github.com/mitodl/edx-sga \
             --ignore https://github.com/open-craft/xblock-poll

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -395,7 +395,8 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
             updated_meta = user_profile.get_meta()
             self.assertEqual(meta, updated_meta)
 
-    @patch('edx_name_affirmation.name_change_validator.NameChangeValidator.validate', Mock(return_value=False))
+    @patch('openedx.core.djangoapps.user_api.accounts.api._does_name_change_require_verification',
+           Mock(return_value=True))
     @patch('openedx.core.djangoapps.user_api.accounts.api.get_certificates_for_user',
            Mock(return_value=[{'status': CertificateStatuses.downloadable}]))
     @patch('openedx.core.djangoapps.user_api.accounts.api.get_verified_enrollments',
@@ -414,8 +415,6 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         account_settings = get_account_settings(self.default_request)[0]
         assert account_settings['name'] != 'New Name'
 
-    @patch('edx_name_affirmation.name_change_validator.NameChangeValidator', Mock())
-    @patch('edx_name_affirmation.name_change_validator.NameChangeValidator.validate', Mock(return_value=True))
     @ddt.data(
         (True, False),
         (False, True),

--- a/openedx/features/name_affirmation_api/tests/test_utils.py
+++ b/openedx/features/name_affirmation_api/tests/test_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import ddt
 from edx_django_utils.plugins import PluginError
 
-from openedx.features.name_affirmation_api.utils import is_name_affirmation_installed, get_name_affirmation_service
+from openedx.features.name_affirmation_api.utils import is_name_affirmation_installed
 
 
 @ddt.ddt
@@ -23,14 +23,3 @@ class TestNameAffirmationAPIUtils(TestCase):
         mock_manager.side_effect = PluginError('No such plugin')
         with self.assertRaises(PluginError):
             self.assertFalse(is_name_affirmation_installed())
-
-    @patch('edx_name_affirmation.services.NameAffirmationService')
-    @ddt.data(True, False)
-    def test_get_name_affirmation_service(self, name_affirmation_installed, mock_service):
-        with patch('openedx.features.name_affirmation_api.utils.is_name_affirmation_installed',
-                   return_value=name_affirmation_installed):
-            name_affirmation_service = get_name_affirmation_service()
-            if name_affirmation_installed:
-                self.assertEqual(name_affirmation_service, mock_service())
-            else:
-                self.assertIsNone(name_affirmation_service)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -218,7 +218,6 @@ django==5.2.7
     #   edx-event-bus-redis
     #   edx-i18n-tools
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -260,7 +259,6 @@ django-config-models==2.9.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
-    #   edx-name-affirmation
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
 django-cors-headers==4.9.0
@@ -305,7 +303,6 @@ django-model-utils==5.0.0
     #   edx-completion
     #   edx-enterprise
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -349,7 +346,6 @@ django-simple-history==3.10.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   enterprise-integrated-channels
@@ -391,7 +387,6 @@ djangorestframework==3.16.1
     #   edx-completion
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
@@ -419,7 +414,6 @@ edx-ace==1.15.0
 edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/kernel.in
-    #   edx-name-affirmation
     #   openedx-authz
 edx-auth-backends==4.6.2
     # via -r requirements/edx/kernel.in
@@ -435,7 +429,6 @@ edx-ccx-keys==2.0.2
 edx-celeryutils==1.4.0
     # via
     #   -r requirements/edx/kernel.in
-    #   edx-name-affirmation
     #   super-csv
 edx-codejail==4.0.0
     # via -r requirements/edx/kernel.in
@@ -458,7 +451,6 @@ edx-django-utils==8.0.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-rest-api-client
     #   edx-toggles
     #   edx-when
@@ -472,7 +464,6 @@ edx-drf-extensions==10.6.0
     #   -r requirements/edx/kernel.in
     #   edx-completion
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -495,8 +486,6 @@ edx-i18n-tools==1.9.0
     #   ora2
     #   xblocks-contrib
 edx-milestones==1.1.0
-    # via -r requirements/edx/kernel.in
-edx-name-affirmation==3.0.2
     # via -r requirements/edx/kernel.in
 edx-opaque-keys[django]==3.0.0
     # via
@@ -553,7 +542,6 @@ edx-toggles==5.4.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-search
     #   edxval
     #   event-tracking
@@ -844,7 +832,6 @@ openedx-events==10.5.0
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   event-tracking
     #   ora2
 openedx-filters==2.1.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -395,7 +395,6 @@ django==5.2.7
     #   edx-event-bus-redis
     #   edx-i18n-tools
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -451,7 +450,6 @@ django-config-models==2.9.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-    #   edx-name-affirmation
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
 django-cors-headers==4.9.0
@@ -514,7 +512,6 @@ django-model-utils==5.0.0
     #   edx-completion
     #   edx-enterprise
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -578,7 +575,6 @@ django-simple-history==3.10.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   enterprise-integrated-channels
@@ -634,7 +630,6 @@ djangorestframework==3.16.1
     #   edx-completion
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
@@ -688,7 +683,6 @@ edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   edx-name-affirmation
     #   openedx-authz
 edx-auth-backends==4.6.2
     # via
@@ -709,7 +703,6 @@ edx-celeryutils==1.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   edx-name-affirmation
     #   super-csv
 edx-codejail==4.0.0
     # via
@@ -740,7 +733,6 @@ edx-django-utils==8.0.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-rest-api-client
     #   edx-toggles
     #   edx-when
@@ -755,7 +747,6 @@ edx-drf-extensions==10.6.0
     #   -r requirements/edx/testing.txt
     #   edx-completion
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -786,10 +777,6 @@ edx-i18n-tools==1.9.0
 edx-lint==5.6.0
     # via -r requirements/edx/testing.txt
 edx-milestones==1.1.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-edx-name-affirmation==3.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -863,7 +850,6 @@ edx-toggles==5.4.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-search
     #   edxval
     #   event-tracking
@@ -1405,7 +1391,6 @@ openedx-events==10.5.0
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   event-tracking
     #   ora2
 openedx-filters==2.1.0

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -280,7 +280,6 @@ django==5.2.7
     #   edx-event-bus-redis
     #   edx-i18n-tools
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -328,7 +327,6 @@ django-config-models==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edx-name-affirmation
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
 django-cors-headers==4.9.0
@@ -376,7 +374,6 @@ django-model-utils==5.0.0
     #   edx-completion
     #   edx-enterprise
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -425,7 +422,6 @@ django-simple-history==3.10.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   enterprise-integrated-channels
@@ -467,7 +463,6 @@ djangorestframework==3.16.1
     #   edx-completion
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
@@ -507,7 +502,6 @@ edx-ace==1.15.0
 edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/base.txt
-    #   edx-name-affirmation
     #   openedx-authz
 edx-auth-backends==4.6.2
     # via -r requirements/edx/base.txt
@@ -523,7 +517,6 @@ edx-ccx-keys==2.0.2
 edx-celeryutils==1.4.0
     # via
     #   -r requirements/edx/base.txt
-    #   edx-name-affirmation
     #   super-csv
 edx-codejail==4.0.0
     # via -r requirements/edx/base.txt
@@ -546,7 +539,6 @@ edx-django-utils==8.0.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-rest-api-client
     #   edx-toggles
     #   edx-when
@@ -560,7 +552,6 @@ edx-drf-extensions==10.6.0
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -583,8 +574,6 @@ edx-i18n-tools==1.9.0
     #   ora2
     #   xblocks-contrib
 edx-milestones==1.1.0
-    # via -r requirements/edx/base.txt
-edx-name-affirmation==3.0.2
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==3.0.0
     # via
@@ -643,7 +632,6 @@ edx-toggles==5.4.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-search
     #   edxval
     #   event-tracking
@@ -1022,7 +1010,6 @@ openedx-events==10.5.0
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   event-tracking
     #   ora2
 openedx-filters==2.1.0

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -76,7 +76,6 @@ edx-enterprise
 edx-event-bus-kafka>=5.6.0          # Kafka implementation of event bus
 edx-event-bus-redis
 edx-milestones
-edx-name-affirmation
 edx-opaque-keys>=2.12.0
 edx-organizations
 edx-proctoring>=2.0.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -307,7 +307,6 @@ django==5.2.7
     #   edx-event-bus-redis
     #   edx-i18n-tools
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -355,7 +354,6 @@ django-config-models==2.9.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edx-name-affirmation
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
 django-cors-headers==4.9.0
@@ -403,7 +401,6 @@ django-model-utils==5.0.0
     #   edx-completion
     #   edx-enterprise
     #   edx-milestones
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -452,7 +449,6 @@ django-simple-history==3.10.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   enterprise-integrated-channels
@@ -494,7 +490,6 @@ djangorestframework==3.16.1
     #   edx-completion
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
@@ -529,7 +524,6 @@ edx-ace==1.15.0
 edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/base.txt
-    #   edx-name-affirmation
     #   openedx-authz
 edx-auth-backends==4.6.2
     # via -r requirements/edx/base.txt
@@ -545,7 +539,6 @@ edx-ccx-keys==2.0.2
 edx-celeryutils==1.4.0
     # via
     #   -r requirements/edx/base.txt
-    #   edx-name-affirmation
     #   super-csv
 edx-codejail==4.0.0
     # via -r requirements/edx/base.txt
@@ -568,7 +561,6 @@ edx-django-utils==8.0.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-rest-api-client
     #   edx-toggles
     #   edx-when
@@ -582,7 +574,6 @@ edx-drf-extensions==10.6.0
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
-    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -607,8 +598,6 @@ edx-i18n-tools==1.9.0
 edx-lint==5.6.0
     # via -r requirements/edx/testing.in
 edx-milestones==1.1.0
-    # via -r requirements/edx/base.txt
-edx-name-affirmation==3.0.2
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==3.0.0
     # via
@@ -667,7 +656,6 @@ edx-toggles==5.4.1
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   edx-search
     #   edxval
     #   event-tracking
@@ -1068,7 +1056,6 @@ openedx-events==10.5.0
     #   edx-enterprise
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
-    #   edx-name-affirmation
     #   event-tracking
     #   ora2
 openedx-filters==2.1.0


### PR DESCRIPTION
This dependency is specific to edx.org and should not be in the default
version of the edx-platform.  There is related code in edx-platform but
circuit breakers should keep that from running for now until we can
clean it up.

Resolves https://github.com/openedx/edx-platform/issues/37598

BREAKING CHANGE: If you are relying on the edx-name-affirmation app
working, you should install it yourself before running the platform.
