### PR TITLE
fix: remove unnecessary help urls tokens

### DIFF
--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -4,27 +4,20 @@
 [pages]
 default = course_author:quickstarts/build_a_course.html
 home = course_author:concepts/open_edx_platform/what_is_studio.html
-develop_course = course_author:how-tos/set_up_course/create_new_course.html
 outline = course_author:concepts/open_edx_platform/about_course_outline.html
 unit = course_author:concepts/open_edx_platform/about_course_units.html
 visibility = course_author:references/controlling_content_visibility.html
-updates = course_author:concepts/communication/about_course_updates_handouts.html
-pages = course_author:how-tos/course_development/manage_custom_page.html
-files = course_author:references/course_development/files_page.html
 textbooks = course_author:how-tos/course_development/manage_textbooks.html
 schedule = course_author:how-tos/set_up_course/set_course_schedule.html
 grading = course_author:how-tos/grading/set_grade_range.html
 team_course = course_author:references/course_development/course_team_roles.html
 team_library = course_author:how-tos/course_development/add_users_to_libraries.html
 advanced = course_author:quickstarts/build_a_course.html
-checklist = course_author:concepts/releasing-course/course_launch_checklist.html
 import_library = course_author:how-tos/course_development/export_import_library.html#import-a-legacy-library
 import_course = course_author:how-tos/releasing-course/import_course.html
 export_library = course_author:how-tos/course_development/export_import_library.html#export-a-legacy-library
 export_course = course_author:how-tos/releasing-course/export_course.html
 welcome = course_author:index.html
-login = course_author:index.html
-register = course_author:index.html
 content_libraries = course_author:concepts/instructional_design/libraries.html
 content_groups = course_author:concepts/advanced_features/about_content_groups.html
 enrollment_tracks = course_author:how-tos/student_management/manage_course_enrollments.html
@@ -33,7 +26,6 @@ container = course_author:references/course_development/parent_child_components.
 video = course_author:references/course_development/guide_to_video.html
 certificates = course_author:concepts/open_edx_platform/about_certificates.html
 content_highlights = course_author:how-tos/course_development/manage_course_highlight_emails.html
-image_accessibility = course_author:references/accessibility/accessibility_best_practices_checklist.html#use-best-practices-for-describing-images
 social_sharing = course_author:how-tos/course_development/social_sharing.html
 
 # below are the language directory names for the different locales

--- a/lms/envs/help_tokens.ini
+++ b/lms/envs/help_tokens.ini
@@ -5,20 +5,11 @@
 default = learner:index.html
 instructor = course_author:index.html
 course = learner:index.html
-profile = learner:concepts/open_edx_platform/what_is_profile_page.html
-dashboard = learner:concepts/open_edx_platform/what_is_course_dashboard.html
-courseinfo = learner:SFD_start_course.html
 progress = learner:SFD_check_progress.html
-learneraccountsettings = learner:how-tos/update_course_specific_settings.html
 learnerdashboard = learner:concepts/open_edx_platform/what_is_course_dashboard.html
 programs = learner:OpenSFD_enrolling.html
-bookmarks = learner:SFD_bookmarks.html
 notes = learner:SFD_notes.html
-wiki = learner:SFD_wiki.html
 discussions = learner:sfd_discussions/index.html
-
-cohortmanual = course_author:references/advanced_features/managing_cohort_assignment.html#implementing-a-manual-assignment-strategy
-cohortautomatic = course_author:references/advanced_features/managing_cohort_assignment.html#implementing-an-automated-assignment-strategy
 
 # below are the language directory names for the different locales
 [locales]


### PR DESCRIPTION
# Description

This PR is intended to remove the help tokens that are no longer referenced within the Open edX repositories. Specifically, a search was conducted across the _openedx_ organization to find references to the functionalities of the [help tokens](https://github.com/openedx/help-tokens) tool.

It is important to note that this PR is part of a commitment made in the following PR: https://github.com/openedx/openedx-platform/pull/37493, where these tokens were updated to use articles from the official Open edX documentation.

# Research Summary

After searching for these tokens across the _openedx_ organization, we obtained the following results, which show the tokens that were found and the location (repository) where they were identified:

- CMS

| Token                | Location                                                   |
| :------------------- | :--------------------------------------------------------- |
| home                 | frontend-app-authoring                                     |
| certificates         | frontend-app-authoring, openedx-platform - legacy template |
| textbooks            | frontend-app-authoring                                     |
| content_highlights   | frontend-app-authoring                                     |
| import_course        | frontend-app-authoring, openedx-platform - legacy template |
| social_sharing       | frontend-app-authoring                                     |
| default              | frontend-app-authoring                                     |
| export_course        | frontend-app-authoring                                     |
| visibility           | frontend-app-authoring                                     |
| grading              | frontend-app-authoring, openedx-platform - legacy template |
| outline              | frontend-app-authoring                                     |
| group_configurations | frontend-app-authoring, openedx-platform - legacy template |
| enrollment_tracks    | frontend-app-authoring, openedx-platform - legacy template |
| content_groups       | frontend-app-authoring                                     |
| team_course          | openedx-platform - legacy template                         |
| team_library         | openedx-platform - legacy template                         |
| export_library       | openedx-platform - legacy template                         |
| import_library       | openedx-platform - legacy template                         |
| welcome              | openedx-platform - legacy template                         |
| schedule             | openedx-platform - legacy template                         |
| container            | openedx-platform - legacy template                         |
| advanced             | openedx-platform - legacy template                         |
| video                | openedx-platform - legacy template                         |
| unit                 | openedx-platform - legacy template                         |
| content_libraries    | openedx-platform - legacy template                         |
| course_rerun         | openedx-platform - legacy template                         |

- LMS

| Token            | Location                           |
| :--------------- | :--------------------------------- |
| progress         | openedx-platform - legacy template |
| instructor       | openedx-platform - legacy template |
| discussions      | openedx-platform - legacy template |
| course           | openedx-platform - legacy template |
| learnerdashboard | openedx-platform - legacy template |
| notes            | openedx-platform - legacy template |
| programs         | openedx-platform - legacy template |

The criteria used for removal was straightforward: any token not found referenced within a repository was marked for deletion.