### PR TITLE
fix: remove text from base query_params

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1018,7 +1018,6 @@ def get_thread_list(
         "group_id": group_id,
         "page": page,
         "per_page": page_size,
-        "text": text_search,
         "sort_key": cc_map.get(order_by),
         "author_id": author_id,
         "flagged": flagged,


### PR DESCRIPTION
## Related Ticket
https://github.com/mitodl/hq/issues/9634 (MIT Internal)

## Description
This pull request makes a small change to the `get_thread_list` function in `lms/djangoapps/discussion/rest_api/api.py`, removing the `text_search` parameter from the returned dictionary.
`text` is not required for `subscribed_threads` and we are adding it else wise

Useful information to include:

In recent [forum updates](https://github.com/openedx/forum/commit/3aa5d3671b602a1177f9bd4e77e9a1bedef13f3e#diff-06511d2865b10a8f91712e4a4e6e2122b5f68cd4b7facb2d240dae8bda3305acL68) we moved from `kwargs` to named arguments that could be the reason this `text` was not throwing any error before

## Steps to Reproduce
1. Make sure discussions are enabled
2. Follow a post on the discussion board for any of your course.
3. Click "All Topics"
4. Then filter by `Following` posts

## Testing instructions
1. Repeat the above steps and there shouldn't be any error now
