### PR TITLE
fix: point to new models in channel_migrations app

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 from consent.models import DataSharingConsent
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
+from django.conf import settings
 from django.core import mail
 from django.core.cache import cache
 from django.test import TestCase
@@ -21,7 +22,6 @@ from enterprise.models import (
     EnterpriseCustomerUser,
     PendingEnterpriseCustomerUser
 )
-from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from social_django.models import UserSocialAuth
@@ -86,6 +86,12 @@ from .retirement_helpers import (  # pylint: disable=unused-import
     fake_completed_retirement,
     setup_retirement_states
 )
+
+# This is a temporary import path while we transition from integrated_channels to channel_integrations
+if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True):
+    from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
+else:
+    from channel_integrations.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 
 
 def build_jwt_headers(user):

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -26,8 +26,6 @@ from edx_ace.recipient import Recipient
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser, PendingEnterpriseCustomerUser
-from integrated_channels.degreed.models import DegreedLearnerDataTransmissionAudit
-from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 from rest_framework import permissions, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import UnsupportedMediaType
@@ -96,6 +94,15 @@ from .serializers import (
 )
 from .signals import USER_RETIRE_LMS_CRITICAL, USER_RETIRE_LMS_MISC, USER_RETIRE_MAILINGS
 from .utils import create_retirement_request_and_deactivate_account, username_suffix_generator
+
+# This is a temporary import path while we transition from integrated_channels to channel_integrations
+if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True):
+    from integrated_channels.degreed.models import DegreedLearnerDataTransmissionAudit
+    from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
+else:
+    from channel_integrations.degreed2.models import Degreed2LearnerDataTransmissionAudit \
+        as DegreedLearnerDataTransmissionAudit
+    from channel_integrations.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 
 log = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/user_api/management/commands/create_user_gdpr_testing.py
+++ b/openedx/core/djangoapps/user_api/management/commands/create_user_gdpr_testing.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 from consent.models import DataSharingConsent
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from enterprise.models import (
     EnterpriseCourseEnrollment,
@@ -18,7 +19,6 @@ from enterprise.models import (
     EnterpriseCustomerUser,
     PendingEnterpriseCustomerUser
 )
-from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 from opaque_keys.edx.keys import CourseKey
 from zoneinfo import ZoneInfo
 
@@ -30,6 +30,12 @@ from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, PendingEmailChange, UserProfile
 
 from ...models import UserOrgTag
+
+# This is a temporary import path while we transition from integrated_channels to channel_integrations
+if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True):
+    from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
+else:
+    from channel_integrations.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 
 
 class Command(BaseCommand):

--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -10,10 +10,6 @@ from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imp
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer
-from integrated_channels.integrated_channel.tasks import (
-    transmit_single_learner_data,
-    transmit_single_subsection_learner_data
-)
 from slumber.exceptions import HttpClientError
 
 from common.djangoapps.student.signals import UNENROLL_DONE
@@ -21,6 +17,18 @@ from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
 from openedx.core.djangoapps.signals.signals import COURSE_ASSESSMENT_GRADE_CHANGED, COURSE_GRADE_NOW_PASSED
 from openedx.features.enterprise_support.tasks import clear_enterprise_customer_data_consent_share_cache
 from openedx.features.enterprise_support.utils import clear_data_consent_share_cache, is_enterprise_learner
+
+# This is a temporary import path while we transition from integrated_channels to channel_integrations
+if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True):
+    from integrated_channels.integrated_channel.tasks import (
+        transmit_single_learner_data,
+        transmit_single_subsection_learner_data
+    )
+else:
+    from channel_integrations.integrated_channel.tasks import (
+        transmit_single_learner_data,
+        transmit_single_subsection_learner_data
+    )
 
 log = logging.getLogger(__name__)
 

--- a/openedx/features/enterprise_support/tests/test_signals.py
+++ b/openedx/features/enterprise_support/tests/test_signals.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import ddt
+from django.conf import settings
 from django.test.utils import override_settings
 from django.utils.timezone import now
 from edx_django_utils.cache import TieredCache
@@ -196,7 +197,9 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
         Test to assert transmit_single_learner_data is called when COURSE_GRADE_NOW_PASSED signal is fired
         """
         with patch(
-            'integrated_channels.integrated_channel.tasks.transmit_single_learner_data.apply_async',
+            'integrated_channels.integrated_channel.tasks.transmit_single_learner_data.apply_async'
+            if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True) else
+            'channel_integrations.integrated_channel.tasks.transmit_single_learner_data.apply_async',
             return_value=None
         ) as mock_task_apply:
             course_key = CourseKey.from_string(self.course_id)
@@ -218,7 +221,9 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
         Test to assert transmit_subsection_learner_data is called when COURSE_ASSESSMENT_GRADE_CHANGED signal is fired.
         """
         with patch(
-            'integrated_channels.integrated_channel.tasks.transmit_single_subsection_learner_data.apply_async',
+            'integrated_channels.integrated_channel.tasks.transmit_single_subsection_learner_data.apply_async'
+            if getattr(settings, 'ENABLE_LEGACY_INTEGRATED_CHANNELS', True) else
+            'channel_integrations.integrated_channel.tasks.transmit_single_subsection_learner_data.apply_async',
             return_value=None
         ) as mock_task_apply:
             course_key = CourseKey.from_string(self.course_id)


### PR DESCRIPTION
As part of the initiative to make integrated_channels a separately installable plugin: https://github.com/openedx/enterprise-integrated-channels, we are temporarily making use of a feature flag to point to new data models. Once the changes are tested, we will roll out a change in openedx to remove the feature flag and entirely rely on new models that live within the channel_integrations app. 