### PR TITLE
WIP: refactor: remove modulestore global

### DIFF
--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -34,10 +34,11 @@ def get_course_updates(location, provided_id, user_id):
     Retrieve the relevant course_info updates and unpack into the model which the client expects:
     [{id : index, date : string, content : html string}]
     """
+    store = modulestore()
     try:
-        course_updates = modulestore().get_item(location)
+        course_updates = store.get_item(location)
     except ItemNotFoundError:
-        course_updates = modulestore().create_item(user_id, location.course_key, location.block_type, location.block_id)
+        course_updates = store.create_item(user_id, location.course_key, location.block_type, location.block_id)
 
     course_update_items = get_course_update_items(course_updates, _get_index(provided_id))
     return _get_visible_update(course_update_items)
@@ -52,10 +53,11 @@ def update_course_updates(location, update, passed_id=None, user=None, request_m
         It will update it if it has a passed_id which has a valid value.
         Until updates have distinct values, the passed_id is the location url + an index into the html structure.
     """
+    store = modulestore()
     try:
-        course_updates = modulestore().get_item(location)
+        course_updates = store.get_item(location)
     except ItemNotFoundError:
-        course_updates = modulestore().create_item(user.id, location.course_key, location.block_type, location.block_id)
+        course_updates = store.create_item(user.id, location.course_key, location.block_type, location.block_id)
 
     course_update_items = list(reversed(get_course_update_items(course_updates)))
     course_update_dict = None

--- a/cms/djangoapps/contentstore/exams.py
+++ b/cms/djangoapps/contentstore/exams.py
@@ -31,12 +31,14 @@ def register_exams(course_key):
         # if feature is not enabled then do a quick exit
         return
 
-    course = modulestore().get_course(course_key)
+    store = modulestore()
+
+    course = store.get_course(course_key)
     if course is None:
         raise ItemNotFoundError("Course {} does not exist", str(course_key))  # lint-amnesty, pylint: disable=raising-format-tuple
 
     # get all sequences, since they can be marked as timed/proctored exams
