### PR TITLE
Revert "refactor: hoist annotations for common settings with differing values"

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -68,6 +68,10 @@ CONTACT_MAILING_ADDRESS = _('Your Contact Mailing Address Here')
 # Dummy secret key for dev/test
 SECRET_KEY = 'dev key'
 
+# .. setting_name: STUDIO_NAME
+# .. setting_default: Your Platform Studio
+# .. setting_description: The name that will appear on the landing page of Studio, as well as in various emails and
+#   templates.
 STUDIO_NAME = _("Your Platform Studio")
 STUDIO_SHORT_NAME = _("Studio")
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -96,6 +96,15 @@ DISPLAY_HISTOGRAMS_TO_STAFF = False  # For large courses this slows down coursew
 
 REROUTE_ACTIVATION_EMAIL = False  # nonempty string = address for all activation emails
 
+# .. toggle_name: settings.ENABLE_DISCUSSION_HOME_PANEL
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Hides or displays a welcome panel under the Discussion tab, which includes a subscription
+#   on/off setting for discussion digest emails.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2013-07-30
+# .. toggle_warning: This should remain off in production until digest notifications are online.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/520
 ENABLE_DISCUSSION_HOME_PANEL = False
 
 # .. toggle_name: settings.ENABLE_DISCUSSION_EMAIL_DIGEST
@@ -278,6 +287,21 @@ ENABLED_PAYMENT_REPORTS = [
     "university_revenue_share",
     "certificate_status"
 ]
+
+# Turn off account locking if failed login attempts exceeds a limit
+# .. toggle_name: settings.ENABLE_MAX_FAILED_LOGIN_ATTEMPTS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: This feature will keep track of the number of failed login attempts on a given user's
+#   email. If the number of consecutive failed login attempts - without a successful login at some point - reaches
+#   a configurable threshold (default 6), then the account will be locked for a configurable amount of seconds
+#   (30 minutes) which will prevent additional login attempts until this time period has passed. If a user
+#   successfully logs in, all the counter which tracks the number of failed attempts will be reset back to 0. If
+#   set to False then account locking will be disabled for failed login attempts.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-01-30
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2331
+ENABLE_MAX_FAILED_LOGIN_ATTEMPTS = True
 
 # Hide any Personally Identifiable Information from application logs
 SQUELCH_PII_IN_LOGS = True
@@ -828,6 +852,11 @@ ALTERNATE_WORKER_QUEUES = 'cms'
 
 DATA_DIR = '/edx/var/edxapp/data'
 
+# .. setting_name: MAINTENANCE_BANNER_TEXT
+# .. setting_default: None
+# .. setting_description: Specifies the text that is rendered on the maintenance banner.
+# .. setting_warning: Depends on the `open_edx_util.display_maintenance_warning` waffle switch.
+#   The banner is only rendered when the switch is activated.
 MAINTENANCE_BANNER_TEXT = None
 
 # Set certificate issued date format. It supports all formats supported by

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1385,31 +1385,6 @@ ENABLE_CREDIT_ELIGIBILITY = True
 # .. toggle_tickets: 'https://openedx.atlassian.net/browse/VAN-622'
 ENABLE_COPPA_COMPLIANCE = False
 
-# .. toggle_name: settings.ENABLE_DISCUSSION_HOME_PANEL
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Hides or displays a welcome panel under the Discussion tab, which includes a subscription
-#   on/off setting for discussion digest emails. (Note: set to False by default in the CMS).
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2013-07-30
-# .. toggle_warning: This should remain off in production until digest notifications are online.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/520
-ENABLE_DISCUSSION_HOME_PANEL: bool
-
-# .. toggle_name: settings.ENABLE_MAX_FAILED_LOGIN_ATTEMPTS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: This feature will keep track of the number of failed login attempts on a given user's
-#   email. If the number of consecutive failed login attempts - without a successful login at some point - reaches
-#   a configurable threshold (default 6), then the account will be locked for a configurable amount of seconds
-#   (30 minutes) which will prevent additional login attempts until this time period has passed. If a user
-#   successfully logs in, all the counter which tracks the number of failed attempts will be reset back to 0. If
-#   set to False then account locking will be disabled for failed login attempts. (Note: set to False by default in the CMS).
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-01-30
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2331
-ENABLE_MAX_FAILED_LOGIN_ATTEMPTS: bool
-
 ###################### CAPA External Code Evaluation #######################
 
 # Used with XQueue
