### PR TITLE
refactor: Remove useless pages_and_resources waffle

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -43,10 +43,7 @@ from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRol
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util import milestones_helpers
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
-from openedx.core.djangoapps.discussions.config.waffle import (
-    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
-    OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
-)
+from openedx.core.djangoapps.discussions.config.waffle import OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.lib.teams_config import TeamsConfig
 from xmodule.fields import Date  # lint-amnesty, pylint: disable=wrong-import-order
@@ -141,26 +138,26 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertEqual(settings_fields["deprecated"], True)
 
     @ddt.data(
-        (False, False, True),
-        (True, False, False),
-        (True, True, True),
-        (False, True, True)
+        (False, True),
+        (False, False),
+        (True, True),
+        (True, True)
     )
     @ddt.unpack
     @override_waffle_flag(toggles.LEGACY_STUDIO_ADVANCED_SETTINGS, True)
-    def test_discussion_fields_available(self, is_pages_and_resources_enabled,
-                                         is_legacy_discussion_setting_enabled, fields_visible):
+    def test_discussion_fields_available(self, is_legacy_discussion_setting_enabled, fields_visible):
         """
         Test to check the availability of discussion related fields when relevant flags are enabled
         """
-
-        with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, is_pages_and_resources_enabled):
-            with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
-                response = self.client.get_html(self.course_setting_url).content.decode('utf-8')
-                self.assertEqual('allow_anonymous' in response, fields_visible)
-                self.assertEqual('allow_anonymous_to_peers' in response, fields_visible)
-                self.assertEqual('discussion_blackouts' in response, fields_visible)
-                self.assertEqual('discussion_topics' in response, fields_visible)
+        with override_waffle_flag(
+            OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG,
+            is_legacy_discussion_setting_enabled,
+        ):
+            response = self.client.get_html(self.course_setting_url).content.decode('utf-8')
+            self.assertEqual('allow_anonymous' in response, fields_visible)
+            self.assertEqual('allow_anonymous_to_peers' in response, fields_visible)
+            self.assertEqual('discussion_blackouts' in response, fields_visible)
+            self.assertEqual('discussion_topics' in response, fields_visible)
 
     @ddt.data(False, True)
     @override_waffle_flag(toggles.LEGACY_STUDIO_ADVANCED_SETTINGS, True)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -85,7 +85,6 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.content_libraries.api import get_container
 from openedx.core.djangoapps.content_tagging.toggles import is_tagging_feature_disabled
 from openedx.core.djangoapps.credit.api import get_credit_requirements, is_credit_course
-from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.core.djangoapps.django_comment_common.models import assign_default_role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
@@ -251,16 +250,11 @@ def get_course_authoring_url(course_locator):
     )
 
 
-def get_pages_and_resources_url(course_locator):
+def get_pages_and_resources_url(course_locator: CourseKey) -> str:
     """
     Gets course authoring microfrontend URL for Pages and Resources view.
     """
-    pages_and_resources_url = None
-    if ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_locator):
-        mfe_base_url = get_course_authoring_url(course_locator)
-        if mfe_base_url:
-            pages_and_resources_url = f'{mfe_base_url}/course/{course_locator}/pages-and-resources'
-    return pages_and_resources_url
+    return f"{get_course_authoring_url(course_locator)}/course/{course_locator}/pages-and-resources"
 
 
 def get_proctored_exam_settings_url(course_locator) -> str:

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -19,7 +19,8 @@ from xmodule.tabs import CourseTab, CourseTabList, InvalidTabsException, StaticT
 
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
-from ..utils import get_pages_and_resources_url, get_custom_pages_url
+
+from ..utils import get_custom_pages_url
 
 __all__ = ["tabs_handler", "update_tabs_handler"]
 
