### PR TITLE
fix: bump learning-core to 0.30.0

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_containers.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_containers.py
@@ -630,7 +630,7 @@ class ContainersTestCase(ContentLibrariesRestApiTest):
         ]
 
     def test_subsection_hierarchy(self):
-        with self.assertNumQueries(93):
+        with self.assertNumQueries(95):
             hierarchy = self._get_container_hierarchy(self.subsection_with_units["id"])
         assert hierarchy["object_key"] == self.subsection_with_units["id"]
         assert hierarchy["components"] == [
@@ -653,7 +653,7 @@ class ContainersTestCase(ContentLibrariesRestApiTest):
         ]
 
     def test_units_hierarchy(self):
-        with self.assertNumQueries(56):
+        with self.assertNumQueries(60):
             hierarchy = self._get_container_hierarchy(self.unit_with_components["id"])
         assert hierarchy["object_key"] == self.unit_with_components["id"]
         assert hierarchy["components"] == [
@@ -679,7 +679,7 @@ class ContainersTestCase(ContentLibrariesRestApiTest):
         )
 
     def test_block_hierarchy(self):
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(27):
             hierarchy = self._get_block_hierarchy(self.problem_block["id"])
         assert hierarchy["object_key"] == self.problem_block["id"]
         assert hierarchy["components"] == [

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -23,7 +23,7 @@ Django<6.0
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# pip 25.3 is incompatible with pip-tools hence causing failures during the build process 
+# pip 25.3 is incompatible with pip-tools hence causing failures during the build process
 # Make upgrade command and all requirements upgrade jobs are broken due to this.
 # See issue https://github.com/openedx/public-engineering/issues/440 for details regarding the ongoing fix.
 # The constraint can be removed once a release (pip-tools > 7.5.1) is available with support for pip 25.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -61,7 +61,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.29.1
+openedx-learning==0.30.0
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -855,7 +855,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/kernel.in
-openedx-learning==0.29.1
+openedx-learning==0.30.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1419,7 +1419,7 @@ openedx-forum==0.3.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.29.1
+openedx-learning==0.30.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1033,7 +1033,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/base.txt
-openedx-learning==0.29.1
+openedx-learning==0.30.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1079,7 +1079,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/base.txt
-openedx-learning==0.29.1
+openedx-learning==0.30.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
This pulls in publishing dependency changes from:

https://github.com/openedx/openedx-learning/pull/369

This fixes a bug where publishing a Content Library v2 container would publish only its direct children instead of publishing all ancestors.