### PR TITLE
Use runtime service lookup for sandbox access

### DIFF
--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -39,7 +39,7 @@ from xblock.fields import (
     ScoreField,
     String,
     Timedelta,
-    XMLString
+    XMLString,
 )
 from xblock.progress import Progress
 from xblock.scorable import ScorableXBlockMixin, Score, ShowCorrectness
@@ -48,7 +48,7 @@ from xblocks_contrib.problem import ProblemBlock as _ExtractedProblemBlock
 from common.djangoapps.xblock_django.constants import (
     ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID,
     ATTR_KEY_USER_ID,
-    ATTR_KEY_USER_IS_STAFF
+    ATTR_KEY_USER_IS_STAFF,
 )
 from openedx.core.djangolib.markup import HTML, Text
 from xmodule.capa import responsetypes
@@ -56,10 +56,8 @@ from xmodule.capa.capa_problem import LoncapaProblem, LoncapaSystem
 from xmodule.capa.inputtypes import Status
 from xmodule.capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
 from xmodule.capa.util import convert_files_to_filenames, get_inner_html_from_xpath
-from xmodule.contentstore.django import contentstore
 from xmodule.raw_block import RawMixin
 from xmodule.util.builtin_assets import add_css_to_fragment, add_webpack_js_to_fragment
-from xmodule.util.sandboxing import SandboxService
 from xmodule.x_module import XModuleMixin, XModuleToXBlockMixin, shim_xmodule_js
 from xmodule.xml_block import XmlMixin
 
@@ -404,7 +402,7 @@ class _BuiltInProblemBlock(  # pylint: disable=too-many-public-methods,too-many-
         """
         return self.student_view(context, show_detailed_errors=True)
 
-    def handle_ajax(self, dispatch, data):
+    def handle_ajax(self, dispatch, data):  # pylint: disable=too-many-locals
         """
         This is called by courseware.block_render, to handle an AJAX call.
 
@@ -717,9 +715,7 @@ class _BuiltInProblemBlock(  # pylint: disable=too-many-public-methods,too-many-
             anonymous_student_id=None,
             cache=None,
             can_execute_unsafe_code=lambda: False,
-            get_python_lib_zip=(
-                lambda: SandboxService(contentstore, self.scope_ids.usage_id.context_key).get_python_lib_zip()
-            ),
+            get_python_lib_zip=(lambda: self.runtime.service(self, "sandbox").get_python_lib_zip()),
             DEBUG=None,
             i18n=self.runtime.service(self, "i18n"),
             render_template=None,


### PR DESCRIPTION
This change updates sandbox access to use self.runtime.service(self, "sandbox") instead of directly instantiating SandboxService.

- related to https://github.com/openedx/edx-platform/issues/36538#issuecomment-3643611955

Tested locally by creating a custom Python problem XBlock, publishing it, and updating it to verify sandbox functionality works as expected.