### PR TITLE
build: Don't clean the `.venv` folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ requirements/edx/private.in
 requirements/edx/private.txt
 lms/envs/private.py
 cms/envs/private.py
+.venv/
 # end-noclean
 
 ### Python artifacts
@@ -143,7 +144,6 @@ autodeploy.properties
 .ws_migrations_complete
 dist
 *.bak
-.venv/
 venv*/
 # Visual Studio Code
 .vscode


### PR DESCRIPTION
Make it so `make clean` doesn't blow away the venv folder.  Given that
this is managed by the developer, we should be able to manage its
lifecycle independently.

It was previously just in the list of files that comes by default from
github's gitignore so it's not like we previously were of the opinion
that we should delete this folder.  Just that previously we had no
opinion about it and now I think we should not delete it.
