### PR TITLE
feat: created api to get course modes in instructor app

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -5142,7 +5142,7 @@ class CourseModeListViewTest(SharedModuleStoreTestCase, APITestCase):
             'instructor_api_v1:course_modes_list',
             kwargs={'course_id': 'course-v1:Missing+Org+Run'}
         )
-        CourseOverview.objects.filter(id=self.course.id).delete()
+        CourseOverview.objects.filter(id='course-v1:Missing+Org+Run').delete()
         response = self.client.get(bad_url)
         self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -36,9 +36,8 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from edx_when.api import get_date_for_block
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from rest_framework.generics import GenericAPIView
-
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_by_name
+from rest_framework.generics import GenericAPIView
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework import serializers, status  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework.permissions import IsAdminUser, IsAuthenticated, BasePermission  # lint-amnesty, pylint: disable=wrong-import-order
@@ -4393,7 +4392,7 @@ class CourseModeListView(GenericAPIView):
 
         :raises 401 Unauthorized: User is not authenticated.
         :raises 403 Forbidden: User lacks instructor or staff permissions for the course.
-        :raises 404 Not Found: The specified `course_key` does not exist.
+        :raises 404 Not Found: The specified `course_id` does not exist.
     """
     permission_classes = (IsAuthenticated, permissions.InstructorPermission)
     permission_name = VIEW_DASHBOARD
@@ -4427,8 +4426,5 @@ class CourseModeListView(GenericAPIView):
         """
         all_modes = CourseMode.objects.filter(course_id=course_id)
 
-        serializer = CourseModeSerializer(all_modes, many=True)
-        modes_data = serializer.data
-        response_data = {'modes': modes_data}
-        response_serializer = CourseModeListSerializer(instance=response_data)
-        return Response(response_serializer.data, status=status.HTTP_200_OK)
+        serializer = CourseModeListSerializer(instance={'modes': all_modes})
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -4346,7 +4346,7 @@ class CourseModeListView(GenericAPIView):
 
         Requires instructor or staff access to the course.
 
-        :param course_id: (Query Param) The unique identifier (course key) for the course.
+        :param course_id: (Path Param) The unique identifier (course key) for the course.
         :type course_id: string
 
         **Example Request:**

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -36,6 +36,8 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from edx_when.api import get_date_for_block
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from rest_framework.generics import GenericAPIView
+
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_by_name
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework import serializers, status  # lint-amnesty, pylint: disable=wrong-import-order
@@ -118,7 +120,7 @@ from lms.djangoapps.instructor.views.serializer import (
     RescoreEntranceExamSerializer,
     OverrideProblemScoreSerializer,
     StudentsUpdateEnrollmentSerializer,
-    ResetEntranceExamAttemptsSerializer
+    ResetEntranceExamAttemptsSerializer, CourseModeListSerializer, CourseModeSerializer
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort, is_course_cohorted
@@ -147,6 +149,7 @@ from .tools import (
     strip_if_string,
 )
 from .. import permissions
+from ..permissions import VIEW_DASHBOARD
 
 log = logging.getLogger(__name__)
 
@@ -264,6 +267,7 @@ def require_sales_admin(func):
             return func(request, course_id)
         else:
             return HttpResponseForbidden()
+
     return wrapped
 
 
@@ -4232,7 +4236,8 @@ def re_validate_certificate(request, course_key, generated_certificate, student)
 
     certificate_invalidation = certs_api.get_certificate_invalidation_entry(generated_certificate)
     if not certificate_invalidation:
-        raise ValueError(_("Certificate Invalidation does not exist, Please refresh the page and try again."))  # lint-amnesty, pylint: disable=raise-missing-from
+        raise ValueError(
+            _("Certificate Invalidation does not exist, Please refresh the page and try again."))  # lint-amnesty, pylint: disable=raise-missing-from
 
     certificate_invalidation.deactivate()
 
@@ -4288,7 +4293,7 @@ def _get_certificate_for_user(course_key, student):
         raise ValueError(_(
             "The student {student} does not have certificate for the course {course}. Kindly verify student "
             "username/email and the selected course are correct and try again.").format(
-                student=student.username, course=course_key.course)
+            student=student.username, course=course_key.course)
         )
 
     return certificate
@@ -4334,3 +4339,96 @@ def _get_branded_email_template(course_overview):
         template_name = template_name.get(course_overview.display_org_with_default)
 
     return template_name
