### PR TITLE
feat: follow migrated legacy library content block

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1677,7 +1677,7 @@ def handle_update_xblock_upstream_link(usage_key):
     except (ItemNotFoundError, InvalidKeyError):
         LOGGER.exception(f'Could not find item for given usage_key: {usage_key}')
         return
-    if not xblock.upstream or not xblock.upstream_version:
+    if not xblock.upstream:
         return
     create_or_update_xblock_upstream_link(xblock)
 

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -1677,7 +1677,7 @@ def handle_update_xblock_upstream_link(usage_key):
     except (ItemNotFoundError, InvalidKeyError):
         LOGGER.exception(f'Could not find item for given usage_key: {usage_key}')
         return
-    if not xblock.upstream:
+    if not xblock.upstream or xblock.upstream_version is None:
         return
     create_or_update_xblock_upstream_link(xblock)
 

--- a/cms/djangoapps/modulestore_migrator/api.py
+++ b/cms/djangoapps/modulestore_migrator/api.py
@@ -141,9 +141,12 @@ def get_target_block_usage_keys(source_key: CourseKey | LibraryLocator) -> dict[
     ).values_list('source__key', 'target__key', 'target__learning_package__key')
 
     def construct_usage_key(row: list[str]):
-        lib_key = LibraryLocatorV2.from_string(row[2])
-        _, block_type, usage_id = row[1].split(":")
-        return str(LibraryUsageLocatorV2(lib_key, block_type=block_type, usage_id=usage_id))
+        try:
+            lib_key = LibraryLocatorV2.from_string(row[2])
+            _, block_type, usage_id = row[1].split(":")
+            return str(LibraryUsageLocatorV2(lib_key, block_type=block_type, usage_id=usage_id))
+        except (ValueError, TypeError):
+            return None
     # Use LibraryUsageLocatorV2 and construct usage key
     return {
         row[0]: construct_usage_key(row) for row in query_set

--- a/cms/djangoapps/modulestore_migrator/api.py
+++ b/cms/djangoapps/modulestore_migrator/api.py
@@ -103,13 +103,17 @@ def start_bulk_migration_to_library(
     )
 
 
-def is_successfully_migrated(source_key: CourseKey | LibraryLocator) -> bool:
+def is_successfully_migrated(
+    source_key: CourseKey | LibraryLocator,
+    source_version: str | None = None,
+) -> bool:
     """
     Check if the source course/library has been migrated successfully.
     """
-    return ModulestoreSource.objects.get_or_create(key=str(source_key))[0].migrations.filter(
-        task_status__state=UserTaskStatus.SUCCEEDED
-    ).exists()
+    filters = {"task_status__state": UserTaskStatus.SUCCEEDED}
+    if source_version is not None:
+        filters["source_version"] = source_version
+    return ModulestoreSource.objects.get_or_create(key=str(source_key))[0].migrations.filter(**filters).exists()
 
 
 def get_migration_info(source_keys: list[CourseKey | LibraryLocator]) -> dict:

--- a/cms/djangoapps/modulestore_migrator/api.py
+++ b/cms/djangoapps/modulestore_migrator/api.py
@@ -6,9 +6,10 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, LearningContextKey, UsageKey
 from opaque_keys.edx.locator import LibraryLocator, LibraryLocatorV2, LibraryUsageLocatorV2
 from openedx_learning.api.authoring import get_collection
+from openedx_learning.api.authoring_models import Component
 from user_tasks.models import UserTaskStatus
 
-from openedx.core.djangoapps.content_libraries.api import get_library
+from openedx.core.djangoapps.content_libraries.api import get_library, library_component_usage_key
 from openedx.core.types.user import AuthUser
 
 from . import tasks
@@ -141,26 +142,20 @@ def get_target_block_usage_keys(source_key: CourseKey | LibraryLocator) -> dict[
     """
     For given source_key, get a map of legacy block key and its new location in migrated v2 library.
     """
-    query_set = ModulestoreBlockMigration.objects.filter(overall_migration__source__key=source_key).values_list(
-        'source__key', 'target__key', 'target__learning_package__key'
+    query_set = ModulestoreBlockMigration.objects.filter(overall_migration__source__key=source_key).select_related(
+        'source', 'target__component__component_type', 'target__learning_package'
     )
 
-    def construct_usage_key(lib_key_str: str, entity_key_str: str) -> LibraryUsageLocatorV2 | None:
+    def construct_usage_key(lib_key_str: str, component: Component) -> LibraryUsageLocatorV2 | None:
         try:
             lib_key = LibraryLocatorV2.from_string(lib_key_str)
         except InvalidKeyError:
             return None
-        try:
-            # Example: xblock.v1:problem:e9eef38f5f4c49de943c83a2d5170211
-            _, block_type, block_id = entity_key_str.split(':')
-            # mypy thinks LibraryUsageLocatorV2 is abstract. It's not.
-            return LibraryUsageLocatorV2(lib_key, block_type=block_type, usage_id=block_id)  # type: ignore[abstract]
-        except ValueError:
-            return None
+        return library_component_usage_key(lib_key, component)
 
     # Use LibraryUsageLocatorV2 and construct usage key
     return {
-        usage_key: construct_usage_key(lib_key_str, entity_key_str)
-        for (usage_key, entity_key_str, lib_key_str) in query_set
-        if usage_key is not None
+        obj.source.key: construct_usage_key(obj.target.learning_package.key, obj.target.component)
+        for obj in query_set
+        if obj.source.key is not None
     }

--- a/cms/djangoapps/modulestore_migrator/api.py
+++ b/cms/djangoapps/modulestore_migrator/api.py
@@ -145,22 +145,22 @@ def get_target_block_usage_keys(source_key: CourseKey | LibraryLocator) -> dict[
         'source__key', 'target__key', 'target__learning_package__key'
     )
 
-    def construct_usage_key(lib_key_str: str, usage_key_str: str) -> LibraryUsageLocatorV2 | None:
+    def construct_usage_key(lib_key_str: str, entity_key_str: str) -> LibraryUsageLocatorV2 | None:
         try:
             lib_key = LibraryLocatorV2.from_string(lib_key_str)
         except InvalidKeyError:
             return None
         try:
             # Example: xblock.v1:problem:e9eef38f5f4c49de943c83a2d5170211
-            _, block_type, usage_id = usage_key_str.split(':')
+            _, block_type, block_id = entity_key_str.split(':')
             # mypy thinks LibraryUsageLocatorV2 is abstract. It's not.
-            return LibraryUsageLocatorV2(lib_key, block_type=block_type, usage_id=usage_id)  # type: ignore[abstract]
+            return LibraryUsageLocatorV2(lib_key, block_type=block_type, usage_id=block_id)  # type: ignore[abstract]
         except ValueError:
             return None
 
     # Use LibraryUsageLocatorV2 and construct usage key
     return {
-        usage_key: construct_usage_key(lib_key_str, usage_key_str)
-        for (usage_key, usage_key_str, lib_key_str) in query_set
+        usage_key: construct_usage_key(lib_key_str, entity_key_str)
+        for (usage_key, entity_key_str, lib_key_str) in query_set
         if usage_key is not None
     }

--- a/cms/djangoapps/modulestore_migrator/api.py
+++ b/cms/djangoapps/modulestore_migrator/api.py
@@ -145,7 +145,7 @@ def get_target_block_usage_keys(source_key: CourseKey | LibraryLocator) -> dict[
         'source__key', 'target__key', 'target__learning_package__key'
     )
 
-    def construct_usage_key(lib_key_str: str, usage_key_str: str) -> str | None:
+    def construct_usage_key(lib_key_str: str, usage_key_str: str) -> LibraryUsageLocatorV2 | None:
         try:
             lib_key = LibraryLocatorV2.from_string(lib_key_str)
         except InvalidKeyError:
@@ -162,4 +162,5 @@ def get_target_block_usage_keys(source_key: CourseKey | LibraryLocator) -> dict[
     return {
         usage_key: construct_usage_key(lib_key_str, usage_key_str)
         for (usage_key, usage_key_str, lib_key_str) in query_set
+        if usage_key is not None
     }

--- a/cms/djangoapps/modulestore_migrator/tests/test_api.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_api.py
@@ -3,7 +3,7 @@ Test cases for the modulestore migrator API.
 """
 
 import pytest
-from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocator
+from opaque_keys.edx.locator import LibraryLocatorV2
 from openedx_learning.api import authoring as authoring_api
 from organizations.tests.factories import OrganizationFactory
 

--- a/cms/djangoapps/modulestore_migrator/tests/test_api.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_api.py
@@ -3,7 +3,7 @@ Test cases for the modulestore migrator API.
 """
 
 import pytest
-from opaque_keys.edx.locator import LibraryLocatorV2
+from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocator
 from openedx_learning.api import authoring as authoring_api
 from organizations.tests.factories import OrganizationFactory
 
@@ -38,6 +38,8 @@ class TestModulestoreMigratorAPI(LibraryTestCase):
         )
         self.library_v2 = lib_api.ContentLibrary.objects.get(slug=self.lib_key_v2.slug)
         self.learning_package = self.library_v2.learning_package
+        for _ in range(3):
+            self._add_simple_content_block()
 
     def test_start_migration_to_library(self):
         """
@@ -384,3 +386,34 @@ class TestModulestoreMigratorAPI(LibraryTestCase):
             assert row.migrations__target__title == "Test Library"
             assert row.migrations__target_collection__key == collection_key
         assert row.migrations__target_collection__title == "Test Collection"
+
+    def test_get_target_block_usage_keys(self):
+        """
+        Test that the API can get the list of target block usage keys for a given library.
+        """
+        user = UserFactory()
+
+        api.start_migration_to_library(
+            user=user,
+            source_key=self.lib_key,
+            target_library_key=self.library_v2.library_key,
+            target_collection_slug=None,
+            composition_level=CompositionLevel.Component.value,
+            repeat_handling_strategy=RepeatHandlingStrategy.Skip.value,
+            preserve_url_slugs=True,
+            forward_source_to_target=True,
+        )
+        with self.assertNumQueries(1):
+            result = api.get_target_block_usage_keys(self.lib_key)
+        expected = {
+            LibraryUsageLocator.from_string(
+                'lib-block-v1:org+lib+type@html+block@html_0'
+            ): 'lb:name0:test-key:html:html_0',
+            LibraryUsageLocator.from_string(
+                'lib-block-v1:org+lib+type@html+block@html_1'
+            ): 'lb:name0:test-key:html:html_1',
+            LibraryUsageLocator.from_string(
+                'lib-block-v1:org+lib+type@html+block@html_2'
+            ): 'lb:name0:test-key:html:html_2',
+        }
+        self.assertDictEqual(result, expected)

--- a/cms/djangoapps/modulestore_migrator/tests/test_api.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_api.py
@@ -38,8 +38,9 @@ class TestModulestoreMigratorAPI(LibraryTestCase):
         )
         self.library_v2 = lib_api.ContentLibrary.objects.get(slug=self.lib_key_v2.slug)
         self.learning_package = self.library_v2.learning_package
+        self.blocks = []
         for _ in range(3):
-            self._add_simple_content_block()
+            self.blocks.append(self._add_simple_content_block().usage_key)
 
     def test_start_migration_to_library(self):
         """
@@ -405,15 +406,5 @@ class TestModulestoreMigratorAPI(LibraryTestCase):
         )
         with self.assertNumQueries(1):
             result = api.get_target_block_usage_keys(self.lib_key)
-        expected = {
-            LibraryUsageLocator.from_string(
-                'lib-block-v1:org+lib+type@html+block@html_0'
-            ): 'lb:name0:test-key:html:html_0',
-            LibraryUsageLocator.from_string(
-                'lib-block-v1:org+lib+type@html+block@html_1'
-            ): 'lb:name0:test-key:html:html_1',
-            LibraryUsageLocator.from_string(
-                'lib-block-v1:org+lib+type@html+block@html_2'
-            ): 'lb:name0:test-key:html:html_2',
-        }
-        self.assertDictEqual(result, expected)
+        for key in self.blocks:
+            assert result.get(key) is not None

--- a/cms/lib/xblock/upstream_sync.py
+++ b/cms/lib/xblock/upstream_sync.py
@@ -26,8 +26,8 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import LibraryContainerLocator, LibraryUsageLocatorV2
 from xblock.core import XBlock, XBlockMixin
 from xblock.exceptions import XBlockNotFoundError
-from xblock.fields import Scope, String, Integer, List
-from xblock.core import XBlockMixin, XBlock
+from xblock.fields import Integer, List, Scope, String
+
 from xmodule.util.keys import BlockKey
 
 if t.TYPE_CHECKING:

--- a/cms/lib/xblock/upstream_sync.py
+++ b/cms/lib/xblock/upstream_sync.py
@@ -17,14 +17,14 @@ from __future__ import annotations
 
 import logging
 import typing as t
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import LibraryContainerLocator, LibraryUsageLocatorV2
-from opaque_keys.edx.keys import UsageKey
+from xblock.core import XBlock, XBlockMixin
 from xblock.exceptions import XBlockNotFoundError
 from xblock.fields import Scope, String, Integer, List
 from xblock.core import XBlockMixin, XBlock

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -632,13 +632,13 @@ function($, _, Backbone, gettext, BasePage,
                     doneAddingBlock = (addResult) => {
                         const $placeholderEl = $(this.createPlaceholderElement());
                         const placeholderElement = $placeholderEl.insertBefore($insertSpot);
-                        placeholderElement.data('locator', addResult.locator);
-                        return this.refreshXBlock(placeholderElement, true);
+                        return this.onNewXBlock(placeholderElement, 0, false, addResult);
                     };
                     doneAddingAllBlocks = () => {};
                 }
                 // Note: adding all the XBlocks in parallel will cause a race condition 😢 so we have to add
                 // them one at a time:
+
                 let lastAdded = $.when();
                 for (const { usageKey, blockType } of selectedBlocks) {
                     const addData = {
@@ -1220,12 +1220,13 @@ function($, _, Backbone, gettext, BasePage,
         refreshXBlock: function(element, block_added, is_duplicate) {
             var xblockElement = this.findXBlockElement(element),
                 parentElement = xblockElement.parent(),
-                rootLocator = this.xblockView.model.id;
+                rootLocator = this.xblockView.model.id,
+                parentBlockType = parentElement.data('block-type');
             if (xblockElement.length === 0 || xblockElement.data('locator') === rootLocator) {
                 if (block_added) {
                     this.render({refresh: true, block_added: block_added});
                 }
-            } else if (parentElement.hasClass('reorderable-container')) {
+            } else if (parentElement.hasClass('reorderable-container') || ["itembank", "library_content"].includes(parentBlockType) ) {
                 this.refreshChildXBlock(xblockElement, block_added, is_duplicate);
             } else {
                 this.refreshXBlock(this.findXBlockElement(parentElement));

--- a/xmodule/assets/library_content/public/js/library_content_edit.js
+++ b/xmodule/assets/library_content/public/js/library_content_edit.js
@@ -31,6 +31,32 @@ window.LibraryContentAuthorView = function(runtime, element) {
             }
         });
     });
+
+    $wrapper.on('click', '.library-block-migrate-btn', function(e) {
+        e.preventDefault();
+        // migrate library content block to item bank block
+        runtime.notify('save', {
+            state: 'start',
+            element: element,
+            message: gettext('Migrating to Problem Bank')
+        });
+        $.post(runtime.handlerUrl(element, 'upgrade_to_v2_library')).done(function() {
+            runtime.notify('save', {
+                state: 'end',
+                element: element
+            });
+            if ($element.closest('.wrapper-xblock').is(':not(.level-page)')) {
+                // We are on a course unit page. The notify('save') should refresh this block,
+                // but that is only working on the container page view of this block.
+                // Why? On the unit page, this XBlock's runtime has no reference to the
+                // XBlockContainerPage - only the top-level XBlock (a vertical) runtime does.
+                // But unfortunately there is no way to get a reference to our parent block's
+                // JS 'runtime' object. So instead we must refresh the whole page:
+                location.reload();
+            }
+        });
+    });
+
     // Hide loader and show element when update task finished.
     var $loader = $wrapper.find('.ui-loading');
     var $xblockHeader = $wrapper.find('.xblock-header');

--- a/xmodule/assets/library_content/public/js/library_content_edit.js
+++ b/xmodule/assets/library_content/public/js/library_content_edit.js
@@ -1,11 +1,39 @@
 /* JavaScript for special editing operations that can be done on LibraryContentXBlock */
-window.LibraryContentAuthorView = function(runtime, element) {
+window.LibraryContentAuthorView = function(runtime, element, initArgs) {
     'use strict';
     var $element = $(element);
     var usage_id = $element.data('usage-id');
     // The "Update Now" button is not a child of 'element', as it is in the validation message area
     // But it is still inside this xblock's wrapper element, which we can easily find:
     var $wrapper = $element.parents('*[data-locator="' + usage_id + '"]');
+    var { is_root: isRoot = false } = initArgs;
+
+    function postMessageToParent(body, callbackFn = null) {
+        try {
+            window.parent.postMessage(body, document.referrer);
+            if (callbackFn) {
+              callbackFn();
+            }
+        } catch (e) {
+            console.error('Failed to post message:', e);
+        }
+    };
+
+    function reloadPreviewPage() {
+        if (window.self !== window.top) {
+            // We are inside iframe
+            // Normal location.reload() reloads the iframe but subsequent calls to
+            // postMessage fails. So we are using postMessage to tell the parent page
+            // to reload the iframe.
+            postMessageToParent({
+                type: 'refreshIframe',
+                message: 'Refresh Iframe',
+                payload: {},
+            })
+        } else {
+            location.reload();
+        }
+    }
 
     $wrapper.on('click', '.library-update-btn', function(e) {
         e.preventDefault();
@@ -20,14 +48,9 @@ window.LibraryContentAuthorView = function(runtime, element) {
                 state: 'end',
                 element: element
             });
-            if ($element.closest('.wrapper-xblock').is(':not(.level-page)')) {
-                // We are on a course unit page. The notify('save') should refresh this block,
-                // but that is only working on the container page view of this block.
-                // Why? On the unit page, this XBlock's runtime has no reference to the
-                // XBlockContainerPage - only the top-level XBlock (a vertical) runtime does.
-                // But unfortunately there is no way to get a reference to our parent block's
-                // JS 'runtime' object. So instead we must refresh the whole page:
-                location.reload();
+            if (isRoot) {
+                // We are inside preview page where all children blocks are listed.
+                reloadPreviewPage();
             }
         });
     });
@@ -45,14 +68,9 @@ window.LibraryContentAuthorView = function(runtime, element) {
                 state: 'end',
                 element: element
             });
-            if ($element.closest('.wrapper-xblock').is(':not(.level-page)')) {
-                // We are on a course unit page. The notify('save') should refresh this block,
-                // but that is only working on the container page view of this block.
-                // Why? On the unit page, this XBlock's runtime has no reference to the
-                // XBlockContainerPage - only the top-level XBlock (a vertical) runtime does.
-                // But unfortunately there is no way to get a reference to our parent block's
-                // JS 'runtime' object. So instead we must refresh the whole page:
-                location.reload();
+            if (isRoot) {
+                // We are inside preview page where all children blocks are listed.
+                reloadPreviewPage();
             }
         });
     });

