### PR TITLE
fix: fix fork on multiple migrations [FC-0097]

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tests/test_api.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_api.py
@@ -276,6 +276,43 @@ class TestModulestoreMigratorAPI(LibraryTestCase):
         )
         assert second_component.display_name == "Updated Block"
 
+        # Update the block again, changing its name
+        library_block.display_name = "Updated Block Again"
+        self.store.update_item(library_block, user.id)
+
+        # Migrate again using the Fork strategy
+        api.start_migration_to_library(
+            user=user,
+            source_key=source.key,
+            target_library_key=self.library_v2.library_key,
+            composition_level=CompositionLevel.Component.value,
+            repeat_handling_strategy=RepeatHandlingStrategy.Fork.value,
+            preserve_url_slugs=True,
+            forward_source_to_target=False,
+        )
+
+        modulestoremigration = ModulestoreMigration.objects.last()
+        assert modulestoremigration is not None
+        assert modulestoremigration.repeat_handling_strategy == RepeatHandlingStrategy.Fork.value
+
+        migrated_components_fork = lib_api.get_library_components(self.library_v2.library_key)
+        assert len(migrated_components_fork) == 3
+
+        first_component = lib_api.LibraryXBlockMetadata.from_component(
+            self.library_v2.library_key, migrated_components_fork[0]
+        )
+        assert first_component.display_name == "Original Block"
+
+        second_component = lib_api.LibraryXBlockMetadata.from_component(
+            self.library_v2.library_key, migrated_components_fork[1]
+        )
+        assert second_component.display_name == "Updated Block"
+
+        third_component = lib_api.LibraryXBlockMetadata.from_component(
+            self.library_v2.library_key, migrated_components_fork[2]
+        )
+        assert third_component.display_name == "Updated Block Again"
+
     def test_get_migration_info(self):
         """
         Test that the API can retrieve migration info.

--- a/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
@@ -447,7 +447,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             title="test_problem"
         )
 
-        context.existing_source_to_target_keys[source_key] = first_result.entity
+        context.existing_source_to_target_keys[source_key] = [first_result.entity]
 
         second_result = _migrate_component(
             context=context,
@@ -489,7 +489,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             title="test_problem"
         )
 
-        context.existing_source_to_target_keys[source_key_1] = first_result.entity
+        context.existing_source_to_target_keys[source_key_1] = [first_result.entity]
 
         second_result = _migrate_component(
             context=context,
@@ -527,7 +527,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             title="original"
         )
 
-        context.existing_source_to_target_keys[source_key] = first_result.entity
+        context.existing_source_to_target_keys[source_key] = [first_result.entity]
 
         updated_olx = '<problem display_name="Updated"><multiplechoiceresponse></multiplechoiceresponse></problem>'
         second_result = _migrate_component(
@@ -708,7 +708,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             title="test_problem"
         )
 
-        context.existing_source_to_target_keys[source_key] = first_result.entity
+        context.existing_source_to_target_keys[source_key] = [first_result.entity]
 
         second_result = _migrate_component(
             context=context,
@@ -863,7 +863,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             children=[],
         )
 
-        context.existing_source_to_target_keys[source_key] = first_result.entity
+        context.existing_source_to_target_keys[source_key] = [first_result.entity]
 
         second_result = _migrate_container(
             context=context,
@@ -909,7 +909,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             children=[],
         )
 
-        context.existing_source_to_target_keys[source_key_1] = first_result.entity
+        context.existing_source_to_target_keys[source_key_1] = [first_result.entity]
 
         second_result = _migrate_container(
             context=context,
@@ -969,7 +969,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             children=[],
         )
 
-        context.existing_source_to_target_keys[source_key] = first_result.entity
+        context.existing_source_to_target_keys[source_key] = [first_result.entity]
 
         second_result = _migrate_container(
             context=context,


### PR DESCRIPTION
## Description

This PR fixes a bug where, when running a migration using the `fork` strategy, it was only looking at the last migration, resulting in a slug reuse, which would cause a component update instead of a new component creation.

## Supporting information

Reported here: https://github.com/openedx/edx-platform/pull/37408#issuecomment-3363806345

## Testing instructions

* Create a Legacy library with a text component.
* Migrate the legacy library using any strategy
* The text component is created
* Update the title of the text component in the legacy library
* Migrate the legacy library using `fork`
* A text component with the next title is created.
* Update the title of the text component in the legacy library
* Migrate the legacy library using `fork`
* A new component must be created
* Update the title of the text component in the legacy library
* Migrate the legacy library using `fork`
* A new component must be created
* Update the title of the text component in the legacy library
* Migrate the legacy library using `update`
* The first migrated component should be updated with the new title

## Deadline

2025-10-09 - We need this for Ulmo

___

Private ref: [FAL-4254](https://tasks.opencraft.com/browse/FAL-4254)