### PR TITLE
fix: Update the repo name in github workflows.

### DIFF
--- a/.github/workflows/check-consistent-dependencies.yml
+++ b/.github/workflows/check-consistent-dependencies.yml
@@ -65,7 +65,7 @@ jobs:
           developers.
 
           Please see the requirements README for information on how to resolve this:
-          https://github.com/openedx/edx-platform/blob/master/requirements/README.rst#inconsistent-dependencies
+          https://github.com/openedx/openedx-platform/blob/master/requirements/README.rst#inconsistent-dependencies
           EOMARKDOWN
           )
 

--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install python dependencies
         run: make dev-requirements
 
-      # As long there are sub-projects[1] in edx-platform, we analyze each
+      # As long there are sub-projects[1] in openedx-platform, we analyze each
       # project separately here, in order to make import-linting errors easier
       # to pinpoint.
       #

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -205,7 +205,7 @@ jobs:
         if: ${{ env.root_all_unit_tests_count != env.shards_all_unit_tests_count }}
         run: |
           echo "::error title='Unit test modules in unit-test-shards.json (unit-tests.yml workflow) are outdated'::unit tests running in unit-tests
-          workflow don't match the count for unit tests for entire edx-platform suite, please update the unit-test-shards.json under .github/workflows
+          workflow don't match the count for unit tests for entire openedx-platform suite, please update the unit-test-shards.json under .github/workflows
           to add any missing apps and match the count. for more details please take a look at scripts/gha-shards-readme.md"
           exit 1
 
@@ -272,7 +272,7 @@ jobs:
 
   # Combine and upload coverage reports.
   coverage:
-    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/openedx-platform' && (startsWith(github.base_ref, 'release') == false))
     runs-on: ubuntu-24.04
     needs: [run-tests]
     strategy:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -12,11 +12,11 @@ on:
 jobs:
   call-upgrade-python-requirements-workflow:
     # Don't run the weekly upgrade job on forks -- it will send a weekly failure email.
-    if: github.repository == 'openedx/edx-platform' || github.event_name != 'schedule'
+    if: github.repository == 'openedx/openedx-platform' || github.event_name != 'schedule'
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
       branch: ${{ github.event.inputs.branch }}
-      team_reviewers: "wg-maintenance-edx-platform"
+      team_reviewers: "wg-maintenance-openedx-platform"
       email_address: orbi-bom@edx.org
       send_success_notification: false
     secrets:


### PR DESCRIPTION
Some workflows had links or conditionals based on the old repo name so
update them to use the new repository name.
