### PR TITLE
feanil/fix branding redirect loop

### DIFF
--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -269,6 +269,20 @@ class TestIndex(SiteMixin, TestCase):
         response = self.client.get(reverse("root"))
         assert response.status_code == 200
 
+    @override_settings(ENABLE_MKTG_SITE=True)
+    @override_settings(MKTG_URLS={'ROOT': 'https://foo.bar/'})
+    @override_settings(LMS_ROOT_URL='https://foo.bar/')
+    def test_index_wont_redirect_to_marketing_root_if_it_matches_lms_root(self):
+        response = self.client.get(reverse("root"))
+        assert response.status_code == 200
+
+    @override_settings(ENABLE_MKTG_SITE=True)
+    @override_settings(MKTG_URLS={'ROOT': 'https://home.foo.bar/'})
+    @override_settings(LMS_ROOT_URL='https://foo.bar/')
+    def test_index_will_redirect_to_new_root_if_mktg_site_is_enabled(self):
+        response = self.client.get(reverse("root"))
+        assert response.status_code == 302
+
     def test_index_redirects_to_marketing_site_with_site_override(self):
         """ Test index view redirects if MKTG_URLS['ROOT'] is set in SiteConfiguration """
         self.use_site(self.site_other)

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -42,7 +42,7 @@ def index(request):
         # page to make it easier to browse for courses (and register)
         if configuration_helpers.get_value(
                 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER',
-                settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
+                getattr(settings,'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
             return redirect('dashboard')
 
     if use_catalog_mfe():
@@ -50,7 +50,7 @@ def index(request):
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        getattr(settings,'ENABLE_MKTG_SITE', False)
     )
 
     if enable_mktg_site:

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -42,7 +42,7 @@ def index(request):
         # page to make it easier to browse for courses (and register)
         if configuration_helpers.get_value(
                 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER',
-                getattr(settings,'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
+                getattr(settings, 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
             return redirect('dashboard')
 
     if use_catalog_mfe():
@@ -50,7 +50,7 @@ def index(request):
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        getattr(settings,'ENABLE_MKTG_SITE', False)
+        getattr(settings, 'ENABLE_MKTG_SITE', False)
     )
 
     if enable_mktg_site:
@@ -58,7 +58,9 @@ def index(request):
             'MKTG_URLS',
             settings.MKTG_URLS
         )
-        return redirect(marketing_urls.get('ROOT'))
+        root_url = marketing_urls.get("ROOT")
+        if root_url != getattr(settings, "LMS_ROOT_URL", None):
+            return redirect(root_url)
 
     domain = request.headers.get('Host')
 


### PR DESCRIPTION
If ENABLE_MKTG_SITE is True, MKTG_URLS['ROOT'] must be set.  However if
it is set to the same value as the LMS_ROOT_URL (which points to this
view), you can end up in an infinite redirect loop.  If the two URLs do
match, don't redirect, just fall through to the content that this page
would have responded with instead.

This impacts https://github.com/openedx/edx-platform/issues/37053 since that would cause the ENABLE_MKTG_SITE=True path to always be called.