### PR TITLE
fix: fixing the documentation article links

### DIFF
--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -2,39 +2,39 @@
 # NOTE: If any of these page settings change, their corresponding test must be updated
 #       in edx-platform/common/test/acceptance/tests/studio/test_studio.help.py
 [pages]
-default = course_author:index.html
-home = course_author:getting_started/CA_get_started_Studio.html
-develop_course = course_author:developing_course/index.html
-outline = course_author:developing_course/course_outline.html
-unit = course_author:developing_course/course_units.html
-visibility = course_author:developing_course/controlling_content_visibility.html
-updates = course_author:course_assets/handouts_updates.html
-pages = course_author:course_assets/pages.html
-files = course_author:course_assets/course_files.html
-textbooks = course_author:course_assets/textbooks.html
-schedule = course_author:set_up_course/studio_add_course_information/index.html
-grading = course_author:grading/index.html
-team_course = course_author:set_up_course/studio_add_course_information/studio_course_staffing.html
-team_library = course_author:course_components/libraries.html#give-other-users-access-to-your-library
-advanced = course_author:index.html
-checklist = course_author:set_up_course/index.html
-import_library = course_author:course_components/libraries.html#import-a-library
-import_course = course_author:releasing_course/export_import_course.html#import-a-course
-export_library = course_author:course_components/libraries.html#export-a-library
-export_course = course_author:releasing_course/export_import_course.html#export-a-course
-welcome = course_author:getting_started/index.html
-login = course_author:getting_started/index.html
-register = course_author:getting_started/index.html
-content_libraries = course_author:course_components/libraries.html
-content_groups = course_author:course_features/cohorts/cohorted_courseware.html
-enrollment_tracks = course_author:course_features/diff_content/enroll_track_courseware.html
-group_configurations = course_author:course_features/content_experiments/content_experiments_configure.html#set-up-group-configurations-in-edx-studio
-container = course_author:developing_course/course_components.html#components-that-contain-other-components
-video = course_author:video/index.html
-certificates = course_author:set_up_course/studio_add_course_information/studio_creating_certificates.html
-content_highlights = course_author:developing_course/course_sections.html#set-course-section-highlights
-image_accessibility = course_author:accessibility/best_practices_course_content_dev.html#use-best-practices-for-describing-images
-social_sharing = course_author:developing_course/social_sharing.html
+default = article:educators/quickstarts/build_a_course.html
+home = article:educators/concepts/open_edx_platform/what_is_studio.html
+develop_course = article:educators/how-tos/set_up_course/create_new_course.html
+outline = article:educators/concepts/open_edx_platform/about_course_outline.html
+unit = article:educators/concepts/open_edx_platform/about_course_units.html
+visibility = article:educators/references/controlling_content_visibility.html
+updates = article:educators/concepts/communication/about_course_updates_handouts.html
+pages = article:educators/how-tos/course_development/manage_custom_page.html
+files = article:educators/references/course_development/files_page.html
+textbooks = article:educators/how-tos/course_development/manage_textbooks.html
+schedule = article:educators/how-tos/set_up_course/set_course_schedule.html
+grading = article:educators/how-tos/grading/set_grade_range.html
+team_course = article:educators/references/course_development/course_team_roles.html
+team_library = article:educators/how-tos/course_development/add_users_to_libraries.html
+advanced = article:educators/quickstarts/build_a_course.html
+checklist = article:educators/concepts/releasing-course/course_launch_checklist.html
+import_library = article:educators/how-tos/course_development/export_import_library.html#import-a-legacy-library
+import_course = article:educators/how-tos/releasing-course/import_course.html
+export_library = article:educators/how-tos/course_development/export_import_library.html#export-a-legacy-library
+export_course = article:educators/how-tos/releasing-course/export_course.html
+welcome = article:educators/index.html
+login = article:educators/index.html
+register = article:educators/index.html
+content_libraries = article:educators/concepts/instructional_design/libraries.html
+content_groups = article:educators/concepts/advanced_features/about_content_groups.html
+enrollment_tracks = article:glossary.html#term-Enrollment-Track
+group_configurations = article:group_configurations = article:educators/concepts/advanced_features/about_content_groups.html
+container = article:educators/references/course_development/parent_child_components.html
+video = article:educators/references/course_development/guide_to_video.html
+certificates = article:educators/concepts/open_edx_platform/about_certificates.html
+content_highlights = article:educators/how-tos/course_development/manage_course_highlight_emails.html
+image_accessibility = article:educators/references/accessibility/accessibility_best_practices_checklist.html#use-best-practices-for-describing-images
+social_sharing = article:educators/how-tos/course_development/social_sharing.html
 
 # below are the language directory names for the different locales
 [locales]

