### PR TITLE
fix: updating advance settings should update corresponding course_app

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
@@ -8,6 +8,7 @@ import ddt
 from django.test import override_settings
 from django.urls import reverse
 from milestones.tests.utils import MilestonesTestCaseMixin
+from rest_framework.exceptions import ValidationError
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 
@@ -154,7 +155,7 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
         Test that exceptions in set_course_app_status are caught and don't break the flow.
         """
         # Mock set_course_app_status to raise an exception
-        mock_set_course_app_status.side_effect = Exception("Course app error")
+        mock_set_course_app_status.side_effect = ValidationError("Course app error")
 
         data = {
             "show_calculator": {

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
@@ -223,7 +223,7 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
         Test that the course app settings mapping is dynamically discovered from plugins.
         """
         # Get the dynamic mapping
-        mapping = CourseAppsPluginManager.get_course_app_settings_mapping()
+        mapping = CourseAppsPluginManager.get_course_app_settings_mapping(self.course.id)
 
         # Verify that calculator and edxnotes are in the mapping
         assert "show_calculator" in mapping

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_advanced_settings.py
@@ -2,6 +2,7 @@
 Tests for the course advanced settings API.
 """
 import json
+from unittest.mock import patch
 
 import ddt
 from django.test import override_settings
@@ -91,3 +92,126 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
         with override_settings(FEATURES={setting: False}):
             resp = self.client.get(self.url, {"fetch_all": 0})
             assert excluded_field not in resp.data
+
+    @patch('cms.djangoapps.contentstore.rest_api.v0.views.advanced_settings.set_course_app_status')
+    def test_patch_multiple_advanced_settings(self, mock_set_course_app_status):
+        """
+        Test that updating multiple advanced settings calls set_course_app_status for corresponding apps.
+        """
+        with override_settings(FEATURES={"ENABLE_EDXNOTES": True}):
+            mock_set_course_app_status.return_value = True
+
+            # Test updating both calculator and edxnotes settings
+            data = {
+                "show_calculator": {
+                    "value": True
+                },
+                "edxnotes": {
+                    "value": True
+                },
+                "other_setting": {
+                    "value": "some_value"
+                }
+            }
+            response = self.client.patch(self.url, json.dumps(data), content_type="application/json")
+
+            assert mock_set_course_app_status.call_count == 2
+            calls = mock_set_course_app_status.call_args_list
+            actual_calls = [call.kwargs for call in calls]
+
+            # Extract the calls without the request object for easier comparison
+            actual_calls = [
+                {
+                    'course_key': call_kwargs['course_key'],
+                    'app_id': call_kwargs['app_id'],
+                    'enabled': call_kwargs['enabled']
+                }
+                for call_kwargs in actual_calls
+            ]
+
+            expected_calls = [
+                {
+                    'course_key': self.course.id,
+                    'app_id': 'calculator',
+                    'enabled': True
+                },
+                {
+                    'course_key': self.course.id,
+                    'app_id': 'edxnotes',
+                    'enabled': True
+                }
+            ]
+
+            # Check that both expected calls were made (order may vary)
+            for expected_call in expected_calls:
+                assert expected_call in actual_calls
+
+            assert response.status_code == 200
+
+    @patch('cms.djangoapps.contentstore.rest_api.v0.views.advanced_settings.set_course_app_status')
+    def test_patch_advanced_setting_with_exception(self, mock_set_course_app_status):
+        """
+        Test that exceptions in set_course_app_status are caught and don't break the flow.
+        """
+        # Mock set_course_app_status to raise an exception
+        mock_set_course_app_status.side_effect = Exception("Course app error")
+
+        data = {
+            "show_calculator": {
+                "value": True
+            },
+            "display_name": {
+                "value": "Updated Course Name"
+            }
+        }
+        response = self.client.patch(self.url, json.dumps(data), content_type="application/json")
+
+        mock_set_course_app_status.assert_called_once()
+        # Check the call arguments (excluding request for easier comparison)
+        call_args = mock_set_course_app_status.call_args.kwargs
+        expected_args = {
+            'course_key': self.course.id,
+            'app_id': 'calculator',
+            'enabled': True
+        }
+
+        for key, expected_value in expected_args.items():
+            assert call_args[key] == expected_value
+
+        # Verify the request still succeeds and other settings are processed
+        assert response.status_code == 200
+
+    @patch('cms.djangoapps.contentstore.rest_api.v0.views.advanced_settings.set_course_app_status')
+    def test_patch_non_advanced_setting_skips_app_status_update(self, mock_set_course_app_status):
+        """
+        Test that updating non-course app settings doesn't call set_course_app_status.
+        """
+        data = {
+            "display_name": {
+                "value": "Updated Course Name"
+            },
+            "start": {
+                "value": "2024-01-01T00:00:00Z"
+            }
+        }
+        response = self.client.patch(self.url, json.dumps(data), content_type="application/json")
+
+        # Verify set_course_app_status was not called
+        mock_set_course_app_status.assert_not_called()
+        assert response.status_code == 200
+
+    @patch('cms.djangoapps.contentstore.rest_api.v0.views.advanced_settings.set_course_app_status')
+    def test_patch_advanced_setting_with_none_value(self, mock_set_course_app_status):
+        """
+        Test that course app settings with None values don't call set_course_app_status.
+        """
+        data = {
+            "show_calculator": {
+                "value": None
+            }
+        }
+        response = self.client.patch(self.url, json.dumps(data), content_type="application/json")
+
+        # Verify set_course_app_status was not called when value is None
+        mock_set_course_app_status.assert_not_called()
+        assert response.status_code == 200

--- a/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
@@ -18,7 +18,6 @@ from ..serializers import CourseAdvancedSettingsSerializer
 from ....views.course import update_course_advanced_settings
 
 
-
 @view_auth_classes(is_authenticated=True)
 class AdvancedCourseSettingsView(DeveloperErrorViewMixin, APIView):
     """
