### PR TITLE
fix: enhance PDF viewer security by removing file parameters and validating URLs

### DIFF
--- a/common/static/js/vendor/pdfjs/viewer.js
+++ b/common/static/js/vendor/pdfjs/viewer.js
@@ -27,7 +27,7 @@
 
 'use strict';
 
-var DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
+var DEFAULT_URL = '';
 var DEFAULT_SCALE_DELTA = 1.1;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 10.0;
@@ -1291,7 +1291,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
           if (this.pagesToSearch < 0) {
             // No point in wrapping again, there were no matches.
             this.updateMatch(false);
-            // while matches were not found, searching for a page 
+            // while matches were not found, searching for a page
             // with matches should nevertheless halt.
             return true;
           }
@@ -1324,7 +1324,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
       offset.matchIdx = null;
 
       this.pagesToSearch--;
-      
+
       if (offset.pageIdx >= numPages || offset.pageIdx < 0) {
         offset.pageIdx = (previous ? numPages - 1 : 0);
         offset.wrapped = true;
@@ -1335,7 +1335,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
       var state = FindStates.FIND_NOTFOUND;
       var wrapped = this.offset.wrapped;
       this.offset.wrapped = false;
-    
+
       if (found) {
         var previousPage = this.selected.pageIdx;
         this.selected.pageIdx = this.offset.pageIdx;
@@ -1346,7 +1346,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
           this.updatePage(previousPage);
         }
       }
-    
+
       this.updateUIState(state, this.state.findPrevious);
       if (this.selected.pageIdx !== -1) {
         this.updatePage(this.selected.pageIdx);
@@ -2708,7 +2708,7 @@ var DocumentProperties = {
 
   parseDate: function documentPropertiesParseDate(inputDate) {
     // This is implemented according to the PDF specification (see
-    // http://www.gnupdf.org/Date for an overview), but note that 
+    // http://www.gnupdf.org/Date for an overview), but note that
     // Adobe Reader doesn't handle changing the date to universal time
     // and doesn't use the user's time zone (they're effectively ignoring
     // the HH' and mm' parts of the date string).

--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -99,6 +99,9 @@ def pdf_index(request, course_id, book_index, chapter=None, page=None):
     if 'chapters' in textbook:
         for entry in textbook['chapters']:
             entry['url'] = remap_static_url(entry['url'], course)
+            # Security: Validate chapter URL doesn't contain dangerous schemes
+            if entry['url'].lower().startswith(('javascript:', 'data:', 'vbscript:', 'file:')):
+                entry['url'] = ''  # Sanitize dangerous URLs
         if chapter is not None and int(chapter) <= (len(textbook['chapters'])):
             current_chapter = textbook['chapters'][int(chapter) - 1]
         else:

--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -86,7 +86,7 @@ def pdf_index(request, course_id, book_index, chapter=None, page=None):
         raise Http404(f"Invalid book index value: {book_index}")
     textbook = course.pdf_textbooks[book_index]
 
-    viewer_params = '&file='
+    viewer_params = ''
     current_url = ''
 
     if 'url' in textbook:

--- a/lms/templates/pdf_viewer.html
+++ b/lms/templates/pdf_viewer.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <%namespace name='static' file='static_content.html'/>
 <%!
 from openedx.core.djangolib.js_utils import (
@@ -46,10 +46,44 @@ http://sourceforge.net/adobe/cmap/wiki/License/
         PDFJS.workerSrc = "${static.url('js/vendor/pdfjs/pdf.worker.js') | n, js_escaped_string}";
         PDFJS.disableWorker = true;
         PDFJS.cMapUrl = "${static.url('css/vendor/pdfjs/cmaps/') | n, js_escaped_string}";
-        PDF_URL = '${current_url | n, js_escaped_string}';
+
+        var PDF_URL = '${current_url | n, js_escaped_string}';
+
+        if (window.parent !== window) {
+          window.parent.postMessage({type: 'request_pdf_url'}, '*');
+
+          function handlePdfUrlResponse(event) {
+            if (event.data && event.data.type === 'pdf_url_response') {
+              PDF_URL = event.data.url;
+
+              if (PDFViewerApplication.open) {
+                PDFViewerApplication.open(PDF_URL);
+                PDFViewerApplication.mouseScroll(0);
+
+                setTimeout(function() {
+                  if (PDFViewerApplication.pdfDocument) {
+                    if (event.data.title) document.getElementById('titleField').textContent = event.data.title;
+                    if (event.data.author) document.getElementById('authorField').textContent = event.data.author;
+                    if (event.data.subject) document.getElementById('subjectField').textContent = event.data.subject;
+                    if (event.data.keywords) document.getElementById('keywordsField').textContent = event.data.keywords;
+                    document.getElementById('creatorField').textContent = 'edX Platform';
+                  }
+                }, 500);
+              }
+            } else if (event.data && event.data.type === 'chapter_change') {
+              window.parent.postMessage({type: 'request_pdf_url'}, '*');
+            }
+          }
+
+          window.addEventListener('message', handlePdfUrlResponse);
+        }
+
+        document.addEventListener('DOMContentLoaded', function () {
+          PDFViewerApplication && PDFViewerApplication.open(PDF_URL);
+        });
     </script>
 
-    <script ${static.url('js/vendor/pdfjs/debugger.js')}></script>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/debugger.js')}"></script>
 
     <%static:js group='main_vendor'/>
     <%static:js group='application'/>
@@ -347,77 +381,77 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
-<div id="mozPrintCallback-shim" hidden>
-  <style scoped>
-#mozPrintCallback-shim {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  z-index: 9999999;
+    <div id="mozPrintCallback-shim" hidden>
+      <style scoped>
+        #mozPrintCallback-shim {
+          position: fixed;
+          top: 0;
+          left: 0;
+          height: 100%;
+          width: 100%;
+          z-index: 9999999;
 
-  display: block;
-  text-align: center;
-  background-color: rgba(0, 0, 0, 0.5);
-}
-#mozPrintCallback-shim[hidden] {
-  display: none;
-}
-@media print {
-  #mozPrintCallback-shim {
-    display: none;
-  }
-}
+          display: block;
+          text-align: center;
+          background-color: rgba(0, 0, 0, 0.5);
+        }
+        #mozPrintCallback-shim[hidden] {
+          display: none;
+        }
+        @media print {
+          #mozPrintCallback-shim {
+            display: none;
+          }
+        }
 
