### PR TITLE
fix: video_config runtime service added when loading for xBlock

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -27,6 +27,7 @@ from milestones import api as milestones_api
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey, UsageKeyV2
 from opaque_keys.edx.locator import BlockUsageLocator, LibraryContainerLocator, LibraryLocator
+from openedx.core.djangoapps.video_config.services import VideoConfigService
 from openedx_events.content_authoring.data import DuplicatedXBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DUPLICATED
 from openedx_events.learning.data import CourseNotificationData
@@ -1314,7 +1315,8 @@ def load_services_for_studio(runtime, user):
         "settings": SettingsService(),
         "lti-configuration": ConfigurationService(CourseAllowPIISharingInLTIFlag),
         "teams_configuration": TeamsConfigurationService(),
-        "library_tools": LegacyLibraryToolsService(modulestore(), user.id)
+        "library_tools": LegacyLibraryToolsService(modulestore(), user.id),
+        "video_config": VideoConfigService(),
     }
 
     runtime._services.update(services)  # lint-amnesty, pylint: disable=protected-access


### PR DESCRIPTION
## Related Ticket
https://github.com/mitodl/hq/issues/9905 (MIT Internal)

## Description

Thanks @farhan for helping me out in understanding the new changing  around VideoXblock and this issue 👍 

This pull request introduces the `VideoConfigService` into the Studio runtime service loader, making video configuration functionality available throughout the Studio application. The main change is the addition of this service to the set of services loaded for Studio.

**Service integration:**

* Imported `VideoConfigService` from `openedx.core.djangoapps.video_config.services` in `cms/djangoapps/contentstore/utils.py`.
* Added `video_config` entry to the services dictionary in the `load_services_for_studio` function, enabling access to video configuration features in Studio.

## Testing instructions

1. Create a new Course or use an existing one
2. Add video Xblock and try to upload transcript(any language)
3. In master branch -- there will be an error (Response: Runtime does not support transcripts.)
4. Deleting the transcript results in same error
5. Checkout to this branch
6. Upload/delete transcript -- It should work fine