### PR TITLE
[FC-0099] feat: filter libraries based on user-role scopes

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -267,7 +267,7 @@ def get_libraries_for_user(user, org=None, text_search=None, order=None) -> Quer
             Q(learning_package__description__icontains=text_search)
         )
 
-    filtered = permissions.perms[permissions.CAN_VIEW_THIS_CONTENT_LIBRARY].filter(user, qs)
+    filtered = permissions.perms[permissions.CAN_VIEW_THIS_CONTENT_LIBRARY].filter(user, qs).distinct()
 
     if order:
         order_query = 'learning_package__'

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -267,6 +267,10 @@ def get_libraries_for_user(user, org=None, text_search=None, order=None) -> Quer
             Q(learning_package__description__icontains=text_search)
         )
 
+    # Using distinct() temporarily to avoid duplicate results caused by overlapping permission checks
+    # between Bridgekeeper and the new authorization framework. This ensures correct results for now,
+    # but it should be removed once Bridgekeeper support is fully dropped and all permission logic
+    # is handled through openedx-authz.
     filtered = permissions.perms[permissions.CAN_VIEW_THIS_CONTENT_LIBRARY].filter(user, qs).distinct()
 
     if order:

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -134,7 +134,7 @@ class HasPermissionInContentLibraryScope(Rule):
         org.short_name='DemoX' and slug='CSPROB'.
     """
 
-    def __init__(self, action_external_key: str, filter_keys: list[str] = ["org", "slug"]):
+    def __init__(self, action_external_key: str, filter_keys: list[str] | None = None):
         """Initialize the rule with the action and filter keys to filter on.
 
         Args:
@@ -143,7 +143,7 @@ class HasPermissionInContentLibraryScope(Rule):
                 Defaults to ['org', 'slug'] for ContentLibrary.
         """
         self.action_external_key = action_external_key
-        self.filter_keys = filter_keys
+        self.filter_keys = filter_keys if filter_keys is not None else ["org", "slug"]
 
     def query(self, user):
         """Convert this rule to a Django Q object for QuerySet filtering.
@@ -194,7 +194,7 @@ class HasPermissionInContentLibraryScope(Rule):
 
         return query
 
-    def check(self, user, instance):
+    def check(self, user, instance, *args, **kwargs):  # pylint: disable=arguments-differ
         """Check if user has permission for a specific object instance.
 
         This method is used for checking permission on individual objects rather
@@ -204,6 +204,8 @@ class HasPermissionInContentLibraryScope(Rule):
         Args:
             user: The Django user object (must have a 'username' attribute).
             instance: The Django model instance to check permission for.
+            *args: Additional positional arguments (for compatibility with parent signature).
+            **kwargs: Additional keyword arguments (for compatibility with parent signature).
 
         Returns:
             bool: True if the user has the permission in the object's scope,

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -2,8 +2,11 @@
 Permissions for Content Libraries (v2, Learning-Core-based)
 """
 from bridgekeeper import perms, rules
-from bridgekeeper.rules import Attribute, ManyRelation, Relation, blanket_rule, in_current_groups
+from bridgekeeper.rules import Attribute, ManyRelation, Relation, blanket_rule, in_current_groups, Rule
 from django.conf import settings
+from django.db.models import Q
+
+from openedx_authz.api.users import is_user_allowed, get_scopes_for_user_and_permission
 
 from openedx.core.djangoapps.content_libraries.models import ContentLibraryPermission
 
@@ -54,6 +57,177 @@ def is_course_creator(user):
 
     return get_course_creator_status(user) == 'granted'
 
