### PR TITLE
Removed DEFAULT_HASHING_ALGORITHM from lms

### DIFF
--- a/cms/envs/mock.yml
+++ b/cms/envs/mock.yml
@@ -297,7 +297,6 @@ STORAGES:
     staticfiles:
       BACKEND: openedx.core.storage.ProductionStorage
 DEFAULT_FROM_EMAIL: no-reply@registration.localhost
-DEFAULT_HASHING_ALGORITHM: sha256
 DEFAULT_SITE_THEME: localhost
 DISABLED_COUNTRIES:
 - US

--- a/lms/envs/mock.yml
+++ b/lms/envs/mock.yml
@@ -382,7 +382,6 @@ STORAGES:
     staticfiles:
       BACKEND: openedx.core.storage.ProductionStorage
 DEFAULT_FROM_EMAIL: sandbox-notifications@example.com
-DEFAULT_HASHING_ALGORITHM: sha256
 DEFAULT_MOBILE_AVAILABLE: true
 DEFAULT_NOTIFICATION_ICON_URL: https://notifications-static.localhost/icons/post_outline.png
 DEFAULT_SITE_THEME: localhost

--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -113,7 +113,6 @@ class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware, MiddlewareMi
         super().__init__(*args, **kwargs)
 
     def process_request(self, request):
-        set_custom_attribute('DEFAULT_HASHING_ALGORITHM', settings.DEFAULT_HASHING_ALGORITHM)
         try:
             # Try and construct a User instance from data stored in the cache
             session_user_id = SafeSessionMiddleware.get_user_id_from_session(request)
@@ -148,18 +147,6 @@ class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware, MiddlewareMi
             # session hash is verified from the default algo, so skip legacy check
             if session_hash_verified:
                 set_custom_attribute('session_hash_verified', "default")
-                return
-
-            if (
-                session_hash and
-                hasattr(request.user, '_legacy_get_session_auth_hash') and
-                constant_time_compare(
-                    session_hash,
-                    request.user._legacy_get_session_auth_hash()  # pylint: disable=protected-access
-                )
-            ):
-                # session hash is verified from legacy hashing algorithm.
-                set_custom_attribute('session_hash_verified', "fallback")
                 return
 
             # The session hash has changed due to a password

--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -146,7 +146,6 @@ class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware, MiddlewareMi
 
             # session hash is verified from the default algo, so skip legacy check
             if session_hash_verified:
-                set_custom_attribute('session_hash_verified', "default")
                 return
 
             # The session hash has changed due to a password

--- a/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
@@ -1,7 +1,6 @@
 """Tests for cached authentication middleware."""
-from unittest.mock import call, patch
+from unittest.mock import patch
 
-import django
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user

--- a/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
@@ -27,53 +27,6 @@ class CachedAuthMiddlewareTestCase(TestCase):
         self.client.response = HttpResponse()
         self.client.response.cookies = SimpleCookie()  # preparing cookies
 
-    def _test_custom_attribute_after_changing_hash(self, test_url, mock_set_custom_attribute):
-        """verify that set_custom_attribute is called with expected values"""
-        password = 'test-password'
-
-        # Test DEFAULT_HASHING_ALGORITHM of 'sha1' for both login and client get
-        with self.settings(DEFAULT_HASHING_ALGORITHM='sha1'):
-            self.client.login(username=self.user.username, password=password)
-            self.client.get(test_url)
-        # For Django 3.2, the setting 'sha1' applies and is the "default".
-        # For Django 4, the setting no longer applies, and 'sha256' will be used for both as the "default".
-        mock_set_custom_attribute.assert_has_calls([
-            call('DEFAULT_HASHING_ALGORITHM', 'sha1'),
-            call('session_hash_verified', "default"),
-        ])
-        mock_set_custom_attribute.reset_mock()
-
-        # Test DEFAULT_HASHING_ALGORITHM of 'sha1' for login and switch to 'sha256' for client get.
-        with self.settings(DEFAULT_HASHING_ALGORITHM='sha1'):
-            self.client.login(username=self.user.username, password=password)
-            with self.settings(DEFAULT_HASHING_ALGORITHM='sha256'):
-                self.client.get(test_url)
-        if django.VERSION < (4, 0):
-            # For Django 3.2, the setting 'sha1' applies to login, and uses 'she256' for client get,
-            # and should "fallback" to 'sha1".
-            mock_set_custom_attribute.assert_has_calls([
-                call('DEFAULT_HASHING_ALGORITHM', 'sha256'),
-                call('session_hash_verified', "fallback"),
-            ])
-        else:
-            # For Django 4, the setting no longer applies, and again 'sha256' will be used for both as the "default".
-            mock_set_custom_attribute.assert_has_calls([
-                call('DEFAULT_HASHING_ALGORITHM', 'sha256'),
-                call('session_hash_verified', "default"),
-            ])
-        mock_set_custom_attribute.reset_mock()
-
-        # Test DEFAULT_HASHING_ALGORITHM of 'sha256' for both login and client get
-        with self.settings(DEFAULT_HASHING_ALGORITHM='sha256'):
-            self.client.login(username=self.user.username, password=password)
-            self.client.get(test_url)
-        # For Django 3.2, the setting 'sha256' applies and is the "default".
-        # For Django 4, the setting no longer applies, and 'sha256' will be used for both as the "default".
-        mock_set_custom_attribute.assert_has_calls([
-            call('DEFAULT_HASHING_ALGORITHM', 'sha256'),
-            call('session_hash_verified', "default"),
-        ])
-
     @skip_unless_lms
     def test_session_change_lms(self):
         """
@@ -115,20 +68,6 @@ class CachedAuthMiddlewareTestCase(TestCase):
         self.assertRedirects(response, redirect_url, target_status_code=302)
         mock_set_custom_attribute.assert_any_call('failed_session_verification', True)
 
-    @skip_unless_lms
-    @patch("openedx.core.djangoapps.cache_toolbox.middleware.set_custom_attribute")
-    def test_custom_attribute_after_changing_hash_lms(self, mock_set_custom_attribute):
-        """Test set_custom_attribute is called with expected values in LMS"""
-        test_url = reverse('dashboard')
-        self._test_custom_attribute_after_changing_hash(test_url, mock_set_custom_attribute)
-
-    @skip_unless_cms
-    @patch("openedx.core.djangoapps.cache_toolbox.middleware.set_custom_attribute")
-    def test_custom_attribute_after_changing_hash_cms(self, mock_set_custom_attribute):
-        """Test set_custom_attribute is called with expected values in CMS"""
-        test_url = reverse('home')
-        self._test_custom_attribute_after_changing_hash(test_url, mock_set_custom_attribute)
-
     def test_user_logout_on_session_hash_change(self):
         """
         Verify that if a user's session auth hash and the request's hash
