### PR TITLE
feat: Libraries v2 backup endpoint

### DIFF
--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -66,6 +66,7 @@ import itertools
 import json
 import logging
 
+import edx_api_doc_tools as apidocs
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login
 from django.contrib.auth.models import Group
@@ -78,14 +79,12 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import TemplateResponseMixin, View
 from drf_yasg.utils import swagger_auto_schema
-from pylti1p3.contrib.django import DjangoCacheDataStorage, DjangoDbToolConf, DjangoMessageLaunch, DjangoOIDCLogin
-from pylti1p3.exception import LtiException, OIDCException
-
-import edx_api_doc_tools as apidocs
 from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
 from organizations.api import ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 from organizations.models import Organization
+from pylti1p3.contrib.django import DjangoCacheDataStorage, DjangoDbToolConf, DjangoMessageLaunch, DjangoOIDCLogin
+from pylti1p3.exception import LtiException, OIDCException
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.generics import GenericAPIView
@@ -93,12 +92,15 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
+import openedx.core.djangoapps.site_configuration.helpers as configuration_helpers
 from cms.djangoapps.contentstore.views.course import (
     get_allowed_organizations_for_libraries,
-    user_can_create_organizations,
+    user_can_create_organizations
 )
 from openedx.core.djangoapps.content_libraries import api, permissions
