### PR TITLE
[Backport] fix: Publish components/container in legacy libraries migration [FC-0112] (#37644)

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
@@ -440,6 +440,9 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             "problem", result.componentversion.component.component_type.name
         )
 
+        # The component is published
+        self.assertFalse(result.componentversion.component.versioning.has_unpublished_changes)
+
     def test_migrate_component_with_static_content(self):
         """
         Test _migrate_component with static file content
@@ -897,6 +900,8 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
 
                 container_version = result.containerversion
                 self.assertEqual(container_version.title, f"Test {block_type.title()}")
+                # The container is published
+                self.assertFalse(authoring_api.contains_unpublished_changes(container_version.container.pk))
 
     def test_migrate_container_replace_existing_false(self):
         """

--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -956,7 +956,7 @@ def delete_library_block_static_asset_file(usage_key, file_path, user=None):
         )
 
 
-def publish_component_changes(usage_key: LibraryUsageLocatorV2, user: UserType):
+def publish_component_changes(usage_key: LibraryUsageLocatorV2, user_id: int):
     """
     Publish all pending changes in a single component.
     """
@@ -969,7 +969,7 @@ def publish_component_changes(usage_key: LibraryUsageLocatorV2, user: UserType):
     drafts_to_publish = authoring_api.get_all_drafts(learning_package.id).filter(entity__key=component.key)
     # Publish the component and update anything that needs to be updated (e.g. search index):
     publish_log = authoring_api.publish_from_drafts(
-        learning_package.id, draft_qset=drafts_to_publish, published_by=user.id,
+        learning_package.id, draft_qset=drafts_to_publish, published_by=user_id,
     )
     # Since this is a single component, it should be safe to process synchronously and in-process:
     tasks.send_events_after_publish(publish_log.pk, str(library_key))

--- a/openedx/core/djangoapps/content_libraries/api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/api/containers.py
@@ -575,7 +575,11 @@ def get_containers_contains_item(
     ]
 
 
-def publish_container_changes(container_key: LibraryContainerLocator, user_id: int | None) -> None:
+def publish_container_changes(
+    container_key: LibraryContainerLocator,
+    user_id: int | None,
+    call_post_publish_events_sync=False,
+) -> None:
     """
     [ 🛑 UNSTABLE ] Publish all unpublished changes in a container and all its child
     containers/blocks.
@@ -595,7 +599,10 @@ def publish_container_changes(container_key: LibraryContainerLocator, user_id: i
     )
     # Update the search index (and anything else) for the affected container + blocks
     # This is mostly synchronous but may complete some work asynchronously if there are a lot of changes.
-    tasks.wait_for_post_publish_events(publish_log, library_key)
+    if call_post_publish_events_sync:
+        tasks.send_events_after_publish(publish_log.pk, str(library_key))
+    else:
+        tasks.wait_for_post_publish_events(publish_log, library_key)
 
 
 def copy_container(container_key: LibraryContainerLocator, user_id: int) -> UserClipboardData:

--- a/openedx/core/djangoapps/content_libraries/rest_api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/blocks.py
@@ -241,7 +241,7 @@ class LibraryBlockPublishView(APIView):
             request.user,
             authz_permissions.PUBLISH_LIBRARY_CONTENT
         )
-        api.publish_component_changes(key, request.user)
+        api.publish_component_changes(key, request.user.id)
         return Response({})
 
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Backport of https://github.com/openedx/edx-platform/pull/37644

## Testing instructions

- Follow the testing instructions in https://github.com/openedx/edx-platform/pull/37644


