### PR TITLE
fix: Only update downstream_customized for upstream-linked blocks

### DIFF
--- a/cms/lib/xblock/upstream_sync.py
+++ b/cms/lib/xblock/upstream_sync.py
@@ -386,6 +386,7 @@ def sever_upstream_link(downstream: XBlock) -> list[XBlock]:
     downstream.copied_from_block = downstream.upstream
     downstream.upstream = None
     downstream.upstream_version = None
+    downstream.downstream_customized = []
     for _, fetched_upstream_field in downstream.get_customizable_fields().items():
         # Downstream-only fields don't have an upstream fetch field
         if fetched_upstream_field is None:
@@ -527,6 +528,10 @@ class UpstreamSyncMixin(XBlockMixin):
         Update `downstream_customized` when a customizable field is modified.
         """
         super().editor_saved(user, old_metadata, old_content)
+        if not self.upstream:
+            # If a block does not have an upstream, then we do not need to track its
+            # customizations.
+            return
         customizable_fields = self.get_customizable_fields()
         new_data = (
             self.get_explicitly_set_fields_by_scope(Scope.settings)


### PR DESCRIPTION
## Description

We only need to track field customizations for upstream-linked (i.e., library-linked) blocks. Thd downstream_customized field is irrelevant for other blocks. It would just add a ton of noise to the OLX.

Additionally, we now clear downstream_customized when severing an upstream link.

## Supporting information

https://github.com/openedx/edx-platform/issues/37411

## Testing

Without this PR:

* Add a component to a course from a library
* Edit the component's title; save and publish
* Add a new component to a course
* Edit the component's title; save and publish
* Export the course
* Notice:
  * The library-sourced component's OLX tag contains `downstream_customized="[&quot;display_name&quot;]"` (desired behavior)
   * The course-based component's OLX tag contains `downstream_customized="[&quot;display_name&quot;]"` (bugged behavior)

With this PR:

* Add a component to a course from a library
* Edit the component's title; save and publish
* Add a new component to a course
* Edit the component's title; save and publish
* Export the course
* Notice:
  * The library-sourced component's OLX tag still contains `downstream_customized="[&quot;display_name&quot;]"`)=
  * The course-based component's OLX tag **does not**  contain`downstream_customized="[&quot;display_name&quot;]"`

## Deadline

ASAP, but especially before the Ulmo so that this doesn't get into release operators' course data.

Since the downstream customization code was [merged in September](https://github.com/openedx/edx-platform/pull/37124), some `downstream_customized` attributes will have gotten into 2U's and potentially MIT OL's course data. It won't be harmful there, just noisy.