### PR TITLE
feat!: remove version from library serializer

### DIFF
--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -38,7 +38,6 @@ class ContentLibraryMetadataSerializer(serializers.Serializer):
     title = serializers.CharField()
     description = serializers.CharField(allow_blank=True)
     num_blocks = serializers.IntegerField(read_only=True)
-    version = serializers.IntegerField(read_only=True)
     last_published = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)
     published_by = serializers.CharField(read_only=True)
     last_draft_created = serializers.DateTimeField(format=DATETIME_FORMAT, read_only=True)

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -69,7 +69,6 @@ class ContentLibrariesTestCase(ContentLibrariesRestApiTest):
             "slug": "téstlꜟط",
             "title": "A Tést Lꜟطrary",
             "description": "Just Téstꜟng",
-            "version": 0,
             "license": CC_4_BY,
             "has_unpublished_changes": False,
             "has_unpublished_deletes": False,


### PR DESCRIPTION
```
The ContentLibraryMetadata used to hold a version field that was meant
to represent the version of the library as a whole. This is a holdover
from v1 libraries, where all changes to the library resulted in a new
version of the content, and that version indicator was used by courses
to know whether or not an update was available.

This maps poorly to Learning Core backed libraries for a number of
reasons:

1. LC-backed libraries have Draft and Published branches, meaning that
   a global "version" may be ambiguous.
2. LC-backed libraries have things like tagging and collections, where
   modifications are explicitly *not* versioned at all, and do not show
   up in either the publish log or the draft change log.
3. Courses that borrow content from LC-backed libraries track
   versioning at the level of the individual thing being borrowed, e.g.
   a single Component. This is in keeping with the goal to have very
   large libraries with many small bits of content to search and use.

This commit removes the notion of a Library-global version entirely for
v2 (LC-backed) libraries. This does not affect legacy v1 libraries that
are backed by ModuleStore.
```