### PR TITLE
fix: avoid anonymous completion lookup in navigation

### DIFF
--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -584,6 +584,25 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         assert response.status_code == 200
         assert response.data.get('blocks') is None
 
+    @override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True)
+    def test_get_unauthenticated_public_course_does_not_lookup_completions(self):
+        """
+        Test that anonymous public course navigation does not query completion data.
+        """
+        self.add_blocks_to_course()
+        BlockFactory.create(parent=self.vertical, category='problem', graded=True, has_score=True)
+        update_outline_from_modulestore(self.course.id)
+        self.course.course_visibility = COURSE_VISIBILITY_PUBLIC
+        self.update_course_and_overview()
+        self.client.logout()
+
+        with patch('lms.djangoapps.course_home_api.outline.views.BlockCompletion.objects.filter') as mock_filter:
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data['blocks'] is not None
+        mock_filter.assert_not_called()
+
     def test_course_staff_can_see_non_user_specific_content_in_masquerade(self):
         """
         Test that course staff can see the outline and other non-user-specific content when masquerading as a learner

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import ddt
 from completion.models import BlockCompletion
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -20,6 +21,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.course_home_api.outline.views import CourseNavigationBlocksView
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_SEND_COURSE_PROGRESS_ANALYTICS_FOR_STUDENT
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
@@ -584,23 +586,18 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         assert response.status_code == 200
         assert response.data.get('blocks') is None
 
-    @override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True)
-    def test_get_unauthenticated_public_course_does_not_lookup_completions(self):
+    def test_anonymous_user_completion_dict_does_not_lookup_completions(self):
         """
-        Test that anonymous public course navigation does not query completion data.
+        Test that anonymous users do not query completion data.
         """
-        self.add_blocks_to_course()
-        BlockFactory.create(parent=self.vertical, category='problem', graded=True, has_score=True)
-        update_outline_from_modulestore(self.course.id)
-        self.course.course_visibility = COURSE_VISIBILITY_PUBLIC
-        self.update_course_and_overview()
-        self.client.logout()
+        view = CourseNavigationBlocksView()
+        view.request = Mock(user=AnonymousUser())
+        view.kwargs = {'course_key_string': str(self.course.id)}
 
         with patch('lms.djangoapps.course_home_api.outline.views.BlockCompletion.objects.filter') as mock_filter:
-            response = self.client.get(self.url)
+            completions = view.completions_dict
 
-        assert response.status_code == 200
-        assert response.data['blocks'] is not None
+        assert completions == {}
         mock_filter.assert_not_called()
 
     def test_course_staff_can_see_non_user_specific_content_in_masquerade(self):

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -613,12 +613,11 @@ class CourseNavigationBlocksView(RetrieveAPIView):
         Dictionary keys are block keys and values are int values
         representing the completion status of the block.
         """
-
         # Anonymous users have no completion rows; return empty data to avoid
         # querying BlockCompletion with AnonymousUser for public course navigation.
         if self.request.user.is_anonymous:
             return {}
-        
+
         course_key_string = self.kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
         completions = BlockCompletion.objects.filter(user=self.request.user, context_key=course_key).values_list(

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -613,6 +613,12 @@ class CourseNavigationBlocksView(RetrieveAPIView):
         Dictionary keys are block keys and values are int values
         representing the completion status of the block.
         """
+
+        # Anonymous users have no completion rows; return empty data to avoid
+        # querying BlockCompletion with AnonymousUser for public course navigation.
+        if self.request.user.is_anonymous:
+            return {}
+        
         course_key_string = self.kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
         completions = BlockCompletion.objects.filter(user=self.request.user, context_key=course_key).values_list(

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -602,6 +602,12 @@ class CourseNavigationBlocksView(RetrieveAPIView):
         Dictionary keys are block keys and values are int values
         representing the completion status of the block.
         """
+
+        # Anonymous users have no completion rows; return empty data to avoid
+        # querying BlockCompletion with AnonymousUser for public course navigation.
+        if self.request.user.is_anonymous:
+            return {}
+        
         course_key_string = self.kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
         completions = BlockCompletion.objects.filter(user=self.request.user, context_key=course_key).values_list(


### PR DESCRIPTION
## Description

This PR fixes course outline loading for anonymous users in the Learning MFE by preventing a server error in the course navigation API.

Previously, anonymous requests to `GET /api/course_home/v1/navigation/{course_key}` could raise a `500` when completion data was queried with `AnonymousUser`. This caused the course outline sidebar to fail to render for logged-out users, even when course visibility and waffle settings allowed public access.

This change adds an anonymous-user guard in `CourseNavigationBlocksView.completions_dict`:

* If `request.user` is anonymous, return an empty completion map (`{}`).
* Keep existing outline access filtering logic (`filter_inaccessible_blocks`) unchanged to preserve access control.

**Implications**

* Anonymous users now receive a valid navigation payload instead of a `500`.
* Visibility/access restrictions continue to be enforced by existing processors and filtering.
* No behavior change for authenticated learners/staff.


## Supporting information

**Relevant code / endpoint**

* File: `lms/djangoapps/course_home_api/outline/views.py`
* Endpoint: `GET /api/course_home/v1/navigation/{course_key}`
* Root cause: completion lookup attempted for `AnonymousUser`

**Configuration context (unchanged)**

* `seo.enable_anonymous_courseware_access` enabled
* Course visibility set to `public` or `public_outline`



## Testing instructions

1. Ensure the course is configured with:

   * visibility set to `public` (or `public_outline`)
   * waffle flag `seo.enable_anonymous_courseware_access` enabled
2. Open the courseware URL in an incognito / logged-out browser session.
3. Confirm `GET /api/course_home/v1/navigation/{course_key}` returns `200` (not `500`).
4. Verify the outline sidebar renders in the Learning MFE.
5. Log in as a learner and as staff/admin and confirm outline behavior is unchanged.
6. Optional regression checks:

   * Confirm hidden/inaccessible content remains filtered as before.
   * Confirm no new traceback appears in LMS logs for anonymous navigation requests.



## Deadline

None.



## Other information

**User roles impacted**

* **Learner:** Yes (logged-out / public access flow)
* **Course Author:** No direct impact
* **Developer:** Yes (API behavior and debugging flow)
* **Operator:** Yes (reduced 500s in logs for anonymous navigation requests)

**UI changes**

* UI impact: course outline now renders for anonymous users on eligible `public` / `public_outline` courses.
* Suggested screenshots to attach:

  1. Before: anonymous courseware page with missing/empty outline + API `500`
  2. After: anonymous courseware page with outline visible + API `200`
  3. Network tab response for `/api/course_home/v1/navigation/{course_key}` (before vs after)

**Configuration changes**

* None.

**Dependencies / special concerns**

* No dependency on other PRs.
* No deprecations or migrations.
* Security/access control is unchanged (no relaxation of access restrictions); this only prevents anonymous completion lookup failures.
* No API contract changes.