@@ -152,14 +91,7 @@ class CachedAuthMiddlewareTestCase(TestCase):
         assert self.client.response.cookies.get('edx-jwt-cookie-header-payload').value == 'test-jwt-payload'
 
         with patch.object(User, 'get_session_auth_hash', return_value='abc123', autospec=True):
-            # Django 3.2 has _legacy_get_session_auth_hash, and Django 4 does not
-            # Remove once we reach Django 4
-            if hasattr(User, '_legacy_get_session_auth_hash'):
-                with patch.object(User, '_legacy_get_session_auth_hash', return_value='abc123'):
-                    CacheBackedAuthenticationMiddleware(get_response=lambda request: None).process_request(self.request)
-
-            else:
-                CacheBackedAuthenticationMiddleware(get_response=lambda request: None).process_request(self.request)
+            CacheBackedAuthenticationMiddleware(get_response=lambda request: None).process_request(self.request)
             SafeSessionMiddleware(get_response=lambda request: None).process_response(
                 self.request, self.client.response
             )

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -233,6 +233,15 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
         assert safe_cookie_data.session_id == 'some_session_id'
         assert safe_cookie_data.verify(self.user.id)
 
+    def test_update_cookie_data_at_step_3_with_sha256(self):
+        """ first encode cookie with default algo sha1 and then check with sha256"""
+        self.assert_response(set_request_user=True, set_session_cookie=True)
+        serialized_cookie_data = self.client.response.cookies[settings.SESSION_COOKIE_NAME].value
+        safe_cookie_data = SafeCookieData.parse(serialized_cookie_data)
+        assert safe_cookie_data.version == SafeCookieData.CURRENT_VERSION
+        assert safe_cookie_data.session_id == 'some_session_id'
+        assert safe_cookie_data.verify(self.user.id)
+
     def test_cant_update_cookie_at_step_3_error(self):
         self.client.response.cookies[settings.SESSION_COOKIE_NAME] = None
         with self.assert_invalid_session_id():

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -233,16 +233,6 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
         assert safe_cookie_data.session_id == 'some_session_id'
         assert safe_cookie_data.verify(self.user.id)
 
-    def test_update_cookie_data_at_step_3_with_sha256(self):
-        """ first encode cookie with default algo sha1 and then check with sha256"""
-        self.assert_response(set_request_user=True, set_session_cookie=True)
-        serialized_cookie_data = self.client.response.cookies[settings.SESSION_COOKIE_NAME].value
-        safe_cookie_data = SafeCookieData.parse(serialized_cookie_data)
-        assert safe_cookie_data.version == SafeCookieData.CURRENT_VERSION
-        assert safe_cookie_data.session_id == 'some_session_id'
-        with self.settings(DEFAULT_HASHING_ALGORITHM='sha256'):
-            assert safe_cookie_data.verify(self.user.id)
-
     def test_cant_update_cookie_at_step_3_error(self):
         self.client.response.cookies[settings.SESSION_COOKIE_NAME] = None
         with self.assert_invalid_session_id():


### PR DESCRIPTION

## Description

Removed unused deprecated `DEFAULT_HASHING_ALGORITHM` django settings from repo.

Useful information to include:

- This will not effect any user.

## Supporting information

This PR solves [issue](https://github.com/openedx/edx-platform/issues/37744)

## Deadline

"None"