@@ -209,7 +208,7 @@ class AdvancedCourseSettingsView(DeveloperErrorViewMixin, APIView):
                         # enabling/disabling the course app setting also updates
                         # the advanced settings, so we remove it from the request data
                         request.data.pop(setting)
-                    except Exception as exc:
+                    except ValidationError:
                         # Ignore errors and let the normal flow handle updates
                         pass
 

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -127,6 +127,7 @@ class CalculatorCourseApp(CourseApp):
     documentation_links = {
         "learn_more_configuration": settings.CALCULATOR_HELP_URL,
     }
+    advanced_setting_field = "show_calculator"
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:
@@ -140,7 +141,7 @@ class CalculatorCourseApp(CourseApp):
         """
         Get calculator enabled status from course overview model.
         """
-        return CourseOverview.get_from_id(course_key).show_calculator
+        return getattr(CourseOverview.get_from_id(course_key), cls.advanced_setting_field, False)
 
     @classmethod
     def set_enabled(cls, course_key: CourseKey, enabled: bool, user: 'User') -> bool:
@@ -148,7 +149,7 @@ class CalculatorCourseApp(CourseApp):
         Update calculator enabled status in modulestore.
         """
         course = get_course_by_id(course_key)
-        course.show_calculator = enabled
+        setattr(course, cls.advanced_setting_field, enabled)
         modulestore().update_item(course, user.id)
         return enabled
 

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -59,6 +59,7 @@ class EdxNotesCourseApp(CourseApp):
     documentation_links = {
         "learn_more_configuration": settings.EDXNOTES_HELP_URL,
     }
+    advanced_setting_field = "edxnotes"
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument
@@ -72,7 +73,7 @@ class EdxNotesCourseApp(CourseApp):
         """
         Get enabled/disabled status from modulestore.
         """
-        return CourseOverview.get_from_id(course_key).edxnotes
+        return getattr(CourseOverview.get_from_id(course_key), cls.advanced_setting_field, False)
 
     @classmethod
     def set_enabled(cls, course_key: CourseKey, enabled: bool, user: 'User') -> bool:
@@ -80,7 +81,7 @@ class EdxNotesCourseApp(CourseApp):
         Enable/disable edxnotes in the modulestore.
         """
         course = get_course_by_id(course_key)
