### PR TITLE
fix: Convert UUIDField columns to uuid type for Mariadb

### DIFF
--- a/cms/djangoapps/contentstore/migrations/0016_mariadb_uuid_conversion.py
+++ b/cms/djangoapps/contentstore/migrations/0016_mariadb_uuid_conversion.py
@@ -1,0 +1,74 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+This migration is necessary because Django 5 changed the behavior of UUIDField for MariaDB
+databases from using CharField(32) to using a proper UUID type. This change isn't managed
+automatically, so we need to generate migrations to safely convert the columns.
+
+This migration only executes for MariaDB databases and is a no-op for other backends.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    """Apply the migration only for MariaDB databases."""
+    connection = schema_editor.connection
+    
+    # Check if this is a MariaDB database
+    if connection.vendor != 'mysql':
+        return
+    
+    # Additional check for MariaDB specifically (vs MySQL)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    # Apply the field changes for MariaDB
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE oel_publishing_learningpackage "
+            "MODIFY uuid uuid NOT NULL"
+        )
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    """Reverse the migration only for MariaDB databases."""
+    connection = schema_editor.connection
+    
+    # Check if this is a MariaDB database
+    if connection.vendor != 'mysql':
+        return
+    
+    # Additional check for MariaDB specifically (vs MySQL)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+    
+    # Reverse the field changes for MariaDB
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE oel_publishing_learningpackage "
+            "MODIFY uuid char(32) NOT NULL"
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contentstore', '0015_switch_to_openedx_content'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_details.py
@@ -53,6 +53,7 @@ class CourseDetailsSerializer(serializers.Serializer):
     pre_requisite_courses = serializers.ListField(child=CourseKeyField())
     run = serializers.CharField()
     self_paced = serializers.BooleanField()
+    has_changes = serializers.BooleanField()
     short_description = serializers.CharField(allow_blank=True)
     start_date = serializers.DateTimeField()
     subtitle = serializers.CharField(allow_blank=True)

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -5,6 +5,7 @@ API Serializers for course waffle flags
 from rest_framework import serializers
 
 from cms.djangoapps.contentstore import toggles
+from openedx.core import toggles as core_toggles
 
 
 class CourseWaffleFlagsSerializer(serializers.Serializer):
@@ -31,6 +32,7 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     use_react_markdown_editor = serializers.SerializerMethodField()
     use_video_gallery_flow = serializers.SerializerMethodField()
     enable_course_optimizer_check_prev_run_links = serializers.SerializerMethodField()
