### PR TITLE
fix: Don't look for a custom Python ZIP in Content Libs V2

### DIFF
--- a/common/djangoapps/util/tests/test_sandboxing.py
+++ b/common/djangoapps/util/tests/test_sandboxing.py
@@ -7,7 +7,7 @@ import ddt
 from django.test import TestCase
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locator import CourseLocator, LibraryLocator
+from opaque_keys.edx.locator import CourseLocator, LibraryLocator, LibraryLocatorV2
 
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.tests.django_utils import upload_file_to_course
@@ -111,6 +111,23 @@ class SandboxServiceTest(TestCase):
     @override_settings(PYTHON_LIB_FILENAME=PYTHON_LIB_FILENAME)
     def test_get_python_lib_zip(self):
         assert self.sandbox_service.get_python_lib_zip() == self.zipfile
+
+    def test_no_python_lib_zip(self):
+        assert self.sandbox_service.get_python_lib_zip() is None
+
+
+class SandboxServiceForLibrariesV2Test(TestCase):
+    """
+    Test SandboxService methods for V2 Content Libraries.
+
+    (Lacks tests for anything other than python_lib_zip)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        library_key = LibraryLocatorV2('test', 'sandbox_test')
+        cls.sandbox_service = SandboxService(course_id=library_key, contentstore=contentstore)
 
     def test_no_python_lib_zip(self):
         assert self.sandbox_service.get_python_lib_zip() is None

--- a/xmodule/util/sandboxing.py
+++ b/xmodule/util/sandboxing.py
@@ -3,6 +3,7 @@
 import re
 
 from django.conf import settings
+from opaque_keys.edx.keys import CourseKey, LearningContextKey
 
 DEFAULT_PYTHON_LIB_FILENAME = 'python_lib.zip'
 
@@ -39,10 +40,14 @@ def can_execute_unsafe_code(course_id):
     return False
 
 
-def get_python_lib_zip(contentstore, course_id):
+def get_python_lib_zip(contentstore, context_key: LearningContextKey):
     """Return the bytes of the course code library file, if it exists."""
+    if not isinstance(context_key, CourseKey):
+        # Although Content Libraries V2 does support python-evaluated capa problems,
+        # it doesn't yet support supplementary python zip files.
+        return None
     python_lib_filename = course_code_library_asset_name()
-    asset_key = course_id.make_asset_key("asset", python_lib_filename)
+    asset_key = context_key.make_asset_key("asset", python_lib_filename)
     zip_lib = contentstore().find(asset_key, throw_on_not_found=False)
     if zip_lib is not None:
         return zip_lib.data


### PR DESCRIPTION
## Description

Python-evaluated problems were failing to render because they were trying to invoke `course_id.make_asset_key` in order to obtain the asset key of the custom Python ZIP file. Learning Core assets work differently (no asset keys, etc.), and, furthermore, we haven't really thought though how and whether we want to support custom Python ZIPs in libraries.

So, this fix punts on supporting Python ZIP files in libraries for now, but enables rendering of advanced CAPA problems which don't rely on a ZIP. This brings us to parity with Legacy Libraries, which didn't support assets at all and thus didn't support Python ZIPs either.

Fixes:
* https://github.com/openedx/edx-platform/issues/37447


## Supporting information

### Python-eval'd problem in the lib sidebar preview

<img width="335" height="390" alt="Screenshot 2025-10-17 at 4 34 09 PM" src="https://github.com/user-attachments/assets/c70039df-5c0b-4cf5-b112-75ad0531e55a" />

### That same problem, linked into a course

<img width="897" height="510" alt="Screenshot 2025-10-17 at 4 42 46 PM" src="https://github.com/user-attachments/assets/4c18fe42-ea7a-45f9-88b0-b4bba57d8a1c" />

## Testing instructions

In the definition of `safe_exec`, add the line `unsafely = True`. This will allow you to render advanced python problems without codejail. (Obviously, this now allows LMS/CMS to run arbitrary course-authored Python on your computer, so remove this when you're done.)

Then, go to the Demo Course, find the unit "Python-Evaluated Input". Copy "Simple Python-Evaluated Input Problem
", and paste it into a V2 library.

Confirm that the pasted library component can be previewed and edited. Confirm that you can submit a correct answer and an incorrect answer and that it evals correctly.

Publish the component and then use it in a course. Publish the course and view the component in the LMS. Confirm that you can submit a correct answer and an incorrect answer and that it evals correctly.

### NOT TESTED: Codejail

I did not actually test this with Codejail running, as I couldn't get it set up on my machine in the time I had today. My thinking is that this PR, at worst, will break nothing, so we should be OK to merge and then test with Codejail on the sandbox.

Reviwers, if this is an issue, let me know and I can try to get local Codejail working next week.

## Deadline

ASAP for Ulmo.

