### PR TITLE
refactor: migrated FEATURES dict settings to top-level in core files and fixed related test files.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -388,6 +388,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         (True, True, True),
     )
     @override_waffle_flag(toggles.LEGACY_STUDIO_SCHEDULE_DETAILS, True)
+    @patch.dict('django.conf.settings.FEATURES', {'MILESTONES_APP': False})
     def test_visibility_of_entrance_exam_section(self, feature_flags):
         """
         Tests entrance exam section is available if ENTRANCE_EXAMS feature is enabled no matter any other
@@ -405,6 +406,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
             )
 
     @override_waffle_flag(toggles.LEGACY_STUDIO_SCHEDULE_DETAILS, True)
+    @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': False, 'MILESTONES_APP': False})
     def test_marketing_site_fetch(self):
         settings_details_url = get_url(self.course.id)
 
@@ -1128,16 +1130,16 @@ class CourseMetadataEditingTest(CourseTestCase):
         self.assertIn('showanswer', test_model, 'showanswer field ')
         self.assertIn('xqa_key', test_model, 'xqa_key field ')
 
-    @patch.dict(settings.FEATURES, {'ENABLE_EXPORT_GIT': True})
-    def test_fetch_giturl_present(self):
+    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=True)
+    def test_fetch_giturl_present(self, mock_is_enabled):
         """
         If feature flag ENABLE_EXPORT_GIT is on, show the setting as a non-deprecated Advanced Setting.
         """
         test_model = CourseMetadata.fetch(self.fullcourse)
         self.assertIn('giturl', test_model)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_EXPORT_GIT': False})
-    def test_fetch_giturl_not_present(self):
+    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=False)
+    def test_fetch_giturl_not_present(self, mock_is_enabled):
         """
         If feature flag ENABLE_EXPORT_GIT is off, don't show the setting at all on the Advanced Settings page.
         """
@@ -1172,8 +1174,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         test_model = CourseMetadata.fetch(self.fullcourse)
         self.assertNotIn('proctoring_escalation_email', test_model)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_EXPORT_GIT': False})
-    def test_validate_update_filtered_off(self):
+    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=False)
+    def test_validate_update_filtered_off(self, mock_is_enabled):
         """
         If feature flag is off, then giturl must be filtered.
         """
@@ -1187,8 +1189,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         )
         self.assertNotIn('giturl', test_model)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_EXPORT_GIT': True})
-    def test_validate_update_filtered_on(self):
+    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=True)
+    def test_validate_update_filtered_on(self, mock_is_enabled):
         """
         If feature flag is on, then giturl must not be filtered.
         """
@@ -1202,8 +1204,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         )
         self.assertIn('giturl', test_model)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_EXPORT_GIT': True})
-    def test_update_from_json_filtered_on(self):
+    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=True)
+    def test_update_from_json_filtered_on(self, mock_is_enabled):
         """
         If feature flag is on, then giturl must be updated.
         """
@@ -1216,8 +1218,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         )
         self.assertIn('giturl', test_model)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_EXPORT_GIT': False})
-    def test_update_from_json_filtered_off(self):
+    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=False)
+    def test_update_from_json_filtered_off(self, mock_is_enabled):
         """
         If feature flag is on, then giturl must not be updated.
         """

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1129,16 +1129,16 @@ class CourseMetadataEditingTest(CourseTestCase):
         self.assertIn('showanswer', test_model, 'showanswer field ')
         self.assertIn('xqa_key', test_model, 'xqa_key field ')
 
-    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=True)
-    def test_fetch_giturl_present(self, mock_is_enabled):
+    @override_settings(ENABLE_EXPORT_GIT=True)
+    def test_fetch_giturl_present(self):
         """
         If feature flag ENABLE_EXPORT_GIT is on, show the setting as a non-deprecated Advanced Setting.
         """
         test_model = CourseMetadata.fetch(self.fullcourse)
         self.assertIn('giturl', test_model)
 
-    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=False)
-    def test_fetch_giturl_not_present(self, mock_is_enabled):
+    @override_settings(ENABLE_EXPORT_GIT=False)
+    def test_fetch_giturl_not_present(self):
         """
         If feature flag ENABLE_EXPORT_GIT is off, don't show the setting at all on the Advanced Settings page.
         """
@@ -1173,8 +1173,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         test_model = CourseMetadata.fetch(self.fullcourse)
         self.assertNotIn('proctoring_escalation_email', test_model)
 
-    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=False)
-    def test_validate_update_filtered_off(self, mock_is_enabled):
+    @override_settings(ENABLE_EXPORT_GIT=False)
+    def test_validate_update_filtered_off(self):
         """
         If feature flag is off, then giturl must be filtered.
         """
@@ -1188,8 +1188,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         )
         self.assertNotIn('giturl', test_model)
 
-    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=True)
-    def test_validate_update_filtered_on(self, mock_is_enabled):
+    @override_settings(ENABLE_EXPORT_GIT=True)
+    def test_validate_update_filtered_on(self):
         """
         If feature flag is on, then giturl must not be filtered.
         """
@@ -1203,8 +1203,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         )
         self.assertIn('giturl', test_model)
 
-    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=True)
-    def test_update_from_json_filtered_on(self, mock_is_enabled):
+    @override_settings(ENABLE_EXPORT_GIT=True)
+    def test_update_from_json_filtered_on(self):
         """
         If feature flag is on, then giturl must be updated.
         """
@@ -1217,8 +1217,8 @@ class CourseMetadataEditingTest(CourseTestCase):
         )
         self.assertIn('giturl', test_model)
 
-    @patch.object(toggles.EXPORT_GIT, 'is_enabled', return_value=False)
-    def test_update_from_json_filtered_off(self, mock_is_enabled):
+    @override_settings(ENABLE_EXPORT_GIT=False)
+    def test_update_from_json_filtered_off(self):
         """
         If feature flag is on, then giturl must not be updated.
         """

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -407,14 +407,14 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
 
     @override_waffle_flag(toggles.LEGACY_STUDIO_SCHEDULE_DETAILS, True)
     @patch.object(milestones_helpers.ENABLE_MILESTONES_APP, 'is_enabled', return_value=False)
-    def test_marketing_site_fetch(self, mock_milestones):
+    @patch.object(core_toggles.ENTRANCE_EXAMS, 'is_enabled', return_value=False)
+    def test_marketing_site_fetch(self, mock_milestones, mock_entrance_exams):
         settings_details_url = get_url(self.course.id)
 
         with mock.patch.dict('django.conf.settings.FEATURES', {
             'ENABLE_PUBLISHER': True,
             'ENABLE_MKTG_SITE': True,
-            'ENTRANCE_EXAMS': False,
-            'ENABLE_PREREQUISITE_COURSES': False
+            'ENABLE_PREREQUISITE_COURSES': False,
         }):
             response = self.client.get_html(settings_details_url)
             self.assertNotContains(response, "Course Summary Page")

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -44,7 +44,6 @@ from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRol
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util import milestones_helpers
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
-from openedx.core import toggles as core_toggles
 from openedx.core.djangoapps.discussions.config.waffle import (
     ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
     OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
@@ -389,15 +388,15 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         (True, True, True),
     )
     @override_waffle_flag(toggles.LEGACY_STUDIO_SCHEDULE_DETAILS, True)
-    @patch.object(milestones_helpers.ENABLE_MILESTONES_APP, 'is_enabled', return_value=False)
-    def test_visibility_of_entrance_exam_section(self, feature_flags, mock_milestones):
+    @override_settings(MILESTONES_APP=False)
+    def test_visibility_of_entrance_exam_section(self, feature_flags):
         """
         Tests entrance exam section is available if ENTRANCE_EXAMS feature is enabled no matter any other
         feature is enabled or disabled i.e ENABLE_PUBLISHER.
         """
         with patch.dict("django.conf.settings.FEATURES", {
             'ENABLE_PUBLISHER': feature_flags[1]
-        }), patch.object(core_toggles.ENTRANCE_EXAMS, 'is_enabled', return_value=feature_flags[0]):
+        }), override_settings(ENTRANCE_EXAMS=feature_flags[0]):
             course_details_url = get_url(self.course.id)
             resp = self.client.get_html(course_details_url)
             self.assertEqual(
@@ -406,9 +405,9 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
             )
 
     @override_waffle_flag(toggles.LEGACY_STUDIO_SCHEDULE_DETAILS, True)
-    @patch.object(milestones_helpers.ENABLE_MILESTONES_APP, 'is_enabled', return_value=False)
-    @patch.object(core_toggles.ENTRANCE_EXAMS, 'is_enabled', return_value=False)
-    def test_marketing_site_fetch(self, mock_milestones, mock_entrance_exams):
+    @override_settings(MILESTONES_APP=False)
+    @override_settings(ENTRANCE_EXAMS=False)
+    def test_marketing_site_fetch(self):
         settings_details_url = get_url(self.course.id)
 
         with mock.patch.dict('django.conf.settings.FEATURES', {

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -913,7 +913,7 @@ class UpdateCourseDetailsTests(ModuleStoreTestCase):
             "self_paced": True,
         }
 
-        utils.update_course_details(mock_request, self.course.id, payload, None)
+        utils.update_course_details(mock_request, self.course.id, payload, self.course)
         mock_update.assert_called_once_with(self.course.id, expected_payload, mock_request.user)
 
     @patch.dict("django.conf.settings.FEATURES", {
@@ -934,7 +934,7 @@ class UpdateCourseDetailsTests(ModuleStoreTestCase):
             "self_paced": False,
         }
 
-        utils.update_course_details(mock_request, self.course.id, payload, None)
+        utils.update_course_details(mock_request, self.course.id, payload, self.course)
         mock_update.assert_called_once_with(self.course.id, payload, mock_request.user)
 
 

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -892,8 +892,8 @@ class UpdateCourseDetailsTests(ModuleStoreTestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {
         "ENABLE_PREREQUISITE_COURSES": False,
-        "ENTRANCE_EXAMS": False,
     })
+    @override_settings(ENTRANCE_EXAMS=False)
     @patch("cms.djangoapps.contentstore.utils.CourseDetails.update_from_json")
     def test_update_course_details_self_paced(self, mock_update):
         """
