### PR TITLE
feat: display the reset toggles for a report

### DIFF
--- a/openedx/core/djangoapps/user_api/admin.py
+++ b/openedx/core/djangoapps/user_api/admin.py
@@ -170,7 +170,8 @@ class UserRetirementPartnerReportingStatusAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
     search_fields = ('user__id', 'original_username', 'original_email', 'original_name')
     actions = [
-        'reset_state',  # See reset_state() below.
+        'reset_state_false',
+        'reset_state_true',
     ]
 
     class Meta:


### PR DESCRIPTION
One retirement partner status report admin toggle has  being renamed, and another has been added. This PR displays them on the appropriate django admin page.