+
+class HasPermissionInContentLibraryScope(Rule):
+    """Bridgekeeper rule that checks permissions via Casbin's policy engine.
+
+    This rule integrates Casbin's role-based authorization with Bridgekeeper's
+    declarative permission system. It checks if a user has been granted a specific
+    permission (action) through their role assignments in Casbin.
+
+    The rule works by:
+    1. Querying Casbin grouping policies to find the user's role assignments
+    2. Querying Casbin permission policies to find which roles grant the action
+    3. Matching role assignments with scopes to determine where the user has permission
+
+    This enables both individual object permission checks and efficient QuerySet
+    filtering - a key feature that allows database-level filtering instead of
+    checking each object individually.
+
+    Attributes:
+        action_external_key (str): The action/permission to check (e.g., 'view', 'edit').
+            This should be the external key WITHOUT the namespace prefix.
+            For example, use 'view' not 'act^view'.
+
+        scope_field (str): The Django model field/property that contains the scope identifier.
+            This tells the rule WHERE to find the scope value in your model.
+            Defaults to 'id'.
+
+            **IMPORTANT**: This can be a model property (like `library_key`) or a field.
+            For ContentLibrary, use 'library_key' which is a @property that returns
+            the LibraryLocatorV2 string representation.
+
+            The scope_field serves two purposes:
+            - **For QuerySet filtering**: Builds SQL like `WHERE scope_field IN (...)`
+            - **For object checks**: Extracts the scope from `instance.scope_field`
+
+            Supports Django ORM field lookups for nested fields:
+            - 'library_key' - a @property on the model (ContentLibrary case)
+            - 'id' - direct field on the model
+            - 'library__id' - field on a related model
+            - 'course__org__key' - multi-level relationship
+
+    Examples:
+        Basic usage with default scope_field:
+            >>> from bridgekeeper import perms
+            >>> from openedx_authz.permissions import HasPermissionInScope
+            >>>
+            >>> # Assumes the model's 'id' field contains the scope
+            >>> can_view = HasPermissionInScope('view')
+            >>> perms['libraries.view'] = can_view
+
+        Specifying a custom scope_field:
+            >>> # When scope is in a field named 'library_id'
+            >>> can_view = HasPermissionInScope('view', scope_field='library_id')
+            >>>
+            >>> # When scope is in a related model
+            >>> can_manage = HasPermissionInScope('manage', scope_field='library__key')
+
+        Compound permissions with boolean operators:
+            >>> from bridgekeeper.rules import Attribute
+            >>>
+            >>> is_active = Attribute('is_active', True)
+            >>> is_staff = Attribute('is_staff', True)
+            >>> can_view = HasPermissionInScope('view', scope_field='library_id')
+            >>>
+            >>> # User must be active AND (staff OR have explicit permission)
+            >>> perms['libraries.view'] = is_active & (is_staff | can_view)
+
+        QuerySet filtering (efficient, database-level):
+            >>> from openedx.core.djangoapps.content_libraries.models import ContentLibrary
+            >>>
+            >>> # Gets all libraries user can view in a single SQL query
+            >>> visible_libraries = perms['libraries.view'].filter(
+            ...     request.user,
+            ...     ContentLibrary.objects.all()
+            ... )
+
+        Individual object checks:
+            >>> library = ContentLibrary.objects.get(library_id='lib:DemoX:CSPROB')
+            >>> if perms['libraries.view'].check(request.user, library):
+            ...     # User can view this specific library
+            ...     return render_library(library)
+
+    Note:
+        The scope identifiers in Casbin policies must match the values in your
+        Django model's scope_field. For example, if Casbin stores
+        'lib:DemoX:CSPROB' and your model has library_id='lib:DemoX:CSPROB',
+        they must match exactly (including format and casing).
+    """
+
+    def __init__(self, action_external_key: str, filter_keys: list[str] = ["org", "slug"]):
+        """Initialize the rule with the action and filter keys to filter on.
+
+        Args:
+            action_external_key (str): The action/permission to check (e.g., 'view', 'edit').
+            filter_keys (list[str]): The model fields to filter on when building QuerySet filters.
+                Defaults to ['org', 'slug'] for ContentLibrary.
+        """
+        self.action_external_key = action_external_key
+        self.filter_keys = filter_keys
+
+    def query(self, user):
+        """Convert this rule to a Django Q object for QuerySet filtering.
+
+        This method enables efficient database-level filtering by:
+        1. Querying the authorization system to get ALL library scopes where the user has this permission
+        2. Parsing the library keys (org/slug pairs) from the scopes
+        3. Building a Django Q object that filters for libraries matching those org/slug combinations
+
+        This avoids N+1 query problems by filtering at the database level rather
+        than checking permission for each object individually.
+
+        Args:
+            user: The Django user object (must have a 'username' attribute).
+
+        Returns:
+            Q: A Django Q object that can be used to filter a QuerySet.
+               The Q object combines multiple conditions using OR (|) operators,
+               where each condition matches a library's org and slug fields:
+               Q(org__short_name='OrgA' & slug='lib-a') | Q(org__short_name='OrgB' & slug='lib-b')
+
+        Example:
+            >>> # User has 'view' permission in scopes: ['lib:OrgA:lib-a', 'lib:OrgB:lib-b']
+            >>> rule = HasPermissionInContentLibraryScope('view', filter_keys=['org', 'slug'])
+            >>> q = rule.query(user)
+            >>> # Results in: Q(org__short_name='OrgA', slug='lib-a') | Q(org__short_name='OrgB', slug='lib-b')
+            >>>
+            >>> # Apply to queryset
+            >>> libraries = ContentLibrary.objects.filter(q)
+            >>> # SQL: SELECT * FROM content_library
+            >>> #      WHERE (org.short_name='OrgA' AND slug='lib-a')
+            >>> #         OR (org.short_name='OrgB' AND slug='lib-b')
+        """
+        scopes = get_scopes_for_user_and_permission(
+            user.username,
+            self.action_external_key
+        )
+
+        library_keys = [scope.library_key for scope in scopes]
+
+        if not library_keys:
+            return Q(pk__in=[])  # No access, return Q that matches nothing
+
+        # Build Q object: OR together (org AND slug) conditions for each library
+        query = Q()
+        for library_key in library_keys:
+            query |= Q(org__short_name=library_key.org, slug=library_key.slug)
+
+        return query
+
+    def check(self, user, instance):
+        """Check if user has permission for a specific object instance.
+
+        This method is used for checking permission on individual objects rather
+        than filtering a QuerySet. It extracts the scope from the object and
+        checks if the user has the required permission in that scope via Casbin.
+
+        Args:
+            user: The Django user object (must have a 'username' attribute).
+            instance: The Django model instance to check permission for.
+
+        Returns:
+            bool: True if the user has the permission in the object's scope,
+                  False otherwise.
+
+        Example:
+            >>> rule = HasPermissionInScope('view')
+            >>> can_view = rule.check(user, library)
+            >>> # Checks if user has 'view' permission in scope 'lib:DemoX:CSPROB'
+        """
+        return is_user_allowed(user.username, self.action_external_key, str(instance.library_key))
+
+
 ########################### Permissions ###########################
 
 # Is the user allowed to view XBlocks from the specified content library
