### PR TITLE
feat: include user and origin_server info in backup libV2

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -27,6 +27,7 @@ import shutil
 from django.core.files.base import ContentFile
 from django.contrib.auth import get_user_model
 from django.core.serializers.json import DjangoJSONEncoder
+from django.conf import settings
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from celery_utils.logged_task import LoggedTask
@@ -557,7 +558,9 @@ def backup_library(self, user_id: int, library_key_str: str) -> None:
         timestamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
         filename = f'{sanitized_lib_key}-{timestamp}.zip'
         file_path = os.path.join(root_dir, filename)
-        create_lib_zip_file(lp_key=str(library_key), path=file_path)
+        user = User.objects.get(id=user_id)
+        origin_server = getattr(settings, 'CMS_BASE', None)
+        create_lib_zip_file(lp_key=str(library_key), path=file_path, user=user, origin_server=origin_server)
         set_custom_attribute("exporting_completed", str(library_key))
 
         with open(file_path, 'rb') as zipfile:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -61,7 +61,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.30.0
+openedx-learning==0.30.1
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -842,7 +842,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/kernel.in
-openedx-learning==0.30.0
+openedx-learning==0.30.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1404,7 +1404,7 @@ openedx-forum==0.3.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.30.0
+openedx-learning==0.30.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1020,7 +1020,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/base.txt
-openedx-learning==0.30.0
+openedx-learning==0.30.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1066,7 +1066,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/base.txt
-openedx-learning==0.30.0
+openedx-learning==0.30.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Resolves: https://github.com/openedx/edx-platform/issues/37596

To include the `user` and `origin_server` metadata in the backup of Libraries V2, this information is now passed through the backup library API.

Changes:

- Passes user information to the backup library API.
- Passes origin_server to the backup library API.
- Updates tests to cover user and origin_server cases.

## Deadline

Ulmo release

