### PR TITLE
fix: Profile MFE redirection issue (URL path override)

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -44,7 +44,7 @@ should_show_order_history = not enterprise_customer_portal
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
         % endif
 
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${urljoin(settings.PROFILE_MICROFRONTEND_URL, f'/u/{user.username}')}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${urljoin(settings.PROFILE_MICROFRONTEND_URL, f'{user.username}')}" role="menuitem">${_("Profile")}</a></div>
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ACCOUNT_MICROFRONTEND_URL}" role="menuitem">${_("Account")}</a></div>
         % if should_show_order_history:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>


### PR DESCRIPTION
This error was occurring because the way the redirect URL was constructed caused the entire base path to be removed. This commit updates the URL construction method to correctly preserve the MFE's path.

## Description

Given that the legacy account and profile pages were deprecated from the Teak version of the platform, certain changes were made to the platform to redirect from a legacy page to the respective Account and Profile MFEs (Micro-Frontends).

For more information about the changes that were made, please refer to this PR: https://github.com/openedx/edx-platform/pull/36219

In this case, the specific change affecting the user experience is fixed in this PR. This change involves the logic responsible for rendering the profile URL in the legacy dropdown.

### Useful information:

It is happening due to the implementation of the legacy user dropdown, as its implementation did not account for scenarios where PROFILE_MICROFRONTEND_URL contains a **path**.

Specifically, it occurs when the following function is called:

```python
urljoin(settings.PROFILE_MICROFRONTEND_URL, f'/u/{user.username}')
```

This is because the `urljoin` function is used to concatenate an absolute URL with a relative URL. In the case of the path configuration, `settings.PROFILE_MICROFRONTEND_URL` would be the absolute URL (e.g., `http://apps.local.openedx.io/profile/u/`), and `/u/{user.username}` would be the relative URL.

However, the `urljoin` function has certain implications. The one that matters in this case is that **if the relative URL begins with a `/` (slash), it replaces the entire path contained within the absolute URL.** In our example, this causes the URL to become:

`http://apps.local.openedx.io/u/{user.username}`

The correct URL, in this case, should be:

`http://apps.local.openedx.io/profile/u/{user.username}`

This incorrect construction makes it impossible to find the Profile MFE by path when accessing it from a legacy page.

## Supporting information

This implementation was based on the solution proposed in tutor-indigo https://github.com/overhangio/tutor-indigo/blob/cf48e296affdfae4d0d0d7b21902d85eb51b739a/tutorindigo/templates/indigo/lms/templates/header/user_dropdown.html#L42 with the aim of making the solution compatible with the default PROFILE_MICROFRONTEND_URL configuration in tutor-mfe: https://github.com/overhangio/tutor-mfe/blob/4e31afa55c3f61a455d6bad3ffdc058e249e47a8/tutormfe/patches/openedx-lms-production-settings#L73

## Testing instructions

1.  Ensure the environment has the **`tutor-indigo` plugin and the Indigo theme deactivated**.
2.  Log in to the LMS with your credentials.
3.  Navigate to a legacy page (e.g., `http://local.openedx.io/courses`).
4.  Click the user dropdown, and then click **Profile**.
