### PR TITLE
Discussion service to enable permission and access provider

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -19,6 +19,7 @@ from xblock.exceptions import NoSuchHandlerError, NotFoundError, ProcessingError
 from xblock.runtime import KvsFieldData
 
 from openedx.core.djangoapps.video_config.services import VideoConfigService
+from openedx.core.djangoapps.discussions.services import DiscussionConfigService
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError as XModuleNotFoundError
 from xmodule.modulestore.django import XBlockI18nService, modulestore
@@ -228,6 +229,7 @@ def _prepare_runtime_for_preview(request, block):
         "cache": CacheService(cache),
         'replace_urls': ReplaceURLService,
         'video_config': VideoConfigService(),
+        'discussion_config': DiscussionConfigService(),
     }
 
     block.runtime.get_block_for_descriptor = partial(_load_preview_block, request)

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -229,7 +229,7 @@ def _prepare_runtime_for_preview(request, block):
         "cache": CacheService(cache),
         'replace_urls': ReplaceURLService,
         'video_config': VideoConfigService(),
-        'discussion_config': DiscussionConfigService(),
+        'discussion_config_service': DiscussionConfigService(),
     }
 
     block.runtime.get_block_for_descriptor = partial(_load_preview_block, request)

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -638,7 +638,7 @@ def prepare_runtime_for_user(
         'publish': EventPublishingService(user, course_id, track_function),
         'enrollments': EnrollmentsService(),
         'video_config': VideoConfigService(),
-        'discussion_config': DiscussionConfigService(),
+        'discussion_config_service': DiscussionConfigService(),
     }
 
     runtime.get_block_for_descriptor = inner_get_block

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -43,6 +43,7 @@ from xblock.runtime import KvsFieldData
 
 from lms.djangoapps.teams.services import TeamsService
 from openedx.core.djangoapps.video_config.services import VideoConfigService
+from openedx.core.djangoapps.discussions.services import DiscussionConfigService
 from openedx.core.lib.xblock_services.call_to_action import CallToActionService
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError as XModuleNotFoundError
@@ -637,6 +638,7 @@ def prepare_runtime_for_user(
         'publish': EventPublishingService(user, course_id, track_function),
         'enrollments': EnrollmentsService(),
         'video_config': VideoConfigService(),
+        'discussion_config': DiscussionConfigService(),
     }
 
     runtime.get_block_for_descriptor = inner_get_block

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -407,11 +407,11 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         """
         # Enable new OPEN_EDX provider for this course
         course_key = self.course.location.course_key
-        # DiscussionsConfiguration.objects.create(
-        #     context_key=course_key,
-        #     enabled=True,
-        #     provider_type=Provider.OPEN_EDX,
-        # )
+        DiscussionsConfiguration.objects.create(
+            context_key=course_key,
+            enabled=True,
+            provider_type=Provider.OPEN_EDX,
+        )
 
         discussion_xblock = get_block_for_descriptor(
             user=self.user,

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -28,6 +28,7 @@ from lms.djangoapps.course_api.blocks.tests.helpers import deserialize_usage_key
 from lms.djangoapps.courseware.block_render import get_block_for_descriptor
 from lms.djangoapps.courseware.tests.helpers import XModuleRenderingTestBase
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
+from openedx.core.djangoapps.discussions.services import DiscussionConfigService
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 
@@ -193,6 +194,14 @@ class TestViews(TestDiscussionXBlock):
             'can_create_subcomment': permission_dict['create_sub_comment'],
         }
 
+        self.add_patcher(
+            patch.multiple(
+                DiscussionConfigService,
+                is_discussion_visible=mock.Mock(return_value=True),
+                is_discussion_enabled=mock.Mock(return_value=True)
+            )
+        )
+
         self.block.has_permission = lambda perm: permission_dict[perm]
         with mock.patch('xmodule.discussion_block.render_to_string', return_value='') as mock_render:
             self.block.student_view()
@@ -223,13 +232,10 @@ class TestTemplates(TestDiscussionXBlock):
         Test for has_permission method.
         """
         permission_canary = object()