-        course.edxnotes = enabled
+        setattr(course, cls.advanced_setting_field, enabled)
         if enabled:
             notes_tab = CourseTabList.get_tab_by_id(course.tabs, 'edxnotes')
             if notes_tab is None:

--- a/openedx/core/djangoapps/course_apps/api.py
+++ b/openedx/core/djangoapps/course_apps/api.py
@@ -66,7 +66,7 @@ def set_course_app_enabled(course_key: CourseKey, app_id: str, enabled: bool, us
     return enabled
 
 
-def set_course_app_status(course_key, app_id, enabled, request):
+def set_course_app_status(course_key: CourseKey, app_id: str, enabled: bool, user: User) -> bool:
     """
     Enable or disable a course app for a given course.
 
@@ -74,7 +74,7 @@ def set_course_app_status(course_key, app_id, enabled, request):
         course_key (CourseKey): The course key for the course to update.
         app_id (str): The app ID of the course app to enable/disable.
         enabled (bool): The desired enabled status.
-        request (HttpRequest): The HTTP request object
+        user (User): The user performing the operation.
 
     Returns:
         bool: The final enabled/disabled status of the app.
@@ -86,4 +86,4 @@ def set_course_app_status(course_key, app_id, enabled, request):
     if not course_app or not course_app.is_available(course_key):
         raise ValidationError({"id": "Invalid app ID"})
 
-    return set_course_app_enabled(course_key=course_key, app_id=app_id, enabled=enabled, user=request.user)
+    return set_course_app_enabled(course_key=course_key, app_id=app_id, enabled=enabled, user=user)

--- a/openedx/core/djangoapps/course_apps/api.py
+++ b/openedx/core/djangoapps/course_apps/api.py
@@ -81,9 +81,9 @@ def set_course_app_status(course_key: CourseKey, app_id: str, enabled: bool, use
     """
     try:
         course_app = CourseAppsPluginManager.get_plugin(app_id)
-    except PluginError:
-        course_app = None
-    if not course_app or not course_app.is_available(course_key):
-        raise ValidationError({"id": "Invalid app ID"})
+    except PluginError as exc:
+        raise ValidationError({"id": f"Invalid app ID={app_id}"}) from exc
+    if not course_app.is_available(course_key):
+        raise ValidationError({"id": f"Unavailable app ID={app_id}"})
 
     return set_course_app_enabled(course_key=course_key, app_id=app_id, enabled=enabled, user=user)

--- a/openedx/core/djangoapps/course_apps/plugins.py
+++ b/openedx/core/djangoapps/course_apps/plugins.py
@@ -30,7 +30,7 @@ class CourseApp(ABC):
     }
     # Advanced setting field name that corresponds to this app (optional)
     # Should be a string representing the field name in course advanced settings
-    advanced_setting_field = None
+    advanced_setting_field: Optional[str] = None
 
     @classmethod
     @abstractmethod
@@ -120,20 +120,23 @@ class CourseAppsPluginManager(PluginManager):
                 yield plugin
 
     @classmethod
-    def get_course_app_settings_mapping(cls) -> Dict[str, str]:
+    def get_course_app_settings_mapping(cls, course_key: CourseKey) -> Dict[str, str]:
         """
         Returns a mapping of advanced setting field names to course app IDs.
 
         This method dynamically discovers all course app plugins and builds a mapping
         based on their advanced_setting_field attributes.
 
+        Args:
+            course_key (CourseKey): The course key for which the mapping is to be generated.
+
         Returns:
             Dict[str, str]: A dictionary mapping advanced setting field names to app IDs.
         """
         settings_mapping = {}
 
-        for plugin in super().get_available_plugins().values():
-            if hasattr(plugin, 'advanced_setting_field') and plugin.advanced_setting_field:
+        for plugin in cls.get_apps_available_for_course(course_key):
+            if getattr(plugin, 'advanced_setting_field', None):
                 settings_mapping[plugin.advanced_setting_field] = plugin.app_id
 
         return settings_mapping

