### PR TITLE
fix: add default to `target_collection_slug` [FC-0097]

### DIFF
--- a/cms/djangoapps/modulestore_migrator/rest_api/v1/serializers.py
+++ b/cms/djangoapps/modulestore_migrator/rest_api/v1/serializers.py
@@ -46,6 +46,7 @@ class ModulestoreMigrationSerializer(serializers.ModelSerializer):
         help_text="The target collection slug within the library to import into. Optional.",
         required=False,
         allow_blank=True,
+        default=None,
     )
     forward_source_to_target = serializers.BooleanField(
         help_text="Forward references of this block source over to the target of this block migration.",


### PR DESCRIPTION
## Description

This PR adds a default `None` value to the `target_collection_slug` parameter of the migration rest API endpoint, to prevent a `KeyError` on the following line:

https://github.com/openedx/edx-platform/blob/ad5830a6c614762a9facf51c4097f135912c703f/cms/djangoapps/modulestore_migrator/rest_api/v1/views.py#L124

- Which edX user roles will this change impact?
"Developer"

## Supporting information
- Related to: #37321

## Testing instructions
- Call `POST` to `/api/modulestore_migrator/v1/migrations/` with a payload like: `'{"source":"library-v1:orgA+big-lib","target":"lib:orgA:migrated-lib2"}'`
- Check that the `KeyError` is not thrown

## Deadline
2025-10-09 - We need this for Ulmo

___
Private ref: [FAL-4252](https://tasks.opencraft.com/browse/FAL-4252)