-        with mock.patch(
-            'xmodule.discussion_block.has_permission',
-            return_value=permission_canary,
-        ) as has_perm:
-            actual_permission = self.block.has_permission("test_permission")
+        self.block.has_permission = mock.Mock(return_value=permission_canary)
+        actual_permission = self.block.has_permission("test_permission")
         assert actual_permission == permission_canary
-        has_perm.assert_called_once_with(self.django_user_canary, 'test_permission', self.course_id)
+        self.block.has_permission.assert_called_once_with("test_permission")
 
     def test_studio_view(self):
         """Test for studio view."""
@@ -251,6 +257,14 @@ class TestTemplates(TestDiscussionXBlock):
             'create_comment': permissions[1],
             'create_sub_comment': permissions[2]
         }
+
+        self.add_patcher(
+            patch.multiple(
+                DiscussionConfigService,
+                is_discussion_visible=mock.Mock(return_value=True),
+                is_discussion_enabled=mock.Mock(return_value=True)
+            )
+        )
 
         self.block.has_permission = lambda perm: permission_dict[perm]
         fragment = self.block.student_view()
@@ -296,7 +310,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
             block = block.get_parent()
         return block
 
-    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_html_with_user(self):
         """
         Test rendered DiscussionXBlock permissions.
@@ -317,7 +331,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         assert 'data-user-create-comment="false"' in html
         assert 'data-user-create-subcomment="false"' in html
 
-    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_discussion_render_successfully_with_orphan_parent(self):
         """
         Test that discussion xblock render successfully
@@ -393,11 +407,11 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         """
         # Enable new OPEN_EDX provider for this course
         course_key = self.course.location.course_key
-        DiscussionsConfiguration.objects.create(
-            context_key=course_key,
-            enabled=True,
-            provider_type=Provider.OPEN_EDX,
-        )
+        # DiscussionsConfiguration.objects.create(
+        #     context_key=course_key,
+        #     enabled=True,
+        #     provider_type=Provider.OPEN_EDX,
+        # )
 
         discussion_xblock = get_block_for_descriptor(
             user=self.user,
@@ -421,7 +435,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
     Test the number of queries executed when rendering the XBlock.
     """
 
