### PR TITLE
temp: Restrict forum bulk-delete to global staff only

### DIFF
--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -6,7 +6,7 @@ from typing import Dict, Set, Union
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions
 
-from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment
+from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseStaffRole,
@@ -19,7 +19,7 @@ from lms.djangoapps.discussion.django_comment_client.utils import (
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
 from openedx.core.djangoapps.django_comment_common.models import (
-    Role, FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR
+    FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR
 )
 
 
@@ -185,46 +185,3 @@ class IsStaffOrAdmin(permissions.BasePermission):
             request.user.is_staff or
             is_user_staff and request.method == "GET"
         )
-
-
-def can_take_action_on_spam(user, course_id):
-    """
-    Returns if the user has access to take action against forum spam posts
-    Parameters:
-        user: User object
-        course_id: CourseKey or string of course_id
-    """
-    if GlobalStaff().has_user(user):
-        return True
-
-    if isinstance(course_id, str):
-        course_id = CourseKey.from_string(course_id)
-    org_id = course_id.org
-    course_ids = CourseEnrollment.objects.filter(user=user).values_list('course_id', flat=True)
-    course_ids = [c_id for c_id in course_ids if c_id.org == org_id]
-    user_roles = set(
-        Role.objects.filter(
-            users=user,
-            course_id__in=course_ids,
-        ).values_list('name', flat=True).distinct()
-    )
-    if bool(user_roles & {FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_MODERATOR}):
-        return True
-
-    if CourseAccessRole.objects.filter(user=user, course_id__in=course_ids, role__in=["instructor", "staff"]).exists():
-        return True
-    return False
-
-
-class IsAllowedToBulkDelete(permissions.BasePermission):
-    """
-    Permission that checks if the user is staff or an admin.
-    """
-
-    def has_permission(self, request, view):
-        """Returns true if the user can bulk delete posts"""
-        if not request.user.is_authenticated:
-            return False
-
-        course_id = view.kwargs.get("course_id")
-        return can_take_action_on_spam(request.user, course_id)

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -917,10 +917,9 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         thread_mock.count_documents.assert_not_called()
         comment_mock.count_documents.assert_not_called()
 
-    @ddt.data(FORUM_ROLE_MODERATOR, FORUM_ROLE_ADMINISTRATOR)
-    def test_bulk_delete_allowed_for_discussion_roles(self, role):
+    def test_bulk_delete_allowed_for_global_staff(self, role):
         """
-        Test bulk delete user posts passed with discussion roles.
+        Test bulk delete user posts passed with global staff.
         """
         self.mock_comment_and_thread_count(comment_count=1, thread_count=1)
         assign_role(self.course.id, self.user, role)


### PR DESCRIPTION
This is one potential solution for:

* https://github.com/openedx/edx-platform/issues/37402

See that ^ issue for details and rationale.

This is a stop-gap solution so that the API can exist in Ulmo, but afterwards, we will either need to:

* add MySQL forum support to this API
* OR remove the API entirely