--- a/openedx/core/djangoapps/course_apps/plugins.py
+++ b/openedx/core/djangoapps/course_apps/plugins.py
@@ -28,6 +28,9 @@ class CourseApp(ABC):
         # eg:
         # "learn_more_configuration": "https://..."
     }
+    # Advanced setting field name that corresponds to this app (optional)
+    # Should be a string representing the field name in course advanced settings
+    advanced_setting_field = None
 
     @classmethod
     @abstractmethod
@@ -115,3 +118,22 @@ class CourseAppsPluginManager(PluginManager):
         for plugin in super().get_available_plugins().values():
             if plugin.is_available(course_key):
                 yield plugin
+
+    @classmethod
+    def get_course_app_settings_mapping(cls) -> Dict[str, str]:
+        """
+        Returns a mapping of advanced setting field names to course app IDs.
+
+        This method dynamically discovers all course app plugins and builds a mapping
+        based on their advanced_setting_field attributes.
+
+        Returns:
+            Dict[str, str]: A dictionary mapping advanced setting field names to app IDs.
+        """
+        settings_mapping = {}
+
+        for plugin in super().get_available_plugins().values():
+            if hasattr(plugin, 'advanced_setting_field') and plugin.advanced_setting_field:
+                settings_mapping[plugin.advanced_setting_field] = plugin.app_id
+
+        return settings_mapping

--- a/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
@@ -192,8 +192,8 @@ class CourseAppsView(DeveloperErrorViewMixin, views.APIView):
         if enabled is None:
             raise ValidationError({"enabled": "Must provide value for `enabled` field."})
 
-        course_app = CourseAppsPluginManager.get_plugin(app_id)
         is_enabled = set_course_app_status(course_key=course_key, app_id=app_id, enabled=enabled, request=request)
