### PR TITLE
fix: fixed embedded video not showing in about page

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3672,3 +3672,18 @@ SSL_AUTH_EMAIL_DOMAIN = "MIT.EDU"
 SSL_AUTH_DN_FORMAT_STRING = (
     "/C=US/ST=Massachusetts/O=Massachusetts Institute of Technology/OU=Client CA v1/CN={0}/emailAddress={1}"
 )
+
+# HTML Sanitization Settings
+# Trusted domains for embedded content (iframes) in course about pages and similar content
+# These domains are considered safe for embedding videos and other interactive content
+ALLOWED_EMBED_HOSTS = [
+    'youtube.com',
+    'www.youtube.com',
+    'youtube-nocookie.com',
+    'www.youtube-nocookie.com',
+    'youtu.be',  # YouTube short links
+    'vimeo.com',
+    'player.vimeo.com',
+    'dailymotion.com',
+    'www.dailymotion.com',
+]

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -64,7 +64,7 @@ def clean_dangerous_html(html):
     Mark a string as already HTML and remove unsafe tags, so that it won't be escaped before output.
 
     Allows embedded content (iframes) only from domains configured in the
-    ALLOWED_EMBED_HOSTS setting. This provides security while enabling 
+    ALLOWED_EMBED_HOSTS setting. This provides security while enabling
     legitimate video embeds in course about pages.
 
     Configuration:

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -60,9 +60,8 @@ def strip_all_tags_but_br(string_to_strip):
 def clean_dangerous_html(html):
     """
     Mark a string as already HTML and remove unsafe tags, so that it won't be escaped before output.
-    
     Allows embedded content (iframes) only from trusted video hosting providers.
-    
+
     Usage:
         <%page expression_filter="h"/>
         <%!
@@ -72,7 +71,7 @@ def clean_dangerous_html(html):
     """
     if not html:
         return html
-    
+
     # Trusted domains for embedded video content
     # These are well-known video hosting services that provide sandboxed embeds
     trusted_video_hosts = [
@@ -83,7 +82,7 @@ def clean_dangerous_html(html):
         'vimeo.com',
         'player.vimeo.com',
     ]
