### PR TITLE
build: enable CI checks in merge queues / merge groups on GitHub

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -7,6 +7,7 @@ name: Consistent Python dependencies
 
 on:
   pull_request:
+  merge_group:
 
 defaults:
   run:

--- a/.github/workflows/check_python_dependencies.yml
+++ b/.github/workflows/check_python_dependencies.yml
@@ -2,6 +2,7 @@ name: Check Python Dependencies
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   check_dependencies:

--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -1,6 +1,8 @@
 name: Static analysis
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   tests:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,7 +3,8 @@
 name: Lint Commit Messages
 
 on:
-  - pull_request
+  pull_request:
+  merge_group:
 
 jobs:
   commitlint:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -2,6 +2,7 @@ name: Javascript tests
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -2,6 +2,7 @@ name: Lint Python Imports
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 jobs:
   version-check:

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -3,6 +3,7 @@ name: Check Django Migrations
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -2,6 +2,7 @@ name: Pylint Checks
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -2,6 +2,7 @@ name: Quality checks
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,6 +7,7 @@ name: Semgrep code quality
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,6 +7,7 @@ name: ShellCheck
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -2,6 +2,7 @@ name: static assets check for lms and cms
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,7 @@ name: unit-tests
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/units-test-scripts-structures-pruning.yml
+++ b/.github/workflows/units-test-scripts-structures-pruning.yml
@@ -2,6 +2,7 @@ name: units-test-scripts-common
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/units-test-scripts-user-retirement.yml
+++ b/.github/workflows/units-test-scripts-user-retirement.yml
@@ -2,6 +2,7 @@ name: units-test-scripts-user-retirement
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
 
 jobs:
   verify_dunder_init:


### PR DESCRIPTION
## Description

We want to turn on GitHub's [Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) feature so that PRs will be rebased and checked before merging. In other words, a merge queue should avoid the problem where a PR passes CI checks, is merged via GitHub's "squash and merge" feature, then causes CI checks on master to fail because of interactions with some other PRs that were merged in the interim.

This PR makes [the required change to our CI config](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions):

> If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. 
