### PR TITLE
feat: make ACCOUNT_MICROFRONTEND_URL site aware.

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -527,8 +527,12 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
 
     """
     user = request.user
+    account_microfrontend_url = configuration_helpers.get_value(
+        'ACCOUNT_MICROFRONTEND_URL',
+        settings.ACCOUNT_MICROFRONTEND_URL,
+    )
     if not UserProfile.objects.filter(user=user).exists():
-        return redirect(settings.ACCOUNT_MICROFRONTEND_URL)
+        return redirect(account_microfrontend_url)
 
     if learner_home_mfe_enabled():
         return redirect(settings.LEARNER_HOME_MICROFRONTEND_URL)
@@ -633,7 +637,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
                         "Go to {link_start}your Account Settings{link_end}.")
                 ).format(
                     link_start=HTML("<a href='{account_setting_page}'>").format(
-                        account_setting_page=settings.ACCOUNT_MICROFRONTEND_URL,
+                        account_setting_page=account_microfrontend_url,
                     ),
                     link_end=HTML("</a>")
                 )
@@ -902,7 +906,10 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     except DashboardRenderStarted.RenderInvalidDashboard as exc:
         response = render_to_response(exc.dashboard_template, exc.template_context)
     except DashboardRenderStarted.RedirectToPage as exc:
-        response = HttpResponseRedirect(exc.redirect_to or settings.ACCOUNT_MICROFRONTEND_URL)
+        response = HttpResponseRedirect(
+            exc.redirect_to or
+            account_microfrontend_url
+        )
     except DashboardRenderStarted.RenderCustomResponse as exc:
         response = exc.response
     else:

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -22,6 +22,7 @@ from openedx.core.lib.api.authentication import (
     BearerAuthenticationAllowInactiveUser
 )
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from common.djangoapps.third_party_auth import pipeline
 from common.djangoapps.third_party_auth.api import serializers
 from common.djangoapps.third_party_auth.api.permissions import TPA_PERMISSIONS
@@ -468,7 +469,10 @@ class ThirdPartyAuthUserStatusView(APIView):
                         state.provider.provider_id,
                         pipeline.AUTH_ENTRY_ACCOUNT_SETTINGS,
                         # The url the user should be directed to after the auth process has completed.
-                        redirect_url=settings.ACCOUNT_MICROFRONTEND_URL,
+                        redirect_url=configuration_helpers.get_value(
+                            'ACCOUNT_MICROFRONTEND_URL',
+                            settings.ACCOUNT_MICROFRONTEND_URL,
+                        ),
                     ),
                     'accepts_logins': state.provider.accepts_logins,
                     # If the user is connected, sending a POST request to this url removes the connection

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -111,7 +111,10 @@ def _get_course_email_context(course):
         'course_url': course_url,
         'course_image_url': image_url,
         'course_end_date': course_end_date,
-        'account_settings_url': settings.ACCOUNT_MICROFRONTEND_URL,
+        'account_settings_url': configuration_helpers.get_value(
+            'ACCOUNT_MICROFRONTEND_URL',
+            settings.ACCOUNT_MICROFRONTEND_URL,
+        ),
         'email_settings_url': '{}{}'.format(lms_root_url, reverse('dashboard')),
         'logo_url': get_logo_url_for_email(),
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -818,6 +818,56 @@ class ViewsTestCase(BaseViewsTestCase):
             response = self.client.get(url)
             self.assertRedirects(response, reverse('signin_user') + '?next=' + url)
 
+    def test_financial_assistance_form_uses_site_config_account_mfe_url(self):
+        """
+        When site configuration defines ACCOUNT_MICROFRONTEND_URL, the view should
+        pass that URL in the render context as 'account_settings_url'.
+        """
+        siteconf_url = "https://accounts.siteconf.example"
+        captured = {}
+
+        def fake_render(template_name, context, *args, **kwargs):
+            captured['context'] = context
+            return HttpResponse("ok")
+
+        with patch.object(views, 'render_to_response', new=fake_render):
+            with patch.object(
+                views.configuration_helpers,
+                'get_value',
+                side_effect=lambda key, default=None, *a, **k:
+                    siteconf_url if key == "ACCOUNT_MICROFRONTEND_URL" else default,
+            ):
+                resp = self.client.get(reverse('financial_assistance_form'))
+
+        assert resp.status_code == 200
+        assert 'context' in captured
+        assert captured['context']['account_settings_url'] == siteconf_url
+
+    def test_financial_assistance_form_falls_back_to_settings_for_account_mfe(self):
+        """
+        If site configuration doesn't override, fall back to settings.ACCOUNT_MICROFRONTEND_URL.
+        """
+        fallback = "https://accounts.settings.example"
+        captured = {}
+
+        def fake_render(template_name, context, *args, **kwargs):
+            captured['context'] = context
+            return HttpResponse("ok")
+
+        with override_settings(ACCOUNT_MICROFRONTEND_URL=fallback):
+            with patch.object(views, 'render_to_response', new=fake_render):
+                with patch.object(
+                    views.configuration_helpers,
+                    'get_value',
+                    side_effect=lambda key, default=None, *a, **k: default,
+                ):
+                    resp = self.client.get(reverse('financial_assistance_form'))
+
+                    assert resp.status_code == 200
+                    assert 'context' in captured
+                    assert captured['context']['account_settings_url'] == fallback
+                    assert captured['context']['account_settings_url'] == settings.ACCOUNT_MICROFRONTEND_URL
+
 
 # Patching 'lms.djangoapps.courseware.views.views.get_programs' would be ideal,
 # but for some unknown reason that patch doesn't seem to be applied.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -2232,7 +2232,10 @@ def financial_assistance_form(request, course_id=None):
         'header_text': _get_fa_header(FINANCIAL_ASSISTANCE_HEADER),
         'course_id': course_id,
         'dashboard_url': reverse('dashboard'),
-        'account_settings_url': settings.ACCOUNT_MICROFRONTEND_URL,
+        'account_settings_url': configuration_helpers.get_value(
+            'ACCOUNT_MICROFRONTEND_URL',
+            settings.ACCOUNT_MICROFRONTEND_URL,
+        ),
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
         'user_details': {
             'email': user.email,

--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -22,6 +22,7 @@ from lms.djangoapps.verify_student.message_types import VerificationExpiry
 from lms.djangoapps.verify_student.models import ManualVerification, SoftwareSecurePhotoVerification, SSOVerification
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.lib.celery.task_utils import emulate_http_request
 
@@ -188,7 +189,13 @@ class Command(BaseCommand):
             return True
 
         site = Site.objects.get_current()
-        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
+        account_base_url = (
+            configuration_helpers.get_value(
+                'ACCOUNT_MICROFRONTEND_URL',
+                settings.ACCOUNT_MICROFRONTEND_URL,
+            ) or
+            ""
+        ).rstrip('/')
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -251,7 +251,13 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
+        account_base_url = (
+            configuration_helpers.get_value(
+                'ACCOUNT_MICROFRONTEND_URL',
+                settings.ACCOUNT_MICROFRONTEND_URL,
+            ) or
+            ""
+        ).rstrip('/')
         location = f'{account_base_url}/id-verification'
         if course_id:
             location += f'?course_id={quote(str(course_id))}'

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1128,7 +1128,13 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
         log.info("[COSMO-184] Denied verification for receipt_id={receipt_id}.".format(receipt_id=receipt_id))
 
         attempt.deny(json.dumps(reason), error_code=error_code)
-        account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
+        account_base_url = (
+            configuration_helpers.get_value(
+                'ACCOUNT_MICROFRONTEND_URL',
+                settings.ACCOUNT_MICROFRONTEND_URL,
+            ) or
+            ""
+        ).rstrip('/')
         reverify_url = f'{account_base_url}/id-verification'
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
 %>
 
@@ -45,7 +46,7 @@ should_show_order_history = not enterprise_customer_portal and settings.ORDER_HI
         % endif
 
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${urljoin(settings.PROFILE_MICROFRONTEND_URL, f'{user.username}')}" role="menuitem">${_("Profile")}</a></div>
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ACCOUNT_MICROFRONTEND_URL}" role="menuitem">${_("Account")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)}" role="menuitem">${_("Account")}</a></div>
         % if should_show_order_history:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
         % endif

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 
 <%
@@ -28,7 +29,7 @@ profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
                 <a data-hj-suppress class="dropdown-toggle" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${username}</a>
                 <ul role="menu" class="dropdown-menu dropdown-menu-right" id="${_("Usermenu")}" aria-labelledby="dropdownMenuLink" tabindex="-1">
                     <li role="presentation"><a role="menuitem" class="dropdown-item" href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
-                    <li role="presentation"><a role="menuitem" class="dropdown-item" href="${settings.ACCOUNT_MICROFRONTEND_URL}">${_("Account")}</a></li>
+                    <li role="presentation"><a role="menuitem" class="dropdown-item" href="${configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)}">${_("Account")}</a></li>
                     <li role="presentation"><a role="menuitem" class="dropdown-item" href="${reverse('logout')}">${_("Sign Out")}</a></li>
                 </ul>
             </div>
@@ -36,7 +37,7 @@ profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
     </div>
     <ul role="menu" class="nav flex-column align-items-center">
         <li role="presentation" class="nav-item nav-item-open-collapsed-only collapse"><a role="menuitem" href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
-        <li role="presentation" class="nav-item nav-item-open-collapsed-only"><a role="menuitem" href="${settings.ACCOUNT_MICROFRONTEND_URL}">${_("Account")}</a></li>
+        <li role="presentation" class="nav-item nav-item-open-collapsed-only"><a role="menuitem" href="${configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)}">${_("Account")}</a></li>
         <li role="presentation" class="nav-item nav-item-open-collapsed-only"><a role="menuitem" href="${reverse('logout')}">${_("Sign Out")}</a></li>
     </ul>
 % else:

--- a/openedx/core/djangoapps/notifications/email/tests/test_utils.py
+++ b/openedx/core/djangoapps/notifications/email/tests/test_utils.py
@@ -199,6 +199,38 @@ class TestContextFunctions(ModuleStoreTestCase):
         assert_list_equal(context['email_digest_updates'], expected_digest_updates)
         assert_list_equal(context['email_content'], expected_email_content)
 
+    def test_email_template_context_notification_settings_url_uses_site_config(self):
+        """
+        When site configuration defines ACCOUNT_MICROFRONTEND_URL (with a trailing slash),
+        the context should build notification_settings_url from it and strip the slash.
+        """
+        siteconf_url = "https://accounts.siteconf.example/"
+
+        with patch(
+            "openedx.core.djangoapps.notifications.email.utils.configuration_helpers.get_value",
+            side_effect=lambda key, default=None, *a, **k:
+                siteconf_url if key == "ACCOUNT_MICROFRONTEND_URL" else default,
+        ):
+            ctx = create_email_template_context(self.user.username)
+
+        assert ctx["notification_settings_url"] == "https://accounts.siteconf.example/#notifications"
+
+    def test_email_template_context_notification_settings_url_falls_back_to_settings(self):
+        """
+        If site config doesn't override, the context should fall back to
+        settings.ACCOUNT_MICROFRONTEND_URL (also stripping any trailing slash).
+        """
+        fallback = "https://accounts.settings.example/"
+
+        with override_settings(ACCOUNT_MICROFRONTEND_URL=fallback):
+            with patch(
+                "openedx.core.djangoapps.notifications.email.utils.configuration_helpers.get_value",
+                side_effect=lambda key, default=None, *a, **k: default,
+            ):
+                ctx = create_email_template_context(self.user.username)
+
+        assert ctx["notification_settings_url"] == "https://accounts.settings.example/#notifications"
+
 
 class TestWaffleFlag(ModuleStoreTestCase):
     """

