### PR TITLE
feat: Add enable_authz_course_authoring flag to course_waffle_flags endpoint

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -5,6 +5,7 @@ API Serializers for course waffle flags
 from rest_framework import serializers
 
 from cms.djangoapps.contentstore import toggles
+from openedx.core import toggles as core_toggles
 
 
 class CourseWaffleFlagsSerializer(serializers.Serializer):
@@ -31,6 +32,7 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
     use_react_markdown_editor = serializers.SerializerMethodField()
     use_video_gallery_flow = serializers.SerializerMethodField()
     enable_course_optimizer_check_prev_run_links = serializers.SerializerMethodField()
+    enable_authz_course_authoring = serializers.SerializerMethodField()
 
     def get_course_key(self):
         """
@@ -201,3 +203,10 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         """
         course_key = self.get_course_key()
         return toggles.enable_course_optimizer_check_prev_run_links(course_key)
+
+    def get_enable_authz_course_authoring(self, obj):
+        """
+        Method to get the authz.enable_course_authoring waffle flag
+        """
+        course_key = self.get_course_key()
+        return core_toggles.enable_authz_course_authoring(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_waffle_flags.py
@@ -38,6 +38,7 @@ class CourseWaffleFlagsViewTest(CourseTestCase):
         "use_react_markdown_editor": False,
         "use_video_gallery_flow": False,
         "enable_course_optimizer_check_prev_run_links": False,
+        "enable_authz_course_authoring": False,
     }
 
     def setUp(self):

--- a/openedx/core/toggles.py
+++ b/openedx/core/toggles.py
@@ -28,3 +28,10 @@ ENTRANCE_EXAMS = SettingToggle(
 # .. toggle_target_removal_date: 2027-06-09
 # .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/37927
 AUTHZ_COURSE_AUTHORING_FLAG = CourseWaffleFlag('authz.enable_course_authoring', __name__)
+
+
+def enable_authz_course_authoring(course_key):
+    """
+    Returns a boolean if the AuthZ for course authoring feature is enabled for the given course.
+    """
+    return AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key)


### PR DESCRIPTION
## Description

Related issue: https://github.com/openedx/frontend-app-authoring/issues/2831

As part of the AuthZ for Course Authoring project, a feature flag was added that allows enabling the new authorization engine selectively on specific courses, orgs or the whole instance.

In order to honor the new granular permissions in the frontend, the code at [frontend-app-authoring](https://github.com/openedx/frontend-app-authoring) will need to know if the flag is enabled for a specific course before querying for permissions to decide to show or hide parts of the UI.

This PR adds the value of the authz.enable_course_authoring Waffle flag to the /api/contentstore/v1/course_waffle_flags and /api/contentstore/v1/course_waffle_flags/(course_key) endpoints, which are currently used by the frontend for other flags.

## Supporting information

Related issue: https://github.com/openedx/frontend-app-authoring/issues/2831

## Testing instructions

### Flag enabled for a specific course:

1. In the Django Admin, go to Home > Waffle_Utils > Waffle flag course overrides (/admin/waffle_utils/waffleflagcourseoverridemodel/)
2. Click on "ADD WAFFLE FLAG COURSE OVERRIDE"
3. Set Waffle flag to "authz.enable_course_authoring"
4. Set Course id to the desired course key
5. Set Override choice to "Force On"
6. Check the "Enabled" box
7. Click "Save"
8. Do an authorized request to `GET /api/contentstore/v1/course_waffle_flags`
	- Response should have the following value:
		```json
		{
			...
			"enable_authz_course_authoring": false
		}
		```
 9. Do an authorized request to `GET /api/contentstore/v1/course_waffle_flags/(desired course_key)`
	- Response should have the following value:
		```json
		{
			...
			"enable_authz_course_authoring": true
		}
		```

### Flag enabled for a specific ORG:

1. Disable any other flag override you added before
2. In the Django Admin, go to Home > Waffle_Utils > Add Waffle flag org override (/admin/waffle_utils/waffleflagorgoverridemodel/)
3. Click on "ADD WAFFLE FLAG ORG OVERRIDE"
4. Set Waffle flag to "authz.enable_course_authoring"
5. Set Course id to the desired Org name matching the course you are using to test
6. Set Override choice to "Force On"
7. Check the "Enabled" box
8. Click "Save"
9. Do an authorized request to `GET /api/contentstore/v1/course_waffle_flags`
	- Response should have the following value:
		```json
		{
			...
			"enable_authz_course_authoring": false
		}
		```
 10. Do an authorized request to `GET /api/contentstore/v1/course_waffle_flags/(desired course_key)`
	- Response should have the following value:
		```json
		{
			...
			"enable_authz_course_authoring": true
		}
		```

### Flag enabled globally:

1. Disable any other flag override you added before
2. In the Django Admin, go to Home > django-waffle > Flags (/admin/waffle/flag/)
3. Click on ADD FLAG
4. Set the Name to "authz.enable_course_authoring"
5. Set Everyone: "Yes"
6. Click "Save"
7. Do an authorized request to `GET /api/contentstore/v1/course_waffle_flags`
	- Response should have the following value:
		```json
		{
			...
			"enable_authz_course_authoring": true
		}
		```
 8. Do an authorized request to `GET /api/contentstore/v1/course_waffle_flags/(desired course_key)`
	- Response should have the following value:
		```json
		{
			...
			"enable_authz_course_authoring": true
		}
		```

## Deadline

Verawood release

