### PR TITLE
Move editor_saved to VideoConfigService

### DIFF
--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -86,7 +86,7 @@ def link_video_to_component(video_component, user):
     if not edx_video_id:
         edx_video_id = create_external_video(display_name='external video')
         video_component.edx_video_id = edx_video_id
-        video_component.save_with_metadata(user)
+        video_component.save_with_metadata(user.id)
 
     return edx_video_id
 
@@ -258,7 +258,7 @@ def upload_transcripts(request):
         if not edx_video_id:
             edx_video_id = create_external_video(display_name='external video')
             video.edx_video_id = edx_video_id
-            video.save_with_metadata(request.user)
+            video.save_with_metadata(request.user.id)
 
         response = JsonResponse({'edx_video_id': edx_video_id, 'status': 'Success'}, status=200)
 
@@ -282,7 +282,7 @@ def upload_transcripts(request):
             )
 
             video.transcripts['en'] = f"{edx_video_id}-en.srt"
-            video.save_with_metadata(request.user)
+            video.save_with_metadata(request.user.id)
             if transcript_created is None:
                 response = JsonResponse({'status': 'Invalid Video ID'}, status=400)
 

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1541,7 +1541,9 @@ class TestEditorSavedMethod(BaseTestVideoXBlock):
         assert isinstance(Transcript.get_asset(item.location, self.file_name), StaticContent)
         assert isinstance(Transcript.get_asset(item.location, 'subs_video.srt.sjson'), StaticContent)
         old_metadata = own_metadata(item)
-        with patch('xmodule.video_block.video_block.manage_video_subtitles_save') as manage_video_subtitles_save:
+        with patch(
+            'openedx.core.djangoapps.video_config.services.manage_video_subtitles_save'
+        ) as manage_video_subtitles_save:
             item.editor_saved(self.user, old_metadata, None)
             assert not manage_video_subtitles_save.called
 

--- a/openedx/core/djangoapps/video_config/transcripts_utils.py
+++ b/openedx/core/djangoapps/video_config/transcripts_utils.py
@@ -403,7 +403,7 @@ def get_html5_ids(html5_sources):
     return html5_ids
 
 
-def manage_video_subtitles_save(item, user, old_metadata=None, generate_translation=False):
+def manage_video_subtitles_save(item, user_id, old_metadata=None, generate_translation=False):
     """
     Does some specific things, that can be done only on save.
 
@@ -459,7 +459,7 @@ def manage_video_subtitles_save(item, user, old_metadata=None, generate_translat
                 except TranscriptException:
                     pass
         if reraised_message:
-            item.save_with_metadata(user)
+            item.save_with_metadata(user_id)
             raise TranscriptException(reraised_message)
 
 

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -38,14 +38,13 @@ from openedx.core.lib.license import LicenseMixin
 from xmodule.contentstore.content import StaticContent
 from xmodule.editing_block import EditingMixin
 from xmodule.exceptions import NotFoundError
-from xmodule.modulestore.inheritance import InheritanceKeyValueStore, own_metadata
+from xmodule.modulestore.inheritance import InheritanceKeyValueStore
 from xmodule.raw_block import EmptyDataRawMixin
 from xmodule.util.builtin_assets import add_css_to_fragment, add_webpack_js_to_fragment
 from xmodule.validation import StudioValidation, StudioValidationMessage
-from xmodule.video_block import manage_video_subtitles_save
 from xmodule.x_module import (
     PUBLIC_VIEW, STUDENT_VIEW,
-    ResourceTemplates, shim_xmodule_js,
+    ResourceTemplates,
     XModuleMixin, XModuleToXBlockMixin,
 )
 from xmodule.xml_block import XmlMixin, deserialize_field, is_pointer_tag, name_to_pathname
@@ -253,18 +252,6 @@ class _BuiltInVideoBlock(
         Renders the Studio preview view.
         """
         return self.student_view(context)
-
-    def studio_view(self, _context):
-        """
-        Return the studio view.
-        """
-        fragment = Fragment(
-            self.runtime.service(self, 'mako').render_cms_template(self.mako_template, self.get_context())
-        )
-        add_css_to_fragment(fragment, 'VideoBlockEditor.css')
-        add_webpack_js_to_fragment(fragment, 'VideoBlockEditor')
-        shim_xmodule_js(fragment, 'TabsEditingDescriptor')
-        return fragment
 
     def public_view(self, context):
         """
@@ -573,49 +560,16 @@ class _BuiltInVideoBlock(
         That means that html5_sources are always in list of fields that were changed (`metadata` param in save_item).
         This should be fixed too.
         """
-        metadata_was_changed_by_user = old_metadata != own_metadata(self)
+        video_config_service = self.runtime.service(self, 'video_config')
+        if video_config_service:
+            video_config_service.handle_editor_saved(self, user.id, old_metadata)
 
