### PR TITLE
build: Don't try to read the database when building docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ from subprocess import check_call
 
 import django
 import git
+from django.db.models.query import QuerySet
 
 from path import Path
 
@@ -379,7 +380,14 @@ def on_init(app):  # lint-amnesty, pylint: disable=redefined-outer-name, unused-
         check_call(args)
 
 
+def skip_querysets(app, what, name, obj, skip, options):
+    # If the object is a Django QuerySet, skip it
+    if isinstance(obj, QuerySet):
+        return True
+    return skip
+
+
 def setup(app):  # lint-amnesty, pylint: disable=redefined-outer-name
     """Sphinx extension: run sphinx-apidoc."""
-    event = 'builder-inited'
-    app.connect(event, on_init)
+    app.connect('builder-inited', on_init)
+    app.connect('autodoc-skip-member', skip_querysets)


### PR DESCRIPTION
Sphinx tries to explore all the defined objects when trying to generate
docs from the code.  When it tries to introspect the QuerySet object, it
results in that object trying to query the database which we don't
really want to setup for a docs build as it's not relevant and fairly
expensive to do.  To circumvent this issue, we add a new filter to the
docs build that essentially skips further introspection of QuerySet
objects.
