### PR TITLE
Decouple Video Block from content/static store bindings via VideoConfigService

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     runs-on: ${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.11"

--- a/openedx/core/djangoapps/video_config/services.py
+++ b/openedx/core/djangoapps/video_config/services.py
@@ -133,10 +133,10 @@ class VideoConfigService:
             filename (str): filename of the asset
             
         Returns:
-            Asset data from store
+            Asset transcript from store
             
         Raises:
-            NotFoundError: If asset not found
+            TranscriptNotFoundError: If transcript not found
         """
         content_location = StaticContent.compute_location(course_key, filename)
         try:
@@ -155,7 +155,10 @@ class VideoConfigService:
             filename (str): filename of the asset
             
         Returns:
-            Asset location
+            transcript location
+
+        Raises:
+            TranscriptNotFoundError: If transcript not found
         """
         try:
             content_location = StaticContent.compute_location(course_key, filename)
@@ -176,10 +179,10 @@ class VideoConfigService:
             filename (str): filename of the asset
             
         Returns:
-            Asset from store
+            Transcript from store
             
         Raises:
-            NotFoundError: If asset not found
+            TranscriptNotFoundError: If asset not transcript
         """
         try:
             content_location = StaticContent.compute_location(course_key, filename)

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -56,6 +56,7 @@ from openedx.core.djangoapps.video_config.transcripts_utils import (
     clean_video_id,
     get_endonym_or_label,
     get_html5_ids,
+    get_transcript_from_store,
     subs_filename
 )
 from .video_handlers import VideoStudentViewHandlers, VideoStudioViewHandlers
@@ -583,8 +584,8 @@ class _BuiltInVideoBlock(
             html5_ids = get_html5_ids(self.html5_sources)
             for subs_id in html5_ids:
                 try:
-                    Transcript.asset(self.location, subs_id)
-                except NotFoundError:
+                    get_transcript_from_store(self, self.location, subs_id)
+                except TranscriptNotFoundError:
                     # If a transcript does not not exist with particular html5_id then there is no need to check other
                     # html5_ids because we have to create a new transcript with this missing html5_id by turning on
                     # metadata_was_changed_by_user flag.


### PR DESCRIPTION
Main ticket: https://github.com/openedx/edx-platform/issues/36282
Relevant xblocks-contrib PR comment: [comment](https://github.com/openedx/xblocks-contrib/pull/83/changes/15327d692be8bf4fd1fa812140fa3077b74207ee#diff-aafc91e94a4686d7210de4ed544c3d83f9153d5fa240e8ca44d30f3e6667a1f5)

### Details:

This PR decouples the remaining dependency of the Video Block that is dependency on the content store.

VideoBlock needs to access the content-store for the persistence of the transcripts as a static content.

VideoBlock code access content-store via  [transcripts_utils](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/video_config/transcripts_utils.py) mainly via [transcripts_utils.Transcript.get_asset()](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/video_config/transcripts_utils.py#L797) method.

We have already introduced the following three transcript-related methods in [VideoConfigService](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/video_config/services.py). These methods are generic and abstract much of the underlying logic. For example, get_transcript encapsulates the logic required to fetch transcripts from either Learning Core or the Content Store.


```python
def get_transcript(
        self,
        video_block,
        lang: str | None = None,
        output_format: str = 'srt',
        youtube_id: str | None = None,
) -> tuple[bytes, str, str]:
    
    ---
    
def upload_transcript(
        self,
        *,
        video_block,
        language_code: str,
        new_language_code: str | None,
        transcript_file: File,
        edx_video_id: str | None,
) -> None:
    
    
    ---
    
def delete_transcript(
        self,
        *,
        video_block,
        edx_video_id: str | None,
        language_code: str,
) -> None:


    ---    
```