-        # There is an edge case when old_metadata and own_metadata are same and we are importing transcript from youtube
-        # then there is a syncing issue where html5_subs are not syncing with youtube sub, We can make sync better by
-        # checking if transcript is present for the video and if any html5_ids transcript is not present then trigger
-        # the manage_video_subtitles_save to create the missing transcript with particular html5_id.
-        if not metadata_was_changed_by_user and self.sub and hasattr(self, 'html5_sources'):
-            html5_ids = get_html5_ids(self.html5_sources)
-            for subs_id in html5_ids:
-                try:
-                    Transcript.asset(self.location, subs_id)
-                except NotFoundError:
-                    # If a transcript does not not exist with particular html5_id then there is no need to check other
-                    # html5_ids because we have to create a new transcript with this missing html5_id by turning on
-                    # metadata_was_changed_by_user flag.
-                    metadata_was_changed_by_user = True
-                    break
-
-        if metadata_was_changed_by_user:
-            self.edx_video_id = self.edx_video_id and self.edx_video_id.strip()
-
-            # We want to override `youtube_id_1_0` with val youtube profile in the first place when someone adds/edits
-            # an `edx_video_id` or its underlying YT val profile. Without this, override will only happen when a user
-            # saves the video second time. This is because of the syncing of basic and advanced video settings which
-            # also syncs val youtube id from basic tab's `Video Url` to advanced tab's `Youtube ID`.
-            if self.edx_video_id and edxval_api:
-                val_youtube_id = edxval_api.get_url_for_profile(self.edx_video_id, 'youtube')
-                if val_youtube_id and self.youtube_id_1_0 != val_youtube_id:
-                    self.youtube_id_1_0 = val_youtube_id
-
-            manage_video_subtitles_save(
-                self,
-                user,
-                old_metadata if old_metadata else None,
-                generate_translation=True
-            )
-
-    def save_with_metadata(self, user):
+    def save_with_metadata(self, user_id):
         """
         Save block with updated metadata to database."
         """
         self.save()
-        self.runtime.modulestore.update_item(self, user.id)
+        self.runtime.modulestore.update_item(self, user_id)
 
     @property
     def editable_metadata_fields(self):


### PR DESCRIPTION
Ticket: https://github.com/openedx/public-engineering/issues/471

Move editor_saved to VideoConfigService

This moves edx-platform-specific logic out of the VideoBlock, in preparation for the VideoBlock extraction:
https://github.com/openedx/edx-platform/issues/36282

### Legacy Video Editor changes in this PR:

**Removed:**
- studio_view() method

**Not removed:**
1. editor_saved
2. get_context() method
3. EditingMixin usage

**Why these methods still retained?**
Removing these method breaks:
1. Transcript uploads on the Video Block in the Content Library (Beta/V2). 
2. Fetching uploaded transcripts on authoring mfe video editor window.

To avoid this regression, they have been kept for now.

Below are the details of the testing.

Here are my testing notes:

### Testing on LMS/Studio:
**A. Uploading transcript**
1. Go to any course, add a video (youtube video) into the course
2. Add the transcript via settings
3. Transcript should be uploaded successfully
4. Transcript should render successfully on the studio
5. Publish the course
6. Video Block and transcript should render successfully on the LMS

**B. Deleting transcript**
1. After performing above steps, now delete the transcript from the video block.
2. Transcript should be deleted successfully and should stop appearing on the studio.
3. Publish the course.
4. Transcript should stop appearing on the lms as well

### Testing on Content Library (Beta/V2):
**C. Uploading transcript**
1. Go to any content library > Units tab

<img width="1916" height="350" alt="image" src="https://github.com/user-attachments/assets/3d1618b1-a053-40dd-aa9a-db5cc904b4f0" />

----

2. Create a new unit and video block as a content in the unit.

<img width="865" height="588" alt="image" src="https://github.com/user-attachments/assets/9dba0ea1-b438-4169-9b7a-6e050a546a41" />

----

3. Save the video and then edit the video again to upload/add the transcript. Transcript should be uploaded/added successfully.

<img width="1126" height="669" alt="image" src="https://github.com/user-attachments/assets/6784b0dc-62df-4c9a-b501-69bf8c4e9cb7" />

----

4. Video and transcript should be render successfully in the content library preview.

5. Go to any course, Add the block/unit from the library via 'Use unit from library' button
6. Transcript should render successfully on the studio
7. Publish the course transcript should render successfully on the studio

**D. Deleting transcript**
1. After performing above steps, now delete the transcript from the video block in the content library.
2. Transcript should be deleted successfully in the content library preview.
3. Sync the block in the course with the content library version.
4. Transcript should stop appearing on the course as well.
5. Publish the course.
6. Transcript should stop appearing on the lms as well

-----

**All the fields of the Video XBlock Editor Window should be edited properly for both studio and content library.**

### Sample screen shot:

<img width="1150" height="517" alt="Screenshot 2026-01-02 at 7 36 38 PM" src="https://github.com/user-attachments/assets/6412b443-c370-4a37-86d2-88cc658e83af" />

-----

**Copy/Paste of the Video Block from Course to the Content Library and vice versa should work properly.**

All testing has been done with in this PR sandbox.

