### PR TITLE
refactor: hoist annotations for common settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -68,10 +68,6 @@ CONTACT_MAILING_ADDRESS = _('Your Contact Mailing Address Here')
 # Dummy secret key for dev/test
 SECRET_KEY = 'dev key'
 
-# .. setting_name: STUDIO_NAME
-# .. setting_default: Your Platform Studio
-# .. setting_description: The name that will appear on the landing page of Studio, as well as in various emails and
-#   templates.
 STUDIO_NAME = _("Your Platform Studio")
 STUDIO_SHORT_NAME = _("Studio")
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -96,15 +96,6 @@ DISPLAY_HISTOGRAMS_TO_STAFF = False  # For large courses this slows down coursew
 
 REROUTE_ACTIVATION_EMAIL = False  # nonempty string = address for all activation emails
 
-# .. toggle_name: settings.ENABLE_DISCUSSION_HOME_PANEL
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Hides or displays a welcome panel under the Discussion tab, which includes a subscription
-#   on/off setting for discussion digest emails.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2013-07-30
-# .. toggle_warning: This should remain off in production until digest notifications are online.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/520
 ENABLE_DISCUSSION_HOME_PANEL = False
 
 # .. toggle_name: settings.ENABLE_DISCUSSION_EMAIL_DIGEST
@@ -288,19 +279,6 @@ ENABLED_PAYMENT_REPORTS = [
     "certificate_status"
 ]
 
-# Turn off account locking if failed login attempts exceeds a limit
-# .. toggle_name: settings.ENABLE_MAX_FAILED_LOGIN_ATTEMPTS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: This feature will keep track of the number of failed login attempts on a given user's
-#   email. If the number of consecutive failed login attempts - without a successful login at some point - reaches
-#   a configurable threshold (default 6), then the account will be locked for a configurable amount of seconds
-#   (30 minutes) which will prevent additional login attempts until this time period has passed. If a user
-#   successfully logs in, all the counter which tracks the number of failed attempts will be reset back to 0. If
-#   set to False then account locking will be disabled for failed login attempts.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-01-30
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2331
 ENABLE_MAX_FAILED_LOGIN_ATTEMPTS = True
 
 # Hide any Personally Identifiable Information from application logs
@@ -852,11 +830,6 @@ ALTERNATE_WORKER_QUEUES = 'cms'
 
 DATA_DIR = '/edx/var/edxapp/data'
 
-# .. setting_name: MAINTENANCE_BANNER_TEXT
-# .. setting_default: None
-# .. setting_description: Specifies the text that is rendered on the maintenance banner.
-# .. setting_warning: Depends on the `open_edx_util.display_maintenance_warning` waffle switch.
-#   The banner is only rendered when the switch is activated.
 MAINTENANCE_BANNER_TEXT = None
 
 # Set certificate issued date format. It supports all formats supported by

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1385,6 +1385,31 @@ ENABLE_CREDIT_ELIGIBILITY = True
 # .. toggle_tickets: 'https://openedx.atlassian.net/browse/VAN-622'
 ENABLE_COPPA_COMPLIANCE = False
 
+# .. toggle_name: settings.ENABLE_DISCUSSION_HOME_PANEL
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Hides or displays a welcome panel under the Discussion tab, which includes a subscription
+#   on/off setting for discussion digest emails. (Note: set to False by default in the CMS).
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2013-07-30
+# .. toggle_warning: This should remain off in production until digest notifications are online.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/520
+ENABLE_DISCUSSION_HOME_PANEL: bool
+
+# .. toggle_name: settings.ENABLE_MAX_FAILED_LOGIN_ATTEMPTS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: This feature will keep track of the number of failed login attempts on a given user's
+#   email. If the number of consecutive failed login attempts - without a successful login at some point - reaches
+#   a configurable threshold (default 6), then the account will be locked for a configurable amount of seconds
+#   (30 minutes) which will prevent additional login attempts until this time period has passed. If a user
+#   successfully logs in, all the counter which tracks the number of failed attempts will be reset back to 0. If
+#   set to False then account locking will be disabled for failed login attempts. (Note: set to False by default in the CMS).
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-01-30
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2331
+ENABLE_MAX_FAILED_LOGIN_ATTEMPTS: bool
+
 ###################### CAPA External Code Evaluation #######################
 
 # Used with XQueue
@@ -2953,3 +2978,17 @@ GEOIP_PATH = REPO_ROOT / "common/static/data/geoip/GeoLite2-Country.mmdb"
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2012-07-13
 WIKI_ENABLED = True
+
+# .. setting_name: MAINTENANCE_BANNER_TEXT
+# .. setting_default: None
+# .. setting_description: Specifies the text that is rendered on the maintenance banner.
+#   (Note: set to 'Sample banner message' by default in the CMS).
+# .. setting_warning: Depends on the `open_edx_util.display_maintenance_warning` waffle switch.
+#   The banner is only rendered when the switch is activated.
+MAINTENANCE_BANNER_TEXT: str | None
+
+# .. setting_name: STUDIO_NAME
+# .. setting_default: Your Platform Studio
+# .. setting_description: The name that will appear on the landing page of Studio, as well as in various emails and
+#   templates. (Note: set to 'Studio' by default in the LMS).
+STUDIO_NAME: str


### PR DESCRIPTION
## Description

Hoist annotations for annotated settings with a type definition of the setting. This uses and fixes the work done in https://github.com/openedx/edx-platform/pull/37800, which was reverted due to `ENABLE_MAX_FAILED_LOGIN_ATTEMPTS` being accidentally removed from `lms/envs/common.py`.

## Supporting information

Reference https://github.com/openedx/edx-platform/pull/37800 and https://github.com/openedx/edx-platform/issues/37281.

## Testing instructions

Verified rendered settings do not differ with [diff_settings.py ](https://github.com/WGU-Open-edX/oex-utils/blob/main/settings_utils/diff_settings.py) script.

## Deadline

None