### PR TITLE
fix: Convert UUIDField columns to uuid type for Mariadb

### DIFF
--- a/cms/djangoapps/contentstore/migrations/0016_mariadb_uuid_conversion.py
+++ b/cms/djangoapps/contentstore/migrations/0016_mariadb_uuid_conversion.py
@@ -1,0 +1,71 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+This migration is necessary because Django 5 changed the behavior of UUIDField for MariaDB
+databases from using CharField(32) to using a proper UUID type. This change isn't managed
+automatically, so we need to generate migrations to safely convert the columns.
+
+This migration only executes for MariaDB databases and is a no-op for other backends.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    """Apply the migration only for MariaDB databases."""
+    connection = schema_editor.connection
+
+    # Check if this is a MariaDB database
+    if connection.vendor != "mysql":
+        return
+
+    # Additional check for MariaDB specifically (vs MySQL)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if "mariadb" not in version.lower():
+            return
+
+    # Apply the field changes for MariaDB
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE oel_publishing_learningpackage MODIFY uuid uuid NOT NULL"
+        )
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    """Reverse the migration only for MariaDB databases."""
+    connection = schema_editor.connection
+
+    # Check if this is a MariaDB database
+    if connection.vendor != "mysql":
+        return
+
+    # Additional check for MariaDB specifically (vs MySQL)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if "mariadb" not in version.lower():
+            return
+
+    # Reverse the field changes for MariaDB
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE oel_publishing_learningpackage MODIFY uuid char(32) NOT NULL"
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("contentstore", "0015_switch_to_openedx_content"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]


### PR DESCRIPTION
Redo of PR #37966

## Description

The behavior of the MariaDB backend has changed behavior for UUIDField from a `CharField(32)` to an actual `uuid` type. This is not converted automatically, which results in all writes to the affected columns to error with a message about the data being too long. This is because the actual string being written is a UUID with the `-` included, resulting in a 36 character value which can't be inserted into a 32 character column.

## Supporting information

https://docs.djangoproject.com/en/5.2/releases/5.0/#migrating-uuidfield

## Testing instructions

Configure edx-platform to use a MariaDB database as well as the work necessary to use Libraries V2 (meilisearch, etc), run the migrations up through the Django 5.2 update, then perform the 5.2 update and try to create a new V2 Library. It will error. After applying these migrations it should work.

## Deadline

This is a blocking error that prevents the LibrariesV2 from being operational when using MariaDB as the database engine.

## Other information

This is in addition to the migrations found in PR https://github.com/openedx/openedx-platform/pull/37494