@@ -913,13 +913,13 @@ class UpdateCourseDetailsTests(ModuleStoreTestCase):
             "self_paced": True,
         }
 
-        utils.update_course_details(mock_request, self.course.id, payload, self.course)
+        utils.update_course_details(mock_request, self.course.id, payload, None)
         mock_update.assert_called_once_with(self.course.id, expected_payload, mock_request.user)
 
     @patch.dict("django.conf.settings.FEATURES", {
         "ENABLE_PREREQUISITE_COURSES": False,
-        "ENTRANCE_EXAMS": False,
     })
+    @override_settings(ENTRANCE_EXAMS=False)
     @patch("cms.djangoapps.contentstore.utils.CourseDetails.update_from_json")
     def test_update_course_details_instructor_paced(self, mock_update):
         """
@@ -934,7 +934,7 @@ class UpdateCourseDetailsTests(ModuleStoreTestCase):
             "self_paced": False,
         }
 
-        utils.update_course_details(mock_request, self.course.id, payload, self.course)
+        utils.update_course_details(mock_request, self.course.id, payload, None)
         mock_update.assert_called_once_with(self.course.id, payload, mock_request.user)
 
 

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -1,13 +1,13 @@
 """
 CMS feature toggles.
 """
-from edx_toggles.toggles import SettingDictToggle, WaffleFlag
+from edx_toggles.toggles import SettingToggle, WaffleFlag
 from openedx.core.djangoapps.content.search import api as search_api
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 
-# .. toggle_name: FEATURES['ENABLE_EXPORT_GIT']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: ENABLE_EXPORT_GIT
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: When enabled, a "Export to Git" menu item is added to the course studio for courses that have a
 #   valid "giturl" attribute. Exporting a course to git causes the course to be exported in the directory indicated by
@@ -17,8 +17,8 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 #   existing directory.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2014-02-13
-EXPORT_GIT = SettingDictToggle(
-    "FEATURES", "ENABLE_EXPORT_GIT", default=False, module_name=__name__
+EXPORT_GIT = SettingToggle(
+    "ENABLE_EXPORT_GIT", default=False, module_name=__name__
 )
 
 # Namespace for studio dashboard waffle flags.
@@ -406,8 +406,8 @@ def default_enable_flexible_peer_openassessments(course_key):
     return DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS.is_enabled(course_key)
 
 
-# .. toggle_name: FEATURES['ENABLE_CONTENT_LIBRARIES']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: ENABLE_CONTENT_LIBRARIES
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: True
 # .. toggle_description: Enables use of the legacy and v2 libraries waffle flags.
 #    Note that legacy content libraries are only supported in courses using split mongo.
@@ -416,8 +416,8 @@ def default_enable_flexible_peer_openassessments(course_key):
 # .. toggle_target_removal_date: 2025-04-09
 # .. toggle_warning: This flag is deprecated in Sumac, and will be removed in favor of the disable_legacy_libraries and
 #    disable_new_libraries waffle flags.
-ENABLE_CONTENT_LIBRARIES = SettingDictToggle(
-    "FEATURES", "ENABLE_CONTENT_LIBRARIES", default=True, module_name=__name__
+ENABLE_CONTENT_LIBRARIES = SettingToggle(
+    "ENABLE_CONTENT_LIBRARIES", default=True, module_name=__name__
 )
 
 # .. toggle_name: contentstore.new_studio_mfe.disable_legacy_libraries

--- a/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
@@ -7,6 +7,7 @@ import json
 from unittest.mock import patch
 
 from django.conf import settings
+from django.test import override_settings
 from django.test.client import RequestFactory
 from milestones.tests.utils import MilestonesTestCaseMixin
 from opaque_keys.edx.keys import UsageKey
@@ -30,7 +31,7 @@ from cms.djangoapps.contentstore.helpers import GRADER_TYPES
 from cms.djangoapps.contentstore.xblock_storage_handlers.create_xblock import create_xblock
 
 
-@patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
+@override_settings(ENTRANCE_EXAMS=True)
 class EntranceExamHandlerTests(CourseTestCase, MilestonesTestCaseMixin):
     """
     Base test class for create, save, and delete
@@ -319,7 +320,7 @@ class EntranceExamHandlerTests(CourseTestCase, MilestonesTestCaseMixin):
         resp = create_entrance_exam(request, self.course.id, None)
         self.assertEqual(resp.status_code, 201)
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': False})
+    @override_settings(ENTRANCE_EXAMS=False)
     def test_entrance_exam_feature_flag_gating(self):
         user = UserFactory()
         user.is_staff = True

--- a/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
@@ -4,7 +4,6 @@ Test module for Entrance Exams AJAX callback handler workflows
 
 
 import json
-from unittest.mock import patch
 
 from django.conf import settings
 from django.test import override_settings

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -162,8 +162,8 @@ class UnitTestLibraries(CourseTestCase):
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(post_response.status_code, 403)
 
-    @patch.object(toggles.ENABLE_CONTENT_LIBRARIES, 'is_enabled', return_value=False)
-    def test_with_libraries_disabled(self, mock_is_enabled):
+    @override_settings(ENABLE_CONTENT_LIBRARIES=False)
+    def test_with_libraries_disabled(self):
         """
         The library URLs should return 404 if libraries are disabled.
         """

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -16,7 +16,6 @@ from opaque_keys.edx.locator import CourseKey, LibraryLocator
 from organizations.api import get_organization_by_short_name
 from organizations.exceptions import InvalidOrganizationException
 
-from cms.djangoapps.contentstore import toggles
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, parse_json
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_library_url
 from cms.djangoapps.course_creators.views import add_user_with_status_granted as grant_course_creator_status

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -16,6 +16,7 @@ from opaque_keys.edx.locator import CourseKey, LibraryLocator
 from organizations.api import get_organization_by_short_name
 from organizations.exceptions import InvalidOrganizationException
 
+from cms.djangoapps.contentstore import toggles
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, parse_json
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_library_url
 from cms.djangoapps.course_creators.views import add_user_with_status_granted as grant_course_creator_status
@@ -161,8 +162,8 @@ class UnitTestLibraries(CourseTestCase):
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(post_response.status_code, 403)
 
-    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_CONTENT_LIBRARIES': False})
-    def test_with_libraries_disabled(self):
+    @patch.object(toggles.ENABLE_CONTENT_LIBRARIES, 'is_enabled', return_value=False)
+    def test_with_libraries_disabled(self, mock_is_enabled):
         """
         The library URLs should return 404 if libraries are disabled.
         """

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -3,7 +3,7 @@ Utility library for working with the edx-milestones app
 """
 from django.conf import settings
 from django.utils.translation import gettext as _
-from edx_toggles.toggles import SettingDictToggle
+from edx_toggles.toggles import SettingToggle
 from milestones import api as milestones_api
 from milestones.exceptions import InvalidMilestoneRelationshipTypeException, InvalidUserException
 from milestones.models import MilestoneRelationshipType
@@ -23,15 +23,15 @@ NAMESPACE_CHOICES = {
 REQUEST_CACHE_NAME = "milestones"
 
 # TODO this should be moved to edx/edx-milestones
-# .. toggle_name: FEATURES['MILESTONES_APP']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: MILESTONES_APP
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Enable the milestones application, which manages significant Course and/or Student events in
 #   the Open edX platform. (see https://github.com/openedx/edx-milestones) Note that this feature is required to enable
 #   course pre-requisites.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2014-11-21
-ENABLE_MILESTONES_APP = SettingDictToggle("FEATURES", "MILESTONES_APP", default=False, module_name=__name__)
+ENABLE_MILESTONES_APP = SettingToggle("MILESTONES_APP", default=False, module_name=__name__)
 
 
 def get_namespace_choices():

--- a/common/djangoapps/util/tests/test_milestones_helpers.py
+++ b/common/djangoapps/util/tests/test_milestones_helpers.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import ddt
 import pytest
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 from milestones import api as milestones_api

--- a/common/djangoapps/util/tests/test_milestones_helpers.py
+++ b/common/djangoapps/util/tests/test_milestones_helpers.py
@@ -7,6 +7,7 @@ import ddt
 import pytest
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.test import override_settings
 from milestones import api as milestones_api
 from milestones.exceptions import InvalidCourseKeyException, InvalidUserException
 from milestones.models import MilestoneRelationshipType
@@ -16,7 +17,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-a
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-@patch.dict(settings.FEATURES, {'MILESTONES_APP': False})
+@override_settings(MILESTONES_APP=False)
 @ddt.ddt
 class MilestonesHelpersTestCase(ModuleStoreTestCase):
     """
@@ -61,8 +62,7 @@ class MilestonesHelpersTestCase(ModuleStoreTestCase):
 
         with patch.dict("django.conf.settings.FEATURES", {
             'ENABLE_PREREQUISITE_COURSES': feature_flags[0],
-            'MILESTONES_APP': feature_flags[1]
-        }):
+        }), override_settings(MILESTONES_APP=feature_flags[1]):
             assert feature_flags[2] == milestones_helpers.is_prerequisite_courses_enabled()
 
     def test_add_milestone_returns_none_when_app_disabled(self):
@@ -123,7 +123,7 @@ class MilestonesHelpersTestCase(ModuleStoreTestCase):
         response = milestones_helpers.get_service()
         assert response is None
 
