### PR TITLE
feat: api to bulk update legacy library references

### DIFF
--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -231,6 +231,16 @@ class TestUserTaskStopped(APITestCase):
 
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_email_not_sent_with_legacy_libary_content_ref_update(self):
+        """
+        Check the signal receiver and email sending.
+        """
+        end_of_task_status = self.status
+        end_of_task_status.name = "Updating legacy library content blocks references of course-v1:UNIX+UN1+2025_T4"
+        user_task_stopped.send(sender=UserTaskStatus, status=end_of_task_status)
+
+        self.assertEqual(len(mail.outbox), 0)
+
     def test_email_sent_with_olx_validations_with_config_enabled(self):
         """
         Tests that email is sent with olx validation errors.

--- a/cms/djangoapps/contentstore/api/__init__.py
+++ b/cms/djangoapps/contentstore/api/__init__.py
@@ -1,2 +1,2 @@
 """Contentstore API"""
-from .views.utils import course_author_access_required
+from .views.utils import course_author_access_required, get_ready_to_migrate_legacy_library_content_blocks

--- a/cms/djangoapps/contentstore/api/tests/test_validation.py
+++ b/cms/djangoapps/contentstore/api/tests/test_validation.py
@@ -1,16 +1,21 @@
 """
 Tests for the course import API views
 """
+from uuid import uuid4
+from cms.djangoapps.contentstore.api.views.course_validation import CourseLegacyLibraryContentMigratorView
+from django.test import TestCase
+from unittest.mock import MagicMock, patch
 
 import factory
 from datetime import datetime
 from django.conf import settings
+from django.contrib.auth import get_user_model
 
 import ddt
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
@@ -18,6 +23,9 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
+
+
+User = get_user_model()
 
 
 @ddt.ddt
@@ -143,3 +151,129 @@ class CourseValidationViewTest(SharedModuleStoreTestCase, APITestCase):
                 'is_self_paced': True,
             }
             self.assertDictEqual(resp.data, expected_data)
+
+
+class TestMigrationViewSetCreate(SharedModuleStoreTestCase, APITestCase):
+    """
+    Test the MigrationViewSet.create() endpoint.
+
+    Focus: validation, return codes, serialization/deserialization.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.course = CourseFactory.create(
+            display_name='test course',
+            run="Testing_course",
+            proctoring_provider='test_proctoring_provider',
+            proctoring_escalation_email='test@example.com',
+        )
+        cls.course_key = cls.course.id
+
+        cls.password = 'test'
+        cls.student = UserFactory(username='dummy', password=cls.password)
+        cls.staff = StaffFactory(course_key=cls.course.id, password=cls.password)
+
+        cls.initialize_course(cls.course)
+
+    @classmethod
+    def initialize_course(cls, course):
+        """
+        Sets up test course structure.
+        """
+        section = BlockFactory.create(
+            parent_location=course.location,
+            category="chapter",
+        )
+        subsection = BlockFactory.create(
+            parent_location=section.location,
+            category="sequential",
+        )
+        unit = BlockFactory.create(
+            parent_location=subsection.location,
+            category="vertical",
+        )
+        cls.block1 = BlockFactory.create(
+            parent_location=unit.location,
+            category="library_content",
+        )
+        cls.block2 = BlockFactory.create(
+            parent_location=unit.location,
+            category="library_content",
+        )
+
+    @patch('cms.djangoapps.contentstore.api.views.utils.has_course_author_access')
+    @patch('cms.djangoapps.contentstore.api.views.course_validation.UserTaskStatus')
+    @patch('xmodule.library_content_block.LegacyLibraryContentBlock.is_ready_to_migrate_to_v2')
+    def test_create_update_reference_success(self, mock_block, mock_user_task_status, mock_auth):
+        """
+        Test successful migration creation with minimal required fields.
+
+        Validates:
+        - 201 status code is returned
+        - Response contains expected serialized fields
+        - Request data is properly deserialized
+        - Permission checks are performed for both source and target
+        """
+        mock_auth.return_value = True
+
+        mock_task_status = MagicMock(autospec=True)
+        mock_task_status.uuid = uuid4()
+        mock_task_status.state = 'Pending'
+        mock_task_status.state_text = 'Pending'
+        mock_task_status.completed_steps = 0
+        mock_task_status.total_steps = 10
+        mock_task_status.attempts = 1
+        mock_task_status.created = '2025-01-01T00:00:00Z'
+        mock_task_status.modified = '2025-01-01T00:00:00Z'
+        mock_task_status.artifacts = []
+        mock_task_status.migrations.all.return_value = []
+
+        mock_user_task_status.objects.get.return_value = mock_task_status
+
+        mock_block.return_value = True
+
+        self.client.login(username=self.staff.username, password=self.password)
+        response = self.client.post(
+            f'/api/courses/v1/migrate_legacy_content_blocks/{self.course_key}/',
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        assert 'uuid' in response.data
+        assert 'state' in response.data
+        assert 'state_text' in response.data
+        assert 'completed_steps' in response.data
+        assert 'total_steps' in response.data
+
+        mock_auth.assert_called_once()
+
+    @patch('cms.djangoapps.contentstore.api.views.utils.has_course_author_access')
+    @patch('xmodule.library_content_block.LegacyLibraryContentBlock.is_ready_to_migrate_to_v2')
+    def test_list_ready_to_update_reference_success(self, mock_block, mock_auth):
+        """
+        Test successful migration creation with minimal required fields.
+
+        Validates:
+        - 201 status code is returned
+        - Response contains expected serialized fields
+        - Request data is properly deserialized
+        - Permission checks are performed for both source and target
+        """
+        mock_auth.return_value = True
+        mock_block.return_value = True
+
+        self.client.login(username=self.staff.username, password=self.password)
+        response = self.client.get(
+            f'/api/courses/v1/migrate_legacy_content_blocks/{self.course_key}/',
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        self.assertListEqual(data, [
+            {'usage_key': str(self.block1.location)},
+            {'usage_key': str(self.block2.location)},
+        ])
+        mock_auth.assert_called_once()

--- a/cms/djangoapps/contentstore/api/tests/test_validation.py
+++ b/cms/djangoapps/contentstore/api/tests/test_validation.py
@@ -1,29 +1,24 @@
 """
 Tests for the course import API views
 """
-from uuid import uuid4
-from cms.djangoapps.contentstore.api.views.course_validation import CourseLegacyLibraryContentMigratorView
-from django.test import TestCase
-from unittest.mock import MagicMock, patch
-
-import factory
 from datetime import datetime
-from django.conf import settings
-from django.contrib.auth import get_user_model
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import ddt
+import factory
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
+from rest_framework.test import APITestCase
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
-from common.djangoapps.student.tests.factories import StaffFactory
-from common.djangoapps.student.tests.factories import UserFactory
-
+from common.djangoapps.student.tests.factories import StaffFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 User = get_user_model()
 

--- a/cms/djangoapps/contentstore/api/urls.py
+++ b/cms/djangoapps/contentstore/api/urls.py
@@ -3,18 +3,26 @@
 
 from django.conf import settings
 from django.urls import re_path
+from django.urls.conf import include, path
+from rest_framework.routers import SimpleRouter
 
 from cms.djangoapps.contentstore.api.views import course_import, course_quality, course_validation
 
-
 app_name = 'contentstore'
 
+ROUTER = SimpleRouter()
+ROUTER.register(
+    fr'^v1/migrate_legacy_content_blocks/{settings.COURSE_ID_PATTERN}',
+    course_validation.CourseLegacyLibraryContentMigratorView,
+    basename='course_ready_to_migrate_legacy_blocks'
+)
+
 urlpatterns = [
+    path('', include(ROUTER.urls)),
     re_path(fr'^v0/import/{settings.COURSE_ID_PATTERN}/$',
             course_import.CourseImportView.as_view(), name='course_import'),
     re_path(fr'^v1/validation/{settings.COURSE_ID_PATTERN}/$',
             course_validation.CourseValidationView.as_view(), name='course_validation'),
     re_path(fr'^v1/quality/{settings.COURSE_ID_PATTERN}/$',
             course_quality.CourseQualityView.as_view(), name='course_quality'),
-
 ]

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -16,7 +16,6 @@ from cms.djangoapps.contentstore.course_info_model import get_course_updates
 from cms.djangoapps.contentstore.tasks import migrate_course_legacy_library_blocks_to_item_bank
 from cms.djangoapps.contentstore.views.certificates import CertificateManager
 from common.djangoapps.util.proctoring import requires_escalation_email
-from openedx.core.djangoapps.course_groups.permissions import IsStaffOrAdmin
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.serializers import StatusSerializerWithUuid
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
@@ -363,6 +362,9 @@ class CourseLegacyLibraryContentSerializer(serializers.Serializer):
 
 
 class CourseLegacyLibraryContentMigratorView(StatusViewSet):
+    """
+    This endpoint is used for migrating legacy library content to the new item bank block library v2.
+    """
     # DELETE is not allowed, as we want to preserve all task status objects.
     # Instead, users can POST to /cancel to cancel running tasks.
     http_method_names = ["get", "post"]
@@ -380,7 +382,7 @@ class CourseLegacyLibraryContentMigratorView(StatusViewSet):
         },
     )
     @course_author_access_required
