### PR TITLE
feat: added grouping for new response notification

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -122,6 +122,7 @@ class DiscussionNotificationSender:
         if not self.parent_id and self.creator.id != int(self.thread.user_id):
             context = {
                 'email_content': clean_thread_html_body(self.comment.body),
+                'group_by_id': str(self.thread.id),
             }
             self._populate_context_with_ids_for_mobile(context, notification_type)
             self._send_notification([self.thread.user_id], notification_type, extra_context=context)
@@ -229,6 +230,7 @@ class DiscussionNotificationSender:
         if not self.parent_id:
             context = {
                 "email_content": clean_thread_html_body(self.comment.body),
+                "group_by_id": str(self.thread.id),
             }
             notification_type = "response_on_followed_post"
             self._populate_context_with_ids_for_mobile(context, notification_type)

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
@@ -148,6 +148,7 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'topic_id': None,
             'thread_id': 1,
             'comment_id': None,
+            'group_by_id': '1',
         }
         self.assertDictEqual(args.context, expected_context)
         self.assertEqual(
@@ -214,6 +215,8 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
             'thread_id': 1,
             'comment_id': 4 if not notification_type == 'response_on_followed_post' else None,
         }
+        if notification_type == 'response_on_followed_post':
+            expected_context['group_by_id'] = '1'
         if parent_id:
             expected_context['author_name'] = 'dummy\'s'
             expected_context['author_pronoun'] = 'dummy\'s'

--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -45,6 +45,8 @@ COURSE_NOTIFICATION_TYPES = {
         'is_core': True,
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> responded to your '
                               'post <{strong}>{post_title}</{strong}></{p}>'),
+        'grouped_content_template': _('<{p}><{strong}>{replier_name}</{strong}> and others have responded to your post '
+                                      '<{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',
             'replier_name': 'replier name',
@@ -98,6 +100,8 @@ COURSE_NOTIFICATION_TYPES = {
         'non_editable': [],
         'content_template': _('<{p}><{strong}>{replier_name}</{strong}> responded to a post you’re following: '
                               '<{strong}>{post_title}</{strong}></{p}>'),
+        'grouped_content_template': _('<{p}><{strong}>{replier_name}</{strong}> and others responded to a post you’re '
+                                      'following: <{strong}>{post_title}</{strong}></{p}>'),
         'content_context': {
             'post_title': 'Post title',
             'replier_name': 'replier name',

--- a/openedx/core/djangoapps/notifications/grouping_notifications.py
+++ b/openedx/core/djangoapps/notifications/grouping_notifications.py
@@ -106,6 +106,38 @@ class OraStaffGrouper(BaseNotificationGrouper):
         return content_context
 
 
+@NotificationRegistry.register('new_response')
+class NewResponseGrouper(BaseNotificationGrouper):
+    """
+    Grouper for new response on post.
+    """
+
+    def group(self, new_notification, old_notification):
+        """
+        Groups new ora staff notifications based on the xblock ID.
+        """
+        content_context = old_notification.content_context
+        content_context.setdefault("grouped", True)
+        content_context["replier_name"] = new_notification.content_context["replier_name"]
+        return content_context
+
+
+@NotificationRegistry.register('response_on_followed_post')
+class NewResponseOnFollowedPostGrouper(BaseNotificationGrouper):
+    """
+    Grouper for new response on post.
+    """
+
+    def group(self, new_notification, old_notification):
+        """
+        Groups new ora staff notifications based on the xblock ID.
+        """
+        content_context = old_notification.content_context
+        content_context.setdefault("grouped", True)
+        content_context["replier_name"] = new_notification.content_context["replier_name"]
+        return content_context
+
+
 def group_user_notifications(new_notification: Notification, old_notification: Notification):
     """
     Groups user notification based on notification type and group_id

--- a/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
+++ b/openedx/core/djangoapps/notifications/tests/test_notification_grouping.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.notifications.grouping_notifications import (
     BaseNotificationGrouper,
     NotificationRegistry,
     group_user_notifications,
-    get_user_existing_notifications, NewPostGrouper
+    get_user_existing_notifications, NewPostGrouper, NewResponseGrouper, NewResponseOnFollowedPostGrouper
 )
 from openedx.core.djangoapps.notifications.models import Notification
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -98,12 +98,13 @@ class TestGroupUserNotifications(ModuleStoreTestCase):
     """
 
     @patch('openedx.core.djangoapps.notifications.grouping_notifications.NotificationRegistry.get_grouper')
-    def test_group_user_notifications(self, mock_get_grouper):
+    @ddt.data(NewPostGrouper, NewResponseGrouper, NewResponseOnFollowedPostGrouper)
+    def test_group_user_notifications(self, grouper_class, mock_get_grouper):
         """
-        Test that the function groups notifications using the appropriate grou
+        Test that the function groups notifications using the appropriate grouping class
         """
         # Mock the grouper
-        mock_grouper = MagicMock(spec=NewPostGrouper)
+        mock_grouper = MagicMock(spec=grouper_class)
         mock_get_grouper.return_value = mock_grouper
 
         new_notification = MagicMock(spec=Notification)


### PR DESCRIPTION
###
Added grouping for `new response on post` and  `response_on_followed_post ` notification type. Now all the notifications on the same post of the user will be grouped and shown as a single notification. 

This PR resolved this issue 
https://github.com/openedx/tutor-contrib-notifications/issues/21


#### Test Case: Verify Discussion Notifications (Owned & Followed)

#### Objective
Verify that a user receives separate notifications for activity on their own post and activity on a post they are explicitly following. and the notifications are grouped when there are multiple responses on the posts.

#### Pre-conditions
* User 1 and User 2 exist on the platform.
* Both users are enrolled in the same course.

#### Test Steps

##### 1. Content Creation
1. Log in as User 1.
2. Navigate to the Discussions App.
3. Create a new discussion post (refer to this as Post A).
4. Log in as User 2.
5. Navigate to the Discussions App.
6. Create a new discussion post (refer to this as Post B).

##### 2. Enable "Follow" Status
1. Log in as User 1.
2. Locate Post B (created by User 2).
3. Click the Follow button on Post B.

##### 3. Trigger Notifications
1. Log in as User 2.
2. Add multiple responses on Post A (User 1's post).
3. Add multiple responses on Post B (User 2's post).

#### Expected Results
Log in as User 1 and check the Notification tray. The user must see exactly two distinct notifications:
* [x] **Notification 1:** Grouped Notification for the reply on Post A (Reason: User 1 is the author).
* [x] **Notification 2:** Grouped Notification for the reply on Post B (Reason: User 1 is following the post).

FYI @bmtcril  @saraburns1 
