### PR TITLE
fix: blank_common.yaml added back to support library_v1 problems

### DIFF
--- a/xmodule/templates/problem/blank_common.yaml
+++ b/xmodule/templates/problem/blank_common.yaml
@@ -1,0 +1,5 @@
+---
+metadata:
+    display_name: Blank Common Problem
+    markdown: ""
+data: "<problem></problem>"


### PR DESCRIPTION
## Related ticket
https://github.com/mitodl/hq/issues/9962 (MIT Internal)

## Description
Legacy Problem Editor was removed under https://github.com/openedx/openedx-platform/pull/37795 however its still being used in [legacy library or library v1](https://github.com/openedx/openedx-platform/blob/master/cms/djangoapps/contentstore/views/component.py#L298-L305) which causes issues and does not show problem option while adding a new component.

This PR just adds `blank_common.yaml` file back into `xmodule > templates > problem` templates to keep library_v1 working as expected for problems

<img width="1574" height="630" alt="image" src="https://github.com/user-attachments/assets/c14be957-20cc-4ea2-a7bb-518157550637" />


Useful information to include:

We can entirely remove it under https://github.com/openedx/openedx-platform/issues/37931

## Testing instructions

1. Make sure the setup is running fine on master branch
2. Add new library(legacy)
3. you should see `Problem` option as well while adding a new component