-    
+
     cleaner = Cleaner(
         style=True,
         inline_style=False,

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -69,6 +69,6 @@ def clean_dangerous_html(html):
     """
     if not html:
         return html
-    cleaner = Cleaner(style=True, inline_style=False, safe_attrs_only=False, embedded= False)
+    cleaner = Cleaner(style=True, inline_style=False, safe_attrs_only=False, embedded=False)
     html = cleaner.clean_html(html)
     return HTML(html)

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -62,22 +62,22 @@ def strip_all_tags_but_br(string_to_strip):
 def clean_dangerous_html(html):
     """
     Mark a string as already HTML and remove unsafe tags, so that it won't be escaped before output.
-    
+
     Allows embedded content (iframes) only from domains configured in the
     ALLOWED_EMBED_HOSTS setting. This provides security while enabling 
     legitimate video embeds in course about pages.
-    
+
     Configuration:
         Set ALLOWED_EMBED_HOSTS in your settings to control which domains
         can embed content:
-        
+
         ALLOWED_EMBED_HOSTS = [
             'youtube.com',
             'www.youtube.com',
             'vimeo.com',
             'custom-video-service.com',  # Add your own
         ]
-    
+
     Usage:
         <%page expression_filter="h"/>
         <%!
@@ -87,7 +87,7 @@ def clean_dangerous_html(html):
     """
     if not html:
         return html
-    
+
     # Get allowed hosts from settings, with sensible defaults
     allowed_hosts = getattr(
         settings,
@@ -99,7 +99,7 @@ def clean_dangerous_html(html):
             'www.youtube-nocookie.com',
         ]
     )
-    
+
     cleaner = Cleaner(
         style=True,
         inline_style=False,

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -89,16 +89,7 @@ def clean_dangerous_html(html):
         return html
 
     # Get allowed hosts from settings, with sensible defaults
-    allowed_hosts = getattr(
-        settings,
-        'ALLOWED_EMBED_HOSTS',
-        [
-            'youtube.com',
-            'www.youtube.com',
-            'youtube-nocookie.com',
-            'www.youtube-nocookie.com',
-        ]
-    )
+    allowed_hosts = getattr(settings, 'ALLOWED_EMBED_HOSTS', [])
 
     cleaner = Cleaner(
         style=True,

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -60,7 +60,10 @@ def strip_all_tags_but_br(string_to_strip):
 def clean_dangerous_html(html):
     """
     Mark a string as already HTML and remove unsafe tags, so that it won't be escaped before output.
-        Usage:
+    
+    Allows embedded content (iframes) only from trusted video hosting providers.
+    
+    Usage:
         <%page expression_filter="h"/>
         <%!
         from openedx.core.djangolib.markup import clean_dangerous_html
@@ -69,6 +72,23 @@ def clean_dangerous_html(html):
     """
     if not html:
         return html
-    cleaner = Cleaner(style=True, inline_style=False, safe_attrs_only=False, embedded=False)
+    
+    # Trusted domains for embedded video content
+    # These are well-known video hosting services that provide sandboxed embeds
+    trusted_video_hosts = [
+        'youtube.com',
+        'www.youtube.com',
+        'youtube-nocookie.com',  # Privacy-enhanced YouTube
+        'www.youtube-nocookie.com',
+        'vimeo.com',
+        'player.vimeo.com',
+    ]
+    
+    cleaner = Cleaner(
+        style=True,
+        inline_style=False,
+        safe_attrs_only=False,
+        host_whitelist=trusted_video_hosts,
+    )
     html = cleaner.clean_html(html)
     return HTML(html)

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -69,6 +69,6 @@ def clean_dangerous_html(html):
     """
     if not html:
         return html
-    cleaner = Cleaner(style=True, inline_style=False, safe_attrs_only=False)
+    cleaner = Cleaner(style=True, inline_style=False, safe_attrs_only=False, embedded= False)
     html = cleaner.clean_html(html)
     return HTML(html)


### PR DESCRIPTION
## Description

Fixes issue where embedded videos (YouTube iframes) appear correctly in Studio course about page preview but are stripped out and don't render in the LMS course about page.
The issue was introduced by the lxml upgrade from 4.9.4 to 5.3.2.

In lxml 5.0+, the `lxml.html.clean` module was deprecated and moved to the 
separate `lxml-html-clean` package, which has different default behaviors.


## Problem

The `clean_dangerous_html()` function in `openedx/core/djangolib/markup.py` uses `lxml.html.clean.Cleaner` which by default removes `<iframe>` elements for security reasons. This causes embedded videos to be stripped from course about pages when viewed in the LMS, even though they appear correctly in Studio preview.

**Observed behavior:**
- Course about page HTML with YouTube iframe displays correctly in Studio
- Same HTML is cleaned when rendered in LMS, removing the iframe
- Users see empty space where video should be

## Solution

Use `host_whitelist` with configurable allowed domains via the `ALLOWED_EMBED_HOSTS` Django setting.

**Implementation:**
- Added `ALLOWED_EMBED_HOSTS` setting in `lms/envs/common.py`
- Modified `clean_dangerous_html()` to read allowed hosts from settings only
- No hardcoded defaults in the function - configuration is explicit in settings
- If `ALLOWED_EMBED_HOSTS` is not configured or empty, all iframes are blocked

**Default configuration** (in `lms/envs/common.py`):
```python
ALLOWED_EMBED_HOSTS = [
    'youtube.com',
    'www.youtube.com',
    'youtube-nocookie.com',
    'www.youtube-nocookie.com',
    'youtu.be',
    'vimeo.com',
    'player.vimeo.com',
]
```

Administrators can override this in production settings or via Tutor configuration.

## Testing

1. Create a course in Studio
2. Add YouTube embed iframe to course about page
3. Verify video appears in Studio preview
4. Navigate to course about page in LMS
5. Confirm video now renders correctly in LMS

The HTML used for the test is:
```
<h1>Hello, World!</h1>
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
<div class="tiny-pageembed" style="width: 800px; height: 800px;"><iframe src="https://www.youtube.com/embed/9C8YTP75HpA?si=jW9BPxEhDyVp14bb" 560="" height="800px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" iframe="" width="800px" scrolling="no"></iframe></div>
```
**Before**

<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/afe168b3-e531-4462-9c9a-4316b5ca0c75" />


**After**

<img width="1851" height="963" alt="image" src="https://github.com/user-attachments/assets/8d2e636c-fbce-4761-bd90-5cbfe469bd13" />

Related issue:

https://github.com/openedx/edx-platform/issues/37655 