### PR TITLE
fix: break with error on postgresql 14

### DIFF
--- a/lms/djangoapps/courseware/fields.py
+++ b/lms/djangoapps/courseware/fields.py
@@ -21,7 +21,7 @@ class UnsignedBigIntAutoField(AutoField):
         elif "postgresql" in connection.settings_dict['ENGINE']:
             # Pg's bigserial is implicitly unsigned (doesn't allow negative numbers) and
             # goes 1-9.2x10^18
-            return "BIGSERIAL"
+            return "BIGINT"
         else:
             return None
 
@@ -31,6 +31,6 @@ class UnsignedBigIntAutoField(AutoField):
         elif connection.settings_dict['ENGINE'] == 'django.db.backends.sqlite3':
             return "integer"
         elif "postgresql" in connection.settings_dict['ENGINE']:
-            return "BIGSERIAL"
+            return "BIGINT"
         else:
             return None


### PR DESCRIPTION
## Description


This pull request makes a targeted update to how PostgreSQL database types are specified in the `courseware/fields.py` file. Specifically, it changes the type returned for PostgreSQL from `BIGSERIAL` to `BIGINT` in both the `db_type` and `rel_db_type` methods. This ensures that auto-incrementing behavior is not implicitly assumed and aligns with scenarios where a plain integer type is needed.

Database type adjustments for PostgreSQL:

* Changed the return value for PostgreSQL from `BIGSERIAL` to `BIGINT` in the `db_type` method of `courseware/fields.py` to avoid implicit auto-increment and better match intended usage.
* Updated the `rel_db_type` method to return `BIGINT` instead of `BIGSERIAL` for PostgreSQL, ensuring consistency in type handling.

Useful information to include:

- When executing migrations with postgresql 14 getting error `ERROR:  both default and identity specified for column "id" of table "grades_persistentsubsectiongrade"`



## Supporting information
It is because django is creating unsupported DDL.

```SQL
CREATE TABLE "grades_persistentsubsectiongrade" ("created" timestamp with time zone NOT NULL, "modified" timestamp with time zone NOT NULL, "id" BIGSERIAL NOT NULL PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY, "user_id" integer NOT NULL, "course_id" varchar(255) NOT NULL, "usage_key" varchar(255) NOT NULL, "subtree_edited_date" timestamp with time zone NOT NULL, "course_version" varchar(255) NOT NULL, "earned_all" double precision NOT NULL, "possible_all" double precision NOT NULL, "earned_graded" double precision NOT NULL, "possible_graded" double precision NOT NULL)
```

## Testing instructions

After adding fix re-applied migrations for Grades app it work this time.
<img width="1314" height="554" alt="image" src="https://github.com/user-attachments/assets/de70b758-1445-4642-9c4f-4296a20dd629" />

It has also added ID column for both the tables `bitint (auto increment)` which is desired type.
<img width="567" height="505" alt="image" src="https://github.com/user-attachments/assets/28f5b7f0-4e38-42de-8782-3d8d92a74b5c" />


## Deadline

None