-    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_permissions_query_load(self):
         """
         Tests that the permissions queries are cached when rendering numerous discussion XBlocks.

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -25,6 +25,7 @@ from openedx_events.learning.signals import (
 
 import lms.djangoapps.discussion.django_comment_client.settings as cc_settings
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from common.djangoapps.student.roles import GlobalStaff
 from common.djangoapps.track import contexts
 from common.djangoapps.util.file import store_uploaded_file
@@ -33,8 +34,7 @@ from lms.djangoapps.courseware.courses import get_course_overview_with_access, g
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion.django_comment_client.permissions import (
     check_permissions_by_view,
-    get_team,
-    has_permission
+    get_team
 )
 from lms.djangoapps.discussion.django_comment_client.utils import (
     JsonError,

--- a/lms/djangoapps/discussion/django_comment_client/permissions.py
+++ b/lms/djangoapps/discussion/django_comment_client/permissions.py
@@ -12,24 +12,9 @@ from lms.djangoapps.teams.models import CourseTeam
 from openedx.core.djangoapps.django_comment_common.comment_client import Thread
 from openedx.core.djangoapps.django_comment_common.models import (
     CourseDiscussionSettings,
-    all_permissions_for_user_in_course
+    has_permission
 )
 from openedx.core.lib.cache_utils import request_cached
-
-
-def has_permission(user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
-    assert isinstance(course_id, (type(None), CourseKey))
-    request_cache_dict = DEFAULT_REQUEST_CACHE.data
-    cache_key = "django_comment_client.permissions.has_permission.all_permissions.{}.{}".format(
-        user.id, course_id
-    )
-    if cache_key in request_cache_dict:
-        all_permissions = request_cache_dict[cache_key]
-    else:
-        all_permissions = all_permissions_for_user_in_course(user, course_id)
-        request_cache_dict[cache_key] = all_permissions
-
-    return permission in all_permissions
 
 
 CONDITIONS = ['is_open', 'is_author', 'is_question_author', 'is_team_member_if_applicable']

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -24,10 +24,10 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 from lms.djangoapps.discussion.django_comment_client.permissions import (
     check_permissions_by_view,
-    get_team,
-    has_permission
+    get_team
 )
 from lms.djangoapps.discussion.django_comment_client.settings import MAX_COMMENT_DEPTH
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id
 from openedx.core.djangoapps.discussions.utils import (
     get_accessible_discussion_xblocks,

--- a/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
@@ -11,7 +11,7 @@ from django.utils.translation import gettext as _, ngettext
 from django.template.defaultfilters import escapejs
 from django.urls import reverse
 
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -28,6 +28,7 @@ from xmodule.modulestore.django import modulestore
 
 import lms.djangoapps.discussion.django_comment_client.utils as utils
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
 from common.djangoapps.util.json_request import JsonResponse, expect_json
@@ -37,7 +38,6 @@ from lms.djangoapps.courseware.views.views import CourseTabView
 from lms.djangoapps.discussion.config.settings import is_forum_daily_digest_enabled
 from lms.djangoapps.discussion.django_comment_client.base.views import track_thread_viewed_event
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
 from lms.djangoapps.discussion.django_comment_client.utils import (
     add_courseware_context,
     course_discussion_division_enabled,

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,7 @@ files =
     # openedx/core/djangoapps/content/search,
     openedx/core/djangoapps/content_staging,
     openedx/core/djangoapps/content_libraries,
+    openedx/core/djangoapps/discussions/services.py,
     openedx/core/djangoapps/programs/rest_api,
     openedx/core/djangoapps/xblock,
     openedx/core/lib/derived.py,

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -7,6 +7,7 @@ for the extracted discussion block in xblocks-contrib repository.
 """
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
@@ -17,7 +18,7 @@ class DiscussionConfigService:
     Service for providing discussion-related configuration and feature flags.
     """
 
-    def has_permission(self, user, permission, course_id: CourseKey = None) -> bool:
+    def has_permission(self, user: User, permission: str, course_id: CourseKey = None) -> bool:
         """
         Return whether the user has the given discussion permission for a given course.
         """

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -7,7 +7,7 @@ for the extracted discussion block in xblocks-contrib repository.
 """
 
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -7,6 +7,7 @@ for the extracted discussion block in xblocks-contrib repository.
 """
 
 from django.conf import settings
+from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 
@@ -16,21 +17,21 @@ class DiscussionConfigService:
     Service for providing discussion-related configuration and feature flags.
     """
 
-    def has_permission(self, user, permission, course_id=None):
+    def has_permission(self, user, permission, course_id: CourseKey = None) -> bool:
         """
-        Return the discussion permission for a user in a given course.
+        Return whether the user has the given discussion permission for a given course.
         """
         return has_permission(user, permission, course_id)
 
-    def is_discussion_visible(self, course_key):
+    def is_discussion_visible(self, course_key: CourseKey) -> bool:
         """
         Discussion Xblock does not support new OPEN_EDX provider
         """
         provider = DiscussionsConfiguration.get(course_key)
         return provider.provider_type == Provider.LEGACY
 
-    def is_discussion_enabled(self):
+    def is_discussion_enabled(self) -> bool:
         """
         Return True if discussions are enabled; else False
         """
-        return settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE')
+        return settings.ENABLE_DISCUSSION_SERVICE

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -1,0 +1,29 @@
+"""
+Discussion Configuration Service for XBlock runtime.
+
+This service provides discussion-related configuration and feature flags
+that are specific to the edx-platform implementation
+for the extracted discussion block in xblocks-contrib repository.
+"""
+
+from django.conf import settings
+from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
+
+class DiscussionConfigService:
+
+    def discussion_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
+        return has_permission(user, permission, course_id)
+
+    def is_discussion_visible(self, course_key):
+        """
+        Discussion Xblock does not support new OPEN_EDX provider
+        """
+        provider = DiscussionsConfiguration.get(course_key)
+        return provider.provider_type == Provider.LEGACY
+
+    def is_discussion_enabled():
+        """
+        Return True if discussions are enabled; else False
+        """
+        return settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE')

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -13,10 +13,10 @@ from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration,
 
 class DiscussionConfigService:
     """
-    Service for providing video-related configuration and feature flags.
+    Service for providing discussion-related configuration and feature flags.
     """
 
