### PR TITLE
fix: apply library_content transformer to all ItemBankMixin xblocks

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -1,5 +1,8 @@
 """
-Content Library Transformer.
+Item Bank Transformer.
+
+Transformers for handling item bank blocks (library_content, itembank, etc.)
+that use ItemBankMixin for randomized content selection.
 """
 
 
@@ -7,6 +10,7 @@ import json
 import logging
 
 from eventtracking import tracker
+from xblock.core import XBlock
 
 from common.djangoapps.track import contexts
 from lms.djangoapps.courseware.models import StudentModule
@@ -14,21 +18,40 @@ from openedx.core.djangoapps.content.block_structure.transformer import (
     BlockStructureTransformer,
     FilteringTransformerMixin,
 )
-from xmodule.library_content_block import LegacyLibraryContentBlock  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.item_bank_block import ItemBankMixin  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..utils import get_student_module_as_dict
 
 logger = logging.getLogger(__name__)
 
+# Module-level cache to avoid repeated XBlock.load_class() calls
+_BLOCK_CLASS_CACHE = {}
+
+
+def _get_block_class(block_type: str):
+    """
+    Get the XBlock class from a block type.
+    """
+    if block_type not in _BLOCK_CLASS_CACHE:
+        try:
+            _BLOCK_CLASS_CACHE[block_type] = XBlock.load_class(block_type)
+        except Exception:  # lint-amnesty, pylint: disable=broad-except
+            logger.exception('Failed to load block class for type %s', block_type)
+            _BLOCK_CLASS_CACHE[block_type] = None
+    return _BLOCK_CLASS_CACHE[block_type]
+
 
 class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransformer):
     """
     A transformer that manipulates the block structure by removing all
-    blocks within a library_content block to which a user should not
-    have access.
+    blocks within item bank blocks (library_content, itembank, etc.)
+    to which a user should not have access.
 
-    Staff users are not to be exempted from library content pathways.
+    This transformer works with any XBlock that inherits from ItemBankMixin,
+    filtering children based on the selection logic defined by each block type.
+
+    Staff users are not to be exempted from item bank pathways.
     """
     WRITE_VERSION = 1
     READ_VERSION = 1
@@ -61,22 +84,27 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 "original_usage_version": str(orig_version) if orig_version else None,
             }
 
-        # For each block check if block is library_content.
-        # If library_content add children array to content_library_children field
+        # For each block check if block uses ItemBankMixin (e.g., library_content, itembank).
+        # Mark these blocks and collect analytics data for their children.
         for block_key in block_structure.topological_traversal(
-                filter_func=lambda block_key: block_key.block_type == 'library_content',
                 yield_descendants_of_unyielded=True,
         ):
-            xblock = block_structure.get_xblock(block_key)
-            for child_key in xblock.children:
-                summary = summarize_block(child_key)
-                block_structure.set_transformer_block_field(child_key, cls, 'block_analytics_summary', summary)
+            block_class = _get_block_class(block_key.block_type)
+            is_item_bank = block_class and issubclass(block_class, ItemBankMixin)
+
+            if is_item_bank:
+                block_structure.set_transformer_block_field(block_key, cls, 'is_item_bank_block', True)
+                xblock = block_structure.get_xblock(block_key)
+                for child_key in xblock.children:
+                    summary = summarize_block(child_key)
+                    block_structure.set_transformer_block_field(child_key, cls, 'block_analytics_summary', summary)
 
     def transform_block_filters(self, usage_info, block_structure):
         all_library_children = set()
         all_selected_children = set()
         for block_key in block_structure:
-            if block_key.block_type != 'library_content':
+            # Check if this block was marked as an ItemBankMixin block during collect
+            if not block_structure.get_transformer_block_field(block_key, self, 'is_item_bank_block'):
                 continue
             library_children = block_structure.get_children(block_key)
             if library_children:
@@ -98,7 +126,12 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
 
                 # Update selected
                 previous_count = len(selected)