-#mozPrintCallback-shim .mozPrintCallback-dialog-box {
-  display: inline-block;
-  margin: -50px auto 0;
-  position: relative;
-  top: 45%;
-  left: 0;
-  min-width: 220px;
-  max-width: 400px;
+        #mozPrintCallback-shim .mozPrintCallback-dialog-box {
+          display: inline-block;
+          margin: -50px auto 0;
+          position: relative;
+          top: 45%;
+          left: 0;
+          min-width: 220px;
+          max-width: 400px;
 
-  padding: 9px;
+          padding: 9px;
 
-  border: 1px solid hsla(0, 0%, 0%, .5);
-  border-radius: 2px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+          border: 1px solid hsla(0, 0%, 0%, .5);
+          border-radius: 2px;
+          box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 
-  background-color: #474747;
+          background-color: #474747;
 
-  color: hsl(0, 0%, 85%);
-  font-size: 16px;
-  line-height: 20px;
-}
-#mozPrintCallback-shim .progress-row {
-  clear: both;
-  padding: 1em 0;
-}
-#mozPrintCallback-shim progress {
-  width: 100%;
-}
-#mozPrintCallback-shim .relative-progress {
-  clear: both;
-  float: right;
-}
-#mozPrintCallback-shim .progress-actions {
-  clear: both;
-}
-  </style>
-  <div class="mozPrintCallback-dialog-box">
-    <!-- TODO: Localise the following strings -->
-    Preparing document for printing...
-    <div class="progress-row">
-      <progress value="0" max="100"></progress>
-      <span class="relative-progress">0%</span>
+          color: hsl(0, 0%, 85%);
+          font-size: 16px;
+          line-height: 20px;
+        }
+        #mozPrintCallback-shim .progress-row {
+          clear: both;
+          padding: 1em 0;
+        }
+        #mozPrintCallback-shim progress {
+          width: 100%;
+        }
+        #mozPrintCallback-shim .relative-progress {
+          clear: both;
+          float: right;
+        }
+        #mozPrintCallback-shim .progress-actions {
+          clear: both;
+        }
+      </style>
+      <div class="mozPrintCallback-dialog-box">
+        <!-- TODO: Localise the following strings -->
+        Preparing document for printing...
+        <div class="progress-row">
+          <progress value="0" max="100"></progress>
+          <span class="relative-progress">0%</span>
+        </div>
+        <div class="progress-actions">
+          <input type="button" value="Cancel" class="mozPrintCallback-cancel">
+        </div>
+      </div>
     </div>
