### PR TITLE
fix: update course-highlights help URL

### DIFF
--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -32,7 +32,7 @@ group_configurations = course_author:course_features/content_experiments/content
 container = course_author:developing_course/course_components.html#components-that-contain-other-components
 video = course_author:video/index.html
 certificates = course_author:set_up_course/studio_add_course_information/studio_creating_certificates.html
-content_highlights = course_author:developing_course/course_sections.html#set-section-highlights-for-weekly-course-highlight-messages
+content_highlights = course_author:developing_course/course_sections.html#set-course-section-highlights
 image_accessibility = course_author:accessibility/best_practices_course_content_dev.html#use-best-practices-for-describing-images
 social_sharing = course_author:developing_course/social_sharing.html
 


### PR DESCRIPTION
**Description**

- Update course highlights help URL in studio
  - `#set-section-highlights-for-weekly-course-highlight-messages` anchor tag was incorrect for `content_highlights` and wasn't aligned with latest frontend changes (mocks [Link](https://github.com/openedx/frontend-app-authoring/blob/523dd1f3893d962fa1a44651a13b34a590c6f0e6/src/help-urls/__mocks__/helpUrls.js#L32)) which are updated & working.
  - In this PR, we replaced above #tag with working anchor tag i.e. `#set-course-section-highlights`.
  - <video src="https://github.com/user-attachments/assets/8a82ccd2-90b4-43f8-aa91-8f057c059394" controls></video>
  - <video src="https://github.com/user-attachments/assets/c73de439-49a3-484d-b8ef-8b9f8e9b9159" controls></video>

**Jira**

- [TNL2-319](https://2u-internal.atlassian.net/browse/TNL2-319)



