### PR TITLE
feat: suppress user task email after importing content in libraries

### DIFF
--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -208,6 +208,16 @@ class TestUserTaskStopped(APITestCase):
         self.assert_msg_subject(msg)
         self.assert_msg_body_fragments(msg, body_fragments)
 
+    def test_email_not_sent_with_libary_import_task(self):
+        """
+        Check that email is not sent when library import task is completed.
+        """
+        end_of_task_status = self.status
+        end_of_task_status.name = "bulk_migrate_from_modulestore"
+        user_task_stopped.send(sender=UserTaskStatus, status=end_of_task_status)
+
+        self.assertEqual(len(mail.outbox), 0)
+
     def test_email_not_sent_with_libary_content_update(self):
         """
         Check the signal receiver and email sending.


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Suppress user task email after completion of content import in libraries.

Useful information to include:

- Which edX user roles will this change impact? "Course Author"

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2525#issuecomment-3627913871

## Testing instructions

* Import any course in a library.
* Check logs for `Suppressing end-of-task email on task bulk_migrate_from_modulestore` message.
* make sure no email was sent by checking `EMAIL_FILE_PATH` setting, i.e., `/tmp/openedx/emails` in tutor based environments.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
