### PR TITLE
refactor: lift shared test settings up to common module

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -14,39 +14,19 @@ sessions. Assumes structure:
 
 
 import os
-from uuid import uuid4
 
 from django.utils.translation import gettext_lazy
-from path import Path as path
-
-from openedx.core.lib.derived import derive_settings
+from edx_django_utils.plugins import add_plugins
 
 from xmodule.modulestore.modulestore_settings import update_module_store_settings  # pylint: disable=wrong-import-order
 
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
+from openedx.core.lib.derived import derive_settings
 from openedx.core.lib.features_setting_proxy import FeaturesProxy
 
 from .common import *
 
-# import settings from LMS for consistent behavior with CMS
-from lms.envs.test import (  # pylint: disable=wrong-import-order, disable=unused-import
-    ACCOUNT_MICROFRONTEND_URL,
-    COMPREHENSIVE_THEME_DIRS,  # unimport:skip
-    ECOMMERCE_API_URL,
-    ENABLE_COMPREHENSIVE_THEMING,
-    JWT_AUTH,
-    LOGIN_ISSUE_SUPPORT_LINK,
-    MEDIA_ROOT,
-    MEDIA_URL,
-    ORDER_HISTORY_MICROFRONTEND_URL,
-    PLATFORM_DESCRIPTION,
-    PLATFORM_NAME,
-    PROFILE_MICROFRONTEND_URL,
-    REGISTRATION_EXTRA_FIELDS,
-    GRADES_DOWNLOAD,
-    SITE_NAME,
-    WIKI_ENABLED,
-    XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE,
-)
+from openedx.envs.test import *  # pylint: disable=wrong-import-order
 
 # A proxy for feature flags stored in the settings namespace
 FEATURES = FeaturesProxy(globals())
@@ -56,40 +36,16 @@ FEATURES = FeaturesProxy(globals())
 STUDIO_NAME = gettext_lazy("Your Platform 𝓢𝓽𝓾𝓭𝓲𝓸")
 STUDIO_SHORT_NAME = gettext_lazy("𝓢𝓽𝓾𝓭𝓲𝓸")
 
-# Allow all hosts during tests, we use a lot of different ones all over the codebase.
-ALLOWED_HOSTS = ["*"]
+COMMON_TEST_DATA_ROOT = COMMON_ROOT / "test" / "data"
 
-# mongo connection settings
-MONGO_PORT_NUM = int(os.environ.get("EDXAPP_TEST_MONGO_PORT", "27017"))
-MONGO_HOST = os.environ.get("EDXAPP_TEST_MONGO_HOST", "localhost")
-
-THIS_UUID = uuid4().hex[:5]
-
-TEST_ROOT = path("test_root")
-
-# Want static files in the same dir for running on jenkins.
-STATIC_ROOT = TEST_ROOT / "staticfiles"
 WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
 WEBPACK_LOADER['DEFAULT']['LOADER_CLASS'] = 'webpack_loader.loader.FakeWebpackLoader'
 
 GITHUB_REPO_ROOT = TEST_ROOT / "data"
-DATA_DIR = TEST_ROOT / "data"
-COMMON_TEST_DATA_ROOT = COMMON_ROOT / "test" / "data"
 
 # For testing "push to lms"
 ENABLE_EXPORT_GIT = True
 GIT_REPO_EXPORT_DIR = TEST_ROOT / "export_course_repos"
-
-# TODO (cpennington): We need to figure out how envs/test.py can inject things into common.py so that we don't have to repeat this sort of thing  # lint-amnesty, pylint: disable=line-too-long
-STATICFILES_DIRS = [
-    COMMON_ROOT / "static",
-    PROJECT_ROOT / "static",
-]
-STATICFILES_DIRS += [
-    (course_dir, COMMON_TEST_DATA_ROOT / course_dir)
-    for course_dir in os.listdir(COMMON_TEST_DATA_ROOT)
-    if os.path.isdir(COMMON_TEST_DATA_ROOT / course_dir)
-]
 
 # Avoid having to run collectstatic before the unit test suite
 # If we don't add these settings, then Django templates that can't
@@ -140,9 +96,6 @@ CMS_BASE = "localhost:8001"
 CMS_ROOT_URL = f"http://{CMS_BASE}"
 
 COURSE_AUTHORING_MICROFRONTEND_URL = "http://course-authoring-mfe"
