### PR TITLE
fix: optimize enrollment counts to use read replica and show all configured modes

### DIFF
--- a/lms/djangoapps/instructor/docs/references/instructor-v2-course-info-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-course-info-spec.yaml
@@ -256,25 +256,27 @@ definitions:
         example: 150
       enrollment_counts:
         type: object
-        description: Enrollment count breakdown by mode
+        description: |
+          Enrollment count breakdown by mode. Keys are the mode slugs
+          configured for the course (e.g. audit, verified, honor,
+          professional) plus a 'total' key. Only modes configured for
+          the course are included; unconfigured modes are omitted.
+          Modes with zero enrollments are included with a count of 0.
         properties:
           total:
             type: integer
             minimum: 0
-          audit:
-            type: integer
-            minimum: 0
-          verified:
-            type: integer
-            minimum: 0
-          honor:
-            type: integer
-            minimum: 0
+            description: Total enrollments across all modes
+        additionalProperties:
+          type: integer
+          minimum: 0
+          description: Enrollment count for a configured course mode
         example:
           total: 150
           audit: 100
           verified: 40
           honor: 10
+          professional: 0
       num_sections:
         type: integer
         minimum: 0

--- a/lms/djangoapps/instructor/docs/references/instructor-v2-course-info-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-course-info-spec.yaml
@@ -254,6 +254,16 @@ definitions:
         minimum: 0
         description: Total number of enrollments across all modes
         example: 150
+      learner_count:
+        type: integer
+        minimum: 0
+        description: Number of enrolled learners (excludes staff and admins)
+        example: 140
+      staff_count:
+        type: integer
+        minimum: 0
+        description: Number of enrolled staff and admins
+        example: 10
       enrollment_counts:
         type: object
         description: |

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -125,6 +125,11 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
         self.assertIn('total_enrollment', data)
         self.assertGreaterEqual(data['total_enrollment'], 3)
 
+        # Verify role-based enrollment counts are present
+        self.assertIn('learner_count', data)
+        self.assertIn('staff_count', data)
+        self.assertEqual(data['total_enrollment'], data['learner_count'] + data['staff_count'])
+
         # Verify permissions structure
         self.assertIn('permissions', data)
         permissions_data = data['permissions']
@@ -216,6 +221,28 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
 
         # Instructor should have instructor permission
         self.assertTrue(permissions_data['instructor'])
+
+    def test_learner_and_staff_counts(self):
+        """
+        Test that learner_count excludes staff/admins and staff_count is the difference.
+        """
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self._get_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+
+        total = data['total_enrollment']
+        learner_count = data['learner_count']
+        staff_count = data['staff_count']
+
+        # Counts must be non-negative and sum to total
+        self.assertGreaterEqual(learner_count, 0)
+        self.assertGreaterEqual(staff_count, 0)
+        self.assertEqual(total, learner_count + staff_count)
+
+        # The student enrolled in setUp is not staff, so learner_count >= 1
+        self.assertGreaterEqual(learner_count, 1)
 
     def test_enrollment_counts_by_mode(self):
         """

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -24,6 +24,7 @@ from common.djangoapps.student.tests.factories import (
     StaffFactory,
     UserFactory,
 )
+from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models.course_enrollment import CourseEnrollment
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor_task.tests.factories import InstructorTaskFactory
@@ -218,17 +219,58 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
 
     def test_enrollment_counts_by_mode(self):
         """
-        Test that enrollment counts include breakdown by mode.
+        Test that enrollment counts include all configured modes,
+        even those with zero enrollments.
         """
+        # Configure modes for the course: audit, verified, honor, and professional
+        for mode_slug in ('audit', 'verified', 'honor', 'professional'):
+            CourseModeFactory.create(course_id=self.course_key, mode_slug=mode_slug)
+
         self.client.force_authenticate(user=self.instructor)
         response = self.client.get(self._get_url())
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         enrollment_counts = response.data['enrollment_counts']
 
-        # Should have total count
+        # All configured modes should be present
+        self.assertIn('audit', enrollment_counts)
+        self.assertIn('verified', enrollment_counts)
+        self.assertIn('honor', enrollment_counts)
+        self.assertIn('professional', enrollment_counts)
         self.assertIn('total', enrollment_counts)
+
+        # professional has no enrollments but should still appear with 0
+        self.assertEqual(enrollment_counts['professional'], 0)
+
+        # Modes with enrollments should have correct counts
+        self.assertGreaterEqual(enrollment_counts['audit'], 1)
+        self.assertGreaterEqual(enrollment_counts['verified'], 1)
+        self.assertGreaterEqual(enrollment_counts['honor'], 1)
         self.assertGreaterEqual(enrollment_counts['total'], 3)
+
+    def test_enrollment_counts_excludes_unconfigured_modes(self):
+        """
+        Test that enrollment counts only include modes configured for the course,
+        not modes that exist on other courses.
+        """
+        # Only configure audit and honor for this course (not verified)
+        CourseModeFactory.create(course_id=self.course_key, mode_slug='audit')
+        CourseModeFactory.create(course_id=self.course_key, mode_slug='honor')
+
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self._get_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        enrollment_counts = response.data['enrollment_counts']
+
+        # Only configured modes should appear
+        self.assertIn('audit', enrollment_counts)
+        self.assertIn('honor', enrollment_counts)
+        self.assertIn('total', enrollment_counts)
+
+        # verified is not configured, so it should not appear
+        # (even though there are verified enrollments from setUp)
+        self.assertNotIn('verified', enrollment_counts)
 
     def _get_tabs_from_response(self, user, course_id=None):
         """Helper to get tabs from API response."""

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -6,12 +6,12 @@ Following REST best practices, serializers encapsulate most of the data processi
 """
 
 from django.conf import settings
