### PR TITLE
fix: Issue when migrating legacy libraries with large keys [FC-0107]

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tasks.py
@@ -580,7 +580,7 @@ def migrate_from_modulestore(
     staged_content = staging_api.stage_xblock_temporarily(
         block=legacy_root,
         user_id=status.user.pk,
-        purpose=CONTENT_STAGING_PURPOSE_TEMPLATE.format(source_key=source_data.source.key),
+        purpose=CONTENT_STAGING_PURPOSE_TEMPLATE.format(source_key=source_pk),
     )
     migration.staged_content = staged_content
     status.increment_completed_steps()
@@ -773,7 +773,7 @@ def bulk_migrate_from_modulestore(
         staged_content = staging_api.stage_xblock_temporarily(
             block=legacy_root_list[i],
             user_id=status.user.pk,
-            purpose=CONTENT_STAGING_PURPOSE_TEMPLATE.format(source_key=source_data.source.key),
+            purpose=CONTENT_STAGING_PURPOSE_TEMPLATE.format(source_key=source_pk),
         )
         source_data.migration.staged_content = staged_content
         status.increment_completed_steps()


### PR DESCRIPTION
## Description

- Fixes https://github.com/openedx/frontend-app-authoring/issues/2557 
- The length of `purpose` in `StagedContent` is 64 ([ref](https://github.com/openedx/edx-platform/blob/15ffc0c97466ed6ace415b80edd388b5b232297b/openedx/core/djangoapps/content_staging/models.py#L50)). The previous code used the legacy content key. So if the library had a very long key, an error occurred. The new code uses the `pk` instead of the `key`
- Which edX user roles will this change impact? "Course Author"


## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2169#issuecomment-3424105797
- This PR doesn't add the regression. That will be implemented in another PR.
- Internal ticket: [FAL-4262](https://tasks.opencraft.com/browse/FAL-4262)

## Testing instructions

- Create a legacy library with a large key, like: `library-v1:LibraryOrganizationField_NOSPACES+LibraryCodeField_NOSPACESALLOWED`
- Follow the migration flow to migrate that library
- Verify that the migration finished successfully.

## Deadline

Before Ulmo Cut

## Other information

N/A