--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -2,39 +2,39 @@
 # NOTE: If any of these page settings change, their corresponding test must be updated
 #       in edx-platform/common/test/acceptance/tests/studio/test_studio.help.py
 [pages]
-default = article:educators/quickstarts/build_a_course.html
-home = article:educators/concepts/open_edx_platform/what_is_studio.html
-develop_course = article:educators/how-tos/set_up_course/create_new_course.html
-outline = article:educators/concepts/open_edx_platform/about_course_outline.html
-unit = article:educators/concepts/open_edx_platform/about_course_units.html
-visibility = article:educators/references/controlling_content_visibility.html
-updates = article:educators/concepts/communication/about_course_updates_handouts.html
-pages = article:educators/how-tos/course_development/manage_custom_page.html
-files = article:educators/references/course_development/files_page.html
-textbooks = article:educators/how-tos/course_development/manage_textbooks.html
-schedule = article:educators/how-tos/set_up_course/set_course_schedule.html
-grading = article:educators/how-tos/grading/set_grade_range.html
-team_course = article:educators/references/course_development/course_team_roles.html
-team_library = article:educators/how-tos/course_development/add_users_to_libraries.html
-advanced = article:educators/quickstarts/build_a_course.html
-checklist = article:educators/concepts/releasing-course/course_launch_checklist.html
-import_library = article:educators/how-tos/course_development/export_import_library.html#import-a-legacy-library
-import_course = article:educators/how-tos/releasing-course/import_course.html
-export_library = article:educators/how-tos/course_development/export_import_library.html#export-a-legacy-library
-export_course = article:educators/how-tos/releasing-course/export_course.html
-welcome = article:educators/index.html
-login = article:educators/index.html
-register = article:educators/index.html
-content_libraries = article:educators/concepts/instructional_design/libraries.html
-content_groups = article:educators/concepts/advanced_features/about_content_groups.html
-enrollment_tracks = article:glossary.html#term-Enrollment-Track
-group_configurations = article:group_configurations = article:educators/concepts/advanced_features/about_content_groups.html
-container = article:educators/references/course_development/parent_child_components.html
-video = article:educators/references/course_development/guide_to_video.html
-certificates = article:educators/concepts/open_edx_platform/about_certificates.html
-content_highlights = article:educators/how-tos/course_development/manage_course_highlight_emails.html
-image_accessibility = article:educators/references/accessibility/accessibility_best_practices_checklist.html#use-best-practices-for-describing-images
-social_sharing = article:educators/how-tos/course_development/social_sharing.html
+default = course_author:quickstarts/build_a_course.html
+home = course_author:concepts/open_edx_platform/what_is_studio.html
+develop_course = course_author:how-tos/set_up_course/create_new_course.html
+outline = course_author:concepts/open_edx_platform/about_course_outline.html
+unit = course_author:concepts/open_edx_platform/about_course_units.html
+visibility = course_author:references/controlling_content_visibility.html
+updates = course_author:concepts/communication/about_course_updates_handouts.html
+pages = course_author:how-tos/course_development/manage_custom_page.html
+files = course_author:references/course_development/files_page.html
+textbooks = course_author:how-tos/course_development/manage_textbooks.html
+schedule = course_author:how-tos/set_up_course/set_course_schedule.html
+grading = course_author:how-tos/grading/set_grade_range.html
+team_course = course_author:references/course_development/course_team_roles.html
+team_library = course_author:how-tos/course_development/add_users_to_libraries.html
+advanced = course_author:quickstarts/build_a_course.html
+checklist = course_author:concepts/releasing-course/course_launch_checklist.html
+import_library = course_author:how-tos/course_development/export_import_library.html#import-a-legacy-library
+import_course = course_author:how-tos/releasing-course/import_course.html
+export_library = course_author:how-tos/course_development/export_import_library.html#export-a-legacy-library
+export_course = course_author:how-tos/releasing-course/export_course.html
+welcome = course_author:index.html
+login = course_author:index.html
+register = course_author:index.html
+content_libraries = course_author:concepts/instructional_design/libraries.html
+content_groups = course_author:concepts/advanced_features/about_content_groups.html
+enrollment_tracks = course_author:how-tos/student_management/manage_course_enrollments.html
+group_configurations = course_author:concepts/advanced_features/about_content_groups.html
+container = course_author:references/course_development/parent_child_components.html
+video = course_author:references/course_development/guide_to_video.html
+certificates = course_author:concepts/open_edx_platform/about_certificates.html
+content_highlights = course_author:how-tos/course_development/manage_course_highlight_emails.html
+image_accessibility = course_author:references/accessibility/accessibility_best_practices_checklist.html#use-best-practices-for-describing-images
+social_sharing = course_author:how-tos/course_development/social_sharing.html
 
 # below are the language directory names for the different locales
 [locales]