-    def has_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def has_permission(self, user, permission, course_id=None):
         """
         Return the discussion permission for a user in a given course.
         """

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -6,15 +6,31 @@ that are specific to the edx-platform implementation
 for the extracted discussion block in xblocks-contrib repository.
 """
 
+from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
+from opaque_keys.edx.keys import CourseKey
+
 from django.conf import settings
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.django_comment_common.models import (
+    all_permissions_for_user_in_course
+)
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 
 
 class DiscussionConfigService:
 
     def discussion_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
-        return has_permission(user, permission, course_id)
+        assert isinstance(course_id, (type(None), CourseKey))
+        request_cache_dict = DEFAULT_REQUEST_CACHE.data
+        cache_key = "django_comment_client.permissions.has_permission.all_permissions.{}.{}".format(
+            user.id, course_id
+        )
+        if cache_key in request_cache_dict:
+            all_permissions = request_cache_dict[cache_key]
+        else:
+            all_permissions = all_permissions_for_user_in_course(user, course_id)
+            request_cache_dict[cache_key] = all_permissions
+
+        return permission in all_permissions
 
     def is_discussion_visible(self, course_key):
         """

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -20,7 +20,7 @@ class DiscussionConfigService:
     """
     Service for providing video-related configuration and feature flags.
     """
-    
+
     def discussion_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
         assert isinstance(course_id, (type(None), CourseKey))
         request_cache_dict = DEFAULT_REQUEST_CACHE.data

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -21,7 +21,7 @@ class DiscussionConfigService:
     Service for providing video-related configuration and feature flags.
     """
 
-    def discussion_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def has_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
         assert isinstance(course_id, (type(None), CourseKey))
         request_cache_dict = DEFAULT_REQUEST_CACHE.data
         cache_key = "django_comment_client.permissions.has_permission.all_permissions.{}.{}".format(

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 
+
 class DiscussionConfigService:
 
     def discussion_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
@@ -22,7 +23,7 @@ class DiscussionConfigService:
         provider = DiscussionsConfiguration.get(course_key)
         return provider.provider_type == Provider.LEGACY
 
-    def is_discussion_enabled():
+    def is_discussion_enabled(self):
         """
         Return True if discussions are enabled; else False
         """

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -6,13 +6,8 @@ that are specific to the edx-platform implementation
 for the extracted discussion block in xblocks-contrib repository.
 """
 
-from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
-from opaque_keys.edx.keys import CourseKey
-
 from django.conf import settings
-from openedx.core.djangoapps.django_comment_common.models import (
-    all_permissions_for_user_in_course
-)
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 
 
@@ -22,18 +17,10 @@ class DiscussionConfigService:
     """
 
     def has_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
-        assert isinstance(course_id, (type(None), CourseKey))
-        request_cache_dict = DEFAULT_REQUEST_CACHE.data
-        cache_key = "django_comment_client.permissions.has_permission.all_permissions.{}.{}".format(
-            user.id, course_id
-        )
-        if cache_key in request_cache_dict:
-            all_permissions = request_cache_dict[cache_key]
-        else:
-            all_permissions = all_permissions_for_user_in_course(user, course_id)
-            request_cache_dict[cache_key] = all_permissions
-
-        return permission in all_permissions
+        """
+        Return the discussion permission for a user in a given course.
+        """
+        return has_permission(user, permission, course_id)
 
     def is_discussion_visible(self, course_key):
         """

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -17,7 +17,10 @@ from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration,
 
 
 class DiscussionConfigService:
