### PR TITLE
feat: Add user email replacement in HTML block data rendering

### DIFF
--- a/xmodule/html_block.py
+++ b/xmodule/html_block.py
@@ -127,14 +127,19 @@ class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
         """ Returns html required for rendering the block. """
         if self.data:
             data = self.data
-            user_id = (
+            user = (
                 self.runtime.service(self, 'user')
                 .get_current_user()
-                .opt_attrs.get(ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID)
             )
+            user_id = user.opt_attrs.get(ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID)
             if user_id:
                 data = data.replace("%%USER_ID%%", user_id)
             data = data.replace("%%COURSE_ID%%", str(self.scope_ids.usage_id.context_key))
+
+            if user.emails:
+                email = user.emails[0]
+                data = data.replace("%%USER_EMAIL%%", email)
+
             return data
         return self.data
 


### PR DESCRIPTION
## Description
This change adds support for `%%USER_EMAIL%%` in the HTML block type in both the LMS and CMS. When authors include the placeholder %%USER_EMAIL%% in a Raw HTML block, the system will replace it with the learner’s email address at runtime (similar to the existing `%%USER_ID%%` and `%%COURSE_ID%%` placeholders).

## Use Case
Adding `%%USER_EMAIL%%` enables course teams and content authors in Open edX to personalize content, messaging and embeds inside HTML blocks with the learner’s actual email address.

[Related Github Issue in platform roadmap](https://github.com/openedx/platform-roadmap/issues/486)

## Testing instructions
- Go to Studio / authoring MFE
- Create a unit
- Click on text block
- select `Raw HTML`
- Add `%%USER_EMAIL%%` somewhere in the text box
- The value will be resolved to the actual email both in LMS and CMS

<img width="1706" height="436" alt="Screenshot 2025-10-30 at 10 22 18 PM" src="https://github.com/user-attachments/assets/fab3d273-aab0-4547-b90b-f1670679c5d8" />

<img width="2559" height="1196" alt="Screenshot 2025-10-30 at 10 22 31 PM" src="https://github.com/user-attachments/assets/8fbe7257-1cc9-4636-a032-c7dcfbf036e1" />

<img width="2559" height="1196" alt="Screenshot 2025-10-30 at 10 22 54 PM" src="https://github.com/user-attachments/assets/ce3a5a4e-5bfa-468a-9d35-bc71538f4794" />