-    def list(self, _, course_key, *args, **kwargs):
+    def list(self, _, course_key):  # pylint: disable=arguments-differ
         """
         Returns all legacy library content blocks ready to be migrated to new item bank block.
         """

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -1,5 +1,4 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
-from rest_framework.decorators import action
 import logging
 
 import dateutil
@@ -19,6 +18,7 @@ from cms.djangoapps.contentstore.tasks import migrate_course_legacy_library_bloc
 from cms.djangoapps.contentstore.views.certificates import CertificateManager
 from common.djangoapps.util.proctoring import requires_escalation_email
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.core.lib.api.serializers import StatusSerializerWithUuid
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from xmodule.course_metadata_utils import DEFAULT_GRADING_POLICY  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -372,6 +372,7 @@ class CourseLegacyLibraryContentMigratorView(StatusViewSet):
         JwtAuthentication,
         SessionAuthenticationAllowInactiveUser,
     )
+    serializer_class = StatusSerializerWithUuid
 
     @apidocs.schema(
         responses={

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -1,19 +1,29 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
+from rest_framework.decorators import action
 import logging
 
 import dateutil
+import edx_api_doc_tools as apidocs
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from pytz import UTC
+from rest_framework import serializers, status
 from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
+from user_tasks.models import UserTaskStatus
+from user_tasks.views import StatusViewSet
 
 from cms.djangoapps.contentstore.course_info_model import get_course_updates
+from cms.djangoapps.contentstore.tasks import migrate_course_legacy_library_blocks_to_item_bank
 from cms.djangoapps.contentstore.views.certificates import CertificateManager
 from common.djangoapps.util.proctoring import requires_escalation_email
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from xmodule.course_metadata_utils import DEFAULT_GRADING_POLICY  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
-from .utils import course_author_access_required, get_bool_param
+from .utils import course_author_access_required, get_bool_param, get_ready_to_migrate_legacy_library_content_blocks
 
 log = logging.getLogger(__name__)
 
@@ -346,3 +356,50 @@ class CourseValidationView(DeveloperErrorViewMixin, GenericAPIView):
             needs_proctoring_escalation_email=requires_escalation_email(course.proctoring_provider),
             has_proctoring_escalation_email=bool(course.proctoring_escalation_email)
         )
+
+
+class CourseLegacyLibraryContentSerializer(serializers.Serializer):
+    usage_key = serializers.CharField()
+
+
+class CourseLegacyLibraryContentMigratorView(StatusViewSet):
+    # DELETE is not allowed, as we want to preserve all task status objects.
+    # Instead, users can POST to /cancel to cancel running tasks.
+    http_method_names = ["get", "post"]
+    permission_classes = (IsAdminUser,)
+    authentication_classes = (
+        BearerAuthenticationAllowInactiveUser,
+        JwtAuthentication,
+        SessionAuthenticationAllowInactiveUser,
+    )
+
+    @apidocs.schema(
+        responses={
+            200: CourseLegacyLibraryContentSerializer(many=True),
+            401: "The requester is not authenticated.",
+        },
+    )
+    @course_author_access_required
+    def list(self, _, course_key, *args, **kwargs):
+        """
+        Returns all legacy library content blocks ready to be migrated to new item bank block.
+        """
+        blocks = get_ready_to_migrate_legacy_library_content_blocks(course_key)
+        serializer = CourseLegacyLibraryContentSerializer(blocks, many=True)
+        return Response(serializer.data)
+
+    @apidocs.schema(
+        responses={
+            200: "In case of success, a 200.",
+            401: "The requester is not authenticated.",
+        },
+    )
+    @course_author_access_required
+    def create(self, request, course_key):
+        """
+        Migrate all legacy library content blocks to new item bank block.
+        """
+        task = migrate_course_legacy_library_blocks_to_item_bank.delay(request.user.id, str(course_key))
+        task_status = UserTaskStatus.objects.get(task_id=task.id)
+        serializer = self.get_serializer(task_status)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -8,7 +8,6 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from pytz import UTC
 from rest_framework import serializers, status
 from rest_framework.generics import GenericAPIView
-from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from user_tasks.models import UserTaskStatus
 from user_tasks.views import StatusViewSet
@@ -17,6 +16,7 @@ from cms.djangoapps.contentstore.course_info_model import get_course_updates
 from cms.djangoapps.contentstore.tasks import migrate_course_legacy_library_blocks_to_item_bank
 from cms.djangoapps.contentstore.views.certificates import CertificateManager
 from common.djangoapps.util.proctoring import requires_escalation_email
+from openedx.core.djangoapps.course_groups.permissions import IsStaffOrAdmin
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.serializers import StatusSerializerWithUuid
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
@@ -366,7 +366,6 @@ class CourseLegacyLibraryContentMigratorView(StatusViewSet):
     # DELETE is not allowed, as we want to preserve all task status objects.
     # Instead, users can POST to /cancel to cancel running tasks.
     http_method_names = ["get", "post"]
-    permission_classes = (IsAdminUser,)
     authentication_classes = (
         BearerAuthenticationAllowInactiveUser,
         JwtAuthentication,

--- a/cms/djangoapps/contentstore/api/views/utils.py
+++ b/cms/djangoapps/contentstore/api/views/utils.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.generics import GenericAPIView
-from xblock.core import XBlock
 
 from common.djangoapps.student.auth import has_course_author_access
 from openedx.core.djangoapps.util.forms import to_bool

--- a/cms/djangoapps/contentstore/api/views/utils.py
+++ b/cms/djangoapps/contentstore/api/views/utils.py
@@ -151,5 +151,5 @@ def get_ready_to_migrate_legacy_library_content_blocks(course_key: CourseKey) ->
     """
     store = modulestore()
     blocks = store.get_items(course_key, qualifiers={'category': 'library_content'})
-    ready_to_migrate_blocks = [block for block in blocks if block.is_ready_to_migrated_to_v2]
+    ready_to_migrate_blocks = [block for block in blocks if block.is_ready_to_migrate_to_v2]
     return ready_to_migrate_blocks

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -2354,6 +2354,6 @@ def migrate_course_legacy_library_blocks_to_item_bank(self, user_id: int, course
             for block in blocks:
                 self.status.set_state(f'Migrating block: {block.usage_key}')
                 block.v2_update_children_upstream_version(user_id)
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         LOGGER.exception(f'Error while migrating blocks: {exc}')
         self.status.fail(str(exc))

--- a/openedx/core/lib/api/serializers.py
+++ b/openedx/core/lib/api/serializers.py
@@ -6,6 +6,7 @@ Serializers to be used in APIs.
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from rest_framework import serializers
+from user_tasks.serializers import StatusSerializer
 
 
 class CollapsedReferenceSerializer(serializers.HyperlinkedModelSerializer):
@@ -70,3 +71,13 @@ class UsageKeyField(serializers.Field):
             return UsageKey.from_string(data)
         except InvalidKeyError as err:
             raise serializers.ValidationError("Invalid usage key") from err
+
+
+class StatusSerializerWithUuid(StatusSerializer):
+    """
+    Serializer for the user task status, including uuid.
+    """
+
+    class Meta:
+        model = StatusSerializer.Meta.model
+        fields = [*StatusSerializer.Meta.fields, 'uuid']

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -315,7 +315,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         self.sync_from_library(upgrade_to_latest=False)
         return True  # Children have been handled
 
-    def _v2_update_children_upstream_version(self):
+    def v2_update_children_upstream_version(self, user=None):
         """
         Update the upstream and upstream version fields of all children to point to library v2 version of the legacy
         library blocks. This essentially converts this legacy block to new ItemBankBlock.
@@ -336,10 +336,10 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
                     child.upstream = ""
                 # Use `modulestore()` instead of `self.runtime.modulestore` to make sure that the XBLOCK_UPDATED signal
                 # is triggered
-                store.update_item(child, None)
+                store.update_item(child, user)
             self.is_migrated_to_v2 = True
             self.save()
-            store.update_item(self, None)
+            store.update_item(self, user)
 
     def _validate_library_version(self, validation, lib_tools, version, library_key):
         """
@@ -405,7 +405,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
             return Response(_("The block has already been upgraded to version 2"), status=400)
         # If the source library is migrated but this block still depends on legacy library
         # Migrate the block by setting upstream field to all children blocks
-        self._v2_update_children_upstream_version()
+        self.v2_update_children_upstream_version()
         return Response()
 
     def validate(self):

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -136,7 +136,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         )
 
     @property
-    def is_ready_to_migrated_to_v2(self) -> bool:
+    def is_ready_to_migrate_to_v2(self) -> bool:
         """
         Returns whether the block can be migrated to v2.
         """
@@ -346,7 +346,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         Validates library version
         """
         latest_version = lib_tools.get_latest_library_version(library_key)
-        if self.is_ready_to_migrated_to_v2:
+        if self.is_ready_to_migrate_to_v2:
             validation.set_summary(
                 StudioValidationMessage(
                     StudioValidationMessage.WARNING,

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -315,7 +315,7 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
         self.sync_from_library(upgrade_to_latest=False)
         return True  # Children have been handled
 
-    def v2_update_children_upstream_version(self, user=None):
+    def v2_update_children_upstream_version(self, user_id=None):
         """
         Update the upstream and upstream version fields of all children to point to library v2 version of the legacy
         library blocks. This essentially converts this legacy block to new ItemBankBlock.
@@ -336,10 +336,10 @@ class LegacyLibraryContentBlock(ItemBankMixin, XModuleToXBlockMixin, XBlock):
                     child.upstream = ""
                 # Use `modulestore()` instead of `self.runtime.modulestore` to make sure that the XBLOCK_UPDATED signal
                 # is triggered
-                store.update_item(child, user)
+                store.update_item(child, user_id)
             self.is_migrated_to_v2 = True
             self.save()
-            store.update_item(self, user)
+            store.update_item(self, user_id)
 
     def _validate_library_version(self, validation, lib_tools, version, library_key):
         """


### PR DESCRIPTION
## Description

Adds API to fetch all legacy library content blocks that are ready to be updated to use library v2 and convert to item banks.
Also adds API to update all the references via a user celery task and to fetch its status.

Useful information to include:

- Which edX user roles will this change impact? "Developer".

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2758
* Related frontend PR: https://github.com/openedx/frontend-app-authoring/pull/2764
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4310

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/2764

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
