### PR TITLE
feat: content gating navigation API

### DIFF
--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -62,6 +62,7 @@ class CourseBlockSerializer(serializers.Serializer):
                 'type': block_type,
                 'has_scheduled_content': block.get('has_scheduled_content'),
                 'hide_from_toc': block.get('hide_from_toc'),
+                'is_gated': block.get('is_gated', False),
             },
         }
         if 'special_exam_info' in self.context.get('extra_fields', []) and block.get('special_exam_info'):


### PR DESCRIPTION
### Dual call for gating content logic
- One with `None` (to fetch all blocks).
- One with `request.user` (to fetch only visible blocks).
Compared both trees to identify which units/sections are hidden for the current user.

### Previous API example
```json
{
    "blocks": {
        "block-v1:edx+ORA101+2025_09+type@course+block@course": {
            "children": [
                "block-v1:edx+ORA101+2025_09+type@chapter+block@1530cc5e2c1e471fa07c7e9abf9ed5f9"
            ],
            "complete": false,
            "description": null,
            "display_name": "test  course",
            "due": null,
            "effort_activities": null,
            "effort_time": null,
            "icon": null,
            "id": "block-v1:edx+ORA101+2025_09+type@course+block@course",
            "lms_web_url": null,
            "resume_block": false,
            "type": "course",
            "has_scheduled_content": null,
            "hide_from_toc": false,
            "completion_stat": {
                "completion": 0,
                "completable_children": 1
            }
        }
}
```
### After API example

```json
{
    "blocks": {
        "block-v1:edx+ORA101+2025_09+type@course+block@course": {
            "children": [
                "block-v1:edx+ORA101+2025_09+type@chapter+block@1530cc5e2c1e471fa07c7e9abf9ed5f9"
            ],
            "complete": false,
            "description": null,
            "display_name": "test  course",
            "due": null,
            "effort_activities": null,
            "effort_time": null,
            "icon": null,
            "id": "block-v1:edx+ORA101+2025_09+type@course+block@course",
            "lms_web_url": null,
            "resume_block": false,
            "type": "course",
            "has_scheduled_content": null,
            "hide_from_toc": false,
            "ïs_gated": false
            "completion_stat": {
                "completion": 0,
                "completable_children": 1
            }
        }
}
```
NOTE: `is_gated` flag