### PR TITLE
chore(requirements): update `edx-search` to `4.4.0`

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -518,7 +518,7 @@ edx-rest-api-client==6.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==4.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -818,7 +818,7 @@ edx-rest-api-client==6.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -608,7 +608,7 @@ edx-rest-api-client==6.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==4.4.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -632,7 +632,7 @@ edx-rest-api-client==6.2.0
     #   edx-enterprise
     #   edx-proctoring
     #   enterprise-integrated-channels
-edx-search==4.3.0
+edx-search==4.4.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum


### PR DESCRIPTION
## Description

`4.4.0` (https://github.com/openedx/edx-search/releases/tag/v4.4.0) includes the new `unstable/v0/course_list_search/` endpoint which is needed for the Catalog MFE (https://github.com/openedx/frontend-app-catalog) to function properly.