### PR TITLE
fix: Remove unused bad validation for images.

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -81,15 +81,7 @@ class CourseRunTeamSerializerMixin(serializers.Serializer):  # lint-amnesty, pyl
             )
 
 
-def image_is_jpeg_or_png(value):
-    content_type = value.content_type
-    if content_type not in list(IMAGE_TYPES.keys()):  # lint-amnesty, pylint: disable=consider-iterating-dictionary
-        raise serializers.ValidationError(
-            f'Only JPEG and PNG image types are supported. {content_type} is not valid')
-
-
 class CourseRunImageField(serializers.ImageField):  # lint-amnesty, pylint: disable=missing-class-docstring
-    default_validators = [image_is_jpeg_or_png]
 
     def get_attribute(self, instance):
         return course_image_url(instance)


### PR DESCRIPTION
The `CourseRunImageField` is a subclass of the DRF
`serializers.ImageField` serializer and that class ignores the
`default_validators` and actually just uses Django's image validation
which is already correct and does in fact validate that the image content
is correct not just that the image extension is correct.

The DRF code that does the validation:
https://github.com/encode/django-rest-framework/blob/main/rest_framework/fields.py#L1621-L1628

Which actually just calls the Django Image Validators.

The Django Field definition:
https://github.com/django/django/blob/main/django/forms/fields.py#L712

And you can see that in the
[`to_python`](https://github.com/django/django/blob/main/django/forms/fields.py#L721)
function of that class it actually checks the image content.

This function is never actually called and so it's just misleading.