-
+    """
+    Service for providing video-related configuration and feature flags.
+    """
+    
     def discussion_permission(self, user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
         assert isinstance(course_id, (type(None), CourseKey))
         request_cache_dict = DEFAULT_REQUEST_CACHE.data

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -18,7 +18,7 @@ class DiscussionConfigService:
     Service for providing discussion-related configuration and feature flags.
     """
 
-    def has_permission(self, user: User, permission: str, course_id: CourseKey = None) -> bool:
+    def has_permission(self, user: User, permission: str, course_id: CourseKey | None = None) -> bool:
         """
         Return whether the user has the given discussion permission for a given course.
         """

--- a/openedx/core/djangoapps/django_comment_common/models.py
+++ b/openedx/core/djangoapps/django_comment_common/models.py
@@ -14,6 +14,8 @@ from django.dispatch import receiver
 from django.utils.translation import gettext_noop
 from jsonfield.fields import JSONField
 from opaque_keys.edx.django.models import CourseKeyField
+from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
+from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from openedx.core.lib.cache_utils import request_cached
@@ -191,6 +193,39 @@ def all_permissions_for_user_in_course(user, course_id):
             permission_names.add(permission)
 
     return permission_names
+
+
+def has_permission(user, permission, course_id=None):
+    """
+    Check whether a user has a specific discussion permission within a course.
+
+    This function resolves all discussion-related permissions for the given
+    user and course, caches them for the duration of the request, and verifies
+    whether the requested permission is present.
+
+    Args:
+        user (User): Django user whose permissions are being checked.
+        permission (str): Discussion permission identifier to check for
+            (e.g., "create_comment", "create_thread").
+        course_id (CourseKey): Course context in which to evaluate
+            the permission
+
+    Returns:
+        bool: True if the user has the specified permission in the given
+        course context; False otherwise.
+    """
+    assert isinstance(course_id, (type(None), CourseKey))
+    request_cache_dict = DEFAULT_REQUEST_CACHE.data
+    cache_key = "django_comment_client.permissions.has_permission.all_permissions.{}.{}".format(
+        user.id, course_id
+    )
+    if cache_key in request_cache_dict:
+        all_permissions = request_cache_dict[cache_key]
+    else:
+        all_permissions = all_permissions_for_user_in_course(user, course_id)
+        request_cache_dict[cache_key] = all_permissions
+
+    return permission in all_permissions
 
 
 class ForumsConfig(ConfigurationModel):

--- a/openedx/core/djangoapps/django_comment_common/models.py
+++ b/openedx/core/djangoapps/django_comment_common/models.py
@@ -197,15 +197,13 @@ def all_permissions_for_user_in_course(user, course_id):
 
 def has_permission(user, permission, course_id=None):
     """
-    Check whether a user has a specific discussion permission within a course.
-
     This function resolves all discussion-related permissions for the given
     user and course, caches them for the duration of the request, and verifies
     whether the requested permission is present.
 
     Args:
         user (User): Django user whose permissions are being checked.
-        permission (str): Discussion permission identifier to check for
+        permission (str): Discussion permission identifier
             (e.g., "create_comment", "create_thread").
         course_id (CourseKey): Course context in which to evaluate
             the permission

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -347,7 +347,7 @@ class XBlockRuntime(RuntimeShim, Runtime):
             # Import here to avoid circular dependency
             from openedx.core.djangoapps.video_config.services import VideoConfigService
             return VideoConfigService()
-        elif service_name == 'discussion_config':
+        elif service_name == 'discussion_config_service':
             from openedx.core.djangoapps.discussions.services import DiscussionConfigService
             return DiscussionConfigService()
 

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -347,6 +347,9 @@ class XBlockRuntime(RuntimeShim, Runtime):
             # Import here to avoid circular dependency
             from openedx.core.djangoapps.video_config.services import VideoConfigService
             return VideoConfigService()
+        elif service_name == 'discussion_config':
+            from openedx.core.djangoapps.discussions.services import DiscussionConfigService
+            return DiscussionConfigService()
 
         # Otherwise, fall back to the base implementation which loads services
         # defined in the constructor:

--- a/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
+++ b/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
@@ -15,7 +15,7 @@ import json
 from django.utils.translation import gettext as _
 from django.template.defaultfilters import escapejs
 
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import course_home_page_title

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -17,8 +17,6 @@ from xblock.utils.resources import ResourceLoader
 from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xblocks_contrib.discussion import DiscussionXBlock as _ExtractedDiscussionXBlock
 
-from openedx.core.djangoapps.django_comment_common.models import has_permission
-from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.xblock_utils import get_css_dependencies, get_js_dependencies
 from xmodule.xml_block import XmlMixin
@@ -37,6 +35,7 @@ def _(text):
 @XBlock.needs('user')  # pylint: disable=abstract-method
 @XBlock.needs('i18n')
 @XBlock.needs('mako')
+@XBlock.needs('discussion_config_service')
 class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
                                XmlMixin):  # lint-amnesty, pylint: disable=abstract-method
     """
@@ -77,6 +76,13 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
     has_author_view = True  # Tells Studio to use author_view
 
     @property
+    def discussion_config_service(self):
+        """
+        Returns discussion configuration service.
+        """
+        return self.runtime.service(self, 'discussion_config_service')
+
+    @property
     def course_key(self):
         return getattr(self.scope_ids.usage_id, 'course_key', None)
 
@@ -85,8 +91,18 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
         """
         Discussion Xblock does not support new OPEN_EDX provider
         """
-        provider = DiscussionsConfiguration.get(self.course_key)
-        return provider.provider_type == Provider.LEGACY
+        if self.discussion_config_service:
+            return self.discussion_config_service.is_discussion_visible(self.course_key)
+        return False
+
+    @property
+    def is_discussion_enabled(self):
+        """
+        Returns True if discussions are enabled; else False
+        """
+        if self.discussion_config_service:
+            return self.discussion_config_service.is_discussion_enabled()
+        return False
 
     @property
     def django_user(self):
@@ -159,15 +175,14 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
         :param str permission: Permission
         :rtype: bool
         """