@@ -87,7 +261,9 @@ perms[CAN_VIEW_THIS_CONTENT_LIBRARY] = is_user_active & (
     is_global_staff |
     # Libraries with "public read" permissions can be accessed only by course creators
     (Attribute('allow_public_read', True) & is_course_creator) |
-    # Otherwise the user must be part of the library's team
+    # Users can access libraries within their authorized scope (via Casbin/role-based permissions)
+    HasPermissionInContentLibraryScope("view_library") |
+    # Fallback to: the user must be part of the library's team (legacy permission system)
     has_explicit_read_permission_for_library
 )
 

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -72,14 +72,9 @@ class HasPermissionInContentLibraryScope(Rule):
     2. Parsing the library keys (org/slug) from the scopes
     3. Building database filters to match ContentLibrary models with those org/slug combinations
 
-    This enables both individual object permission checks and efficient QuerySet
-    filtering - a key feature that allows database-level filtering instead of
-    checking each object individually.
-
     Attributes:
-        action_external_key (str): The action/permission to check (e.g., 'view_library', 'edit_library').
-            This should be the external key WITHOUT the namespace prefix.
-            For example, use 'view_library' not 'act^view_library'.
+        permission (PermissionData): The permission object representing the action to check
+            (e.g., 'view', 'edit'). This is used to look up scopes in the authorization system.
 
         filter_keys (list[str]): The Django model fields to use when building QuerySet filters.
             Defaults to ['org', 'slug'] for ContentLibrary models.
@@ -127,7 +122,6 @@ class HasPermissionInContentLibraryScope(Rule):
             >>> library = ContentLibrary.objects.get(org__short_name='DemoX', slug='CSPROB')
             >>> if perms['libraries.view_library'].check(request.user, library):
             ...     # User can view this specific library
-            ...     return render_library(library)
 
     Note:
         The library keys in authorization scopes must have the format 'lib:ORG:SLUG'