-                block_keys = LegacyLibraryContentBlock.make_selection(selected, library_children, max_count)
+                # Get the cached block class to call make_selection
+                block_class = _get_block_class(block_key.block_type)
+                if not block_class:
+                    logger.error('Failed to load block class for %s', block_key)
+                    continue
+                block_keys = block_class.make_selection(selected, library_children, max_count)
                 selected = block_keys['selected']
 
                 # Save back any changes
@@ -128,7 +161,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             """
             Return True if selected block should be removed.
 
-            Block is removed if it is part of library_content, but has
+            Block is removed if it is a child of an item bank block, but has
             not been selected for current user.
             """
             if block_key not in all_library_children:
@@ -156,6 +189,12 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 json_result.append(info)
             return json_result
 
+        # Get the cached block class to call publish_selected_children_events
+        block_class = _get_block_class(location.block_type)
+        if not block_class:
+            logger.error('Failed to load block class for publishing events: %s', location)
+            return
+
         def publish_event(event_name, result, **kwargs):
             """
             Helper function to publish an event for analytics purposes
@@ -170,11 +209,12 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             context = contexts.course_context_from_course_id(location.course_key)
             if user_id:
                 context['user_id'] = user_id
-            full_event_name = f"edx.librarycontentblock.content.{event_name}"
+            event_prefix = block_class.get_selected_event_prefix()
+            full_event_name = f"{event_prefix}.{event_name}"
             with tracker.get_tracker().context(full_event_name, context):
                 tracker.emit(full_event_name, event_data)
 
-        LegacyLibraryContentBlock.publish_selected_children_events(
+        block_class.publish_selected_children_events(
             block_keys,
             format_block_keys,
             publish_event,
@@ -184,12 +224,14 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
 class ContentLibraryOrderTransformer(BlockStructureTransformer):
     """
     A transformer that manipulates the block structure by modifying the order of the
-    selected blocks within a library_content block to match the order of the selections
-    made by the ContentLibraryTransformer or the corresponding XBlock. So this transformer
-    requires the selections for the randomized content block to be already
-    made either by the ContentLibraryTransformer or the XBlock.
+    selected blocks within item bank blocks (library_content, itembank, etc.)
+    to match the order of the selections made by the ContentLibraryTransformer or the
+    corresponding XBlock. This transformer requires the selections for the item bank block
+    to be already made either by the ContentLibraryTransformer or the XBlock.
 
-    Staff users are *not* exempted from library content pathways.
+    This transformer works with any XBlock that inherits from ItemBankMixin.
+
+    Staff users are *not* exempted from item bank pathways.
     """
     WRITE_VERSION = 1
     READ_VERSION = 1
@@ -217,7 +259,10 @@ class ContentLibraryOrderTransformer(BlockStructureTransformer):
         to match the order of the selections made and stored in the XBlock 'selected' field.
         """
         for block_key in block_structure:
-            if block_key.block_type != 'library_content':
+            # Check if this block was marked as an ItemBankMixin block by ContentLibraryTransformer
+            if not block_structure.get_transformer_block_field(
+                block_key, ContentLibraryTransformer, 'is_item_bank_block'
+            ):
                 continue
 
             library_children = block_structure.get_children(block_key)
@@ -228,7 +273,7 @@ class ContentLibraryOrderTransformer(BlockStructureTransformer):
                 current_selected_blocks = {item[1] for item in state_dict.get('selected', [])}
 
                 # As the selections should have already been made by the ContentLibraryTransformer,