+from openedx.core.djangoapps.content_libraries.api.libraries import get_backup_task_status
 from openedx.core.djangoapps.content_libraries.rest_api.serializers import (
+    ContentLibraryAddPermissionByEmailSerializer,
     ContentLibraryBlockImportTaskCreateSerializer,
     ContentLibraryBlockImportTaskSerializer,
     ContentLibraryFilterSerializer,
@@ -106,20 +108,20 @@ from openedx.core.djangoapps.content_libraries.rest_api.serializers import (
     ContentLibraryPermissionLevelSerializer,
     ContentLibraryPermissionSerializer,
     ContentLibraryUpdateSerializer,
+    LibraryBackupResponseSerializer,
+    LibraryBackupTaskStatusSerializer,
     LibraryXBlockCreationSerializer,
     LibraryXBlockMetadataSerializer,
     LibraryXBlockTypeSerializer,
-    ContentLibraryAddPermissionByEmailSerializer,
-    PublishableItemSerializer,
+    PublishableItemSerializer
 )
-import openedx.core.djangoapps.site_configuration.helpers as configuration_helpers
-from openedx.core.lib.api.view_utils import view_auth_classes
+from openedx.core.djangoapps.content_libraries.tasks import backup_library
 from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.xblock import api as xblock_api
+from openedx.core.lib.api.view_utils import view_auth_classes
 
-from .utils import convert_exceptions
 from ..models import ContentLibrary, LtiGradedResource, LtiProfile
-
+from .utils import convert_exceptions
 
 User = get_user_model()
 log = logging.getLogger(__name__)
@@ -683,6 +685,109 @@ class LibraryImportTaskViewSet(GenericViewSet):
 
         import_task = api.ContentLibraryBlockImportTask.objects.get(pk=pk)
         return Response(ContentLibraryBlockImportTaskSerializer(import_task).data)
+
+
+# Library Backup Views
+# ====================
+
+@method_decorator(non_atomic_requests, name="dispatch")
+@view_auth_classes()
+class LibraryBackupView(APIView):
+    """
+    **Use Case**
+    * Start an asynchronous task to back up the content of a library to a .zip file
+    * Get a status on an asynchronous export task
+
+    **Example Requests**
+        POST /api/libraries/v2/{library_id}/backup/
+        GET  /api/libraries/v2/{library_id}/backup/?task_id={task_id}
+
+    **POST Response Values**
+
+        If the import task is started successfully, an HTTP 200 "OK" response is
+        returned.
+
+        The HTTP 200 response has the following values:
+
+        * task_id: UUID of the created task, usable for checking status
+
+    **Example POST Response**
+
+        {
+            "task_id": "7069b95b-ccea-4214-b6db-e00f27065bf7"
+        }
+
+    **GET Parameters**
+
+        A GET request must include the following parameters:
+
+        * task_id: (required) The UUID of the task to check.
+
+    **GET Response Values**
+
+        If the import task is found successfully by the UUID provided, an HTTP
+        200 "OK" response is returned.
+
+        The HTTP 200 response has the following values:
+
+        * state: String description of the state of the task.
+            Possible states: "Pending", "Exporting", "Succeeded", "Failed".
+        * url: (may be null) If the task is complete, a URL to download the .zip file
+
+    **Example GET Response**
+        {
+            "state": "Succeeded",
+            "url": "/media/user_tasks/2025/10/03/lib-wgu-csprob-2025-10-03-153633.zip"
+        }
+
+    """
+
+    @apidocs.schema(
+        body=None,
+        responses={200: LibraryBackupResponseSerializer}
+    )
+    @convert_exceptions
+    def post(self, request, lib_key_str):
+        """
+        Start backup task for the specified library.
+        """
+        library_key = LibraryLocatorV2.from_string(lib_key_str)
+        # Using CAN_EDIT_THIS_CONTENT_LIBRARY permission for now. This should eventually become its own permission
+        api.require_permission_for_library_key(library_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY)
+
+        async_result = backup_library.delay(request.user.id, str(library_key))
+        result = {'task_id': async_result.task_id}
+
+        return Response(LibraryBackupResponseSerializer(result).data)
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.query_parameter(
+                'task_id',
+                str,
+                description="The ID of the backup task to retrieve."
+            ),
+        ],
+        responses={200: LibraryBackupTaskStatusSerializer}
+    )
+    @convert_exceptions
+    def get(self, request, lib_key_str):
+        """
+        Get the status of the specified backup task for the specified library.
+        """
+        library_key = LibraryLocatorV2.from_string(lib_key_str)
+        # Using CAN_EDIT_THIS_CONTENT_LIBRARY permission for now. This should eventually become its own permission
+        api.require_permission_for_library_key(library_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY)
+
+        task_id = request.query_params.get('task_id', None)
+        if not task_id:
+            raise ValidationError(detail={'task_id': _('This field is required.')})
+        result = get_backup_task_status(request.user.id, task_id)
+
+        if not result:
+            raise NotFound(detail="No backup found for this library.")
+
+        return Response(LibraryBackupTaskStatusSerializer(result).data)
 
 
 # LTI 1.3 Views

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -3,26 +3,22 @@ Serializers for the content libraries REST API
 """
 # pylint: disable=abstract-method
 from django.core.validators import validate_unicode_slug
+from opaque_keys import InvalidKeyError, OpaqueKey
+from opaque_keys.edx.locator import LibraryContainerLocator, LibraryUsageLocatorV2
+from openedx_learning.api.authoring_models import Collection
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from opaque_keys import OpaqueKey
-from opaque_keys.edx.locator import LibraryContainerLocator, LibraryUsageLocatorV2
-from opaque_keys import InvalidKeyError
-
-from openedx_learning.api.authoring_models import Collection
 from openedx.core.djangoapps.content_libraries.api.containers import ContainerType
-from openedx.core.djangoapps.content_libraries.constants import (
-    ALL_RIGHTS_RESERVED,
-    LICENSE_OPTIONS,
-)
+from openedx.core.djangoapps.content_libraries.constants import ALL_RIGHTS_RESERVED, LICENSE_OPTIONS
 from openedx.core.djangoapps.content_libraries.models import (
-    ContentLibraryPermission, ContentLibraryBlockImportTask,
-    ContentLibrary
+    ContentLibrary,
+    ContentLibraryBlockImportTask,
+    ContentLibraryPermission
 )
 from openedx.core.lib.api.serializers import CourseKeyField
-from .. import permissions
 
+from .. import permissions
 
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -416,3 +412,18 @@ class ContainerHierarchySerializer(serializers.Serializer):
     units = serializers.ListField(child=ContainerHierarchyMemberSerializer(), allow_empty=True)
     components = serializers.ListField(child=ContainerHierarchyMemberSerializer(), allow_empty=True)
     object_key = OpaqueKeySerializer()
+
+
+class LibraryBackupResponseSerializer(serializers.Serializer):
+    """
+    Serializer for the response after requesting a backup of a content library.
+    """
+    task_id = serializers.CharField()
+
+
+class LibraryBackupTaskStatusSerializer(serializers.Serializer):
+    """
+    Serializer for checking the status of a library backup task.
+    """
+    state = serializers.CharField()
+    url = serializers.URLField(allow_null=True)

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -32,6 +32,8 @@ URL_LIB_TEAM = URL_LIB_DETAIL + 'team/'  # Get the list of users/groups authoriz
 URL_LIB_TEAM_USER = URL_LIB_TEAM + 'user/{username}/'  # Add/edit/remove a user's permission to use this library
 URL_LIB_TEAM_GROUP = URL_LIB_TEAM + 'group/{group_name}/'  # Add/edit/remove a group's permission to use this library
 URL_LIB_PASTE_CLIPBOARD = URL_LIB_DETAIL + 'paste_clipboard/'  # Paste user clipboard (POST) containing Xblock data
+URL_LIB_BACKUP = URL_LIB_DETAIL + 'backup/'  # Start a backup task for this library
+URL_LIB_BACKUP_GET = URL_LIB_BACKUP + '?{query_params}'  # Get status on a backup task for this library
 URL_LIB_BLOCK = URL_PREFIX + 'blocks/{block_key}/'  # Get data about a block, or delete it
 URL_LIB_BLOCK_PUBLISH = URL_LIB_BLOCK + 'publish/'  # Publish changes from a specified XBlock
 URL_LIB_BLOCK_OLX = URL_LIB_BLOCK + 'olx/'  # Get or set the OLX of the specified XBlock
@@ -318,6 +320,17 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
         """ Paste's the users clipboard content into Library """
         url = URL_LIB_PASTE_CLIPBOARD.format(lib_key=lib_key)
         return self._api('post', url, {}, expect_response)