-from django.db.models import Count
 from django.utils.html import escape
 from django.utils.translation import gettext as _
 from edx_when.api import is_enabled_for_course
 from rest_framework import serializers
 
+from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import (
     CourseFinanceAdminRole,
@@ -266,25 +266,16 @@ class CourseInformationSerializerV2(serializers.Serializer):
 
     def get_total_enrollment(self, data):
         """Get total enrollment count."""
-        total_enrollments = CourseEnrollment.objects.filter(
-            course_id=data['course'].id,
-            is_active=True
-        ).count()
-        return total_enrollments
+        return self.get_enrollment_counts(data)['total']
 
     def get_enrollment_counts(self, data):
-        """Get enrollment counts by mode."""
-        course = data['course']
-        total_enrollments = self.get_total_enrollment(data)
-        enrollments_by_mode = CourseEnrollment.objects.filter(
-            course_id=course.id,
-            is_active=True
-        ).values('mode').annotate(count=Count('mode'))
-
-        by_mode = {item['mode']: item['count'] for item in enrollments_by_mode}
-        by_mode['total'] = total_enrollments
-
-        return by_mode
+        """Get enrollment counts for all configured course modes."""
+        course_id = data['course'].id
+        counts = CourseEnrollment.objects.enrollment_counts(course_id)
+        configured_modes = CourseMode.modes_for_course(course_id)
+        result = {mode.slug: counts[mode.slug] for mode in configured_modes}
+        result['total'] = counts['total']
+        return result
 
     def get_num_sections(self, data):
         """Get number of sections in the course."""

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -54,6 +54,10 @@ class CourseInformationSerializerV2(serializers.Serializer):
     has_started = serializers.SerializerMethodField(help_text="Whether the course has started based on current time")
     has_ended = serializers.SerializerMethodField(help_text="Whether the course has ended based on current time")
     total_enrollment = serializers.SerializerMethodField(help_text="Total number of enrollments across all modes")
+    learner_count = serializers.SerializerMethodField(
+        help_text="Number of enrolled learners (excludes staff and admins)"
+    )
+    staff_count = serializers.SerializerMethodField(help_text="Number of enrolled staff and admins")
     enrollment_counts = serializers.SerializerMethodField(help_text="Enrollment count breakdown by mode")
     num_sections = serializers.SerializerMethodField(help_text="Number of sections/chapters in the course")
     grade_cutoffs = serializers.SerializerMethodField(help_text="Formatted string of grade cutoffs")
@@ -267,6 +271,14 @@ class CourseInformationSerializerV2(serializers.Serializer):
     def get_total_enrollment(self, data):
         """Get total enrollment count."""
         return self.get_enrollment_counts(data)['total']
+
+    def get_learner_count(self, data):
+        """Get enrollment count excluding staff and admins."""
+        return CourseEnrollment.objects.num_enrolled_in_exclude_admins(data['course'].id)
+
+    def get_staff_count(self, data):
+        """Get enrollment count for staff and admins only."""
+        return self.get_total_enrollment(data) - self.get_learner_count(data)
 
     def get_enrollment_counts(self, data):
         """Get enrollment counts for all configured course modes."""


### PR DESCRIPTION
## Description                                                                                                                                                         
                                                                                                                                                                         
  Optimizes the enrollment data in the Instructor API v2 Course Info endpoint (`CourseInformationSerializerV2`) to fix several issues:                                     

  1. **Show all configured modes**: Enrollment counts now include all modes configured for the course via `CourseMode.modes_for_course()`, even those with 0 enrollments. Modes not configured for the course are omitted. Previously, only modes with at least 1 enrollment appeared in the response.
  2. **Reduce redundant DB queries**: Replaced 3 separate database queries with a single call to the existing `CourseEnrollment.objects.enrollment_counts()` manager method.
  3. **Use read replica**: The manager method routes queries through `use_read_replica_if_available()`, reducing load on the primary database.
4. **Role-based enrollment counts**: Added `learner_count` (enrollments excluding staff and admins) and `staff_count` (total minus learner count) to support the enrollment summary UI.

**Impacted roles**: Course Author, Operator (Instructor Dashboard MFE consumers)

  **Files changed**:
  - `lms/djangoapps/instructor/views/serializers_v2.py` — Refactored `get_enrollment_counts()` and `get_total_enrollment()`
  - `lms/djangoapps/instructor/tests/test_api_v2.py` — Updated and added enrollment count tests
  - `lms/djangoapps/instructor/docs/references/instructor-v2-course-info-spec.yaml` — Updated schema to document dynamic mode keys

  ## Supporting information

  - Fixes: #38006
  - [Slack discussion on enrollment mode display](https://openedx.slack.com/archives/C097S3TF5L7/p1760652702169319)

##  Other information

  - No database migrations required
  - No dependencies on other changes
  - Backward compatible — the response shape is the same (object with mode keys + total), but now includes additional keys for configured modes that previously had 0 enrollments