+
+
+class CourseModeListView(GenericAPIView):
+    """
+        Retrieves the available enrollment modes (e.g., audit, verified) for a specific course.
+
+        Requires instructor or staff access to the course.
+
+        :param course_id: (Query Param) The unique identifier (course key) for the course.
+        :type course_id: string
+
+        **Example Request:**
+
+        .. code-block:: http
+
+            GET /api/instructor/course/mode/?course_key=course-v1:MyOrg+CS101+2025
+
+        **Success Response (200 OK):**
+
+        Returns a JSON object containing a list of the course's enrollment modes.
+
+        .. code-block:: json
+
+            {
+                "modes": [
+                    {
+                        "mode_slug": "audit",
+                        "mode_display_name": "Audit Track",
+                        "min_price": 0,
+                        "currency": "USD",
+                        "expiration_datetime": null,
+                        "description": "Access the course materials for free, but without a certificate.",
+                        "sku": null,
+                        "android_sku": null,
+                        "ios_sku": null,
+                        "bulk_sku": null
+                    },
+                    {
+                        "mode_slug": "verified",
+                        "mode_display_name": "Verified Track",
+                        "min_price": 49,
+                        "currency": "USD",
+                        "expiration_datetime": null,
+                        "description": "Access all materials, graded assignments, and earn a verified certificate.",
+                        "sku": null,
+                        "android_sku": null,
+                        "ios_sku": null,
+                        "bulk_sku": null
+                    }
+                ]
+            }
+
+        :raises 401 Unauthorized: User is not authenticated.
+        :raises 403 Forbidden: User lacks instructor or staff permissions for the course.
+        :raises 404 Not Found: The specified `course_key` does not exist.
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = VIEW_DASHBOARD
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+        ],
+        responses={
+            200: CourseModeListSerializer,
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks instructor access to the course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    def get(self, request, course_id):
+        """
+        Handles the GET request for course modes.
+
+        Args:
+            request (Request): The DRF request object.
+            course_id (CourseKey): The course key, parsed from the URL.
+
+        Returns:
+            Response: A DRF Response object containing the serialized
+                      course modes or an error.
+        """
+        all_modes = CourseMode.objects.filter(course_id=course_id)
+
+        serializer = CourseModeSerializer(all_modes, many=True)
+        modes_data = serializer.data
+        response_data = {'modes': modes_data}
+        response_serializer = CourseModeListSerializer(instance=response_data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -119,7 +119,7 @@ from lms.djangoapps.instructor.views.serializer import (
     RescoreEntranceExamSerializer,
     OverrideProblemScoreSerializer,
     StudentsUpdateEnrollmentSerializer,
-    ResetEntranceExamAttemptsSerializer, CourseModeListSerializer, CourseModeSerializer
+    ResetEntranceExamAttemptsSerializer, CourseModeListSerializer
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort, is_course_cohorted
@@ -4342,57 +4342,47 @@ def _get_branded_email_template(course_overview):
 
 class CourseModeListView(GenericAPIView):
     """
