### PR TITLE
chore: bump edxval to 3.1.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -553,7 +553,7 @@ edx-when==3.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-edxval==3.0.0
+edxval==3.1.0
     # via -r requirements/edx/kernel.in
 elasticsearch==7.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -855,7 +855,7 @@ edx-when==3.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-edxval==3.0.0
+edxval==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -639,7 +639,7 @@ edx-when==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==3.0.0
+edxval==3.1.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -662,7 +662,7 @@ edx-when==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==3.0.0
+edxval==3.1.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.9.1
     # via


### PR DESCRIPTION
## Description

Updates edx-val: https://github.com/openedx/edx-val/compare/v3.0.0...v3.1.0