### PR TITLE
feat: Validate country input during student registration

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -19,6 +19,7 @@ import pytz
 import edx_api_doc_tools as apidocs
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django_countries.fields import Country
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
@@ -416,6 +417,17 @@ class RegisterAndEnrollStudents(APIView):
                 else:
                     cohort_name = None
                     course_mode = None
+
+                if not Country(country).name:
+                    row_errors.append({
+                        'username': username,
+                        'email': email,
+                        'response': _(
+                            'Invalid country: {country}. '
+                            'Please enter a valid country code. e.g., US, GB'
+                        ).format(country=country)
+                    })
+                    continue
 
                 # Validate cohort name, and get the cohort object.  Skip if course
                 # is not cohorted.


### PR DESCRIPTION
## Description
While using the CSV enroll option in LMS instructor tab if an instructor use full country name instead ISO country code a general DataError is raised which can be confusing for instructors.

## Roadmap
https://github.com/openedx/platform-roadmap/issues/487


## Before
<img width="2557" height="1050" alt="image" src="https://github.com/user-attachments/assets/84ce0067-5ba6-4186-99b8-dd579a74be1f" />


## After
<img width="2557" height="1192" alt="image" src="https://github.com/user-attachments/assets/8947a213-014a-49cc-a148-9e6ca33a79f3" />


## Testing instructions
1. Set `ALLOW_AUTOMATED_SIGNUPS` as True in site configurations
2. Open a course on LMS as instructor
3. Click on Instructor tab
4. Click on membership
5. Upload a csv with fields in correct order
6. For country give value in `Non-ISO` code format
7. A verbose error will be returned instead of a general `DataError`