-        return has_permission(self.django_user, permission, self.course_key)
+        if self.discussion_config_service:
+            return self.discussion_config_service.has_permission(self.django_user, permission, self.course_key)
+        return False
 
     def student_view(self, context=None):
         """
         Renders student view for LMS.
         """
-        # to prevent a circular import issue
-        import lms.djangoapps.discussion.django_comment_client.utils as utils
-
         fragment = Fragment()
 
         if not self.is_visible:
@@ -193,7 +208,7 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
                     url='{}?{}'.format(reverse('register_user'), qs),
                 ),
             )
-        if utils.is_discussion_enabled(self.course_key):
+        if self.is_discussion_enabled:
             context = {
                 'discussion_id': self.discussion_id,
                 'display_name': self.display_name if self.display_name else _("Discussion"),

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -85,7 +85,6 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
         """
         Discussion Xblock does not support new OPEN_EDX provider
         """
-        
         provider = DiscussionsConfiguration.get(self.course_key)
         return provider.provider_type == Provider.LEGACY
 

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -17,7 +17,7 @@ from xblock.utils.resources import ResourceLoader
 from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xblocks_contrib.discussion import DiscussionXBlock as _ExtractedDiscussionXBlock
 
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.xblock_utils import get_css_dependencies, get_js_dependencies
@@ -85,6 +85,7 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
         """
         Discussion Xblock does not support new OPEN_EDX provider
         """
+        
         provider = DiscussionsConfiguration.get(self.course_key)
         return provider.provider_type == Provider.LEGACY
 
@@ -282,8 +283,17 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
                 setattr(block, field_name, value)
 
 
-DiscussionXBlock = (
-    _ExtractedDiscussionXBlock if settings.USE_EXTRACTED_DISCUSSION_BLOCK
-    else _BuiltInDiscussionXBlock
-)
+DiscussionXBlock = None
+
+
+def reset_class():
+    """Reset class as per django settings flag"""
+    global DiscussionXBlock
+    DiscussionXBlock = (
+        _ExtractedDiscussionXBlock if settings.USE_EXTRACTED_DISCUSSION_BLOCK
+        else _BuiltInDiscussionXBlock
+    )
+    return DiscussionXBlock
+
+reset_class()
 DiscussionXBlock.__name__ = "DiscussionXBlock"

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -35,7 +35,7 @@ def _(text):
 @XBlock.needs('user')  # pylint: disable=abstract-method
 @XBlock.needs('i18n')
 @XBlock.needs('mako')
-@XBlock.needs('discussion_config_service')
+@XBlock.wants('discussion_config_service')
 class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
                                XmlMixin):  # lint-amnesty, pylint: disable=abstract-method
     """

--- a/xmodule/tests/__init__.py
+++ b/xmodule/tests/__init__.py
@@ -33,7 +33,7 @@ from xmodule.util.sandboxing import SandboxService
 from xmodule.x_module import DoNothingCache, XModuleMixin, ModuleStoreRuntime
 from openedx.core.djangoapps.video_config.services import VideoConfigService
 from openedx.core.lib.cache_utils import CacheService
-
+from openedx.core.djangoapps.discussions.services import DiscussionConfigService
 
 MODULE_DIR = path(__file__).dirname()
 # Location of common test DATA directory
@@ -161,6 +161,7 @@ def get_test_system(
         'field-data': DictFieldData({}),
         'sandbox': SandboxService(contentstore, course_id),
         'video_config': VideoConfigService(),
+        'discussion_config_service': DiscussionConfigService()
     }
 
     descriptor_system.get_block_for_descriptor = get_block  # lint-amnesty, pylint: disable=attribute-defined-outside-init
@@ -217,6 +218,7 @@ def prepare_block_runtime(
         'field-data': DictFieldData({}),
         'sandbox': SandboxService(contentstore, course_id),
         'video_config': VideoConfigService(),
+        'discussion_config_service': DiscussionConfigService()
     }
 
     if add_overrides:


### PR DESCRIPTION
## Description

In edx-platform discussion 's specific permissions and discussion 's provider settings are managing with django models which are difficult to manage in discussion block extraction. 
Ref: Discussion permissions
https://github.com/openedx/edx-platform/blob/5b1951228efca6afe0a3f18837236bd797cfadf4/lms/djangoapps/discussion/django_comment_client/permissions.py#L20

https://github.com/openedx/edx-platform/blob/5b1951228efca6afe0a3f18837236bd797cfadf4/openedx/core/djangoapps/django_comment_common/models.py#L163

Ref: DiscussionProvider
https://github.com/openedx/edx-platform/blob/5b1951228efca6afe0a3f18837236bd797cfadf4/openedx/core/djangoapps/discussions/models.py#L408

https://github.com/openedx/edx-platform/blob/5b1951228efca6afe0a3f18837236bd797cfadf4/openedx/core/djangoapps/discussions/models.py#L37


In this PR we created a service `DiscussionConfig` with the required methods to get the permissions and provider settings, added the service in runtime so that it can be  easily accessible in xblocks-contrib. 


Ticket: https://github.com/orgs/openedx/projects/55/views/1?pane=issue&itemId=149237882&issue=openedx%7Cpublic-engineering%7C481


## Acceptance Criteria

- Discussion block UI and functionality should be functional.
- All test should be green

## How to test 

1. Enable Discussion xblock
     ```
      tutor plugins install forum
      tutor plugins enable forum
      tutor dev do init -l forum
    ```
2. There are two types of provider (`openedx`, `legacy`) to load the discussion block. We can set these provider in `Discussions/Discussions configurations` in django admin.
3. Set the provider to `legacy`.
4. Add discussion xblock in studio from components.
5. Test the discussion xblock functionality and UI on LMS.

## Testing Results
<img width="1479" height="795" alt="Screenshot 2026-01-26 at 3 29 46 PM" src="https://github.com/user-attachments/assets/f970e80a-a0e0-4352-8ec1-6768cb9d0791" />
<img width="1130" height="744" alt="Screenshot 2026-01-26 at 3 30 22 PM" src="https://github.com/user-attachments/assets/000763f0-f3d2-489a-9096-194cebeb33d8" />
<img width="1403" height="780" alt="Screenshot 2026-01-26 at 3 30 33 PM" src="https://github.com/user-attachments/assets/fd9e479a-32cf-47da-acb9-3514961b7871" />
<img width="1149" height="584" alt="Screenshot 2026-01-26 at 3 30 06 PM" src="https://github.com/user-attachments/assets/381d7d37-7b38-4b61-ac61-267bf2f60c88" />