-    @patch.dict(settings.FEATURES, {'MILESTONES_APP': True})
+    @override_settings(MILESTONES_APP=True)
     def test_any_unfulfilled_milestones(self):
         """
         Tests any_unfulfilled_milestones for invalid arguments with the app enabled.
@@ -137,7 +137,7 @@ class MilestonesHelpersTestCase(ModuleStoreTestCase):
         with pytest.raises(InvalidUserException):
             milestones_helpers.any_unfulfilled_milestones(self.course.id, None)
 
-    @patch.dict(settings.FEATURES, {'MILESTONES_APP': True})
+    @override_settings(MILESTONES_APP=True)
     def test_get_required_content_with_anonymous_user(self):
         course = CourseFactory()
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -681,7 +681,8 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         assert access._has_access_course(staff, 'see_in_catalog', course)
         assert access._has_access_course(staff, 'see_about_page', course)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True, 'MILESTONES_APP': True})
+    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(MILESTONES_APP=True)
     def test_access_on_course_with_pre_requisites(self):
         """
         Test course access when a course has pre-requisite course yet to be completed

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -5,6 +5,7 @@ Tests use cases related to LMS Entrance Exam behavior, such as gated content acc
 
 from unittest.mock import patch
 from crum import set_current_request
+from django.test import override_settings
 from django.urls import reverse
 from milestones.tests.utils import MilestonesTestCaseMixin
 from lms.djangoapps.courseware.entrance_exams import (
@@ -36,7 +37,7 @@ from common.djangoapps.util.milestones_helpers import (
 )
 
 
-@patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
+@override_settings(ENTRANCE_EXAMS=True)
 class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Check that content is properly gated.
@@ -44,7 +45,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
     Creates a test course from scratch. The tests below are designed to execute
     workflows regardless of the feature flag settings.
     """
-    @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
+    @override_settings(ENTRANCE_EXAMS=True)
     def setUp(self):
         """
         Test case scaffolding

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -8,6 +8,7 @@ import pytest
 from crum import set_current_request
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
+from django.test import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 from milestones.tests.utils import MilestonesTestCaseMixin
@@ -333,12 +334,12 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertContains(resp, self.xml_data)
 
 
-@patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
+@override_settings(ENTRANCE_EXAMS=True)
 class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Validate tab behavior when dealing with Entrance Exams
     """
-    @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
+    @override_settings(ENTRANCE_EXAMS=True)
     def setUp(self):
         """
         Test case scaffolding

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -3368,7 +3368,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         assert response.status_code == 200
         assert act.called
 
-    @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
+    @override_settings(ENTRANCE_EXAMS=True)
     def test_course_has_entrance_exam_in_student_attempts_reset(self):
         """ Test course has entrance exam id set while resetting attempts"""
         url = reverse('reset_student_attempts_for_entrance_exam',
@@ -3379,7 +3379,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         })
         assert response.status_code == 400
 
-    @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
+    @override_settings(ENTRANCE_EXAMS=True)
     def test_rescore_entrance_exam_with_invalid_exam(self):
         """ Test course has entrance exam id set while re-scoring. """
         url = reverse('rescore_entrance_exam', kwargs={'course_id': str(self.course.id)})
@@ -3389,7 +3389,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         assert response.status_code == 400
 
 
-@patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
+@override_settings(ENTRANCE_EXAMS=True)
 @ddt.ddt
 class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -5,6 +5,7 @@ Test the use cases of the views of the mfe api.
 from unittest.mock import call, patch
 
 import ddt
+from django.core.cache import cache
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
@@ -30,6 +31,7 @@ class MFEConfigTestCase(APITestCase):
 
     def setUp(self):
         self.mfe_config_api_url = reverse("mfe_config_api:config")
+        cache.clear()
         return super().setUp()
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -45,7 +45,16 @@ class MFEConfigTestCase(APITestCase):
         def side_effect(key, default=None):
             if key == "MFE_CONFIG":
                 return {"EXAMPLE_VAR": "value"}
-            # Return default for all legacy config keys to use Django settings
+            # Explicitly return values that match default_legacy_config
+            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
+                return True
+            if key == "homepage_promo_video_youtube_id":
+                return None
+            if key == "HOMEPAGE_COURSE_MAX":
+                return None
+            if key == "course_about_twitter_account":
+                return "@YourPlatformTwitterAccount"
+            # Return default for all other keys
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -73,6 +82,16 @@ class MFEConfigTestCase(APITestCase):
                 return {"EXAMPLE_VAR": "value", "OTHER": "other"}
             if key == "MFE_CONFIG_OVERRIDES":
                 return {"mymfe": {"EXAMPLE_VAR": "mymfe_value"}}
+            # Explicitly return values that match default_legacy_config
+            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
+                return True
+            if key == "homepage_promo_video_youtube_id":
+                return None
+            if key == "HOMEPAGE_COURSE_MAX":
+                return None
+            if key == "course_about_twitter_account":
+                return "@YourPlatformTwitterAccount"
+            # Return default for all other keys
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -149,6 +168,15 @@ class MFEConfigTestCase(APITestCase):
                 return mfe_config
             if key == "MFE_CONFIG_OVERRIDES":
                 return mfe_config_overrides
+            # Explicitly return values that match default_legacy_config
+            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
+                return True
+            if key == "homepage_promo_video_youtube_id":
+                return None
+            if key == "HOMEPAGE_COURSE_MAX":
+                return None
+            if key == "course_about_twitter_account":
+                return "@YourPlatformTwitterAccount"
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -174,7 +202,16 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG_OVERRIDES":
                 # Return the Django settings value explicitly
                 return settings.MFE_CONFIG_OVERRIDES
-            # For legacy config keys, return default to use Django settings fallbacks
+            # For legacy config keys, return specific values to ensure consistency
+            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
+                return True
+            if key == "homepage_promo_video_youtube_id":
+                return None
+            if key == "HOMEPAGE_COURSE_MAX":
+                return None
+            if key == "course_about_twitter_account":
+                return "@YourPlatformTwitterAccount"
+            # For any other keys, return default
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -200,7 +237,16 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG_OVERRIDES":
                 # Return the Django settings value explicitly
                 return settings.MFE_CONFIG_OVERRIDES
-            # For legacy config keys, return default to use Django settings fallbacks
+            # For legacy config keys, return specific values to ensure consistency
+            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
+                return True
+            if key == "homepage_promo_video_youtube_id":
+                return None
+            if key == "HOMEPAGE_COURSE_MAX":
+                return None
+            if key == "course_about_twitter_account":
+                return "@YourPlatformTwitterAccount"
+            # For any other keys, return default
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -45,10 +45,6 @@ class MFEConfigTestCase(APITestCase):
         def side_effect(key, default=None):
             if key == "MFE_CONFIG":
                 return {"EXAMPLE_VAR": "value"}
-            # Handle legacy config calls
-            if key in ["ENABLE_COURSE_SORTING_BY_START_DATE", "homepage_promo_video_youtube_id", 
-                      "HOMEPAGE_COURSE_MAX", "course_about_twitter_account"]:
-                return default
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -71,10 +67,6 @@ class MFEConfigTestCase(APITestCase):
                 return {"EXAMPLE_VAR": "value", "OTHER": "other"}
             if key == "MFE_CONFIG_OVERRIDES":
                 return {"mymfe": {"EXAMPLE_VAR": "mymfe_value"}}
-            # Handle legacy config calls
-            if key in ["ENABLE_COURSE_SORTING_BY_START_DATE", "homepage_promo_video_youtube_id", 
-                      "HOMEPAGE_COURSE_MAX", "course_about_twitter_account"]:
-                return default
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -82,7 +74,7 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
                  call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls, any_order=True)
+        configuration_helpers_mock.get_value.assert_has_calls(calls)
         self.assertEqual(
             response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
         )
@@ -151,14 +143,6 @@ class MFEConfigTestCase(APITestCase):
                 return mfe_config
             if key == "MFE_CONFIG_OVERRIDES":
                 return mfe_config_overrides
-            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
-                return True  # matches default_legacy_config
-            if key == "homepage_promo_video_youtube_id":
-                return None
-            if key == "HOMEPAGE_COURSE_MAX":
-                return None  # matches default_legacy_config
-            if key == "course_about_twitter_account":
-                return "@YourPlatformTwitterAccount"  # matches default_legacy_config
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -166,7 +150,7 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
                  call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls, any_order=True)
+        configuration_helpers_mock.get_value.assert_has_calls(calls)
         self.assertEqual(response.json(), expected_response)
 
     def test_get_mfe_config_from_django_settings(self):
@@ -281,10 +265,6 @@ class MFEConfigTestCase(APITestCase):
                 return 5  # Plain site configuration
             if key == "homepage_promo_video_youtube_id":
                 return "site-conf-youtube-id"
-            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
-                return False
-            if key == "course_about_twitter_account":
-                return ""
             return default
 
         configuration_helpers_mock.get_value.side_effect = side_effect

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -67,14 +67,23 @@ class MFEConfigTestCase(APITestCase):
                 return {"EXAMPLE_VAR": "value", "OTHER": "other"}
             if key == "MFE_CONFIG_OVERRIDES":
                 return {"mymfe": {"EXAMPLE_VAR": "mymfe_value"}}
+            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
+                return True
+            if key == "homepage_promo_video_youtube_id":
+                return None
+            if key == "HOMEPAGE_COURSE_MAX":
+                return None
+            if key == "course_about_twitter_account":
+                return "@YourPlatformTwitterAccount"
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
         response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
-                 call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls)
+        configuration_helpers_mock.get_value.assert_has_calls([
+            call("MFE_CONFIG", settings.MFE_CONFIG),
+            call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)
+        ], any_order=True)
         self.assertEqual(
             response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
         )
@@ -143,36 +152,53 @@ class MFEConfigTestCase(APITestCase):
                 return mfe_config
             if key == "MFE_CONFIG_OVERRIDES":
                 return mfe_config_overrides
+            if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
+                return True
+            if key == "homepage_promo_video_youtube_id":
+                return None
+            if key == "HOMEPAGE_COURSE_MAX":
+                return None
+            if key == "course_about_twitter_account":
+                return "@YourPlatformTwitterAccount"
             return default
         configuration_helpers_mock.get_value.side_effect = side_effect
 
         response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
-                 call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls)
+        configuration_helpers_mock.get_value.assert_has_calls([
+            call("MFE_CONFIG", settings.MFE_CONFIG),
+            call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)
+        ], any_order=True)
         self.assertEqual(response.json(), expected_response)
 