+        course_app = CourseAppsPluginManager.get_plugin(app_id)
         serializer = CourseAppSerializer(
             course_app,
             context={

--- a/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
@@ -191,8 +191,7 @@ class CourseAppsView(DeveloperErrorViewMixin, views.APIView):
             raise ValidationError({"id": "App id is missing"})
         if enabled is None:
             raise ValidationError({"enabled": "Must provide value for `enabled` field."})
-
-        is_enabled = set_course_app_status(course_key=course_key, app_id=app_id, enabled=enabled, request=request)
+        is_enabled = set_course_app_status(course_key, app_id, enabled, request.user)
         course_app = CourseAppsPluginManager.get_plugin(app_id)
         serializer = CourseAppSerializer(
             course_app,

--- a/openedx/core/djangoapps/course_apps/tests/test_dynamic_settings_mapping.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_dynamic_settings_mapping.py
@@ -1,0 +1,98 @@
+"""
+Tests for dynamic course app settings mapping functionality.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from openedx.core.djangoapps.course_apps.plugins import CourseAppsPluginManager, CourseApp
+
+
+class MockCourseAppWithSetting(CourseApp):
+    """Mock course app with an advanced setting field."""
+
+    app_id = "settings_app"
+    name = "Settings App"
+    description = "An app with advanced settings"
+    advanced_setting_field = "settings_app_field"
+
+    @classmethod
+    def is_available(cls, course_key):
+        return True
+
+    @classmethod
+    def is_enabled(cls, course_key):
+        return True
+
+    @classmethod
+    def set_enabled(cls, course_key, enabled, user):
+        return enabled
+
+    @classmethod
+    def get_allowed_operations(cls, course_key, user=None):
+        return {"enable": True, "configure": True}
+
+
+class MockCourseAppNoSettings(CourseApp):
+    """Mock course app with no advanced settings mapping."""
+
+    app_id = "no_settings_app"
+    name = "No Settings App"
+    description = "An app without advanced settings"
+
+    @classmethod
+    def is_available(cls, course_key):
+        return True
+
+    @classmethod
+    def is_enabled(cls, course_key):
+        return True
+
+    @classmethod
+    def set_enabled(cls, course_key, enabled, user):
+        return enabled
+
+    @classmethod
+    def get_allowed_operations(cls, course_key, user=None):
+        return {"enable": True, "configure": True}
+
+
+class DynamicSettingsMappingTest(TestCase):
+    """Test dynamic course app settings mapping functionality."""
+
+    def test_app_with_advanced_setting_mapping(self):
+        """Test that a course app with an advanced setting field is mapped correctly."""
+        mock_plugins = {
+            "settings_app": MockCourseAppWithSetting(),
+        }
+
+        with patch('edx_django_utils.plugins.PluginManager.get_available_plugins', return_value=mock_plugins):
+            mapping = CourseAppsPluginManager.get_course_app_settings_mapping()
+
+            assert "settings_app_field" in mapping
+            assert mapping["settings_app_field"] == "settings_app"
+
+    def test_no_advanced_setting_fields(self):
+        """Test that a course app without advanced_setting_fields is not included in mapping."""
+        mock_plugins = {
+            "no_settings_app": MockCourseAppNoSettings(),
+        }
+
+        with patch('edx_django_utils.plugins.PluginManager.get_available_plugins', return_value=mock_plugins):
+            mapping = CourseAppsPluginManager.get_course_app_settings_mapping()
+
+            assert len(mapping) == 0
+
+    def test_mixed_apps_mapping(self):
+        """Test mapping with a mix of apps with and without advanced settings."""
+        mock_plugins = {
+            "settings_app": MockCourseAppWithSetting(),
+            "no_settings_app": MockCourseAppNoSettings(),
+        }
+
+        with patch('edx_django_utils.plugins.PluginManager.get_available_plugins', return_value=mock_plugins):
+            mapping = CourseAppsPluginManager.get_course_app_settings_mapping()
+
+            # Should only include apps with advanced_setting_field
+            assert len(mapping) == 1
+            assert mapping["settings_app_field"] == "settings_app"


### PR DESCRIPTION
### Related Ticket (Internal):
https://github.com/mitodl/hq/issues/9178

## Description

This PR adds bidirectional sync for common settings that can be control from both "Pages & Resources" page and advanced settings page.
It updates:
1. Advanced_settings `PATCH` request to update corresponding course_app status if exists 
2. Adds advance setting key/field in plugins to identify its related setting
3. Adds a new function in PluginManager to return the mappings for course advance setting  -> plugin app

### Steps to Reproduce
1. Go to the `Pages & Resources` section of a course
1. Change the flags for `Notes` and `Calculator` each to be disabled.
1. Go to Settings -> Advanced Settings
1. Find "Enable student notes" - the field should read "false"
1. Change the field to "true"
1. Find "Show calculator" - the field should read "false"
1. Change the field to "true"
1. Save changes
1. Go back to Content -> Pages & Resources
1. Open the settings for `Notes` and `Calculator` - both will be disabled.
1. View the course live and go to any unit.
1. Both the calculator and Notes feature will be available.
1. Go back to the Pages & Resources
1. Change the setting on Notes to first be enabled (save), and then disabled again (save again)
1. Viewing the advanced settings page will show that notes are now disabled.
1. View the course live.
1. Notes will be disabled.
1. Repeat step 14-17 for calculator and it will also be disabled.

### Expected Behavior
The two settings should match - changing the state of the setting in Advanced Settings should update the setting on Pages & Resources.

For a working example, see "Flexible peer grading for ORAs" - which links to "Force Flexible Grading for Peer ORAs" in the advanced settings. Changing the setting on Pages & Resources to disabled or enabled will change the setting in Advanced Settings to true or false.

### Actual Behavior
Changing the settings for calculator and notes within Advanced Settings does not change the settings on Pages & Resources. The course will update based on what is in the Advanced Settings, meaning that there can be a mismatch between the two settings but the course will always follow the flag in the Advanced Setting.

Updating the flag in Pages & Resources _will_ update the Advanced Settings.

## Testing instructions

1. Follow the steps to reproduce after checkout to this branch
4. Verify that updating advance_settings also updates related/corresponding course app status as well

