### PR TITLE
Move learning core methods to video config service

### DIFF
--- a/openedx/core/djangoapps/video_config/services.py
+++ b/openedx/core/djangoapps/video_config/services.py
@@ -21,6 +21,10 @@ from openedx.core.djangoapps.video_config.models import (
 )
 from openedx.core.djangoapps.video_config.toggles import TRANSCRIPT_FEEDBACK
 from openedx.core.djangoapps.video_pipeline.config.waffle import DEPRECATE_YOUTUBE
+from openedx.core.djangoapps.content_libraries.api import (
+    add_library_block_static_asset_file,
+    delete_library_block_static_asset_file,
+)
 
 log = logging.getLogger(__name__)
 
@@ -100,9 +104,7 @@ class VideoConfigService:
         This method provides access to the library API for adding static assets
         to Learning Core components.
         """
-        # Import here to avoid circular dependency
-        from openedx.core.djangoapps.content_libraries.api import lib_api
-        lib_api.add_library_block_static_asset_file(
+        add_library_block_static_asset_file(
             usage_key,
             filename,
             content,
@@ -114,9 +116,7 @@ class VideoConfigService:
         This method provides access to the library API for deleting static assets
         from Learning Core components.
         """
-        # Import here to avoid circular dependency
-        from openedx.core.djangoapps.content_libraries.api import lib_api
-        lib_api.delete_library_block_static_asset_file(
+        delete_library_block_static_asset_file(
             usage_key,
             filename,
         )

--- a/openedx/core/djangoapps/video_config/services.py
+++ b/openedx/core/djangoapps/video_config/services.py
@@ -8,8 +8,11 @@ for the extracted video block in xblocks-contrib repository.
 
 import logging
 
-from opaque_keys.edx.keys import CourseKey, UsageKey
-
+from opaque_keys.edx.keys import (
+    CourseKey,
+    UsageKey,
+    UsageKeyV2,
+)
 from openedx.core.djangoapps.video_config import sharing
 from organizations.api import get_course_organization
 from openedx.core.djangoapps.video_config.models import (
@@ -91,3 +94,30 @@ class VideoConfigService:
         Check if HLS playback is enabled for the course.
         """
         return HLSPlaybackEnabledFlag.feature_enabled(course_id)
+
+    def add_library_static_asset(self, usage_key: UsageKeyV2, filename: str, content: bytes) -> bool:
+        """
+        This method provides access to the library API for adding static assets
+        to Learning Core components.
+        """
+        # Import here to avoid circular dependency
+        from openedx.core.djangoapps.content_libraries.api import lib_api
+        lib_api.add_library_block_static_asset_file(
+            usage_key,
+            filename,
+            content,
+        )
+        return True
+
+    def delete_library_static_asset(self, usage_key: UsageKeyV2, filename: str) -> bool:
+        """
+        This method provides access to the library API for deleting static assets
+        from Learning Core components.
+        """
+        # Import here to avoid circular dependency
+        from openedx.core.djangoapps.content_libraries.api import lib_api
+        lib_api.delete_library_block_static_asset_file(
+            usage_key,
+            filename,
+        )
+        return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -232,3 +232,7 @@ ignore_imports =
     # Content libraries imports contentstore.helpers which imports upstream_sync
     openedx.core.djangoapps.content_libraries.api.blocks -> cms.djangoapps.contentstore.helpers
     openedx.core.djangoapps.content_libraries.api.libraries -> cms.djangoapps.contentstore.helpers
+    # Core is calling lms which should be refactored
+    openedx.core.djangoapps.content.course_overviews.models -> lms.djangoapps.*.*
+    openedx.core.djangoapps.xblock.runtime.runtime -> lms.djangoapps.grades.api
+    openedx.core.djangoapps.schedules.content_highlights -> lms.djangoapps.courseware.block_render


### PR DESCRIPTION
Move learning core methods directly used in Video XBlock to video config service

Some ignore imports has been added to setup.cfg to fix [these](https://github.com/openedx/edx-platform/actions/runs/19471090492/job/55718292829)