### PR TITLE
Simplify Content Groups API v2 Response

### DIFF
--- a/openedx/core/djangoapps/course_groups/rest_api/docs/content-groups-api-v2-spec.yaml
+++ b/openedx/core/djangoapps/course_groups/rest_api/docs/content-groups-api-v2-spec.yaml
@@ -46,10 +46,10 @@ paths:
     get:
       tags:
         - Content Groups
-      summary: List content group configurations
+      summary: List content groups
       description: |
-        Returns all content group configurations (scheme='cohort') for a course.
-        If no content group exists, an empty one is automatically created.
+        Returns the content groups for a course along with the configuration ID
+        and a link to Studio for managing content groups.
       operationId: listGroupConfigurations
       produces:
         - application/json
@@ -153,20 +153,15 @@ definitions:
   ContentGroupsListResponse:
     type: object
     properties:
-      all_group_configurations:
+      id:
+        type: integer
+        nullable: true
+        description: ID of the content group configuration (null if none exists)
+      groups:
         type: array
         items:
-          $ref: '#/definitions/ContentGroupConfiguration'
-        description: List of content group configurations
-      should_show_enrollment_track:
-        type: boolean
-        description: Whether enrollment track groups should be displayed
-      should_show_experiment_groups:
-        type: boolean
-        description: Whether experiment groups should be displayed
-      group_configuration_url:
+          $ref: '#/definitions/Group'
+        description: Flat list of content groups for the course
+      studio_content_groups_link:
         type: string
-        description: Base URL for accessing individual configurations
-      course_outline_url:
-        type: string
-        description: URL to the course outline
+        description: Full URL to Studio's content group configuration page

--- a/openedx/core/djangoapps/course_groups/rest_api/serializers.py
+++ b/openedx/core/djangoapps/course_groups/rest_api/serializers.py
@@ -36,10 +36,15 @@ class ContentGroupConfigurationSerializer(serializers.Serializer):
 class ContentGroupsListResponseSerializer(serializers.Serializer):
     """
     Response serializer for listing all content groups.
+
+    Returns the content group configuration ID, a flat list of content groups,
+    and a link to Studio where instructors can manage content groups.
     """
-    all_group_configurations = ContentGroupConfigurationSerializer(many=True)
-    should_show_enrollment_track = serializers.BooleanField()
-    should_show_experiment_groups = serializers.BooleanField()
-    context_course = serializers.JSONField(required=False, allow_null=True)
-    group_configuration_url = serializers.CharField()
-    course_outline_url = serializers.CharField()
+    id = serializers.IntegerField(
+        allow_null=True,
+        help_text="ID of the content group configuration (null if none exists)"
+    )
+    groups = GroupSerializer(many=True)
+    studio_content_groups_link = serializers.CharField(
+        help_text="Full URL to Studio's content group configuration page"
+    )


### PR DESCRIPTION
## Description

- Flatten the Content Groups API v2 response to return only groups and studio_content_groups_link                                                                                            
- Remove unnecessary metadata fields that were designed for Studio's internal use                                                                                                            
- Update tests to match the new response structure

### New Response Format
```JSON
{                                                                                                                                                                                            
    "groups": [                                                                                                                                                                                
      {"id": 123, "name": "Content Group A", "version": 1, "usage": []}                                                                                                                        
    ],                                                                                                                                                                                         
    "studio_content_groups_link": "/course/course-v1:org+course+run/group_configurations"                                                                                                      
  } 
```

## Supporting information

Implements: https://github.com/openedx/openedx-platform/issues/37973

## Testing instructions

- Manual test: GET /api/cohorts/v2/courses/{course_id}/group_configurations returns simplified response with content groups
- Manual test: GET /api/cohorts/v2/courses/{course_id}/group_configurations returns empty groups array when no content groups exist

## Deadline

None

## Other information

None