--- a/xmodule/item_bank_block.py
+++ b/xmodule/item_bank_block.py
@@ -463,7 +463,7 @@ class ItemBankMixin(
         """
         raise NotImplementedError
 
-    def _validate(self):
+    def validate(self):
         """
         Validates the state of this ItemBankBlock Instance.
         """
@@ -527,12 +527,6 @@ class ItemBankBlock(ItemBankMixin, XBlock):
         default="Problem Bank",
         scope=Scope.settings,
     )
-
-    def validate(self):
-        """
-        Validates the state of this ItemBankBlock Instance.
-        """
-        return self._validate()
 
     @classmethod
     def get_selected_event_prefix(cls) -> str:

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -359,7 +359,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         We also use this method to migrate this legacy block to new ItemBankBlock which uses
         library v2 blocks as children.
         """
-        if self.is_source_lib_migrated_to_v2:
+        if self.is_source_lib_migrated_to_v2 and not self.is_migrated_to_v2:
             # If the source library is migrated but this block still depends on legacy library
             # Migrate the block by setting upstream field to all children blocks
             self._v2_update_children_upstream_version()

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -309,8 +309,8 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
                 # appears when it is published
                 child.upstream_version = 0
                 child.save()
-                # Use `modulestore()` instead of `self.runtime.modulestore` to make sure that the XBLOCK_UPDATED signal is
-                # triggered
+                # Use `modulestore()` instead of `self.runtime.modulestore` to make sure that the XBLOCK_UPDATED signal
+                # is triggered
                 store.update_item(child, None)
             self.is_migrated_to_v2 = True
             self.save()

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -337,12 +337,15 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
             validation.set_summary(
                 StudioValidationMessage(
                     StudioValidationMessage.WARNING,
-                    _('A new version of this content is available from the library'),
+                    _(
+                        'This legacy library reference is no longer supported, and'
+                        ' needs to be updated to receive future changes'
+                    ),
                     # TODO: change this to action_runtime_event='...' once the unit page supports that feature.
                     # See https://openedx.atlassian.net/browse/TNL-993
                     action_class='library-block-migrate-btn',
                     # Translators: {refresh_icon} placeholder is substituted to "↻" (without double quotes)
-                    action_label=_("{refresh_icon} Update now").format(refresh_icon="↻")
+                    action_label=_('{refresh_icon} Update reference').format(refresh_icon='↻'),
                 )
             )
             return False

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -273,7 +273,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
 
         if self.is_migrated_to_v2:
             # If the block is already migrated to v2 i.e. ItemBankBlock, Do nothing
-            return True
+            return False  # Children have not been handled
 
         self._validate_sync_permissions()
         self.get_tools(to_read_library_content=True).trigger_duplication(source_block=source_block, dest_block=self)
@@ -288,7 +288,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
 
         if self.is_migrated_to_v2:
             # If the block is already migrated to v2 i.e. ItemBankBlock, Do nothing
-            return True
+            return False  # Children have not been handled
 
         self.sync_from_library(upgrade_to_latest=False)
         return True  # Children have been handled
@@ -298,8 +298,6 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         Update the upstream and upstream version fields of all children to point to library v2 version of the legacy
         library blocks. This essentially converts this legacy block to new ItemBankBlock.
         """
-        if not self.is_source_lib_migrated_to_v2:
-            return
         from cms.djangoapps.modulestore_migrator.api import get_target_block_usage_keys
         blocks = get_target_block_usage_keys(self.source_library_key)
         store = modulestore()

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -175,7 +175,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         else:
             fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_edit.js'))
 
-        fragment.initialize_js('LibraryContentAuthorView')
+        fragment.initialize_js('LibraryContentAuthorView', {"is_root": is_root})
         return fragment
 
     @property

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
-from gettext import ngettext, gettext
+from gettext import gettext, ngettext
 
 import nh3
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
@@ -23,8 +23,8 @@ from xblock.core import XBlock
 from xblock.fields import Integer, Scope, String
 
 from xmodule.capa.responsetypes import registry
-from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.item_bank_block import ItemBankMixin
+from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.validation import StudioValidation, StudioValidationMessage
 from xmodule.x_module import XModuleToXBlockMixin
 
@@ -117,6 +117,12 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         Normal studio view: If block is properly configured, displays library status summary
         Studio container view: displays a preview of all possible children.
         """
+        from cms.djangoapps.modulestore_migrator.api import is_successfully_migrated
+
+        lib_key = LibraryLocator.from_string(self.source_library_id)
+        if is_successfully_migrated(lib_key):
+            # Show ItemBank UI in this case
+            return super().author_view(context)
         fragment = Fragment()
         root_xblock = context.get('root_xblock')
         is_root = root_xblock and root_xblock.location == self.location

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -118,7 +118,12 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         Determines whether the source library has been migrated to v2.
         """
         from cms.djangoapps.modulestore_migrator.api import is_successfully_migrated
-        return self.source_library_id and is_successfully_migrated(self.source_library_key)
+
+        return (
+            self.source_library_id
+            and self.source_library_version
+            and is_successfully_migrated(self.source_library_key, source_version=self.source_library_version)
+        )
 
     def author_view(self, context):
         """

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -352,20 +352,25 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         if validation.empty:
             validation.set_summary(summary)
 
-    def validate(self):
+    def render(self, *args, **kwargs):
         """
-        Validates the state of this Library Content Block Instance.
+        Render `view` with this block's runtime and the supplied `context`
 
         We also use this method to migrate this legacy block to new ItemBankBlock which uses
         library v2 blocks as children.
         """
-        if self.is_migrated_to_v2:
-            # If the block is already migrated to v2 i.e. ItemBankBlock
-            return self._validate()
         if self.is_source_lib_migrated_to_v2:
             # If the source library is migrated but this block still depends on legacy library
             # Migrate the block by setting upstream field to all children blocks
             self._v2_update_children_upstream_version()
+        return super().render(*args, **kwargs)
+
+    def validate(self):
+        """
+        Validates the state of this Library Content Block Instance.
+        """
+        if self.is_migrated_to_v2:
+            # If the block is already migrated to v2 i.e. ItemBankBlock
             return self._validate()
 
         validation = super().validate()

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -227,7 +227,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         Returns 403/404 if user lacks read access on source library or write access on this block.
         """
         if self.is_migrated_to_v2:
-            # If the block is already migrated to v2 i.e. ItemBankBlock
+            # If the block is already migrated to behave like ItemBankBlock
             return Response(
                 _("This block is already migrated to use library v2. You can sync individual blocks now"),
                 status=400
@@ -284,7 +284,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
             super().studio_post_duplicate(store, source_block)
 
         if self.is_migrated_to_v2:
-            # If the block is already migrated to v2 i.e. ItemBankBlock, Do nothing
+            # If the block is already migrated to behave like ItemBankBlock
             return False  # Children have not been handled
 
         self._validate_sync_permissions()
@@ -299,7 +299,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
             super().studio_post_paste(store, source_node)
 
         if self.is_migrated_to_v2:
-            # If the block is already migrated to v2 i.e. ItemBankBlock, Do nothing
+            # If the block is already migrated to behave like ItemBankBlock
             return False  # Children have not been handled
 
         self.sync_from_library(upgrade_to_latest=False)
@@ -337,12 +337,12 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
             validation.set_summary(
                 StudioValidationMessage(
                     StudioValidationMessage.WARNING,
-                    _('The source library has been migrated to v2, this block can be migrated to Problem bank'),
+                    _('A new version of this content is available from the library'),
                     # TODO: change this to action_runtime_event='...' once the unit page supports that feature.
                     # See https://openedx.atlassian.net/browse/TNL-993
                     action_class='library-block-migrate-btn',
                     # Translators: {refresh_icon} placeholder is substituted to "↻" (without double quotes)
-                    action_label=_("{refresh_icon} Migrate").format(refresh_icon="↻")
+                    action_label=_("{refresh_icon} Update now").format(refresh_icon="↻")
                 )
             )
             return False
@@ -380,10 +380,11 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
     @XBlock.handler
     def upgrade_to_v2_library(self, request=None, suffix=None):
         """
-        Migrate this legacy block to new ItemBankBlock which uses library v2 blocks as children.
+        Upgrate this legacy block to a mode where it behaves like the new ItemBankBlock which uses library v2 blocks as
+        children.
         """
         if not self.is_source_lib_migrated_to_v2:
-            return Response(_("The source library was not migrated to version 2"), status=400)
+            return Response(_("The source library has not been migrated to version 2"), status=400)
         if self.is_migrated_to_v2:
             return Response(_("The block has already been upgraded to version 2"), status=400)
         # If the source library is migrated but this block still depends on legacy library

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -98,8 +98,13 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         values=_get_capa_types(),
         scope=Scope.settings,
     )
+    # This is a hidden field that stores whether child blocks are migrated to v2, i.e., whether they have an upstream.
+    # We cannot completely remove this block code until we force-migrate course content. Otherwise, we'll lose student
+    # data (such as selected fields), which tracks the children selected for each user.
+    # However, once all legacy libraries are migrated to v2 and removed, this block can be converted into a very thin
+    # compatibility wrapper around ItemBankBlock. All other aspects of LegacyLibraryContentBlock (the editor, the child
+    # viewer, the block picker, the legacy syncing mechanism, etc.) can then be removed.
     is_migrated_to_v2 = Boolean(
-        # This is a hidden field that stores whether children blocks are migrated to v2 i.e, have upstream set
         display_name=_("Is Migrated to library v2"),
         scope=Scope.settings,
         default=False,

--- a/xmodule/tests/test_library_content.py
+++ b/xmodule/tests/test_library_content.py
@@ -503,7 +503,7 @@ class TestLegacyLibraryContentBlockWithSearchIndex(LegacyLibraryContentBlockTest
 
     def _get_search_response(self, field_dictionary=None):
         """ Mocks search response as returned by search engine """
-        target_type = field_dictionary.get('problem_types')
+        target_type = (field_dictionary or {}).get('problem_types')
         matched_block_locations = [
             key for key, problem_types in
             self.problem_type_lookup.items() if target_type in problem_types

--- a/xmodule/tests/test_library_content.py
+++ b/xmodule/tests/test_library_content.py
@@ -767,6 +767,8 @@ class TestMigratedLibraryContentRender(LegacyLibraryContentTest):
             preserve_url_slugs=True,
             forward_source_to_target=True,
         )
+        # Migrate block
+        self.lc_block.upgrade_to_v2_library(None, None)
 
     def test_preview_view(self):
         """ Test preview view rendering """

--- a/xmodule/tests/test_library_content.py
+++ b/xmodule/tests/test_library_content.py
@@ -8,15 +8,15 @@ from bson.objectid import ObjectId
 from fs.memoryfs import MemoryFS
 from lxml import etree
 from opaque_keys.edx.locator import LibraryLocator, LibraryLocatorV2
+from organizations.tests.factories import OrganizationFactory
 from rest_framework import status
 from search.search_engine_base import SearchEngine
 from web_fragments.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
-from organizations.tests.factories import OrganizationFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
-from openedx.core.djangolib.testing.utils import skip_unless_cms
 from openedx.core.djangoapps.content_libraries import api as lib_api
+from openedx.core.djangolib.testing.utils import skip_unless_cms
 from xmodule.capa_block import ProblemBlock
 from xmodule.library_content_block import ANY_CAPA_TYPE_VALUE, LegacyLibraryContentBlock
 from xmodule.library_tools import LegacyLibraryToolsService
@@ -44,7 +44,12 @@ class LegacyLibraryContentTest(MixedSplitTestCase):
         self.tools = LegacyLibraryToolsService(self.store, self.user_id)
         self.library = LibraryFactory.create(modulestore=self.store)
         self.lib_blocks = [
-            self.make_block("html", self.library, data=f"Hello world from block {i}")
+            self.make_block(
+                "html",
+                self.library,
+                data=f"Hello world from block {i}",
+                display_name=f"html {i}"
+            )
             for i in range(1, 5)
         ]
         self.course = CourseFactory.create(modulestore=self.store)
@@ -148,7 +153,8 @@ class TestLibraryContentExportImport(LegacyLibraryContentTest):
 
         self.expected_olx = (
             f'<library_content display_name="{self.lc_block.display_name}" max_count="{self.lc_block.max_count}"'
-            f' source_library_id="{self.lc_block.source_library_id}" source_library_version="{self.lc_block.source_library_version}">\n'  # noqa: E501
+            f' source_library_id="{self.lc_block.source_library_id}" '
+            f'source_library_version="{self.lc_block.source_library_version}">\n'
             f'  <html url_name="{self.lc_block.children[0].block_id}"/>\n'
             f'  <html url_name="{self.lc_block.children[1].block_id}"/>\n'
             f'  <html url_name="{self.lc_block.children[2].block_id}"/>\n'
@@ -194,7 +200,8 @@ class TestLibraryContentExportImport(LegacyLibraryContentTest):
         olx_with_comments = (
             '<!-- Comment -->\n'
             f'<library_content display_name="{self.lc_block.display_name}" max_count="{self.lc_block.max_count}"'
-            f' source_library_id="{self.lc_block.source_library_id}" source_library_version="{self.lc_block.source_library_version}">\n'  # noqa: E501
+            f' source_library_id="{self.lc_block.source_library_id}" '
+            f'source_library_version="{self.lc_block.source_library_version}">\n'
             '<!-- Comment -->\n'
             f'  <html url_name="{self.lc_block.children[0].block_id}"/>\n'
             f'  <html url_name="{self.lc_block.children[1].block_id}"/>\n'
@@ -805,7 +812,7 @@ class TestMigratedLibraryContentRender(LegacyLibraryContentTest):
         expected_olx_export = (
             f'<library_content display_name="{self.lc_block.display_name}" is_migrated_to_v2="true"'
             f' max_count="{self.lc_block.max_count}" source_library_id="{self.lc_block.source_library_id}" '
-            f'source_library_version="{self.lc_block.source_library_version}">\n'  # noqa: E501
+            f'source_library_version="{self.lc_block.source_library_version}">\n'
             f'  <html url_name="{self.lc_block.children[0].block_id}"/>\n'
             f'  <html url_name="{self.lc_block.children[1].block_id}"/>\n'
             f'  <html url_name="{self.lc_block.children[2].block_id}"/>\n'


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Allows authors to migrate legacy library content block in course to library v2 if the source library was migrated. The block works with the new library and has the same functionality as the new ItemBankBlock.

This PR also fixes some issues with Problem Bank like `Add components` button not working in the preview page and iframe postMessage failure after syncing of component in the preview page.

https://github.com/user-attachments/assets/68017884-0cca-4fc8-9ab1-d30af1fd4fc0

**Latest update in UI**

https://github.com/user-attachments/assets/0edb1e13-71ed-4eb8-8de0-42baa7e21561


Requirements as per The LegacyLibraryContentBlock OLX must work forever.
* [x] The LegacyLibraryContentBlock OLX must work forever.
* L points at a legacy library, which has been migrated to a new V2 library.
    * [x] Block Behavior: Preview and settings editor should look just like a modern ItemBank block.
    * [x] Child Behavior: If updates are available (see below), they are shown per-child on the View page, using the migrated child blocks as the update source.
* L points at a legacy library, which has not been migrated.
    * [x] Block and Child Behavior: Use existing LegacyLibraryContentBlock interface behavior.
* L is None, malformed, or doesn't point to an existing or migrated legacy library:
    * [x] Block Behavior: Display a validation error. Syncing is not allowed. (existing behavior)
    * [x] Child Behavior: Children are displayed if they exist, but no option to sync is offered.
**Sync behavior**
* [x] The parent LegacyLibraryContentBlock's version does not equal the migrated source library version (indicating that the legacy library received updates before its migration happened)

Useful information to include:

- Which edX user roles will this change impact? "Course Author" and "Developer"

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2386
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4251
* Related PR: https://github.com/openedx/frontend-app-authoring/pull/2491

## Testing instructions

* Create a legacy library with some components.
* Add a legacy library content block in course unit.
* Now migrate the legacy library.
* Refresh the course unit page, a new alert should appear on top of the library content block.
* Click on migrate button in the alert and verify that the block is migrated to Problem bank and behaves like it.
* The children blocks have upstream field set and show sync button if the v2 library component is updated.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
