### PR TITLE
fix: bump openedx-learning to 0.30.2

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -22,10 +22,3 @@ Django<6.0
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
-
-# pip 25.3 is incompatible with pip-tools hence causing failures during the build process
-# Make upgrade command and all requirements upgrade jobs are broken due to this.
-# See issue https://github.com/openedx/public-engineering/issues/440 for details regarding the ongoing fix.
-# The constraint can be removed once a release (pip-tools > 7.5.1) is available with support for pip 25.3
-# Issue to track this dependency and unpin later on: https://github.com/openedx/edx-lint/issues/503
-pip<25.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -61,7 +61,7 @@ numpy<2.0.0
 # Date: 2023-09-18
 # pinning this version to avoid updates while the library is being developed
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-learning==0.30.1
+openedx-learning==0.30.2
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -856,7 +856,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/kernel.in
-openedx-learning==0.30.1
+openedx-learning==0.30.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1420,7 +1420,7 @@ openedx-forum==0.3.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-learning==0.30.1
+openedx-learning==0.30.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1034,7 +1034,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/base.txt
-openedx-learning==0.30.1
+openedx-learning==0.30.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1080,7 +1080,7 @@ openedx-filters==2.1.0
     #   ora2
 openedx-forum==0.3.8
     # via -r requirements/edx/base.txt
-openedx-learning==0.30.1
+openedx-learning==0.30.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,8 +9,6 @@ wheel==0.45.1
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.2
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+    # via -r requirements/pip.in
 setuptools==80.9.0
     # via -r requirements/pip.in


### PR DESCRIPTION
This includes an important fix for assigning the correct user to library backup/restore actions.