--- a/openedx/core/djangoapps/notifications/email/utils.py
+++ b/openedx/core/djangoapps/notifications/email/utils.py
@@ -101,7 +101,13 @@ def create_email_template_context(username):
         'channel': 'email',
         'value': False
     }
-    account_base_url = (settings.ACCOUNT_MICROFRONTEND_URL or "").rstrip('/')
+    account_base_url = (
+        configuration_helpers.get_value(
+            'ACCOUNT_MICROFRONTEND_URL',
+            settings.ACCOUNT_MICROFRONTEND_URL,
+        ) or
+        ""
+    ).rstrip('/')
     return {
         "platform_name": settings.PLATFORM_NAME,
         "mailing_address": settings.CONTACT_MAILING_ADDRESS,

--- a/openedx/core/djangoapps/password_policy/compliance.py
+++ b/openedx/core/djangoapps/password_policy/compliance.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.utils.translation import gettext as _
 
 from openedx.core.djangolib.markup import HTML
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from common.djangoapps.util.date_utils import DEFAULT_SHORT_DATE_FORMAT, strftime_localized
 from common.djangoapps.util.password_policy_validators import validate_password
 
@@ -97,7 +98,10 @@ def enforce_compliance_on_login(user, password):
                 platform_name=settings.PLATFORM_NAME,
                 deadline=strftime_localized(deadline, DEFAULT_SHORT_DATE_FORMAT),
                 anchor_tag_open=HTML('<a href="{account_settings_url}">').format(
-                    account_settings_url=settings.ACCOUNT_MICROFRONTEND_URL
+                    account_settings_url=configuration_helpers.get_value(
+                        'ACCOUNT_MICROFRONTEND_URL',
+                        settings.ACCOUNT_MICROFRONTEND_URL,
+                    ),
                 ),
                 anchor_tag_close=HTML('</a>')
             )

