### PR TITLE
fix: handle PluginMissingError while migrating legacy blocks to libraries v2

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tasks.py
@@ -1162,9 +1162,12 @@ def _migrate_component(
             libraries_api.validate_can_add_block_to_library(
                 context.target_library_key, target_key.block_type, target_key.block_id
             )
-        except (libraries_api.IncompatibleTypesError, PluginMissingError) as e:
+        except libraries_api.IncompatibleTypesError as e:
             log.error(f"Error validating block for library {context.target_library_key}: {e}")
             return None, str(e)
+        except PluginMissingError as e:
+            log.error(f"Block type not supported in {context.target_library_key}: {e}")
+            return None, f"Invalid block type: {e}"
         component = authoring_api.create_component(
             context.target_package_id,
             component_type=component_type,

--- a/cms/djangoapps/modulestore_migrator/tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tasks.py
@@ -41,6 +41,7 @@ from openedx_learning.api.authoring_models import (
 )
 from user_tasks.tasks import UserTask, UserTaskStatus
 from xblock.core import XBlock
+from xblock.plugin import PluginMissingError
 
 from common.djangoapps.split_modulestore_django.models import SplitModulestoreCourseIndex
 from common.djangoapps.util.date_utils import DEFAULT_DATE_TIME_FORMAT, strftime_localized
@@ -1161,7 +1162,7 @@ def _migrate_component(
             libraries_api.validate_can_add_block_to_library(
                 context.target_library_key, target_key.block_type, target_key.block_id
             )
-        except libraries_api.IncompatibleTypesError as e:
+        except (libraries_api.IncompatibleTypesError, PluginMissingError) as e:
             log.error(f"Error validating block for library {context.target_library_key}: {e}")
             return None, str(e)
         component = authoring_api.create_component(

--- a/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
@@ -1843,6 +1843,35 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             f"Not a valid source context key: {invalid_key}. Source key must reference a course or a legacy library."
         )
 
+    def test_migrate_component_with_fake_block_type(self):
+        """
+        Test _migrate_component with with_fake_block_type
+        """
+        source_key = self.course.id.make_usage_key("fake_block", "test_fake_block")
+        olx = '<fake_block display_name="Test fake_block"></fake_block>'
+        context = _MigrationContext(
+            existing_source_to_target_keys={},
+            target_package_id=self.learning_package.id,
+            target_library_key=self.library.library_key,
+            source_context_key=self.course.id,
+            content_by_filename={},
+            composition_level=CompositionLevel.Unit,
+            repeat_handling_strategy=RepeatHandlingStrategy.Skip,
+            preserve_url_slugs=True,
+            created_at=timezone.now(),
+            created_by=self.user.id,
+        )
+
+        result, reason = _migrate_component(
+            context=context,
+            source_key=source_key,
+            olx=olx,
+            title="test"
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(reason, "Invalid block type: fake_block")
+
     def test_migrate_from_modulestore_nonexistent_modulestore_item(self):
         """
         Test migration when modulestore item doesn't exist


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Unhandled exception while migration legacy xblocks into new library stops the migration process abruptly causing following issues:

* Components not being collected into Collections for successful migrations
* Data being corrupted for already migrated blocks most likely due to incomplete transaction.

## Supporting information

* https://github.com/openedx/edx-platform/issues/37712#issuecomment-3605005152
https://github.com/openedx/frontend-app-authoring/issues/2169#issuecomment-3412840187

## Testing instructions

* Create a legacy library and import the `tar.gz` file attached in https://github.com/openedx/edx-platform/issues/37712#issuecomment-3605005152
* Migrate this library to a new library.
* Without this PR, the migrations fails and components are migrated half-way causing above mentioned problems.

## Deadline

ASAP, before Ulmo release.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
