### PR TITLE
refactor: include container display name in children api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -180,3 +180,4 @@ class ContainerChildrenSerializer(serializers.Serializer):
     children = ContainerChildSerializer(many=True)
     is_published = serializers.BooleanField()
     can_paste_component = serializers.BooleanField()
+    display_name = serializers.CharField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_index.py
@@ -230,6 +230,7 @@ class ContainerChildrenView(APIView, ContainerHandlerMixin):
             ],
             "is_published": false,
             "can_paste_component": true,
+            "display_name": "Vertical block 1"
         }
         ```
         """
@@ -277,6 +278,7 @@ class ContainerChildrenView(APIView, ContainerHandlerMixin):
                 "children": children,
                 "is_published": is_published,
                 "can_paste_component": is_course,
+                "display_name": current_xblock.display_name_with_default,
             }
             serializer = ContainerChildrenSerializer(container_data)
             return Response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -204,9 +204,11 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
         url = self.get_reverse_url(self.vertical.location)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["children"]), 2)
-        self.assertFalse(response.data["is_published"])
-        self.assertTrue(response.data["can_paste_component"])
+        data = response.json()
+        self.assertEqual(len(data["children"]), 2)
+        self.assertFalse(data["is_published"])
+        self.assertTrue(data["can_paste_component"])
+        self.assertEqual(data["display_name"], "Unit")
 
     def test_xblock_is_published(self):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Update container children API to include `display_name` of the container block that is being previewed.


Useful information to include:

- Which edX user roles will this change impact? "Developer"

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2476

## Testing instructions

TBD

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
