### PR TITLE
fix: add missing staff_ora_grading_url field to ORA list endpoint

### DIFF
--- a/lms/djangoapps/instructor/docs/references/instructor-v2-ora-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-ora-api-spec.yaml
@@ -220,6 +220,7 @@ definitions:
       - waiting
       - staff
       - final_grade_received
+      - staff_ora_grading_url
     properties:
       block_id:
         type: string
@@ -268,7 +269,11 @@ definitions:
         minimum: 0
         description: Responses with final grade assigned
         example: 20
-
+      staff_ora_grading_url:
+        type: string
+        format: uri
+        description: URL to the staff grading interface for this ORA assessment
+        example: "https://courses.example.com/instructor/ora_grading/block-v1:edX+DemoX+Demo_Course+type@openassessment+block@ora1"
   Error:
     type: object
     description: Error response

--- a/lms/djangoapps/instructor/docs/references/instructor-v2-ora-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-ora-api-spec.yaml
@@ -273,7 +273,7 @@ definitions:
         type: string
         format: uri
         description: URL to the staff grading interface for this ORA assessment
-        example: "https://courses.example.com/instructor/ora_grading/block-v1:edX+DemoX+Demo_Course+type@openassessment+block@ora1"
+        example: "http://apps.local.openedx.io:1993/ora-grading/block-v1:WGU+CS002+2025_T1+type@openassessment+block@ff4f5fddf42d4b9787e69c1a8cbeb058"
   Error:
     type: object
     description: Error response

--- a/lms/djangoapps/instructor/ora.py
+++ b/lms/djangoapps/instructor/ora.py
@@ -62,7 +62,9 @@ def get_open_response_assessment_list(course):
         has_staff_assessment = 'staff-assessment' in block.assessment_steps
         is_team_enabled = block.teams_enabled
         if ora_grading_base_url and has_staff_assessment and not is_team_enabled:
-            # During the migration to the ORA grading microfrontend,
+            # Always generate a URL that points to the ORA Grading Microfrontend (MFE).
+            #
+            # During the migration to the ORA microfrontend,
             # only provide the grading URL for non-team assignments with staff assessment.
             # This logic was based on the original implementation in instructor_dashboard:
             #   - lms/djangoapps/instructor/views/instructor_dashboard.py

--- a/lms/djangoapps/instructor/ora.py
+++ b/lms/djangoapps/instructor/ora.py
@@ -1,6 +1,8 @@
 """Utilities for retrieving Open Response Assessments (ORAs) data for instructor dashboards."""
 
 from django.utils.translation import gettext as _
+from django.conf import settings
+
 from openassessment.data import OraAggregateData
 
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -37,6 +39,7 @@ def get_open_response_assessment_list(course):
 
     parents_cache = {}
     ora_items = []
+    ora_grading_base_url = getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', None)
 
     for block in openassessment_blocks:
         block_id = str(block.location)
@@ -54,10 +57,26 @@ def get_open_response_assessment_list(course):
             else block.display_name
         )
 
+        staff_ora_grading_url = None
+
+        has_staff_assessment = 'staff-assessment' in block.assessment_steps
+        is_team_enabled = block.teams_enabled
+        if ora_grading_base_url and has_staff_assessment and not is_team_enabled:
+            # During the migration to the ORA grading microfrontend,
+            # only provide the grading URL for non-team assignments with staff assessment.
+            # This logic was based on the original implementation in instructor_dashboard:
+            #   - lms/djangoapps/instructor/views/instructor_dashboard.py
+            #     (_section_open_response_assessment)
+            #   - edx-ora2:
+            #     https://github.com/openedx/edx-ora2/blob/801fbd14ebb059ab8c5ee8d5a39c260c7f87ab81/
+            #     openassessment/xblock/static/js/src/lms/oa_course_items_listing.js#L73
+            staff_ora_grading_url = f"{ora_grading_base_url}/{block_id}"
+
         ora_assessment_data = {
             'id': block_id,
             'name': assessment_name,
             'parent_name': parent_block.display_name,
+            'staff_ora_grading_url': staff_ora_grading_url,
             **DEFAULT_ORA_METRICS,
         }
 

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -460,6 +460,7 @@ class ORASerializer(serializers.Serializer):
     waiting = serializers.IntegerField()
     staff = serializers.IntegerField()
     final_grade_received = serializers.IntegerField(source="done")
+    staff_ora_grading_url = serializers.URLField(allow_null=True)
 
 
 class ORASummarySerializer(serializers.Serializer):


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

During testing of the new V2 ORA List endpoint, an issue was identified in the final response: the ORA grading URL field for staff assessment was missing. Initially, it was assumed that this URL would be constructed on the frontend. However, we later determined that it should be provided by the backend, since the MFE grading URL is configured there.