+
+    def _start_library_backup_task(self, lib_key, expect_response=200):
+        """ Start a backup task for this library """
+        url = URL_LIB_BACKUP.format(lib_key=lib_key)
+        return self._api('post', url, {}, expect_response)
+
+    def _get_library_backup_task(self, lib_key, task_id, expect_response=200):
+        """ Get the status of a backup task for this library """
+        query_params = urlencode({"task_id": task_id})
+        url = URL_LIB_BACKUP_GET.format(lib_key=lib_key, query_params=query_params)
+        return self._api('get', url, None, expect_response)
 
     def _render_block_view(self, block_key, view_name, version=None, expect_response=200):
         """

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -823,6 +823,40 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest):
                 "id": f"lb:CL-TEST:test_lib_paste_clipboard:problem:{pasted_usage_key.block_id}",
             })
 
+    def test_start_library_backup(self):
+        """
+        Test starting a backup operation on a content library.
+        """
+        author = UserFactory.create(username="Author", email="author@example.com", is_staff=True)
+        with self.as_user(author):
+            lib = self._create_library(
+                slug="test_lib_backup",
+                title="Backup Test Library",
+                description="Testing backup for library"
+            )
+            lib_id = lib["id"]
+            response = self._start_library_backup_task(lib_id)
+            assert response["task_id"] is not None
+
+    def test_get_library_backup_status(self):
+        """
+        Test getting the status of a backup operation on a content library.
+        """
+        author = UserFactory.create(username="Author", email="author@example.com", is_staff=True)
+        with self.as_user(author):
+            lib = self._create_library(
+                slug="test_lib_backup_status",
+                title="Backup Status Test Library",
+                description="Testing backup status for library"
+            )
+            lib_id = lib["id"]
+            response = self._start_library_backup_task(lib_id)
+            task_id = response["task_id"]
+
+            # Now check the status of the backup task
+            status_response = self._get_library_backup_task(lib_id, task_id)
+            assert status_response["state"] in ["Pending", "Exporting", "Succeeded", "Failed"]
+
     @override_settings(LIBRARY_ENABLED_BLOCKS=['problem', 'video', 'html'])
     def test_library_get_enabled_blocks(self):
         expected = [

--- a/openedx/core/djangoapps/content_libraries/tests/test_tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_tasks.py
@@ -1,0 +1,45 @@
+"""
+Unit tests for content libraries Celery tasks
+"""
+
+from ..models import ContentLibrary
+from .base import ContentLibrariesRestApiTest
+
+from openedx.core.djangoapps.content_libraries.tasks import backup_library
+from user_tasks.models import UserTaskArtifact
+
+
+class ContentLibraryBackupTaskTest(ContentLibrariesRestApiTest):
+    """
+    Tests for Content Library export task.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        # Create Content Libraries
+        self._create_library("test-lib-task-1", "Test Library Task 1")
+
+        # Fetch the created ContentLibrary objects so we can access their learning_package.id
+        self.lib1 = ContentLibrary.objects.get(slug="test-lib-task-1")
+        self.wrong_task_id = '11111111-1111-1111-1111-111111111111'
+
+    def test_backup_task_returns_task_id(self):
+        result = backup_library.delay(self.user.id, str(self.lib1.library_key))
+        assert result.task_id is not None
+
+    def test_backup_task_success(self):
+        result = backup_library.delay(self.user.id, str(self.lib1.library_key))
+        assert result.state == 'SUCCESS'
+        # Ensure an artifact was created with the output file
+        artifact = UserTaskArtifact.objects.filter(status__task_id=result.task_id, name='Output').first()
+        assert artifact is not None
+        assert artifact.file.name.endswith('.zip')
+
+    def test_backup_task_failure(self):
+        result = backup_library.delay(self.user.id, self.wrong_task_id)
+        assert result.state == 'FAILURE'
+        # Ensure an error artifact was created
+        artifact = UserTaskArtifact.objects.filter(status__task_id=result.task_id, name='Error').first()
+        assert artifact is not None
+        assert artifact.text is not None

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -54,6 +54,8 @@ urlpatterns = [
             path('import_blocks/', include(import_blocks_router.urls)),
             # Paste contents of clipboard into library
             path('paste_clipboard/', libraries.LibraryPasteClipboardView.as_view()),
+            # Start a backup task for this library
+            path('backup/', libraries.LibraryBackupView.as_view()),
             # Library Collections
             path('', include(library_collections_router.urls)),
         ])),


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds endpoints for Library v2 backup functionality, related to the new library import/export functionality being implemented in openedx-learning by @dwong2708.

