### PR TITLE
fix: Adding components to xblocks with children.

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -305,7 +305,9 @@ function($, _, Backbone, gettext, BasePage,
 
         renderAddXBlockComponents: function() {
             var self = this;
-            if (self.options.canEdit && (!self.options.isIframeEmbed || self.isSplitTestContentPage)) {
+            // If the container is the Unit element(aka Vertical), then we don't render the
+            // add buttons because those should get rendered by the authoring MFE
+            if (self.options.canEdit && (!self.options.isIframeEmbed || !self.model.isVertical())) {
                 this.$('.add-xblock-component').each(function(index, element) {
                     var component = new AddXBlockComponent({
                         el: element,


### PR DESCRIPTION
Previously the container JS would remove the `add-xblock-component` for
every component that was in an iframe that was not the split test
component.  We're changing the logic to say that we should not render
the old buttons on pages where the authoring view provides an
alternative set of buttons.  Which in this case is just the
unit/vertical page.  All other containers should render the old buttons
since the new authoring MFE does not provide them.

## Before
<img width="1173" height="1160" alt="xblock_with_children_before" src="https://github.com/user-attachments/assets/e9265440-0f41-46ac-9fba-51158751cd19" />

## After
<img width="1171" height="1249" alt="xblock_with_children_after" src="https://github.com/user-attachments/assets/b67a8826-8a76-4016-8b82-1efe809491ae" />

