### PR TITLE
build: Fix workflow triggers for the Dunder init check.

### DIFF
--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -2,9 +2,10 @@ name: Verify Dunder __init__.py Files
 
 on:
   pull_request:
+  merge_group:
+  push:
     branches:
       - master
-  merge_group:
 
 jobs:
   verify_dunder_init:


### PR DESCRIPTION
This check was previously only running on PRs to master, which makes it annoying to stack PRs and have all the checks run.  Update it so that the check runs on all PRs and on pushes to master.