### PR TITLE
chore: bump learning-core version to 0.29.0

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1201,6 +1201,7 @@ INSTALLED_APPS = [
     "openedx_learning.apps.authoring.units",
     "openedx_learning.apps.authoring.subsections",
     "openedx_learning.apps.authoring.sections",
+    "openedx_learning.apps.authoring.backup_restore",
 ]
 
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -61,7 +61,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.27.1
+openedx-learning==0.29.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -842,7 +842,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.6
     # via -r requirements/edx/kernel.in
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1395,7 +1395,7 @@ openedx-forum==0.3.6
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1016,7 +1016,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.6
     # via -r requirements/edx/base.txt
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1061,7 +1061,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.6
     # via -r requirements/edx/base.txt
-openedx-learning==0.27.1
+openedx-learning==0.29.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

These changes include bumping the **Learning Core** version to **0.29.0** and updating the configuration required to install the **backup_restore** application from it.

## Deadline

**October 23rd**