### PR TITLE
Move available_translations into VideoConfigService

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -953,13 +953,14 @@ class TestStudioTranscriptTranslationPostDispatch(TestVideo):  # lint-amnesty, p
             "error_message": "A transcript file is required."
         },
     )
+    @patch('openedx.core.djangoapps.video_config.services.VideoConfigService.available_translations')
     @ddt.unpack
-    def test_studio_transcript_post_validations(self, post_data, error_message):
+    def test_studio_transcript_post_validations(self, mock_available_translations, post_data, error_message):
         """
         Verify that POST request validations works as expected.
         """
-        # mock available_translations method
-        self.block.available_translations = lambda transcripts, verify_assets: ['ur']
+        # mock available_translations method to return ['ur']
+        mock_available_translations.return_value = ['ur']
         request = Request.blank('/translation', POST=post_data)
         response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.json['error'] == error_message

--- a/openedx/core/djangoapps/video_config/transcripts_utils.py
+++ b/openedx/core/djangoapps/video_config/transcripts_utils.py
@@ -749,53 +749,6 @@ class VideoTranscriptsMixin:
     This is necessary for VideoBlock.
     """
 
-    def available_translations(self, transcripts, verify_assets=None, is_bumper=False):
-        """
-        Return a list of language codes for which we have transcripts.
-
-        Arguments:
-            verify_assets (boolean): If True, checks to ensure that the transcripts
-                really exist in the contentstore. If False, we just look at the
-                VideoBlock fields and do not query the contentstore. One reason
-                we might do this is to avoid slamming contentstore() with queries
-                when trying to make a listing of videos and their languages.
-
-                Defaults to `not FALLBACK_TO_ENGLISH_TRANSCRIPTS`.
-
-            transcripts (dict): A dict with all transcripts and a sub.
-            include_val_transcripts(boolean): If True, adds the edx-val transcript languages as well.
-        """
-        translations = []
-        if verify_assets is None:
-            verify_assets = not settings.FEATURES.get('FALLBACK_TO_ENGLISH_TRANSCRIPTS')
-
-        sub, other_langs = transcripts["sub"], transcripts["transcripts"]
-
-        if verify_assets:
-            all_langs = dict(**other_langs)
-            if sub:
-                all_langs.update({'en': sub})
-
-            for language, filename in all_langs.items():
-                try:
-                    # for bumper videos, transcripts are stored in content store only
-                    if is_bumper:
-                        get_transcript_for_video(self.location, filename, filename, language)
-                    else:
-                        get_transcript(self, language)
-                except NotFoundError:
-                    continue
-
-                translations.append(language)
-        else:
-            # If we're not verifying the assets, we just trust our field values
-            translations = list(other_langs)
-            if not translations or sub:
-                translations += ['en']
-
-        # to clean redundant language codes.
-        return list(set(translations))
-
     def get_default_transcript_language(self, transcripts, dest_lang=None):
         """
         Returns the default transcript language for this video block.

--- a/xmodule/tests/test_video.py
+++ b/xmodule/tests/test_video.py
@@ -1102,7 +1102,8 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
         '''
 
         block = instantiate_block(data=xml_data_transcripts)
-        translations = block.available_translations(block.get_transcripts_info())
+        video_config_service = block.runtime.service(block, 'video_config')
+        translations = video_config_service.available_translations(block, block.get_transcripts_info())
         assert sorted(translations) == sorted(['hr', 'ge'])
 
     def test_video_with_no_transcripts_translation_retrieval(self):
@@ -1112,13 +1113,14 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
         does not throw an exception.
         """
         block = instantiate_block(data=None)
-        translations_with_fallback = block.available_translations(block.get_transcripts_info())
+        video_config_service = block.runtime.service(block, 'video_config')
+        translations_with_fallback = video_config_service.available_translations(block, block.get_transcripts_info())
         assert translations_with_fallback == ['en']
 
         with patch.dict(settings.FEATURES, FALLBACK_TO_ENGLISH_TRANSCRIPTS=False):
             # Some organizations don't have English transcripts for all videos
             # This feature makes it configurable
-            translations_no_fallback = block.available_translations(block.get_transcripts_info())
+            translations_no_fallback = video_config_service.available_translations(block, block.get_transcripts_info())
             assert translations_no_fallback == []
 
     @override_settings(ALL_LANGUAGES=ALL_LANGUAGES)
@@ -1142,7 +1144,12 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
             </video>
         '''
         block = instantiate_block(data=xml_data_transcripts)
