### PR TITLE
chore: add end date to course outline api [FC-0114]

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1249,6 +1249,7 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                 xblock_info.update(
                     {
                         "highlights_enabled_for_messaging": course.highlights_enabled_for_messaging,
+                        "end": xblock.fields["end"].to_json(xblock.end),
                     }
                 )
             xblock_info.update(


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds end date of course to api.

Useful information to include:

- Which edX user roles will this change impact? "Course Author" and "Developer".

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2622
* Related PR: https://github.com/openedx/frontend-app-authoring/pull/2735
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4290

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/2735

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
