### PR TITLE
fix: add @edxnotes decorator to extracted HTML block to enable studen…

### DIFF
--- a/xmodule/html_block.py
+++ b/xmodule/html_block.py
@@ -385,7 +385,6 @@ class _ExtractedHtmlBlock(_OriginalExtractedHtmlBlock):  # lint-amnesty, pylint:
     Extracted HTML XBlock with edxnotes support.
     Wraps the original extracted block from xblocks-contrib to add notes functionality.
     """
-    pass
 
 
 @edxnotes
@@ -394,7 +393,6 @@ class _ExtractedHtmlBlockMixin(_OriginalExtractedHtmlBlockMixin):  # lint-amnest
     Extracted HTML XBlock Mixin with edxnotes support.
     Wraps the original extracted mixin from xblocks-contrib to add notes functionality.
     """
-    pass
 
 
 HtmlBlockMixin = None

--- a/xmodule/html_block.py
+++ b/xmodule/html_block.py
@@ -15,8 +15,8 @@ from path import Path as path
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Boolean, List, Scope, String
-from xblocks_contrib.html import HtmlBlock as _ExtractedHtmlBlock
-from xblocks_contrib.html import HtmlBlockMixin as _ExtractedHtmlBlockMixin
+from xblocks_contrib.html import HtmlBlock as _OriginalExtractedHtmlBlock
+from xblocks_contrib.html import HtmlBlockMixin as _OriginalExtractedHtmlBlockMixin
 
 from common.djangoapps.xblock_django.constants import ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID
 from xmodule.contentstore.content import StaticContent
@@ -377,6 +377,24 @@ class _BuiltInHtmlBlock(_BuiltinHtmlBlockMixin):  # lint-amnesty, pylint: disabl
     Nothing extra is required; this is just a wrapper to include edxnotes support.
     """
     is_extracted = False
+
+
+@edxnotes
+class _ExtractedHtmlBlock(_OriginalExtractedHtmlBlock):  # lint-amnesty, pylint: disable=abstract-method
+    """
+    Extracted HTML XBlock with edxnotes support.
+    Wraps the original extracted block from xblocks-contrib to add notes functionality.
+    """
+    pass
+
+
+@edxnotes
+class _ExtractedHtmlBlockMixin(_OriginalExtractedHtmlBlockMixin):  # lint-amnesty, pylint: disable=abstract-method
+    """
+    Extracted HTML XBlock Mixin with edxnotes support.
+    Wraps the original extracted mixin from xblocks-contrib to add notes functionality.
+    """
+    pass
 
 
 HtmlBlockMixin = None


### PR DESCRIPTION
### What are the relevant tickets?
[#9533](https://github.com/mitodl/hq/issues/9533)

### Description (What does it do?)

This PR fixes a bug where the student notes feature (text highlighting and annotation) was not working when `USE_EXTRACTED_HTML_BLOCK=True`. When Open edX migrated HTML blocks to the external [xblocks-contrib](https://github.com/openedx/xblocks-contrib) package, the `@edxnotes` decorator was not applied to the [extracted implementation](https://github.com/openedx/xblocks-contrib/blob/main/xblocks_contrib/html/html.py#L245), preventing the notes wrapper HTML and JavaScript from being generated using the extracted HTML Block. 

This fix wraps the extracted `HtmlBlock` and `HtmlBlockMixin` classes from `xblocks-contrib` with the `@edxnotes` decorator, ensuring notes functionality works regardless of the `USE_EXTRACTED_HTML_BLOCK` setting. 

The issue could be solved by setting `USE_EXTRACTED_HTML_BLOCK=False` but since edx-platform plans to extract all the xBlocks eventually this flag would be removed and Extracted blocks would be used. Ref: https://github.com/openedx/openedx-platform/issues/34827 & [toggle-definition](https://github.com/openedx/openedx-platform/blob/43690553f6ee2d723e32a0b4b2769092f4fd2a91/openedx/envs/common.py#L2070)

Note: The decorator includes multiple safety checks (feature flag, Studio mode, course settings) to ensure it only wraps content when appropriate, making this a low-risk change that restores expected functionality without affecting other features.


### Testing Steps

To start with,

1. Ensure `ENABLE_EDXNOTES = True` & `USE_EXTRACTED_HTML_BLOCK=True` in your environment settings
2. Ensure you have an OAuth2 Application configured for edx-notes (or the edx-notes API service)
3. Ensure the course has notes enabled in Studio (Advanced Settings → Enable Student Notes)

Then,

1. As a student, navigate to any unit containing an HTML/Text block
2. Open browser developer console, verify the notes wrapper is present (the following value should be >0):

```javascript
   console.log('Notes wrappers:', document.querySelectorAll('.edx-notes-wrapper').length);
```

3. Highlight any text in the HTML block and verify a popup should appear with options to create a note
4. Create a note and verify it saves successfully
5. Refresh the page and verify existing notes are displayed