### PR TITLE
[ulmo] build: Upgrade to ora2==6.17.2 which removes loremipsum base dep

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -726,8 +726,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/kernel.in
 lxml[html-clean]==5.3.2
@@ -862,7 +860,7 @@ openedx-learning==0.30.2
     #   -r requirements/edx/kernel.in
 optimizely-sdk==5.2.0
     # via -r requirements/edx/bundled.in
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/bundled.in
 packaging==25.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1208,11 +1208,6 @@ libsass==0.10.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.txt
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via
     #   -r requirements/edx/doc.txt
@@ -1429,7 +1424,7 @@ optimizely-sdk==5.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==6.17.1
+ora2==6.17.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -881,10 +881,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/base.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
@@ -1040,7 +1036,7 @@ openedx-learning==0.30.2
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.2.0
     # via -r requirements/edx/base.txt
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -923,10 +923,6 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-loremipsum==1.0.5
-    # via
-    #   -r requirements/edx/base.txt
-    #   ora2
 lti-consumer-xblock==9.14.3
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
@@ -1086,7 +1082,7 @@ openedx-learning==0.30.2
     #   -r requirements/edx/base.txt
 optimizely-sdk==5.2.0
     # via -r requirements/edx/base.txt
-ora2==6.17.1
+ora2==6.17.2
     # via -r requirements/edx/base.txt
 packaging==25.0
     # via


### PR DESCRIPTION
Backports: https://github.com/openedx/openedx-platform/pull/37991

This will fix ulmo.2 but will not be sufficient to fix ulmo.1 builds. So we may need to patch tutor, too.