### PR TITLE
feat: Add Waffle flag for AuthZ for Course Authoring

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -548,8 +548,9 @@ def enable_course_optimizer_check_prev_run_links(course_key):
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: This toggle will enable the new openedx-authz authorization engine for course authoring.
-# .. toggle_warning: Enabling this toggle triggers a data migration to move role assignations between the legacy and the openedx-authz system.
+# .. toggle_warning: Enabling this toggle will trigger a data migration to move role assignations between the legacy and the openedx-authz system.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2026-02-05
+# .. toggle_target_removal_date: 2027-06-09
 # .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/37927
 AUTHZ_COURSE_AUTHORING_FLAG = CourseWaffleFlag('authz.enable_course_authoring', __name__)

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -542,15 +542,3 @@ def enable_course_optimizer_check_prev_run_links(course_key):
     Returns a boolean if previous run course optimizer feature is enabled for the given course.
     """
     return ENABLE_COURSE_OPTIMIZER_CHECK_PREV_RUN_LINKS.is_enabled(course_key)
-
-
-# .. toggle_name: authz.enable_course_authoring
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: This toggle will enable the new openedx-authz authorization engine for course authoring.
-# .. toggle_warning: Enabling this toggle will trigger a data migration to move role assignations between the legacy and the openedx-authz system.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2026-02-05
-# .. toggle_target_removal_date: 2027-06-09
-# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/37927
-AUTHZ_COURSE_AUTHORING_FLAG = CourseWaffleFlag('authz.enable_course_authoring', __name__)

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -542,3 +542,14 @@ def enable_course_optimizer_check_prev_run_links(course_key):
     Returns a boolean if previous run course optimizer feature is enabled for the given course.
     """
     return ENABLE_COURSE_OPTIMIZER_CHECK_PREV_RUN_LINKS.is_enabled(course_key)
+
+
+# .. toggle_name: authz.enable_course_authoring
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This toggle will enable the new openedx-authz authorization engine for course authoring.
+# .. toggle_warning: Enabling this toggle triggers a data migration to move role assignations between the legacy and the openedx-authz system.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-02-05
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/37927
+AUTHZ_COURSE_AUTHORING_FLAG = CourseWaffleFlag('authz.enable_course_authoring', __name__)

--- a/openedx/core/toggles.py
+++ b/openedx/core/toggles.py
@@ -3,6 +3,8 @@ Feature toggles used across the platform. Toggles should only be added to this m
 for them. Generally speaking, they should be added to the most appropriate app or repo.
 """
 from edx_toggles.toggles import SettingToggle
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
 
 # .. toggle_name: ENTRANCE_EXAMS
 # .. toggle_implementation: SettingToggle
@@ -15,3 +17,14 @@ from edx_toggles.toggles import SettingToggle
 ENTRANCE_EXAMS = SettingToggle(
     "ENTRANCE_EXAMS", default=False, module_name=__name__
 )
+
+# .. toggle_name: authz.enable_course_authoring
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This toggle will enable the new openedx-authz authorization engine for course authoring.
+# .. toggle_warning: Enabling this toggle will trigger a data migration to move role assignations between the legacy and the openedx-authz system.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2026-02-05
+# .. toggle_target_removal_date: 2027-06-09
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/37927
+AUTHZ_COURSE_AUTHORING_FLAG = CourseWaffleFlag('authz.enable_course_authoring', __name__)


### PR DESCRIPTION
## Description

This PR adds a feature flag that will be used to toggle the new authorization implementation (openedx-authz) over the Course Authoring experience.

This is a temporary flag that will be deprecated after Willow as specified in this ADR: https://github.com/openedx/openedx-authz/blob/main/docs/decisions/0010-course-authoring-flag.rst

## Supporting information

This is part of the Phase 2 of the RBAC AuthZ project, related ticket: https://github.com/openedx/openedx-platform/issues/37927

The following ADR specifies the rationales and decisions related to this change: https://github.com/openedx/openedx-authz/blob/main/docs/decisions/0010-course-authoring-flag.rst

## Testing instructions

### How to use

```python
# Import the flag
from openedx.core.toggles import AUTHZ_COURSE_AUTHORING_FLAG

# Check if it's enabled, passing the course_key
is_enabled = AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key=course_key)
```

### To enable it globally:

1. In the Django Admin, go to Home > django-waffle > Flags (/admin/waffle/flag/)
2. Click on ADD FLAG
3. Set the Name to "authz.enable_course_authoring"
4. Set Everyone: "Yes"
5. Click "Save"

### To enable for a specific course (or override if it was previously enabled globally):

1. In the Django Admin, go to Home > Waffle_Utils > Waffle flag course overrides (/admin/waffle_utils/waffleflagcourseoverridemodel/)
2. Click on "ADD WAFFLE FLAG COURSE OVERRIDE"
3. Set Waffle flag to  "authz.enable_course_authoring"
4. Set Course id to the desired course key
5. Set Override choice to the desired effect
6. Check the "Enabled" box
7. Click "Save"

### To enable for an org (or override if it was previously enabled globally):

9. In the Django Admin, go to Home > Waffle_Utils > Add Waffle flag org override (/admin/waffle_utils/waffleflagorgoverridemodel/)
10. Click on "ADD WAFFLE FLAG ORG OVERRIDE"
11. Set Waffle flag to  "authz.enable_course_authoring"
12. Set Course id to the desired Org name
13. Set Override choice to the desired effect
14. Check the "Enabled" box
15. Click "Save"

### How will the flag behave:

- Course level flags take precedence over Org level flags. 
- Both override the global Flag.
- Course and Org level flags need to be "Enabled" for the override to apply

### Caveats:

Waffle Flags allow configuring the flag to be enabled to specific users or groups of users. This won't be supported by the openedx-authz implementation because it would cause validation inconsistencies. A Waffle Switch would have been a better fit, but there are no existing ways to override Waffle Switchs for specific courses or orgs.

## Deadline

Verawood release

## Other information

This flag will be used in follow-up changes related to the RBAC AuthZ Phase 2 project.
