### PR TITLE
fix: update course apps status on transaction commit

### DIFF
--- a/openedx/core/djangoapps/course_apps/handlers.py
+++ b/openedx/core/djangoapps/course_apps/handlers.py
@@ -1,6 +1,7 @@
 """
 Signal handlers for course apps.
 """
+from django.db import transaction
 from django.dispatch import receiver
 from opaque_keys.edx.keys import CourseKey
 from xmodule.modulestore.django import SignalHandler
@@ -16,7 +17,9 @@ def update_course_apps(sender, course_key, **kwargs):  # pylint: disable=unused-
     Whenever the course is published, update the status of course apps in the
     django models to match their status in the course.
     """
-    update_course_apps_status.delay(str(course_key))
+    # Adding transaction.on_commit to ensure that the course publish operations
+    # are fully complete before we attempt to read the course data.
+    transaction.on_commit(lambda: update_course_apps_status.delay(str(course_key)))
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
## Related Ticket
https://github.com/mitodl/hq/issues/9178 (MIT Internal)

## Description
This pull request updates the signal handler logic for course apps to ensure that background tasks are triggered only after database transactions are fully committed. This change helps prevent issues where background tasks might read incomplete or inconsistent data during course publishing.

**Transaction handling improvements:**

- Updated the `update_course_apps` signal handler in `handlers.py` to use `transaction.on_commit`, ensuring that the `update_course_apps_status` task is only triggered after all course publish operations are fully completed.

## Testing instructions

I am not able to fully reproduce it locally, yet. 

I can see the flags are not updated immediately by adding the following code before and after [updating item](https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/contentstore/views/course.py#L1363)
`print(CourseOverview.get_from_id(course_block.id).show_calculator)`

**Adding the steps to possibly get the issue**

1. Go to the "Pages & Resources" section of a course
2. Change the flags for "Notes" and "Calculator" each to be disabled.
3. Go to Settings -> Advanced Settings
4. Find "Enable student notes" - the field should read "false"
5. Change the field to "true"
6. Find "Show calculator" - the field should read "false"
7. Change the field to "true"
8. Save changes
9. Go back to Content -> "Pages & Resources"
10. Open the settings for Notes and Calculator - both will be disabled.
11. View the course live and go to any unit.
12. Both the calculator and Notes feature will be available.
13. Go back to the "Pages & Resources"
14. Change the setting on Notes to first be enabled (save), and then disabled again (save again)
15. Viewing the advanced settings page will show that notes are now disabled.
16. View the course live.
17. Notes will be disabled.
18. Repeat step 14-17 for calculator and it will also be disabled.
