### PR TITLE
chore: updated version of enterprise-integrated-channels

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -562,7 +562,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.25
+enterprise-integrated-channels==0.1.28
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -878,7 +878,7 @@ enmerkar-underscore==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-enterprise-integrated-channels==0.1.25
+enterprise-integrated-channels==0.1.28
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -655,7 +655,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.25
+enterprise-integrated-channels==0.1.28
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -679,7 +679,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.25
+enterprise-integrated-channels==0.1.28
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via


### PR DESCRIPTION
This pull request updates the `enterprise-integrated-channels` dependency from version 0.1.25 to 0.1.28 across several requirements files. This ensures that all development, documentation, testing, and base environments use the latest compatible version of this package.

Dependency updates:

* Updated `enterprise-integrated-channels` to version 0.1.28 in `requirements/edx/base.txt`
* Updated `enterprise-integrated-channels` to version 0.1.28 in `requirements/edx/development.txt`
* Updated `enterprise-integrated-channels` to version 0.1.28 in `requirements/edx/doc.txt`
* Updated `enterprise-integrated-channels` to version 0.1.28 in `requirements/edx/testing.txt`