### PR TITLE
 feat: added update mode price api for instructors

### DIFF
--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -7,6 +7,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission
 
+from common.djangoapps.student.roles import GlobalStaff
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.rules import HasAccessRule, HasRolesRule
 from lms.djangoapps.discussion.django_comment_client.utils import has_forum_access
@@ -83,6 +84,8 @@ perms[VIEW_FORUM_MEMBERS] = HasAccessRule('staff')
 class InstructorPermission(BasePermission):
     """Generic permissions"""
     def has_permission(self, request, view):
+        if GlobalStaff().has_user(request.user):
+            return True
         course = get_course_by_id(CourseKey.from_string(view.kwargs.get('course_id')))
         permission = getattr(view, 'permission_name', None)
         return request.user.has_perm(permission, course)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -5243,7 +5243,7 @@ class TestCourseModePriceView(SharedModuleStoreTestCase, APITestCase):
             org='org'
         )
 
-        self.staff_user = UserFactory(is_staff=True)
+
         self.student_user = UserFactory()
         self.instructor_user = UserFactory()
         self.staff_user = UserFactory()

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -172,7 +172,6 @@ INSTRUCTOR_GET_ENDPOINTS = {
     'instructor_api_v1:list_instructor_tasks',
     'instructor_api_v1:list_report_downloads',
     'instructor_api_v1:course_modes_list',
-    'instructor_api_v1:course_mode_price',
 }
 INSTRUCTOR_POST_ENDPOINTS = {
     'add_users_to_cohorts',
@@ -5259,7 +5258,7 @@ class TestCourseModePriceView(SharedModuleStoreTestCase, APITestCase):
             currency='USD'
         )
 
