### PR TITLE
Remove branding related code from video xblock.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -88,7 +88,6 @@ class TestVideoYouTube(TestVideo):  # lint-amnesty, pylint: disable=missing-clas
 
         expected_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': 'null',
             'block_id': str(self.block.location),
@@ -177,7 +176,6 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
 
         expected_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': 'null',
             'block_id': str(self.block.location),
@@ -454,7 +452,6 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         expected_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': 'null',
             'block_id': str(self.block.location),
@@ -587,7 +584,6 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         initial_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': 'null',
             'block_id': str(self.block.location),
@@ -726,7 +722,6 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         initial_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': 'null',
             'block_id': str(self.block.location),
@@ -914,7 +909,6 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         initial_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': 'null',
             'block_id': str(self.block.location),
@@ -971,20 +965,11 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         return context, expected_context
 
     # pylint: disable=invalid-name
-    @patch('xmodule.video_block.video_block.BrandingInfoConfig')
     @patch('xmodule.video_block.video_block.rewrite_video_url')
-    def test_get_html_cdn_source(self, mocked_get_video, mock_BrandingInfoConfig):
+    def test_get_html_cdn_source(self, mocked_get_video):
         """
         Test if sources got from CDN
         """
-
-        mock_BrandingInfoConfig.get_config.return_value = {
-            "CN": {
-                'url': 'http://www.xuetangx.com',
-                'logo_src': 'http://www.xuetangx.com/static/images/logo.png',
-                'logo_tag': 'Video hosted by XuetangX.com'
-            }
-        }
 
         def side_effect(*args, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
             cdn = {
@@ -1031,11 +1016,6 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         initial_context = {
             'autoadvance_enabled': False,
-            'branding_info': {
-                'logo_src': 'http://www.xuetangx.com/static/images/logo.png',
-                'logo_tag': 'Video hosted by XuetangX.com',
-                'url': 'http://www.xuetangx.com'
-            },
             'license': None,
             'bumper_metadata': 'null',
             'block_id': str(self.block.location),
@@ -1138,7 +1118,6 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         initial_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': 'null',
             'cdn_eval': False,
@@ -2380,7 +2359,6 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
 
         expected_context = {
             'autoadvance_enabled': False,
-            'branding_info': None,
             'license': None,
             'bumper_metadata': json.dumps(OrderedDict({
                 'saveStateUrl': self.block.ajax_url + '/save_user_state',
@@ -2480,7 +2458,6 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
 
         context = {
             'autoadvance_enabled': autoadvanceenabled_flag,
-            'branding_info': None,
             'block_id': str(self.block.location),
             'course_id': str(self.block.location.course_key),
             'license': None,

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -140,12 +140,6 @@ from openedx.core.djangolib.js_utils import (
                 <a class="btn-link" href="${handout}">${_('Download Handout')}</a>
             </div>
             % endif
-            % if branding_info:
-            <div class="branding">
-                <span class="host-tag">${branding_info['logo_tag']}</span>
-                <a href="${branding_info['url']}"><img class="brand-logo" src="${branding_info['logo_src']}" alt="${branding_info['logo_tag']}" /></a>
-            </div>
-            % endif
         </div>
         % endif
         % if transcript_feedback_enabled and video_id:

--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -78,7 +78,7 @@
 .xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section .wrapper-download-video,
 .xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section .wrapper-download-transcripts,
 .xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section .wrapper-handouts,
-.xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section .branding,
+.xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section ,
 .xmodule_display.xmodule_VideoBlock .video .wrapper-video-bottom-section .wrapper-transcript-feedback {
     margin-top: var(--baseline, 20px);
     padding-right: var(--baseline, 20px);
@@ -118,11 +118,11 @@
     padding-left: 4px;
 }
 
-.xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .branding {
+.xmodule_display.xmodule_VideoBlock .video .wrapper-downloads {
     padding-right: 0;
 }
 
-.xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .branding .host-tag {
+.xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .host-tag {
     position: absolute;
     left: -9999em;
     display: inline-block;
@@ -130,7 +130,7 @@
     color: var(--body-color, #313131);
 }
 
-.xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .branding .brand-logo {
+.xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .brand-logo {
     display: inline-block;
     max-width: 100%;
     max-height: calc((var(--baseline, 20px) * 2));

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -103,11 +103,6 @@ try:
 except ImportError:
     edxval_api = None
 
-try:
-    from lms.djangoapps.branding.models import BrandingInfoConfig
-except ImportError:
-    BrandingInfoConfig = None
-
 log = logging.getLogger(__name__)
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
@@ -294,7 +289,6 @@ class _BuiltInVideoBlock(
         sources = [source for source in self.html5_sources if source]
 
         download_video_link = None
-        branding_info = None
         youtube_streams = ""
         video_duration = None
         video_status = None
@@ -358,7 +352,6 @@ class _BuiltInVideoBlock(
         # Video caching is disabled for Studio. User_location is always None in Studio.
         # CountryMiddleware disabled for Studio.
         if getattr(self, 'video_speed_optimizations', True) and cdn_url:
-            branding_info = BrandingInfoConfig.get_config().get(user_location)
 
             if self.edx_video_id and edxval_api and video_status != 'external':
                 for index, source_url in enumerate(sources):
@@ -477,7 +470,6 @@ class _BuiltInVideoBlock(
 
         template_context = {
             'autoadvance_enabled': autoadvance_enabled,
-            'branding_info': branding_info,
             'bumper_metadata': json.dumps(self.bumper['metadata']),  # pylint: disable=E1101
             'cdn_eval': cdn_eval,
             'cdn_exp_group': cdn_exp_group,


### PR DESCRIPTION
## Description

In this PR, we are removing the branding-related code from video block since it’s no longer being used.
We have plan to remove the specialized VIDEO_CDN_URL in the next phase.
When we do that, nothing will reference the branding code so we're removing it first.

More Detail:
As part of simplification efforts under the ([Video XBlock extraction](https://github.com/orgs/openedx/projects/55/views/1?pane=issue&itemId=98706666&issue=openedx%7Cedx-platform%7C36282)
), we have adopted a strategy to gradually identify and remove small, unused portions of the Video Block code. This approach will help us create smaller, more focused PRs that are easier to review during the extraction phase.

Ticket: https://github.com/orgs/openedx/projects/55?pane=issue&itemId=133832922&issue=openedx%7Cpublic-engineering%7C425