@@ -80,14 +81,11 @@ def get_course_tabs(course_item: CourseBlock, user: User) -> Iterable[CourseTab]
         Iterable[CourseTab]: An iterable containing course tab objects from the
         course
     """
-    pages_and_resources_mfe_enabled = bool(get_pages_and_resources_url(course_item.id))
     for tab in CourseTabList.iterate_displayable(course_item, user=user, inline_collections=False, include_hidden=True):
         if isinstance(tab, StaticTab):
             # static tab needs its locator information to render itself as an xmodule
             static_tab_loc = course_item.id.make_usage_key("static_tab", tab.url_slug)
             tab.locator = static_tab_loc
-        # If the course apps MFE is set up and pages and resources is enabled, then only show static tabs
-        if isinstance(tab, StaticTab) or not pages_and_resources_mfe_enabled:
             yield tab
 
 

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -9,7 +9,6 @@
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
   from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_course_libraries_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url, get_optimizer_url
-  from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
 <div class="wrapper-header wrapper" id="view-top">
@@ -45,7 +44,6 @@
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': str(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
-            pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
             video_upload_mfe_enabled = toggles.use_new_video_uploads_page(context_course.id)
             schedule_details_mfe_enabled = toggles.use_new_schedule_details_page(context_course.id)
             grading_mfe_enabled = toggles.use_new_grading_page(context_course.id)
@@ -85,24 +83,12 @@
                   <li class="nav-item nav-course-courseware-updates">
                     <a href="${get_updates_url(course_key)}">${_("Updates")}</a>
                   </li>
-                  % if not pages_and_resources_mfe_enabled:
-                  <li class="nav-item nav-course-courseware-pages">
-                    <a href="${tabs_url}">${_("Pages")}</a>
-                  </li>
-                  % endif
-                  % if pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-pages-resources">
                     <a href="${get_pages_and_resources_url(course_key)}">${_("Pages & Resources")}</a>
                   </li>
-                  % endif
                   <li class="nav-item nav-course-courseware-uploads">
                     <a href="${get_files_uploads_url(course_key)}">${_("Files")}</a>
                   </li>
-                  % if not pages_and_resources_mfe_enabled:
-                  <li class="nav-item nav-course-courseware-textbooks">
-                    <a href="${textbooks_url}">${_("Textbooks")}</a>
-                  </li>
-                  % endif
                   % if context_course.video_pipeline_configured and not video_upload_mfe_enabled:
                   <li class="nav-item nav-course-courseware-videos">
                     <a href="${videos_url}">${_("Video Uploads")}</a>

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -34,10 +34,7 @@ from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2
 from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
-from openedx.core.djangoapps.discussions.config.waffle import (
-    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
-    OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
-)
+from openedx.core.djangoapps.discussions.config.waffle import OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
 
@@ -148,60 +145,61 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         assert has_instructor_tab(org_researcher, self.course)
 
     @ddt.data(
-        ('staff', False, False, True),
-        ('staff', True, False, False),
-        ('staff', True, True, True),
-        ('staff', False, True, True),
-        ('instructor', False, False, True),
-        ('instructor', True, False, False),
-        ('instructor', True, True, True),
-        ('instructor', False, True, True)
+        ('staff', False, True),
+        ('staff', False, False),
+        ('staff', True, True),
+        ('staff', True, True),
+        ('instructor', False, True),
+        ('instructor', False, False),
+        ('instructor', True, True),
+        ('instructor', True, True),
     )
     @ddt.unpack
-    def test_discussion_tab_for_course_staff_role(self, access_role, is_pages_and_resources_enabled,
-                                                  is_legacy_discussion_setting_enabled, is_discussion_tab_available):
+    def test_discussion_tab_for_course_staff_role(
+        self,
+        access_role,
+        is_legacy_discussion_setting_enabled,
+        is_discussion_tab_available
+    ):
         """
         Verify that the Discussion tab is available for course for course staff role.
         """
         discussion_section = ('<li class="nav-item"><button type="button" class="btn-link discussions_management" '
                               'data-section="discussions_management">Discussions</button></li>')
 
-        with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, is_pages_and_resources_enabled):
-            with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
-                user = UserFactory.create()
-                CourseAccessRoleFactory(
-                    course_id=self.course.id,
-                    user=user,
-                    role=access_role,
-                    org=self.course.id.org
-                )
-                set_course_cohorted(self.course.id, True)
-                self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
-                response = self.client.get(self.url).content.decode('utf-8')
-                self.assertEqual(discussion_section in response, is_discussion_tab_available)
+        with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
+            user = UserFactory.create()
+            CourseAccessRoleFactory(
+                course_id=self.course.id,
+                user=user,
+                role=access_role,
+                org=self.course.id.org
+            )
+            set_course_cohorted(self.course.id, True)
+            self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
+            response = self.client.get(self.url).content.decode('utf-8')
+            self.assertEqual(discussion_section in response, is_discussion_tab_available)
 
     @ddt.data(
-        (False, False, True),
-        (True, False, False),
-        (True, True, True),
-        (False, True, True),
+        (False, True),
+        (False, False),
+        (True, True),
+        (True, True),
     )
     @ddt.unpack
-    def test_discussion_tab_for_global_user(self, is_pages_and_resources_enabled,
-                                            is_legacy_discussion_setting_enabled, is_discussion_tab_available):
+    def test_discussion_tab_for_global_user(self, is_legacy_discussion_setting_enabled, is_discussion_tab_available):
         """
         Verify that the Discussion tab is available for course for global user.
         """
         discussion_section = ('<li class="nav-item"><button type="button" class="btn-link discussions_management" '
                               'data-section="discussions_management">Discussions</button></li>')
 
-        with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, is_pages_and_resources_enabled):
-            with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
-                user = UserFactory.create(is_staff=True)
-                set_course_cohorted(self.course.id, True)
-                self.client.login(username=user.username, password=self.TEST_PASSWORD)
-                response = self.client.get(self.url).content.decode('utf-8')
-                self.assertEqual(discussion_section in response, is_discussion_tab_available)
+        with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
+            user = UserFactory.create(is_staff=True)
+            set_course_cohorted(self.course.id, True)
+            self.client.login(username=user.username, password=self.TEST_PASSWORD)
+            response = self.client.get(self.url).content.decode('utf-8')
+            self.assertEqual(discussion_section in response, is_discussion_tab_available)
 
     @ddt.data(
         ('staff', False, False),

--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -19,20 +19,6 @@ OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG = CourseWaffleFlag(
     f"{WAFFLE_FLAG_NAMESPACE}.override_discussion_legacy_settings", __name__
 )
 
-
-# .. toggle_name: discussions.pages_and_resources_mfe
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable new Pages and Resources experience for course.
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2021-05-24
-# .. toggle_target_removal_date: 2021-12-31
-# .. toggle_warning: When the flag is ON, the new experience for Pages and Resources will be enabled.
-# .. toggle_tickets: TNL-7791
-ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND = CourseWaffleFlag(
-    f"{WAFFLE_FLAG_NAMESPACE}.pages_and_resources_mfe", __name__
-)
-
 # .. toggle_name: discussions.enable_new_structure_discussions
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/openedx/core/djangoapps/discussions/config/waffle_utils.py
+++ b/openedx/core/djangoapps/discussions/config/waffle_utils.py
@@ -2,15 +2,11 @@
 Utils methods for Discussion app waffle flags.
 """
 
-from openedx.core.djangoapps.discussions.config.waffle import (
-    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
-    OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
-)
+from openedx.core.djangoapps.discussions.config.waffle import OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
 
 
 def legacy_discussion_experience_enabled(course_key):
     """
     Checks for relevant flags and returns a boolean whether to show legacy discussion settings or not
     """
-    return bool(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG.is_enabled(course_key) or
-                not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key))
+    return OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG.is_enabled(course_key)


### PR DESCRIPTION
## Description

The waffle flag `discussions.pages_and_resources_mfe` was intended to gate the Studio MFE Pages and Resources view, but it has not actually done that for some time. The MFE Pages and Resources view has been shown to all MFE Studio users regardless of its value, possibly as far back as Quince. There are some minor behaviors that the flag tweaked in Legacy Studio, but all of Legacy Studio (including the old Custom Pages interface, which the MFE Pages and Resource view subsumes and replaces) is deprecated and in the process of removal.

We do not expect this to have any end-user impact, except a minor impact on Legacy Studio pages: the Legacy Studio header will now always show a "Pages and Resources" link rather than a "Pages" link.

## Supporting information

Related to: https://github.com/openedx/edx-platform/issues/36275

## Deadline

None