+    enable_authz_course_authoring = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -201,3 +203,10 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         """
         course_key = self.get_course_key()
         return toggles.enable_course_optimizer_check_prev_run_links(course_key)
+
+    def get_enable_authz_course_authoring(self, obj):
+        """
+        Method to get the authz.enable_course_authoring waffle flag
+        """
+        course_key = self.get_course_key()
+        return core_toggles.enable_authz_course_authoring(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/vertical_block.py
@@ -125,7 +125,7 @@ class UpstreamLinkSerializer(serializers.Serializer):
     error_message = serializers.CharField(allow_null=True)
     ready_to_sync = serializers.BooleanField()
     downstream_customized = serializers.ListField(child=serializers.CharField(), allow_empty=True)
-    has_top_level_parent = serializers.BooleanField()
+    top_level_parent_key = serializers.CharField(allow_null=True)
     ready_to_sync_children = UpstreamChildrenInfoSerializer(many=True, required=False)
 
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -38,6 +38,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "use_react_markdown_editor": False,
         "use_video_gallery_flow": False,
         "enable_course_optimizer_check_prev_run_links": False,
+        "enable_authz_course_authoring": False,
     }
 
     def setUp(self):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -323,7 +323,7 @@ class ContainerVerticalViewTest(BaseXBlockContainer):
                     "version_declined": None,
                     "error_message": None,
                     "ready_to_sync": True,
-                    "has_top_level_parent": False,
+                    "top_level_parent_key": None,
                     "downstream_customized": [],
                 },
                 "user_partition_info": expected_user_partition_info,

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_downstreams.py
@@ -50,7 +50,7 @@ def _get_upstream_link_good_and_syncable(downstream):
         version_declined=downstream.upstream_version_declined,
         error_message=None,
         downstream_customized=[],
-        has_top_level_parent=False,
+        top_level_parent_key=None,
         upstream_name=downstream.upstream_display_name,
     )
 

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -35,7 +35,7 @@ from olxcleaner.exceptions import ErrorLevel
 from olxcleaner.reporting import report_error_summary, report_errors
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryContainerLocator, LibraryLocator, BlockUsageLocator
+from opaque_keys.edx.locator import LibraryContainerLocator, LibraryLocator
 from openedx_events.content_authoring.data import CourseData
 from openedx_events.content_authoring.signals import COURSE_RERUN_COMPLETED
 from organizations.api import add_organization_course, ensure_organization
@@ -1641,11 +1641,7 @@ def handle_create_xblock_upstream_link(usage_key):
         return
     if xblock.top_level_downstream_parent_key is not None:
         block_key = BlockKey.from_string(xblock.top_level_downstream_parent_key)
-        top_level_parent_usage_key = BlockUsageLocator(
-            xblock.course_id,
-            block_key.type,
-            block_key.id,
-        )
+        top_level_parent_usage_key = block_key.to_usage_key(xblock.course_id)
         try:
             ContainerLink.get_by_downstream_usage_key(top_level_parent_usage_key)
         except ContainerLink.DoesNotExist:

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -19,6 +19,7 @@ from xblock.exceptions import NoSuchHandlerError, NotFoundError, ProcessingError
 from xblock.runtime import KvsFieldData
 
 from openedx.core.djangoapps.video_config.services import VideoConfigService
+from openedx.core.djangoapps.discussions.services import DiscussionConfigService
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError as XModuleNotFoundError
 from xmodule.modulestore.django import XBlockI18nService, modulestore
@@ -228,6 +229,7 @@ def _prepare_runtime_for_preview(request, block):
         "cache": CacheService(cache),
         'replace_urls': ReplaceURLService,
         'video_config': VideoConfigService(),
+        'discussion_config_service': DiscussionConfigService(),
     }
 
     block.runtime.get_block_for_descriptor = partial(_load_preview_block, request)

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1202,6 +1202,9 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                 "edited_on": get_default_time_display(xblock.subtree_edited_on)
                 if xblock.subtree_edited_on
                 else None,
+                "edited_on_raw": str(xblock.subtree_edited_on)
+                if xblock.subtree_edited_on
+                else None,
                 "published": published,
                 "published_on": published_on,
                 "studio_url": xblock_studio_url(xblock, parent_xblock),
@@ -1331,7 +1334,7 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
             # Disable adding or removing children component if xblock is imported from library
             xblock_actions["childAddable"] = False
             # Enable unlinking only for top level imported components
-            xblock_actions["unlinkable"] = not upstream_info["has_top_level_parent"]
+            xblock_actions["unlinkable"] = not upstream_info["top_level_parent_key"]
 
         if is_xblock_unit:
             # if xblock is a Unit we add the discussion_enabled option

--- a/cms/static/sass/course-unit-mfe-iframe-bundle.scss
+++ b/cms/static/sass/course-unit-mfe-iframe-bundle.scss
@@ -1174,3 +1174,11 @@ select {
     @extend %button-primary-outline;
   }
 }
+
+.tooltip {
+  background: $primary-base;
+  white-space: normal;
+  max-width: 200px;
+  line-height: 1.5;
+  text-align: center;
+}

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import gettext as _
-from openedx.core.djangolib.markup import Text
+from openedx.core.djangolib.markup import HTML, Text
 from cms.djangoapps.contentstore.helpers import xblock_studio_url
 from cms.djangoapps.contentstore.utils import is_visible_to_specific_partition_groups, get_editor_page_base_url, determine_label
 from lms.lib.utils import is_unit
@@ -25,7 +25,7 @@ has_not_configured_message = messages.get('summary',{}).get('type', None) == 'no
 block_is_unit = is_unit(xblock)
 
 upstream_info = UpstreamLink.try_get_for_block(xblock, log_error=False)
-can_unlink = upstream_info.upstream_ref and not upstream_info.has_top_level_parent
+can_unlink = upstream_info.upstream_ref and not upstream_info.top_level_parent_key
 %>
 
 <%namespace name='static' file='static_content.html'/>
@@ -111,7 +111,7 @@ can_unlink = upstream_info.upstream_ref and not upstream_info.has_top_level_pare
                 % else:
                     % if upstream_info.upstream_ref:
                         % if upstream_info.error_message:
-                            <div class="library-info-icon two-icons" data-tooltip="${_("The referenced library or library object is not available.")}">
+                            <div class="library-info-icon two-icons" data-tooltip="${_("The referenced library or library object is not available")}">
                                 <!-- "library" icon from https://fonts.google.com/icons?selected=Material+Symbols+Outlined:newsstand:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24 -->
                                 <svg role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 -960 960 960" fill="currentColor" style="vertical-align: middle;">
                                     <path d="M80-160v-80h800v80H80Zm80-160v-320h80v320h-80Zm160 0v-480h80v480h-80Zm160 0v-480h80v480h-80Zm280 0L600-600l70-40 160 280-70 40Z"/>
@@ -120,10 +120,10 @@ can_unlink = upstream_info.upstream_ref and not upstream_info.has_top_level_pare
                                 <svg role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 -960 960 960" fill="currentColor" style="vertical-align: middle;">
                                     <path d="m770-302-60-62q40-11 65-42.5t25-73.5q0-50-35-85t-85-35H520v-80h160q83 0 141.5 58.5T880-480q0 57-29.5 105T770-302ZM634-440l-80-80h86v80h-6ZM792-56 56-792l56-56 736 736-56 56ZM440-280H280q-83 0-141.5-58.5T80-480q0-69 42-123t108-71l74 74h-24q-50 0-85 35t-35 85q0 50 35 85t85 35h160v80ZM320-440v-80h65l79 80H320Z"/>
                                 </svg>
-                                <span class="sr-only">${_("The referenced library or library object is not available.")}</span>
+                                <span class="sr-only">${_("The referenced library or library object is not available")}</span>
                             </div>
                         % elif upstream_info.ready_to_sync:
-                            <button class="library-info-icon two-icons library-sync-button sync-state" data-tooltip="${Text(_("The linked {upstream_name} has updates available.")).format(upstream_name=upstream_info.upstream_name)}">
+                            <button class="library-info-icon two-icons library-sync-button sync-state" data-tooltip="${Text(_("The linked {upstream_name} has updates available")).format(upstream_name=HTML('<strong>{name}</strong>').format(name=upstream_info.upstream_name))}">
                                 <!-- "library" icon from https://fonts.google.com/icons?selected=Material+Symbols+Outlined:newsstand:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24 -->
                                 <svg role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 -960 960 960" fill="currentColor" style="vertical-align: middle;">
                                     <path d="M80-160v-80h800v80H80Zm80-160v-320h80v320h-80Zm160 0v-480h80v480h-80Zm160 0v-480h80v480h-80Zm280 0L600-600l70-40 160 280-70 40Z"/>
@@ -132,10 +132,10 @@ can_unlink = upstream_info.upstream_ref and not upstream_info.has_top_level_pare
                                 <svg role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 -960 960 960" fill="currentColor" style="vertical-align: middle;">
                                     <path d="M160-160v-80h110l-16-14q-52-46-73-105t-21-119q0-111 66.5-197.5T400-790v84q-72 26-116 88.5T240-478q0 45 17 87.5t53 78.5l10 10v-98h80v240H160Zm400-10v-84q72-26 116-88.5T720-482q0-45-17-87.5T650-648l-10-10v98h-80v-240h240v80H690l16 14q49 49 71.5 106.5T800-482q0 111-66.5 197.5T560-170Z"/>
                                 </svg>
-                                <span class="sr-only">${_("The linked library object has updates available.")}</span>
+                                <span class="sr-only">${_("The linked library object has updates available")}</span>
                             </button>
                         % elif len(upstream_info.downstream_customized) > 0:
-                            <div class="library-info-icon two-icons" data-tooltip="${_("This library reference has course overrides applied.")}">
+                            <div class="library-info-icon two-icons" data-tooltip="${_("This library reference has course overrides applied")}">
                                 <!-- "library" icon from https://fonts.google.com/icons?selected=Material+Symbols+Outlined:newsstand:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24 -->
                                 <svg role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 -960 960 960" fill="currentColor" style="vertical-align: middle;">
                                     <path d="M80-160v-80h800v80H80Zm80-160v-320h80v320h-80Zm160 0v-480h80v480h-80Zm160 0v-480h80v480h-80Zm280 0L600-600l70-40 160 280-70 40Z"/>
@@ -144,15 +144,15 @@ can_unlink = upstream_info.upstream_ref and not upstream_info.has_top_level_pare
                                 <svg role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 -960 960 960" fill="currentColor" style="vertical-align: middle;">
                                     <path d="M440-160v-304L240-664v104h-80v-240h240v80H296l224 224v336h-80Zm154-376-58-58 128-126H560v-80h240v240h-80v-104L594-536Z"/>
                                 </svg>
-                                <span class="sr-only">${_("This library reference has course overrides applied.")}</span>
+                                <span class="sr-only">${_("This library reference has course overrides applied")}</span>
                             </div>
                         % else:
-                            <div class="library-info-icon" data-tooltip="${Text(_("This is referenced via {upstream_name}")).format(upstream_name=upstream_info.upstream_name)}">
+                            <div class="library-info-icon" data-tooltip="${Text(_("This is referenced via {upstream_name}")).format(upstream_name=HTML('<strong>{name}</strong>').format(name=upstream_info.upstream_name))}">
                                 <!-- "library" icon from https://fonts.google.com/icons?selected=Material+Symbols+Outlined:newsstand:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24 -->
                                 <svg role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 -960 960 960" fill="currentColor" style="vertical-align: middle;">
                                     <path d="M80-160v-80h800v80H80Zm80-160v-320h80v320h-80Zm160 0v-480h80v480h-80Zm160 0v-480h80v480h-80Zm280 0L600-600l70-40 160 280-70 40Z"/>
                                 </svg>
-                                <span class="sr-only">${_("This item is linked to a library item.")}</span>
+                                <span class="sr-only">${_("This item is linked to a library item")}</span>
                             </div>
                         % endif
                     % endif

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -69,8 +69,10 @@
             pageX = typeof pageX !== 'undefined' ? pageX : element.offset().left + element.width() / 2;
             pageY = typeof pageY !== 'undefined' ? pageY : element.offset().top + element.height() / 2;
             var tooltipText = $(element).attr('data-tooltip');
+            // Tooltip content comes from data-tooltip attributes which are server-rendered
+            // with proper escaping using Text() and HTML() from openedx.core.djangolib.markup
             this.tooltip
-                .text(tooltipText)
+                .html(tooltipText)  // xss-lint: disable=javascript-jquery-html
                 .css(this.getCoords(pageX, pageY));
         },
 

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -43,6 +43,7 @@ from xblock.runtime import KvsFieldData
 
 from lms.djangoapps.teams.services import TeamsService
 from openedx.core.djangoapps.video_config.services import VideoConfigService
+from openedx.core.djangoapps.discussions.services import DiscussionConfigService
 from openedx.core.lib.xblock_services.call_to_action import CallToActionService
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError as XModuleNotFoundError
@@ -637,6 +638,7 @@ def prepare_runtime_for_user(
         'publish': EventPublishingService(user, course_id, track_function),
         'enrollments': EnrollmentsService(),
         'video_config': VideoConfigService(),
+        'discussion_config_service': DiscussionConfigService(),
     }
 
     runtime.get_block_for_descriptor = inner_get_block

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -71,8 +71,6 @@ from lms.djangoapps.courseware.block_render import get_block, handle_xblock_call
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin, get_expiration_banner_text
 from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
 from lms.djangoapps.courseware.toggles import (
-    COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR,
-    COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR,
     COURSEWARE_MICROFRONTEND_SEARCH_ENABLED,
     COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
 )
@@ -3251,13 +3249,10 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         self.client = APIClient()
         self.apiUrl = reverse('courseware_navigation_sidebar_toggles_view', kwargs={'course_id': str(self.course.id)})
 
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
     @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_disabled_completion_track_disabled(self):
+    def test_courseware_mfe_navigation_sidebar_completion_track_disabled(self):
         """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar doesn't open.
