### PR TITLE
feat: add library restore endpoint

### DIFF
--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -79,6 +79,8 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import TemplateResponseMixin, View
 from drf_yasg.utils import swagger_auto_schema
+from user_tasks.models import UserTaskStatus
+
 from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
 from organizations.api import ensure_organization
 from organizations.exceptions import InvalidOrganizationException
@@ -97,6 +99,9 @@ from cms.djangoapps.contentstore.views.course import (
     get_allowed_organizations_for_libraries,
     user_can_create_organizations
 )
+from cms.djangoapps.contentstore.storage import course_import_export_storage
+from openedx.core.djangoapps.content_libraries.tasks import restore_library
+
 from openedx.core.djangoapps.content_libraries import api, permissions
 from openedx.core.djangoapps.content_libraries.api.libraries import get_backup_task_status
 from openedx.core.djangoapps.content_libraries.rest_api.serializers import (
@@ -110,6 +115,9 @@ from openedx.core.djangoapps.content_libraries.rest_api.serializers import (
     ContentLibraryUpdateSerializer,
     LibraryBackupResponseSerializer,
     LibraryBackupTaskStatusSerializer,
+    LibraryRestoreFileSerializer,
+    LibraryRestoreTaskRequestSerializer,
+    LibraryRestoreTaskResultSerializer,
     LibraryXBlockCreationSerializer,
     LibraryXBlockMetadataSerializer,
     LibraryXBlockTypeSerializer,
@@ -788,6 +796,82 @@ class LibraryBackupView(APIView):
             raise NotFound(detail="No backup found for this library.")
         # Passing request context to the serializer so the url absolute path is correctly generated
         return Response(LibraryBackupTaskStatusSerializer(result, context={'request': request}).data)
+
+
+@method_decorator(non_atomic_requests, name="dispatch")
+@view_auth_classes()
+class LibraryRestoreView(APIView):
+    """
+    Restore a library from a backup file.
+
+    After the file is uploaded, a background task will be started to process the
+    file and restore the library contents. You can use the returned `task_id` to
+    check the status of the restore task.
+
+    The result of the restore task will be a "staged" learning package that can
+    then be saved into a content library.
+
+    **POST Parameters**
+
+        A POST request must include the following parameters.
+
+        * file: (required) The backup file to restore the library from. Must be a
+          .zip file.
+
+    **GET Parameters**
+
+        A GET request must include the following parameters.
+
+        * task_id: (required) The UUID of a restore task.
+    """
+    @apidocs.schema(
+        body=LibraryRestoreFileSerializer,
+        responses={200: LibraryRestoreFileSerializer}
+    )
+    def post(self, request):
+        """
+        Restore a library from a backup file.
+        """
+        if not request.user.has_perm(permissions.CAN_CREATE_CONTENT_LIBRARY):
+            raise PermissionDenied
+
+        serializer = LibraryRestoreFileSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        upload = serializer.validated_data['file']
+
+        storage_path = course_import_export_storage.save(f'library_restore/{upload.name}', upload)
+
+        log.info("Learning package archive upload %s: Upload complete", upload.name)
+
+        async_result = restore_library.delay(request.user.id, storage_path)
+
+        return Response(LibraryRestoreFileSerializer({'task_id': async_result.task_id}).data)
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.query_parameter(
+                'task_id',
+                str,
+                description="The ID of the restore library task to retrieve."
+            ),
+        ],
+        responses={200: LibraryRestoreTaskResultSerializer}
+    )
+    def get(self, request):
+        """
+        Check the status of a library restore task.
+        """
+        # validate input
+        serializer = LibraryRestoreTaskRequestSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        task_id = serializer.validated_data.get('task_id')
+
+        # get task status and related artifact
+        task_status = get_object_or_404(UserTaskStatus, task_id=task_id, user=request.user)
+
+        # serialize and return result
+        result_serializer = LibraryRestoreTaskResultSerializer.from_task_status(task_status, request)
+        return Response(result_serializer.data)
 
 
 # LTI 1.3 Views

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -470,6 +470,10 @@ class RestoreSuccessDataSerializer(serializers.Serializer):
     title = serializers.CharField(source="lp_restored_data.title")
     org = serializers.CharField(source="lp_restored_data.archive_org_key")
     slug = serializers.CharField(source="lp_restored_data.archive_slug")
+
+    # The `key` is a unique temporary key assigned to the learning package during the restore process,
+    # whereas the `archive_key` is the original key of the learning package from the backup.
+    # The temporary learning package key is replaced with a standard key once it is added to a content library.
     key = serializers.CharField(source="lp_restored_data.key")
     archive_key = serializers.CharField(source="lp_restored_data.archive_lp_key")
 
