### PR TITLE
fix: don't send emails on library backup/restore

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -108,6 +108,8 @@ __all__ = [
     "get_backup_task_status",
     "assign_library_role_to_user",
     "user_has_permission_across_lib_authz_systems",
+    "is_library_backup_task",
+    "is_library_restore_task",
 ]
 
 
@@ -851,3 +853,15 @@ def _is_legacy_permission(permission: str) -> bool:
     or the new openedx-authz system.
     """
     return permission in LEGACY_LIB_PERMISSIONS
+
+
+def is_library_backup_task(task_name: str) -> bool:
+    """Case-insensitive match to see if a task is a library backup."""
+    from ..tasks import LibraryBackupTask  # avoid circular import error
+    return task_name.startswith(LibraryBackupTask.NAME_PREFIX.lower())
+
+
+def is_library_restore_task(task_name: str) -> bool:
+    """Case-insensitive match to see if a task is a library restore."""
+    from ..tasks import LibraryRestoreTask  # avoid circular import error
+    return task_name.startswith(LibraryRestoreTask.NAME_PREFIX.lower())

--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -512,6 +512,7 @@ class LibraryBackupTask(UserTask):  # pylint: disable=abstract-method
     """
     Base class for tasks related with Library backup functionality.
     """
+    NAME_PREFIX = "Library Learning Package Backup"
 
     @classmethod
     def generate_name(cls, arguments_dict) -> str:
@@ -529,7 +530,7 @@ class LibraryBackupTask(UserTask):  # pylint: disable=abstract-method
             str: The generated name
         """
         key = arguments_dict['library_key_str']
-        return f'Backup of {key}'
+        return f'{cls.NAME_PREFIX} of {key}'
 
 
 @shared_task(base=LibraryBackupTask, bind=True)
@@ -591,10 +592,12 @@ class LibraryRestoreTask(UserTask):
 
     ERROR_LOG_ARTIFACT_NAME = 'Error log'
 
+    NAME_PREFIX = "Library Learning Package Restore"
+
     @classmethod
     def generate_name(cls, arguments_dict):
         storage_path = arguments_dict['storage_path']
-        return f'learning package restore of {storage_path}'
+        return f'{cls.NAME_PREFIX} of {storage_path}'
 
     def fail_with_error_log(self, logfile) -> None:
         """


### PR DESCRIPTION
Backport of https://github.com/openedx/edx-platform/pull/37722

There is no way to resume either the backup or restore library actions, i.e. if you navigate away from it, you have to do it again. This is a limitation of the current UI because we wanted to get something quick and simple in for Ulmo, but it also reflects the fact that library backup/restore should be much faster than course import/export has historically been.

In any case, sending an email for a 5-10 second task is unnecessary and distracting, so this commit suppresses the email.

Note: I'm using local imports to get around the fact that the content_libraries public API is used by content_libraries/tasks.py which defines the tasks. I can't import from content_libraries/tasks.py directly, because that would violate import linter rules forbidding other apps from importing things outside of api.py. This isn't ideal, but it keeps the fix small and it keeps the logic in the content_libraries app.