### PR TITLE
[FC-0099] feat: assign library roles after successful library creation

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -65,6 +65,7 @@ from openedx_learning.api.authoring_models import Component, LearningPackage
 from organizations.models import Organization
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from xblock.core import XBlock
+from openedx_authz.api import assign_role_to_user_in_scope
 
 from openedx.core.types import User as UserType
 
@@ -102,6 +103,7 @@ __all__ = [
     "publish_changes",
     "revert_changes",
     "get_backup_task_status",
+    "assign_library_role_to_user",
 ]
 
 
@@ -148,6 +150,12 @@ class AccessLevel:
     AUTHOR_LEVEL = ContentLibraryPermission.AUTHOR_LEVEL
     READ_LEVEL = ContentLibraryPermission.READ_LEVEL
     NO_ACCESS = None
+
+
+ACCESS_LEVEL_TO_LIBRARY_ROLE = {
+    AccessLevel.ADMIN_LEVEL: "library_admin",
+    AccessLevel.AUTHOR_LEVEL: "library_author",
+}
 
 
 @dataclass(frozen=True)
@@ -510,6 +518,29 @@ def set_library_user_permissions(library_key: LibraryLocatorV2, user: UserType, 
             user=user,
             defaults={"access_level": access_level},
         )
+
+def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, access_level: str | None):
+    """Grant a role to the specified user for this library.
+
+    Args:
+        library_key (LibraryLocatorV2): The key of the content library.
+        user (UserType): The user to whom the role will be granted.
+        access_level (str | None): The access level to be granted. This access level maps to a specific role.
+
+    Raises:
+        TypeError: If the user is an instance of AnonymousUser.
+    """
+    if isinstance(user, AnonymousUser):
+        raise TypeError("Invalid user type")
+
+    role = ACCESS_LEVEL_TO_LIBRARY_ROLE.get(access_level)
+    if role is None:
+        raise ValueError(f"Invalid access level: {access_level}")
+
+    if assign_role_to_user_in_scope(user.username, role, str(library_key)):
+        log.info(f"Assigned role '{role}' to user '{user.username}' for library '{library_key}'")
+    else:
+        log.warning(f"Failed to assign role '{role}' to user '{user.username}' for library '{library_key}'")
 
 
 def set_library_group_permissions(library_key: LibraryLocatorV2, group, access_level: str):

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -519,7 +519,8 @@ def set_library_user_permissions(library_key: LibraryLocatorV2, user: UserType, 
             defaults={"access_level": access_level},
         )
 