--- a/cms/envs/mock.yml
+++ b/cms/envs/mock.yml
@@ -482,7 +482,8 @@ GRADES_DOWNLOAD:
     querystring_expire: 300
   STORAGE_TYPE: ''
 HELP_TOKENS_BOOKS:
-  article: https://docs.openedx.org
+  course_author: https://docs.openedx.org/en/latest/educators
+  learner: https://docs.openedx.org/en/latest/learners
 HOTJAR_ID: 7890
 ICP_LICENSE: icp_license
 ICP_LICENSE_INFO:

--- a/cms/envs/mock.yml
+++ b/cms/envs/mock.yml
@@ -482,8 +482,7 @@ GRADES_DOWNLOAD:
     querystring_expire: 300
   STORAGE_TYPE: ''
 HELP_TOKENS_BOOKS:
-  course_author: https://edx.readthedocs.io/projects/edx-partner-course-staff
-  learner: https://edx.readthedocs.io/projects/edx-guide-for-students
+  article: https://docs.openedx.org
 HOTJAR_ID: 7890
 ICP_LICENSE: icp_license
 ICP_LICENSE_INFO:

--- a/lms/envs/help_tokens.ini
+++ b/lms/envs/help_tokens.ini
@@ -2,23 +2,23 @@
 # NOTE: If any of these page settings change, then their corresponding test should be updated
 #       in edx-platform/common/test/acceptance/tests/lms/test_lms_help.py
 [pages]
-default = learner:index.html
-instructor = course_author:CA_instructor_dash_help.html
-course = learner:index.html
-profile = learner:SFD_dashboard_profile_SectionHead.html#adding-profile-information
-dashboard = learner:SFD_dashboard_profile_SectionHead.html
-courseinfo = learner:SFD_start_course.html
-progress = learner:SFD_check_progress.html
-learneraccountsettings = learner:SFD_update_acct_settings.html
-learnerdashboard = learner:SFD_dashboard_profile_SectionHead.html
-programs = learner:SFD_enrolling.html
-bookmarks = learner:SFD_bookmarks.html
-notes = learner:SFD_notes.html
-wiki = learner:SFD_wiki.html
-discussions = learner:sfd_discussions/index.html
+default = article:learners/index.html
+instructor = article:educators/index.html
+course = article:learners/index.html
+profile = article:learners/concepts/open_edx_platform/what_is_profile_page.html
+dashboard = article:learners/concepts/open_edx_platform/what_is_course_dashboard.html
+courseinfo = article:learners/SFD_start_course.html
+progress = article:learners/SFD_check_progress.html
+learneraccountsettings = article:learners/how-tos/update_course_specific_settings.html
+learnerdashboard = article:learners/concepts/open_edx_platform/what_is_course_dashboard.html
+programs = article:learners/OpenSFD_enrolling.html
+bookmarks = article:learners/SFD_bookmarks.html
+notes = article:learners/SFD_notes.html
+wiki = article:learners/SFD_wiki.html
+discussions = article:learners/sfd_discussions/index.html
 
-cohortmanual = course_author:course_features/cohorts/cohort_config.html#assign-learners-to-cohorts-manually
-cohortautomatic = course_author:course_features/cohorts/cohorts_overview.html#all-automated-assignment
+cohortmanual = article:educators/references/advanced_features/managing_cohort_assignment.html#implementing-a-manual-assignment-strategy
+cohortautomatic = article:educators/references/advanced_features/managing_cohort_assignment.html#implementing-an-automated-assignment-strategy
 
 # below are the language directory names for the different locales
 [locales]

--- a/lms/envs/help_tokens.ini
+++ b/lms/envs/help_tokens.ini
@@ -2,23 +2,23 @@
 # NOTE: If any of these page settings change, then their corresponding test should be updated
 #       in edx-platform/common/test/acceptance/tests/lms/test_lms_help.py
 [pages]
