### PR TITLE
143: remove deprecated LibraryLocator field run

### DIFF
--- a/common/djangoapps/split_modulestore_django/models.py
+++ b/common/djangoapps/split_modulestore_django/models.py
@@ -94,7 +94,7 @@ class SplitModulestoreCourseIndex(models.Model):
             "_id": ObjectId(self.objectid),
             "org": self.course_id.org,
             "course": get_library_or_course_attribute(self.course_id),
-            "run": self.course_id.run,  # pylint: disable=no-member
+            "run": get_library_or_course_attribute(self.course_id).run,  # pylint: disable=no-member
             "edited_by": self.edited_by_id,
             "edited_on": self.edited_on,
             "last_update": self.last_update,

--- a/xmodule/contentstore/mongo.py
+++ b/xmodule/contentstore/mongo.py
@@ -636,5 +636,5 @@ def query_for_course(course_key, category=None):
     if getattr(course_key, 'deprecated', False):
         dbkey[f'{prefix}.run'] = {'$exists': False}
     else:
-        dbkey[f'{prefix}.run'] = course_key.run
+        dbkey[f'{prefix}.run'] = get_library_or_course_attribute(course_key).run
     return dbkey

--- a/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -52,7 +52,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):  # li
         # needed by capa_problem (as runtime.resources_fs via this.resources_fs)
         course_library = get_library_or_course_attribute(course_entry.course_key)
         if course_library:
-            root = modulestore.fs_root / course_entry.course_key.org / course_library / course_entry.course_key.run  # lint-amnesty, pylint: disable=line-too-long
+            root = modulestore.fs_root / course_entry.course_key.org / course_library / get_library_or_course_attribute(course_entry.course_key).run  # lint-amnesty, pylint: disable=line-too-long
         else:
             root = modulestore.fs_root / str(course_entry.structure['_id'])
         root.makedirs_p()  # create directory if it doesn't exist

--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -214,7 +214,10 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
         if not isinstance(course_key, (CourseLocator, LibraryLocator)):
             raise TypeError(f'{course_key!r} is not a CourseLocator or LibraryLocator')
         # handle version_guid based retrieval locally
-        if course_key.org is None or get_library_or_course_attribute(course_key) is None or course_key.run is None:
+
+        course = get_library_or_course_attribute(course_key)
+
+        if course_key.org is None or course is None or course.run is None:
             return self._active_bulk_ops.records[
                 course_key.replace(org=None, course=None, run=None, branch=None)
             ]
@@ -231,7 +234,9 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
         if not isinstance(course_key, (CourseLocator, LibraryLocator)):
             raise TypeError(f'{course_key!r} is not a CourseLocator or LibraryLocator')
 
-        if course_key.org and get_library_or_course_attribute(course_key) and course_key.run:
+
+        course = get_library_or_course_attribute(course_key)
+        if course_key.org and course and course.run:
             del self._active_bulk_ops.records[course_key.replace(branch=None, version_guid=None)]
         else:
             del self._active_bulk_ops.records[
@@ -830,7 +835,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         """
         if not course_key.version_guid:
             head_validation = True
-        if head_validation and course_key.org and get_library_or_course_attribute(course_key) and course_key.run:
+        if head_validation and course_key.org and get_library_or_course_attribute(course_key) and get_library_or_course_attribute(course_key).run:
             if course_key.branch is None:
                 raise InsufficientSpecificationError(course_key)
 
@@ -1904,7 +1909,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 '_id': ObjectId(),
                 'org': locator.org,
                 'course': get_library_or_course_attribute(locator),
-                'run': locator.run,
+                'run': get_library_or_course_attribute(locator).run,
                 'edited_by': user_id,
                 'edited_on': datetime.datetime.now(UTC),
                 'versions': versions_dict,
@@ -2930,7 +2935,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         """
         if (course_key.org is None or
                 get_library_or_course_attribute(course_key) is None or
-                course_key.run is None or course_key.branch is None):
+                get_library_or_course_attribute(course_key).run is None or course_key.branch is None):
             return None
         else:
             index_entry = self.get_course_index(course_key)

--- a/xmodule/modulestore/xml_exporter.py
+++ b/xmodule/modulestore/xml_exporter.py
@@ -25,6 +25,7 @@ from xmodule.modulestore import LIBRARY_ROOT, EdxJSONEncoder, ModuleStoreEnum
 from xmodule.modulestore.draft_and_published import DIRECT_ONLY_CATEGORIES
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.modulestore.store_utilities import draft_node_constructor, get_draft_subtree_roots
+from xmodule.util.misc import get_library_or_course_attribute
 
 DRAFT_DIR = "drafts"
 PUBLISHED_DIR = "published"
@@ -171,7 +172,7 @@ class ExportManager:
                 # change all of the references inside the course to use the xml expected key type w/o version & branch
                 xml_centric_courselike_key = self.get_key()
                 adapt_references(courselike, xml_centric_courselike_key, export_fs)
-                root.set('url_name', self.courselike_key.run)
+                root.set('url_name', get_library_or_course_attribute(self.courselike_key).run)
                 courselike.add_xml_to_node(root)
 
             # Make any needed adjustments to the root node.


### PR DESCRIPTION
Issue: [143](https://github.com/openedx/public-engineering/issues/143)

### Description
- Refactor the deprecated LibraryLocator field `run` usage. See https://github.com/openedx/opaque-keys/blob/master/opaque_keys/edx/locator.py#L485
- Fixed 2097 Deprecation Warnings by making this change.
