### PR TITLE
feat: `ObjectTag.is_copied` field added to serializer [FC-0114]

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/serializers.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/serializers.py
@@ -105,6 +105,11 @@ class ObjectTagCopiedMinimalSerializer(ObjectTagMinimalSerializer):
     object tags if is copied.
     """
 
+    is_copied = serializers.BooleanField(read_only=True)
+
+    class Meta(ObjectTagMinimalSerializer.Meta):
+        fields = ObjectTagMinimalSerializer.Meta.fields + ["is_copied"]
+
     def get_can_delete_objecttag(self, instance):
         """
         Verify if the user can delete the object tag.

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1880,8 +1880,18 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
             'taxonomy_id': taxonomy.pk,
             'can_tag_object': True,
             'tags': [
-                {'value': 'Tag 1', 'lineage': ['Tag 1'], 'can_delete_objecttag': True},
-                {'value': 'Tag 2', 'lineage': ['Tag 2'], 'can_delete_objecttag': True},
+                {
+                    'value': 'Tag 1',
+                    'lineage': ['Tag 1'],
+                    'can_delete_objecttag': True,
+                    'is_copied': False,
+                },
+                {
+                    'value': 'Tag 2',
+                    'lineage': ['Tag 2'],
+                    'can_delete_objecttag': True,
+                    'is_copied': False,
+                },
             ],
         }]
 
@@ -1913,8 +1923,18 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
             'can_tag_object': True,
             'export_id': self.t1.export_id,
             'tags': [
-                {'value': 'android', 'lineage': ['ALPHABET', 'android'], 'can_delete_objecttag': False},
-                {'value': 'anvil', 'lineage': ['ALPHABET', 'anvil'], 'can_delete_objecttag': True}
+                {
+                    'value': 'android',
+                    'lineage': ['ALPHABET', 'android'],
+                    'can_delete_objecttag': False,
+                    'is_copied': True,
+                },
+                {
+                    'value': 'anvil',
+                    'lineage': ['ALPHABET', 'anvil'],
+                    'can_delete_objecttag': True,
+                    'is_copied': False,
+                },
             ]
         }]
 
@@ -1952,8 +1972,18 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
         object_id = str(object_key)
         tagging_api.tag_object(object_id=object_id, taxonomy=self.t1, tags=["anvil", "android"])
         expected_tags = [
-            {"value": "android", "lineage": ["ALPHABET", "android"], "can_delete_objecttag": expected_perm},
-            {"value": "anvil", "lineage": ["ALPHABET", "anvil"], "can_delete_objecttag": expected_perm},
+            {
+                "value": "android",
+                "lineage": ["ALPHABET", "android"],
+                "can_delete_objecttag": expected_perm,
+                "is_copied": False,
+            },
+            {
+                "value": "anvil",
+                "lineage": ["ALPHABET", "anvil"],
+                "can_delete_objecttag": expected_perm,
+                "is_copied": False,
+            },
         ]
         url = OBJECT_TAGS_URL.format(object_id=object_id)
         user = getattr(self, user_attr)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- `ObjectTag.is_copied` field added to serializer
- Which edX user roles will this change impact? "Developer"

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2234
- Used in: https://github.com/openedx/frontend-app-authoring/pull/2812
- Internal ticket: https://tasks.opencraft.com/browse/FAL-4294

## Testing instructions

- Follow the testing instructions in: https://tasks.opencraft.com/browse/FAL-4294

## Deadline

None

## Other information

N/A