-    def test_get_mfe_config_from_django_settings(self):
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_get_mfe_config_from_django_settings(self, configuration_helpers_mock):
         """Test that when there is no site configuration, the API takes the django settings.
 
         Expected result:
         - The status of the response of the request is a HTTP_200_OK.
         - The json response is equal to MFE_CONFIG in lms/envs/test.py"""
+
+        configuration_helpers_mock.get_value.side_effect = lambda key, default: default
+
         response = self.client.get(self.mfe_config_api_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), default_legacy_config | settings.MFE_CONFIG)
+        expected_response = {**default_legacy_config, **settings.MFE_CONFIG}
+        self.assertEqual(response.json(), expected_response)
 
-    def test_get_mfe_config_with_queryparam_from_django_settings(self):
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_get_mfe_config_with_queryparam_from_django_settings(self, configuration_helpers_mock):
         """Test that when there is no site configuration, the API with queryparam takes the django settings.
 
         Expected result:
         - The status of the response of the request is a HTTP_200_OK.
         - The json response is equal to MFE_CONFIG merged with MFE_CONFIG_OVERRIDES['mymfe']
         """
+        configuration_helpers_mock.get_value.side_effect = lambda key, default: default
+
         response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected = default_legacy_config | settings.MFE_CONFIG | settings.MFE_CONFIG_OVERRIDES["mymfe"]
+        expected = {**default_legacy_config, **settings.MFE_CONFIG, **settings.MFE_CONFIG_OVERRIDES["mymfe"]}
         self.assertEqual(response.json(), expected)
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
@@ -196,25 +222,19 @@ class MFEConfigTestCase(APITestCase):
         - The configuration_helpers get_value is called for each catalog-specific configuration.
         - The catalog-specific values are included in the response.
         """
-        mfe_config = {"BASE_URL": "https://catalog.example.com", "COURSE_ABOUT_TWITTER_ACCOUNT": "@TestAccount"}
-        mfe_config_overrides = {
-            "catalog": {
-                "SOME_SETTING": "catalog_value",
-                "NON_BROWSABLE_COURSES": True,
-            }
-        }
-
         def side_effect(key, default=None):
             if key == "MFE_CONFIG":
-                return mfe_config
+                return {"BASE_URL": "https://catalog.example.com"}
             if key == "MFE_CONFIG_OVERRIDES":
-                return mfe_config_overrides
+                return {"catalog": {"SOME_SETTING": "catalog_value", "NON_BROWSABLE_COURSES": True}}
             if key == "ENABLE_COURSE_SORTING_BY_START_DATE":
                 return True
             if key == "homepage_promo_video_youtube_id":
                 return None
             if key == "HOMEPAGE_COURSE_MAX":
                 return 8
+            if key == "course_about_twitter_account":
+                return "@TestAccount"
             return default
 
         configuration_helpers_mock.get_value.side_effect = side_effect

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -109,17 +109,36 @@ class MFEConfigTestCase(APITestCase):
         dict(
             mfe_config={},
             mfe_config_overrides={},
-            expected_response={**default_legacy_config},
+            expected_response={
+                **default_legacy_config,
+                # When both mfe_config and mfe_config_overrides are empty, they fall back to settings
+                "BASE_URL": "https://name_of_mfe.example.com",
+                "LANGUAGE_PREFERENCE_COOKIE_NAME": "mymfe-language-preference",
+                "LOGO_URL": "https://courses.example.com/mymfe-logo.png",
+            },
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={},
-            expected_response={**default_legacy_config, "EXAMPLE_VAR": "value"},
+            expected_response={
+                **default_legacy_config,
+                "EXAMPLE_VAR": "value",
+                # When mfe_config_overrides is empty, it falls back to settings.MFE_CONFIG_OVERRIDES
+                "LANGUAGE_PREFERENCE_COOKIE_NAME": "mymfe-language-preference",
+                "LOGO_URL": "https://courses.example.com/mymfe-logo.png",
+            },
         ),
         dict(
             mfe_config={},
             mfe_config_overrides={"mymfe": {"EXAMPLE_VAR": "mymfe_value"}},
-            expected_response={**default_legacy_config, "EXAMPLE_VAR": "mymfe_value"},
+            expected_response={
+                **default_legacy_config,
+                "EXAMPLE_VAR": "mymfe_value",
+                # When mfe_config is empty, it falls back to settings.MFE_CONFIG
+                "BASE_URL": "https://name_of_mfe.example.com",
+                "LANGUAGE_PREFERENCE_COOKIE_NAME": "example-language-preference",
+                "LOGO_URL": "https://courses.example.com/logo.png",
+            },
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
@@ -134,7 +153,11 @@ class MFEConfigTestCase(APITestCase):
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},
             mfe_config_overrides={"yourmfe": {"EXAMPLE_VAR": "yourmfe_value"}},
-            expected_response={**default_legacy_config, "EXAMPLE_VAR": "value"},
+            expected_response={
+                **default_legacy_config,
+                "EXAMPLE_VAR": "value",
+                # yourmfe doesn't have mymfe overrides, so no MFE-specific values
+            },
         ),
         dict(
             mfe_config={"EXAMPLE_VAR": "value"},

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -32,8 +32,7 @@ class MFEConfigTestCase(APITestCase):
         self.mfe_config_api_url = reverse("mfe_config_api:config")
         return super().setUp()
 
-    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
-    def test_get_mfe_config(self, configuration_helpers_mock):
+    def test_get_mfe_config(self):
         """Test the get mfe config from site configuration with the mfe api.
 
         Expected result:
@@ -46,14 +45,15 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG":
                 return {"EXAMPLE_VAR": "value"}
             return default
-        configuration_helpers_mock.get_value.side_effect = side_effect
+        
+        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
+            configuration_helpers_mock.get_value.side_effect = side_effect
 
-        response = self.client.get(self.mfe_config_api_url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {**default_legacy_config, "EXAMPLE_VAR": "value"})
+            response = self.client.get(self.mfe_config_api_url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json(), {**default_legacy_config, "EXAMPLE_VAR": "value"})
 
-    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
-    def test_get_mfe_config_with_queryparam(self, configuration_helpers_mock):
+    def test_get_mfe_config_with_queryparam(self):
         """Test the get mfe config with a query param from site configuration.
 
         Expected result:
@@ -68,16 +68,18 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG_OVERRIDES":
                 return {"mymfe": {"EXAMPLE_VAR": "mymfe_value"}}
             return default
-        configuration_helpers_mock.get_value.side_effect = side_effect
+        
+        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
+            configuration_helpers_mock.get_value.side_effect = side_effect
 
-        response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
-                 call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls)
-        self.assertEqual(
-            response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
-        )
+            response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
+                     call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
+            configuration_helpers_mock.get_value.assert_has_calls(calls)
+            self.assertEqual(
+                response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
+            )
 
     @ddt.unpack
     @ddt.data(
@@ -120,10 +122,8 @@ class MFEConfigTestCase(APITestCase):
             expected_response={**default_legacy_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
     )
-    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_get_mfe_config_with_queryparam_multiple_configs(
         self,
-        configuration_helpers_mock,
         mfe_config,
         mfe_config_overrides,
         expected_response,
@@ -138,20 +138,21 @@ class MFEConfigTestCase(APITestCase):
         and once with the parameters ("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES).
         - The json of the response is the expected_response passed by ddt.data.
         """
-        def side_effect(key, default=None):
-            if key == "MFE_CONFIG":
-                return mfe_config
-            if key == "MFE_CONFIG_OVERRIDES":
-                return mfe_config_overrides
-            return default
-        configuration_helpers_mock.get_value.side_effect = side_effect
+        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
+            def side_effect(key, default=None):
+                if key == "MFE_CONFIG":
+                    return mfe_config
+                if key == "MFE_CONFIG_OVERRIDES":
+                    return mfe_config_overrides
+                return default
+            configuration_helpers_mock.get_value.side_effect = side_effect
 
-        response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
-                 call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls)
-        self.assertEqual(response.json(), expected_response)
+            response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
+                     call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
+            configuration_helpers_mock.get_value.assert_has_calls(calls)
+            self.assertEqual(response.json(), expected_response)
 
     def test_get_mfe_config_from_django_settings(self):
         """Test that when there is no site configuration, the API takes the django settings.
@@ -175,21 +176,20 @@ class MFEConfigTestCase(APITestCase):
         expected = default_legacy_config | settings.MFE_CONFIG | settings.MFE_CONFIG_OVERRIDES["mymfe"]
         self.assertEqual(response.json(), expected)
 
-    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     @override_settings(ENABLE_MFE_CONFIG_API=False)
-    def test_404_get_mfe_config(self, configuration_helpers_mock):
+    def test_404_get_mfe_config(self):
         """Test the 404 not found response from get mfe config.
 
         Expected result:
         - The get_value method of configuration_helpers is not called.
         - The status of the response of the request is a HTTP_404_NOT_FOUND.
         """
-        response = self.client.get(self.mfe_config_api_url)
-        configuration_helpers_mock.get_value.assert_not_called()
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
+            response = self.client.get(self.mfe_config_api_url)
+            configuration_helpers_mock.get_value.assert_not_called()
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
-    def test_get_mfe_config_for_catalog(self, configuration_helpers_mock):
+    def test_get_mfe_config_for_catalog(self):
         """Test the mfe config by explicitly using catalog mfe as an example.
 
         Expected result:
@@ -217,23 +217,23 @@ class MFEConfigTestCase(APITestCase):
                 return 8
             return default
 
-        configuration_helpers_mock.get_value.side_effect = side_effect
+        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
+            configuration_helpers_mock.get_value.side_effect = side_effect
 
