### PR TITLE
feat: add Waffle flag to control start date access for masquerading users

### DIFF
--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -23,7 +23,11 @@ from lms.djangoapps.courseware.access_response import (
     StartDateError,
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
-from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, COURSE_PRE_START_ACCESS_FLAG
+from openedx.features.course_experience import (
+    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
+    COURSE_PRE_START_ACCESS_FLAG,
+    ENFORCE_MASQUERADE_START_DATES,
+)
 from xmodule.course_block import COURSE_VISIBILITY_PUBLIC  # lint-amnesty, pylint: disable=wrong-import-order
 
 DEBUG_ACCESS = False
@@ -137,7 +141,10 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
     if start_dates_disabled and not masquerading_as_student:
         return ACCESS_GRANTED
     else:
-        if start is None or get_course_masquerade(user, course_key):
+        if start is None:
+            return ACCESS_GRANTED
+
+        if not ENFORCE_MASQUERADE_START_DATES.is_enabled(course_key) and get_course_masquerade(user, course_key):
             return ACCESS_GRANTED
 
         if now is None:

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -83,6 +83,23 @@ RELATIVE_DATES_DISABLE_RESET_FLAG = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.r
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-36
 CALENDAR_SYNC_FLAG = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.calendar_sync', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
+# .. toggle_name: course_experience.enforce_masquerade_start_dates
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, staff masquerading as students will see the same start date
+#   restrictions as actual students. This provides a more accurate preview experience by enforcing
+#   section and subsection start dates even when viewing the course as a masqueraded user.
+#   When disabled (default), masquerading continues to bypass start date restrictions as before.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2025-10-08
+# .. toggle_warning: Enabling this flag means staff members masquerading as students will not be able to access course
+#   content before its start date, which may impact course testing workflows.
+#   Also, when you masquerade as a student in a course that starts in the future, you will lock yourself out of the
+#   course in the current Django session. To revert this, you need to log out and log back in.
+ENFORCE_MASQUERADE_START_DATES = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.enforce_masquerade_start_dates', __name__
+)
+
 
 def course_home_page_title(_course):
     """


### PR DESCRIPTION
## Description

Staff members masquerading as students currently bypass start date restrictions, which means they don't experience the course the same way students do. This makes it difficult to accurately preview and test how content will appear to students based on section and subsection start dates.

This PR adds the `course_experience.enforce_masquerade_start_dates` Waffle flag to allow enforcing start date restrictions for masquerading users. When enabled, staff viewing the course as a masqueraded student will see the same start date restrictions as actual students, providing a more accurate preview experience.
The flag is disabled by default, preserving the existing bypass behavior to avoid disrupting current workflows.

## Testing instructions

1. Create a course with a section in the future.
2. Enroll a regular (non-staff) user in the course.
3. As staff, view the course outline as the user from the previous point.
4. Ensure that you can see the section that's scheduled for the future.
5. Add the `course_experience.enforce_masquerade_start_dates` Waffle flag (`/admin/waffle/flag/`).
6. Reload the course outline page and ensure you no longer see the section scheduled for the future.

## Deadline

None.

## Other information

When enabled, masquerading into a course with a future start date will lock staff out of that course in the current session. Staff will need to log out and back in to regain normal access (or just wait until the course starts). I did not modify this behavior to avoid making too invasive changes to the code that handles permissions (high risk).

_Private-ref: [BB-9603](https://tasks.opencraft.com/browse/BB-9603)_