@@ -149,14 +143,6 @@ class HasPermissionInContentLibraryScope(Rule):
 
     def query(self, user):
         """Convert this rule to a Django Q object for QuerySet filtering.
-
-        This method enables efficient database-level filtering by:
-        1. Querying the authorization system to get ALL library scopes where the user has this permission
-        2. Parsing the library keys (org/slug pairs) from the scopes
-        3. Building a Django Q object that filters for libraries matching those org/slug combinations
-
-        This avoids N+1 query problems by filtering at the database level rather
-        than checking permission for each object individually.
 
         Args:
             user: The Django user object (must have a 'username' attribute).

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -200,7 +200,7 @@ class HasPermissionInContentLibraryScope(Rule):
                   False otherwise.
 
         Example:
-            >>> rule = HasPermissionInScope('view')
+            >>> rule = HasPermissionInContentLibraryScope('view')
             >>> can_view = rule.check(user, library)
             >>> # Checks if user has 'view' permission in scope 'lib:DemoX:CSPROB'
         """

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -6,8 +6,7 @@ from bridgekeeper.rules import Attribute, ManyRelation, Relation, blanket_rule, 
 from django.conf import settings
 from django.db.models import Q
 
-from openedx_authz.api.data import PermissionData
-from openedx_authz.api.users import is_user_allowed, get_scopes_for_user_and_permission
+from openedx_authz import api as authz_api
 from openedx_authz.constants.permissions import VIEW_LIBRARY
 
 from openedx.core.djangoapps.content_libraries.models import ContentLibraryPermission
@@ -130,7 +129,7 @@ class HasPermissionInContentLibraryScope(Rule):
         org.short_name='DemoX' and slug='CSPROB'.
     """
 
-    def __init__(self, permission: PermissionData, filter_keys: list[str] | None = None):
+    def __init__(self, permission: authz_api.PermissionData, filter_keys: list[str] | None = None):
         """Initialize the rule with the action and filter keys to filter on.
 
         Args:
@@ -165,7 +164,7 @@ class HasPermissionInContentLibraryScope(Rule):
             >>> #      WHERE (org.short_name='OrgA' AND slug='lib-a')
             >>> #         OR (org.short_name='OrgB' AND slug='lib-b')
         """
-        scopes = get_scopes_for_user_and_permission(
+        scopes = authz_api.get_scopes_for_user_and_permission(
             user.username,
             self.permission.identifier
         )
@@ -204,7 +203,7 @@ class HasPermissionInContentLibraryScope(Rule):
             >>> can_view = rule.check(user, library)
             >>> # Checks if user has 'view' permission in scope 'lib:DemoX:CSPROB'
         """
-        return is_user_allowed(user.username, self.permission.identifier, str(instance.library_key))
+        return authz_api.is_user_allowed(user.username, self.permission.identifier, str(instance.library_key))
 
 
 ########################### Permissions ###########################

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1243,7 +1243,9 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
             lib2 = self._create_library(slug="lib2", org="org2", title="Library 2")
             lib3 = self._create_library(slug="lib3", org="org1", title="Library 3")
 
-        with patch('openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission') as mock_get_scopes:
+        with patch(
+            'openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission'
+        ) as mock_get_scopes:
             # Mock: User authorized for lib1 (org1:lib1) and lib2 (org2:lib2) only, NOT lib3
             mock_scope1 = type('Scope', (), {'library_key': LibraryLocatorV2.from_string(lib1['id'])})()
             mock_scope2 = type('Scope', (), {'library_key': LibraryLocatorV2.from_string(lib2['id'])})()
@@ -1339,7 +1341,10 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
         with self.as_user(self.admin_user):
             lib = self._create_library(slug="empty-lib", title="Empty Scopes Test")
 
