### PR TITLE
Potential fix for code scanning alert no. 332: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,6 @@
 name: unit-tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/openedx/edx-platform/security/code-scanning/332](https://github.com/openedx/edx-platform/security/code-scanning/332)

To fix the issue, edit the `.github/workflows/unit-tests.yml` workflow and add a `permissions` block at the workflow root, directly beneath the `name` declaration, before the `on:` trigger. Set `permissions: contents: read`, which suffices for the jobs shown (running tests, downloading/uploading artifacts, checking out code). If any job needs write permissions for other scopes, you would add those at the job level. For now, the most robust fix is a single `permissions:` block at the workflow root level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
