### PR TITLE
fix: set correct final grade value for ORA summary endpoint

### DIFF
--- a/lms/djangoapps/instructor/ora.py
+++ b/lms/djangoapps/instructor/ora.py
@@ -12,7 +12,7 @@ DEFAULT_ORA_METRICS = {
     'self': 0,
     'waiting': 0,
     'staff': 0,
-    'final_grade_received': 0,
+    'done': 0,
 }
 
 
@@ -93,5 +93,5 @@ def get_ora_summary(course):
         summary['self'] += item['self']
         summary['waiting'] += item['waiting']
         summary['staff'] += item['staff']
-        summary['final_grade_received'] += item['final_grade_received']
+        summary['final_grade_received'] += item['done']
     return summary

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -1055,6 +1055,32 @@ class ORASummaryViewTest(ORABaseViewsTest):
             course_id = str(self.course_key)
         return reverse(self.view_name, kwargs={'course_id': course_id})
 
+    @patch('openassessment.data.OraAggregateData.collect_ora2_responses')
+    def test_get_ora_summary_with_final_grades(self, mock_get_responses):
+        """Test retrieving the ORA summary with final grades."""
+
+        mock_get_responses.return_value = {
+            self.ora_usage_key: {
+                "done": 3,
+                "total": 2,
+                "total_responses": 0,
+                "training": 0,
+                "peer": 0,
+                "self": 0,
+                "waiting": 0,
+                "staff": 0,
+            }
+        }
+
+        response = self.client.get(
+            self._get_url()
+        )
+
+        assert response.status_code == 200
+        data = response.data
+
+        assert data['final_grade_received'] == 3
+
     def test_get_ora_summary(self):
         """Test retrieving the ORA summary."""
 

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -432,7 +432,7 @@ class ORASerializer(serializers.Serializer):
     self = serializers.IntegerField()
     waiting = serializers.IntegerField()
     staff = serializers.IntegerField()
-    final_grade_received = serializers.IntegerField()
+    final_grade_received = serializers.IntegerField(source="done")
 
 
 class ORASummarySerializer(serializers.Serializer):


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

During testing of the new V2 ORA summary endpoints, an issue was identified with the final grade value. The problem was caused by an incorrect mapping when retrieving data from the OraAggregateData interface.
