### PR TITLE
VideoBlock code Optimization/Correction

### DIFF
--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -105,8 +105,8 @@ EXPORT_IMPORT_COURSE_DIR = 'course'
 EXPORT_IMPORT_STATIC_DIR = 'static'
 
 
-@XBlock.wants('settings', 'completion', 'i18n', 'request_cache', 'video_config')
-@XBlock.needs('mako', 'user')
+@XBlock.wants('settings', 'completion', 'request_cache', 'video_config')
+@XBlock.needs('mako', 'user', 'i18n')
 class _BuiltInVideoBlock(
         VideoFields, VideoTranscriptsMixin, VideoStudioViewHandlers, VideoStudentViewHandlers,
         EmptyDataRawMixin, XmlMixin, EditingMixin, XModuleToXBlockMixin,
@@ -265,7 +265,7 @@ class _BuiltInVideoBlock(
 
         fragment = Fragment(self.get_html(view=PUBLIC_VIEW, context=context))
         add_css_to_fragment(fragment, 'VideoBlockDisplay.css')
-        add_webpack_js_to_fragment(fragment, 'VideoBlockMain')
+        add_webpack_js_to_fragment(fragment, 'VideoBlockDisplay')
         fragment.initialize_js('Video')
         return fragment
 


### PR DESCRIPTION
We are going to do these changes for the extracted Video Block resides in `xblocks-contrib` in this [PR](https://github.com/openedx/xblocks-contrib/pull/142).

Aximprovements team has decided we should directly do the changes within edx-platform for the code correction and it will get early test/response by the community.

Relevant old [PR](https://github.com/openedx/openedx-platform/pull/36595/changes#diff-0c437f410aa8b98a76aa91ccd72e2b9c2da8c49f09168fa66ed63861529eebafR283) of edx-platform

### Details:

- Change the `i18n` service declaration from `wants` to `needs`, since the runtime must provide it for the block to function correctly.
- Update the `public_view` webpack JS reference from `VideoBlockMain` to `VideoBlockDisplay`, as all VideoBlock JS files are bundled into `VideoBlockDisplay` and `VideoBlockMain` is not referring to anything or no longer exists in the repository.


### Testing/Screenshots:

I have verified on Preview/Live Version/LMS/Studio, video block in redering fine on sandbox and local setup.
Here are the screenshots.

<img width="1341" height="626" alt="Screenshot 2026-02-17 at 11 46 53 AM" src="https://github.com/user-attachments/assets/862d8c0d-c10a-4dd1-8cc3-a5b399273717" />

----

<img width="2704" height="3800" alt="screencapture-apps-local-openedx-io-2001-authoring-course-course-v1-axim-1-1-container-block-v1-axim-1-1-type-vertical-block-vertical3-block-v1-axim-1-1-type-sequential-block-e90f308c5b314389899787459ced3361-2026-02-17-12_08_14" src="https://github.com/user-attachments/assets/211417ec-dfe0-4e7f-9477-9ace8c4f162f" />

----

<img width="2704" height="2584" alt="screencapture-apps-local-openedx-io-2000-learning-course-course-v1-axim-1-1-block-v1-axim-1-1-type-sequential-block-e90f308c5b314389899787459ced3361-block-v1-axim-1-1-type-vertical-block-vertical3-2026-02-17-12_08_08" src="https://github.com/user-attachments/assets/a2dec6cc-6ce8-4aa9-bacd-55d619329898" />