-                # the current children of the library_content block should be the same as the stored
+                # the current children of the item bank block should be the same as the stored
                 # selections. If they aren't, some other transformer that ran before this transformer
                 # has modified those blocks (for example, content gating may have affected this). So do not
                 # transform the order in that case.

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -37,7 +37,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
 
     Staff users are not to be exempted from item bank pathways.
     """
-    WRITE_VERSION = 2
+    WRITE_VERSION = 1
     READ_VERSION = 1
 
     @classmethod
@@ -69,32 +69,23 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             }
 
         # For each block check if block uses ItemBankMixin (e.g., library_content, itembank).
-        # Mark these blocks and collect analytics data for their children.
+        # If so add block analytics summary for each of its children.
         for block_key in block_structure.topological_traversal(
+                filter_func=lambda block_key: issubclass(XBlock.load_class(block_key.block_type), ItemBankMixin),
                 yield_descendants_of_unyielded=True,
         ):
-            block_class = XBlock.load_class(block_key.block_type)
-            is_item_bank = block_class and issubclass(block_class, ItemBankMixin)
-
-            if is_item_bank:
-                block_structure.set_transformer_block_field(block_key, cls, 'is_item_bank_block', True)
-                xblock = block_structure.get_xblock(block_key)
-                for child_key in xblock.children:
-                    summary = summarize_block(child_key)
-                    block_structure.set_transformer_block_field(child_key, cls, 'block_analytics_summary', summary)
+            xblock = block_structure.get_xblock(block_key)
+            for child_key in xblock.children:
+                summary = summarize_block(child_key)
+                block_structure.set_transformer_block_field(child_key, cls, 'block_analytics_summary', summary)
 
     def transform_block_filters(self, usage_info, block_structure):
         all_library_children = set()
         all_selected_children = set()
         for block_key in block_structure:
-            # Check if this block was marked as an ItemBankMixin block during collect
-            is_item_bank = block_structure.get_transformer_block_field(block_key, self, 'is_item_bank_block')
-            # Fallback for old cache that doesn't have the 'is_item_bank_block' field
-            if is_item_bank is None:
-                block_class = XBlock.load_class(block_key.block_type)
-                is_item_bank = block_class and issubclass(block_class, ItemBankMixin)
+            block_class = XBlock.load_class(block_key.block_type)
 
-            if not is_item_bank:
+            if block_class is None or not issubclass(block_class, ItemBankMixin):
                 continue
             library_children = block_structure.get_children(block_key)
             if library_children:
@@ -118,7 +109,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 previous_count = len(selected)
                 # Get the cached block class to call make_selection
                 block_class = XBlock.load_class(block_key.block_type)
-                if not block_class:
+                if block_class is None:
                     logger.error('Failed to load block class for %s', block_key)
                     continue
                 block_keys = block_class.make_selection(selected, library_children, max_count)
@@ -181,7 +172,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
 
         # Get the cached block class to call publish_selected_children_events
         block_class = XBlock.load_class(location.block_type)
-        if not block_class:
+        if block_class is None:
             logger.error('Failed to load block class for publishing events: %s', location)
             return
 
@@ -249,19 +240,8 @@ class ContentLibraryOrderTransformer(BlockStructureTransformer):
         to match the order of the selections made and stored in the XBlock 'selected' field.
         """
         for block_key in block_structure:
-            # Try to read from cache (collected by ContentLibraryTransformer)
-            is_item_bank = block_structure.get_transformer_block_field(
-                block_key,
-                ContentLibraryTransformer,
-                'is_item_bank_block'
-            )
-
-            # Fallback for old cache that doesn't have the 'is_item_bank_block' field
-            if is_item_bank is None:
-                block_class = XBlock.load_class(block_key.block_type)
-                is_item_bank = block_class and issubclass(block_class, ItemBankMixin)
-
-            if not is_item_bank:
+            block_class = XBlock.load_class(block_key.block_type)
+            if block_class is None or not issubclass(block_class, ItemBankMixin):
                 continue
 
             library_children = block_structure.get_children(block_key)

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -25,22 +25,6 @@ from ..utils import get_student_module_as_dict
 
 logger = logging.getLogger(__name__)
 