@@ -485,6 +489,12 @@ class RestoreSuccessDataSerializer(serializers.Serializer):
     created_by = serializers.SerializerMethodField()
 
     def get_created_by(self, obj):
+        """
+        Get the user information of the archive creator, if available.
+
+        The information is stored in the backup metadata of the archive and references
+        a user that may not exist in the system where the restore is being performed.
+        """
         username = obj["backup_metadata"].get("created_by")
         email = obj["backup_metadata"].get("created_by_email")
         return {"username": username, "email": email}

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -8,7 +8,7 @@ import logging
 from django.core.validators import validate_unicode_slug
 from opaque_keys import InvalidKeyError, OpaqueKey
 from opaque_keys.edx.locator import LibraryContainerLocator, LibraryUsageLocatorV2
-from openedx_learning.api.authoring_models import Collection
+from openedx_learning.api.authoring_models import Collection, LearningPackage
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from user_tasks.models import UserTaskStatus
@@ -44,6 +44,7 @@ class ContentLibraryMetadataSerializer(serializers.Serializer):
     slug = serializers.CharField(source="key.slug", validators=(validate_unicode_slug, ))
     title = serializers.CharField()
     description = serializers.CharField(allow_blank=True)
+    learning_package = serializers.PrimaryKeyRelatedField(queryset=LearningPackage.objects.all(), required=False)
     num_blocks = serializers.IntegerField(read_only=True)
     last_published = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
     published_by = serializers.CharField(read_only=True)

