### PR TITLE
remove unused copy_or_rename_transcript method

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -7,7 +7,7 @@ import re
 import tempfile
 import textwrap
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import ddt
@@ -141,13 +141,6 @@ class TestSaveSubsToStore(SharedModuleStoreTestCase):
         super().setUp()
         self.addCleanup(self.clear_subs_content)
         self.clear_subs_content()
-
-    def test_save_unicode_filename(self):
-        # Mock a video item
-        item = Mock(location=Mock(course_key=self.course.id))
-        transcripts_utils.save_subs_to_store(self.subs, self.subs_id, self.course)
-        transcripts_utils.copy_or_rename_transcript(self.subs_copied_id, self.subs_id, item)
-        self.assertTrue(contentstore().find(self.content_copied_location))
 
     def test_save_subs_to_store(self):
         with self.assertRaises(NotFoundError):

--- a/openedx/core/djangoapps/video_config/transcripts_utils.py
+++ b/openedx/core/djangoapps/video_config/transcripts_utils.py
@@ -395,23 +395,6 @@ def generate_sjson_from_srt(srt_subs):
     return sjson_subs
 
 
-def copy_or_rename_transcript(new_name, old_name, item, delete_old=False, user=None):
-    """
-    Renames `old_name` transcript file in storage to `new_name`.
-
-    If `old_name` is not found in storage, raises `NotFoundError`.
-    If `delete_old` is True, removes `old_name` files from storage.
-    """
-    filename = f'subs_{old_name}.srt.sjson'
-    content_location = StaticContent.compute_location(item.location.course_key, filename)
-    transcripts = contentstore().find(content_location).data.decode('utf-8')
-    save_subs_to_store(json.loads(transcripts), new_name, item)
-    item.sub = new_name
-    item.save_with_metadata(user)
-    if delete_old:
-        remove_subs_from_store(old_name, item)
-
-
 def get_html5_ids(html5_sources):
     """
     Helper method to parse out an HTML5 source into the ideas
@@ -434,18 +417,10 @@ def manage_video_subtitles_save(item, user, old_metadata=None, generate_translat
 
     `old_metadata` contains old values of XFields.
 
-    # 1.
-    If value of `sub` field of `new_item` is different from values of video fields of `new_item`,
-    and `new_item.sub` file is present, then code in this function creates copies of
-    `new_item.sub` file with new names. That names are equal to values of video fields of `new_item`
-    After that `sub` field of `new_item` is changed to one of values of video fields.
-    This whole action ensures that after user changes video fields, proper `sub` files, corresponding
-    to new values of video fields, will be presented in system.
-
-    # 2. convert /static/filename.srt  to filename.srt in self.transcripts.
+    # 1. convert /static/filename.srt  to filename.srt in self.transcripts.
     (it is done to allow user to enter both /static/filename.srt and filename.srt)
 
-    # 3. Generate transcripts translation only  when user clicks `save` button, not while switching tabs.
+    # 2. Generate transcripts translation only  when user clicks `save` button, not while switching tabs.
     a) delete sjson translation for those languages, which were removed from `item.transcripts`.
         Note: we are not deleting old SRT files to give user more flexibility.
     b) For all SRT files in`item.transcripts` regenerate new SJSON files.
@@ -454,37 +429,12 @@ def manage_video_subtitles_save(item, user, old_metadata=None, generate_translat
     """
     _ = item.runtime.service(item, "i18n").gettext
 
-    # # 1.
-    # html5_ids = get_html5_ids(item.html5_sources)
-
-    # # Youtube transcript source should always have a higher priority than html5 sources. Appending
-    # # `youtube_id_1_0` at the end helps achieve this when we read transcripts list.
-    # possible_video_id_list = html5_ids + [item.youtube_id_1_0]
-    # sub_name = item.sub
-    # for video_id in possible_video_id_list:
-    #     if not video_id:
-    #         continue
-    #     if not sub_name:
-    #         remove_subs_from_store(video_id, item)
-    #         continue
-    #     # copy_or_rename_transcript changes item.sub of module
-    #     try:
-    #         # updates item.sub with `video_id`, if it is successful.
-    #         copy_or_rename_transcript(video_id, sub_name, item, user=user)
-    #     except NotFoundError:
-    #         # subtitles file `sub_name` is not presented in the system. Nothing to copy or rename.
-    #         log.debug(
-    #             "Copying %s file content to %s name is failed, "
-    #             "original file does not exist.",
-    #             sub_name, video_id
-    #         )
-
-    # 2.
+    # 1.
     if generate_translation:
         for lang, filename in item.transcripts.items():
             item.transcripts[lang] = os.path.split(filename)[-1]
 
-    # 3.
+    # 2.
     if generate_translation:
         old_langs = set(old_metadata.get('transcripts', {})) if old_metadata else set()
         new_langs = set(item.transcripts)


### PR DESCRIPTION
Remove unused **copy_or_rename_transcript** method

### Need of removing:
The removal of un-used methods will decouple the Video Block with the edx-platform or content store.
It will make the Video Block extraction to `xblocks-contrib` easy. [Ticket](https://github.com/openedx/edx-platform/issues/36282)

### History:

**Introduction of the method**
method was introduced in this [PR](https://github.com/openedx/edx-platform/pull/1111) and used [here](https://github.com/openedx/edx-platform/pull/1111/changes#diff-2d4e0b053abb2331a2f5562ad90a3dd29a8f2afb211d5a1593db9b3c6cf61db0R334)

**Discountinue of the usage**
method usage was discontinued in this [PR](https://github.com/openedx/edx-platform/pull/17718) over [here](https://github.com/openedx/edx-platform/pull/17718/files#diff-72aaa2ed27d55f64b6148574bdb353f43347b5059f9ebe416cef7d34697ac5c8R408)

### Testing Notes:
1. Video Block is working fine on the content-library/lms/studio.
2. Video Block editor is working fine on the content-library/lms/studio.
