### PR TITLE
fix: Typo in unsupported reason message in content libraries [FC-0114]

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
@@ -257,7 +257,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
                 self.course.id.make_usage_key('library_content', 'test_library_content'),
                 None,
                 'The "library_content" XBlock (ID: "test_library_content") has children, '
-                'so it not supported in content libraries. It has 2 children blocks.',
+                'so it is not supported in content libraries. It has 2 children blocks.',
             ),
         )
         self.assertEqual(len(result.children), 0)
@@ -394,7 +394,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
         self.assertEqual(
             reason,
             'The "library_content" XBlock (ID: "test_library_content") has children,'
-            ' so it not supported in content libraries.',
+            ' so it is not supported in content libraries.',
         )
 
     def test_migrate_component_with_static_content(self):

--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -310,7 +310,7 @@ def validate_can_add_block_to_library(
     if block_class.has_children:
         raise IncompatibleTypesError(
             _(
-                'The "{block_type}" XBlock (ID: "{block_id}") has children, so it not supported in content libraries.'
+                'The "{block_type}" XBlock (ID: "{block_id}") has children, so it is not supported in content libraries.'
             ).format(block_type=block_type, block_id=block_id)
         )
     # Make sure the new ID is not taken already:

--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -310,7 +310,8 @@ def validate_can_add_block_to_library(
     if block_class.has_children:
         raise IncompatibleTypesError(
             _(
-                'The "{block_type}" XBlock (ID: "{block_id}") has children, so it is not supported in content libraries.'
+                'The "{block_type}" XBlock (ID: "{block_id}") has children,'
+                ' so it is not supported in content libraries.'
             ).format(block_type=block_type, block_id=block_id)
         )
     # Make sure the new ID is not taken already:


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

- Fix a simple typo in an unsupported reason message for blocks with children in content libraries
- Which edX user roles will this change impact? "Course Author", "Developer".

## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2525#issuecomment-3862737018
- Related PR: https://github.com/openedx/frontend-app-authoring/pull/2871
- Internal ticket: FAL-4308

## Testing instructions

- Follow the testing instructions in https://github.com/openedx/frontend-app-authoring/pull/2871

## Deadline

None

## Other information

The unsupported reasons are stored in the database. This only fixes messages saved after this PR. Since it's a minor bug, the best option to fix previous messages is to run these commands on your instance:

```
# Preview the affected records
blocks = ModulestoreBlockMigration.objects.filter(unsupported_reason__contains='so it not supported')
print(blocks.count())

# Fix them
for block in blocks:
    block.unsupported_reason = block.unsupported_reason.replace('so it not supported', 'so it is not supported')
    block.save(update_fields=['unsupported_reason'])
```