--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -16,11 +16,17 @@ Architecture note:
 """
 from __future__ import annotations
 
+from io import StringIO
 import logging
 import os
 from datetime import datetime
-from tempfile import mkdtemp
+from tempfile import mkdtemp, NamedTemporaryFile
+import json
+import shutil
 
+from django.core.files.base import ContentFile
+from django.contrib.auth import get_user_model
+from django.core.serializers.json import DjangoJSONEncoder
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from celery_utils.logged_task import LoggedTask
@@ -66,11 +72,17 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.mixed import MixedModuleStore
 
+from cms.djangoapps.contentstore.storage import course_import_export_storage
+
 from . import api
 from .models import ContentLibraryBlockImportTask
 
 log = logging.getLogger(__name__)
 TASK_LOGGER = get_task_logger(__name__)
+
+User = get_user_model()
+
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'  # Should match serializer format. Redefined to avoid circular import.
 
 
 @shared_task(base=LoggedTask)
@@ -547,3 +559,121 @@ def backup_library(self, user_id: int, library_key_str: str) -> None:
         TASK_LOGGER.exception('Error exporting library %s', library_key, exc_info=True)
         if self.status.state != UserTaskStatus.FAILED:
             self.status.fail({'raw_error_msg': str(exception)})
+
+
+class LibraryRestoreLoadError(Exception):
+    def __init__(self, message, logfile=None):
+        super().__init__(message)
+        self.logfile = logfile
+
+
+class LibraryRestoreTask(UserTask):
+    """
+    Base class for library restore tasks.
+    """
+
+    ARTIFACT_NAMES = {
+        UserTaskStatus.FAILED: 'Error log',
+        UserTaskStatus.SUCCEEDED: 'Library Restore',
+    }
+
+    ERROR_LOG_ARTIFACT_NAME = 'Error log'
+
+    @classmethod
+    def generate_name(cls, arguments_dict):
+        storage_path = arguments_dict['storage_path']
+        return f'learning package restore of {storage_path}'
+
+    def fail_with_error_log(self, logfile) -> None:
+        """
+        Helper method to create an error log artifact and fail the task.
+
+        Args:
+            logfile (io.StringIO): The error log content
+        """
+        # Prepare the error log to be saved as a file
+        error_log_file = ContentFile(logfile.getvalue().encode("utf-8"))
+
+        # Save the error log as an artifact
+        artifact = UserTaskArtifact(status=self.status, name=self.ERROR_LOG_ARTIFACT_NAME)
+        artifact.file.save(name=f'{self.status.task_id}-error.log', content=error_log_file)
+        artifact.save()
+
+        self.status.fail(json.dumps({'error': 'Error(s) restoring learning package'}))
+
+    def load_learning_package(self, storage_path, user):
+        """
+        Load learning package from a backup file in storage.
+
+        Args:
+            storage_path (str): The path to the backup file in storage
+
+        Returns:
+            dict: The result of loading the learning package, including status and info
+        Raises:
+            LibraryRestoreLoadError: If there is an error loading the learning package
+        """
+        # First ensure the backup file exists
+        if not course_import_export_storage.exists(storage_path):
+            raise LibraryRestoreLoadError(f'Uploaded file {storage_path} not found')
+
+        # Temporarily copy the file locally, and then load the learning package from it
+        with NamedTemporaryFile(suffix=".zip") as tmp_file:
+            with course_import_export_storage.open(storage_path, "rb") as storage_file:
+                shutil.copyfileobj(storage_file, tmp_file)
+                tmp_file.flush()
+
+            TASK_LOGGER.info('Restoring learning package from temporary file %s', tmp_file.name)
+
+            result = authoring_api.load_learning_package(tmp_file.name, user=user)
+
+            # If there was an error during the load, fail the task with the error log
+            if result.get("status") == "error":
+                raise LibraryRestoreLoadError(
+                    "Error(s) loading learning package",
+                    logfile=result.get("log_file_error")
+                )
+
+            return result
+
+
+@shared_task(base=LibraryRestoreTask, bind=True)
+def restore_library(self, user_id, storage_path):
+    """
+    Restore a learning package from a backup file.
+    """
+    ensure_cms("restore_library may only be executed in a CMS context")
+    set_code_owner_attribute_from_module(__name__)
+
+    TASK_LOGGER.info('Starting restore of learning package from %s', storage_path)
+
+    try:
+        # Load the learning package from the backup file
+        user = User.objects.get(id=user_id)
+        result = self.load_learning_package(storage_path, user=user)
+        learning_package_data = result.get("lp_restored_data", {})
+
+        TASK_LOGGER.info(
+            'Restored learning package (id: %s) with key %s',
+            learning_package_data.get('id'),
+            learning_package_data.get('key')
+        )
+
+        # Save the restore details as an artifact in JSON format
+        restore_data = json.dumps(result, cls=DjangoJSONEncoder)
+
+        UserTaskArtifact.objects.create(
+            status=self.status,
+            name=self.ARTIFACT_NAMES[UserTaskStatus.SUCCEEDED],
+            text=restore_data
+        )
+        TASK_LOGGER.info('Finished restore of learning package from %s', storage_path)
+
+    except Exception as exc:  # pylint: disable=broad-except
+        TASK_LOGGER.exception('Error restoring learning package from %s', storage_path)
+        logfile = getattr(exc, 'logfile', StringIO("Unexpected error during library restore: " + str(exc)))
+        self.fail_with_error_log(logfile)
+    finally:
+        # Make sure to clean up the uploaded file from storage
+        course_import_export_storage.delete(storage_path)
+        TASK_LOGGER.info('Deleted uploaded file %s after restore', storage_path)

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -141,18 +141,21 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
 
     def _create_library(
         self, slug, title, description="", org=None,
-        license_type=ALL_RIGHTS_RESERVED, expect_response=200,
+        license_type=ALL_RIGHTS_RESERVED, expect_response=200, learning_package=None
     ):
         """ Create a library """
         if org is None:
             org = self.organization.short_name
-        return self._api('post', URL_LIB_CREATE, {
+        data = {
             "org": org,
             "slug": slug,
             "title": title,
             "description": description,
             "license": license_type,
-        }, expect_response)
+        }
+        if learning_package is not None:
+            data["learning_package"] = learning_package
+        return self._api('post', URL_LIB_CREATE, data, expect_response)
 
     def _list_libraries(self, query_params_dict=None, expect_response=200):
         """ List libraries """

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -34,6 +34,8 @@ URL_LIB_TEAM_GROUP = URL_LIB_TEAM + 'group/{group_name}/'  # Add/edit/remove a g
 URL_LIB_PASTE_CLIPBOARD = URL_LIB_DETAIL + 'paste_clipboard/'  # Paste user clipboard (POST) containing Xblock data
 URL_LIB_BACKUP = URL_LIB_DETAIL + 'backup/'  # Start a backup task for this library
 URL_LIB_BACKUP_GET = URL_LIB_BACKUP + '?{query_params}'  # Get status on a backup task for this library
+URL_LIB_RESTORE = URL_PREFIX + 'restore/'  # Restore a library from a learning package backup file
+URL_LIB_RESTORE_GET = URL_LIB_RESTORE + '?{query_params}'  # Get status/result of a library restore task
 URL_LIB_BLOCK = URL_PREFIX + 'blocks/{block_key}/'  # Get data about a block, or delete it
 URL_LIB_BLOCK_PUBLISH = URL_LIB_BLOCK + 'publish/'  # Publish changes from a specified XBlock
 URL_LIB_BLOCK_OLX = URL_LIB_BLOCK + 'olx/'  # Get or set the OLX of the specified XBlock
@@ -330,6 +332,21 @@ class ContentLibrariesRestApiTest(APITransactionTestCase):
         """ Get the status of a backup task for this library """
         query_params = urlencode({"task_id": task_id})
         url = URL_LIB_BACKUP_GET.format(lib_key=lib_key, query_params=query_params)
+        return self._api('get', url, None, expect_response)
+
+    def _start_library_restore_task(self, file, expect_response=200):
+        """ Start a library restore task from a backup file """
+        url = URL_LIB_RESTORE
+        data = {"file": file}
+        response = self.client.post(url, data, format='multipart')
+        assert response.status_code == expect_response, \
+            f'Unexpected response code {response.status_code}:\n{getattr(response, "data", "(no data)")}'
+        return response.data
+
+    def _get_library_restore_task(self, task_id, expect_response=200):
+        """ Get the status/result of a library restore task """
+        query_params = urlencode({"task_id": task_id})
+        url = URL_LIB_RESTORE_GET.format(query_params=query_params)
         return self._api('get', url, None, expect_response)
 
     def _render_block_view(self, block_key, view_name, version=None, expect_response=200):

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1046,18 +1046,28 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
         learning_package_id = task_result['learning_package_id']
         self.assertTrue(LearningPackage.objects.filter(pk=learning_package_id).exists())
 
+        library_title = "Restored Library"
+        library_description = "A library restored from a learning package"
+
         with self.as_user(self.admin_user):
             create_response_data = self._create_library(
                 org=self.org_short_name,
                 slug=self.library_slug,
-                title="Restored Library",
-                description="A library restored from a learning package",
+                title=library_title,
+                description=library_description,
                 learning_package=learning_package_id,
             )
 
         self.assertIn('id', create_response_data)
         library_locator = LibraryLocatorV2.from_string(create_response_data['id'])
-        self.assertIsNotNone(ContentLibrary.objects.get_by_key(library_locator))
+        content_library = ContentLibrary.objects.get_by_key(library_locator)
+
+        self.assertIsNotNone(content_library)
+        self.assertEqual(content_library.learning_package.id, learning_package_id)
+        self.assertEqual(content_library.learning_package.title, library_title)
+        self.assertEqual(content_library.learning_package.description, library_description)
+        self.assertIn(self.org_short_name, content_library.library_key.org)
+        self.assertIn(self.library_slug, content_library.library_key.slug)
 
     def test_restore_library_unauthorized(self):
         """

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('api/libraries/v2/', include([
         # list of libraries / create a library:
         path('', libraries.LibraryRootView.as_view()),
+        path('restore/', libraries.LibraryRestoreView.as_view()),
         path('<str:lib_key_str>/', include([
             # get data about a library, update a library, or delete a library:
             path('', libraries.LibraryDetailsView.as_view()),

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -61,7 +61,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.27.1
+openedx-learning==0.29.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -841,7 +841,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.7
     # via -r requirements/edx/kernel.in
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1393,7 +1393,7 @@ openedx-forum==0.3.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1015,7 +1015,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.7
     # via -r requirements/edx/base.txt
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1059,7 +1059,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.7
     # via -r requirements/edx/base.txt
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Adds a library restore endpoint to restore a learning package from a backup. The learning package can then be used to create a content library.

### POST /api/libraries/v2/restore/

Requires a `file` field, which must be a ZIP file.

A library restore task will be queued for execution, and a task id will be returned in the JSON response.

```json
{
    "task_id": "29cd29cb-a963-427b-8aaa-675c999832a1"
}
```

### GET /api/libraries/v2/restore/

Requires a `task_id` parameter to be provided. If given a valid `task_id` it will return the task status and data based on the result of the restore.

Success:
```json
{
    "state": "Succeeded",
    "result": {
        "learning_package_id": 1,
        "title": "Demo Learning Package",
        "org": "CL-TEST",
        "slug": "LIB_C001",
        "key": "lp-restore:Admin:CL-TEST:LIB_C001:1761076028573",
        "archive_key": "lib:CL-TEST:LIB_C001",
        "containers": 0,
        "components": 0,
        "collections": 0,
        "sections": 0,
        "subsections": 0,
        "units": 0,
        "created_on_server": "cms.test",
        "created_at": "2025-10-05T18:23:45.180Z",
        "created_by": {
            "username": "test_author",
            "email": "author@example.com"
        }
    },
    "error": null,
    "error_log": null
}

```

Failure:
```json
{
    "state": "Failed",
    "result": null,
    "error": "Library restore failed. See error log for details.",
    "error_log": "http://testserver/uploads/user_tasks/2025/10/21/2cff2a1c-7fa9-4097-b8ca-6b1b80126475-error.log"
}

```

Pending (All other non-final states, like "In-Progress", will have the same result - only state is provided)
```json
{
    "state": "Pending",
    "result": null,
    "error": null,
    "error_log": null
}
```

## Supporting information

Resolves https://github.com/openedx/openedx-learning/issues/388.

## Testing instructions

```sh
pytest -p no:randomly --ds cms.envs.test \
openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py::LibraryRestoreViewTestCase
```

## Deadline

Ulmo release