### PR TITLE
style: Drop unused imports.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -39,9 +39,7 @@ When refering to XBlocks, we use the entry-point name. For example,
 # pylint: disable=unused-import, useless-suppression, wrong-import-order, wrong-import-position
 
 import importlib.util
-import json
 import os
-import sys
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from datetime import timedelta
@@ -53,19 +51,12 @@ import lms.envs.common
 from openedx.envs.common import *  # pylint: disable=wildcard-import
 
 from path import Path as path
-from django.urls import reverse_lazy
 
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 from cms.lib.xblock.authoring_mixin import AuthoringMixin
 from cms.lib.xblock.upstream_sync import UpstreamSyncMixin
 from xmodule.modulestore.edit_info import EditInfoMixin
-from openedx.core.djangoapps.theming.helpers_dirs import (
-    get_themes_unchecked,
-    get_theme_base_dirs_from_settings
-)
-from openedx.core.lib.license import LicenseMixin
 from openedx.core.lib.derived import Derived
-from openedx.core.release import doc_version
 from openedx.core.lib.features_setting_proxy import FeaturesProxy
 
 # A proxy for feature flags stored in the settings namespace
@@ -734,8 +725,6 @@ STATICFILES_FINDERS = [
     'openedx.core.lib.xblock_pipeline.finder.XBlockPipelineFinder',
     'pipeline.finders.PipelineFinder',
 ]
-
-from openedx.core.lib.rooted_paths import rooted_glob
 
 PIPELINE['STYLESHEETS'] = {
     'style-vendor': {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -41,10 +41,8 @@ Conventions
 # pylint: disable=invalid-name
 
 import importlib.util
-import sys
 import os
 
-import django
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from path import Path as path
 from django.utils.translation import gettext_lazy as _

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -37,8 +37,8 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_theme_base_dirs_from_settings
 )
 
-# For some reason other parts of the system reference these constants
-# via the settings module.
+# We have legacy components that reference these constants via the settings module.
+# New code should import them directly from `openedx.core.constants` instead.
 from openedx.core.constants import (  # pylint: disable=unused-import
     ASSET_KEY_PATTERN,
     COURSE_KEY_REGEX,

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -37,6 +37,8 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_theme_base_dirs_from_settings
 )
 
+# For some reason other parts of the system reference these constants
+# via the settings module.
 from openedx.core.constants import (  # pylint: disable=unused-import
     ASSET_KEY_PATTERN,
     COURSE_KEY_REGEX,


### PR DESCRIPTION
I was looking at these files for some other reason and saw that these
imports were unused. Some of it looks like an artifact of the hoisting
of some settings up to the `openedx/env/common.py` file and others look
like some ancient unused imports.

I tested this with the [diff_settings.sh script](https://github.com/openedx/edx-platform/pull/36306) and the only difference was the different memory addresses of the FeaturesProxy object.
