### PR TITLE
feat: add user certificate to context in HTML view

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -560,6 +560,9 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
 
         context['certificate_data'] = active_configuration
 
+        # Append user certificate to context
+        context["user_certificate"] = user_certificate
+
         # Append/Override the existing view context values with any mode-specific ConfigurationModel values
         context.update(configuration.get(user_certificate.mode, {}))
 


### PR DESCRIPTION
## Description

This PR appends the user certificate to the context in the `render_html_view` function, enhancing the data available in the `CertificateRenderStarted` filter.

### Use Case

This change enables developers to access the user’s certificate instance (`GeneratedCertificate`) when handling the `CertificateRenderStarted` filter.

Previously, the context provided to this filter contained course and user information, but did not include the specific certificate object being rendered. As a result, custom plugins could not easily customize certificate rendering based on properties of the actual certificate (if it exists).

With this update, the `user_certificate` object is now appended to the `context`, allowing for more powerful and dynamic use cases such as:

- Adding conditional logic based on certificate attributes.
- Customizing certificate templates according to user or course metadata related to the certificate.

## Testing instructions

Using Tutor:

1. Create a mount of `edx-platform` using the changes in this PR.
2. Create a course and configure certificates.
3. Create a new `PipelineStep` in a custom plugin to use the `CertificateRenderStarted` filter.
4. Configure the `OPEN_EDX_FILTERS_CONFIG` using a Tutor plugin, e.g.:
    
    ```yml
    name: filter-settings
    version: 1.0.0
    patches:
      openedx-common-settings: |
        OPEN_EDX_FILTERS_CONFIG = {
          "org.openedx.learning.certificate.render.started.v1": {
              "fail_silently": False,
              "pipeline": [
                "path.to.your.pipeline.Class",
              ]
          },
        }
    ```
5. Print the new `user_certificate` key in the `context` dict in the `run_filter()` method:

    ```python
    >>> print(context['user_certificate'])
    >>> GeneratedCertificate object (1)
    ```

> [!NOTE]
> It was tested in the 3 different ways:
> 1. Preview certificate from Studio.
> 2. View my own certificate in LMS.
> 3. View certificates of other users using the certificate public link.  

## Deadline

None