### PR TITLE
feat: make LEARNING_MICROFRONTEND_URL site aware.

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -68,7 +68,8 @@ def send_course_enrollment_email(
             "LMS_ROOT_URL", settings.LMS_ROOT_URL
         ),
         "learning_base_url": configuration_helpers.get_value(
-            "LEARNING_MICROFRONTEND_URL", settings.LEARNING_MICROFRONTEND_URL
+            "LEARNING_MICROFRONTEND_URL",
+            settings.LEARNING_MICROFRONTEND_URL,
         ),
         "track_mode": track_mode
     }

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -73,11 +73,11 @@ def send_ace_message(goal, session_id):
     message_context = get_base_template_context(site)
 
     course_home_url = get_learning_mfe_home_url(course_key=goal.course_key, url_fragment='home')
-
-    goals_unsubscribe_url = (
-        f'{configuration_helpers.get_value("LEARNING_MICROFRONTEND_URL", settings.LEARNING_MICROFRONTEND_URL)}'
-        f'/goal-unsubscribe/{goal.unsubscribe_token}'
+    learning_microfrontend_url = configuration_helpers.get_value(
+        'LEARNING_MICROFRONTEND_URL',
+        settings.LEARNING_MICROFRONTEND_URL,
     )
+    goals_unsubscribe_url = f'{learning_microfrontend_url}/goal-unsubscribe/{goal.unsubscribe_token}'
     language = get_user_preference(user, LANGUAGE_KEY)
 
     # Code to allow displaying different banner images for different languages

--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -74,8 +74,10 @@ def send_ace_message(goal, session_id):
 
     course_home_url = get_learning_mfe_home_url(course_key=goal.course_key, url_fragment='home')
 
-    goals_unsubscribe_url = f'{settings.LEARNING_MICROFRONTEND_URL}/goal-unsubscribe/{goal.unsubscribe_token}'
-
+    goals_unsubscribe_url = (
+        f'{configuration_helpers.get_value("LEARNING_MICROFRONTEND_URL", settings.LEARNING_MICROFRONTEND_URL)}'
+        f'/goal-unsubscribe/{goal.unsubscribe_token}'
+    )
     language = get_user_preference(user, LANGUAGE_KEY)
 
     # Code to allow displaying different banner images for different languages

--- a/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
@@ -12,6 +12,7 @@ import ddt
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
+from django.test.utils import override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag
 from freezegun import freeze_time
 from waffle import get_waffle_flag_model  # pylint: disable=invalid-django-waffle-import

--- a/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
@@ -238,12 +238,12 @@ class TestGoalReminderEmailCommand(TestCase):
     def test_goals_unsubscribe_url_uses_site_config(self):
         """Test goals unsubscribe URL uses site-configured MFE base."""
         goal = self.make_valid_goal()
-        with mock.patch('lms.djangoapps.course_goals.management.commands.goal_reminder_email.ace.send') as mock_ace, \
-             mock.patch(
+        with mock.patch('lms.djangoapps.course_goals.management.commands.goal_reminder_email.ace.send') as mock_ace:
+            with mock.patch(
                 'lms.djangoapps.course_goals.management.commands.goal_reminder_email.configuration_helpers.get_value',
                 return_value='https://learning.siteconf',
             ) as mock_get_value:
-            assert send_ace_message(goal, str(uuid.uuid4())) is True
+                assert send_ace_message(goal, str(uuid.uuid4())) is True
 
         assert mock_ace.call_count == 1
         msg = mock_ace.call_args[0][0]
@@ -259,12 +259,15 @@ class TestGoalReminderEmailCommand(TestCase):
         with override_settings(LEARNING_MICROFRONTEND_URL=default_url):
             with mock.patch(
                 'lms.djangoapps.course_goals.management.commands.goal_reminder_email.ace.send',
-            ) as mock_ace, \
-            mock.patch(
-                'lms.djangoapps.course_goals.management.commands.goal_reminder_email.configuration_helpers.get_value',
-                side_effect=lambda k, d: d,
-            ) as mock_get_value:
-                assert send_ace_message(goal, str(uuid.uuid4())) is True
+            ) as mock_ace:
+                with mock.patch(
+                    (
+                        'lms.djangoapps.course_goals.management.commands.'
+                        'goal_reminder_email.configuration_helpers.get_value'
+                    ),
+                    side_effect=lambda k, d: d,
+                ) as mock_get_value:
+                    assert send_ace_message(goal, str(uuid.uuid4())) is True
 
         assert mock_ace.call_count == 1
         msg = mock_ace.call_args[0][0]

--- a/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
@@ -235,6 +235,42 @@ class TestGoalReminderEmailCommand(TestCase):
         send_ace_message(goal, str(uuid.uuid4()))
         assert mock_ace.called is value
 
+    def test_goals_unsubscribe_url_uses_site_config(self):
+        """Test goals unsubscribe URL uses site-configured MFE base."""
+        goal = self.make_valid_goal()
+        with mock.patch('lms.djangoapps.course_goals.management.commands.goal_reminder_email.ace.send') as mock_ace, \
+             mock.patch(
+                'lms.djangoapps.course_goals.management.commands.goal_reminder_email.configuration_helpers.get_value',
+                return_value='https://learning.siteconf',
+            ) as mock_get_value:
+            assert send_ace_message(goal, str(uuid.uuid4())) is True
+
+        assert mock_ace.call_count == 1
+        msg = mock_ace.call_args[0][0]
+        assert msg.context[
+            'goals_unsubscribe_url'
+        ] == f'https://learning.siteconf/goal-unsubscribe/{goal.unsubscribe_token}'
+        mock_get_value.assert_any_call('LEARNING_MICROFRONTEND_URL', settings.LEARNING_MICROFRONTEND_URL)
+
+    def test_goals_unsubscribe_url_falls_back_to_settings(self):
+        """Test goals unsubscribe URL falls back to settings when site config is absent."""
+        default_url = 'https://learning.default'
+        goal = self.make_valid_goal()
+        with override_settings(LEARNING_MICROFRONTEND_URL=default_url):
+            with mock.patch(
+                'lms.djangoapps.course_goals.management.commands.goal_reminder_email.ace.send',
+            ) as mock_ace, \
+            mock.patch(
+                'lms.djangoapps.course_goals.management.commands.goal_reminder_email.configuration_helpers.get_value',
+                side_effect=lambda k, d: d,
+            ) as mock_get_value:
+                assert send_ace_message(goal, str(uuid.uuid4())) is True
+
+        assert mock_ace.call_count == 1
+        msg = mock_ace.call_args[0][0]
+        assert msg.context['goals_unsubscribe_url'] == f'{default_url}/goal-unsubscribe/{goal.unsubscribe_token}'
+        mock_get_value.assert_any_call('LEARNING_MICROFRONTEND_URL', default_url)
+
 
 class TestGoalReminderEmailSES(TestCase):
     """

--- a/openedx/core/djangoapps/enrollments/enrollments_notifications.py
+++ b/openedx/core/djangoapps/enrollments/enrollments_notifications.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 from openedx_events.learning.data import UserNotificationData
 from openedx_events.learning.signals import USER_NOTIFICATION_REQUESTED
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 class EnrollmentNotificationSender:
@@ -21,6 +22,10 @@ class EnrollmentNotificationSender:
         """
         Send audit access expiring soon notification to user
         """
+        learning_microfrontend_url = configuration_helpers.get_value(
+            'LEARNING_MICROFRONTEND_URL',
+            settings.LEARNING_MICROFRONTEND_URL,
+        )
 
         notification_data = UserNotificationData(
             user_ids=[int(self.user_id)],
@@ -29,7 +34,7 @@ class EnrollmentNotificationSender:
                 'audit_access_expiry': self.audit_access_expiry,
             },
             notification_type='audit_access_expiring_soon',
-            content_url=f"{settings.LEARNING_MICROFRONTEND_URL}/course/{str(self.course.id)}/home",
+            content_url=f"{learning_microfrontend_url}/course/{str(self.course.id)}/home",
             app_name="enrollments",
             course_key=self.course.id,
         )

--- a/openedx/core/djangoapps/enrollments/tests/test_enrollments_notifications.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_enrollments_notifications.py
@@ -5,11 +5,14 @@ import unittest
 import datetime
 from unittest.mock import MagicMock, patch
 
-from django.conf import settings
+from django.test.utils import override_settings
 import pytest
 
 from openedx.core.djangoapps.enrollments.enrollments_notifications import EnrollmentNotificationSender
 from openedx_events.learning.data import UserNotificationData
+
+DEFAULT_MFE_URL = "https://learning.default"
+SITE_CONF_MFE_URL = "https://learning.siteconf"
 
 
 @pytest.mark.django_db
@@ -26,14 +29,20 @@ class TestEnrollmentsNotificationSender(unittest.TestCase):
         self.user_id = '123'
         self.notification_sender = EnrollmentNotificationSender(self.course, self.user_id, self.expiry_date)
 
+    @override_settings(LEARNING_MICROFRONTEND_URL=DEFAULT_MFE_URL)
+    @patch(
+        'openedx.core.djangoapps.enrollments.enrollments_notifications.configuration_helpers.get_value',
+        return_value=SITE_CONF_MFE_URL,
+    )
     @patch('openedx.core.djangoapps.enrollments.enrollments_notifications.USER_NOTIFICATION_REQUESTED.send_event')
-    def test_send_audit_access_expiring_soon_notification(self, mock_send_notification):
+    def test_send_audit_access_expiring_soon_notification(self, mock_send_notification, mock_get_value):
         """
         Test that audit access expiring soon notification event is sent with correct parameters.
         """
 
         self.notification_sender.send_audit_access_expiring_soon_notification()
 
+        mock_get_value.assert_called_once_with('LEARNING_MICROFRONTEND_URL', DEFAULT_MFE_URL)
         mock_send_notification.assert_called_once()
         notification_data = UserNotificationData(
             user_ids=[int(self.user_id)],
@@ -42,8 +51,39 @@ class TestEnrollmentsNotificationSender(unittest.TestCase):
                 'audit_access_expiry': self.expiry_date,
             },
             notification_type='audit_access_expiring_soon',
-            content_url=f"{settings.LEARNING_MICROFRONTEND_URL}/course/{str(self.course.id)}/home",
+            content_url=f"{SITE_CONF_MFE_URL}/course/{str(self.course.id)}/home",
             app_name="enrollments",
             course_key=self.course.id,
         )
         mock_send_notification.assert_called_with(notification_data=notification_data)
+
+    @override_settings(LEARNING_MICROFRONTEND_URL=DEFAULT_MFE_URL)
+    @patch(
+        'openedx.core.djangoapps.enrollments.enrollments_notifications.configuration_helpers.get_value',
+        side_effect=lambda key, default: default,
+    )
+    @patch('openedx.core.djangoapps.enrollments.enrollments_notifications.USER_NOTIFICATION_REQUESTED.send_event')
+    def test_send_audit_access_expiring_soon_notification_falls_back_to_settings(
+        self,
+        mock_send_event,
+        mock_get_value
+    ):
+        """
+        Test mocks missing site-config value and verifies default URL and get_value args.
+        """
+        self.notification_sender.send_audit_access_expiring_soon_notification()
+
+        mock_get_value.assert_called_once_with('LEARNING_MICROFRONTEND_URL', DEFAULT_MFE_URL)
+
+        expected_notification = UserNotificationData(
+            user_ids=[int(self.user_id)],
+            context={
+                'course': self.course.name,
+                'audit_access_expiry': self.expiry_date,
+            },
+            notification_type='audit_access_expiring_soon',
+            content_url=f"{DEFAULT_MFE_URL}/course/{str(self.course.id)}/home",
+            app_name="enrollments",
+            course_key=self.course.id,
+        )
+        mock_send_event.assert_called_once_with(notification_data=expected_notification)

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -22,6 +22,7 @@ from openedx.core.djangoapps.notifications.email_notifications import EmailCaden
 from openedx.core.djangoapps.notifications.events import notification_preference_unsubscribe_event
 from openedx.core.djangoapps.notifications.models import NotificationPreference
 from openedx.core.djangoapps.user_api.models import UserPreference
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.modulestore.django import modulestore
 
 from .notification_icons import NotificationTypeIcons
@@ -71,7 +72,12 @@ def get_unsubscribe_link(username):
     Returns unsubscribe url for username with patch preferences
     """
     encrypted_username = encrypt_string(username)
-    return f"{settings.LEARNING_MICROFRONTEND_URL}/preferences-unsubscribe/{encrypted_username}/"
+    learning_microfrontend_url = configuration_helpers.get_value(
+        'LEARNING_MICROFRONTEND_URL',
+        settings.LEARNING_MICROFRONTEND_URL,
+    )
+
+    return f'{learning_microfrontend_url}/preferences-unsubscribe/{encrypted_username}/'
 
 
 def create_email_template_context(username):

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -22,19 +22,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 User = get_user_model()
 
 
-def _learning_mfe_base_url() -> str:
-    """
-    Return the site-aware base URL for the Learning MFE.
-
-    Reads `LEARNING_MICROFRONTEND_URL` from Site Configuration when available;
-    otherwise falls back to `settings.LEARNING_MICROFRONTEND_URL`.
-    """
-    return configuration_helpers.get_value(
-        'LEARNING_MICROFRONTEND_URL',
-        settings.LEARNING_MICROFRONTEND_URL,
-    )
-
-
 def get_courseware_url(
         usage_key: UsageKey,
         request: Optional[HttpRequest] = None,
@@ -139,7 +126,11 @@ def make_learning_mfe_courseware_url(
     strings. They're only ever used to concatenate a URL string.
     `params` is an optional QueryDict object (e.g. request.GET)
     """
-    mfe_link = f'{_learning_mfe_base_url()}/course/{course_key}'
+    learning_microfrontend_url = configuration_helpers.get_value(
+        'LEARNING_MICROFRONTEND_URL',
+        settings.LEARNING_MICROFRONTEND_URL,
+    )
+    mfe_link = f'{learning_microfrontend_url}/course/{course_key}'
     get_params = params.copy() if params else None
 
     if preview:
@@ -149,7 +140,7 @@ def make_learning_mfe_courseware_url(
             get_params = None
 
         if (unit_key or sequence_key):
-            mfe_link = f'{_learning_mfe_base_url()}/preview/course/{course_key}'
+            mfe_link = f'{learning_microfrontend_url}/preview/course/{course_key}'
 
     if sequence_key:
         mfe_link += f'/{sequence_key}'
@@ -179,7 +170,11 @@ def get_learning_mfe_home_url(
     `url_fragment` is an optional string.
     `params` is an optional QueryDict object (e.g. request.GET)
     """
-    mfe_link = f'{_learning_mfe_base_url()}/course/{course_key}'
+    learning_microfrontend_url = configuration_helpers.get_value(
+        'LEARNING_MICROFRONTEND_URL',
+        settings.LEARNING_MICROFRONTEND_URL,
+    )
+    mfe_link = f'{learning_microfrontend_url}/course/{course_key}'
 
     if url_fragment:
         mfe_link += f'/{url_fragment}'
@@ -194,7 +189,10 @@ def is_request_from_learning_mfe(request: HttpRequest):
     """
     Returns whether the given request was made by the frontend-app-learning MFE.
     """
-    url_str = _learning_mfe_base_url()
+    url_str = configuration_helpers.get_value(
+        'LEARNING_MICROFRONTEND_URL',
+        settings.LEARNING_MICROFRONTEND_URL,
+    )
     if not url_str:
         return False
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR updates multiple code paths to source the Learning MFE base URL via Site Configuration instead of reading directly from Django settings. Concretely, usages of settings.LEARNING_MICROFRONTEND_URL are replaced with:

`configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL', settings.LEARNING_MICROFRONTEND_URL)`

This allows Operators to override the Learning MFE base URL per Site (multi‑tenant / stage) without code changes or deploy‑time env tweaks. The change also adds targeted unit tests that lock down the behavior for both the override and fallback paths.

### Impacted areas
- Email tasks / notifications
- common.djangoapps.student.tasks.send_course_enrollment_email: learning_base_url (and existing lms_base_url) now pulled via configuration_helpers.
- openedx.core.djangoapps.enrollments.enrollments_notifications.EnrollmentNotificationSender.send_audit_access_expiring_soon_notification: content_url now uses the config-derived MFE URL.
- openedx.core.djangoapps.notifications.email.utils.get_unsubscribe_link: unsubscribe URL uses the config-derived MFE URL.
- lms.djangoapps.course_goals.management.commands.goal_reminder_email.send_ace_message:
- goals_unsubscribe_url now uses the config-derived MFE URL.
- platform_name now also uses configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME).
- Learning URL helpers
- openedx.features.course_experience.url_helpers: introduces a module‑level
LEARNING_MICROFRONTEND_URL = configuration_helpers.get_value(...) used by:
- make_learning_mfe_courseware_url
- get_learning_mfe_home_url
- is_request_from_learning_mfe

### Secondary improvement (enrollment email task analytics)
- Emits a Segment event edx.course.enrollment.email.missingdata when course run or course dates are unavailable, to help Operators monitor data quality.

#### User roles impacted
- Learners: links in emails and course navigation consistently point at the correct MFE host for their Site.
- Operators: can override the MFE base URL per Site via Site Configuration (no code changes).
- Developers: consistent pattern for reading the MFE base URL.

**If not set in Site Configuration, the code falls back to the Django setting.**

## Supporting information

- No migrations; no operator action required for default deployments.

## Testing instructions

### Automated tests

Run the updated/added tests:

```
# from repo root (LMS)
pytest -q \
  common/djangoapps/student/tests/test_tasks.py \
  openedx/core/djangoapps/enrollments/tests/test_enrollments_notifications.py \
  openedx/core/djangoapps/notifications/email/tests/test_utils.py \
  lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py \
  openedx/features/course_experience/tests/test_url_helpers.py
```

These assert that:
- configuration_helpers.get_value is consulted with the exact key LEARNING_MICROFRONTEND_URL (and PLATFORM_NAME where applicable).
- When an override is present, URLs in payloads/contexts use the override.
- When no override is present, behavior falls back to settings.LEARNING_MICROFRONTEND_URL.
- Enrollment email task continues to send and (on missing data) emits the Segment event.

#### Manual validation (optional)
**1.** Set a Site Configuration override for LEARNING_MICROFRONTEND_URL (e.g., https://mfe.override.local).
**2.** In a Django shell, verify helpers:
```
from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
print(get_learning_mfe_home_url("course-v1:Org+Num+Run", "home"))
# Expect: https://mfe.override.local/course/course-v1:Org+Num+Run/home
```
**3.** Trigger an enrollment email task (or inspect mocked payload in tests) and confirm learning_base_url matches the override.
**4.** Generate an audit‑access‑expiring notification and confirm content_url base matches the override.
**5.** Call get_unsubscribe_link(username) and confirm it uses the override base.
**6.** Run ./manage.py lms goal_reminder_email in a test setup and inspect the ACE message context for:
- goals_unsubscribe_url base = override
- platform_name = site-config override (if set)

## Other information

- **Backwards compatibility:** If no Site Configuration override is present, behavior is unchanged (falls back to settings).
- **Risk:** Low. Changes are read‑only lookups and string concatenations; no DB schema or data changes.
- **Dependencies:** None.
- **Security/Privacy:** No new PII exposure; unsubscribe URLs continue to include encrypted usernames exactly as before.
- **Performance:** Negligible impact; configuration lookup happens once at module import in URL helpers, or inline during email/notification composition.
- **Operator note:** For multi‑site instances, ensure each Site has a correct LEARNING_MICROFRONTEND_URL. If omitted, defaults apply.
