### PR TITLE
feat!: Bump xblocks-contrib to install PDF block by default

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1268,7 +1268,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.10.2
+xblocks-contrib==0.11.0
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2298,7 +2298,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.10.2
+xblocks-contrib==0.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1607,7 +1607,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.10.2
+xblocks-contrib==0.11.0
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1697,7 +1697,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.10.2
+xblocks-contrib==0.11.0
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via


### PR DESCRIPTION
## Description

This merge request bumps xblocks-contrib to the latest version.

```
BREAKING CHANGE: The `pdf` XBlock is now built into the platform core and
installed by default. If you previously installed a third-party pdf
implementation such as https://github.com/open-craft/xblock-pdf, then the
built-in implementation will likely work as a drop-in replacement, so you can
uninstall the third-party implementation. However, if you’d rather continue
using a third-party pdf implementation, then use the `xblock.v1.overrides`
entrypoint. In either case, the third-party implementation must be removed from
the `xblock.v1` entrypoint, otherwise you will see an AmbiguousPluginError.
```

## Supporting information

https://github.com/openedx/xblocks-contrib/pull/148

## Visual changes

<img width="1653" height="950" alt="image" src="https://github.com/user-attachments/assets/d9462e38-4d6c-4a3c-9a8f-a1496615b3ce" />

<img width="1653" height="950" alt="image" src="https://github.com/user-attachments/assets/c9555134-6256-4c09-84d2-01f902032b59" />

<img width="1782" height="876" alt="image" src="https://github.com/user-attachments/assets/87e7712b-d394-48e2-9645-712787de66c1" />

Further refinements to the PDF block (including file uploads) will be contributed to `frontend-app-authoring`. For now, we're porting the existing interface.

## Testing instructions

1. Add "pdf" to the advanced modules list for a course
2. Add a PDF block to the course using the advanced modules list.
3. Verify that the block shows up as expected.

## Deadline

Sooner's better than later.

## Other information

https://openedx.atlassian.net/wiki/spaces/OEPM/pages/5335908397/Proposal+Add+PDF+Block+to+Base+Installation