### PR TITLE
fix: prevent overwriting staticfiles cache setting

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -153,7 +153,7 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-if 'staticfiles' in CACHES:
+if 'staticfiles' in CACHES and 'KEY_PREFIX' not in CACHES['staticfiles']:
     CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -154,7 +154,7 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-if 'staticfiles' in CACHES:
+if 'staticfiles' in CACHES and 'KEY_PREFIX' not in CACHES['staticfiles']:
     CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 # In order to transition from local disk asset storage to S3 backed asset storage,


### PR DESCRIPTION
## Description

Prevent the production settings from overwriting the value of `CACHES['staticfiles']['KEY_PREFIX']` taken from the `CONFIG_FILE` (yml).

When a setting is defined in the CACHES dictionary in lms.yaml (and similarly in cms.yaml) as in the following example:
```
CACHES:
...
  staticfiles:
    BACKEND: django.core.cache.backends.locmem.LocMemCache
    KEY_PREFIX: staticfiles_lms
    LOCATION: staticfiles_lms
...
```
the value of `CACHES['staticfiles']['KEY_PREFIX']` is overwritten regardless of whether the `EDX_PLATFORM_REVISION` variable is defined with a meaningful value.

This change affect Operator roles, but won't affect operators using the default behaviour of the staticfiles cache setting.

I believe that this change aligns with the goal of [Django settings simplification](https://github.com/openedx/edx-platform/blob/master/docs/decisions/0022-settings-simplification.rst).

## Supporting information

Ref: https://github.com/openedx/edx-platform/issues/37378

## Other information

The [Universidad de Chile's platform](https://open.uchile.cl/) has been using djangoapps with different customizations between LMS & CMS, resulting in different staticfile names for djangojs.xxx.js bundles for each variant, so a single memcached instance for caching both lms & cms requires a prefix to differentiate staticfiles cache values. This fix is essential for that kind of setting.
