### PR TITLE
temp: Run tests with MySQL

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     runs-on: ${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.11"

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -85,9 +85,15 @@ CONTENTSTORE = {
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": TEST_ROOT / "db" / "cms.db",
-        "ATOMIC_REQUESTS": True,
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'edxapp',
+        'USER': 'edxapp001',
+        'PASSWORD': 'password',
+        'HOST': '127.0.0.1',
+        'PORT': '3306',
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
+        }
     },
 }
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -128,9 +128,16 @@ CONTENTSTORE = {
 }
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'ATOMIC_REQUESTS': True,
+    "default": {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'edxapp',
+        'USER': 'edxapp001',
+        'PASSWORD': 'password',
+        'HOST': '127.0.0.1',
+        'PORT': '3306',
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
+        }
     },
     'student_module_history': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
We install mysql as part of the unit testing workflow, but it seems that we actually run tests with SQLite.

This is probably because running tests with MySQL on every PR would be a lot slower.

Opening this PR to see how many failures we get....

@ormsbee @bradenmacdonald 