### PR TITLE
feat: allow specifying custom page size for course list api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v2/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/home.py
@@ -15,6 +15,7 @@ from cms.djangoapps.contentstore.rest_api.v2.serializers import CourseHomeTabSer
 
 class HomePageCoursesPaginator(PageNumberPagination):
     """Custom paginator for the home page courses view version 2."""
+    page_size_query_param = 'page_size'
 
     def get_paginated_response(self, data):
         """Return a paginated style `Response` object for the given output data."""
@@ -77,6 +78,11 @@ class HomePageCoursesViewV2(APIView):
                 apidocs.ParameterLocation.QUERY,
                 description="Query param to paginate the courses",
             ),
+            apidocs.string_parameter(
+                "page_size",
+                apidocs.ParameterLocation.QUERY,
+                description="Query param to set page size",
+            ),
         ],
         responses={
             200: CourseHomeTabSerializerV2,
@@ -96,6 +102,7 @@ class HomePageCoursesViewV2(APIView):
             GET /api/contentstore/v2/home/courses?active_only=true
             GET /api/contentstore/v2/home/courses?archived_only=true
             GET /api/contentstore/v2/home/courses?page=2
+            GET /api/contentstore/v2/home/courses?page_size=20
 
         **Response Values**
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Adds query param `page_size` to customize page size of course list api.

Useful information to include:

- Which edX user roles will this change impact? "Developer"

## Supporting information

* Related to: https://github.com/openedx/frontend-app-authoring/pull/2773
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4308

## Testing instructions

See https://github.com/openedx/frontend-app-authoring/pull/2773

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