--- a/openedx/core/djangoapps/user_api/legacy_urls.py
+++ b/openedx/core/djangoapps/user_api/legacy_urls.py
@@ -6,6 +6,8 @@ from django.urls import path, re_path, include
 from django.views.generic import RedirectView
 from rest_framework import routers
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 from . import views as user_api_views
 from .models import UserPreference
 
@@ -17,7 +19,12 @@ urlpatterns = [
     # This redirect is needed for backward compatibility with the old URL structure for the authentication
     # workflows using third-party authentication providers until the authentication workflows fully support
     # the URL structure with MFEs.
-    re_path(r'^account(?:/settings)?/?$', RedirectView.as_view(url=settings.ACCOUNT_MICROFRONTEND_URL)),
+    re_path(r'^account(?:/settings)?/?$', RedirectView.as_view(
+        url=configuration_helpers.get_value(
+            'ACCOUNT_MICROFRONTEND_URL',
+            settings.ACCOUNT_MICROFRONTEND_URL,
+        )),
+    ),
     path('user_api/v1/', include(USER_API_ROUTER.urls)),
     re_path(
         fr'^user_api/v1/preferences/(?P<pref_key>{UserPreference.KEY_REGEX})/users/$',

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -23,6 +23,7 @@ from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_from_token
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
 
@@ -245,7 +246,10 @@ def _get_user_info_cookie_data(request, user):
     # External sites will need to have fallback mechanisms to handle this case
     # (most likely just hiding the links).
     try:
-        header_urls['account_settings'] = settings.ACCOUNT_MICROFRONTEND_URL
+        header_urls['account_settings'] = configuration_helpers.get_value(
+            'ACCOUNT_MICROFRONTEND_URL',
+            settings.ACCOUNT_MICROFRONTEND_URL,
+        )
         header_urls['learner_profile'] = urljoin(settings.PROFILE_MICROFRONTEND_URL, f'/u/{user.username}')
     except NoReverseMatch:
         pass


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR makes the Account MFE base URL site‑aware. All reads of settings.ACCOUNT_MICROFRONTEND_URL are replaced with:

`configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)`

This lets Operators override the Account MFE host per Site Configuration (multi‑tenant / stage) without code changes or deploy‑time env tweaks. If no override is present, behavior falls back to the Django setting.  ￼

### Impacted areas

- Student dashboard
Redirects and inlined links now resolve the Account URL via Site Configuration.
- Third‑party auth (TPA) API
The redirect_url used post‑auth/linking flows now pulls from Site Configuration. 
- ID Verification (IDV) flows
    - Management command send_verification_expiry_email: builds account_base_url from Site Configuration.
    - verify_student.services.get_verify_location: Account base resolved via Site Configuration.
    - verify_student.views.results_callback: reverify_url uses the config‑derived base.
- Header / user dropdown templates
“Account” links in Mako templates read the Account base via configuration_helpers.get_value(...).
- Legacy account URLs & cookies
    - openedx.core.djangoapps.user_api.legacy_urls: legacy /account(/settings) redirects point at the config‑derived Account MFE.
    - openedx.core.djangoapps.user_authn.cookies: header_urls['account_settings'] uses the config value. 
- Email & UI helpers
    - Bulk email context: account_settings_url now site‑aware; platform_name read via Site Configuration.
    - Financial assistance view context: account_settings_url site‑aware; platform_name via Site Configuration.
    - Notifications email utils: account_base_url built from Site Configuration for link construction.
- Password policy enforcement
    - Non‑compliance banner/link uses the config‑derived Account URL.

### Secondary improvement

- Platform name configurability
In the bulk email and financial assistance contexts, PLATFORM_NAME is fetched via
configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME) to allow per‑site branding.

## Supporting information
- No migrations; no operator action required for default deployments.
- Changes are read‑only lookups and string concatenations; no DB schema or data changes.

## Testing instructions

### Manual validation
1. Set a Site Configuration override for ACCOUNT_MICROFRONTEND_URL (e.g., https://account.override.local).
2. Navigation links: Log in and open the user dropdown; “Account” should point to the override host.
3.  Legacy redirects: Hit /account and /account/settings in LMS; you should be redirected to the override host.
4. TPA flows: Start a provider connection and confirm the post‑auth redirect_url lands on the override Account MFE.
5. IDV: Trigger a failure/denial path in IDV and confirm the “Reverify” link uses the override base; inspect get_verify_location(...) output if testing in a shell.
6. Emails/contexts:
- Render a bulk‑email context and verify account_settings_url uses the override; platform_name respects Site Configuration.
- Render a notifications email template context and confirm account_base_url uses the override.
7. Password policy: Force a password policy non‑compliant state and verify the banner’s “Account Settings” link points to the override.

### Automated tests

```
# from repo root
pytest -q \
  common/djangoapps/third_party_auth/api/tests/test_views.py \
  lms/djangoapps/bulk_email/tests/test_tasks.py \
  lms/djangoapps/courseware/tests/test_views.py \
  lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py \
  lms/djangoapps/verify_student/tests/test_services.py \
  lms/djangoapps/verify_student/tests/test_views.py \
  openedx/core/djangoapps/notifications/email/tests/test_utils.py \
  openedx/core/djangoapps/password_policy/tests/test_compliance.py \
  openedx/core/djangoapps/user_authn/tests/test_cookies.py

```
## Other information
- Risk: Low.
- Dependencies: None.
- Security/Privacy: No new PII exposure; URLs and encrypted parameters are unchanged beyond host selection.
- Performance: Negligible. Lookups either happen inline or once per import (depending on the module).
- Operator note: For multi‑site instances, ensure each Site sets a correct ACCOUNT_MICROFRONTEND_URL. If omitted, defaults apply.