-        response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        data = response.json()
-        self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
-        self.assertEqual(data["SOME_SETTING"], "catalog_value")
-        self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], True)
-        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], None)
-        self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
-        self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
-        self.assertEqual(data["NON_BROWSABLE_COURSES"], True)
-        self.assertEqual(data["ENABLE_COURSE_DISCOVERY"], False)
+            data = response.json()
+            self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
+            self.assertEqual(data["SOME_SETTING"], "catalog_value")
+            self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], True)
+            self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], None)
+            self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
+            self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
+            self.assertEqual(data["NON_BROWSABLE_COURSES"], True)
+            self.assertEqual(data["ENABLE_COURSE_DISCOVERY"], False)
 
-    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
-    def test_config_order_of_precedence(self, configuration_helpers_mock):
+    def test_config_order_of_precedence(self):
         """Test the precedence of configuration values by explicitly using catalog MFE as an example.
 
         Expected result:
@@ -245,50 +245,51 @@ class MFEConfigTestCase(APITestCase):
             5. Plain site configuration
             6. Plain settings
         """
-        mfe_config = {
-            "HOMEPAGE_COURSE_MAX": 10,
-            "ENABLE_COURSE_SORTING_BY_START_DATE": False,
-            "PRESERVED_SETTING": "preserved"
-        }
-        mfe_config_overrides = {
-            "catalog": {
-                "HOMEPAGE_COURSE_MAX": 15,
+        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
+            mfe_config = {
+                "HOMEPAGE_COURSE_MAX": 10,
+                "ENABLE_COURSE_SORTING_BY_START_DATE": False,
+                "PRESERVED_SETTING": "preserved"
             }
-        }
-
-        def side_effect(key, default=None):
-            if key == "MFE_CONFIG":
-                return mfe_config
-            if key == "MFE_CONFIG_OVERRIDES":
-                return mfe_config_overrides
-            if key == "HOMEPAGE_COURSE_MAX":
-                return 5  # Plain site configuration
-            if key == "homepage_promo_video_youtube_id":
-                return "site-conf-youtube-id"
-            return default
-
-        configuration_helpers_mock.get_value.side_effect = side_effect
-
-        with override_settings(
-            HOMEPAGE_COURSE_MAX=3,  # Plain settings (lowest precedence)
-            FEATURES={              # Settings FEATURES
-                "ENABLE_COURSE_SORTING_BY_START_DATE": True,
-                "ENABLE_COURSE_DISCOVERY": True,
+            mfe_config_overrides = {
+                "catalog": {
+                    "HOMEPAGE_COURSE_MAX": 15,
+                }
             }
-        ):
-            response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
+            def side_effect(key, default=None):
+                if key == "MFE_CONFIG":
+                    return mfe_config
+                if key == "MFE_CONFIG_OVERRIDES":
+                    return mfe_config_overrides
+                if key == "HOMEPAGE_COURSE_MAX":
+                    return 5  # Plain site configuration
+                if key == "homepage_promo_video_youtube_id":
+                    return "site-conf-youtube-id"
+                return default
 
-        # MFE_CONFIG_OVERRIDES from site conf (highest precedence)
-        self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 15)
+            configuration_helpers_mock.get_value.side_effect = side_effect
 
-        # MFE_CONFIG from site conf takes precedence over plain site configuration and settings
-        self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], False)
+            with override_settings(
+                HOMEPAGE_COURSE_MAX=3,  # Plain settings (lowest precedence)
+                FEATURES={              # Settings FEATURES
+                    "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+                    "ENABLE_COURSE_DISCOVERY": True,
+                }
+            ):
+                response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
 
-        # Plain site configuration takes precedence over plain settings
-        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "site-conf-youtube-id")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            data = response.json()
 
-        # Value in original MFE_CONFIG not overridden by catalog config should be preserved
-        self.assertEqual(data["PRESERVED_SETTING"], "preserved")
+            # MFE_CONFIG_OVERRIDES from site conf (highest precedence)
+            self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 15)
+
+            # MFE_CONFIG from site conf takes precedence over plain site configuration and settings
+            self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], False)
+
+            # Plain site configuration takes precedence over plain settings
+            self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "site-conf-youtube-id")
+
+            # Value in original MFE_CONFIG not overridden by catalog config should be preserved
+            self.assertEqual(data["PRESERVED_SETTING"], "preserved")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -74,7 +74,7 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
                  call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls)
+        configuration_helpers_mock.get_value.assert_has_calls(calls, any_order=True)
         self.assertEqual(
             response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
         )
@@ -150,7 +150,7 @@ class MFEConfigTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
                  call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-        configuration_helpers_mock.get_value.assert_has_calls(calls)
+        configuration_helpers_mock.get_value.assert_has_calls(calls, any_order=True)
         self.assertEqual(response.json(), expected_response)
 
     def test_get_mfe_config_from_django_settings(self):

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -271,8 +271,10 @@ class MFEConfigTestCase(APITestCase):
 
         with override_settings(
             HOMEPAGE_COURSE_MAX=3,  # Plain settings (lowest precedence)
-            ENABLE_COURSE_SORTING_BY_START_DATE=True,
-            ENABLE_COURSE_DISCOVERY=True,
+            FEATURES={              # Settings FEATURES
+                "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+                "ENABLE_COURSE_DISCOVERY": True,
+            }
         ):
             response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
 

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -13,11 +13,11 @@ from rest_framework.test import APITestCase
 
 # Default legacy configuration values, used in tests to build a correct expected response
 default_legacy_config = {
+    "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+    "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": None,
+    "HOMEPAGE_COURSE_MAX": None,
     "COURSE_ABOUT_TWITTER_ACCOUNT": "@YourPlatformTwitterAccount",
     "NON_BROWSABLE_COURSES": False,
-    "ENABLE_COURSE_SORTING_BY_START_DATE": True,
-    "HOMEPAGE_COURSE_MAX": None,
-    "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": None,
     "ENABLE_COURSE_DISCOVERY": False,
 }
 
@@ -45,7 +45,7 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG":
                 return {"EXAMPLE_VAR": "value"}
             return default
-        
+
         with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
             configuration_helpers_mock.get_value.side_effect = side_effect
 
@@ -68,7 +68,7 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG_OVERRIDES":
                 return {"mymfe": {"EXAMPLE_VAR": "mymfe_value"}}
             return default
-        
+
         with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
             configuration_helpers_mock.get_value.side_effect = side_effect
 

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -5,7 +5,6 @@ Test the use cases of the views of the mfe api.
 from unittest.mock import call, patch
 
 import ddt
-from django.core.cache import cache
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
@@ -14,11 +13,11 @@ from rest_framework.test import APITestCase
 
 # Default legacy configuration values, used in tests to build a correct expected response
 default_legacy_config = {
-    "ENABLE_COURSE_SORTING_BY_START_DATE": True,
-    "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": None,
-    "HOMEPAGE_COURSE_MAX": None,
     "COURSE_ABOUT_TWITTER_ACCOUNT": "@YourPlatformTwitterAccount",
     "NON_BROWSABLE_COURSES": False,
+    "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+    "HOMEPAGE_COURSE_MAX": None,
+    "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": None,
     "ENABLE_COURSE_DISCOVERY": False,
 }
 
@@ -31,10 +30,10 @@ class MFEConfigTestCase(APITestCase):
 
     def setUp(self):
         self.mfe_config_api_url = reverse("mfe_config_api:config")
-        cache.clear()
         return super().setUp()
 
-    def test_get_mfe_config(self):
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_get_mfe_config(self, configuration_helpers_mock):
         """Test the get mfe config from site configuration with the mfe api.
 
         Expected result:
@@ -47,15 +46,14 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG":
                 return {"EXAMPLE_VAR": "value"}
             return default
+        configuration_helpers_mock.get_value.side_effect = side_effect
 
-        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
-            configuration_helpers_mock.get_value.side_effect = side_effect
+        response = self.client.get(self.mfe_config_api_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {**default_legacy_config, "EXAMPLE_VAR": "value"})
 
-            response = self.client.get(self.mfe_config_api_url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertEqual(response.json(), {**default_legacy_config, "EXAMPLE_VAR": "value"})
-
-    def test_get_mfe_config_with_queryparam(self):
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_get_mfe_config_with_queryparam(self, configuration_helpers_mock):
         """Test the get mfe config with a query param from site configuration.
 
         Expected result:
@@ -70,18 +68,16 @@ class MFEConfigTestCase(APITestCase):
             if key == "MFE_CONFIG_OVERRIDES":
                 return {"mymfe": {"EXAMPLE_VAR": "mymfe_value"}}
             return default
+        configuration_helpers_mock.get_value.side_effect = side_effect
 