-def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, access_level: str | None):
+
+def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, access_level: str):
     """Grant a role to the specified user for this library.
 
     Args:

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -253,6 +253,12 @@ class LibraryRootView(GenericAPIView):
                 result = api.create_library(org=org, **data)
                 # Grant the current user admin permissions on the library:
                 api.set_library_user_permissions(result.key, request.user, api.AccessLevel.ADMIN_LEVEL)
+
+                # Grant the current user the library admin role for this library.
+                # Other role assignments are handled by openedx-authz and the Console MFE.
+                # This ensures the creator has access to new libraries. From the library views,
+                # users can then manage roles for others.
+                api.assign_library_role_to_user(result.key, request.user, api.AccessLevel.ADMIN_LEVEL)
         except api.LibraryAlreadyExists:
             raise ValidationError(detail={"slug": "A library with that ID already exists."})  # lint-amnesty, pylint: disable=raise-missing-from
 

--- a/openedx/core/djangoapps/content_libraries/tests/test_api.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_api.py
@@ -7,7 +7,7 @@ import hashlib
 import uuid
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from user_tasks.models import UserTaskStatus
 
 from opaque_keys.edx.keys import (

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -22,3 +22,10 @@
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
+
+# pip 25.3 is incompatible with pip-tools hence causing failures during the build process 
+# Make upgrade command and all requirements upgrade jobs are broken due to this.
+# See issue https://github.com/openedx/public-engineering/issues/440 for details regarding the ongoing fix.
+# The constraint can be removed once a release (pip-tools > 7.5.1) is available with support for pip 25.3
+# Issue to track this dependency and unpin later on: https://github.com/openedx/edx-lint/issues/503
+pip<25.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -40,6 +40,7 @@ attrs==25.4.0
     #   edx-ace
     #   jsonschema
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-learning
     #   referencing
@@ -81,6 +82,8 @@ botocore==1.40.57
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
+bracex==2.6
+    # via wcmatch
 bridgekeeper==0.9
     # via -r requirements/edx/kernel.in
 cachecontrol==0.14.3
@@ -91,6 +94,8 @@ cachetools==6.2.1
     #   google-auth
 camel-converter[pydantic]==5.0.0
     # via meilisearch
+casbin-django-orm-adapter==1.7.0
+    # via openedx-authz
 celery==5.5.3
     # via
     #   -c requirements/constraints.txt
@@ -170,6 +175,7 @@ django==5.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
+    #   casbin-django-orm-adapter
     #   django-appconf
     #   django-autocomplete-light
     #   django-celery-results
@@ -229,6 +235,7 @@ django==5.2.7
     #   help-tokens
     #   jsonfield
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-django-pyfs
     #   openedx-django-wiki
     #   openedx-events
@@ -389,6 +396,7 @@ djangorestframework==3.16.1
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
+    #   openedx-authz
     #   openedx-forum
     #   openedx-learning
     #   ora2
@@ -413,6 +421,7 @@ edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-name-affirmation
+    #   openedx-authz
 edx-auth-backends==4.6.2
     # via -r requirements/edx/kernel.in
 edx-bulk-grades==1.2.0
@@ -471,6 +480,7 @@ edx-drf-extensions==10.6.0
     #   edx-when
     #   edxval
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-learning
 edx-enterprise==6.5.1
     # via
@@ -503,6 +513,7 @@ edx-opaque-keys[django]==3.0.0
     #   edx-when
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-filters
     #   ora2
@@ -813,7 +824,10 @@ openedx-atlas==0.7.0
     # via
     #   -r requirements/edx/kernel.in
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-forum
+openedx-authz==0.6.0
+    # via -r requirements/edx/kernel.in
 openedx-calc==4.0.2
     # via -r requirements/edx/kernel.in
 openedx-django-pyfs==3.8.0
@@ -910,6 +924,10 @@ pyasn1==0.6.1
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
+pycasbin==2.4.0
+    # via
+    #   casbin-django-orm-adapter
+    #   openedx-authz
 pycountry==24.6.1
     # via -r requirements/edx/kernel.in
 pycparser==2.23
@@ -1086,6 +1104,8 @@ semantic-version==2.10.0
     # via edx-drf-extensions
 shapely==2.1.2
     # via -r requirements/edx/kernel.in
+simpleeval==1.0.3
+    # via pycasbin
 simplejson==3.20.2
     # via
     #   -r requirements/edx/kernel.in
@@ -1218,6 +1238,8 @@ voluptuous==0.15.2
     # via ora2
 walrus==0.9.5
     # via edx-event-bus-redis
+wcmatch==10.1
+    # via pycasbin
 wcwidth==0.2.14
     # via prompt-toolkit
 web-fragments==3.1.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -826,7 +826,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.6.0
+openedx-authz==0.11.0
     # via -r requirements/edx/kernel.in
 openedx-calc==4.0.2
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -826,7 +826,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.11.0
+openedx-authz==0.11.1
     # via -r requirements/edx/kernel.in
 openedx-calc==4.0.2
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1372,7 +1372,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.11.0
+openedx-authz==0.11.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1372,7 +1372,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.6.0
+openedx-authz==0.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -89,6 +89,7 @@ attrs==25.4.0
     #   edx-ace
     #   jsonschema
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-learning
     #   referencing
@@ -151,6 +152,11 @@ botocore==1.40.57
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
+bracex==2.6
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   wcmatch
 bridgekeeper==0.9
     # via
     #   -r requirements/edx/doc.txt
@@ -176,6 +182,11 @@ camel-converter[pydantic]==5.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   meilisearch
+casbin-django-orm-adapter==1.7.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   openedx-authz
 celery==5.5.3
     # via
     #   -c requirements/constraints.txt
@@ -334,6 +345,7 @@ django==5.2.7
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   casbin-django-orm-adapter
     #   django-appconf
     #   django-autocomplete-light
     #   django-celery-results
@@ -396,6 +408,7 @@ django==5.2.7
     #   help-tokens
     #   jsonfield
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-django-pyfs
     #   openedx-django-wiki
     #   openedx-events
@@ -622,6 +635,7 @@ djangorestframework==3.16.1
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
+    #   openedx-authz
     #   openedx-forum
     #   openedx-learning
     #   ora2
@@ -672,6 +686,7 @@ edx-api-doc-tools==2.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
+    #   openedx-authz
 edx-auth-backends==4.6.2
     # via
     #   -r requirements/edx/doc.txt
@@ -744,6 +759,7 @@ edx-drf-extensions==10.6.0
     #   edx-when
     #   edxval
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-learning
 edx-enterprise==6.5.1
     # via
@@ -789,6 +805,7 @@ edx-opaque-keys[django]==3.0.0
     #   edx-when
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-filters
     #   ora2
@@ -1353,7 +1370,12 @@ openedx-atlas==0.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-forum
+openedx-authz==0.6.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
 openedx-calc==4.0.2
     # via
     #   -r requirements/edx/doc.txt
@@ -1535,6 +1557,12 @@ pyasn1-modules==0.4.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-auth
+pycasbin==2.4.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   casbin-django-orm-adapter
+    #   openedx-authz
 pycodestyle==2.8.0
     # via
     #   -c requirements/constraints.txt
@@ -1886,6 +1914,11 @@ shapely==2.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+simpleeval==1.0.3
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   pycasbin
 simplejson==3.20.2
     # via
     #   -r requirements/edx/doc.txt
@@ -2192,6 +2225,11 @@ walrus==0.9.5
     #   edx-event-bus-redis
 watchdog==6.0.0
     # via -r requirements/edx/development.in
+wcmatch==10.1
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   pycasbin
 wcwidth==0.2.14
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -64,6 +64,7 @@ attrs==25.4.0
     #   edx-ace
     #   jsonschema
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-learning
     #   referencing
@@ -116,6 +117,10 @@ botocore==1.40.57
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
+bracex==2.6
+    # via
+    #   -r requirements/edx/base.txt
+    #   wcmatch
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
 cachecontrol==0.14.3
@@ -131,6 +136,10 @@ camel-converter[pydantic]==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
+casbin-django-orm-adapter==1.7.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   openedx-authz
 celery==5.5.3
     # via
     #   -c requirements/constraints.txt
@@ -228,6 +237,7 @@ django==5.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
+    #   casbin-django-orm-adapter
     #   django-appconf
     #   django-autocomplete-light
     #   django-celery-results
@@ -287,6 +297,7 @@ django==5.2.7
     #   help-tokens
     #   jsonfield
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-django-pyfs
     #   openedx-django-wiki
     #   openedx-events
@@ -461,6 +472,7 @@ djangorestframework==3.16.1
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
+    #   openedx-authz
     #   openedx-forum
     #   openedx-learning
     #   ora2
@@ -497,6 +509,7 @@ edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
+    #   openedx-authz
 edx-auth-backends==4.6.2
     # via -r requirements/edx/base.txt
 edx-bulk-grades==1.2.0
@@ -555,6 +568,7 @@ edx-drf-extensions==10.6.0
     #   edx-when
     #   edxval
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-learning
 edx-enterprise==6.5.1
     # via
@@ -587,6 +601,7 @@ edx-opaque-keys[django]==3.0.0
     #   edx-when
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-filters
     #   ora2
@@ -986,7 +1001,10 @@ openedx-atlas==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-forum
+openedx-authz==0.6.0
+    # via -r requirements/edx/base.txt
 openedx-calc==4.0.2
     # via -r requirements/edx/base.txt
 openedx-django-pyfs==3.8.0
@@ -1106,6 +1124,11 @@ pyasn1-modules==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   google-auth
+pycasbin==2.4.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   casbin-django-orm-adapter
+    #   openedx-authz
 pycountry==24.6.1
     # via -r requirements/edx/base.txt
 pycparser==2.23
@@ -1330,6 +1353,10 @@ semantic-version==2.10.0
     #   edx-drf-extensions
 shapely==2.1.2
     # via -r requirements/edx/base.txt
+simpleeval==1.0.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   pycasbin
 simplejson==3.20.2
     # via
     #   -r requirements/edx/base.txt
@@ -1539,6 +1566,10 @@ walrus==0.9.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
+wcmatch==10.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   pycasbin
 wcwidth==0.2.14
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1003,7 +1003,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.6.0
+openedx-authz==0.11.0
     # via -r requirements/edx/base.txt
 openedx-calc==4.0.2
     # via -r requirements/edx/base.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1003,7 +1003,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.11.0
+openedx-authz==0.11.1
     # via -r requirements/edx/base.txt
 openedx-calc==4.0.2
     # via -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -161,3 +161,4 @@ wrapt                               # Better functools.wrapped. TODO: functools 
 XBlock[django]                      # Courseware component architecture
 xss-utils                           # https://github.com/openedx/edx-platform/pull/20633 Fix XSS via Translations
 unicodeit                           # Converts mathjax equation to plain text by using unicode symbols
+openedx-authz                       # Authorization Framework for the Open edX Ecosystem

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1047,7 +1047,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.11.0
+openedx-authz==0.11.1
     # via -r requirements/edx/base.txt
 openedx-calc==4.0.2
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1047,7 +1047,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==0.6.0
+openedx-authz==0.11.0
     # via -r requirements/edx/base.txt
 openedx-calc==4.0.2
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -63,6 +63,7 @@ attrs==25.4.0
     #   edx-ace
     #   jsonschema
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-learning
     #   referencing
@@ -113,6 +114,10 @@ botocore==1.40.57
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
+bracex==2.6
+    # via
+    #   -r requirements/edx/base.txt
+    #   wcmatch
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
 cachecontrol==0.14.3
@@ -129,6 +134,10 @@ camel-converter[pydantic]==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   meilisearch
+casbin-django-orm-adapter==1.7.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   openedx-authz
 celery==5.5.3
     # via
     #   -c requirements/constraints.txt
@@ -253,6 +262,7 @@ django==5.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
+    #   casbin-django-orm-adapter
     #   django-appconf
     #   django-autocomplete-light
     #   django-celery-results
@@ -312,6 +322,7 @@ django==5.2.7
     #   help-tokens
     #   jsonfield
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-django-pyfs
     #   openedx-django-wiki
     #   openedx-events
@@ -486,6 +497,7 @@ djangorestframework==3.16.1
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
+    #   openedx-authz
     #   openedx-forum
     #   openedx-learning
     #   ora2
@@ -517,6 +529,7 @@ edx-api-doc-tools==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
+    #   openedx-authz
 edx-auth-backends==4.6.2
     # via -r requirements/edx/base.txt
 edx-bulk-grades==1.2.0
@@ -575,6 +588,7 @@ edx-drf-extensions==10.6.0
     #   edx-when
     #   edxval
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-learning
 edx-enterprise==6.5.1
     # via
@@ -609,6 +623,7 @@ edx-opaque-keys[django]==3.0.0
     #   edx-when
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
+    #   openedx-authz
     #   openedx-events
     #   openedx-filters
     #   ora2
@@ -1030,7 +1045,10 @@ openedx-atlas==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels
+    #   openedx-authz
     #   openedx-forum
+openedx-authz==0.6.0
+    # via -r requirements/edx/base.txt
 openedx-calc==4.0.2
     # via -r requirements/edx/base.txt
 openedx-django-pyfs==3.8.0
@@ -1168,6 +1186,11 @@ pyasn1-modules==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   google-auth
+pycasbin==2.4.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   casbin-django-orm-adapter
+    #   openedx-authz
 pycodestyle==2.8.0
     # via
     #   -c requirements/constraints.txt
@@ -1438,6 +1461,10 @@ semantic-version==2.10.0
     #   edx-drf-extensions
 shapely==2.1.2
     # via -r requirements/edx/base.txt
+simpleeval==1.0.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   pycasbin
 simplejson==3.20.2
     # via
     #   -r requirements/edx/base.txt
@@ -1623,6 +1650,10 @@ walrus==0.9.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-redis
+wcmatch==10.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   pycasbin
 wcwidth==0.2.14
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,6 +9,8 @@ wheel==0.45.1
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.2
-    # via -r requirements/pip.in
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in
 setuptools==80.9.0
     # via -r requirements/pip.in


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR grants the library_admin role to a user after they create a content library. The assigned role matches the current access level defined in the migration plan: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/5252317270/Libraries+Roles+and+Permissions+Migration+Plan. This ensures the user keeps the same level of access in the new authorization framework.

This PR only handles the role assignment. The actual permission checks for this new role will be added in a separate PR, so this one has no functional effect yet.

The upcoming PR that introduces these checks, along with other roles related to the Administration Console experience, is here: [https://github.com/openedx/edx-platform/pull/37501](https://github.com/openedx/edx-platform/pull/37501). The integration with the Authoring MFE, where this role will take effect, is still a work in progress. I'll link it here once it's ready.

## Supporting information

https://github.com/openedx/openedx-authz/issues/111#issue-3542135208
https://github.com/openedx/openedx-authz/?tab=readme-ov-file#openedx-authz
https://discuss.openedx.org/t/depr-libraries-roles-and-permission-system/17392

## Testing instructions

1. Login into studio with course creator permissions, then create a library from scratch
2. You can use the openedx-authz REST API to get all roles for users, and review whether the role was assigned to the user you just used: http://local.openedx.io:8000/api-docs/#/authz/authz_v1_roles_users_list, where scope is the ID of the library you just created