@@ -2978,17 +2953,3 @@ GEOIP_PATH = REPO_ROOT / "common/static/data/geoip/GeoLite2-Country.mmdb"
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2012-07-13
 WIKI_ENABLED = True
-
-# .. setting_name: MAINTENANCE_BANNER_TEXT
-# .. setting_default: None
-# .. setting_description: Specifies the text that is rendered on the maintenance banner.
-#   (Note: set to 'Sample banner message' by default in the CMS).
-# .. setting_warning: Depends on the `open_edx_util.display_maintenance_warning` waffle switch.
-#   The banner is only rendered when the switch is activated.
-MAINTENANCE_BANNER_TEXT: str | None
-
-# .. setting_name: STUDIO_NAME
-# .. setting_default: Your Platform Studio
-# .. setting_description: The name that will appear on the landing page of Studio, as well as in various emails and
-#   templates. (Note: set to 'Studio' by default in the LMS).
-STUDIO_NAME: str


### PR DESCRIPTION
Reverts openedx/edx-platform#37800
Because of this error 

```
lms-1  | 2026-01-14 07:05:21,651 ERROR 22 [django.request] [user None] [ip 110.39.173.34] log.py:253 - Internal Server Error: /api/user/v2/account/login_session/
lms-1  | Traceback (most recent call last):
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
lms-1  |     response = get_response(request)
lms-1  |                ^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
lms-1  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
lms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
lms-1  |     return func(*args, **kwds)
lms-1  |            ^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
lms-1  |     return view_func(request, *args, **kwargs)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/generic/base.py", line 105, in view
lms-1  |     return self.dispatch(request, *args, **kwargs)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/utils/decorators.py", line 48, in _wrapper
lms-1  |     return bound_method(*args, **kwargs)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/debug.py", line 143, in sensitive_post_parameters_wrapper
lms-1  |     return view(request, *args, **kwargs)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/user_authn/views/login.py", line 777, in dispatch
lms-1  |     return super().dispatch(request, *args, **kwargs)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 515, in dispatch
lms-1  |     response = self.handle_exception(exc)
lms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 475, in handle_exception
lms-1  |     self.raise_uncaught_exception(exc)
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
lms-1  |     raise exc
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 512, in dispatch
lms-1  |     response = handler(request, *args, **kwargs)
lms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/utils/decorators.py", line 48, in _wrapper
lms-1  |     return bound_method(*args, **kwargs)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/utils/decorators.py", line 192, in _view_wrapper
lms-1  |     result = _process_exception(request, e)
lms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/utils/decorators.py", line 190, in _view_wrapper
lms-1  |     response = view_func(request, *args, **kwargs)
lms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/user_authn/views/login.py", line 773, in post
lms-1  |     return login_user(request, api_version)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/utils/decorators.py", line 192, in _view_wrapper
lms-1  |     result = _process_exception(request, e)
lms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/utils/decorators.py", line 190, in _view_wrapper
lms-1  |     response = view_func(request, *args, **kwargs)
lms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/http.py", line 64, in inner
lms-1  |     return func(request, *args, **kwargs)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django_ratelimit/decorators.py", line 27, in _wrapped
lms-1  |     return fn(request, *args, **kw)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django_ratelimit/decorators.py", line 27, in _wrapped
lms-1  |     return fn(request, *args, **kw)
lms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/user_authn/views/login.py", line 593, in login_user
lms-1  |     _check_excessive_login_attempts(user)
lms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/user_authn/views/login.py", line 158, in _check_excessive_login_attempts
lms-1  |     if user and LoginFailures.is_feature_enabled():
lms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/edx-platform/common/djangoapps/student/models/user.py", line 974, in is_feature_enabled
lms-1  |     return settings.FEATURES['ENABLE_MAX_FAILED_LOGIN_ATTEMPTS']
lms-1  |            ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1  |   File "/openedx/edx-platform/openedx/core/lib/features_setting_proxy.py", line 30, in __getitem__
lms-1  |     return self.ns[key]
lms-1  |            ~~~~~~~^^^^^
lms-1  | KeyError: 'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS'

```