-        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
-            configuration_helpers_mock.get_value.side_effect = side_effect
-
-            response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
-                     call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-            configuration_helpers_mock.get_value.assert_has_calls(calls)
-            self.assertEqual(
-                response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
-            )
+        response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
+                 call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
+        configuration_helpers_mock.get_value.assert_has_calls(calls)
+        self.assertEqual(
+            response.json(), {**default_legacy_config, "EXAMPLE_VAR": "mymfe_value", "OTHER": "other"}
+        )
 
     @ddt.unpack
     @ddt.data(
@@ -124,8 +120,10 @@ class MFEConfigTestCase(APITestCase):
             expected_response={**default_legacy_config, "EXAMPLE_VAR": "mymfe_value"},
         ),
     )
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_get_mfe_config_with_queryparam_multiple_configs(
         self,
+        configuration_helpers_mock,
         mfe_config,
         mfe_config_overrides,
         expected_response,
@@ -140,21 +138,20 @@ class MFEConfigTestCase(APITestCase):
         and once with the parameters ("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES).
         - The json of the response is the expected_response passed by ddt.data.
         """
-        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
-            def side_effect(key, default=None):
-                if key == "MFE_CONFIG":
-                    return mfe_config
-                if key == "MFE_CONFIG_OVERRIDES":
-                    return mfe_config_overrides
-                return default
-            configuration_helpers_mock.get_value.side_effect = side_effect
+        def side_effect(key, default=None):
+            if key == "MFE_CONFIG":
+                return mfe_config
+            if key == "MFE_CONFIG_OVERRIDES":
+                return mfe_config_overrides
+            return default
+        configuration_helpers_mock.get_value.side_effect = side_effect
 
-            response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
-                     call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
-            configuration_helpers_mock.get_value.assert_has_calls(calls)
-            self.assertEqual(response.json(), expected_response)
+        response = self.client.get(f"{self.mfe_config_api_url}?mfe=mymfe")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        calls = [call("MFE_CONFIG", settings.MFE_CONFIG),
+                 call("MFE_CONFIG_OVERRIDES", settings.MFE_CONFIG_OVERRIDES)]
+        configuration_helpers_mock.get_value.assert_has_calls(calls)
+        self.assertEqual(response.json(), expected_response)
 
     def test_get_mfe_config_from_django_settings(self):
         """Test that when there is no site configuration, the API takes the django settings.
@@ -178,20 +175,21 @@ class MFEConfigTestCase(APITestCase):
         expected = default_legacy_config | settings.MFE_CONFIG | settings.MFE_CONFIG_OVERRIDES["mymfe"]
         self.assertEqual(response.json(), expected)
 
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     @override_settings(ENABLE_MFE_CONFIG_API=False)
-    def test_404_get_mfe_config(self):
+    def test_404_get_mfe_config(self, configuration_helpers_mock):
         """Test the 404 not found response from get mfe config.
 
         Expected result:
         - The get_value method of configuration_helpers is not called.
         - The status of the response of the request is a HTTP_404_NOT_FOUND.
         """
-        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
-            response = self.client.get(self.mfe_config_api_url)
-            configuration_helpers_mock.get_value.assert_not_called()
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        response = self.client.get(self.mfe_config_api_url)
+        configuration_helpers_mock.get_value.assert_not_called()
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_get_mfe_config_for_catalog(self):
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_get_mfe_config_for_catalog(self, configuration_helpers_mock):
         """Test the mfe config by explicitly using catalog mfe as an example.
 
         Expected result:
@@ -219,23 +217,23 @@ class MFEConfigTestCase(APITestCase):
                 return 8
             return default
 
-        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
-            configuration_helpers_mock.get_value.side_effect = side_effect
+        configuration_helpers_mock.get_value.side_effect = side_effect
 
-            response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            data = response.json()
-            self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
-            self.assertEqual(data["SOME_SETTING"], "catalog_value")
-            self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], True)
-            self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], None)
-            self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
-            self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
-            self.assertEqual(data["NON_BROWSABLE_COURSES"], True)
-            self.assertEqual(data["ENABLE_COURSE_DISCOVERY"], False)
+        data = response.json()
+        self.assertEqual(data["BASE_URL"], "https://catalog.example.com")
+        self.assertEqual(data["SOME_SETTING"], "catalog_value")
+        self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], True)
+        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], None)
+        self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 8)
+        self.assertEqual(data["COURSE_ABOUT_TWITTER_ACCOUNT"], "@TestAccount")
+        self.assertEqual(data["NON_BROWSABLE_COURSES"], True)
+        self.assertEqual(data["ENABLE_COURSE_DISCOVERY"], False)
 
-    def test_config_order_of_precedence(self):
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_config_order_of_precedence(self, configuration_helpers_mock):
         """Test the precedence of configuration values by explicitly using catalog MFE as an example.
 
         Expected result:
@@ -247,51 +245,50 @@ class MFEConfigTestCase(APITestCase):
             5. Plain site configuration
             6. Plain settings
         """
-        with patch("lms.djangoapps.mfe_config_api.views.configuration_helpers") as configuration_helpers_mock:
-            mfe_config = {
-                "HOMEPAGE_COURSE_MAX": 10,
-                "ENABLE_COURSE_SORTING_BY_START_DATE": False,
-                "PRESERVED_SETTING": "preserved"
+        mfe_config = {
+            "HOMEPAGE_COURSE_MAX": 10,
+            "ENABLE_COURSE_SORTING_BY_START_DATE": False,
+            "PRESERVED_SETTING": "preserved"
+        }
+        mfe_config_overrides = {
+            "catalog": {
+                "HOMEPAGE_COURSE_MAX": 15,
             }
-            mfe_config_overrides = {
-                "catalog": {
-                    "HOMEPAGE_COURSE_MAX": 15,
-                }
+        }
+
+        def side_effect(key, default=None):
+            if key == "MFE_CONFIG":
+                return mfe_config
+            if key == "MFE_CONFIG_OVERRIDES":
+                return mfe_config_overrides
+            if key == "HOMEPAGE_COURSE_MAX":
+                return 5  # Plain site configuration
+            if key == "homepage_promo_video_youtube_id":
+                return "site-conf-youtube-id"
+            return default
+
+        configuration_helpers_mock.get_value.side_effect = side_effect
+
+        with override_settings(
+            HOMEPAGE_COURSE_MAX=3,  # Plain settings (lowest precedence)
+            FEATURES={              # Settings FEATURES
+                "ENABLE_COURSE_SORTING_BY_START_DATE": True,
+                "ENABLE_COURSE_DISCOVERY": True,
             }
+        ):
+            response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
 
-            def side_effect(key, default=None):
-                if key == "MFE_CONFIG":
-                    return mfe_config
-                if key == "MFE_CONFIG_OVERRIDES":
-                    return mfe_config_overrides
-                if key == "HOMEPAGE_COURSE_MAX":
-                    return 5  # Plain site configuration
-                if key == "homepage_promo_video_youtube_id":
-                    return "site-conf-youtube-id"
-                return default
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
 
-            configuration_helpers_mock.get_value.side_effect = side_effect
+        # MFE_CONFIG_OVERRIDES from site conf (highest precedence)
+        self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 15)
 
-            with override_settings(
-                HOMEPAGE_COURSE_MAX=3,  # Plain settings (lowest precedence)
-                FEATURES={              # Settings FEATURES
-                    "ENABLE_COURSE_SORTING_BY_START_DATE": True,
-                    "ENABLE_COURSE_DISCOVERY": True,
-                }
-            ):
-                response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
+        # MFE_CONFIG from site conf takes precedence over plain site configuration and settings
+        self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], False)
 
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            data = response.json()
+        # Plain site configuration takes precedence over plain settings
+        self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "site-conf-youtube-id")
 
-            # MFE_CONFIG_OVERRIDES from site conf (highest precedence)
-            self.assertEqual(data["HOMEPAGE_COURSE_MAX"], 15)
-
-            # MFE_CONFIG from site conf takes precedence over plain site configuration and settings
-            self.assertEqual(data["ENABLE_COURSE_SORTING_BY_START_DATE"], False)
-
-            # Plain site configuration takes precedence over plain settings
-            self.assertEqual(data["HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID"], "site-conf-youtube-id")
-
-            # Value in original MFE_CONFIG not overridden by catalog config should be preserved
-            self.assertEqual(data["PRESERVED_SETTING"], "preserved")
+        # Value in original MFE_CONFIG not overridden by catalog config should be preserved
+        self.assertEqual(data["PRESERVED_SETTING"], "preserved")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -5,6 +5,7 @@ Test the use cases of the views of the mfe api.
 from unittest.mock import call, patch
 
 import ddt
+from django.core.cache import cache
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
@@ -30,6 +31,7 @@ class MFEConfigTestCase(APITestCase):
 
     def setUp(self):
         self.mfe_config_api_url = reverse("mfe_config_api:config")
+        cache.clear()
         return super().setUp()
 
     def test_get_mfe_config(self):

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -77,6 +77,9 @@ class MFEConfigView(APIView):
 
         # Get values from mfe configuration, either from django settings (level 4) or site configuration (level 3)
         mfe_config = configuration_helpers.get_value("MFE_CONFIG", settings.MFE_CONFIG)
+        # Ensure mfe_config is never None or empty
+        if not mfe_config:
+            mfe_config = settings.MFE_CONFIG
 
         # Get values from mfe overrides, either from django settings (level 2) or site configuration (level 1)
         mfe_config_overrides = {}
@@ -86,10 +89,17 @@ class MFEConfigView(APIView):
                 "MFE_CONFIG_OVERRIDES",
                 settings.MFE_CONFIG_OVERRIDES,
             )
+            # Ensure app_config is never None
+            if not app_config:
+                app_config = settings.MFE_CONFIG_OVERRIDES
             mfe_config_overrides = app_config.get(mfe, {})
 
         # Merge the three configs in the order of precedence
         merged_config = legacy_config | mfe_config | mfe_config_overrides
+
+        # Ensure merged_config is never empty and always has required structure
+        if not merged_config:
+            merged_config = legacy_config | settings.MFE_CONFIG
 
         return JsonResponse(merged_config, status=status.HTTP_200_OK)
 

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -101,7 +101,7 @@ class MFEConfigView(APIView):
         return {
             "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
-                settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
+                settings.ENABLE_COURSE_SORTING_BY_START_DATE
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
@@ -115,6 +115,6 @@ class MFEConfigView(APIView):
                 "course_about_twitter_account",
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
-            "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
-            "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
+            "NON_BROWSABLE_COURSES": not settings.COURSES_ARE_BROWSABLE,
+            "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -77,9 +77,6 @@ class MFEConfigView(APIView):
 
         # Get values from mfe configuration, either from django settings (level 4) or site configuration (level 3)
         mfe_config = configuration_helpers.get_value("MFE_CONFIG", settings.MFE_CONFIG)
-        # Ensure mfe_config is never None or empty
-        if not mfe_config:
-            mfe_config = settings.MFE_CONFIG
 
         # Get values from mfe overrides, either from django settings (level 2) or site configuration (level 1)
         mfe_config_overrides = {}
@@ -89,17 +86,10 @@ class MFEConfigView(APIView):
                 "MFE_CONFIG_OVERRIDES",
                 settings.MFE_CONFIG_OVERRIDES,
             )
-            # Ensure app_config is never None
-            if not app_config:
-                app_config = settings.MFE_CONFIG_OVERRIDES
             mfe_config_overrides = app_config.get(mfe, {})
 
         # Merge the three configs in the order of precedence
         merged_config = legacy_config | mfe_config | mfe_config_overrides
-
-        # Ensure merged_config is never empty and always has required structure
-        if not merged_config:
-            merged_config = legacy_config | settings.MFE_CONFIG
 
         return JsonResponse(merged_config, status=status.HTTP_200_OK)
 
@@ -111,7 +101,7 @@ class MFEConfigView(APIView):
         return {
             "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
-                getattr(settings, 'ENABLE_COURSE_SORTING_BY_START_DATE', True)
+                settings.ENABLE_COURSE_SORTING_BY_START_DATE
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
@@ -119,12 +109,12 @@ class MFEConfigView(APIView):
             ),
             "HOMEPAGE_COURSE_MAX": configuration_helpers.get_value(
                 "HOMEPAGE_COURSE_MAX",
-                getattr(settings, 'HOMEPAGE_COURSE_MAX', None)
+                settings.HOMEPAGE_COURSE_MAX
             ),
             "COURSE_ABOUT_TWITTER_ACCOUNT": configuration_helpers.get_value(
                 "course_about_twitter_account",
-                getattr(settings, 'PLATFORM_TWITTER_ACCOUNT', "@YourPlatformTwitterAccount")
+                settings.PLATFORM_TWITTER_ACCOUNT
             ),
-            "NON_BROWSABLE_COURSES": not getattr(settings, "COURSES_ARE_BROWSABLE", True),
-            "ENABLE_COURSE_DISCOVERY": getattr(settings, "ENABLE_COURSE_DISCOVERY", False),
+            "NON_BROWSABLE_COURSES": not settings.COURSES_ARE_BROWSABLE,
+            "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -101,7 +101,7 @@ class MFEConfigView(APIView):
         return {
             "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
-                settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
+                getattr(settings, 'ENABLE_COURSE_SORTING_BY_START_DATE', True)
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
@@ -109,12 +109,12 @@ class MFEConfigView(APIView):
             ),
             "HOMEPAGE_COURSE_MAX": configuration_helpers.get_value(
                 "HOMEPAGE_COURSE_MAX",
-                settings.HOMEPAGE_COURSE_MAX
+                getattr(settings, 'HOMEPAGE_COURSE_MAX', None)
             ),
             "COURSE_ABOUT_TWITTER_ACCOUNT": configuration_helpers.get_value(
                 "course_about_twitter_account",
-                settings.PLATFORM_TWITTER_ACCOUNT
+                getattr(settings, 'PLATFORM_TWITTER_ACCOUNT', "@YourPlatformTwitterAccount")
             ),
-            "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
-            "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
+            "NON_BROWSABLE_COURSES": not getattr(settings, "COURSES_ARE_BROWSABLE", True),
+            "ENABLE_COURSE_DISCOVERY": getattr(settings, "ENABLE_COURSE_DISCOVERY", False),
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -76,7 +76,7 @@ class MFEConfigView(APIView):
         legacy_config = self._get_legacy_config()
 
         # Get values from mfe configuration, either from django settings (level 4) or site configuration (level 3)
-        mfe_config = configuration_helpers.get_value("MFE_CONFIG", getattr(settings, 'MFE_CONFIG', {}))
+        mfe_config = configuration_helpers.get_value("MFE_CONFIG", settings.MFE_CONFIG)
 
         # Get values from mfe overrides, either from django settings (level 2) or site configuration (level 1)
         mfe_config_overrides = {}
@@ -84,7 +84,7 @@ class MFEConfigView(APIView):
             mfe = str(request.query_params.get("mfe"))
             app_config = configuration_helpers.get_value(
                 "MFE_CONFIG_OVERRIDES",
-                getattr(settings, 'MFE_CONFIG_OVERRIDES', {}),
+                settings.MFE_CONFIG_OVERRIDES,
             )
             mfe_config_overrides = app_config.get(mfe, {})
 
@@ -101,7 +101,7 @@ class MFEConfigView(APIView):
         return {
             "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
-                getattr(settings, 'ENABLE_COURSE_SORTING_BY_START_DATE', True)
+                settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
@@ -109,12 +109,12 @@ class MFEConfigView(APIView):
             ),
             "HOMEPAGE_COURSE_MAX": configuration_helpers.get_value(
                 "HOMEPAGE_COURSE_MAX",
-                getattr(settings, 'HOMEPAGE_COURSE_MAX', None)
+                settings.HOMEPAGE_COURSE_MAX
             ),
             "COURSE_ABOUT_TWITTER_ACCOUNT": configuration_helpers.get_value(
                 "course_about_twitter_account",
-                getattr(settings, 'PLATFORM_TWITTER_ACCOUNT', "@YourPlatformTwitterAccount")
+                settings.PLATFORM_TWITTER_ACCOUNT
             ),
-            "NON_BROWSABLE_COURSES": not getattr(settings, 'COURSES_ARE_BROWSABLE', True),
-            "ENABLE_COURSE_DISCOVERY": getattr(settings, 'ENABLE_COURSE_DISCOVERY', False),
+            "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
+            "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -101,7 +101,7 @@ class MFEConfigView(APIView):
         return {
             "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
-                settings.ENABLE_COURSE_SORTING_BY_START_DATE
+                settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
@@ -115,6 +115,6 @@ class MFEConfigView(APIView):
                 "course_about_twitter_account",
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
-            "NON_BROWSABLE_COURSES": not settings.COURSES_ARE_BROWSABLE,
-            "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
+            "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
+            "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -76,7 +76,7 @@ class MFEConfigView(APIView):
         legacy_config = self._get_legacy_config()
 
         # Get values from mfe configuration, either from django settings (level 4) or site configuration (level 3)
-        mfe_config = configuration_helpers.get_value("MFE_CONFIG", settings.MFE_CONFIG)
+        mfe_config = configuration_helpers.get_value("MFE_CONFIG", getattr(settings, 'MFE_CONFIG', {}))
 
         # Get values from mfe overrides, either from django settings (level 2) or site configuration (level 1)
         mfe_config_overrides = {}
@@ -84,7 +84,7 @@ class MFEConfigView(APIView):
             mfe = str(request.query_params.get("mfe"))
             app_config = configuration_helpers.get_value(
                 "MFE_CONFIG_OVERRIDES",
-                settings.MFE_CONFIG_OVERRIDES,
+                getattr(settings, 'MFE_CONFIG_OVERRIDES', {}),
             )
             mfe_config_overrides = app_config.get(mfe, {})
 
@@ -101,7 +101,7 @@ class MFEConfigView(APIView):
         return {
             "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
-                settings.ENABLE_COURSE_SORTING_BY_START_DATE
+                getattr(settings, 'ENABLE_COURSE_SORTING_BY_START_DATE', True)
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
@@ -109,12 +109,12 @@ class MFEConfigView(APIView):
             ),
             "HOMEPAGE_COURSE_MAX": configuration_helpers.get_value(
                 "HOMEPAGE_COURSE_MAX",
-                settings.HOMEPAGE_COURSE_MAX
+                getattr(settings, 'HOMEPAGE_COURSE_MAX', None)
             ),
             "COURSE_ABOUT_TWITTER_ACCOUNT": configuration_helpers.get_value(
                 "course_about_twitter_account",
-                settings.PLATFORM_TWITTER_ACCOUNT
+                getattr(settings, 'PLATFORM_TWITTER_ACCOUNT', "@YourPlatformTwitterAccount")
             ),
-            "NON_BROWSABLE_COURSES": not settings.COURSES_ARE_BROWSABLE,
-            "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
+            "NON_BROWSABLE_COURSES": not getattr(settings, 'COURSES_ARE_BROWSABLE', True),
+            "ENABLE_COURSE_DISCOVERY": getattr(settings, 'ENABLE_COURSE_DISCOVERY', False),
         }

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from crum import set_current_request
 from django.conf import settings
+from django.test import override_settings
 
 from common.djangoapps.util.milestones_helpers import add_prerequisite_course, fulfill_course_milestone
 from lms.djangoapps.courseware.access_response import MilestoneAccessError
@@ -56,7 +57,8 @@ class MobileAPIMilestonesMixin:
         self.init_course_access()
         self.api_response()
 
-    @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True, 'ENABLE_MKTG_SITE': True})
+    @override_settings(ENTRANCE_EXAMS=True)
+    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_unpassed_entrance_exam(self):
         """
         Tests the case where the user has not passed the entrance exam
@@ -65,7 +67,8 @@ class MobileAPIMilestonesMixin:
         self.init_course_access()
         self._verify_unfulfilled_milestone_response()
 
-    @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True, 'ENABLE_MKTG_SITE': True})
+    @override_settings(ENTRANCE_EXAMS=True)
+    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_unpassed_entrance_exam_for_staff(self):
         self._add_entrance_exam()
         self.user.is_staff = True
