### PR TITLE
fix: do not autogenerate username if coming through SSO

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -1009,7 +1009,7 @@ def get_username(strategy, details, backend, user=None, *args, **kwargs):  # lin
         else:
             slug_func = lambda val: val
 
-        if is_auto_generated_username_enabled():
+        if is_auto_generated_username_enabled() and details.get('username') is None:
             username = get_auto_generated_username(details)
         else:
             if email_as_username and details.get('email'):


### PR DESCRIPTION
Description:

Username is not being picked up from SAML response for enterprise learners due to `is_auto_generated_username_enabled` being enabled. 

**JIRA**:
- https://2u-internal.atlassian.net/browse/ENT-10906
- https://2u-internal.atlassian.net/browse/ENT-11076

Fix:
Verify if we are receiving any username value in the response payload and give it preference over the auto-generated username. This approach is similar to how it is handled in the Registration flow: https://github.com/openedx/edx-platform/pull/34562/files#diff-10e2a9ce44f5002369208fb96f3f95512c889dd126dfd416bee3ac3807f3358fR581