### PR TITLE
[FC-0099] feat: assign access_level role for user when pasting blocks

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -943,6 +943,7 @@ def copy_v1_user_roles_into_v2_library(v2_library_key, v1_library_key):
     for access_level in permissions.keys():  # lint-amnesty, pylint: disable=consider-iterating-dictionary
         for user in permissions[access_level]:
             v2contentlib_api.set_library_user_permissions(v2_library_key, user, access_level)
+            v2contentlib_api.assign_library_role_to_user(v2_library_key, user, access_level)
 
 
 def _create_copy_content_task(v2_library_key, v1_library_key):

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -542,7 +542,8 @@ def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, a
 
     role = ACCESS_LEVEL_TO_LIBRARY_ROLE.get(access_level)
     if role is None:
-        raise ValueError(f"Invalid access level: {access_level}")
+        log.warning(f"No role mapping found for access level '{access_level}'")
+        return
 
     if assign_role_to_user_in_scope(user.username, role, str(library_key)):
         log.info(f"Assigned role '{role}' to user '{user.username}' for library '{library_key}'")

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -525,6 +525,29 @@ def set_library_user_permissions(library_key: LibraryLocatorV2, user: UserType, 
             defaults={"access_level": access_level},
         )
 
+def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, access_level: str | None):
+    """Grant a role to the specified user for this library.
+
+    Args:
+        library_key (LibraryLocatorV2): The key of the content library.
+        user (UserType): The user to whom the role will be granted.
+        access_level (str | None): The access level to be granted. This access level maps to a specific role.
+
+    Raises:
+        TypeError: If the user is an instance of AnonymousUser.
+    """
+    if isinstance(user, AnonymousUser):
+        raise TypeError("Invalid user type")
+
+    role = ACCESS_LEVEL_TO_LIBRARY_ROLE.get(access_level)
+    if role is None:
+        raise ValueError(f"Invalid access level: {access_level}")
+
+    if assign_role_to_user_in_scope(user.username, role, str(library_key)):
+        log.info(f"Assigned role '{role}' to user '{user.username}' for library '{library_key}'")
+    else:
+        log.warning(f"Failed to assign role '{role}' to user '{user.username}' for library '{library_key}'")
+
 
 def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, access_level: str):
     """Grant a role to the specified user for this library.

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -525,7 +525,8 @@ def set_library_user_permissions(library_key: LibraryLocatorV2, user: UserType, 
             defaults={"access_level": access_level},
         )
 
-def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, access_level: str | None):
+
+def assign_library_role_to_user(library_key: LibraryLocatorV2, user: UserType, access_level: str):
     """Grant a role to the specified user for this library.
 
     Args:


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR copies the permissions of a library v1 to a library v2 but in the context of the new authz framework - for parity reasons.