@@ -73,7 +76,8 @@ class MobileAPIMilestonesMixin:
         self.init_course_access()
         self.api_response()
 
-    @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True, 'ENABLE_MKTG_SITE': True})
+    @override_settings(ENTRANCE_EXAMS=True)
+    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_passed_entrance_exam(self):
         """
         Tests access when user has passed the entrance exam

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models.signals import post_save
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import translation
 from elasticsearch.exceptions import ConnectionError  # lint-amnesty, pylint: disable=redefined-builtin
@@ -1673,7 +1674,7 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
             assert team['name'] == 'foo'
 
 
-@patch.dict(settings.FEATURES, {'ENABLE_ORA_TEAM_SUBMISSIONS': True})
+@override_settings(ENABLE_ORA_TEAM_SUBMISSIONS=True)
 @ddt.ddt
 class TestTeamAssignmentsView(TeamAPITestCase):
     """ Tests for the TeamAssignmentsView """
@@ -1756,7 +1757,7 @@ class TestTeamAssignmentsView(TeamAPITestCase):
         expected_status = 404
         self.get_team_assignments(team_id, expected_status, user=user)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_ORA_TEAM_SUBMISSIONS': False})
+    @override_settings(ENABLE_ORA_TEAM_SUBMISSIONS=False)
     def test_get_assignments_feature_not_enabled(self):
         # Given the team submissions feature is not enabled
         user = 'student_enrolled'

--- a/lms/djangoapps/teams/toggles.py
+++ b/lms/djangoapps/teams/toggles.py
@@ -1,7 +1,7 @@
 """
 Togglable settings for Teams behavior
 """
-from edx_toggles.toggles import SettingDictToggle
+from edx_toggles.toggles import SettingToggle
 
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
@@ -9,8 +9,8 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 WAFFLE_NAMESPACE = "openresponseassessment"
 TEAM_SUBMISSIONS_FLAG = "team_submissions"
 
-# .. toggle_name: FEATURES['ENABLE_ORA_TEAM_SUBMISSIONS']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: ENABLE_ORA_TEAM_SUBMISSIONS
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Set to True to enable team-based ORA submissions.
 # .. toggle_use_cases: temporary
@@ -20,8 +20,8 @@ TEAM_SUBMISSIONS_FLAG = "team_submissions"
 # .. toggle_warning: This temporary feature toggle does not have a target removal date. This can be overridden by a
 #      course waffle flags or a waffle switch with identical name.
 # TODO: this should be moved to edx/edx-ora2
-TEAM_SUBMISSIONS_FEATURE = SettingDictToggle(
-    "FEATURES", "ENABLE_ORA_TEAM_SUBMISSIONS", default=False, module_name=__name__
+TEAM_SUBMISSIONS_FEATURE = SettingToggle(
+    "ENABLE_ORA_TEAM_SUBMISSIONS", default=False, module_name=__name__
 )
 
 

--- a/openedx/core/djangoapps/credentials/helpers.py
+++ b/openedx/core/djangoapps/credentials/helpers.py
@@ -2,12 +2,12 @@
 Helpers for the credentials service.
 """
 
