### PR TITLE
fix: Call `LIBRARY_CONTAINER_PUBLISHED` for parent of containers

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -133,7 +133,6 @@ def send_events_after_publish(publish_log_pk: int, library_key_str: str) -> None
                 # e.g. so the search index can update the "has_unpublished_changes"
                 for parent_container in api.get_containers_contains_item(container_key):
                     affected_containers.add(parent_container.container_key)
-                    # TODO: should this be a CONTAINER_CHILD_PUBLISHED event instead of CONTAINER_PUBLISHED ?
             except api.ContentLibraryContainerNotFound:
                 # The deleted children remains in the entity, so, in this case, the container may not be found.
                 pass

--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -127,6 +127,16 @@ def send_events_after_publish(publish_log_pk: int, library_key_str: str) -> None
         elif hasattr(record.entity, "container"):
             container_key = api.library_container_locator(library_key, record.entity.container)
             affected_containers.add(container_key)
+
+            try:
+                # We do need to notify listeners that the parent container(s) have changed,
+                # e.g. so the search index can update the "has_unpublished_changes"
+                for parent_container in api.get_containers_contains_item(container_key):
+                    affected_containers.add(parent_container.container_key)
+                    # TODO: should this be a CONTAINER_CHILD_PUBLISHED event instead of CONTAINER_PUBLISHED ?
+            except api.ContentLibraryContainerNotFound:
+                # The deleted children remains in the entity, so, in this case, the container may not be found.
+                pass
         else:
             log.warning(
                 f"PublishableEntity {record.entity.pk} / {record.entity.key} was modified during publish operation "

--- a/openedx/core/djangoapps/content_libraries/tests/test_events.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_events.py
@@ -449,6 +449,53 @@ class ContentLibrariesEventsTestCase(ContentLibrariesRestApiTest):
         c2_after = self._get_container(container2["id"])
         assert c2_after["has_unpublished_changes"]
 
+    def test_publish_child_container(self):
+        """
+        Test the events that get emitted when we publish the changes to a container that is child of another container
+        """
+        # Create some containers
+        container1 = self._create_container(self.lib1_key, "unit", display_name="Alpha Unit", slug=None)
+        container2 = self._create_container(self.lib1_key, "subsection", display_name="Bravo Subsection", slug=None)
+
+        # Add one container as child
+        self._add_container_children(container2["id"], children_ids=[container1["id"]])
+
+        # At first everything is unpublished:
+        c1_before = self._get_container(container1["id"])
+        assert c1_before["has_unpublished_changes"]
+        c2_before = self._get_container(container2["id"])
+        assert c2_before["has_unpublished_changes"]
+
+        # clear event log after the initial mock data setup is complete:
+        self.clear_events()
+
+        # Now publish only Container 1
+        self._publish_container(container1["id"])
+
+        # Now it is published:
+        c1_after = self._get_container(container1["id"])
+        assert c1_after["has_unpublished_changes"] is False
+
+        # And publish events were emitted:
+        self.expect_new_events(
+            {  # An event for container 1 being published:
+                "signal": LIBRARY_CONTAINER_PUBLISHED,
+                "library_container": LibraryContainerData(
+                    container_key=LibraryContainerLocator.from_string(container1["id"]),
+                ),
+            },
+            {   # An event for parent (container 2):
+                "signal": LIBRARY_CONTAINER_PUBLISHED,
+                "library_container": LibraryContainerData(
+                    container_key=LibraryContainerLocator.from_string(container2["id"]),
+                ),
+            },
+        )
+
+        # note that container 2 is still unpublished
+        c2_after = self._get_container(container2["id"])
+        assert c2_after["has_unpublished_changes"]
+
     def test_restore_unit(self) -> None:
         """
         Test restoring a deleted unit via the "restore" API.

--- a/openedx/core/djangoapps/content_libraries/tests/test_events.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_events.py
@@ -454,46 +454,46 @@ class ContentLibrariesEventsTestCase(ContentLibrariesRestApiTest):
         Test the events that get emitted when we publish the changes to a container that is child of another container
         """
         # Create some containers
-        container1 = self._create_container(self.lib1_key, "unit", display_name="Alpha Unit", slug=None)
-        container2 = self._create_container(self.lib1_key, "subsection", display_name="Bravo Subsection", slug=None)
+        unit = self._create_container(self.lib1_key, "unit", display_name="Alpha Unit", slug=None)
+        subsection = self._create_container(self.lib1_key, "subsection", display_name="Bravo Subsection", slug=None)
 
         # Add one container as child
-        self._add_container_children(container2["id"], children_ids=[container1["id"]])
+        self._add_container_children(subsection["id"], children_ids=[unit["id"]])
 
         # At first everything is unpublished:
-        c1_before = self._get_container(container1["id"])
+        c1_before = self._get_container(unit["id"])
         assert c1_before["has_unpublished_changes"]
-        c2_before = self._get_container(container2["id"])
+        c2_before = self._get_container(subsection["id"])
         assert c2_before["has_unpublished_changes"]
 
         # clear event log after the initial mock data setup is complete:
         self.clear_events()
 
-        # Now publish only Container 1
-        self._publish_container(container1["id"])
+        # Now publish only the unit
+        self._publish_container(unit["id"])
 
         # Now it is published:
-        c1_after = self._get_container(container1["id"])
+        c1_after = self._get_container(unit["id"])
         assert c1_after["has_unpublished_changes"] is False
 
         # And publish events were emitted:
         self.expect_new_events(
-            {  # An event for container 1 being published:
+            {  # An event for the unit being published:
                 "signal": LIBRARY_CONTAINER_PUBLISHED,
                 "library_container": LibraryContainerData(
-                    container_key=LibraryContainerLocator.from_string(container1["id"]),
+                    container_key=LibraryContainerLocator.from_string(unit["id"]),
                 ),
             },
-            {   # An event for parent (container 2):
+            {   # An event for parent (subsection):
                 "signal": LIBRARY_CONTAINER_PUBLISHED,
                 "library_container": LibraryContainerData(
-                    container_key=LibraryContainerLocator.from_string(container2["id"]),
+                    container_key=LibraryContainerLocator.from_string(subsection["id"]),
                 ),
             },
         )
 
-        # note that container 2 is still unpublished
-        c2_after = self._get_container(container2["id"])
+        # note that subsection is still unpublished
+        c2_after = self._get_container(subsection["id"])
         assert c2_after["has_unpublished_changes"]
 
     def test_restore_unit(self) -> None:


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- Fix the issue described in https://github.com/openedx/frontend-app-authoring/issues/2465
- Calls `LIBRARY_CONTAINER_PUBLISHED` when publishing a container that is child of another container.

## Supporting information

- Github Issue: https://github.com/openedx/frontend-app-authoring/issues/2465
- Internal ticket: [FAL-4270](https://tasks.opencraft.com/browse/FAL-4270)

## Testing instructions

- Go to the library home of a library
- Create this structure Unit > Subsection > Section.
- Publish all the changes.
- Update the Unit name. Verify that the Unit and the Subsection have the `unpublished changes` chip.
- Publish the Unit. Verify that the `unpublished changes` chip is gone for the Unit and the Subsection.
- Update the Subsection name. Verify that the Subsection and the Section have the `unpublished changes` chip.
- Publish the Subsection. Verify that the `unpublished changes` chip is gone for the Subsection and the Section.

## Deadline

None

## Other information

N/A
