### PR TITLE
Update VideoConfigService get_transcript method

### DIFF
--- a/openedx/core/djangoapps/video_config/services.py
+++ b/openedx/core/djangoapps/video_config/services.py
@@ -123,6 +123,7 @@ class VideoConfigService:
         lang: str | None = None,
         output_format: str = 'srt',
         youtube_id: str | None = None,
+        is_bumper=False,
     ) -> tuple[bytes, str, str]:
         """
         Retrieve a transcript from the runtime's storage.
@@ -135,7 +136,7 @@ class VideoConfigService:
             TranscriptNotFoundError: If the transcript cannot be found or retrieved
         """
         try:
-            return get_transcript(video_block, lang, output_format, youtube_id)
+            return get_transcript(video_block, lang, output_format, youtube_id, is_bumper)
         except NotFoundError as exc:
             raise TranscriptNotFoundError(
                 f"Failed to get transcript: {exc}"

--- a/openedx/core/djangoapps/video_config/transcripts_utils.py
+++ b/openedx/core/djangoapps/video_config/transcripts_utils.py
@@ -1049,7 +1049,7 @@ def get_transcript_from_learning_core(video_block, language, output_format, tran
     return output_transcript, output_filename, Transcript.mime_types[output_format]
 
 
-def get_transcript(video, lang=None, output_format=Transcript.SRT, youtube_id=None):
+def get_transcript(video, lang=None, output_format=Transcript.SRT, youtube_id=None, is_bumper=False):
     """
     Get video transcript from edx-val or content store.
 
@@ -1062,7 +1062,14 @@ def get_transcript(video, lang=None, output_format=Transcript.SRT, youtube_id=No
     Returns:
         tuple containing content, filename, mimetype
     """
-    transcripts_info = video.get_transcripts_info()
+    transcripts_info = video.get_transcripts_info(is_bumper)
+    if is_bumper:
+        return get_transcript_from_contentstore(
+            video,
+            lang,
+            Transcript.SJSON,
+            transcripts_info
+        )
     if not lang:
         lang = video.get_default_transcript_language(transcripts_info)
 


### PR DESCRIPTION
## Description

This moves edx-platform-specific logic out of the VideoBlock, in preparation for the VideoBlock extraction:
https://github.com/openedx/edx-platform/issues/36282


## Testing instructions

Testing has been done on the sandbox created within this PR.

1. I have created youtube video xblock on studio/content-library
2. I have uploaded the english/french transcripts on these video xblocks
3. Transcripts feature is working fine on studio/content-library video xblocks
4. Transcripts feature is working fine on lms for both course and library added video xblock in the course videos.

Note: Bumper video testing can't be done as not frontend exist for this feature. It seems un-used feature for some time. Test cases are passing so we can assume its functionality will be un-changed in this PR.

## Acceptance Criteria:

- Transcripts feature should work for the video xblocks.
- There should be no logic change.

----

<img width="1331" height="638" alt="Screenshot 2025-12-26 at 3 20 37 PM" src="https://github.com/user-attachments/assets/eb094cb4-4abc-4a2a-9389-2f241d4477f6" />

----

<img width="1332" height="635" alt="Screenshot 2025-12-26 at 3 20 25 PM" src="https://github.com/user-attachments/assets/10a1b545-329c-4673-883e-777202707b78" />

----

<img width="1348" height="638" alt="Screenshot 2025-12-26 at 3 20 16 PM" src="https://github.com/user-attachments/assets/1a19ceac-1e7f-43a5-8c63-07861b7d26ea" />

----

<img width="1327" height="628" alt="Screenshot 2025-12-26 at 3 20 50 PM" src="https://github.com/user-attachments/assets/3bd2e288-ede8-4fe8-b2b5-ca1d92648581" />

----
