### PR TITLE
feat: Prevent empty wrapper divs for about sections with no content

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -418,7 +418,10 @@ def get_course_about_section(request, course, section_key):
 
             if about_block is not None:
                 try:
-                    html = about_block.render(STUDENT_VIEW).content
+                    # Only render XBlock if content exists to avoid generating empty wrapper divs
+                    content = about_block.data
+                    if content and content.strip():
+                        html = about_block.render(STUDENT_VIEW).content
                 except Exception:  # pylint: disable=broad-except
                     html = render_to_string('courseware/error-message.html', None)
                     log.exception(

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -53,6 +53,7 @@ from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, CourseRun
 from lms.djangoapps.courseware.masquerade import check_content_start_date_for_masquerade_user
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.block_render import get_block
+from lms.djangoapps.courseware.utils import is_empty_html
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.survey.utils import SurveyRequiredAccessError, check_survey_required_and_unanswered
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
@@ -420,7 +421,7 @@ def get_course_about_section(request, course, section_key):
                 try:
                     # Only render XBlock if content exists to avoid generating empty wrapper divs
                     content = about_block.data
-                    if content and content.strip():
+                    if not is_empty_html(content):
                         html = about_block.render(STUDENT_VIEW).content
                 except Exception:  # pylint: disable=broad-except
                     html = render_to_string('courseware/error-message.html', None)

--- a/lms/djangoapps/courseware/utils.py
+++ b/lms/djangoapps/courseware/utils.py
@@ -4,6 +4,7 @@
 import datetime
 import hashlib
 import logging
+from bs4 import BeautifulSoup
 
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -229,3 +230,16 @@ def _use_new_financial_assistance_flow(course_id):
     ):
         return True
     return False
+
+
+def is_empty_html(html_content):
+    """
+    Check if HTML content is effectively empty.
+    """
+    if not html_content:
+        return True
+
+    soup = BeautifulSoup(html_content, 'html.parser')
+    text = soup.get_text(strip=True)
+
+    return not text


### PR DESCRIPTION
## Description

Added a content check before rendering the xblock. If the about section is empty or contains only whitespace, return an empty string instead of rendering the xblock.

Useful information to include:

- [html_block.py](https://github.com/openedx/edx-platform/blob/master/xmodule/html_block.py#L97)
- [xblock_utils/__init__.py](https://github.com/openedx/edx-platform/blob/master/openedx/core/lib/xblock_utils/__init__.py#L65)
- [xblock_wrapper.html](https://github.com/openedx/edx-platform/blob/master/common/templates/xblock_wrapper.html)
- [Slack conversation](https://openedx.slack.com/archives/C08QR8K7K38/p1761318184800149)

## Supporting information

Empty `about_sidebar_html` (and other about sections) were generating unnecessary xblock wrapper divs even when they contained no content, causing extra DOM elements and potential styling issues.

## Initial setup

Go to [https://github.com/openedx/frontend-app-catalog/pull/38](https://github.com/openedx/frontend-app-catalog/pull/38) and follow all the steps to set up and run the new Catalog MFE.

## Testing instructions

1. Open the new Catalog MFE Course About page and the Schedule and Details page.
2. Add any content to the Course About Sidebar HTML section and save it.
3. Verify that the content is displayed correctly on both the updated MFE page and the legacy page.
4. Make sure the content is wrapped in the xblock wrapper.
5. Go back to the Schedule and Details page and remove the content from the Course About Sidebar HTML section.
6. Confirm that the `about_sidebar_html` field returns an empty string without xblock stuff.