### PR TITLE
fix: index and entity link sync issues on parent block deletion

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -221,6 +221,7 @@ def handle_item_deleted(**kwargs):
             id_list.add(block.location)
 
         ComponentLink.objects.filter(downstream_usage_key__in=id_list).delete()
+        ContainerLink.objects.filter(downstream_usage_key__in=id_list).delete()
 
 
 @receiver(GRADING_POLICY_CHANGED)

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -651,6 +651,13 @@ def delete_index_doc(key: OpaqueKey, *, delete_children: bool = False) -> None:
         _delete_documents(f'{Fields.breadcrumbs}.{Fields.usage_key} = "{key}"')
 
 
+def delete_docs_with_context_key(key: OpaqueKey) -> None:
+    """
+    Delete all docs for given context key
+    """
+    _delete_documents(f'{Fields.context_key} = "{key}"')
+
+
 def _delete_documents(filter: str) -> None:
     """
     Deletes all documents from the search index that match the given filter

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -658,14 +658,14 @@ def delete_docs_with_context_key(key: OpaqueKey) -> None:
     _delete_documents(f'{Fields.context_key} = "{key}"')
 
 
-def _delete_documents(filter: str) -> None:
+def _delete_documents(filter_query: str) -> None:
     """
     Deletes all documents from the search index that match the given filter
 
     Args:
         filter (str): The query to use when filtering documents
     """
-    if not filter:
+    if not filter_query:
         return
 
     client = _get_meilisearch_client()
@@ -674,8 +674,8 @@ def _delete_documents(filter: str) -> None:
     tasks = []
     if current_rebuild_index_name:
         # If there is a rebuild in progress, the document will also be removed from the new index.
-        tasks.append(client.index(current_rebuild_index_name).delete_documents(filter=filter))
-    tasks.append(client.index(STUDIO_INDEX_NAME).delete_documents(filter=filter))
+        tasks.append(client.index(current_rebuild_index_name).delete_documents(filter=filter_query))
+    tasks.append(client.index(STUDIO_INDEX_NAME).delete_documents(filter=filter_query))
 
     _wait_for_meili_tasks(tasks)
 

--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -48,8 +48,9 @@ class Fields:
     org = "org"
     access_id = "access_id"  # .models.SearchAccess.id
     # breadcrumbs: an array of {"display_name": "..."} entries. First one is the name of the course/library itself.
-    # After that is the name of any parent Section/Subsection/Unit/etc.
+    # After that is the name of any parent Section/Subsection/Unit/etc and its usage_key.
     # It's a list of dictionaries because for now we just include the name of each but in future we may add their IDs.
+    # Example: [{"display_name": "My course"}, {"display_name": "Section1", "usage_key": "..."}]}
     breadcrumbs = "breadcrumbs"
     # tags (dictionary)
     # See https://blog.meilisearch.com/nested-hierarchical-facets-guide/

--- a/openedx/core/djangoapps/content/search/index_config.py
+++ b/openedx/core/djangoapps/content/search/index_config.py
@@ -26,6 +26,7 @@ INDEX_FILTERABLE_ATTRIBUTES = [
     Fields.last_published,
     Fields.content + "." + Fields.problem_types,
     Fields.publish_status,
+    Fields.breadcrumbs + "." + Fields.usage_key,
 ]
 
 # Mark which attributes are used for keyword search, in order of importance:

--- a/openedx/core/djangoapps/content/search/tasks.py
+++ b/openedx/core/djangoapps/content/search/tasks.py
@@ -59,7 +59,8 @@ def delete_xblock_index_doc(usage_key_str: str) -> None:
 
     log.info("Updating content index document for XBlock with id: %s", usage_key)
 
-    api.delete_index_doc(usage_key)
+    # Delete children index data for course blocks.
+    api.delete_index_doc(usage_key, delete_children=True)
 
 
 @shared_task(base=LoggedTask, autoretry_for=(MeilisearchError, ConnectionError))

--- a/openedx/core/djangoapps/content/search/tasks.py
+++ b/openedx/core/djangoapps/content/search/tasks.py
@@ -169,3 +169,17 @@ def delete_library_container_index_doc(container_key_str: str) -> None:
     log.info("Deleting content index document for library block with id: %s", container_key)
 
     api.delete_index_doc(container_key)
+
+
+@shared_task(base=LoggedTask, autoretry_for=(MeilisearchError, ConnectionError))
+@set_code_owner_attribute
+def delete_course_index_docs(course_key_str: str) -> None:
+    """
+    Celery task to delete the content index documents for a Course
+    """
+    course_key = CourseKey.from_string(course_key_str)
+
+    log.info("Deleting all index documents related to course_key: %s", course_key)
+
+    # Delete children index data for course blocks.
+    api.delete_docs_with_context_key(course_key)

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -618,12 +618,16 @@ class TestSearchApi(ModuleStoreTestCase):
     @override_settings(MEILISEARCH_ENABLED=True)
     def test_delete_index_xblock(self, mock_meilisearch) -> None:
         """
