### PR TITLE
fix: lgeacy library block child.save fails in production instance while migrating

### DIFF
--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -325,7 +325,6 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
                 # Since after migration, the component in library is in draft state, we want to make sure that sync icon
                 # appears when it is published
                 child.upstream_version = 0
-                child.save()
                 # Use `modulestore()` instead of `self.runtime.modulestore` to make sure that the XBLOCK_UPDATED signal
                 # is triggered
                 store.update_item(child, None)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

The `child.save()` call while migrating legacy library block to library version 2 fails with `InvalidScopeError` due to presence of `LmsFieldData` in `_bound_field_data` field.
Removing this call does not seem to have any adverse affect.

**Error log:**
```logs
Traceback (most recent call last):
  File "/openedx/edx-platform/cms/djangoapps/contentstore/views/preview.py", line 77, in preview_handler
    resp = instance.handle(handler, req, suffix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/xblock/core.py", line 483, in handle
    return self.runtime.handle(self, handler_name, request, suffix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/xmodule/x_module.py", line 1008, in handle
    return super().handle(block, handler_name, request, suffix=suffix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/venv/lib/python3.11/site-packages/xblock/runtime.py", line 1057, in handle
    results = handler(request, suffix)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/xmodule/library_content_block.py", line 401, in upgrade_to_v2_library
    self._v2_update_children_upstream_version()
  File "/openedx/edx-platform/xmodule/library_content_block.py", line 329, in _v2_update_children_upstream_version
    child.save()
  File "/openedx/venv/lib/python3.11/site-packages/xblock/core.py", line 514, in save
    self.force_save_fields(fields_to_save)
  File "/openedx/venv/lib/python3.11/site-packages/xblock/core.py", line 531, in force_save_fields
    self._field_data.set_many(self, fields_to_save_json)
  File "/openedx/venv/lib/python3.11/site-packages/xblock/field_data.py", line 166, in set_many
    field_data.set_many(block, new_update_dict)
  File "/openedx/venv/lib/python3.11/site-packages/xblock/field_data.py", line 88, in set_many
    self.set(block, key, value)
  File "/openedx/venv/lib/python3.11/site-packages/xblock/field_data.py", line 196, in set
    raise InvalidScopeError(f"{block}.{name} is read-only, cannot set")
xblock.exceptions.InvalidScopeError
```

**Child field data:**
```python
{'_asides': [], '_cds_init_args': False, '_parent_block': <LegacyLibraryContentBlockWithMixins @5303 copied_from_block=None, downstream_customized=[], top_level_downstream_parent_key=None, upstream=None, upstream_display_name=None, upstream_version=None, upstream_version_declined=None, name=None, parent=BlockUsageLocator(CourseLocator('SampleTaxonomyOrg1', 'Chris456', 'chris456', None, None), 'vertical', 'd6b6fc5fd9104961aa83406773ddeea9'), tags=[], display_name='Randomized Content Block', course_edit_method='Studio', days_early_for_beta=None, due=None, edxnotes=False, edxnotes_visibility=True, giturl=None, graceperiod=None, graded=False, group_access={}, hide_from_toc=False, in_entrance_exam=False, matlab_api_key=None, max_attempts=None, relative_weeks_due=None, rerandomize='never', self_paced=False, show_correctness='always', show_reset_button=False, showanswer='finished', start=datetime.datetime(2030, 1, 1, 0, 0, tzinfo=tzlocal()), static_asset_path='', use_latex_compiler=False, user_partitions=[], video_auto_advance=False, video_bumper={}, video_speed_optimizations=True, visible_to_staff_only=False, xqa_key=None, chrome=None, default_tab=None, format=None, source_file=None, allow_resetting_children=False, children=[BlockUsageLocator(CourseLocator('SampleTaxonomyOrg1', 'Chris456', 'chris456', None, None), 'video', '4efeb593d14c61314395')], max_count=1, selected=[], xml_attributes={}, capa_type='any', is_migrated_to_v2=False, source_library_id='library-v1:tlmigration+tl123', source_library_version='68dc402f7ef716eebf702cf0'>, '_parent_block_id': BlockUsageLocator(CourseLocator('SampleTaxonomyOrg1', 'Chris456', 'chris456', None, None), 'library_content', '69629111a73b4504a0467511696a42ef'), '_child_cache': {}, '_runtime': <xmodule.modulestore.split_mongo.runtime.SplitModuleStoreRuntime object at 0x7f69e3bc34d0>, '_deprecated_per_instance_field_data': None, '_field_data_cache': {'upstream': 'lb:OpenCraft:chrislibrary:video:2cd6ffa4549b40ea8eb0521f9d34c3a8', 'upstream_version': 0}, '_dirty_fields': {<String upstream>: fields.EXPLICITLY_SET, <Integer upstream_version>: fields.EXPLICITLY_SET}, 'scope_ids': ScopeIds(user_id=40, block_type='video', def_id=ObjectId('68dc402f7ef716eebf702cef'), usage_id=BlockUsageLocator(CourseLocator('SampleTaxonomyOrg1', 'Chris456', 'chris456', None, None), 'video', '4efeb593d14c61314395')), '_edited_by': 40, '_edited_on': datetime.datetime(2025, 10, 30, 5, 51, 54, 319000, tzinfo=<bson.tz_util.FixedOffset object at 0x7f69e3bcdc50>), 'previous_version': None, 'update_version': ObjectId('6902fcfab505035c80dbd175'), 'source_version': None, 'definition_locator': DefinitionLocator(ObjectId('68dc402f7ef716eebf702cef'), 'video'), 'course_version': ObjectId('6902fcfab505035c80dbd175'), '_bound_field_data': LmsFieldData(ReadOnlyFieldData(InheritingFieldData(<xmodule.modulestore.split_mongo.split_mongo_kvs.SplitMongoKVS object at 0x7f69e3c2f010>)), KvsFieldData(<cms.djangoapps.contentstore.views.session_kv_store.SessionKeyValueStore object at 0x7f69e3c2c390>))}
```

## Supporting information

* Related PR: https://github.com/openedx/edx-platform/pull/37405

## Deadline

**Before ULMO Cut off**

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
