### PR TITLE
fix: Video Xblock - position dropdown menus relative to control bar height

### DIFF
--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -485,7 +485,7 @@
     transition: none;
     position: absolute;
     display: none;
-    bottom: calc((var(--baseline, 20px) * 2));
+    bottom: 100%;
     right: 0;
     width: 120px;
     margin: 0;
@@ -598,7 +598,7 @@
     transition: none;
     display: none;
     position: absolute;
-    bottom: calc((var(--baseline, 20px) * 2));
+    bottom: 100%;
     right: 0;
     width: 41px;
     height: 120px;


### PR DESCRIPTION
### Summary

This PR fixes an issue in Video XBlock where dropdown menus (playback speed, captions, etc.) become unreachable when custom fonts or font sizes reduce the height of the video control bar.

Currently, menu positioning depends on bottom: calc(var(--baseline, 20px) * 2) (≈ 40 px).
When the control bar height is smaller (e.g. 36 px), a small gap appears between the control button and the dropdown.
As a result, the menu immediately closes when the user moves the mouse toward it.

https://github.com/user-attachments/assets/6a7be81b-6e0b-455b-ab7d-a55995849b6e

### Proposed Fix

Position the dropdown relative to its container rather than to a fixed baseline value

**After fix:**

https://github.com/user-attachments/assets/c600fc65-e195-4550-ba9e-caaba892a5b9

