### PR TITLE
fix: Course search pill not cleared when text deleted.

### DIFF
--- a/lms/static/js/discovery/discovery_factory.js
+++ b/lms/static/js/discovery/discovery_factory.js
@@ -31,11 +31,11 @@
             listing = new CoursesListing({model: courseListingModel});
 
             dispatcher.listenTo(form, "search", function (query) {
-            form.showLoadingIndicator();
-            if (!query || query.trim() === "") {
-                filters.remove("search_query");
-            }
-            search.performSearch(query, filters.getTerms());
+                form.showLoadingIndicator();
+                if (!query || query.trim() === "") {
+                    filters.remove("search_query");
+                }
+                search.performSearch(query, filters.getTerms());
             });
 
             dispatcher.listenTo(refineSidebar, 'selectOption', function(type, query, name) {

--- a/lms/static/js/discovery/discovery_factory.js
+++ b/lms/static/js/discovery/discovery_factory.js
@@ -30,9 +30,12 @@
             }
             listing = new CoursesListing({model: courseListingModel});
 
-            dispatcher.listenTo(form, 'search', function(query) {
-                form.showLoadingIndicator();
-                search.performSearch(query, filters.getTerms());
+            dispatcher.listenTo(form, "search", function (query) {
+            form.showLoadingIndicator();
+            if (!query || query.trim() === "") {
+                filters.remove("search_query");
+            }
+            search.performSearch(query, filters.getTerms());
             });
 
             dispatcher.listenTo(refineSidebar, 'selectOption', function(type, query, name) {


### PR DESCRIPTION
### Problem
When users cleared the search bar and performed an empty search, the filter pill with the previous search term remained visible, even though all courses were correctly returned. This created a confusing UX where the UI state didn't match the actual search results.

### Solution
Added a check in the search event handler to remove the `search_query` filter when the search input is empty. Now when users clear the search bar and hit search/enter, the filter pill is properly removed.

### Changes
- Check if query is empty or contains only whitespace before performing search
- Remove `search_query` filter when empty search is detected
- Maintains expected behavior: pill clears when search bar is cleared and search is performed

### Testing
![2025-12-01 11-31-10](https://github.com/user-attachments/assets/3b5518ac-ff8f-43e4-a49d-0546fcaddf90)
