### PR TITLE
build: Upgrade to `ora2==6.17.2` which removes loremipsum base dep

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -708,8 +708,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/kernel.in
 lxml[html-clean]==5.3.2
@@ -840,7 +838,7 @@ openedx-learning==0.31.0
     #   -r requirements/edx/kernel.in
 optimizely-sdk==5.4.0
     # via -r requirements/edx/bundled.in
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/bundled.in
 packaging==25.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1190,11 +1190,6 @@ libsass==0.10.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.txt
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via
     #   -r requirements/edx/doc.txt
@@ -1413,7 +1408,7 @@ optimizely-sdk==5.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.17.1
+ora2==6.17.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -865,10 +865,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/base.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
@@ -1019,7 +1015,7 @@ openedx-learning==0.31.0
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -907,10 +907,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/base.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
@@ -1069,7 +1065,7 @@ openedx-learning==0.31.0
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via


### PR DESCRIPTION
## Description

We hope this will fix an error caused by the fact that loremipsum is using `pkg_resources`, which setuptools dropped support for as of v82 (released yesterday).

## Supporting information

Issue report from community member: https://discuss.openedx.org/t/course-catalog-is-empty/18379/7?u=kmccormick



```
tutor images build openedx
Building image docker.io/overhangio/openedx:21.0.0-indigo
docker buildx build --tag=docker.io/overhangio/openedx:21.0.0-indigo --output=type=docker --cache-from=type=registry,ref=docker.io/overhangio/openedx:21.0.0-indigo-cache /home/tutor/.local/share/tutor/env/build/openedx
[+] Building 6.5s (27/66)                                                                                                                                                               docker-container:max3cpu
 => [internal] load build definition from Dockerfile                                                                                                                                                        0.0s
 => => transferring dockerfile: 12.68kB                                                                                                                                                                     0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                                                   0.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6                                                                             0.0s
.......
 => CACHED [python-requirements 1/7] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt update     && apt install -y software-p  0.0s
 => CACHED [python-requirements 2/7] RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared     uv pip install     setuptools==69.1.1 pip==24.0 wheel==0.43.0                                     0.0s
 => ERROR [python-requirements 3/7] RUN --mount=type=bind,from=edx-platform,source=/requirements/edx/base.txt,target=/openedx/edx-platform/requirements/edx/base.txt     --mount=type=bind,from=edx-platfo  1.3s
------
 > [python-requirements 3/7] RUN --mount=type=bind,from=edx-platform,source=/requirements/edx/base.txt,target=/openedx/edx-platform/requirements/edx/base.txt     --mount=type=bind,from=edx-platform,source=/requirements/edx/assets.txt,target=/openedx/edx-platform/requirements/edx/assets.txt     --mount=type=cache,target=/openedx/.cache/pip,sharing=shared     uv pip install -r /openedx/edx-platform/requirements/edx/base.txt -r /openedx/edx-platform/requirements/edx/assets.txt:
0.140 Using Python 3.11.8 environment at: /openedx/venv
1.257   × Failed to build `loremipsum==1.0.5`
1.257   ├─▶ The build backend returned an error
1.257   ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
1.257       status: 1)
1.257
1.257       [stderr]
1.257       Traceback (most recent call last):
1.257         File "<string>", line 14, in <module>
1.257         File
1.257       "/openedx/.cache/pip/builds-v0/.tmpgTeYXs/lib/python3.11/site-packages/setuptools/build_meta.py",
1.257       line 333, in get_requires_for_build_wheel
1.257           return self._get_build_requires(config_settings, requirements=[])
1.257                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1.257         File
1.257       "/openedx/.cache/pip/builds-v0/.tmpgTeYXs/lib/python3.11/site-packages/setuptools/build_meta.py",
1.257       line 301, in _get_build_requires
1.257           self.run_setup()
1.257         File
1.257       "/openedx/.cache/pip/builds-v0/.tmpgTeYXs/lib/python3.11/site-packages/setuptools/build_meta.py",
1.257       line 520, in run_setup
1.257           super().run_setup(setup_script=setup_script)
1.257         File
1.257       "/openedx/.cache/pip/builds-v0/.tmpgTeYXs/lib/python3.11/site-packages/setuptools/build_meta.py",
1.257       line 317, in run_setup
1.257           exec(code, locals())
1.257         File "<string>", line 13, in <module>
1.257         File
1.257       "/openedx/.cache/pip/sdists-v9/pypi/loremipsum/1.0.5/LKbpG553hq161wdZGTyob/src/loremipsum/__init__.py",
1.257       line 61, in <module>
1.257           from .generator import Generator, DictionaryError, SampleError
1.257         File
1.257       "/openedx/.cache/pip/sdists-v9/pypi/loremipsum/1.0.5/LKbpG553hq161wdZGTyob/src/loremipsum/generator.py",
1.257       line 8, in <module>
1.257           from pkg_resources import resource_string
1.257       ModuleNotFoundError: No module named 'pkg_resources'
1.257
1.257       hint: This error likely indicates that `loremipsum@1.0.5` depends
1.257       on `pkg_resources`, but doesn't declare it as a build dependency. If
1.257       `loremipsum` is a first-party package, consider adding `pkg_resources`
1.257       to its `build-system.requires`. Otherwise, either add it to your
1.257       `pyproject.toml` under:
1.257
1.257       [tool.uv.extra-build-dependencies]
1.257       loremipsum = ["pkg_resources"]
1.257
1.257       or `uv pip install pkg_resources` into the environment and re-run with
1.257       `--no-build-isolation`.
------
Dockerfile:91
--------------------
  90 |     # Install base requirements and asset-building requirements
  91 | >>> RUN --mount=type=bind,from=edx-platform,source=/requirements/edx/base.txt,target=/openedx/edx-platform/requirements/edx/base.txt \
  92 | >>>     --mount=type=bind,from=edx-platform,source=/requirements/edx/assets.txt,target=/openedx/edx-platform/requirements/edx/assets.txt \
  93 | >>>     --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
  94 | >>>     $PIP_COMMAND install -r /openedx/edx-platform/requirements/edx/base.txt -r /openedx/edx-platform/requirements/edx/assets.txt
  95 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c $PIP_COMMAND install -r /openedx/edx-platform/requirements/edx/base.txt -r /openedx/edx-platform/requirements/edx/assets.txt" did not complete successfully: exit code: 1
Error: Command failed with status 1: docker buildx build --tag=docker.io/overhangio/openedx:21.0.0-indigo --output=type=docker --cache-from=type=registry,ref=docker.io/overhangio/openedx:21.0.0-indigo-cache /home/tutor/.local/share/tutor/env/build/openedx
```

Related links:
* setuptools 82: https://setuptools.pypa.io/en/latest/history.html#v82-0-0
* ORA2 PR: https://github.com/openedx/edx-ora2/pull/2360
* ORA2 6.17.2 release: https://pypi.org/project/ora2/6.17.2/

## Testing instructions

I am currently running a `tutor images build openedx openedx-dev` to see if this PR fixes the build issue.

Even if it doesn't, we'll want to merge this PR, and then keep digging in order to find other packages relying on `pkg_resources`.

No need to manually test application code, in my opinion.

## Deadline

ASAP, as this blocks basically all Open edX developers and site operators from building the platform image from scratch. 

## Other information

We should backport this to Ulmo, and possibly to older releases as well.

We did not fix the usage of `loremipsum` in edx-ora2 test code. That'll need to be done as followup later, but it's not critical to unblocking general open edx backend development.

* https://github.com/openedx/edx-ora2/issues/2361