### PR TITLE
refactor: convert global modulestore to request-cached

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -44,6 +44,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, is_active=True)
 
         self.transformers = BlockStructureTransformers([self.TRANSFORMER_CLASS_TO_TEST(False)])
+        self.clear_caches()
 
     def setup_gated_section(self, gated_block, gating_block):
         """
@@ -184,7 +185,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
             self.user,
         )
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             self.get_blocks_and_check_against_expected(self.user, self.ALL_BLOCKS_EXCEPT_SPECIAL)
 
     def test_staff_access(self):

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -289,7 +289,7 @@ class TestGradeIteration(SharedModuleStoreTestCase):
             else mock_course_grade.return_value
             for student in self.students
         ]
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(21):
             all_course_grades, all_errors = self._course_grades_and_errors_for(self.course, self.students)
         assert {student: str(all_errors[student]) for student in all_errors} == {
             student3: 'Error for student3.',

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -11,7 +11,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewi
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..utils import format_social_link, validate_social_link
@@ -63,7 +63,7 @@ class UserAccountSettingsTest(TestCase):
 
 
 @ddt.ddt
-class CompletionUtilsTestCase(SharedModuleStoreTestCase, CompletionWaffleTestMixin, TestCase):
+class CompletionUtilsTestCase(ModuleStoreTestCase, CompletionWaffleTestMixin, TestCase):
     """
     Test completion utility functions
     """


### PR DESCRIPTION
A re-push of https://github.com/openedx/edx-platform/pull/37859 because I think something in the CI for that PR is broken.

```
Having a global modulestore reference is a holdover from the early days,
when the XML modulestore would be extremely expensive to initialize.
That is no longer the case, and we should eliminate the global here to
reduce the chances of multi-threading bugs that might mutate the global.

Unfortunately, a lot of code currently assumes that calls to the
modulestore() function are essentially free, instead of the 1-2 ms it
is without caching. There are cases where this may be called thousands of
times deep in loops somewhere while doing course content traversal, so
it's risky to eliminate the caching behavior altogether. The thought here
is that we'll tie to the RequestCache, which should at least not be shared
across users/threads.

Since new instances of the modulestore will not have cached entries for
a particular course, it means that some query count tests have to be
adjusted upward.
```