+        Getter to check if completion tracking is disabled.
         """
         response = self.client.get(self.apiUrl, content_type='application/json')
         body = json.loads(response.content.decode('utf-8'))
@@ -3266,40 +3261,14 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         self.assertEqual(
             body,
             {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": False,
                 "enable_completion_tracking": False,
             },
         )
 
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
     @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_disabled_completion_track_enabled(self):
+    def test_courseware_mfe_navigation_sidebar_completion_track_enabled(self):
         """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar doesn't open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": False,
-                "enable_completion_tracking": True,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_enabled_completion_track_disabled(self):
-        """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar should always open.
+        Getter to check if completion tracking is enabled.
         """
         response = self.client.get(self.apiUrl, content_type='application/json')
         body = json.loads(response.content.decode('utf-8'))
@@ -3308,111 +3277,6 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         self.assertEqual(
             body,
             {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": False,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_enabled_completion_track_enabled(self):
-        """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar should always open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": True,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_disabled_aux_enabled_completion_track_disabled(self):
-        """
-        Getter to check if the Courseware navigation sidebar shouldn't be shown to a user
-        and auxiliary sidebar should always open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": False,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_disabled_aux_enabled_completion_track_enabled(self):
-        """
-        Getter to check if the Courseware navigation sidebar shouldn't be shown to a user
-        and auxiliary sidebar should always open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": True,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_toggles_disabled_completion_track_disabled(self):
-        """
-        Getter to check if neither navigation sidebar nor auxiliary sidebar is shown.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": False,
-                "enable_completion_tracking": False,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_toggles_disabled_completion_track_enabled(self):
-        """
-        Getter to check if neither navigation sidebar nor auxiliary sidebar is shown.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": False,
                 "enable_completion_tracking": True,
             },
         )

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -83,33 +83,6 @@ COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffl
     f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar_blocks_caching', __name__
 )
 
-# .. toggle_name: courseware.enable_navigation_sidebar
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enable navigation sidebar on Learning MFE
-# .. toggle_use_cases: opt_out, open_edx
-# .. toggle_creation_date: 2024-03-07
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: FC-0056
-COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.enable_navigation_sidebar', __name__
-)
-
-# .. toggle_name: courseware.always_open_auxiliary_sidebar
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: True
-# .. toggle_description: Waffle flag that determines whether the auxiliary sidebar,
-#   such as discussion or notification, should automatically expand
-#   on each course unit page within the Learning MFE, without preserving
-#   the previous state of the sidebar.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2024-04-28
-# .. toggle_target_removal_date: 2024-07-28
-# .. toggle_tickets: FC-0056
-COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.always_open_auxiliary_sidebar', __name__
-)
-
 # .. toggle_name: courseware.mfe_progress_milestones_streak_discount_enabled
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -101,8 +101,6 @@ from lms.djangoapps.courseware.permissions import MASQUERADE_AS_STUDENT, VIEW_CO
 from lms.djangoapps.courseware.toggles import (
     course_is_invitation_only,
     courseware_mfe_search_is_enabled,
-    COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR,
-    COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR,
 )
 from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
@@ -2398,8 +2396,6 @@ def courseware_mfe_navigation_sidebar_toggles(request, course_id=None):
         return JsonResponse({"error": "Invalid course_id"})
 
     return JsonResponse({
-        "enable_navigation_sidebar": COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR.is_enabled(course_key),
-        "always_open_auxiliary_sidebar": COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR.is_enabled(course_key),
         # Add completion tracking status for the sidebar use while a global place for switches is put in place
         "enable_completion_tracking": ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled()
     })

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -25,6 +25,7 @@ from openedx_events.learning.signals import (
 
 import lms.djangoapps.discussion.django_comment_client.settings as cc_settings
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from common.djangoapps.student.roles import GlobalStaff
 from common.djangoapps.track import contexts
 from common.djangoapps.util.file import store_uploaded_file
@@ -33,8 +34,7 @@ from lms.djangoapps.courseware.courses import get_course_overview_with_access, g
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion.django_comment_client.permissions import (
     check_permissions_by_view,
-    get_team,
-    has_permission
+    get_team
 )
 from lms.djangoapps.discussion.django_comment_client.utils import (
     JsonError,

--- a/lms/djangoapps/discussion/django_comment_client/permissions.py
+++ b/lms/djangoapps/discussion/django_comment_client/permissions.py
@@ -12,24 +12,9 @@ from lms.djangoapps.teams.models import CourseTeam
 from openedx.core.djangoapps.django_comment_common.comment_client import Thread
 from openedx.core.djangoapps.django_comment_common.models import (
     CourseDiscussionSettings,
-    all_permissions_for_user_in_course
+    has_permission
 )
 from openedx.core.lib.cache_utils import request_cached
-
-
-def has_permission(user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
-    assert isinstance(course_id, (type(None), CourseKey))
-    request_cache_dict = DEFAULT_REQUEST_CACHE.data
-    cache_key = "django_comment_client.permissions.has_permission.all_permissions.{}.{}".format(
-        user.id, course_id
-    )
-    if cache_key in request_cache_dict:
-        all_permissions = request_cache_dict[cache_key]
-    else:
-        all_permissions = all_permissions_for_user_in_course(user, course_id)
-        request_cache_dict[cache_key] = all_permissions
-
-    return permission in all_permissions
 
 
 CONDITIONS = ['is_open', 'is_author', 'is_question_author', 'is_team_member_if_applicable']

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -24,10 +24,10 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 from lms.djangoapps.discussion.django_comment_client.permissions import (
     check_permissions_by_view,
-    get_team,
-    has_permission
+    get_team
 )
 from lms.djangoapps.discussion.django_comment_client.settings import MAX_COMMENT_DEPTH
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id
 from openedx.core.djangoapps.discussions.utils import (
     get_accessible_discussion_xblocks,

--- a/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
@@ -11,7 +11,7 @@ from django.utils.translation import gettext as _, ngettext
 from django.template.defaultfilters import escapejs
 from django.urls import reverse
 
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -28,6 +28,7 @@ from xmodule.modulestore.django import modulestore
 
 import lms.djangoapps.discussion.django_comment_client.utils as utils
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
 from common.djangoapps.util.json_request import JsonResponse, expect_json
@@ -37,7 +38,6 @@ from lms.djangoapps.courseware.views.views import CourseTabView
 from lms.djangoapps.discussion.config.settings import is_forum_daily_digest_enabled
 from lms.djangoapps.discussion.django_comment_client.base.views import track_thread_viewed_event
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
 from lms.djangoapps.discussion.django_comment_client.utils import (
     add_courseware_context,
     course_discussion_division_enabled,

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,7 @@ files =
     # openedx/core/djangoapps/content/search,
     openedx/core/djangoapps/content_staging,
     openedx/core/djangoapps/content_libraries,
+    openedx/core/djangoapps/discussions/services.py,
     openedx/core/djangoapps/programs/rest_api,
     openedx/core/djangoapps/xblock,
     openedx/core/lib/derived.py,

--- a/openedx/core/djangoapps/discussions/services.py
+++ b/openedx/core/djangoapps/discussions/services.py
@@ -1,0 +1,38 @@
+"""
+Discussion Configuration Service for XBlock runtime.
+
+This service provides discussion-related configuration and feature flags
+that are specific to the edx-platform implementation
+for the extracted discussion block in xblocks-contrib repository.
+"""
+
+from django.conf import settings
+from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.django_comment_common.models import has_permission
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
+
+
+class DiscussionConfigService:
+    """
+    Service for providing discussion-related configuration and feature flags.
+    """
+
+    def has_permission(self, user: User, permission: str, course_id: CourseKey | None = None) -> bool:
+        """
+        Return whether the user has the given discussion permission for a given course.
+        """
+        return has_permission(user, permission, course_id)
+
+    def is_discussion_visible(self, course_key: CourseKey) -> bool:
+        """
+        Discussion Xblock does not support new OPEN_EDX provider
+        """
+        provider = DiscussionsConfiguration.get(course_key)
+        return provider.provider_type == Provider.LEGACY
+
+    def is_discussion_enabled(self) -> bool:
+        """
+        Return True if discussions are enabled; else False
+        """
+        return settings.ENABLE_DISCUSSION_SERVICE

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -77,6 +77,7 @@ class CourseDetails:
         self.self_paced = None
         self.learning_info = []
         self.instructor_info = []
+        self.has_changes = None
 
     @classmethod
     def fetch_about_attribute(cls, course_key, attribute):
@@ -127,6 +128,7 @@ class CourseDetails:
         course_details.video_thumbnail_image_asset_path = course_image_url(block, 'video_thumbnail_image')
         course_details.language = block.language
         course_details.self_paced = block.self_paced
+        course_details.has_changes = modulestore().has_changes(block)
         course_details.learning_info = block.learning_info
         course_details.instructor_info = block.instructor_info
         course_details.title = block.display_name

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -347,6 +347,9 @@ class XBlockRuntime(RuntimeShim, Runtime):
             # Import here to avoid circular dependency
             from openedx.core.djangoapps.video_config.services import VideoConfigService
             return VideoConfigService()
+        elif service_name == 'discussion_config_service':
+            from openedx.core.djangoapps.discussions.services import DiscussionConfigService
+            return DiscussionConfigService()
 
         # Otherwise, fall back to the base implementation which loads services
         # defined in the constructor:

--- a/openedx/core/toggles.py
+++ b/openedx/core/toggles.py
@@ -3,6 +3,8 @@ Feature toggles used across the platform. Toggles should only be added to this m
 for them. Generally speaking, they should be added to the most appropriate app or repo.
 """
 from edx_toggles.toggles import SettingToggle
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
 
 # .. toggle_name: ENTRANCE_EXAMS
 # .. toggle_implementation: SettingToggle
@@ -15,3 +17,21 @@ from edx_toggles.toggles import SettingToggle
 ENTRANCE_EXAMS = SettingToggle(
     "ENTRANCE_EXAMS", default=False, module_name=__name__
 )
+
+# .. toggle_name: authz.enable_course_authoring
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This toggle will enable the new openedx-authz authorization engine for course authoring.
+# .. toggle_warning: Enabling this toggle will trigger a data migration to move role assignations between the legacy and the openedx-authz system.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-02-05
+# .. toggle_target_removal_date: 2027-06-09
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/37927
+AUTHZ_COURSE_AUTHORING_FLAG = CourseWaffleFlag('authz.enable_course_authoring', __name__)
+
+
+def enable_authz_course_authoring(course_key):
+    """
+    Returns a boolean if the AuthZ for course authoring feature is enabled for the given course.
+    """
+    return AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key)

--- a/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
+++ b/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
@@ -15,7 +15,7 @@ import json
 from django.utils.translation import gettext as _
 from django.template.defaultfilters import escapejs
 
-from lms.djangoapps.discussion.django_comment_client.permissions import has_permission
+from openedx.core.djangoapps.django_comment_common.models import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import course_home_page_title

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -708,8 +708,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/kernel.in
 lxml[html-clean]==5.3.2
@@ -840,7 +838,7 @@ openedx-learning==0.31.0
     #   -r requirements/edx/kernel.in
 optimizely-sdk==5.4.0
     # via -r requirements/edx/bundled.in
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/bundled.in
 packaging==25.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1190,11 +1190,6 @@ libsass==0.10.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.txt
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via
     #   -r requirements/edx/doc.txt
@@ -1413,7 +1408,7 @@ optimizely-sdk==5.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.17.1
+ora2==6.17.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -865,10 +865,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/base.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
@@ -1019,7 +1015,7 @@ openedx-learning==0.31.0
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -907,10 +907,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/base.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
@@ -1069,7 +1065,7 @@ openedx-learning==0.31.0
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via

--- a/xmodule/tests/__init__.py
+++ b/xmodule/tests/__init__.py
@@ -33,7 +33,7 @@ from xmodule.util.sandboxing import SandboxService
 from xmodule.x_module import DoNothingCache, XModuleMixin, ModuleStoreRuntime
 from openedx.core.djangoapps.video_config.services import VideoConfigService
 from openedx.core.lib.cache_utils import CacheService
-
+from openedx.core.djangoapps.discussions.services import DiscussionConfigService
 
 MODULE_DIR = path(__file__).dirname()
 # Location of common test DATA directory
@@ -161,6 +161,7 @@ def get_test_system(
         'field-data': DictFieldData({}),
         'sandbox': SandboxService(contentstore, course_id),
         'video_config': VideoConfigService(),
+        'discussion_config_service': DiscussionConfigService()
     }
 
     descriptor_system.get_block_for_descriptor = get_block  # lint-amnesty, pylint: disable=attribute-defined-outside-init
@@ -217,6 +218,7 @@ def prepare_block_runtime(
         'field-data': DictFieldData({}),
         'sandbox': SandboxService(contentstore, course_id),
         'video_config': VideoConfigService(),
+        'discussion_config_service': DiscussionConfigService()
     }
 
     if add_overrides:

--- a/xmodule/tests/test_util_keys.py
+++ b/xmodule/tests/test_util_keys.py
@@ -1,15 +1,15 @@
 """
 Tests for xmodule/util/keys.py
 """
-import ddt
-import pytest
 from unittest import TestCase
 from unittest.mock import Mock
 
-from opaque_keys.edx.locator import BlockUsageLocator
+import ddt
+import pytest
 from opaque_keys.edx.keys import CourseKey
-from xmodule.util.keys import BlockKey, derive_key
+from opaque_keys.edx.locator import BlockUsageLocator
 
+from xmodule.util.keys import BlockKey, derive_key
 
 mock_block = Mock()
 mock_block.id = CourseKey.from_string('course-v1:Beeper+B33P+BOOP')
@@ -70,3 +70,19 @@ class TestBlockKeyParsing(TestCase):
     @ddt.unpack
     def test_block_key_to_string(self, block_key, block_key_str):
         assert str(block_key) == block_key_str
+
+    @ddt.data(
+        [BlockKey('chapter', 'some-id'), BlockUsageLocator(
+            mock_block.id,
+            'chapter',
+            'some-id'
+        )],
+        [BlockKey('section', 'one-more-id'), BlockUsageLocator(
+            mock_block.id,
+            'section',
+            'one-more-id'
+        )]
+    )
+    @ddt.unpack
+    def test_block_key_to_usage_key(self, block_key: BlockKey, block_key_str):
+        assert block_key.to_usage_key(mock_block.id) == block_key_str

--- a/xmodule/util/keys.py
+++ b/xmodule/util/keys.py
@@ -6,7 +6,7 @@ Consider moving these into opaque-keys if they generalize well.
 import hashlib
 from typing import NamedTuple, Self
 
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 
 class BlockKey(NamedTuple):
@@ -39,6 +39,12 @@ class BlockKey(NamedTuple):
         if len(parts) != 2 or not parts[0] or not parts[1]:
             raise ValueError(f"Invalid string format for BlockKey: {s}")
         return cls(parts[0], parts[1])
+
+    def to_usage_key(self, course_key: CourseKey) -> UsageKey:
+        """
+        Converts this BlockKey into a UsageKey.
+        """
+        return course_key.make_usage_key(self.type, self.id)
 
 
 def derive_key(source: UsageKey, dest_parent: BlockKey) -> BlockKey:


### PR DESCRIPTION
## Description

The behavior of the MariaDB backend has changed behavior for UUIDField from a `CharField(32)` to an actual `uuid` type. This is not converted automatically, which results in all writes to the affected columns to error with a message about the data being too long. This is because the actual string being written is a UUID with the `-` included, resulting in a 36 character value which can't be inserted into a 32 character column.

## Supporting information

https://docs.djangoproject.com/en/5.2/releases/5.0/#migrating-uuidfield

## Testing instructions

Configure edx-platform to use a MariaDB database as well as the work necessary to use Libraries V2 (meilisearch, etc), run the migrations up through the Django 5.2 update, then perform the 5.2 update and try to create a new V2 Library. It will error. After applying these migrations it should work.

## Deadline

This is a blocking error that prevents the LibrariesV2 from being operational when using MariaDB as the database engine.

## Other information

This is in addition to the migrations found in PR https://github.com/openedx/openedx-platform/pull/37494

