### PR TITLE
chore: upgrade enterprise-integrated-channels to 0.1.38

### DIFF
--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -71,28 +71,28 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(3), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
-        num_queries = 42
+        num_queries = 44
         with self.assertNumQueries(num_queries), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=0.5)  # updated to grade of .5
 
-        num_queries = 6
+        num_queries = 8
         with self.assertNumQueries(num_queries), mock_get_score(1, 4):
             grade_factory.update(self.request.user, self.course, force_update_subsections=False)
 
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=0.5)  # NOT updated to grade of .25
 
-        num_queries = 18
+        num_queries = 20
         with self.assertNumQueries(num_queries), mock_get_score(2, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=1.0)  # updated to grade of 1.0
 
-        num_queries = 28
+        num_queries = 30
         with self.assertNumQueries(num_queries), mock_get_score(0, 0):  # the subsection now is worth zero
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -558,7 +558,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.29
+enterprise-integrated-channels==0.1.38
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via
@@ -1116,7 +1116,9 @@ slumber==0.7.1
     #   edx-enterprise
     #   enterprise-integrated-channels
 snowflake-connector-python==4.2.0
-    # via edx-enterprise
+    # via
+    #   edx-enterprise
+    #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
     #   -c requirements/constraints.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -876,7 +876,7 @@ enmerkar-underscore==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-enterprise-integrated-channels==0.1.29
+enterprise-integrated-channels==0.1.38
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1965,6 +1965,7 @@ snowflake-connector-python==4.2.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
+    #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
     #   -c requirements/constraints.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -653,7 +653,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.29
+enterprise-integrated-channels==0.1.38
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via
@@ -1376,6 +1376,7 @@ snowflake-connector-python==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+    #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
     #   -c requirements/constraints.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -677,7 +677,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.29
+enterprise-integrated-channels==0.1.38
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via
@@ -1492,6 +1492,7 @@ snowflake-connector-python==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+    #   enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via
     #   -c requirements/constraints.txt


### PR DESCRIPTION
ENT-11229

---

Note: This requirement isn't pinned or anything, running `make upgrade` will upgrade it.  So why is it so behind?  Well, apparently the last time anybody actually ran `make upgrade` against edx-platform was October of last year.  As a result, running `make upgrade` will have a lot of side-effects that I'm not prepared to deal with.  Hence manually bumping the version surgically.