-        Test deleting an XBlock doc from the index.
+        Test deleting an XBlock doc and its children docs from the index.
         """
-        api.delete_index_doc(self.sequential.usage_key)
+        api.delete_index_doc(self.sequential.usage_key, delete_children=True)
 
         mock_meilisearch.return_value.index.return_value.delete_document.assert_called_once_with(
             self.doc_sequential['id']
+        )
+
+        mock_meilisearch.return_value.index.return_value.delete_documents.assert_called_once_with(
+            filter=f'breadcrumbs.usage_key = "{self.sequential.usage_key}"'
         )
 
     @override_settings(MEILISEARCH_ENABLED=True)
@@ -819,6 +823,17 @@ class TestSearchApi(ModuleStoreTestCase):
 
         mock_meilisearch.return_value.index.return_value.delete_document.assert_called_once_with(
             self.doc_problem1['id']
+        )
+
+    @override_settings(MEILISEARCH_ENABLED=True)
+    def test_delete_docs_with_context_key(self, mock_meilisearch) -> None:
+        """
+        Test deleting a all Block docs from the index using context_key.
+        """
+        api.delete_docs_with_context_key(self.course.id)
+
+        mock_meilisearch.return_value.index.return_value.delete_documents.assert_called_once_with(
+            filter=f'context_key = "{self.course.id}"'
         )
 
     @override_settings(MEILISEARCH_ENABLED=True)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Meilisearch index documents were not synced properly when any block with children blocks like units, subsections, sections etc. were being deleted as the `XBLOCK_DELETED` is only triggered for the deleted block.
This PR fixes it by deleting all index documents that contain the deleted block in its `breadcrumbs` field as only blocks that are children of this block will have it its breadcrumbs field.

Similarly, the entity links that store links between course and library blocks was not synced properly due to children `ContainerLinks` not being deleted.

Useful information to include:

- Which edX user roles will this change impact? "Learner", "Course Author", "Developer", and "Operator".

## Supporting information

* https://github.com/openedx/edx-platform/issues/37427
* Discussion in: https://github.com/openedx/frontend-app-authoring/issues/2525
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4267

## Testing instructions

* Create a section, subsection, units with children in a course.
* Check the Meilisearch dashboard: http://meilisearch.<tutor-url>:7700/ and verify that the index documents are created for them.
* Check the django admin: `admin/contentstore/containerlink/` and verify that the container links are created.
* Now delete the section without the changes in this PR, the index will still contain documents for subsection, units and its children, only the parent section is removed.
* The container links for children containers are not deleted.
* Checkout this PR.
* **Reset meilisearch index using** `tutor dev run cms ./manage.py cms reindex_studio --experimental --reset` and `tutor dev run cms ./manage.py cms reindex_studio --experimental`
* This is required due to addition of `breadcrumbs.usage_key` field to filterable fields list.
* Repeat first 5 steps. All documents under the section will be deleted and all chidlren container links are deleted.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