-default = article:learners/index.html
-instructor = article:educators/index.html
-course = article:learners/index.html
-profile = article:learners/concepts/open_edx_platform/what_is_profile_page.html
-dashboard = article:learners/concepts/open_edx_platform/what_is_course_dashboard.html
-courseinfo = article:learners/SFD_start_course.html
-progress = article:learners/SFD_check_progress.html
-learneraccountsettings = article:learners/how-tos/update_course_specific_settings.html
-learnerdashboard = article:learners/concepts/open_edx_platform/what_is_course_dashboard.html
-programs = article:learners/OpenSFD_enrolling.html
-bookmarks = article:learners/SFD_bookmarks.html
-notes = article:learners/SFD_notes.html
-wiki = article:learners/SFD_wiki.html
-discussions = article:learners/sfd_discussions/index.html
+default = learner:index.html
+instructor = course_author:index.html
+course = learner:index.html
+profile = learner:concepts/open_edx_platform/what_is_profile_page.html
+dashboard = learner:concepts/open_edx_platform/what_is_course_dashboard.html
+courseinfo = learner:SFD_start_course.html
+progress = learner:SFD_check_progress.html
+learneraccountsettings = learner:how-tos/update_course_specific_settings.html
+learnerdashboard = learner:concepts/open_edx_platform/what_is_course_dashboard.html
+programs = learner:OpenSFD_enrolling.html
+bookmarks = learner:SFD_bookmarks.html
+notes = learner:SFD_notes.html
+wiki = learner:SFD_wiki.html
+discussions = learner:sfd_discussions/index.html
 
-cohortmanual = article:educators/references/advanced_features/managing_cohort_assignment.html#implementing-a-manual-assignment-strategy
-cohortautomatic = article:educators/references/advanced_features/managing_cohort_assignment.html#implementing-an-automated-assignment-strategy
+cohortmanual = course_author:references/advanced_features/managing_cohort_assignment.html#implementing-a-manual-assignment-strategy
+cohortautomatic = course_author:references/advanced_features/managing_cohort_assignment.html#implementing-an-automated-assignment-strategy
 
 # below are the language directory names for the different locales
 [locales]

--- a/lms/envs/mock.yml
+++ b/lms/envs/mock.yml
@@ -688,8 +688,7 @@ GRADES_DOWNLOAD:
     querystring_expire: 300
   STORAGE_TYPE: ''
 HELP_TOKENS_BOOKS:
-  course_author: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
-  learner: http://edx.readthedocs.io/projects/open-edx-learner-guide
+  article: https://docs.openedx.org
 HIBP_LOGIN_BLOCK_PASSWORD_FREQUENCY_THRESHOLD: 5
 HOME_MICROFRONTEND_URL: hello
 HOTJAR_SITE_ID: 12345

--- a/lms/envs/mock.yml
+++ b/lms/envs/mock.yml
@@ -688,7 +688,8 @@ GRADES_DOWNLOAD:
     querystring_expire: 300
   STORAGE_TYPE: ''
 HELP_TOKENS_BOOKS:
-  article: https://docs.openedx.org
+  course_author: https://docs.openedx.org/en/latest/educators
+  learner: https://docs.openedx.org/en/latest/learners
 HIBP_LOGIN_BLOCK_PASSWORD_FREQUENCY_THRESHOLD: 5
 HOME_MICROFRONTEND_URL: hello
 HOTJAR_SITE_ID: 12345

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2078,8 +2078,7 @@ HELP_TOKENS_LANGUAGE_CODE = Derived(lambda settings: settings.LANGUAGE_CODE)
 HELP_TOKENS_VERSION = Derived(lambda settings: doc_version())
 
 HELP_TOKENS_BOOKS = {
-    'learner': 'https://edx.readthedocs.io/projects/open-edx-learner-guide',
-    'course_author': 'https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course',
+    'article': 'https://docs.openedx.org',
 }
 
 ################################ Retirement ################################

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2078,7 +2078,8 @@ HELP_TOKENS_LANGUAGE_CODE = Derived(lambda settings: settings.LANGUAGE_CODE)
 HELP_TOKENS_VERSION = Derived(lambda settings: doc_version())
 
 HELP_TOKENS_BOOKS = {
-    'article': 'https://docs.openedx.org',
+    'learner': 'https://docs.openedx.org/en/latest/learners',
+    'course_author': 'https://docs.openedx.org/en/latest/educators',
 }
 
 ################################ Retirement ################################


### PR DESCRIPTION
# Description

Upon reviewing the documentation article links displayed in _edx-platform_ as a resource for users, it was evident that the links were pointing to the old documentation: https://edx.readthedocs.io

Many of these links no longer work today, and attempting to access them results in errors. An example of this can be found on the Studio homepage, in the link highlighted in the image below:

<img width="1847" height="855" alt="Screenshot From 2025-10-16 13-21-32" src="https://github.com/user-attachments/assets/78e03dbe-065a-422e-a859-2dd4b96574af" />

As part of the process, I created the following document: **[Procedure for Resolving Broken Links](https://docs.google.com/spreadsheets/d/10l-beCT2eSNsaWpzZmILyU9RKkHU_YxA3aUuabeA_lY/edit?gid=0#gid=0)**, which contains the current documentation links (old documentation) and the proposed current documentation links in this PR.

I believe it would be important to use this PR for a discussion regarding the proposed links so that we can select the best options.

