### PR TITLE
refactor: remove deprecated sidebar toggles

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -71,8 +71,6 @@ from lms.djangoapps.courseware.block_render import get_block, handle_xblock_call
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin, get_expiration_banner_text
 from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
 from lms.djangoapps.courseware.toggles import (
-    COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR,
-    COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR,
     COURSEWARE_MICROFRONTEND_SEARCH_ENABLED,
     COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
 )
@@ -3251,13 +3249,10 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         self.client = APIClient()
         self.apiUrl = reverse('courseware_navigation_sidebar_toggles_view', kwargs={'course_id': str(self.course.id)})
 
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
     @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_disabled_completion_track_disabled(self):
+    def test_courseware_mfe_navigation_sidebar_completion_track_disabled(self):
         """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar doesn't open.
+        Getter to check if completion tracking is disabled.
         """
         response = self.client.get(self.apiUrl, content_type='application/json')
         body = json.loads(response.content.decode('utf-8'))
@@ -3266,40 +3261,14 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         self.assertEqual(
             body,
             {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": False,
                 "enable_completion_tracking": False,
             },
         )
 
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
     @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_disabled_completion_track_enabled(self):
+    def test_courseware_mfe_navigation_sidebar_completion_track_enabled(self):
         """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar doesn't open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": False,
-                "enable_completion_tracking": True,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_enabled_completion_track_disabled(self):
-        """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar should always open.
+        Getter to check if completion tracking is enabled.
         """
         response = self.client.get(self.apiUrl, content_type='application/json')
         body = json.loads(response.content.decode('utf-8'))
@@ -3308,111 +3277,6 @@ class TestCoursewareMFENavigationSidebarTogglesAPI(SharedModuleStoreTestCase):
         self.assertEqual(
             body,
             {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": False,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=True)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_enabled_aux_enabled_completion_track_enabled(self):
-        """
-        Getter to check if it is allowed to show the Courseware navigation sidebar to a user
-        and auxiliary sidebar should always open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": True,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": True,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_disabled_aux_enabled_completion_track_disabled(self):
-        """
-        Getter to check if the Courseware navigation sidebar shouldn't be shown to a user
-        and auxiliary sidebar should always open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": False,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=True)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_disabled_aux_enabled_completion_track_enabled(self):
-        """
-        Getter to check if the Courseware navigation sidebar shouldn't be shown to a user
-        and auxiliary sidebar should always open.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": True,
-                "enable_completion_tracking": True,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=False)
-    def test_courseware_mfe_navigation_sidebar_toggles_disabled_completion_track_disabled(self):
-        """
-        Getter to check if neither navigation sidebar nor auxiliary sidebar is shown.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": False,
-                "enable_completion_tracking": False,
-            },
-        )
-
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR, active=False)
-    @override_waffle_flag(COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR, active=False)
-    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
-    def test_courseware_mfe_navigation_sidebar_toggles_disabled_completion_track_enabled(self):
-        """
-        Getter to check if neither navigation sidebar nor auxiliary sidebar is shown.
-        """
-        response = self.client.get(self.apiUrl, content_type='application/json')
-        body = json.loads(response.content.decode('utf-8'))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            body,
-            {
-                "enable_navigation_sidebar": False,
-                "always_open_auxiliary_sidebar": False,
                 "enable_completion_tracking": True,
             },
         )

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -83,33 +83,6 @@ COURSEWARE_MICROFRONTEND_NAVIGATION_SIDEBAR_BLOCKS_DISABLE_CACHING = CourseWaffl
     f'{WAFFLE_FLAG_NAMESPACE}.disable_navigation_sidebar_blocks_caching', __name__
 )
 
-# .. toggle_name: courseware.enable_navigation_sidebar
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enable navigation sidebar on Learning MFE
-# .. toggle_use_cases: opt_out, open_edx
-# .. toggle_creation_date: 2024-03-07
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: FC-0056
-COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.enable_navigation_sidebar', __name__
-)
-
-# .. toggle_name: courseware.always_open_auxiliary_sidebar
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: True
-# .. toggle_description: Waffle flag that determines whether the auxiliary sidebar,
-#   such as discussion or notification, should automatically expand
-#   on each course unit page within the Learning MFE, without preserving
-#   the previous state of the sidebar.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2024-04-28
-# .. toggle_target_removal_date: 2024-07-28
-# .. toggle_tickets: FC-0056
-COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR = CourseWaffleFlag(
-    f'{WAFFLE_FLAG_NAMESPACE}.always_open_auxiliary_sidebar', __name__
-)
-
 # .. toggle_name: courseware.mfe_progress_milestones_streak_discount_enabled
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -101,8 +101,6 @@ from lms.djangoapps.courseware.permissions import MASQUERADE_AS_STUDENT, VIEW_CO
 from lms.djangoapps.courseware.toggles import (
     course_is_invitation_only,
     courseware_mfe_search_is_enabled,
-    COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR,
-    COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR,
 )
 from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
@@ -2398,8 +2396,6 @@ def courseware_mfe_navigation_sidebar_toggles(request, course_id=None):
         return JsonResponse({"error": "Invalid course_id"})
 
     return JsonResponse({
-        "enable_navigation_sidebar": COURSEWARE_MICROFRONTEND_ENABLE_NAVIGATION_SIDEBAR.is_enabled(course_key),
-        "always_open_auxiliary_sidebar": COURSEWARE_MICROFRONTEND_ALWAYS_OPEN_AUXILIARY_SIDEBAR.is_enabled(course_key),
         # Add completion tracking status for the sidebar use while a global place for switches is put in place
         "enable_completion_tracking": ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled()
     })


### PR DESCRIPTION
## Description

This PR removes the sidebar toggles that have been deprecated. See
* https://github.com/openedx/public-engineering/issues/316

The learning MFE no longer uses these, and site operators can instead now customize this behavior by utilizing Frontend Plugin Framework slots. See
* https://github.com/openedx/frontend-app-learning/pull/1713

## Testing instructions

I verified the Learning MFE renders properly and does not produce any API errors, both locally and in the PR sandbox.

