### PR TITLE
fix: Return an absolute url on libraries v2 backup endpoint.

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -681,7 +681,7 @@ def get_backup_task_status(
 
     Returns a dictionary with the following keys:
         - state: One of "Pending", "Exporting", "Succeeded", "Failed"
-        - url: If state is "Succeeded", the URL where the exported .zip file can be downloaded. Otherwise, None.
+        - file: If state is "Succeeded", the FileField of the exported .zip. Otherwise, None.
     If no task is found, returns None.
     """
 
@@ -690,10 +690,10 @@ def get_backup_task_status(
     except UserTaskStatus.DoesNotExist:
         return None
 
-    result = {'state': task_status.state, 'url': None}
+    result = {'state': task_status.state, 'file': None}
 
     if task_status.state == UserTaskStatus.SUCCEEDED:
         artifact = UserTaskArtifact.objects.get(status=task_status, name='Output')
-        result['url'] = artifact.file.storage.url(artifact.file.name)
+        result['file'] = artifact.file
 
     return result

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -786,8 +786,8 @@ class LibraryBackupView(APIView):
 
         if not result:
             raise NotFound(detail="No backup found for this library.")
-
-        return Response(LibraryBackupTaskStatusSerializer(result).data)
+        # Passing request context to the serializer so the url absolute path is correctly generated
+        return Response(LibraryBackupTaskStatusSerializer(result, context={'request': request}).data)
 
 
 # LTI 1.3 Views

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -425,4 +425,4 @@ class LibraryBackupTaskStatusSerializer(serializers.Serializer):
     Serializer for checking the status of a library backup task.
     """
     state = serializers.CharField()
-    url = serializers.URLField(allow_null=True)
+    url = serializers.FileField(source='file', allow_null=True, use_url=True)

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -1430,7 +1430,7 @@ class ContentLibraryExportTest(ContentLibrariesRestApiTest):
             status = api.get_backup_task_status(self.user.id, task_id=task_id)
             assert status is not None
             assert status['state'] == UserTaskStatus.IN_PROGRESS
-            assert status['url'] is None
+            assert status['file'] is None
 
     def test_get_backup_task_status_succeeded(self) -> None:
         # Create a mock UserTaskStatus in SUCCEEDED state
@@ -1444,7 +1444,7 @@ class ContentLibraryExportTest(ContentLibrariesRestApiTest):
 
         # Create a mock UserTaskArtifact
         mock_artifact = mock.Mock()
-        mock_artifact.file.storage.url.return_value = "/media/user_tasks/2025/10/01/library-libOEXCSPROB_mOw1rPL.zip"
+        mock_artifact.file.url = "/media/user_tasks/2025/10/01/library-libOEXCSPROB_mOw1rPL.zip"
 
         with mock.patch(
             'openedx.core.djangoapps.content_libraries.api.libraries.UserTaskStatus.objects.get'
@@ -1458,7 +1458,7 @@ class ContentLibraryExportTest(ContentLibrariesRestApiTest):
             status = api.get_backup_task_status(self.user.id, task_id=task_id)
             assert status is not None
             assert status['state'] == UserTaskStatus.SUCCEEDED
-            assert status['url'] == "/media/user_tasks/2025/10/01/library-libOEXCSPROB_mOw1rPL.zip"
+            assert status['file'].url == "/media/user_tasks/2025/10/01/library-libOEXCSPROB_mOw1rPL.zip"
 
     def test_get_backup_task_status_failed(self) -> None:
         # Create a mock UserTaskStatus in FAILED state
@@ -1478,4 +1478,4 @@ class ContentLibraryExportTest(ContentLibrariesRestApiTest):
             status = api.get_backup_task_status(self.user.id, task_id=task_id)
             assert status is not None
             assert status['state'] == UserTaskStatus.FAILED
-            assert status['url'] is None
+            assert status['file'] is None


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

The 'url' field on the GET /api/libraries/v2/{library_id}/backup/?task_id={task_id} endpoint was returning realtive paths when the file was stored on the default FileSystemStorage backend, which makes it inconsistent with other storage backends and semantically incorrect.

This PR addresses this making sure it always returns an absolute url.

## Supporting information

Context on this comment: https://github.com/openedx/edx-platform/pull/37419#discussion_r2441265180
Required by: https://github.com/openedx/frontend-app-authoring/issues/2448

## Testing instructions

1. Create a new library from the studio interface (from the "**Libraries Beta**" tab, not "~~Legacy Libraries~~")
2. note the Library key from the URL when looking at the library details (something like lib:WGU:CSPROB)
3. do a **POST** to ``/api/libraries/v2/lib:WGU:CSPROB/backup/`` (change the library key with yours)
4. You should get a response like ``{"task_id":"747e5ab3-5aef-4aef-88a3-6a195c849e12"}``
5. do a **GET** to ``/api/libraries/v2/lib:WGU:CSPROB/backup/?task_id=747e5ab3-5aef-4aef-88a3-6a195c849e12`` (change the library key and the task_id to yours)
6. You should get a response like:
```
{
    "state": "Succeeded",
    "url": "http://studio.local.openedx.io:8001/media/user_tasks/2025/10/03/lib-wgu-csprob-2025-10-03-153633.zip"
}
```
## Deadline

Ulmo Release
