### PR TITLE
chore: deprecate content libraries authorization permissions, apis, rest apis and models

### DIFF
--- a/openedx/core/djangoapps/content_libraries/admin.py
+++ b/openedx/core/djangoapps/content_libraries/admin.py
@@ -2,16 +2,8 @@
 Admin site for content libraries
 """
 from django.contrib import admin
-from .models import ContentLibrary, ContentLibraryPermission
 
-
-class ContentLibraryPermissionInline(admin.TabularInline):
-    """
-    Inline form for a content library's permissions
-    """
-    model = ContentLibraryPermission
-    raw_id_fields = ("user", "group", )
-    extra = 0
+from .models import ContentLibrary
 
 
 @admin.register(ContentLibrary)
@@ -29,7 +21,6 @@ class ContentLibraryAdmin(admin.ModelAdmin):
         "authorized_lti_configs",
     )
     list_display = ("slug", "org",)
-    inlines = (ContentLibraryPermissionInline, )
 
     def get_readonly_fields(self, request, obj=None):
         """

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -496,7 +496,9 @@ def get_library_team(library_key: LibraryLocatorV2) -> list[ContentLibraryPermis
     Get the list of users/groups granted permission to use this library.
     """
     warnings.warn(
-        "get_library_team is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        "get_library_team is deprecated. "
+        "Use get_all_user_role_assignments_in_scope from the openedx-authz API instead. "
+        "See https://github.com/openedx/openedx-platform/issues/37409.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -514,7 +516,9 @@ def get_library_user_permissions(library_key: LibraryLocatorV2, user: UserType) 
     permissions have been granted.
     """
     warnings.warn(
-        "get_library_user_permissions is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        "get_library_user_permissions is deprecated. "
+        "Use get_user_role_assignments_in_scope from the openedx-authz API instead. "
+        "See https://github.com/openedx/openedx-platform/issues/37409.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -539,7 +543,9 @@ def set_library_user_permissions(library_key: LibraryLocatorV2, user: UserType, 
     access_level should be one of the AccessLevel values defined above.
     """
     warnings.warn(
-        "set_library_user_permissions is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        "set_library_user_permissions is deprecated. "
+        "Use assign_library_role_to_user instead. "
+        "See https://github.com/openedx/openedx-platform/issues/37409.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -593,7 +599,9 @@ def set_library_group_permissions(library_key: LibraryLocatorV2, group, access_l
     access_level should be one of the AccessLevel values defined above.
     """
     warnings.warn(
-        "set_library_group_permissions is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        "set_library_group_permissions is deprecated. "
+        "Use assign_library_role_to_user instead. "
+        "See https://github.com/openedx/openedx-platform/issues/37409.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -42,6 +42,7 @@ could be promoted to the core XBlock API and made generic.
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from datetime import datetime
@@ -494,6 +495,12 @@ def get_library_team(library_key: LibraryLocatorV2) -> list[ContentLibraryPermis
     """
     Get the list of users/groups granted permission to use this library.
     """
+    warnings.warn(
+        "get_library_team is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     ref = ContentLibrary.objects.get_by_key(library_key)
     return [
         ContentLibraryPermissionEntry(user=entry.user, group=entry.group, access_level=entry.access_level)
@@ -506,6 +513,12 @@ def get_library_user_permissions(library_key: LibraryLocatorV2, user: UserType) 
     Fetch the specified user's access information. Will return None if no
     permissions have been granted.
     """
+    warnings.warn(
+        "get_library_user_permissions is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if isinstance(user, AnonymousUser):
         return None  # Mostly here for the type checker
     ref = ContentLibrary.objects.get_by_key(library_key)
@@ -525,6 +538,12 @@ def set_library_user_permissions(library_key: LibraryLocatorV2, user: UserType, 
 
     access_level should be one of the AccessLevel values defined above.
     """
+    warnings.warn(
+        "set_library_user_permissions is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if isinstance(user, AnonymousUser):
         raise TypeError("Invalid user type")  # Mostly here for the type checker
     ref = ContentLibrary.objects.get_by_key(library_key)
@@ -573,6 +592,12 @@ def set_library_group_permissions(library_key: LibraryLocatorV2, group, access_l
 
     access_level should be one of the AccessLevel values defined above.
     """
+    warnings.warn(
+        "set_library_group_permissions is deprecated. See https://github.com/openedx/openedx-platform/issues/37409.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     ref = ContentLibrary.objects.get_by_key(library_key)
 
     if access_level is None:

--- a/openedx/core/djangoapps/content_libraries/api/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/api/permissions.py
@@ -1,5 +1,8 @@
 """
-Public permissions that are part of the content libraries API
+Public permissions that are part of the content libraries API.
+
+Deprecated. This module re-exports legacy content library permissions.
+See https://github.com/openedx/openedx-platform/issues/37409.
 """
 # pylint: disable=unused-import
 

--- a/openedx/core/djangoapps/content_libraries/models.py
+++ b/openedx/core/djangoapps/content_libraries/models.py
@@ -36,8 +36,9 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import ClassVar
 import uuid
+import warnings
+from typing import ClassVar
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -64,6 +65,15 @@ from .apps import ContentLibrariesConfig
 
 
 log = logging.getLogger(__name__)
+
+
+warnings.warn(
+    (
+        "ContentLibraryPermission model and related content library authorization "
+        "APIs are deprecated. See https://github.com/openedx/openedx-platform/issues/37409."
+    ),
+    DeprecationWarning
+)
 
 User = get_user_model()
 
@@ -186,6 +196,8 @@ class ContentLibrary(models.Model):
 class ContentLibraryPermission(models.Model):
     """
     Row recording permissions for a content library
+
+    Deprecated https://github.com/openedx/openedx-platform/issues/37409.
 
     .. no_pii:
     """

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -1,5 +1,8 @@
 """
 Permissions for Content Libraries (v2, openedx_content-based)
+
+Deprecated: The legacy permission rules and constants that rely on ContentLibraryPermission
+are deprecated in favor of openedx-authz. See https://github.com/openedx/openedx-platform/issues/37409.
 """
 from bridgekeeper import perms, rules
 from bridgekeeper.rules import Attribute, ManyRelation, Relation, blanket_rule, in_current_groups, Rule

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -65,6 +65,7 @@ the api module instead.
 import itertools
 import json
 import logging
+import warnings
 
 import edx_api_doc_tools as apidocs
 from django.conf import settings
@@ -134,6 +135,15 @@ from .utils import convert_exceptions
 
 User = get_user_model()
 log = logging.getLogger(__name__)
+
+
+warnings.warn(
+    (
+        "Content library team authorization REST APIs are deprecated. "
+        "See https://github.com/openedx/openedx-platform/issues/37409."
+    ),
+    DeprecationWarning
+)
 
 
 class LibraryApiPaginationDocs:
@@ -323,6 +333,8 @@ class LibraryTeamView(APIView):
 
     Note also the 'allow_public_' settings which can be edited by PATCHing the
     library itself (LibraryDetailsView.patch).
+
+    Deprecated https://github.com/openedx/openedx-platform/issues/37409
     """
     @convert_exceptions
     def post(self, request, lib_key_str):
@@ -369,6 +381,8 @@ class LibraryTeamUserView(APIView):
     """
     View to add/remove/edit an individual user's permissions for a content
     library.
+
+    Deprecated https://github.com/openedx/openedx-platform/issues/37409
     """
     @convert_exceptions
     def put(self, request, lib_key_str, username):
@@ -422,6 +436,8 @@ class LibraryTeamUserView(APIView):
 class LibraryTeamGroupView(APIView):
     """
     View to add/remove/edit a group's permissions for a content library.
+
+    Deprecated https://github.com/openedx/openedx-platform/issues/37409
     """
     @convert_exceptions
     def put(self, request, lib_key_str, group_name):

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -342,6 +342,12 @@ class LibraryTeamView(APIView):
         Add a user to this content library via email, with permissions specified in the
         request body.
         """
+        warnings.warn(
+            "LibraryTeamView is deprecated. Use RoleUserAPIView from openedx-authz instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY_TEAM)
         serializer = ContentLibraryAddPermissionByEmailSerializer(data=request.data)
@@ -369,6 +375,12 @@ class LibraryTeamView(APIView):
         Get the list of users and groups who have permissions to view and edit
         this library.
         """
+        warnings.warn(
+            "LibraryTeamView is deprecated. Use RoleUserAPIView from openedx-authz instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_VIEW_THIS_CONTENT_LIBRARY_TEAM)
         team = api.get_library_team(key)
@@ -390,6 +402,12 @@ class LibraryTeamUserView(APIView):
         Add a user to this content library, with permissions specified in the
         request body.
         """
+        warnings.warn(
+            "LibraryTeamUserView is deprecated. Use RoleUserAPIView from openedx-authz instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY_TEAM)
         serializer = ContentLibraryPermissionLevelSerializer(data=request.data)
@@ -407,6 +425,12 @@ class LibraryTeamUserView(APIView):
         """
         Gets the current permissions settings for a particular user.
         """
+        warnings.warn(
+            "LibraryTeamUserView is deprecated. Use RoleUserAPIView from openedx-authz instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_VIEW_THIS_CONTENT_LIBRARY_TEAM)
         user = get_object_or_404(User, username=username)
@@ -421,6 +445,12 @@ class LibraryTeamUserView(APIView):
         Remove the specified user's permission to access or edit this content
         library.
         """
+        warnings.warn(
+            "LibraryTeamUserView is deprecated. Use RoleUserAPIView from openedx-authz instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY_TEAM)
         user = get_object_or_404(User, username=username)
@@ -445,6 +475,12 @@ class LibraryTeamGroupView(APIView):
         Add a group to this content library, with permissions specified in the
         request body.
         """
+        warnings.warn(
+            "LibraryTeamGroupView is deprecated. Use RoleUserAPIView from openedx-authz instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY_TEAM)
         serializer = ContentLibraryPermissionLevelSerializer(data=request.data)
@@ -459,6 +495,12 @@ class LibraryTeamGroupView(APIView):
         Remove the specified user's permission to access or edit this content
         library.
         """
+        warnings.warn(
+            "LibraryTeamGroupView is deprecated. Use RoleUserAPIView from openedx-authz instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         key = LibraryLocatorV2.from_string(lib_key_str)
         api.require_permission_for_library_key(key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY_TEAM)
         group = get_object_or_404(Group, username=username)


### PR DESCRIPTION
## Description

This PR deprecates the Content Libraries team roles/permission system backed by the `ContentLibraryPermission` model, following [OEP-0021](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html).

Concretely, this PR:
- Marks the `ContentLibraryPermission` model as deprecated via docstring and a `DeprecationWarning`.
- Marks the Content Libraries authorization/team REST API endpoints as deprecated in their docstrings and via a module-level `DeprecationWarning`.
- Marks the authorization API methods in `openedx/core/djangoapps/content_libraries/api/libraries.py` as deprecated (`get_library_team`, `get_library_user_permissions`, `set_library_user_permissions`, `set_library_group_permissions`) with a `DeprecationWarning` on each call.
-  Marks the legacy permission rules and constants in `permissions.py` (and the re-exports in `api/permissions.py`) as deprecated in their module docstrings, in favor of openedx-authz and `HasPermissionInContentLibraryScope`.
- Removes the `ContentLibraryPermission` inline from the `ContentLibrary` Django admin so new permissions are no longer managed through that model.

## Supporting information

- https://github.com/openedx/openedx-platform/issues/37409
- [Discuss Post](https://discuss.openedx.org/t/depr-libraries-roles-and-permission-system/17392)

## Deadline

None