-DISCUSSIONS_MICROFRONTEND_URL = "http://discussions-mfe"
-ACCOUNT_MICROFRONTEND_URL = 'http://account-mfe'
-LEARNING_MICROFRONTEND_URL = 'http://learning-mfe'
 
 CACHES = {
     # This is the cache used for most things.
@@ -180,49 +133,12 @@ CACHES = {
 
 ################################# CELERY ######################################
 
-CELERY_ALWAYS_EAGER = True
-CELERY_RESULT_BACKEND = "django-cache"
-
-CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = False
-
 # test_status_cancel in cms/cms_user_tasks/test.py is failing without this
 # @override_setting for BROKER_URL is not working in testcase, so updating here
 BROKER_URL = "memory://localhost/"
 
-########################### Server Ports ###################################
-
-# These ports are carefully chosen so that if the browser needs to
-# access them, they will be available through the SauceLabs SSH tunnel
-XQUEUE_PORT = 8040
-YOUTUBE_PORT = 8031
-LTI_PORT = 8765
-VIDEO_SOURCE_PORT = 8777
-
-
-################### Make tests faster
-# http://slacy.com/blog/2012/04/make-your-tests-faster-in-django-1-4/
-PASSWORD_HASHERS = [
-    "django.contrib.auth.hashers.MD5PasswordHasher",
-]
-
 # No segment key
 CMS_SEGMENT_KEY = None
-
-DISABLE_SET_JWT_COOKIES_FOR_TESTS = True
-
-ENABLE_SERVICE_STATUS = True
-
-# Toggles embargo on for testing
-EMBARGO = True
-
-TEST_THEME = COMMON_ROOT / "test" / "test-theme"
-
-# For consistency in user-experience, keep the value of this setting in sync with
-# the one in lms/envs/test.py
-ENABLE_DISCUSSION_SERVICE = False
-
-# Enable a parental consent age limit for testing
-PARENTAL_CONSENT_AGE_LIMIT = 13
 
 # Enable certificates for the tests
 CERTIFICATES_HTML_VIEW = True
@@ -230,22 +146,12 @@ CERTIFICATES_HTML_VIEW = True
 # Enable content libraries code for the tests
 ENABLE_CONTENT_LIBRARIES = True
 
-ENABLE_EDXNOTES = True
-
-# MILESTONES
-MILESTONES_APP = True
-
 # ENTRANCE EXAMS
 ENTRANCE_EXAMS = True
-
-VIDEO_CDN_URL = {"CN": "http://api.xuetangx.com/edx/video?s3_url="}
 
 # Courseware Search Index
 ENABLE_COURSEWARE_INDEX = True
 ENABLE_LIBRARY_INDEX = True
-SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
-
-ENABLE_ENROLLMENT_TRACK_USER_PARTITION = True
 
 ########################## AUTHOR PERMISSION #######################
 ENABLE_CREATOR_GROUP = False
@@ -253,15 +159,11 @@ ENABLE_CREATOR_GROUP = False
 # teams feature
 ENABLE_TEAMS = True
 
-# Dummy secret key for dev/test
-SECRET_KEY = "85920908f28904ed733fe576320db18cabd7b6cd"
-
 ######### custom courses #########
 INSTALLED_APPS += [
     "openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig",
     "common.djangoapps.third_party_auth.apps.ThirdPartyAuthConfig",
 ]
-CUSTOM_COURSES_EDX = True
 
 ########################## VIDEO IMAGE STORAGE ############################
 VIDEO_IMAGE_SETTINGS = dict(
@@ -275,23 +177,13 @@ VIDEO_IMAGE_SETTINGS = dict(
 )
 VIDEO_IMAGE_DEFAULT_FILENAME = "default_video_image.png"
 
-########################## VIDEO TRANSCRIPTS STORAGE ############################
-VIDEO_TRANSCRIPTS_SETTINGS = dict(
-    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,  # 3 MB
-    STORAGE_KWARGS=dict(
-        location=MEDIA_ROOT,
-        base_url=MEDIA_URL,
-    ),
-    DIRECTORY_PREFIX="video-transcripts/",
-)
+############################## Authentication ##############################
+
+# Most of the JWT_AUTH settings come from cms/envs/common.py (from openedx/envs/common.py),
+# but here we update to use JWKS values from openedx/envs/test.py for testing.
+JWT_AUTH.update(jwt_jwks_values)
 
 ####################### Plugin Settings ##########################
-
-# pylint: disable=wrong-import-position, wrong-import-order
-from edx_django_utils.plugins import add_plugins
-
-# pylint: disable=wrong-import-position, wrong-import-order
-from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 
 add_plugins(__name__, ProjectType.CMS, SettingsType.TEST)
 
@@ -299,62 +191,42 @@ add_plugins(__name__, ProjectType.CMS, SettingsType.TEST)
 
 derive_settings(__name__)
 
-############### Settings for edx-rbac  ###############
-SYSTEM_WIDE_ROLE_CLASSES = os.environ.get("SYSTEM_WIDE_ROLE_CLASSES", [])
+################################ Templates #################################
 
-DEFAULT_MOBILE_AVAILABLE = True
-
-PROCTORING_SETTINGS = {}
-
-# Used in edx-proctoring for ID generation in lieu of SECRET_KEY - dummy value
-# (ref MST-637)
-PROCTORING_USER_OBFUSCATION_KEY = "85920908f28904ed733fe576320db18cabd7b6cd"
+# For the "preview" template engine, the CMS uses the same dirs as the LMS. Here we mutate
+# the DIRS list to match the MAKO_TEMPLATE_DIRS_BASE list produced by lms.envs.test.
+preview_template = next(d for d in TEMPLATES if d["NAME"] == "preview")
+preview_template['DIRS'].extend([
+    COMMON_ROOT / 'test' / 'templates',
+    COMMON_ROOT / 'test' / 'test_sites',
+    REPO_ROOT / 'openedx' / 'core' / 'djangolib' / 'tests' / 'templates',
+])
+for theme_dir in COMPREHENSIVE_THEME_DIRS:  # pylint: disable=not-an-iterable
+    preview_template['DIRS'].insert(0, theme_dir)
 
 ############### Settings for Django Rate limit #####################
 
 RATELIMIT_RATE = '2/m'
-
-##### LOGISTRATION RATE LIMIT SETTINGS #####
-LOGISTRATION_RATELIMIT_RATE = "5/5m"
-LOGISTRATION_PER_EMAIL_RATELIMIT_RATE = "6/5m"
-LOGISTRATION_API_RATELIMIT = "5/m"
-
-REGISTRATION_VALIDATION_RATELIMIT = "5/minute"
-REGISTRATION_RATELIMIT = "5/minute"
-OPTIONAL_FIELD_API_RATELIMIT = "5/m"
-
-RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = "2/m"
-RESET_PASSWORD_API_RATELIMIT = "2/m"
-
-############### Settings for proctoring  ###############
-PROCTORING_USER_OBFUSCATION_KEY = "test_key"
-
-#################### Network configuration ####################
-# Tests are not behind any proxies
-CLOSEST_CLIENT_IP_FROM_HEADERS = []
-
-COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = {
-    "KEY": "***",
-    "SECRET": "***",
-    "URL": "***",
-}
 
 ############## openedx-learning (Learning Core) config ##############
 OPENEDX_LEARNING = {
     "MEDIA": {"BACKEND": "django.core.files.storage.InMemoryStorage", "OPTIONS": {"location": MEDIA_ROOT + "_private"}}
 }
 
+
+# This value has traditionally been imported from the LMS. Now we modify it to match to avoid dependency
+# on the LMS settings. The default in cms/envs/common.py includes the `marketing_emails_opt_in` field which is not
+# in the dict that was previously imported from the LMS for testing so we remove it here
+REGISTRATION_EXTRA_FIELDS.pop("marketing_emails_opt_in", None)
+
+# Course Live
+COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = big_blue_button_credentials
+
+# Proctoring
+PROCTORING_SETTINGS = {}
+
 #### Override default production settings for testing purposes
 
-AWS_QUERYSTRING_AUTH = False
-AWS_S3_CUSTOM_DOMAIN = "SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)"
-AWS_STORAGE_BUCKET_NAME = "SET-ME-PLEASE (ex. bucket-name)"
-CELERY_BROKER_HOSTNAME = "localhost"
-CELERY_BROKER_PASSWORD = "celery"
-CELERY_BROKER_TRANSPORT = "amqp"
-CELERY_BROKER_USER = "celery"
-CHAT_COMPLETION_API = "https://example.com/chat/completion"
-CHAT_COMPLETION_API_KEY = "i am a key"
 del AUTHORING_API_URL
 del BROKER_HEARTBEAT
 del BROKER_HEARTBEAT_CHECKRATE
@@ -364,18 +236,6 @@ del PARSE_KEYS
 del SESSION_INACTIVITY_TIMEOUT_IN_SECONDS
 ENTERPRISE_API_URL = "https://localhost:18000/enterprise/api/v1/"
 ENTERPRISE_CONSENT_API_URL = "https://localhost:18000/consent/api/v1/"
-ENTERPRISE_ENROLLMENT_API_URL = "https://localhost:18000/api/enrollment/v1/"
 INACTIVE_USER_URL = "http://localhost:18010"
-LMS_INTERNAL_ROOT_URL = "https://localhost:18000"
-OPENAPI_CACHE_TIMEOUT = 0
 POLICY_CHANGE_GRADES_ROUTING_KEY = "edx.lms.core.default"
-SECURE_PROXY_SSL_HEADER = None
-SESSION_COOKIE_DOMAIN = ""
-SESSION_ENGINE = "django.contrib.sessions.backends.db"
-SHARED_COOKIE_DOMAIN = ""
 SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY = "edx.lms.core.default"
-SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = "edx.lms.core.default"
-STATIC_ROOT_BASE = "/edx/var/edxapp/staticfiles"
-STATIC_URL_BASE = "/static/"
-
-CATALOG_MICROFRONTEND_URL = "http://catalog-mfe"

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -15,12 +15,8 @@ sessions. Assumes structure:
 
 import logging
 from collections import OrderedDict
-from uuid import uuid4
 
-import openid.oidutil
-from django.utils.translation import gettext_lazy
 from edx_django_utils.plugins import add_plugins
-from path import Path as path
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 from openedx.core.lib.derived import derive_settings
@@ -31,20 +27,11 @@ from openedx.core.lib.features_setting_proxy import FeaturesProxy
 
 from .common import *
 
-from common.djangoapps.util.testing import patch_sessions, patch_testcase  # pylint: disable=wrong-import-order
+from openedx.envs.test import *
+
 
 # A proxy for feature flags stored in the settings namespace
 FEATURES = FeaturesProxy(globals())
-
-# This patch disables the commit_on_success decorator during tests
-# in TestCase subclasses.
-patch_testcase()
-patch_sessions()
-
-# Allow all hosts during tests, we use a lot of different ones all over the codebase.
-ALLOWED_HOSTS = [
-    '*'
-]
 
 # Silence noisy logs to make troubleshooting easier when tests fail.
 LOG_OVERRIDES = [
@@ -54,62 +41,26 @@ LOG_OVERRIDES = [
 for log_name, log_level in LOG_OVERRIDES:
     logging.getLogger(log_name).setLevel(log_level)
 
-# mongo connection settings
-MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))
-MONGO_HOST = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'localhost')
-
-THIS_UUID = uuid4().hex[:5]
-
-DISABLE_SET_JWT_COOKIES_FOR_TESTS = True
-
 # can't test start dates with this True, but on the other hand,
 # can test everything else :)
 DISABLE_START_DATES = True
 
-# Most tests don't use the discussion service, so we turn it off to speed them up.
-# Tests that do can enable this flag, but must use the UrlResetMixin class to force urls.py
-# to reload. For consistency in user-experience, keep the value of this setting in sync with
-# the one in cms/envs/test.py
-ENABLE_DISCUSSION_SERVICE = False
-
-ENABLE_SERVICE_STATUS = True
-
 ENABLE_VERIFIED_CERTIFICATES = True
-
-# Toggles embargo on for testing
-EMBARGO = True
-
-# Enable the milestones app in tests to be consistent with it being enabled in production
-MILESTONES_APP = True
-
-ENABLE_ENROLLMENT_TRACK_USER_PARTITION = True
 
 ENABLE_BULK_ENROLLMENT_VIEW = True
 
 ENABLE_BULK_USER_RETIREMENT = True
 
-DEFAULT_MOBILE_AVAILABLE = True
+COMMON_TEST_DATA_ROOT = COMMON_ROOT / "test" / "data"
 
-# Need wiki for courseware views to work. TODO (vshnayder): shouldn't need it.
-WIKI_ENABLED = True
-
-# Enable a parental consent age limit for testing
-PARENTAL_CONSENT_AGE_LIMIT = 13
-
-# Local Directories
-TEST_ROOT = path("test_root")
-# Want static files in the same dir for running on jenkins.
-STATIC_ROOT = TEST_ROOT / "staticfiles"
 WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = STATIC_ROOT / "webpack-stats.json"
 WEBPACK_LOADER['DEFAULT']['LOADER_CLASS'] = 'webpack_loader.loader.FakeWebpackLoader'
 
 STATUS_MESSAGE_PATH = TEST_ROOT / "status_message.json"
 
 COURSES_ROOT = TEST_ROOT / "data"
-DATA_DIR = COURSES_ROOT
 
-COMMON_TEST_DATA_ROOT = COMMON_ROOT / "test" / "data"
-# Where the content data is checked out.  This may not exist on jenkins.
+# Where the content data is checked out.
 GITHUB_REPO_ROOT = ENV_ROOT / "data"
 
 USE_I18N = True
@@ -140,18 +91,6 @@ DJFS = {
 API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 
 ############################ STATIC FILES #############################
-
-# TODO (cpennington): We need to figure out how envs/test.py can inject things
-# into common.py so that we don't have to repeat this sort of thing
-STATICFILES_DIRS = [
-    COMMON_ROOT / "static",
-    PROJECT_ROOT / "static",
-]
-STATICFILES_DIRS += [
-    (course_dir, COMMON_TEST_DATA_ROOT / course_dir)
-    for course_dir in os.listdir(COMMON_TEST_DATA_ROOT)
-    if os.path.isdir(COMMON_TEST_DATA_ROOT / course_dir)
-]
 
 # Avoid having to run collectstatic before the unit test suite
 # If we don't add these settings, then Django templates that can't
@@ -262,13 +201,6 @@ OAUTH_ENFORCE_SECURE = False
 ENABLE_MOBILE_REST_API = True
 ENABLE_VIDEO_ABSTRACTION_LAYER_API = True
 
-################################# CELERY ######################################
-
-CELERY_ALWAYS_EAGER = True
-CELERY_RESULT_BACKEND = 'django-cache'
-
-CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = False
-
 ######################### MARKETING SITE ###############################
 
 MKTG_URL_LINK_MAP = {
@@ -295,78 +227,17 @@ SUPPORT_SITE_LINK = 'https://example.support.edx.org'
 PASSWORD_RESET_SUPPORT_LINK = 'https://support.example.com/password-reset-help.html'
 ACTIVATION_EMAIL_SUPPORT_LINK = 'https://support.example.com/activation-email-help.html'
 SEND_ACTIVATION_EMAIL_URL = 'https://courses.example.edx.org/api/send_account_activation_email'
-LOGIN_ISSUE_SUPPORT_LINK = 'https://support.example.com/login-issue-help.html'
 ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS = OrderedDict([
     ("utm_campaign", "edX.org Referral"),
     ("utm_source", "edX.org"),
     ("utm_medium", "Footer"),
 ])
 
-############################ STATIC FILES #############################
-STORAGES['default']['BACKEND'] = 'django.core.files.storage.FileSystemStorage'
-MEDIA_ROOT = TEST_ROOT / "uploads"
-MEDIA_URL = "/uploads/"
-STATICFILES_DIRS.append(("uploads", MEDIA_ROOT))
-
-_NEW_STATICFILES_DIRS = []
-# Strip out any static files that aren't in the repository root
-# so that the tests can run with only the edx-platform directory checked out
-for static_dir in STATICFILES_DIRS:
-    # Handle both tuples and non-tuple directory definitions
-    try:
-        _, data_dir = static_dir
-    except ValueError:
-        data_dir = static_dir
-
-    if data_dir.startswith(REPO_ROOT):
-        _NEW_STATICFILES_DIRS.append(static_dir)
-STATICFILES_DIRS = _NEW_STATICFILES_DIRS
-
-FILE_UPLOAD_TEMP_DIR = TEST_ROOT / "uploads"
-FILE_UPLOAD_HANDLERS = [
-    'django.core.files.uploadhandler.MemoryFileUploadHandler',
-    'django.core.files.uploadhandler.TemporaryFileUploadHandler',
-]
-
-########################### Server Ports ###################################
-
-# These ports are carefully chosen so that if the browser needs to
-# access them, they will be available through the SauceLabs SSH tunnel
-XQUEUE_PORT = 8040
-YOUTUBE_PORT = 8031
-LTI_PORT = 8765
-VIDEO_SOURCE_PORT = 8777
-
 ############### Module Store Items ##########
 HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = {}
 
-
-################### Make tests faster
-
-PASSWORD_HASHERS = [
-    'django.contrib.auth.hashers.MD5PasswordHasher',
-]
-
 ### This enables the Metrics tab for the Instructor dashboard ###########
 CLASS_DASHBOARD = True
-
-################### Make tests quieter
-
-# OpenID spews messages like this to stderr, we don't need to see them:
-# Generated checkid_setup request to http://testserver/openid/provider/login/
-# With assocication {HMAC-SHA1}{51d49995}{s/kRmA==}
-
-openid.oidutil.log = lambda message, level=0: None
-
-
-# Include a non-ascii character in PLATFORM_NAME and PLATFORM_DESCRIPTION to uncover possible
-# UnicodeEncodeErrors in tests. Also use lazy text to reveal possible json dumps errors
-PLATFORM_NAME = gettext_lazy("édX")
-PLATFORM_DESCRIPTION = gettext_lazy("Open édX Platform")
-
-SITE_NAME = "edx.org"
-
-TEST_THEME = COMMON_ROOT / "test" / "test-theme"
 
 # add extra template directory for test-only templates
 MAKO_TEMPLATE_DIRS_BASE.extend([
@@ -375,15 +246,10 @@ MAKO_TEMPLATE_DIRS_BASE.extend([
     REPO_ROOT / 'openedx' / 'core' / 'djangolib' / 'tests' / 'templates',
 ])
 
-
 # Setting for the testing of Software Secure Result Callback
 VERIFY_STUDENT["SOFTWARE_SECURE"] = {
     "API_ACCESS_KEY": "BBBBBBBBBBBBBBBBBBBB",
     "API_SECRET_KEY": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
-}
-
-VIDEO_CDN_URL = {
-    'CN': 'http://api.xuetangx.com/edx/video?s3_url='
 }
 
 ######### dashboard git log settings #########
@@ -397,17 +263,11 @@ MONGODB_LOG = {
 
 NOTES_DISABLED_TABS = []
 
-# Enable EdxNotes for tests.
-ENABLE_EDXNOTES = True
-
 # Enable courseware search for tests
 ENABLE_COURSEWARE_SEARCH = True
 
 # Enable dashboard search for tests
 ENABLE_DASHBOARD_SEARCH = True
-
-# Use MockSearchEngine as the search engine for test scenario
-SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
 
 FACEBOOK_APP_SECRET = "Test"
 FACEBOOK_APP_ID = "Test"
@@ -415,7 +275,6 @@ FACEBOOK_API_VERSION = "v2.8"
 
 ######### custom courses #########
 INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
-CUSTOM_COURSES_EDX = True
 
 # Set dummy values for profile image settings.
 PROFILE_IMAGE_BACKEND = {
@@ -447,9 +306,7 @@ COURSE_BLOCKS_API_EXTRA_FIELDS = [
 COURSE_CATALOG_URL_ROOT = 'https://catalog.example.com'
 COURSE_CATALOG_API_URL = f'{COURSE_CATALOG_URL_ROOT}/api/v1'
 
-COMPREHENSIVE_THEME_DIRS = [REPO_ROOT / "themes", REPO_ROOT / "common/test"]
 COMPREHENSIVE_THEME_LOCALE_PATHS = [REPO_ROOT / "themes/conf/locale", ]
-ENABLE_COMPREHENSIVE_THEMING = True
 
 PREPEND_LOCALE_PATHS = []
 
@@ -463,7 +320,6 @@ FRONTEND_REGISTER_URL = '/register'
 # Programs Learner Portal URL
 LEARNER_PORTAL_URL_ROOT = 'http://localhost:8734'
 
-ECOMMERCE_API_URL = 'https://ecommerce.example.com/api/v2/'
 ECOMMERCE_PUBLIC_URL_ROOT = None
 ENTERPRISE_API_URL = 'http://enterprise.example.com/enterprise/api/v1/'
 ENTERPRISE_CONSENT_API_URL = 'http://enterprise.example.com/consent/api/v1/'
@@ -490,49 +346,12 @@ TEMPLATES.append(
     }
 )
 
-########################## VIDEO TRANSCRIPTS STORAGE ############################
-VIDEO_TRANSCRIPTS_SETTINGS = dict(
-    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
-    STORAGE_KWARGS=dict(
-        location=MEDIA_ROOT,
-        base_url=MEDIA_URL,
-    ),
-    DIRECTORY_PREFIX='video-transcripts/',
-)
+############################## Authentication ##############################
 
-####################### Authentication Settings ##########################
-JWT_AUTH.update({
-    'JWT_PUBLIC_SIGNING_JWK_SET': """
-       {
-            "keys":[
-                {
-                    "kid":"BTZ9HA6K",
-                    "e":"AQAB",
-                    "kty":"RSA",
-                    "n":"o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6sprmYfWWokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ"
-                }
-            ]
-        }
-    """,
-    'JWT_PRIVATE_SIGNING_JWK': """
-        {
-            "kid": "BTZ9HA6K",
-            "kty": "RSA",
-            "key_ops": [
-                "sign"
-            ],
-            "n": "o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6sprmYfWWokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ",
-            "e": "AQAB",
-            "d": "HIiV7KNjcdhVbpn3KT-I9n3JPf5YbGXsCIedmPqDH1d4QhBofuAqZ9zebQuxkRUpmqtYMv0Zi6ECSUqH387GYQF_XvFUFcjQRPycISd8TH0DAKaDpGr-AYNshnKiEtQpINhcP44I1AYNPCwyoxXA1fGTtmkKChsuWea7o8kytwU5xSejvh5-jiqu2SF4GEl0BEXIAPZsgbzoPIWNxgO4_RzNnWs6nJZeszcaDD0CyezVSuH9QcI6g5QFzAC_YuykSsaaFJhZ05DocBsLczShJ9Omf6PnK9xlm26I84xrEh_7x4fVmNBg3xWTLh8qOnHqGko93A1diLRCrKHOvnpvgQ",
-            "p": "3T3DEtBUka7hLGdIsDlC96Uadx_q_E4Vb1cxx_4Ss_wGp1Loz3N3ZngGyInsKlmbBgLo1Ykd6T9TRvRNEWEtFSOcm2INIBoVoXk7W5RuPa8Cgq2tjQj9ziGQ08JMejrPlj3Q1wmALJr5VTfvSYBu0WkljhKNCy1KB6fCby0C9WE",
-            "q": "vUqzWPZnDG4IXyo-k5F0bHV0BNL_pVhQoLW7eyFHnw74IOEfSbdsMspNcPSFIrtgPsn7981qv3lN_staZ6JflKfHayjB_lvltHyZxfl0dvruShZOx1N6ykEo7YrAskC_qxUyrIvqmJ64zPW3jkuOYrFs7Ykj3zFx3Zq1H5568G0",
-            "dp": "Azh08H8r2_sJuBXAzx_mQ6iZnAZQ619PnJFOXjTqnMgcaK8iSHLL2CgDIUQwteUcBphgP0uBrfWIBs5jmM8rUtVz4CcrPb5jdjhHjuu4NxmnFbPlhNoOp8OBUjPP3S-h-fPoaFjxDrUqz_zCdPVzp4S6UTkf6Hu-SiI9CFVFZ8E",
-            "dq": "WQ44_KTIbIej9qnYUPMA1DoaAF8ImVDIdiOp9c79dC7FvCpN3w-lnuugrYDM1j9Tk5bRrY7-JuE6OaKQgOtajoS1BIxjYHj5xAVPD15CVevOihqeq5Zx0ZAAYmmCKRrfUe0iLx2QnIcoKH1-Azs23OXeeo6nysznZjvv9NVJv60",
-            "qi": "KSWGH607H1kNG2okjYdmVdNgLxTUB-Wye9a9FNFE49UmQIOJeZYXtDzcjk8IiK3g-EU3CqBeDKVUgHvHFu4_Wj3IrIhKYizS4BeFmOcPDvylDQCmJcC9tXLQgHkxM_MEJ7iLn9FOLRshh7GPgZphXxMhezM26Cz-8r3_mACHu84"
-        }
-    """,
-})
-# pylint: enable=unicode-format-string  # lint-amnesty, pylint: disable=bad-option-value
+# Most of the JWT_AUTH settings come from lms/envs/common.py (from openedx/envs/common.py),
+# but here we update to use JWKS values from openedx/envs/test.py for testing.
+JWT_AUTH.update(jwt_jwks_values)
+
 ####################### Plugin Settings ##########################
 
 add_plugins(__name__, ProjectType.LMS, SettingsType.TEST)
@@ -541,21 +360,28 @@ add_plugins(__name__, ProjectType.LMS, SettingsType.TEST)
 
 derive_settings(__name__)
 
-# Dummy secret key for dev
-SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
+############################ STATIC FILES #############################
+STATICFILES_DIRS.append(("uploads", MEDIA_ROOT))
 
-############### Settings for edx-rbac  ###############
-SYSTEM_WIDE_ROLE_CLASSES = os.environ.get("SYSTEM_WIDE_ROLE_CLASSES", [])
+_NEW_STATICFILES_DIRS = []
+# Strip out any static files that aren't in the repository root
+# so that the tests can run with only the edx-platform directory checked out
+for static_dir in STATICFILES_DIRS:  # pylint: disable=not-an-iterable
+    # Handle both tuples and non-tuple directory definitions
+    try:
+        _, data_dir = static_dir
+    except ValueError:
+        data_dir = static_dir
 
-###################### Grade Downloads ######################
-# These keys are used for all of our asynchronous downloadable files, including
-# the ones that contain information other than grades.
+    if data_dir.startswith(REPO_ROOT):
+        _NEW_STATICFILES_DIRS.append(static_dir)
+STATICFILES_DIRS = _NEW_STATICFILES_DIRS
 
-GRADES_DOWNLOAD = {
-    'STORAGE_TYPE': 'localfs',
-    'BUCKET': 'edx-grades',
-    'ROOT_PATH': '/tmp/edx-s3/grades',
-}
+FILE_UPLOAD_TEMP_DIR = TEST_ROOT / "uploads"
+FILE_UPLOAD_HANDLERS = [
+    'django.core.files.uploadhandler.MemoryFileUploadHandler',
+    'django.core.files.uploadhandler.TemporaryFileUploadHandler',
+]
 
 # Configuration used for generating PDF Receipts/Invoices
 
@@ -566,17 +392,11 @@ PDF_RECEIPT_BILLING_ADDRESS = 'add your own billing address here with appropriat
 PDF_RECEIPT_TERMS_AND_CONDITIONS = 'add your own terms and conditions'
 PDF_RECEIPT_TAX_ID_LABEL = 'Tax ID'
 
-PROFILE_MICROFRONTEND_URL = "http://profile-mfe"
-ORDER_HISTORY_MICROFRONTEND_URL = "http://order-history-mfe/"
-ACCOUNT_MICROFRONTEND_URL = "http://account-mfe"
 AUTHN_MICROFRONTEND_URL = "http://authn-mfe"
 AUTHN_MICROFRONTEND_DOMAIN = "authn-mfe"
-LEARNING_MICROFRONTEND_URL = "http://learning-mfe"
-DISCUSSIONS_MICROFRONTEND_URL = "http://discussions-mfe"
 LEARNER_HOME_MICROFRONTEND_URL = "http://learner-home-mfe"
 ORA_GRADING_MICROFRONTEND_URL = "http://ora-grading-mfe"
 ORA_MICROFRONTEND_URL = "http://ora-mfe"
-CATALOG_MICROFRONTEND_URL = "http://catalog-mfe"
 
 ########################## limiting dashboard courses ######################
 
@@ -588,11 +408,6 @@ PROCTORING_SETTINGS = {
         'faq': 'https://support.example.com/proctoring-faq.html'
     }
 }
-PROCTORING_USER_OBFUSCATION_KEY = 'test_key'
-
-# Used in edx-proctoring for ID generation in lieu of SECRET_KEY - dummy value
-# (ref MST-637)
-PROCTORING_USER_OBFUSCATION_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 
 ############## Exams CONFIGURATION SETTINGS ####################
 EXAMS_SERVICE_URL = 'http://exams.example.com/api/v1'
@@ -602,30 +417,9 @@ EXAMS_SERVICE_URL = 'http://exams.example.com/api/v1'
 RATELIMIT_RATE = '2/m'
 
 ##### LOGISTRATION RATE LIMIT SETTINGS #####
-LOGISTRATION_RATELIMIT_RATE = '5/5m'
-LOGISTRATION_PER_EMAIL_RATELIMIT_RATE = '6/5m'
-LOGISTRATION_API_RATELIMIT = '5/m'
 LOGIN_AND_REGISTER_FORM_RATELIMIT = '5/5m'
 
-REGISTRATION_VALIDATION_RATELIMIT = '5/minute'
-REGISTRATION_RATELIMIT = '5/minute'
-OPTIONAL_FIELD_API_RATELIMIT = '5/m'
-
-RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = '2/m'
-RESET_PASSWORD_API_RATELIMIT = '2/m'
-
 CORS_ORIGIN_WHITELIST = ['https://sandbox.edx.org']
-
-#################### Network configuration ####################
-# Tests are not behind any proxies
-CLOSEST_CLIENT_IP_FROM_HEADERS = []
-
-
-COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = {
-    "KEY": "***",
-    "SECRET": "***",
-    "URL": "***",
-}
 
 ################## MFE API ####################
 ENABLE_MFE_CONFIG_API = True
@@ -698,22 +492,15 @@ TOKEN_SIGNING = {
     """,  # noqa: E501
 }
 
+### Course Live
+COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = big_blue_button_credentials
 
 ### Override default production settings for testing purposes
 
 API_ACCESS_FROM_EMAIL = "api-requests@example.com"
-AWS_QUERYSTRING_AUTH = False
-AWS_S3_CUSTOM_DOMAIN = "SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)"
-AWS_STORAGE_BUCKET_NAME = "SET-ME-PLEASE (ex. bucket-name)"
 BRANCH_IO_KEY = ""
 CC_MERCHANT_NAME = "Your Platform Name Here"
-CELERY_BROKER_HOSTNAME = "localhost"
-CELERY_BROKER_PASSWORD = "celery"
-CELERY_BROKER_TRANSPORT = "amqp"
-CELERY_BROKER_USER = "celery"
 CERT_QUEUE = "certificates"
-CHAT_COMPLETION_API = "https://example.com/chat/completion"
-CHAT_COMPLETION_API_KEY = "i am a key"
 CMS_BASE = "localhost:18010"
 COMMENTS_SERVICE_KEY = "password"
 del BROKER_HEARTBEAT
@@ -730,20 +517,10 @@ del SESSION_INACTIVITY_TIMEOUT_IN_SECONDS
 del SSL_AUTH_DN_FORMAT_STRING
 del SSL_AUTH_EMAIL_DOMAIN
 EDX_API_KEY = "PUT_YOUR_API_KEY_HERE"
-ENTERPRISE_ENROLLMENT_API_URL = "https://localhost:18000/api/enrollment/v1/"
 ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = "https://localhost:18000/api/enrollment/v1/"
 GOOGLE_ANALYTICS_LINKEDIN = "GOOGLE_ANALYTICS_LINKEDIN_DUMMY"
 GOOGLE_SITE_VERIFICATION_ID = ""
 ID_VERIFICATION_SUPPORT_LINK = ""
-LMS_INTERNAL_ROOT_URL = "https://localhost:18000"
 MAINTENANCE_BANNER_TEXT = "Sample banner message"
-OPENAPI_CACHE_TIMEOUT = 0
-SECURE_PROXY_SSL_HEADER = None
-SESSION_COOKIE_DOMAIN = ""
-SESSION_ENGINE = "django.contrib.sessions.backends.db"
-SHARED_COOKIE_DOMAIN = ""
-SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = "edx.lms.core.default"
-STATIC_ROOT_BASE = "/edx/var/edxapp/staticfiles"
-STATIC_URL_BASE = "/static/"
 ZENDESK_API_KEY = ""
 ZENDESK_USER = ""

--- a/openedx/envs/test.py
+++ b/openedx/envs/test.py
@@ -1,0 +1,246 @@
+"""
+Common test related Django settings for Open edX services.
+
+Shared test values between the LMS and CMS should be declared here when possible
+rather than duplicated or imported accross services.
+"""
+import os
+from path import Path as path
+from uuid import uuid4
+
+from django.utils.translation import gettext_lazy
+
+from openedx.core.lib.derived import Derived
+
+from common.djangoapps.util.testing import patch_sessions, patch_testcase
+
+
+# This patch disables the commit_on_success decorator during tests
+# in TestCase subclasses.
+patch_testcase()
+patch_sessions()
+
+# Allow all hosts during tests, we use a lot of different ones all over the codebase.
+ALLOWED_HOSTS = ["*"]
+
+SITE_NAME = "edx.org"
+
+# mongo connection settings
+MONGO_PORT_NUM = int(os.environ.get("EDXAPP_TEST_MONGO_PORT", "27017"))
+MONGO_HOST = os.environ.get("EDXAPP_TEST_MONGO_HOST", "localhost")
+
+THIS_UUID = uuid4().hex[:5]
+
+DISABLE_SET_JWT_COOKIES_FOR_TESTS = True
+
+# Most tests don't use the discussion service, so we turn it off to speed them up.
+# Tests that do can enable this flag, but must use the UrlResetMixin class to force urls.py
+# to reload.
+ENABLE_DISCUSSION_SERVICE = False
+
+ENABLE_SERVICE_STATUS = True
+
+# Toggles embargo on for testing
+EMBARGO = True
+
+# Enable the milestones app in tests to be consistent with it being enabled in production
+MILESTONES_APP = True
+
+ENABLE_ENROLLMENT_TRACK_USER_PARTITION = True
+
+# Need wiki for courseware views to work. TODO (vshnayder): shouldn't need it.
+WIKI_ENABLED = True
+
+# Directory settings
+TEST_ROOT = path("test_root")
+STATIC_ROOT = TEST_ROOT / "staticfiles"
+DATA_DIR = TEST_ROOT / "data"
+
+
+def make_staticfile_dirs(settings):
+    """
+    Derives the final list of static files directories based on the provided settings.
+
+    Args:
+        settings: A Django settings module object.
+
+    Returns:
+        list: A list of static files directories (path.Path objects)
+    """
+    staticfiles_dirs = [
+        settings.COMMON_ROOT / "static",
+        settings.PROJECT_ROOT / "static",
+    ]
+    staticfiles_dirs += [
+        (course_dir, settings.COMMON_TEST_DATA_ROOT / course_dir)
+        for course_dir in os.listdir(settings.COMMON_TEST_DATA_ROOT)
+        if os.path.isdir(settings.COMMON_TEST_DATA_ROOT / course_dir)
+    ]
+    return staticfiles_dirs
+
+STATICFILES_DIRS = Derived(make_staticfile_dirs)
+
+# Platform names with unicode for testing
+PLATFORM_NAME = gettext_lazy("édX")
+PLATFORM_DESCRIPTION = gettext_lazy("Open édX Platform")
+
+# Enable a parental consent age limit for testing
+PARENTAL_CONSENT_AGE_LIMIT = 13
+
+# Test theme
+TEST_THEME = Derived(lambda settings: settings.COMMON_ROOT / "test" / "test-theme")
+ENABLE_COMPREHENSIVE_THEMING = True
+COMPREHENSIVE_THEME_DIRS = Derived(lambda settings: [settings.REPO_ROOT / "themes", settings.REPO_ROOT / "common/test"])
+
+# Enable EdxNotes for tests
+ENABLE_EDXNOTES = True
+
+# Use MockSearchEngine as the search engine for test scenario
+SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
+
+# Custom courses
+CUSTOM_COURSES_EDX = True
+
+# These ports are carefully chosen so that if the browser needs to
+# access them, they will be available through the SauceLabs SSH tunnel
+XQUEUE_PORT = 8040
+YOUTUBE_PORT = 8031
+LTI_PORT = 8765
+VIDEO_SOURCE_PORT = 8777
+
+# Fast password hashing for tests
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]
+
+# Dummy secret key for tests
+SECRET_KEY = "85920908f28904ed733fe576320db18cabd7b6cd"
+
+jwt_jwks_values = {
+    'JWT_PUBLIC_SIGNING_JWK_SET': """
+       {
+            "keys":[
+                {
+                    "kid":"BTZ9HA6K",
+                    "e":"AQAB",
+                    "kty":"RSA",
+                    "n":"o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6sprmYfWWokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ"
+                }
+            ]
+        }
+    """,
+    'JWT_PRIVATE_SIGNING_JWK': """
+        {
+            "kid": "BTZ9HA6K",
+            "kty": "RSA",
+            "key_ops": [
+                "sign"
+            ],
+            "n": "o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6sprmYfWWokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ",
+            "e": "AQAB",
+            "d": "HIiV7KNjcdhVbpn3KT-I9n3JPf5YbGXsCIedmPqDH1d4QhBofuAqZ9zebQuxkRUpmqtYMv0Zi6ECSUqH387GYQF_XvFUFcjQRPycISd8TH0DAKaDpGr-AYNshnKiEtQpINhcP44I1AYNPCwyoxXA1fGTtmkKChsuWea7o8kytwU5xSejvh5-jiqu2SF4GEl0BEXIAPZsgbzoPIWNxgO4_RzNnWs6nJZeszcaDD0CyezVSuH9QcI6g5QFzAC_YuykSsaaFJhZ05DocBsLczShJ9Omf6PnK9xlm26I84xrEh_7x4fVmNBg3xWTLh8qOnHqGko93A1diLRCrKHOvnpvgQ",
+            "p": "3T3DEtBUka7hLGdIsDlC96Uadx_q_E4Vb1cxx_4Ss_wGp1Loz3N3ZngGyInsKlmbBgLo1Ykd6T9TRvRNEWEtFSOcm2INIBoVoXk7W5RuPa8Cgq2tjQj9ziGQ08JMejrPlj3Q1wmALJr5VTfvSYBu0WkljhKNCy1KB6fCby0C9WE",
+            "q": "vUqzWPZnDG4IXyo-k5F0bHV0BNL_pVhQoLW7eyFHnw74IOEfSbdsMspNcPSFIrtgPsn7981qv3lN_staZ6JflKfHayjB_lvltHyZxfl0dvruShZOx1N6ykEo7YrAskC_qxUyrIvqmJ64zPW3jkuOYrFs7Ykj3zFx3Zq1H5568G0",
+            "dp": "Azh08H8r2_sJuBXAzx_mQ6iZnAZQ619PnJFOXjTqnMgcaK8iSHLL2CgDIUQwteUcBphgP0uBrfWIBs5jmM8rUtVz4CcrPb5jdjhHjuu4NxmnFbPlhNoOp8OBUjPP3S-h-fPoaFjxDrUqz_zCdPVzp4S6UTkf6Hu-SiI9CFVFZ8E",
+            "dq": "WQ44_KTIbIej9qnYUPMA1DoaAF8ImVDIdiOp9c79dC7FvCpN3w-lnuugrYDM1j9Tk5bRrY7-JuE6OaKQgOtajoS1BIxjYHj5xAVPD15CVevOihqeq5Zx0ZAAYmmCKRrfUe0iLx2QnIcoKH1-Azs23OXeeo6nysznZjvv9NVJv60",
+            "qi": "KSWGH607H1kNG2okjYdmVdNgLxTUB-Wye9a9FNFE49UmQIOJeZYXtDzcjk8IiK3g-EU3CqBeDKVUgHvHFu4_Wj3IrIhKYizS4BeFmOcPDvylDQCmJcC9tXLQgHkxM_MEJ7iLn9FOLRshh7GPgZphXxMhezM26Cz-8r3_mACHu84"
+        }
+    """,
+}
+
+# Celery settings
+CELERY_ALWAYS_EAGER = True
+CELERY_RESULT_BACKEND = "django-cache"
+CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = False
+
+# Static files
+MEDIA_ROOT = TEST_ROOT / "uploads"
+MEDIA_URL = "/uploads/"
+
+# Video CDN
+VIDEO_CDN_URL = {"CN": "http://api.xuetangx.com/edx/video?s3_url="}
+
+# Video transcripts storage
+VIDEO_TRANSCRIPTS_SETTINGS = dict(
+    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,  # 3 MB
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
+    ),
+    DIRECTORY_PREFIX="video-transcripts/",
+)
+
+# Microfrontend URLs
+ACCOUNT_MICROFRONTEND_URL = "http://account-mfe"
+LEARNING_MICROFRONTEND_URL = "http://learning-mfe"
+DISCUSSIONS_MICROFRONTEND_URL = "http://discussions-mfe"
+ORDER_HISTORY_MICROFRONTEND_URL = "http://order-history-mfe/"
+PROFILE_MICROFRONTEND_URL = "http://profile-mfe"
+CATALOG_MICROFRONTEND_URL = "http://catalog-mfe"
+
+# API URLs
+ECOMMERCE_API_URL = "https://ecommerce.example.com/api/v2/"
+LOGIN_ISSUE_SUPPORT_LINK = "https://support.example.com/login-issue-help.html"
+
+# Rate Limits
+LOGISTRATION_RATELIMIT_RATE = "5/5m"
+LOGISTRATION_PER_EMAIL_RATELIMIT_RATE = "6/5m"
+LOGISTRATION_API_RATELIMIT = "5/m"
+
+REGISTRATION_VALIDATION_RATELIMIT = "5/minute"
+REGISTRATION_RATELIMIT = "5/minute"
+OPTIONAL_FIELD_API_RATELIMIT = "5/m"
+
+RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = "2/m"
+RESET_PASSWORD_API_RATELIMIT = "2/m"
+
+# These keys are used for all of our asynchronous downloadable files, including
+# the ones that contain information other than grades.
+GRADES_DOWNLOAD = {
+    "STORAGE_TYPE": "localfs",
+    "BUCKET": "edx-grades",
+    "ROOT_PATH": "/tmp/edx-s3/grades",
+}
+
+# edx-rbac
+SYSTEM_WIDE_ROLE_CLASSES = os.environ.get("SYSTEM_WIDE_ROLE_CLASSES", [])
+
+# Used in edx-proctoring for ID generation in lieu of SECRET_KEY - dummy value
+# (ref MST-637)
+PROCTORING_USER_OBFUSCATION_KEY = "85920908f28904ed733fe576320db18cabd7b6cd"
+
+# Network configuration
+CLOSEST_CLIENT_IP_FROM_HEADERS = []
+
+# For tests, both the CMS and LMS add these credentials to the COURSE_LIVE_GLOBAL_CREDENTIALS
+# setting. We cannot update this setting here because we don't have access to it in this
+# module. If we inherit variables from openedx/envs/common.py in the future, we could then
+# set the value directly here.
+big_blue_button_credentials = {
+    "KEY": "***",
+    "SECRET": "***",
+    "URL": "***",
+}
+
+DEFAULT_MOBILE_AVAILABLE = True
+
+# Override production settings for testing
+AWS_QUERYSTRING_AUTH = False
+AWS_S3_CUSTOM_DOMAIN = "SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)"
+AWS_STORAGE_BUCKET_NAME = "SET-ME-PLEASE (ex. bucket-name)"
+CELERY_BROKER_HOSTNAME = "localhost"
+CELERY_BROKER_PASSWORD = "celery"
+CELERY_BROKER_TRANSPORT = "amqp"
+CELERY_BROKER_USER = "celery"
+CHAT_COMPLETION_API = "https://example.com/chat/completion"
+CHAT_COMPLETION_API_KEY = "i am a key"
+ENTERPRISE_ENROLLMENT_API_URL = "https://localhost:18000/api/enrollment/v1/"
+LMS_INTERNAL_ROOT_URL = "https://localhost:18000"
+OPENAPI_CACHE_TIMEOUT = 0
+SECURE_PROXY_SSL_HEADER = None
+SESSION_COOKIE_DOMAIN = ""
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
+SHARED_COOKIE_DOMAIN = ""
+SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = "edx.lms.core.default"
+STATIC_ROOT_BASE = "/edx/var/edxapp/staticfiles"
+STATIC_URL_BASE = "/static/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,6 @@ ignore_imports =
     cms.djangoapps.contentstore.course_group_config -> lms.lib.utils
     cms.djangoapps.contentstore.views.preview -> lms.djangoapps.lms_xblock.field_data
     cms.envs.common -> lms.djangoapps.lms_xblock.mixin
-    cms.envs.test -> lms.envs.test
     # cms.djangoapps.contentstore.views.tests.test_group_configurations
     #   -> openedx.features.content_type_gating.helpers
     #   -> lms.djangoapps.courseware.masquerade


### PR DESCRIPTION
## Description

Fixes https://github.com/openedx/edx-platform/issues/37348.

Extract common test setting values into a new shared module, `openedx/envs/test.py`. This prevents duplication and also allows us to remove the `cms/envs/test.py` dependency on `lms/envs/test.py`.

## Supporting information

Part of effort to simplify settings. See [ADR 0022 - Simplify Django Settings.](https://github.com/openedx/edx-platform/blob/master/docs/decisions/0022-settings-simplification.rst)

## Testing instructions

Run the `dump_settings` management command on the different terminal settings modules, given different `yml` config files and compare the diff on the rendered settings between `master` and `tpayne/add-common-test-module`. To simplify this, I used the script [diff_settings.py](https://github.com/WGU-Open-edX/oex-utils/tree/main/settings_utils#diff_settingspy) and also table_diff.py to simplify the diff output. I've added the output of these scripts in this [gist](https://gist.github.com/wgu-taylor-payne/ee3ba04d8e839d30e8a1f216741a4d1f).

There are two differences in the rendered `cms/envs/test.py` settings that I thought were tolerable:

`PROCTORING_USER_OBFUSCATION_KEY` - This was previously declared twice in `cms/envs/test.py`. It didn't seem that anything directly depends on this key having a specific value. This change aligns the value with `lms/envs/test.py`.

`VERIFY_STUDENT` - With the introduction of `openedx/envs/common.py`, when `lms/envs/test.py` would alter this value, it would also alter the value for `cms/envs/test.py`, since they are pointing to the same mutable object. Now, since we do not import, and thus not execute `lms/envs/test.py`, this value is no longer mutated.

## Deadline

None
