### PR TITLE
Enable word cloud XBlock

### DIFF
--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1666,7 +1666,7 @@ XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 # .. toggle_warning: Not production-ready until https://github.com/openedx/edx-platform/issues/34840 is done.
 # .. toggle_creation_date: 2024-11-10
 # .. toggle_target_removal_date: 2025-06-01
-USE_EXTRACTED_WORD_CLOUD_BLOCK = False
+USE_EXTRACTED_WORD_CLOUD_BLOCK = True
 
 # .. toggle_name: USE_EXTRACTED_ANNOTATABLE_BLOCK
 # .. toggle_default: False

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1277,7 +1277,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.9.0
+xblocks-contrib==0.9.1
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2308,7 +2308,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.9.0
+xblocks-contrib==0.9.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1615,7 +1615,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.9.0
+xblocks-contrib==0.9.1
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1708,7 +1708,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.9.0
+xblocks-contrib==0.9.1
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via


### PR DESCRIPTION
Enable word cloud XBlock

Relevant xblocks-contrib PR: https://github.com/openedx/xblocks-contrib/pull/124

**Acceptance Criteria:**

- [x] WordCloud XBlock can be created in a Content Library V2 library, edited, published
- [x] WordCloud Xlock from a library can be used in a course, and its text can be overridden