-        with patch('openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission', return_value=[]):
+        with patch(
+            'openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission',
+            return_value=[]
+        ):
             filtered = perms[CAN_VIEW_THIS_CONTENT_LIBRARY].filter(
                 user,
                 ContentLibrary.objects.filter(slug="empty-lib")
@@ -1362,7 +1367,9 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
         user = UserFactory.create(username="q_user")
         rule = HasPermissionInContentLibraryScope('view_library', filter_keys=['org', 'slug'])
 
-        with patch("openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission") as mock_get_scopes:
+        with patch(
+            "openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission"
+        ) as mock_get_scopes:
             # Create scopes with specific org/slug values we can verify
             mock_scope1 = type("Scope", (), {
                 "library_key": type("Key", (), {"org": "specific-org1", "slug": "specific-slug1"})()
@@ -1433,7 +1440,9 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
             lib3 = self._create_library(slug="pair-lib3", org="pair-org1", title="Pair Lib 3")  # Same org as lib1
             lib4 = self._create_library(slug="pair-lib1", org="pair-org3", title="Pair Lib 4")  # Same slug as lib1
 
-        with patch('openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission') as mock_get_scopes:
+        with patch(
+            'openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission'
+        ) as mock_get_scopes:
             # Authorize ONLY (pair-org1, pair-lib1) and (pair-org2, pair-lib2)
             lib1_key = LibraryLocatorV2.from_string(lib1['id'])
             lib2_key = LibraryLocatorV2.from_string(lib2['id'])

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -37,6 +37,7 @@ from openedx.core.djangoapps.content_libraries.tests.base import (
 )
 from openedx.core.djangoapps.xblock import api as xblock_api
 from openedx.core.djangolib.testing.utils import skip_unless_cms
+from openedx_authz.constants.permissions import VIEW_LIBRARY
 
 from ..models import ContentLibrary
 from ..permissions import CAN_VIEW_THIS_CONTENT_LIBRARY, HasPermissionInContentLibraryScope
@@ -1365,7 +1366,7 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
         (Q(org__short_name='org1') & Q(slug='lib1')) | (Q(org__short_name='org2') & Q(slug='lib2'))
         """
         user = UserFactory.create(username="q_user")
-        rule = HasPermissionInContentLibraryScope('view_library', filter_keys=['org', 'slug'])
+        rule = HasPermissionInContentLibraryScope(VIEW_LIBRARY, filter_keys=['org', 'slug'])
 
         with patch(
             "openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission"
@@ -1428,7 +1429,7 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
         - lib4: org3 + lib1 (NOT authorized - same slug, different org)
         """
         user = UserFactory.create(username="exact_pair_user")
-        rule = HasPermissionInContentLibraryScope('view_library', filter_keys=['org', 'slug'])
+        rule = HasPermissionInContentLibraryScope(VIEW_LIBRARY, filter_keys=['org', 'slug'])
 
         Organization.objects.get_or_create(short_name="pair-org1", defaults={"name": "Pair Org 1"})
         Organization.objects.get_or_create(short_name="pair-org2", defaults={"name": "Pair Org 2"})

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1351,11 +1351,16 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
                 ContentLibrary.objects.filter(slug="empty-lib")
             )
 
-            self.assertEqual(filtered.count(), 0,
-                           "Should return 0 libraries when user has no authorized scopes")
+            self.assertEqual(
+                filtered.count(),
+                0,
+                "Should return 0 libraries when user has no authorized scopes",
+            )
 
-            self.assertTrue(ContentLibrary.objects.filter(slug="empty-lib").exists(),
-                          "Library should exist in database")
+            self.assertTrue(
+                ContentLibrary.objects.filter(slug="empty-lib").exists(),
+                "Library should exist in database",
+            )
 
     def test_authz_scope_q_object_has_correct_structure(self):
         """
@@ -1386,31 +1391,52 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
             self.assertIsInstance(q_obj, Q)
 
             # Test 2: Verify Q object uses OR connector (for multiple scopes)
-            self.assertEqual(q_obj.connector, 'OR',
-                           "Should use OR to combine different library scopes")
+            self.assertEqual(
+                q_obj.connector,
+                'OR',
+                "Should use OR to combine different library scopes",
+            )
 
             # Test 3: Verify the Q object string contains the exact fields and values
             q_str = str(q_obj)
 
             # Should filter by org__short_name field
-            self.assertIn("org__short_name", q_str,
-                         "Q object must filter by org__short_name field")
+            self.assertIn(
+                "org__short_name",
+                q_str,
+                "Q object must filter by org__short_name field",
+            )
 
             # Should filter by slug field
-            self.assertIn("slug", q_str,
-                         "Q object must filter by slug field")
+            self.assertIn(
+                "slug",
+                q_str,
+                "Q object must filter by slug field",
+            )
 
             # Should contain exact org values
-            self.assertIn("specific-org1", q_str,
-                         "Q object must include 'specific-org1'")
-            self.assertIn("specific-org2", q_str,
-                         "Q object must include 'specific-org2'")
+            self.assertIn(
+                "specific-org1",
+                q_str,
+                "Q object must include 'specific-org1'",
+            )
+            self.assertIn(
+                "specific-org2",
+                q_str,
+                "Q object must include 'specific-org2'",
+            )
 
             # Should contain exact slug values
-            self.assertIn("specific-slug1", q_str,
-                         "Q object must include 'specific-slug1'")
-            self.assertIn('specific-slug2', q_str,
-                         "Q object must include 'specific-slug2'")
+            self.assertIn(
+                "specific-slug1",
+                q_str,
+                "Q object must include 'specific-slug1'",
+            )
+            self.assertIn(
+                'specific-slug2',
+                q_str,
+                "Q object must include 'specific-slug2'",
+            )
 
     def test_authz_scope_q_object_matches_exact_org_slug_pairs(self):
         """
@@ -1457,34 +1483,52 @@ class LibraryRestoreViewTestCase(ContentLibrariesRestApiTest):
             filtered = ContentLibrary.objects.filter(q_obj)
 
             # TEST: Verify EXACTLY 2 libraries match (lib1 and lib2 only)
-            self.assertEqual(filtered.count(), 2,
-                           "Must match EXACTLY 2 libraries - only those with authorized (org, slug) pairs")
+            self.assertEqual(
+                filtered.count(),
+                2,
+                "Must match EXACTLY 2 libraries - only those with authorized (org, slug) pairs",
+            )
 
             # TEST: Verify lib1 matches (pair-org1, pair-lib1)
             lib1_result = filtered.filter(slug='pair-lib1', org__short_name='pair-org1')
-            self.assertEqual(lib1_result.count(), 1,
-                           "Must match lib1: (pair-org1, pair-lib1) - this exact pair is authorized")
+            self.assertEqual(
+                lib1_result.count(),
+                1,
+                "Must match lib1: (pair-org1, pair-lib1) - this exact pair is authorized",
+            )
 
             # TEST: Verify lib2 matches (pair-org2, pair-lib2)
             lib2_result = filtered.filter(slug='pair-lib2', org__short_name='pair-org2')
-            self.assertEqual(lib2_result.count(), 1,
-                           "Must match lib2: (pair-org2, pair-lib2) - this exact pair is authorized")
+            self.assertEqual(
+                lib2_result.count(),
+                1,
+                "Must match lib2: (pair-org2, pair-lib2) - this exact pair is authorized",
+            )
 
             # TEST: Verify lib3 does NOT match (pair-org1, pair-lib3)
             lib3_result = filtered.filter(slug='pair-lib3', org__short_name='pair-org1')
-            self.assertEqual(lib3_result.count(), 0,
-                           "Must NOT match lib3: (pair-org1, pair-lib3) - only pair-lib1 is authorized for pair-org1")
+            self.assertEqual(
+                lib3_result.count(),
+                0,
+                "Must NOT match lib3: (pair-org1, pair-lib3) - only pair-lib1 is authorized for pair-org1",
+            )
 
             # TEST: Verify lib4 does NOT match (pair-org3, pair-lib1)
             lib4_result = filtered.filter(slug='pair-lib1', org__short_name='pair-org3')
-            self.assertEqual(lib4_result.count(), 0,
-                           "Must NOT match lib4: (pair-org3, pair-lib1) - only pair-org1 is authorized for pair-lib1")
+            self.assertEqual(
+                lib4_result.count(),
+                0,
+                "Must NOT match lib4: (pair-org3, pair-lib1) - only pair-org1 is authorized for pair-lib1",
+            )
 
             # TEST: Verify the result set contains exactly the right libraries
             result_pairs = set(filtered.values_list('org__short_name', 'slug'))
             expected_pairs = {('pair-org1', 'pair-lib1'), ('pair-org2', 'pair-lib2')}
-            self.assertEqual(result_pairs, expected_pairs,
-                           f"Result must contain exactly {expected_pairs}, got {result_pairs}")
+            self.assertEqual(
+                result_pairs,
+                expected_pairs,
+                f"Result must contain exactly {expected_pairs}, got {result_pairs}",
+            )
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1264,7 +1264,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         with self.as_user(self.admin_user):
             lib1 = self._create_library(slug="lib1", org="org1", title="Library 1")
             lib2 = self._create_library(slug="lib2", org="org2", title="Library 2")
-            lib3 = self._create_library(slug="lib3", org="org1", title="Library 3")
+            self._create_library(slug="lib3", org="org1", title="Library 3")
 
         # CRITICAL: Ensure user has NO legacy permissions (test ONLY AuthZ filtering)
         ContentLibraryPermission.objects.filter(user=user).delete()
@@ -1374,7 +1374,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         user = UserFactory.create(username="empty_user", is_staff=False)
 
         with self.as_user(self.admin_user):
-            lib = self._create_library(slug="empty-lib", title="Empty Scopes Test")
+            self._create_library(slug="empty-lib", title="Empty Scopes Test")
 
         # CRITICAL: Ensure user has NO legacy permissions (test ONLY AuthZ)
         ContentLibraryPermission.objects.filter(user=user).delete()
@@ -1504,8 +1504,8 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         with self.as_user(self.admin_user):
             lib1 = self._create_library(slug="pair-lib1", org="pair-org1", title="Pair Lib 1")
             lib2 = self._create_library(slug="pair-lib2", org="pair-org2", title="Pair Lib 2")
-            lib3 = self._create_library(slug="pair-lib3", org="pair-org1", title="Pair Lib 3")  # Same org as lib1
-            lib4 = self._create_library(slug="pair-lib1", org="pair-org3", title="Pair Lib 4")  # Same slug as lib1
+            self._create_library(slug="pair-lib3", org="pair-org1", title="Pair Lib 3")  # Same org as lib1
+            self._create_library(slug="pair-lib1", org="pair-org3", title="Pair Lib 4")  # Same slug as lib1
 
         # CRITICAL: Ensure user has NO legacy permissions (test ONLY AuthZ filtering)
         ContentLibraryPermission.objects.filter(user=user).delete()

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1270,7 +1270,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         ContentLibraryPermission.objects.filter(user=user).delete()
 
         with patch(
-            'openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission'
+            'openedx_authz.api.get_scopes_for_user_and_permission'
         ) as mock_get_scopes:
             # Mock: User authorized for lib1 (org1:lib1) and lib2 (org2:lib2) only, NOT lib3
             mock_scope1 = type('Scope', (), {'library_key': LibraryLocatorV2.from_string(lib1['id'])})()
@@ -1319,7 +1319,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         # CRITICAL: Ensure user has NO legacy permissions (test ONLY AuthZ)
         ContentLibraryPermission.objects.filter(user=user).delete()
 
-        with patch("openedx.core.djangoapps.content_libraries.permissions.is_user_allowed", return_value=True):
+        with patch("openedx_authz.api.is_user_allowed", return_value=True):
             result = perms[CAN_VIEW_THIS_CONTENT_LIBRARY].check(user, library_obj)
 
             self.assertTrue(result, "Should return True when user is authorized")
@@ -1348,7 +1348,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         # CRITICAL: Ensure user has NO legacy permissions (test ONLY AuthZ)
         ContentLibraryPermission.objects.filter(user=user).delete()
 
-        with patch('openedx.core.djangoapps.content_libraries.permissions.is_user_allowed', return_value=False):
+        with patch('openedx_authz.api.is_user_allowed', return_value=False):
             result = perms[CAN_VIEW_THIS_CONTENT_LIBRARY].check(user, library_obj)
 
             self.assertFalse(result, "Should return False when user is not authorized")
@@ -1380,7 +1380,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         ContentLibraryPermission.objects.filter(user=user).delete()
 
         with patch(
-            'openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission',
+            'openedx_authz.api.get_scopes_for_user_and_permission',
             return_value=[]
         ):
             filtered = perms[CAN_VIEW_THIS_CONTENT_LIBRARY].filter(
@@ -1414,7 +1414,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         rule = HasPermissionInContentLibraryScope(VIEW_LIBRARY, filter_keys=['org', 'slug'])
 
         with patch(
-            "openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission"
+            "openedx_authz.api.get_scopes_for_user_and_permission"
         ) as mock_get_scopes:
             # Create scopes with specific org/slug values we can verify
             mock_scope1 = type("Scope", (), {
@@ -1511,7 +1511,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         ContentLibraryPermission.objects.filter(user=user).delete()
 
         with patch(
-            'openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission'
+            'openedx_authz.api.get_scopes_for_user_and_permission'
         ) as mock_get_scopes:
             # Authorize ONLY (pair-org1, pair-lib1) and (pair-org2, pair-lib2)
             lib1_key = LibraryLocatorV2.from_string(lib1['id'])
@@ -1626,7 +1626,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
         )
 
         with patch(
-            'openedx.core.djangoapps.content_libraries.permissions.get_scopes_for_user_and_permission'
+            'openedx_authz.api.get_scopes_for_user_and_permission'
         ) as mock_get_scopes:
             # Set up AuthZ permissions: lib1 (AuthZ only), lib3 (both)
             lib1_key = LibraryLocatorV2.from_string(lib1['id'])

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1278,7 +1278,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
             mock_get_scopes.return_value = [mock_scope1, mock_scope2]
 
             all_libs = ContentLibrary.objects.filter(slug__in=['lib1', 'lib2', 'lib3'])
-            filtered = perms[CAN_VIEW_THIS_CONTENT_LIBRARY].filter(user, all_libs)
+            filtered = perms[CAN_VIEW_THIS_CONTENT_LIBRARY].filter(user, all_libs).distinct()
 
             # TEST: Verify exactly 2 libraries returned (lib1 and lib2, not lib3)
             self.assertEqual(filtered.count(), 2, "Should return exactly 2 authorized libraries")
@@ -1386,7 +1386,7 @@ class ContentLibrariesAuthZTestCase(ContentLibrariesRestApiTest):
             filtered = perms[CAN_VIEW_THIS_CONTENT_LIBRARY].filter(
                 user,
                 ContentLibrary.objects.filter(slug="empty-lib")
-            )
+            ).distinct()
 
             self.assertEqual(
                 filtered.count(),


### PR DESCRIPTION
## Description

This PR adds filtering for content libraries based on user permissions, using the bridgekeeper filtering functionality built on top of the new authorization framework (based on the Casbin engine). This is the more straightforward approach since it piggybacks on the current architecture.

**How it works:**

The implementation introduces a custom Bridgekeeper rule (`HasPermissionInContentLibraryScope`) that integrates the openedx-authz authorization system with Bridgekeeper's declarative permission system. This rule enables **both** individual object permission checks **and** efficient QuerySet filtering:

1. **Database-level filtering** (`query()` method): Queries the authorization system to get all library scopes where the user has permission, then builds Django Q objects to filter libraries at the database level. The permission check prioritizes the new authorization framework but falls back to the content library model permissions (the existing `has_explicit_read_permission_for_library` rule) for backward compatibility. Although it follows a backward compatibility approach, a migration script will be provided to support the new authorization framework. See https://github.com/openedx/edx-platform/issues/37409

2. **Individual object checks** (`check()` method): For checking permission on specific library instances, it extracts the scope from the object and verifies permission via openedx-authz. This method is not currently used in favor of https://github.com/openedx/edx-platform/pull/37501

## Supporting information

Related documentation:
- Authorization Framework (openedx-authz): https://github.com/openedx/openedx-authz/
- Bridgekeeper documentation: https://bridgekeeper.readthedocs.io/en/latest/
- Django permissions system: https://docs.djangoproject.com/en/stable/topics/auth/default/#permissions-and-authorization

## Testing instructions

1. Start with a clean installation and load the authorization policies:
   ```bash
   python manage.py {lms|cms} load_policies
   ```

2. Create a new content library using a user account without admin access

4. Create additional libraries using different user accounts (preferably with different organizations)

5. Go to the libraries list page

6. Verify that only the libraries you have permission to view are shown in the list
   - Libraries where you have explicit role assignments should appear
   - Libraries where you have no authorization should NOT appear

## Deadline

Before end-of-week (hopefully)
