### PR TITLE
pin celery to avoid 5.6.1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,11 +17,13 @@
 # Stay on LTS version, remove once this is added to common constraint
 Django<6.0
 
-# Date: 2020-02-26
-# As it is not clarified what exact breaking changes will be introduced as per
-# the next major release, ensure the installed version is within boundaries.
+# Date: 2026-01-13
+# We would normally pin celery to <6.0.0 to avoid auto-updating across a major
+# version boundary without more thorough testing. The reason it's currently also
+# pinned to !=5.6.1 is because of a celery bug related to the eta and countdown
+# parameters. This bug caused operational issues in MIT's deployment.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35280
-celery>=5.2.2,<6.0.0
+celery>=5.2.2,!=5.6.1,<6.0.0
 
 # Date: 2020-02-10
 # django-oauth-toolkit version >=2.0.0 has breaking changes. More details

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -94,7 +94,7 @@ camel-converter[pydantic]==5.0.0
     # via meilisearch
 casbin-django-orm-adapter==1.7.0
     # via openedx-authz
-celery==5.6.1
+celery==5.6.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -187,7 +187,7 @@ casbin-django-orm-adapter==1.7.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-authz
-celery==5.6.1
+celery==5.6.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -138,7 +138,7 @@ casbin-django-orm-adapter==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-authz
-celery==5.6.1
+celery==5.6.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -138,7 +138,7 @@ casbin-django-orm-adapter==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-authz
-celery==5.6.1
+celery==5.6.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
This is to address an operational issue around grading tasks that MIT encountered.

FYI: @blarghmatey, @feanil, @kdmccormick 