### PR TITLE
feat: add number of blocks migrated in migration info api

### DIFF
--- a/cms/djangoapps/modulestore_migrator/api.py
+++ b/cms/djangoapps/modulestore_migrator/api.py
@@ -2,6 +2,7 @@
 API for migration from modulestore to learning core
 """
 from collections import defaultdict
+from django.db.models import Count
 from celery.result import AsyncResult
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, LearningContextKey, UsageKey
@@ -157,6 +158,7 @@ def get_all_migrations_info(source_keys: list[CourseKey | LibraryLocator]) -> di
         'migrations__target_collection__key',
         'migrations__target_collection__title',
         'key',
+        migrated_blocks=Count("migrations__block_migrations"),
     ):
         results[info['key']].append(info)
     return dict(results)

--- a/cms/djangoapps/modulestore_migrator/rest_api/v1/serializers.py
+++ b/cms/djangoapps/modulestore_migrator/rest_api/v1/serializers.py
@@ -193,6 +193,7 @@ class MigrationInfoSerializer(serializers.Serializer):
         source="migrations__target_collection__title",
         allow_null=True
     )
+    migrated_blocks = serializers.IntegerField()
 
 
 class MigrationInfoResponseSerializer(serializers.Serializer):

--- a/cms/djangoapps/modulestore_migrator/tests/test_api.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_api.py
@@ -447,11 +447,13 @@ class TestModulestoreMigratorAPI(LibraryTestCase):
             assert row[0].get('migrations__target__title') == "Test Library"
             assert row[0].get('migrations__target_collection__key') == collection_key
             assert row[0].get('migrations__target_collection__title') == "Test Collection"
+            assert row[0].get('migrated_blocks') == 3
 
             assert row[1].get('migrations__target__key') == str(self.lib_key_v2_2)
             assert row[1].get('migrations__target__title') == "Test Library 2"
             assert row[1].get('migrations__target_collection__key') == collection_key_2
             assert row[1].get('migrations__target_collection__title') == "Test Collection 2"
+            assert row[0].get('migrated_blocks') == 3
 
     def test_get_target_block_usage_keys(self):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds `migrated_blocks` i.e. number of blocks migrated to migration info api.

Useful information to include:

- Which edX user roles will this change impact? "Developer"

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2525
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4267

## Testing instructions

Verify that the tests are passing.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
