### PR TITLE
feat: remove "experimental" param from reindex_studio

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -386,13 +386,13 @@ def init_index(status_cb: Callable[[str], None] | None = None, warn_cb: Callable
         if _index_is_empty(STUDIO_INDEX_NAME):
             warn_cb(
                 "The studio search index is empty. Please run ./manage.py cms reindex_studio"
-                " --experimental [--incremental]"
+                " [--incremental]"
             )
             return
         if not _is_index_configured(STUDIO_INDEX_NAME):
             warn_cb(
                 "A rebuild of the index is required. Please run ./manage.py cms reindex_studio"
-                " --experimental [--incremental]"
+                " [--incremental]"
             )
             return
         status_cb("Index already exists and is configured.")

--- a/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
+++ b/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
@@ -12,13 +12,15 @@ from ... import api
 
 class Command(BaseCommand):
     """
-    Build or re-build the search index for courses and libraries (in Studio, i.e. Draft mode)
+    Build or re-build the Meilisearch search index for courses and libraries in Studio.
 
-    This is experimental and not recommended for production use.
+    This is separate from LMS search features like courseware search or forum search.
     """
 
+    # TODO: improve this - see https://github.com/openedx/edx-platform/issues/36868
+
     def add_arguments(self, parser):
-        parser.add_argument("--experimental", action="store_true")
+        parser.add_argument("--experimental", action="store_true")  # kept for compatibility but ignored.
         parser.add_argument("--reset", action="store_true")
         parser.add_argument("--init", action="store_true")
         parser.add_argument("--incremental", action="store_true")
@@ -30,12 +32,6 @@ class Command(BaseCommand):
         """
         if not api.is_meilisearch_enabled():
             raise CommandError("Meilisearch is not enabled. Please set MEILISEARCH_ENABLED to True in your settings.")
-
-        if not options["experimental"]:
-            raise CommandError(
-                "This command is experimental and not recommended for production. "
-                "Use the --experimental argument to acknowledge and run it."
-            )
 
         if options["reset"]:
             api.reset_index(self.stdout.write)


### PR DESCRIPTION
## Description

The Studio search features are perfectly fine for production use now, so we should remove the "experimental" flag.

## Testing instructions

e.g. run `tutor dev exec cms -- ./manage.py cms reindex_studio --incremental` and make sure it works.

## Deadline

Ulmo would be good.

## Other notes

Vaguely relates to https://github.com/openedx/edx-platform/issues/36868