### Use Case

* Start an asynchronous task to back up the content of a library to a .zip file
* Get a status on an asynchronous export task, including the download url

### Example Requests
    
- POST /api/libraries/v2/{library_id}/backup/
- GET  /api/libraries/v2/{library_id}/backup/?task_id={task_id}

### POST Response Values

If the import task is started successfully, an HTTP 200 "OK" response is returned.

The HTTP 200 response has the following values:
* task_id: UUID of the created task, usable for checking status

### Example POST Response

```json
{
    "task_id": "7069b95b-ccea-4214-b6db-e00f27065bf7"
}
```

### GET Parameters

A GET request can include the following parameters:

* task_id: (required) The UUID of the task to check.

### GET Response Values

If the import task is found successfully by the UUID provided, an HTTP 200 "OK" response is returned.

The HTTP 200 response has the following values:

* state: String description of the state of the task
* url: (may be null) If the task is complete, a URL to download the .zip file

### Example GET Response

```json
{
    "state": "Succeeded",
    "url": "/media/user_tasks/2025/10/03/lib-wgu-csprob-2025-10-03-153633.zip"
}
```

## Supporting information

Resolves: https://github.com/openedx/openedx-learning/issues/387
Required by: https://github.com/openedx/frontend-app-authoring/issues/2448

## Testing instructions

1. Create a new library from the studio interface (from the "**Libraries Beta**" tab, not "~~Legacy Libraries~~")
2. note the Library key from the URL when looking at the library details (something like lib:WGU:CSPROB)
3. do a **POST** to ``/api/libraries/v2/lib:WGU:CSPROB/backup/`` (change the library key with yours)
4. You should get a response like ``{"task_id":"747e5ab3-5aef-4aef-88a3-6a195c849e12"}``
5. do a **GET** to ``/api/libraries/v2/lib:WGU:CSPROB/backup/?task_id=747e5ab3-5aef-4aef-88a3-6a195c849e12`` (change the library key and the task_id to yours)
6. You should get a response like:
```
{
    "state": "Succeeded",
    "url": "/media/user_tasks/2025/10/03/lib-wgu-csprob-2025-10-03-153633.zip"
}
```

## Deadline

Ulmo Release

## Other information

- Depends on changes in openedx-learning, which are partially merged as of Oct 3 2025. This means the export works, but the contents of the generated zip file may be incomplete.