-        translations = block.available_translations(block.get_transcripts_info(), verify_assets=False)
+        video_config_service = block.runtime.service(block, 'video_config')
+        translations = video_config_service.available_translations(
+            block,
+            block.get_transcripts_info(),
+            verify_assets=False
+        )
         assert translations != ['ur']
 
     def assert_validation_message(self, validation, expected_msg):

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -1204,7 +1204,14 @@ class _BuiltInVideoBlock(
                     "file_size": 0,  # File size is not relevant for external link
                 }
 
-        available_translations = self.available_translations(self.get_transcripts_info())
+        video_config_service = self.runtime.service(self, 'video_config')
+        if video_config_service:
+            available_translations = video_config_service.available_translations(
+                self,
+                self.get_transcripts_info()
+            )
+        else:
+            available_translations = []
         transcripts = {
             lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang, thirdparty=True)
             for lang in available_translations

--- a/xmodule/video_block/video_handlers.py
+++ b/xmodule/video_block/video_handlers.py
@@ -322,7 +322,11 @@ class VideoStudentViewHandlers:
                 mimetype
             )
         elif dispatch.startswith('available_translations'):
-            available_translations = self.available_translations(
+            video_config_service = self.runtime.service(self, 'video_config')
+            if not video_config_service:
+                return Response(status=404)
+            available_translations = video_config_service.available_translations(
+                self,
                 transcripts,
                 verify_assets=True,
                 is_bumper=is_bumper
@@ -395,7 +399,14 @@ class VideoStudioViewHandlers:
 
         # Get available transcript languages.
         transcripts = self.get_transcripts_info()
-        available_translations = self.available_translations(transcripts, verify_assets=True)
+        video_config_service = self.runtime.service(self, 'video_config')
+        if not video_config_service:
+            return error
+        available_translations = video_config_service.available_translations(
+            self,
+            transcripts,
+            verify_assets=True
+        )
 
         if missing:
             error = _('The following parameters are required: {missing}.').format(missing=', '.join(missing))


### PR DESCRIPTION
## Description

This moves edx-platform-specific logic out of the VideoBlock, in preparation for the VideoBlock extraction:
https://github.com/openedx/edx-platform/issues/36282


## Testing instructions

[point](https://github.com/openedx/edx-platform/blob/farhan/move-available-translations/xmodule/assets/video/public/js/09_video_caption.js#L662) where available_translation method calls as a fallback on error.

I have manually called the required javascript function by adding test code in this file to hit the `available_translations` function and tested the api on my local machine.

**Here are the results:**
----


<img width="1906" height="829" alt="Screenshot 2025-12-24 at 3 39 27 PM" src="https://github.com/user-attachments/assets/0df053ee-10f2-41d2-8502-5952fbbeac60" />

----

<img width="1068" height="290" alt="Screenshot 2025-12-24 at 3 39 33 PM" src="https://github.com/user-attachments/assets/63db991a-91ed-4022-a564-8dbbfbbfae85" />

----

Following are the screenshots of the sanbox created within this PR:

----

<img width="1484" height="774" alt="Screenshot 2025-12-24 at 3 45 08 PM" src="https://github.com/user-attachments/assets/2a9a8cc4-3c07-4df0-b6c8-a45a6aac505b" />

----

<img width="1516" height="794" alt="Screenshot 2025-12-24 at 3 45 00 PM" src="https://github.com/user-attachments/assets/89ee9580-ef94-468c-88e0-c1897964f38f" />