-# Module-level cache to avoid repeated XBlock.load_class() calls
-_BLOCK_CLASS_CACHE = {}
-
-
-def _get_block_class(block_type: str):
-    """
-    Get the XBlock class from a block type.
-    """
-    if block_type not in _BLOCK_CLASS_CACHE:
-        try:
-            _BLOCK_CLASS_CACHE[block_type] = XBlock.load_class(block_type)
-        except Exception:  # lint-amnesty, pylint: disable=broad-except
-            logger.exception('Failed to load block class for type %s', block_type)
-            _BLOCK_CLASS_CACHE[block_type] = None
-    return _BLOCK_CLASS_CACHE[block_type]
-
 
 class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransformer):
     """
@@ -89,7 +73,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
         for block_key in block_structure.topological_traversal(
                 yield_descendants_of_unyielded=True,
         ):
-            block_class = _get_block_class(block_key.block_type)
+            block_class = XBlock.load_class(block_key.block_type)
             is_item_bank = block_class and issubclass(block_class, ItemBankMixin)
 
             if is_item_bank:
@@ -107,7 +91,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             is_item_bank = block_structure.get_transformer_block_field(block_key, self, 'is_item_bank_block')
             # Fallback for old cache that doesn't have the 'is_item_bank_block' field
             if is_item_bank is None:
-                block_class = _get_block_class(block_key.block_type)
+                block_class = XBlock.load_class(block_key.block_type)
                 is_item_bank = block_class and issubclass(block_class, ItemBankMixin)
 
             if not is_item_bank:
@@ -133,7 +117,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 # Update selected
                 previous_count = len(selected)
                 # Get the cached block class to call make_selection
-                block_class = _get_block_class(block_key.block_type)
+                block_class = XBlock.load_class(block_key.block_type)
                 if not block_class:
                     logger.error('Failed to load block class for %s', block_key)
                     continue
@@ -196,7 +180,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             return json_result
 
         # Get the cached block class to call publish_selected_children_events
-        block_class = _get_block_class(location.block_type)
+        block_class = XBlock.load_class(location.block_type)
         if not block_class:
             logger.error('Failed to load block class for publishing events: %s', location)
             return
@@ -274,7 +258,7 @@ class ContentLibraryOrderTransformer(BlockStructureTransformer):
 
             # Fallback for old cache that doesn't have the 'is_item_bank_block' field
             if is_item_bank is None:
-                block_class = _get_block_class(block_key.block_type)
+                block_class = XBlock.load_class(block_key.block_type)
                 is_item_bank = block_class and issubclass(block_class, ItemBankMixin)
 
             if not is_item_bank:

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -4,6 +4,8 @@ Tests for ContentLibraryTransformer.
 
 from unittest import mock
 
+from ddt import data, ddt
+
 import openedx.core.djangoapps.content.block_structure.api as bs_api
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
@@ -26,6 +28,7 @@ class MockedModule:
         self.state = state
 
 
+@ddt
 class ContentLibraryTransformerTestCase(CourseStructureTestCase):
     """
     ContentLibraryTransformer Test
@@ -37,9 +40,14 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
         Setup course structure and create user for content library transformer test.
         """
         super().setUp()
+        self._initialize_course_hierarchy()
 
+    def _initialize_course_hierarchy(self, block_type='library_content'):
+        """
+        Initialize course hierarchy with the given block type.
+        """
         # Build course.
-        self.course_hierarchy = self.get_course_hierarchy()
+        self.course_hierarchy = self.get_course_hierarchy(block_type)
         self.blocks = self.build_course(self.course_hierarchy)
         self.course = self.blocks['course']
         # Do this manually because publish signals are not fired by default in tests.
@@ -49,14 +57,14 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
         # Enroll user in course.
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, is_active=True)
 
-    def get_course_hierarchy(self):
+    def get_course_hierarchy(self, block_type='library_content'):
         """
         Get a course hierarchy to test with.
         """
         return [{
             'org': 'ContentLibraryTransformer',
             'course': 'CL101F',
-            'run': 'test_run',
+            'run': f'test_run_{block_type}',
             '#type': 'course',
             '#ref': 'course',
             '#children': [
@@ -73,8 +81,8 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                                     '#ref': 'vertical1',
                                     '#children': [
                                         {
-                                            '#type': 'library_content',
-                                            '#ref': 'library_content1',
+                                            '#type': block_type,
+                                            '#ref': f'{block_type}1',
                                             '#children': [
                                                 {
                                                     'metadata': {'display_name': "CL Vertical 2"},
@@ -111,13 +119,18 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
             ]
         }]
 
-    def test_content_library(self):
+    @data('library_content', 'itembank')
+    def test_content_library(self, block_type):
         """
         Test when course has content library section.
         First test user can't see any content library section,
         and after that mock response from MySQL db.
         Check user can see mocked sections in content library.
         """
+        # Re-initialize if testing with a different block type
+        if block_type != 'library_content':
+            self._initialize_course_hierarchy(block_type)
+
         raw_block_structure = get_course_blocks(
             self.user,
             self.course.location,
@@ -136,7 +149,7 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
         # Should dynamically assign a block to student
         trans_keys = set(trans_block_structure.get_block_keys())
         block_key_set = self.get_block_key_set(
-            self.blocks, 'course', 'chapter1', 'lesson1', 'vertical1', 'library_content1'
+            self.blocks, 'course', 'chapter1', 'lesson1', 'vertical1', f'{block_type}1'
         )
         for key in block_key_set:
             assert key in trans_keys
@@ -160,11 +173,12 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
             assert set(trans_block_structure.get_block_keys()) == self.get_block_key_set(self.blocks, 'course',
                                                                                          'chapter1', 'lesson1',
                                                                                          'vertical1',
-                                                                                         'library_content1',
+                                                                                         f'{block_type}1',
                                                                                          selected_vertical,
                                                                                          selected_child), f"Expected 'selected' equality failed in iteration {i}."  # pylint: disable=line-too-long
 
 
+@ddt
 class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
     """
     ContentLibraryOrderTransformer Test