-from edx_toggles.toggles import SettingDictToggle
+from edx_toggles.toggles import SettingToggle
 
 from openedx.core.djangoapps.site_configuration import helpers as config_helpers
 
-# .. toggle_name: FEATURES['ENABLE_LEARNER_RECORDS']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: ENABLE_LEARNER_RECORDS
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: True
 # .. toggle_description: Enable learner records for the whole platform. This setting may be overridden by site- and
 #   org-specific site configurations with the same name.
@@ -15,8 +15,8 @@ from openedx.core.djangoapps.site_configuration import helpers as config_helpers
 #   setting.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-10-01
-ENABLE_LEARNER_RECORDS = SettingDictToggle(
-    "FEATURES", "ENABLE_LEARNER_RECORDS", default=True, module_name=__name__
+ENABLE_LEARNER_RECORDS = SettingToggle(
+    "ENABLE_LEARNER_RECORDS", default=True, module_name=__name__
 )
 
 

--- a/openedx/core/djangoapps/credentials/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tasks.py
@@ -549,7 +549,7 @@ class TestSendGradeIfInteresting(TestCase):
         _mock_is_learner_issuance_enabled
     ):
         assert is_learner_records_enabled()
-        with override_settings(FEATURES={"ENABLE_LEARNER_RECORDS": False}):
+        with override_settings(ENABLE_LEARNER_RECORDS=False):
             assert not is_learner_records_enabled()
             tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         assert not mock_send_grade_to_credentials.delay.called

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -9,7 +9,6 @@ import pytest
 import ddt
 from zoneinfo import ZoneInfo
 
-from django.conf import settings
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -33,10 +33,7 @@ class CourseDetailsTestCase(ModuleStoreTestCase):
 
     @ddt.data(True, False)
     def test_virgin_fetch(self, should_have_default_enroll_start):
-        features = settings.FEATURES.copy()
-        features['CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE'] = should_have_default_enroll_start
-
-        with override_settings(FEATURES=features):
+        with override_settings(CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE=should_have_default_enroll_start):
             course = CourseFactory.create(default_enrollment_start=should_have_default_enroll_start)
             details = CourseDetails.fetch(course.id)
             wrong_enrollment_start_msg = (

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -28,10 +28,10 @@ class ToggleStateViewTests(TestCase):  # lint-amnesty, pylint: disable=missing-c
     def test_response_with_existing_setting_dict_toggle(self):
         response = get_toggle_state_response()
         assert {
-            "name": "FEATURES['MILESTONES_APP']",
+            "name": "MILESTONES_APP",
             "is_active": True,
             "module": "common.djangoapps.util.milestones_helpers",
-            "class": "SettingDictToggle",
+            "class": "SettingToggle",
         } in response.data["django_settings"]
 
     def test_response_with_course_override(self):

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -25,7 +25,7 @@ class ToggleStateViewTests(TestCase):  # lint-amnesty, pylint: disable=missing-c
         response = get_toggle_state_response(is_staff=False)
         assert response.status_code == 403
 
-    def test_response_with_existing_setting_dict_toggle(self):
+    def test_response_with_existing_setting_toggle(self):
         response = get_toggle_state_response()
         assert {
             "name": "MILESTONES_APP",

--- a/openedx/core/toggles.py
+++ b/openedx/core/toggles.py
@@ -2,16 +2,16 @@
 Feature toggles used across the platform. Toggles should only be added to this module if we don't have a better place
 for them. Generally speaking, they should be added to the most appropriate app or repo.
 """
-from edx_toggles.toggles import SettingDictToggle
+from edx_toggles.toggles import SettingToggle
 
-# .. toggle_name: FEATURES['ENTRANCE_EXAMS']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: ENTRANCE_EXAMS
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Enable entrance exams feature. When enabled, students see an exam xblock as the first unit
 #   of the course.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2015-12-01
 # .. toggle_tickets: https://openedx.atlassian.net/browse/SOL-40
-ENTRANCE_EXAMS = SettingDictToggle(
-    "FEATURES", "ENTRANCE_EXAMS", default=False, module_name=__name__
+ENTRANCE_EXAMS = SettingToggle(
+    "ENTRANCE_EXAMS", default=False, module_name=__name__
 )

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -11,7 +11,7 @@ import dateutil.parser
 import requests
 from django.conf import settings
 from django.core.validators import validate_email
-from edx_toggles.toggles import SettingDictToggle
+from edx_toggles.toggles import SettingToggle
 from lazy import lazy
 from lxml import etree
 from path import Path as path
@@ -59,8 +59,8 @@ COURSE_VISIBILITY_PRIVATE = 'private'
 COURSE_VISIBILITY_PUBLIC_OUTLINE = 'public_outline'
 COURSE_VISIBILITY_PUBLIC = 'public'
 
-# .. toggle_name: FEATURES['CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: The default behavior, when this is disabled, is that a newly created course has no
 #   enrollment_start date set. When the feature is enabled - the newly created courses will have the
@@ -71,8 +71,8 @@ COURSE_VISIBILITY_PUBLIC = 'public'
 #   the newly created (empty) course from appearing in the course listing.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2023-06-22
-CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE = SettingDictToggle(
-    "FEATURES", "CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE", default=False, module_name=__name__
+CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE = SettingToggle(
+    "CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE", default=False, module_name=__name__
 )
 
 

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -23,7 +23,7 @@ from xblock.exceptions import NoSuchServiceError
 from xblock.fields import Boolean, Date, Integer, List, Scope, String
 from xblock.progress import Progress
 
-from edx_toggles.toggles import WaffleFlag, SettingDictToggle
+from edx_toggles.toggles import WaffleFlag, SettingToggle
 from xmodule.util.builtin_assets import add_webpack_js_to_fragment, add_css_to_fragment
 from xmodule.x_module import (
     ResourceTemplates,
@@ -54,14 +54,14 @@ TIMED_EXAM_GATING_WAFFLE_FLAG = WaffleFlag(  # lint-amnesty, pylint: disable=tog
     'xmodule.rev_1377_rollout', __name__
 )
 
-# .. toggle_name: FEATURES['SHOW_PROGRESS_BAR']
-# .. toggle_implementation: SettingDictToggle
+# .. toggle_name: SHOW_PROGRESS_BAR
+# .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Set to True to show progress bar.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2022-02-09
 # .. toggle_target_removal_date: None
-SHOW_PROGRESS_BAR = SettingDictToggle("FEATURES", "SHOW_PROGRESS_BAR", default=False, module_name=__name__)
+SHOW_PROGRESS_BAR = SettingToggle("SHOW_PROGRESS_BAR", default=False, module_name=__name__)
 
 
 class SequenceFields:  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/xmodule/tests/test_course_block.py
+++ b/xmodule/tests/test_course_block.py
@@ -42,9 +42,7 @@ class CourseFieldsTestCase(unittest.TestCase):  # lint-amnesty, pylint: disable=
 
     @ddt.data(True, False)
     def test_default_enrollment_start_date(self, should_have_default_enroll_start):
-        features = settings.FEATURES.copy()
-        features['CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE'] = should_have_default_enroll_start
-        with override_settings(FEATURES=features):
+        with override_settings(CREATE_COURSE_WITH_DEFAULT_ENROLLMENT_START_DATE=should_have_default_enroll_start):
             # reimport, so settings override could take effect
             del sys.modules['xmodule.course_block']
             import xmodule.course_block  # lint-amnesty, pylint: disable=redefined-outer-name, reimported


### PR DESCRIPTION
### Description:
Refactored `FEATURES` settings to top-level in core files and updated related tests for consistency and maintainability.
### Solution:

- Modified the `SettingDictToggle` class to `SettingToggle`.
- Moved `FEATURES` setting to top level in core file.
- Fixed the related settings in test files leaving other unrelated `FEATURE` references intact. 

**Note:**  The unrelated `FEATURE` references are working fine due to the use of `featureproxy` , hence for the time being left those unchanged.

### Private JIRA Link:
[BOMS-200](https://2u-internal.atlassian.net/browse/BOMS-200)

### Reference PR:
https://github.com/openedx/edx-platform/pull/37067

### Note:

- On investigating how the top-level-settings are working in edx platform , found these few settings are still getting derived from the `FEATURES` dict. 
- Planned to move these settings to top level.