-    _timed_exams = modulestore().get_items(
+    _timed_exams = store.get_items(
         course_key,
         qualifiers={
             'category': 'sequential',

--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -70,11 +70,12 @@ def get_parent_xblock(xblock):
     Returns the xblock that is the parent of the specified xblock, or None if it has no parent.
     """
     locator = xblock.location
-    parent_location = modulestore().get_parent_location(locator)
+    store = modulestore()
+    parent_location = store.get_parent_location(locator)
 
     if parent_location is None:
         return None
-    return modulestore().get_item(parent_location)
+    return store.get_item(parent_location)
 
 
 def is_unit(xblock, parent_xblock=None):

--- a/cms/djangoapps/contentstore/proctoring.py
+++ b/cms/djangoapps/contentstore/proctoring.py
@@ -39,7 +39,8 @@ def register_special_exams(course_key):
         # if feature is not enabled then do a quick exit
         return
 
-    course = modulestore().get_course(course_key)
+    store = modulestore()
+    course = store.get_course(course_key)
     if course is None:
         raise ItemNotFoundError("Course {} does not exist", str(course_key))  # lint-amnesty, pylint: disable=raising-format-tuple
 
@@ -49,7 +50,7 @@ def register_special_exams(course_key):
         return
 
     # get all sequences, since they can be marked as timed/proctored exams
-    _timed_exams = modulestore().get_items(
+    _timed_exams = store.get_items(
         course_key,
         qualifiers={
             'category': 'sequential',

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -638,13 +638,14 @@ def find_release_date_source(xblock):
     if xblock.category == 'chapter':
         return xblock
 
-    parent_location = modulestore().get_parent_location(xblock.location,
-                                                        revision=ModuleStoreEnum.RevisionOption.draft_preferred)
+    store = modulestore()
+    parent_location = store.get_parent_location(xblock.location,
+                                                revision=ModuleStoreEnum.RevisionOption.draft_preferred)
     # Orphaned xblocks set their own release date
     if not parent_location:
         return xblock
 
-    parent = modulestore().get_item(parent_location)
+    parent = store.get_item(parent_location)
     if parent.start != xblock.start:
         return xblock
     else:
@@ -665,13 +666,14 @@ def find_staff_lock_source(xblock):
     if xblock.category == 'chapter':
         return None
 
-    parent_location = modulestore().get_parent_location(xblock.location,
+    store = modulestore()
+    parent_location = store.get_parent_location(xblock.location,
                                                         revision=ModuleStoreEnum.RevisionOption.draft_preferred)
     # Orphaned xblocks set their own staff lock
     if not parent_location:
         return None
 
-    parent = modulestore().get_item(parent_location)
+    parent = store.get_item(parent_location)
     return find_staff_lock_source(parent)
 
 
@@ -680,12 +682,13 @@ def ancestor_has_staff_lock(xblock, parent_xblock=None):
     Returns True iff one of xblock's ancestors has staff lock.
     Can avoid mongo query by passing in parent_xblock.
     """
+    store = modulestore()
     if parent_xblock is None:
-        parent_location = modulestore().get_parent_location(xblock.location,
-                                                            revision=ModuleStoreEnum.RevisionOption.draft_preferred)
+        parent_location = store.get_parent_location(xblock.location,
+                                                    revision=ModuleStoreEnum.RevisionOption.draft_preferred)
         if not parent_location:
             return False
-        parent_xblock = modulestore().get_item(parent_location)
+        parent_xblock = store.get_item(parent_location)
     return parent_xblock.visible_to_staff_only
 
 
@@ -1116,9 +1119,10 @@ def get_subsections_by_assignment_type(course_key):
     the display name of the section they are in
     """
     subsections_by_assignment_type = defaultdict(list)
+    store = modulestore()
 
-    with modulestore().bulk_operations(course_key):
-        course = modulestore().get_course(course_key, depth=3)
+    with store.bulk_operations(course_key):
+        course = store.get_course(course_key, depth=3)
         sections = course.get_children()
         for section in sections:
             subsections = section.get_children()

--- a/xmodule/modulestore/tests/django_utils.py
+++ b/xmodule/modulestore/tests/django_utils.py
@@ -19,7 +19,7 @@ from django.test.utils import override_settings
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import _CONTENTSTORE
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import SignalHandler, clear_existing_modulestores, modulestore
+from xmodule.modulestore.django import SignalHandler, modulestore
 from xmodule.modulestore.tests.factories import XMODULE_FACTORY_LOCK
 from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
 
@@ -321,7 +321,6 @@ class ModuleStoreIsolationMixin(CacheIsolationMixin, SignalIsolationMixin):
         override.__enter__()  # pylint: disable=unnecessary-dunder-call
         cls.__settings_overrides.append(override)
         XMODULE_FACTORY_LOCK.enable()
-        clear_existing_modulestores()
         cls.store = modulestore()
 
     @classmethod
@@ -525,10 +524,6 @@ class ModuleStoreTestCase(
 
           The reason is: XML courses are not editable, so to reset
           a course you have to reload it from disk, which is slow.
-
-          If you do need to reset an XML course, use
-          `clear_existing_modulestores()` directly in
-          your `setUp()` method.
     """
 
     CREATE_USER = True


### PR DESCRIPTION
Let's see how much stuff breaks if we just remove the cache modulestore global.

This could introduce a performance regression if it's called many times (it looks like it takes something like 1-2 ms per invocation). If it is a problem, request-level caching may be enough to take care of it.

Holding onto global modulestore references has long been a source of memory leaks and gives us many opportunities to shoot ourselves in the foot when dealing with multiple threads and potential cross-contamination of the shared object across multiple users. This could remove a whole class of bugs if it works. Of course, it could also break things in unanticipated ways.

There are a bunch of places where we call `modulestore()` repeatedly in the same function instead of assigning to a variable, on the assumption that it's a singleton. We would want to clean that up. It might involve passing the modulestore as an optional argument in a bunch of places, so we stop recreating it so casually, like:

```python
def some_fn(foo, bar, store=None):
    store = store or modulestore()
    # rest of function
```

The risk is performance regression from calling modulestore init functions many times.

It's also possible that we can make modulestore init even cheaper than it is today.