-        self.url = reverse('instructor_api_v1:course_mode_price', kwargs={
+        self.url = django_reverse('instructor_api_v1:course_mode_price', kwargs={
             'course_id': self.course.id,
             'mode_slug': self.verified_mode.mode_slug
         })
@@ -5330,7 +5329,7 @@ class TestCourseModePriceView(SharedModuleStoreTestCase, APITestCase):
         """
         self.client.force_authenticate(user=self.instructor_user)
 
-        invalid_url = reverse('instructor_api_v1:course_mode_price', kwargs={
+        invalid_url = django_reverse('instructor_api_v1:course_mode_price', kwargs={
             'course_id': 'course-v1:FakeOrg+Nope+123',
             'mode_slug': 'non-existent-mode'
         })
@@ -5349,7 +5348,7 @@ class TestCourseModePriceView(SharedModuleStoreTestCase, APITestCase):
         """
         self.client.force_authenticate(user=self.instructor_user)
 
-        invalid_url = reverse('instructor_api_v1:course_mode_price', kwargs={
+        invalid_url = django_reverse('instructor_api_v1:course_mode_price', kwargs={
             'course_id': self.course.id,
             'mode_slug': 'non-existent-mode'
         })

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1642,7 +1642,7 @@ class GetInactiveEnrolledStudents(DeveloperErrorViewMixin, APIView):
 
 def _cohorts_csv_validator(file_storage, file_to_validate):
     """
-    Verifies that the expected columns are present in the CSV` used to add users to cohorts.
+    Verifies that the expected columns are present in the CSV used to add users to cohorts.
     """
     with file_storage.open(file_to_validate) as f:
         reader = csv.reader(f.read().decode('utf-8-sig').splitlines())
@@ -4449,7 +4449,7 @@ class CourseModePriceView(GenericAPIView):
 
         .. code-block:: http
 
-            PATCH /api/instructor/course/modes/course-v1:MyOrg+CS101+2025/verified/price
+            PATCH /api/instructor/v1/course/course-v1:MyOrg+CS101+2025/modes/verified/price
             Content-Type: application/merge-patch+json
 
         **Request Body:**
@@ -4495,7 +4495,7 @@ class CourseModePriceView(GenericAPIView):
             204: "Mode price updated successfully (no content returned).",
             400: "Invalid request body or parameters.",
             401: "The requesting user is not authenticated.",
-            403: "The requesting user lacks Finance/Sales Admin permissions.",
+            403: "The requesting user lacks instructor, staff, or data researcher permissions.",
             404: "The requested course or mode does not exist.",
             415: "Unsupported Media Type - must use application/merge-patch+json.",
         },
@@ -4519,7 +4519,15 @@ class CourseModePriceView(GenericAPIView):
         new_price = serializer.validated_data['price']
 
         try:
-            mode = CourseMode.objects.get(course_id=course_id, mode_slug=mode_slug)
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            return Response(
+                {"error": "Invalid course_id format."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            mode = CourseMode.objects.get(course_id=course_key, mode_slug=mode_slug)
         except CourseMode.DoesNotExist:
             return Response(
                 {"error": f"Mode '{mode_slug}' not found for course '{course_id}'."},

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -21,7 +21,12 @@ v1_api_urls = [
         f'courses/{COURSE_ID_PATTERN}/modes',
         api.CourseModeListView.as_view(),
         name='course_modes_list'
-    )
+    ),
+    path(
+        'course/<course_id>/modes/<mode_slug>/price',
+        api.CourseModePriceView.as_view(),
+        name='course_mode_price'
+    ),
 ]
 
 urlpatterns = [

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -22,8 +22,8 @@ v1_api_urls = [
         api.CourseModeListView.as_view(),
         name='course_modes_list'
     ),
-    path(
-        'course/<course_id>/modes/<mode_slug>/price',
+    re_path(
+        rf'courses/{COURSE_ID_PATTERN}/modes/(?P<mode_slug>[^/]+)/price',
         api.CourseModePriceView.as_view(),
         name='course_mode_price'
     ),

--- a/lms/djangoapps/instructor/views/serializer.py
+++ b/lms/djangoapps/instructor/views/serializer.py
@@ -620,5 +620,3 @@ class ModePriceUpdateSerializer(serializers.Serializer):
         help_text="The new price in the smallest currency unit (e.g., cents)."
     )
 
-    class Meta:
-        fields = ['price']

--- a/lms/djangoapps/instructor/views/serializer.py
+++ b/lms/djangoapps/instructor/views/serializer.py
@@ -605,3 +605,20 @@ class CourseModeListSerializer(serializers.Serializer):
     matching the OpenAPI spec structure.
     """
     modes = CourseModeSerializer(many=True, read_only=True)
+
+
+class ModePriceUpdateSerializer(serializers.Serializer):
+    """
+    Validates the request body for a course mode price update.
+
+    Ensures that the request body contains a valid 'price' field.
+    """
+
+    price = serializers.IntegerField(
+        required=True,
+        min_value=0,
+        help_text="The new price in the smallest currency unit (e.g., cents)."
+    )
+
+    class Meta:
+        fields = ['price']


### PR DESCRIPTION
**Description**

Issue:  https://github.com/openedx/edx-platform/issues/37465

This PR adds a new PATCH API endpoint to allow an instructor to update the price for a specific course enrollment mode (e.g., verified).

PATCH /api/instructor/v1/courses/{course_key}/modes/{mode_slug}/price

This endpoint requires InstructorPermission (is_staff) and expects the Content-Type header to be application/merge-patch+json. The price should be sent as an integer in the smallest currency unit (e.g., cents).

**Example Request**

````
PATCH /api/instructor/v1/courses/course-v1:TestOrg+CS101+2025/modes/verified/price
Content-Type: application/merge-patch+json
Accept: application/json
X-CSRFToken: [Your-Token-Here]

{
    "price": 3900
}

````

**Success Response**

The endpoint returns an empty body with a 204 No Content status upon a successful price update.

````
HTTP 204 No Content
Allow: PATCH, HEAD, OPTIONS
````

**Error Responses**

- 400 Bad Request: If the price field is missing, not an integer, or negative.
- 401 Unauthorized: If the user is not authenticated.
- 403 Forbidden: If the user is not an instructor (is_staff=False).
- 404 Not Found: If the course_key or mode_slug does not exist.
- 415 Unsupported Media Type: If the Content-Type is not application/merge-patch+json.

**Testing**

- Added new unit tests in lms/djangoapps/instructor/tests/test_api.py under the TestCourseModePriceView class.
- Tests cover success (204), auth (401), permissions (403), not found (404), and various bad request (400) scenarios.