-        Retrieves the available enrollment modes (e.g., audit, verified) for a specific course.
-
-        Requires instructor or staff access to the course.
-
-        :param course_id: (Path Param) The unique identifier (course key) for the course.
-        :type course_id: string
-
-        **Example Request:**
-
-        .. code-block:: http
-
-            GET /api/instructor/course/mode/?course_key=course-v1:MyOrg+CS101+2025
-
-        **Success Response (200 OK):**
-
-        Returns a JSON object containing a list of the course's enrollment modes.
-
-        .. code-block:: json
-
-            {
-                "modes": [
-                    {
-                        "mode_slug": "audit",
-                        "mode_display_name": "Audit Track",
-                        "min_price": 0,
-                        "currency": "USD",
-                        "expiration_datetime": null,
-                        "description": "Access the course materials for free, but without a certificate.",
-                        "sku": null,
-                        "android_sku": null,
-                        "ios_sku": null,
-                        "bulk_sku": null
-                    },
-                    {
-                        "mode_slug": "verified",
-                        "mode_display_name": "Verified Track",
-                        "min_price": 49,
-                        "currency": "USD",
-                        "expiration_datetime": null,
-                        "description": "Access all materials, graded assignments, and earn a verified certificate.",
-                        "sku": null,
-                        "android_sku": null,
-                        "ios_sku": null,
-                        "bulk_sku": null
-                    }
-                ]
-            }
-
-        :raises 401 Unauthorized: User is not authenticated.
-        :raises 403 Forbidden: User lacks instructor or staff permissions for the course.
-        :raises 404 Not Found: The specified `course_id` does not exist.
+    Retrieves the available enrollment modes (e.g., audit, verified) for a specific course.
+    Requires instructor or staff access to the course.
+    :param course_id: (Query Param) The unique identifier (course key) for the course.
+    :type course_id: string
+    **Example Request:**
+    .. code-block:: http
+        GET /api/instructor/courses/{COURSE_ID_PATTERN}/modes
+    **Success Response (200 OK):**
+    Returns a JSON object containing a list of the course's enrollment modes.
+    .. code-block:: json
+        {
+            "modes": [
+                {
+                    "mode_slug": "audit",
+                    "mode_display_name": "Audit Track",
+                    "min_price": 0,
+                    "currency": "USD",
+                    "expiration_datetime": null,
+                    "description": "Access the course materials for free, but without a certificate.",
+                    "sku": null,
+                    "android_sku": null,
+                    "ios_sku": null,
+                    "bulk_sku": null
+                },
+                {
+                    "mode_slug": "verified",
+                    "mode_display_name": "Verified Track",
+                    "min_price": 49,
+                    "currency": "USD",
+                    "expiration_datetime": null,
+                    "description": "Access all materials, graded assignments, and earn a verified certificate.",
+                    "sku": null,
+                    "android_sku": null,
+                    "ios_sku": null,
+                    "bulk_sku": null
+                }
+            ]
+        }
+    :raises 401 Unauthorized: User is not authenticated.
+    :raises 403 Forbidden: User lacks instructor or staff permissions for the course.
+    :raises 404 Not Found: The specified `course_key` does not exist.
     """
     permission_classes = (IsAuthenticated, permissions.InstructorPermission)
     permission_name = VIEW_DASHBOARD

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -18,10 +18,10 @@ v1_api_urls = [
     re_path(rf'^reports/{COURSE_ID_PATTERN}/generate/problem_responses$', api.ProblemResponseReportInitiate.as_view(),
             name='generate_problem_responses', ),
     re_path(
-        f'courses/{COURSE_ID_PATTERN}/modes',
+        rf'^courses/{COURSE_ID_PATTERN}/modes$',
         api.CourseModeListView.as_view(),
         name='course_modes_list'
-    )
+    ),
 ]
 
 urlpatterns = [

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -2,7 +2,6 @@
 """
 Instructor API endpoint urls.
 """
-
 from django.urls import path, re_path
 
 from lms.djangoapps.instructor.views import api, gradebook_api
@@ -18,6 +17,11 @@ v1_api_urls = [
     re_path(rf'^reports/{COURSE_ID_PATTERN}$', api.ReportDownloads.as_view(), name='list_report_downloads', ),
     re_path(rf'^reports/{COURSE_ID_PATTERN}/generate/problem_responses$', api.ProblemResponseReportInitiate.as_view(),
             name='generate_problem_responses', ),
+    re_path(
+        f'courses/{COURSE_ID_PATTERN}/modes',
+        api.CourseModeListView.as_view(),
+        name='course_modes_list'
+    )
 ]
 
 urlpatterns = [
@@ -100,4 +104,5 @@ urlpatterns = [
         api.CertificateInvalidationView.as_view(),
         name='certificate_invalidation_view'
     ),
+
 ]

--- a/lms/djangoapps/instructor/views/serializer.py
+++ b/lms/djangoapps/instructor/views/serializer.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.instructor.access import ROLES
 from openedx.core.djangoapps.django_comment_common.models import (
@@ -570,3 +571,37 @@ class OverrideProblemScoreSerializer(UniqueStudentIdentifierSerializer):
     score = serializers.FloatField(
         help_text=_("The overriding score to set."),
     )
+
+
+class CourseModeSerializer(serializers.ModelSerializer):
+    """
+    Serializes CourseMode data for the API.
+
+    This serializer surfaces the key pricing, SKU, and expiration
+    information for a course's enrollment mode.
+    """
+
+    expiration_datetime = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = CourseMode
+        fields = [
+            'mode_slug',
+            'mode_display_name',
+            'min_price',
+            'currency',
+            'expiration_datetime',
+            'description',
+            'sku',
+            'android_sku',
+            'ios_sku',
+            'bulk_sku',
+        ]
+
+
+class CourseModeListSerializer(serializers.Serializer):
+    """
+    Serializes the top-level response for the course modes list endpoint,
+    matching the OpenAPI spec structure.
+    """
+    modes = CourseModeSerializer(many=True, read_only=True)


### PR DESCRIPTION
# Description 

Issue : https://github.com/openedx/edx-platform/issues/37465

This PR added API  endpoint to get course modes for instructor dashboard . 

`/api/instructor/v1/courses/{course_key}/modes `

```javascript
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "modes": [
        {
            "mode_slug": "audit",
            "mode_display_name": "Audit Track",
            "min_price": 0,
            "currency": "USD",
            "expiration_datetime": null,
            "description": "Access the course materials for free, but without a certificate.",
            "sku": null,
            "android_sku": null,
            "ios_sku": null,
            "bulk_sku": null
        },
        {
            "mode_slug": "verified",
            "mode_display_name": "Verified Track",
            "min_price": 49,
            "currency": "USD",
            "expiration_datetime": null,
            "description": "Access all materials, graded assignments, and earn a verified certificate.",
            "sku": null,
            "android_sku": null,
            "ios_sku": null,
            "bulk_sku": null
        }
    ]
}
``` 