@@ -176,7 +190,13 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
         Setup course structure and create user for content library order transformer test.
         """
         super().setUp()
-        self.course_hierarchy = self.get_course_hierarchy()
+        self._initialize_course_hierarchy()
+
+    def _initialize_course_hierarchy(self, block_type='library_content'):
+        """
+        Initialize course hierarchy with the given block type.
+        """
+        self.course_hierarchy = self.get_course_hierarchy(block_type)
         self.blocks = self.build_course(self.course_hierarchy)
         self.course = self.blocks['course']
         bs_api.update_course_in_cache(self.course.id)
@@ -185,14 +205,14 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
         # Enroll user in course.
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, is_active=True)
 
-    def get_course_hierarchy(self):
+    def get_course_hierarchy(self, block_type='library_content'):
         """
         Get a course hierarchy to test with.
         """
         return [{
             'org': 'ContentLibraryTransformer',
             'course': 'CL101F',
-            'run': 'test_run',
+            'run': f'test_run_{block_type}',
             '#type': 'course',
             '#ref': 'course',
             '#children': [
@@ -209,8 +229,8 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
                                     '#ref': 'vertical1',
                                     '#children': [
                                         {
-                                            '#type': 'library_content',
-                                            '#ref': 'library_content1',
+                                            '#type': block_type,
+                                            '#ref': f'{block_type}1',
                                             '#children': [
                                                 {
                                                     'metadata': {'display_name': "CL Vertical 2"},
@@ -260,11 +280,15 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
         }]
 
     @mock.patch('lms.djangoapps.course_blocks.transformers.library_content.get_student_module_as_dict')
-    def test_content_library_randomize(self, mocked):
+    @data('library_content', 'itembank')
+    def test_content_library_randomize(self, block_type, mocked):
         """
         Test whether the order of the children blocks matches the order of the selected blocks when
         course has content library section
         """
+        # Re-initialize if testing with a different block type
+        if block_type != 'library_content':
+            self._initialize_course_hierarchy(block_type)
         mocked.return_value = {
             'selected': [
                 ['vertical', 'vertical_vertical3'],
@@ -280,7 +304,7 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
             )
             children = []
             for block_key in trans_block_structure.topological_traversal():
-                if block_key.block_type == 'library_content':
+                if block_key.block_type == block_type:
                     children = trans_block_structure.get_children(block_key)
                     break
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds logic to the library_content transformer to support all xblocks that inherit from ItemBankMixin.

## Supporting information

### Specific case (The problem)
When creating a Problem Bank component, the structure of the xblock doesn't match (the user can solve 3 problems of 5), in the grade the system evaluates 5 problems when only 3 are solvable for the user.

<img width="969" height="498" alt="image" src="https://github.com/user-attachments/assets/851bb6c6-d1e8-47c1-84c8-97c52104eb88" />
Screenshot in Studio of a Problem Bank
<img width="1073" height="531" alt="Screenshot from 2026-01-06 15-59-37" src="https://github.com/user-attachments/assets/4d44a811-5674-4c91-9625-d92e1d86285b" />
Screenshot in LMS of the Problem Bank
<img width="1058" height="266" alt="image" src="https://github.com/user-attachments/assets/7db292a3-6fb9-47ac-914d-00b3cc363ca5" />
Screenshot in Progress inside the LMS, related to the Problem Bank



#### Inside
The transformer didn't remove the non-selected children from the problem bank (randomized content from a content library v2 - itembankblock in the code), so the structure shows inconsistent information (more questions/grades than the user is available to see/solve)

### Solution
Adding the logic to analyze the block_class and check whether it inherits from itembankmixin. I apply the same logic as the legacy library content to all xblocks with randomized content, without removing support for the legacy libraries.

## Testing instructions

Pre-requisites:
- Have a tutor environment with a master or a release greater than or equal to teak (cherry-pick the commit from this branch or use this branch if you are using master)
- Have a course, and in Settings > Scheduled & Details, verify the course start date (use an old date, for example, 2020)
- Configure grading Settings > Grading.

### Test:
**LegacyLibraries**
1. Create a Legacy Library (in Studio, click Legacy Libraries, and then +New Library) and add some problems for testing.
2. In a course, add a subsection, and then a unit, and then a "Legacy Library" component. (configure grade to the subsection)
3. Edit the "Legacy Library" component to use the library created, and if you want, you can configure how many problems are going to show to the student.
4. Publish the content.
5. Click view live version.

Things to verify in LMS (with the live version or a student account):
- In the outline, the section shows the correct number of questions.
- In the progress page, in the detailed grades, you should only see the gradable XBlocks available.

**ProblemBank**
1. Create a Content Library (in Studio, click +New Library) and add some problems for testing.
2. In a course, add a subsection, and then a unit, and then a "Problem Bank" component. (configure grade to the subsection)
3. Add components to the "Problem Bank", and if you want, you can configure how many problems are going to show to the student.
4. Publish the content.
5. Click view live version.

Things to verify in LMS (with the live version or a student account):
The same from the LegacyLibraries

**Another Xblock (optional)**
1. Install an Xblock that inherits from ItemBankMixin (for example, https://github.com/eduNEXT-collab/xblock-exam-question-bank)
2. Activate the plugin in the course https://github.com/eduNEXT-collab/xblock-exam-question-bank?tab=readme-ov-file#enabling-the-xblock-in-a-course
3. In a course, add a subsection, and then a unit, and then an "Advanced" component, and select the custom XBlock. (configure grade to the subsection)
4. Publish the content.
5. Click view live version.

Things to verify in LMS (with the live version or a student account):
The same from the LegacyLibraries

## Screenshots

Base
<img width="1482" height="742" alt="image" src="https://github.com/user-attachments/assets/a7ac4673-706b-4652-bede-4bb1a810e9f5" />
Problem Bank Configuration (to show 1 of 4 problems)

Before
<img width="1634" height="733" alt="image" src="https://github.com/user-attachments/assets/17a424b2-a0a2-430a-b21e-60de5a5a14a7" />
Problem Bank in LMS (problem: in the sidebar bar, it shows we had four problems available when we have 1)

After
<img width="1633" height="648" alt="image" src="https://github.com/user-attachments/assets/f63f6c69-8380-40b6-b7fb-e2bfa991e694" />
Problem Bank in LMS (It shows we have 1 question) ✅
<img width="1111" height="339" alt="image" src="https://github.com/user-attachments/assets/ac2047a7-6e12-4b26-890c-e222792a3a17" />
Progress in LMS (In the grade details, we have the correct information) ✅