### PR TITLE
fix: remove unused waffle switch for optimizing learner retrieval

### DIFF
--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -29,6 +29,7 @@ USE_ON_DISK_GRADE_REPORTING = CourseWaffleFlag(
     f'{WAFFLE_NAMESPACE}.use_on_disk_grade_reporting', __name__
 )
 
+
 def problem_grade_report_verified_only(course_id):
     """
     Returns True if problem grade reports should only

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -3,17 +3,10 @@ This module contains various configuration settings via
 waffle switches for the instructor_task app.
 """
 
-from edx_toggles.toggles import WaffleSwitch
-
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 
 WAFFLE_NAMESPACE = 'instructor_task'
-
-# Waffle switches
-OPTIMIZE_GET_LEARNERS_FOR_COURSE = WaffleSwitch(  # lint-amnesty, pylint: disable=toggle-missing-annotation
-    f'{WAFFLE_NAMESPACE}.optimize_get_learners_for_course', __name__
-)
 
 # Course override flags
 GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
@@ -35,14 +28,6 @@ GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY = CourseWaffleFlag(  # lint-amnesty, 
 USE_ON_DISK_GRADE_REPORTING = CourseWaffleFlag(
     f'{WAFFLE_NAMESPACE}.use_on_disk_grade_reporting', __name__
 )
-
-
-def optimize_get_learners_switch_enabled():
-    """
-    Returns True if optimize get learner switch is enabled, otherwise False.
-    """
-    return OPTIMIZE_GET_LEARNERS_FOR_COURSE.is_enabled()
-
 
 def problem_grade_report_verified_only(course_id):
     """


### PR DESCRIPTION
 Remove unused waffle switch for optimizing learner retrieval.

The toggle was not removed with the original code removal PR:
- Added - https://github.com/openedx/edx-platform/pull/22316
- Removed - https://github.com/openedx/edx-platform/pull/31458
 
 ### Private JIRA link:
https://2u-internal.atlassian.net/browse/BOMS-16