### PR TITLE
fix: try deleting the XBlock from draft-branch if not in published

### DIFF
--- a/xmodule/modulestore/tests/test_publish.py
+++ b/xmodule/modulestore/tests/test_publish.py
@@ -810,14 +810,8 @@ class ElementalDeleteItemTests(DraftPublishedOpBaseTestSetup):
             self.assertOLXIsDraftOnly(block_list_to_delete)
             # MODULESTORE_DIFFERENCE:
             if self.is_split_modulestore:
-                if revision in (ModuleStoreEnum.RevisionOption.published_only, ModuleStoreEnum.RevisionOption.all):
-                    # Split throws an exception when trying to delete an item from the published branch
-                    # that isn't yet published.
-                    with pytest.raises(ValueError):
-                        self.delete_item(block_list_to_delete, revision=revision)
-                else:
-                    self.delete_item(block_list_to_delete, revision=revision)
-                    self._check_for_item_deletion(block_list_to_delete, result)
+                self.delete_item(block_list_to_delete, revision=revision)
+                self._check_for_item_deletion(block_list_to_delete, result)
             else:
                 raise Exception("Must test either Old Mongo or Split modulestore!")
 
@@ -846,11 +840,8 @@ class ElementalDeleteItemTests(DraftPublishedOpBaseTestSetup):
             # The vertical is a draft.
             self.assertOLXIsDraftOnly(block_list_to_delete)
             if revision in (ModuleStoreEnum.RevisionOption.published_only, ModuleStoreEnum.RevisionOption.all):
-                # MODULESTORE_DIFFERENCE:
-                # Split throws an exception when trying to delete an item from the published branch
-                # that isn't yet published.
-                with pytest.raises(ValueError):
-                    self.delete_item(block_list_to_delete, revision=revision)
+                self.delete_item(block_list_to_delete, revision=revision)
+                self._check_for_item_deletion(block_list_to_delete, result)
             else:
                 self.delete_item(block_list_to_delete, revision=revision)
                 self._check_for_item_deletion(block_list_to_delete, result)


### PR DESCRIPTION
### Related Ticket
https://github.com/mitodl/hq/issues/9456 (MIT Internal)

## Description
This pull request improves the logic for deleting course blocks in the `delete_item` method of the `split.py` modulestore. It specifically addresses scenarios where a subsection has been moved to another section in the draft branch, ensuring that deletions are handled correctly across both the main/publish and draft branches.

**Enhanced block deletion logic:**

* If a block to be deleted does not exist in the original structure, the code now checks the draft branch for its presence. If found, deletion proceeds using the draft structure; if not, a clearer error is raised. This helps handle cases where subsections are moved in drafts and then deleted.

**Steps to Reproduce**
1. Go to a studio outline for a course
2. Create a new subsection inside of any section
3. Move the subsection to a different Section
4. Attempt to delete the new subsection
5. Page will show the "are you sure" dialogue box, and will then show the "deleting" message at the bottom of the screen, but then an error message "cannot save changes" will appear at the top of the screen
6. Go to the three dot menu of the new subsection and click "publish;" approve the publish action
7. Attempt to delete again - this time the deletion will be successful

## Testing instructions
1. Checkout to this branch and repeat the steps from above
2. Sub-section should be deleted without any issue