-    <div class="progress-actions">
-      <input type="button" value="Cancel" class="mozPrintCallback-cancel">
-    </div>
-  </div>
-</div>
     <script type="text/javascript" src="${static.url('js/vendor/pdfjs/viewer.js')}"></script>
     <script type="text/javascript" src="${static.url('js/pdf-analytics.js')}"></script>
   </body>

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -17,23 +17,8 @@ from openedx.core.djangolib.js_utils import (
 
 
 <%include file="/courseware/course_navigation.html" args="active_page='pdftextbook/{0}'.format(book_index)" />
-<script>
-$(function(){
-  $('.chapter').click(function(e){
-    e.preventDefault();
-    var url = $(this).attr('rel');
-    $('#viewer-frame').attr({
-        'src': '${request.path | n, js_escaped_string}?viewer=true&file=' + url + '#zoom=page-fit&disableRange=true',
-        'title': $(this).text()
-        });
-    $('#viewer-frame').focus();
-    Logger.log("textbook.pdf.chapter.navigated", {"name": "textbook.pdf.chapter.navigated", "chapter": url, "chapter_title": $(this).text()});
-    });
-});
-</script>
-
 <main id="main" aria-label="${_('Content')}" tabindex="-1">
-    <div class="book-wrapper">
+  <div class="book-wrapper">
     %if 'chapters' in textbook:
     <section class="book-sidebar" aria-label="${_('Textbook Navigation')}">
         <ul id="booknav">
@@ -47,15 +32,61 @@ $(function(){
     %endif
 
     <div class="book">
-    <iframe
-    title="${current_chapter['title']}"
-    id="viewer-frame"
-    src="${request.path}?viewer=true${viewer_params}"
-    width="856"
-    height="1108"
-    frameborder="0"
-    tabindex="-1"
-    seamless></iframe>
+      <iframe
+        title="${current_chapter.get('title')}"
+        id="viewer-frame"
+        src="${request.path}?viewer=true${viewer_params}"
+        width="856" height="1108" frameborder="0" tabindex="-1" seamless></iframe>
     </div>
-    </div>
+  </div>
 </main>
+<script type="text/javascript">
+  $(function(){
+    var currentChapterUrl = null;
+    var currentChapterTitle = null;
+
+    // Handle PDF URL requests from iframe (PostMessage API requires 'message' event type)
+    function handlePdfUrlRequest(event) {
+      // Verify this is a PDF URL request from our iframe
+      if (event.data && event.data.type === 'request_pdf_url') {
+        if (currentChapterUrl) {
+          // Send the selected chapter URL back to the PDF viewer iframe
+          event.source.postMessage({
+            type: 'pdf_url_response',
+            url: currentChapterUrl,
+            title: currentChapterTitle || '',
+            author: 'edX Course',
+            subject: 'Course Material',
+            keywords: 'education,textbook,course'
+          }, '*');
+        }
+      }
+    }
+
+    // Listen for PostMessage communication from PDF viewer iframe
+    window.addEventListener('message', handlePdfUrlRequest);
+
+    $('.chapter').click(function(e){
+      e.preventDefault();
+      var $this = $(this);
+      var url = $this.attr('rel');
+      var chapterTitle = $this.text();
+
+      // Store the current chapter URL for postMessage
+      currentChapterUrl = url;
+      currentChapterTitle = chapterTitle;
+
+      $('#viewer-frame')[0].contentWindow.postMessage({type: 'chapter_change'}, '*');
+      Logger.log("textbook.pdf.chapter.navigated", {
+        "name": "textbook.pdf.chapter.navigated",
+        "chapter": url,
+        "chapter_title": chapterTitle
+      });
+    });
+
+    // Load iframe without file parameter - secure approach (first time only)
+    $('#viewer-frame').attr({
+      'src': '${request.path | n, js_escaped_string}?viewer=true${viewer_params | n, js_escaped_string}'
+    }).focus();
+  });
+</script>


### PR DESCRIPTION
This pull request is to fix the file param in URL which is creating security issue by sending arbitrary data in query param which can put cms under risk of different attacks like
- random load which is read
- xss attack if pdf.js is not handling properly while reading file param

Issue Screenshots:
<img width="2628" height="1752" alt="image" src="https://github.com/user-attachments/assets/dd1a3d8d-4a1c-44da-8beb-386eea21aec6" />

<img width="3802" height="2340" alt="image" src="https://github.com/user-attachments/assets/906b800a-abd5-4fae-be8b-1ecd215fdef1" />

Fixes done:
- Removed File param from iframe src
- Added postmessage based communication to pass on file path for loading the PDF on the pdf.js
- When the url of iframe is opened it will always show chapters first pdf by default.


https://github.com/user-attachments/assets/f478f275-1ef7-4d15-b869-45cb66fb0635


