### PR TITLE
build: Fix make upgrade (astroid, setuptools, types-requests)

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -148,3 +148,22 @@ pact-python<3.0.0
 # building requirements with Python 3.12
 # https://github.com/openedx/edx-platform/issues/37880
 sphinx-autoapi<3.6.1
+
+# Date 2026-03-02
+# setuptools 82.0.0 removed pkg_resources from its distribution, but fs (pyfilesystem2)
+# still uses pkg_resources for namespace package declarations. This constraint can be
+# removed once pyfilesystem2 drops its pkg_resources usage.
+# https://github.com/PyFilesystem/pyfilesystem2/issues/577
+# Issue for unpinning: https://github.com/openedx/openedx-platform/issues/38068
+setuptools<82
+
+# Date 2026-03-02
+# The latest version of pylint pins back astroid to an older version.
+# This holdback is not caught in the docs requirements file and since both the docs
+# and testing file are required in the development.in file, we fail to compile
+# development.txt because of conflicting dependencies.
+#
+# Holding astroid back until pylint releases a new version that works with the latest
+# version of astroid.
+# https://github.com/openedx/openedx-platform/issues/38066
+astroid==4.0.4

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -32,7 +32,7 @@ lxml[html-clean]==5.3.2
     #   -r requirements/edx-sandbox/base.in
     #   lxml-html-clean
     #   openedx-calc
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via lxml
 markupsafe==3.0.3
     # via
@@ -44,7 +44,7 @@ mpmath==1.3.0
     # via sympy
 networkx==3.6.1
     # via -r requirements/edx-sandbox/base.in
-nltk==3.9.2
+nltk==3.9.3
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
@@ -58,13 +58,13 @@ numpy==1.26.4
     #   scipy
 openedx-calc==4.0.3
     # via -r requirements/edx-sandbox/base.in
-packaging==25.0
+packaging==26.0
     # via matplotlib
-pillow==12.1.0
+pillow==12.1.1
     # via matplotlib
-pycparser==2.23
+pycparser==3.0
     # via cffi
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
@@ -74,9 +74,9 @@ python-dateutil==2.9.0.post0
     # via matplotlib
 random2==1.0.2
     # via -r requirements/edx-sandbox/base.in
-regex==2026.1.15
+regex==2026.2.28
     # via nltk
-scipy==1.17.0
+scipy==1.17.1
     # via
     #   -r requirements/edx-sandbox/base.in
     #   chem
@@ -86,5 +86,5 @@ sympy==1.14.0
     # via
     #   -r requirements/edx-sandbox/base.in
     #   openedx-calc
-tqdm==4.67.1
+tqdm==4.67.3
     # via nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -26,7 +26,7 @@ anyio==4.12.1
     # via httpx
 appdirs==1.4.4
     # via fs
-asgiref==3.11.0
+asgiref==3.11.1
     # via
     #   django
     #   django-cors-headers
@@ -44,7 +44,7 @@ attrs==25.4.0
     #   openedx-core
     #   openedx-events
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/kernel.in
     #   enmerkar
@@ -67,14 +67,14 @@ bleach[css]==6.3.0
     #   ora2
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-boto3==1.42.30
+boto3==1.42.59
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.42.30
+botocore==1.42.59
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -86,7 +86,7 @@ bridgekeeper==0.9
     # via -r requirements/edx/kernel.in
 cachecontrol==0.14.4
     # via firebase-admin
-cachetools==6.2.4
+cachetools==7.0.1
     # via edxval
 camel-converter[pydantic]==5.0.0
     # via meilisearch
@@ -103,7 +103,7 @@ celery==5.6.2
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-core
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   elasticsearch
     #   httpcore
@@ -114,7 +114,7 @@ cffi==2.0.0
     # via
     #   cryptography
     #   pynacl
-chardet==5.2.0
+chardet==6.0.0.post1
     # via pysrt
 charset-normalizer==3.4.4
     # via
@@ -151,6 +151,7 @@ cryptography==45.0.7
     #   -r requirements/edx/kernel.in
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
@@ -337,7 +338,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
-django-ses==4.6.0
+django-ses==4.7.2
     # via -r requirements/edx/bundled.in
 django-simple-history==3.11.0
     # via
@@ -402,13 +403,13 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-spectacular==0.29.0
     # via -r requirements/edx/kernel.in
-drf-yasg==1.21.14
+drf-yasg==1.21.15
     # via
     #   django-user-tasks
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via -r requirements/edx/kernel.in
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-authz
@@ -558,7 +559,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.44
+enterprise-integrated-channels==0.1.46
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via
@@ -568,9 +569,9 @@ event-tracking==3.3.0
     #   edx-search
 fastavro==1.12.1
     # via openedx-events
-filelock==3.20.3
+filelock==3.25.0
     # via snowflake-connector-python
-firebase-admin==7.1.0
+firebase-admin==7.2.0
     # via edx-ace
 frozenlist==1.8.0
     # via
@@ -590,13 +591,13 @@ geoip2==5.2.0
     # via -r requirements/edx/kernel.in
 glob2==0.7
     # via -r requirements/edx/kernel.in
-google-api-core[grpc]==2.29.0
+google-api-core[grpc]==2.30.0
     # via
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.47.0
+google-auth==2.48.0
     # via
     #   google-api-core
     #   google-cloud-core
@@ -608,7 +609,7 @@ google-cloud-core==2.5.0
     #   google-cloud-storage
 google-cloud-firestore==2.23.0
     # via firebase-admin
-google-cloud-storage==3.8.0
+google-cloud-storage==3.9.0
     # via firebase-admin
 google-crc32c==1.8.0
     # via
@@ -620,13 +621,13 @@ googleapis-common-protos==1.72.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.76.0
+grpcio==1.78.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.76.0
+grpcio-status==1.78.0
     # via google-api-core
-gunicorn==23.0.0
+gunicorn==25.1.0
     # via -r requirements/edx/kernel.in
 h11==0.16.0
     # via httpcore
@@ -646,7 +647,7 @@ httpx[http2]==0.28.1
     # via firebase-admin
 hyperframe==6.1.0
     # via h2
-icalendar==6.3.2
+icalendar==7.0.2
     # via -r requirements/edx/kernel.in
 idna==3.11
     # via
@@ -670,7 +671,7 @@ isodate==0.7.2
     # via python3-saml
 jinja2==3.1.6
     # via code-annotations
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
@@ -724,7 +725,7 @@ lxml[html-clean]==5.3.2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via lxml
 mailsnake==1.6.4
     # via -r requirements/edx/bundled.in
@@ -735,7 +736,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.10
+markdown==3.10.2
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
@@ -748,7 +749,7 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==3.0.0
+maxminddb==3.1.0
     # via geoip2
 meilisearch==0.40.0
     # via
@@ -764,19 +765,19 @@ mpmath==1.3.0
     # via sympy
 msgpack==1.1.2
     # via cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-forum
-nh3==0.3.2
+nh3==0.3.3
     # via
     #   -r requirements/edx/kernel.in
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.9.3
     # via chem
 nodeenv==1.10.0
     # via -r requirements/edx/kernel.in
@@ -839,12 +840,13 @@ optimizely-sdk==5.4.0
     # via -r requirements/edx/bundled.in
 ora2==6.17.2
     # via -r requirements/edx/bundled.in
-packaging==25.0
+packaging==26.0
     # via
     #   drf-yasg
     #   gunicorn
     #   kombu
     #   snowflake-connector-python
+    #   wheel
 paramiko==4.0.0
     # via edx-enterprise
 path==16.11.0
@@ -862,13 +864,13 @@ pgpy==0.6.0
     # via edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/kernel.in
-pillow==12.1.0
+pillow==12.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via snowflake-connector-python
 polib==1.2.0
     # via edx-i18n-tools
@@ -878,22 +880,22 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-proto-plus==1.27.0
+proto-plus==1.27.1
     # via
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.2.1
+psutil==7.2.2
     # via
     #   -r requirements/edx/kernel.in
     #   edx-django-utils
-psycopg2-binary==2.9.10
+psycopg2-binary==2.9.11
     # via -r requirements/edx/kernel.in
 pyasn1==0.6.2
     # via
@@ -902,13 +904,13 @@ pyasn1==0.6.2
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycasbin==2.7.1
+pycasbin==2.8.0
     # via
     #   casbin-django-orm-adapter
     #   openedx-authz
-pycountry==24.6.1
+pycountry==26.2.16
     # via -r requirements/edx/kernel.in
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pycryptodomex==3.23.0
     # via
@@ -919,7 +921,7 @@ pydantic==2.12.5
     # via camel-converter
 pydantic-core==2.41.5
     # via pydantic
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via
     #   -r requirements/edx/kernel.in
     #   drf-jwt
@@ -954,7 +956,7 @@ pynliner==0.8.0
     # via -r requirements/edx/kernel.in
 pyopenssl==25.3.0
     # via snowflake-connector-python
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via
     #   chem
     #   openedx-calc
@@ -981,7 +983,7 @@ python-ipware==3.0.0
     # via django-ipware
 python-slugify==8.0.4
     # via code-annotations
-python-swiftclient==4.9.0
+python-swiftclient==4.10.0
     # via ora2
 python3-openid==3.2.0 ; python_version >= "3"
     # via
@@ -1021,7 +1023,7 @@ random2==1.0.2
     # via -r requirements/edx/kernel.in
 recommender-xblock==3.1.0
     # via -r requirements/edx/bundled.in
-redis==7.1.0
+redis==7.2.1
     # via
     #   -r requirements/edx/kernel.in
     #   walrus
@@ -1029,7 +1031,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.1.15
+regex==2026.2.28
     # via nltk
 requests==2.32.5
     # via
@@ -1076,7 +1078,7 @@ s3transfer==0.16.0
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
-scipy==1.17.0
+scipy==1.17.1
     # via chem
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -1114,7 +1116,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.3.0
     # via
     #   edx-enterprise
     #   enterprise-integrated-channels
@@ -1123,12 +1125,12 @@ social-auth-app-django==5.4.1
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
-social-auth-core==4.8.3
+social-auth-core==4.8.5
     # via
     #   -r requirements/edx/kernel.in
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
@@ -1142,7 +1144,7 @@ sqlparse==0.5.5
     # via django
 staff-graded-xblock==3.1.0
     # via -r requirements/edx/bundled.in
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   -r requirements/edx/kernel.in
     #   code-annotations
@@ -1166,7 +1168,7 @@ tomlkit==0.14.0
     # via
     #   openedx-core
     #   snowflake-connector-python
-tqdm==4.67.1
+tqdm==4.67.3
     # via nltk
 typing-extensions==4.15.0
     # via
@@ -1176,6 +1178,7 @@ typing-extensions==4.15.0
     #   django-countries
     #   edx-opaque-keys
     #   grpcio
+    #   icalendar
     #   jwcrypto
     #   pydantic
     #   pydantic-core
@@ -1219,7 +1222,7 @@ walrus==0.9.8
     # via edx-event-bus-redis
 wcmatch==10.1
     # via pycasbin
-wcwidth==0.2.14
+wcwidth==0.6.0
     # via prompt-toolkit
 web-fragments==3.1.0
     # via
@@ -1238,9 +1241,9 @@ webob==1.8.9
     # via
     #   -r requirements/edx/kernel.in
     #   xblock
-wheel==0.45.1
+wheel==0.46.3
     # via django-pipeline
-wrapt==2.0.1
+wrapt==2.1.1
     # via -r requirements/edx/kernel.in
 xblock[django]==5.3.0
     # via
@@ -1268,7 +1271,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.11.0
+xblocks-contrib==0.11.1
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via
@@ -1276,7 +1279,7 @@ xmlsec==1.3.14
     #   python3-saml
 xss-utils==0.8.0
     # via -r requirements/edx/kernel.in
-yarl==1.22.0
+yarl==1.23.0
     # via aiohttp
 zipp==3.23.0
     # via importlib-metadata

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-chardet==5.2.0
+chardet==6.0.0.post1
     # via diff-cover
-coverage==7.13.1
+coverage==7.13.4
     # via -r requirements/edx/coverage.in
 diff-cover==10.2.0
     # via -r requirements/edx/coverage.in

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -21,5 +21,6 @@ django-stubs[compatible-mypy]           # Typing stubs for Django, so it works w
 djangorestframework-stubs               # Typing stubs for DRF
 mypy                                    # static type checking
 pywatchman                              # More efficient checking for runserver reload trigger events
+types-requests                          # Typing stubs for requests
 vulture                                 # Detects possible dead/unused code, used in scripts/find-dead-code.sh
 watchdog                                # Used by `npm run watch` to auto-recompile when assets are changed

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -66,7 +66,7 @@ appdirs==1.4.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   fs
-asgiref==3.11.0
+asgiref==3.11.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -78,8 +78,9 @@ asn1crypto==1.5.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-astroid==4.0.3
+astroid==4.0.4
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -97,7 +98,7 @@ attrs==25.4.0
     #   openedx-core
     #   openedx-events
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -137,7 +138,7 @@ bleach[css]==6.3.0
     #   ora2
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-boto3==1.42.30
+boto3==1.42.59
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -145,7 +146,7 @@ boto3==1.42.30
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.42.30
+botocore==1.42.59
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -170,7 +171,7 @@ cachecontrol==0.14.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
-cachetools==6.2.4
+cachetools==7.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -198,7 +199,7 @@ celery==5.6.2
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-core
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -213,13 +214,12 @@ cffi==2.0.0
     #   -r requirements/edx/testing.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
+chardet==6.0.0.post1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   diff-cover
     #   pysrt
-    #   tox
 charset-normalizer==3.4.4
     # via
     #   -r requirements/edx/doc.txt
@@ -284,7 +284,7 @@ colorama==0.4.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-coverage[toml]==7.13.1
+coverage[toml]==7.13.4
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -299,13 +299,14 @@ cryptography==45.0.7
     #   -r requirements/edx/testing.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
     #   pyjwt
     #   pyopenssl
     #   snowflake-connector-python
-cssselect==1.3.0
+cssselect==1.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
@@ -562,7 +563,7 @@ django-sekizai==4.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-django-wiki
-django-ses==4.6.0
+django-ses==4.7.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -588,12 +589,12 @@ django-storages==1.14.6
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edxval
-django-stubs[compatible-mypy]==5.2.8
+django-stubs[compatible-mypy]==5.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/development.in
     #   djangorestframework-stubs
-django-stubs-ext==5.2.8
+django-stubs-ext==5.2.9
     # via django-stubs
 django-user-tasks==3.4.4
     # via
@@ -634,7 +635,7 @@ djangorestframework==3.16.1
     #   openedx-forum
     #   ora2
     #   super-csv
-djangorestframework-stubs==3.16.7
+djangorestframework-stubs==3.16.8
     # via -r requirements/edx/development.in
 djangorestframework-xml==2.0.0
     # via
@@ -665,7 +666,7 @@ drf-spectacular==0.29.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-drf-yasg==1.21.14
+drf-yasg==1.21.15
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -675,7 +676,7 @@ edx-ace==1.15.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -876,7 +877,7 @@ enmerkar-underscore==2.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-enterprise-integrated-channels==0.1.44
+enterprise-integrated-channels==0.1.46
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -893,27 +894,29 @@ execnet==2.1.2
     #   pytest-xdist
 factory-boy==3.3.3
     # via -r requirements/edx/testing.txt
-faker==40.1.2
+faker==40.5.1
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.128.0
+fastapi==0.135.1
     # via
     #   -r requirements/edx/testing.txt
+    #   import-linter
     #   pact-python
 fastavro==1.12.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.20.3
+filelock==3.25.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==7.1.0
+firebase-admin==7.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -952,7 +955,7 @@ glob2==0.7
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-google-api-core[grpc]==2.29.0
+google-api-core[grpc]==2.30.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -960,7 +963,7 @@ google-api-core[grpc]==2.29.0
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.47.0
+google-auth==2.48.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -979,7 +982,7 @@ google-cloud-firestore==2.23.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
-google-cloud-storage==3.8.0
+google-cloud-storage==3.9.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1005,18 +1008,18 @@ grimp==3.14
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
-grpcio==1.76.0
+grpcio==1.78.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.76.0
+grpcio-status==1.78.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
-gunicorn==23.0.0
+gunicorn==25.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1062,7 +1065,7 @@ hyperframe==6.1.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   h2
-icalendar==6.3.2
+icalendar==7.0.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1080,7 +1083,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-import-linter==2.9
+import-linter==2.10
     # via -r requirements/edx/testing.txt
 importlib-metadata==8.7.1
     # via
@@ -1110,7 +1113,7 @@ isodate==0.7.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   python3-saml
-isort==7.0.0
+isort==8.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -1122,7 +1125,7 @@ jinja2==3.1.6
     #   diff-cover
     #   sphinx
     #   sphinx-autoapi
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1184,7 +1187,7 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-librt==0.7.8
+librt==0.8.1
     # via mypy
 libsass==0.10.0
     # via
@@ -1210,7 +1213,7 @@ lxml[html-clean]==5.3.2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1227,7 +1230,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.10
+markdown==3.10.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1247,7 +1250,7 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==3.0.0
+maxminddb==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1295,7 +1298,7 @@ msgpack==1.1.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1307,17 +1310,17 @@ mypy==1.19.1
     #   django-stubs
 mypy-extensions==1.1.0
     # via mypy
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   openedx-forum
-nh3==0.3.2
+nh3==0.3.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.9.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1411,7 +1414,7 @@ ora2==6.17.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1426,6 +1429,7 @@ packaging==25.0
     #   snowflake-connector-python
     #   sphinx
     #   tox
+    #   wheel
 pact-python==1.6.0
     # via
     #   -c requirements/constraints.txt
@@ -1449,7 +1453,7 @@ path-py==12.5.0
     #   edx-enterprise
     #   ora2
     #   staff-graded-xblock
-pathspec==1.0.3
+pathspec==1.0.4
     # via mypy
 pgpy==0.6.0
     # via
@@ -1464,20 +1468,21 @@ piexif==1.1.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pillow==12.1.0
+pillow==12.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-pip-tools==7.5.2
+pip-tools==7.5.3
     # via -r requirements/pip-tools.txt
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pylint
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
@@ -1504,13 +1509,13 @@ propcache==0.4.1
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-proto-plus==1.27.0
+proto-plus==1.27.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1519,14 +1524,14 @@ protobuf==6.33.4
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.2.1
+psutil==7.2.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
     #   pact-python
     #   pytest-xdist
-psycopg2-binary==2.9.10
+psycopg2-binary==2.9.11
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1544,7 +1549,7 @@ pyasn1-modules==0.4.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   google-auth
-pycasbin==2.7.1
+pycasbin==2.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1554,11 +1559,11 @@ pycodestyle==2.8.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.txt
-pycountry==24.6.1
+pycountry==26.2.16
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1594,7 +1599,7 @@ pygments==2.19.2
     #   rich
     #   sphinx
     #   sphinx-mdinclude
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1613,7 +1618,7 @@ pylatexenc==2.10
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==4.0.4
+pylint==4.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1668,7 +1673,7 @@ pyopenssl==25.3.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1710,7 +1715,7 @@ pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
 pytest-cov==7.0.0
     # via -r requirements/edx/testing.txt
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/edx/testing.txt
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.txt
@@ -1737,6 +1742,10 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
+python-discovery==1.1.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   virtualenv
 python-ipware==3.0.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1747,7 +1756,7 @@ python-slugify==8.0.4
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   code-annotations
-python-swiftclient==4.9.0
+python-swiftclient==4.10.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1805,7 +1814,7 @@ recommender-xblock==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-redis==7.1.0
+redis==7.2.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1816,7 +1825,7 @@ referencing==0.37.0
     #   -r requirements/edx/testing.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.1.15
+regex==2026.2.28
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1855,7 +1864,7 @@ requests-oauthlib==2.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   social-auth-core
-rich==14.2.0
+rich==14.3.3
     # via
     #   -r requirements/edx/testing.txt
     #   import-linter
@@ -1891,7 +1900,7 @@ sailthru-client==2.2.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-ace
-scipy==1.17.0
+scipy==1.17.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1942,7 +1951,6 @@ six==1.17.0
     #   libsass
     #   pact-python
     #   python-dateutil
-    #   sphinxcontrib-httpdomain
 slumber==0.7.1
     # via
     #   -r requirements/edx/doc.txt
@@ -1958,7 +1966,7 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.3.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1970,13 +1978,13 @@ social-auth-app-django==5.4.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
-social-auth-core==4.8.3
+social-auth-core==4.8.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2029,7 +2037,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-sphinxcontrib-httpdomain==1.8.1
+sphinxcontrib-httpdomain==2.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   sphinxcontrib-openapi
@@ -2037,7 +2045,7 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-sphinxcontrib-openapi==0.8.4
+sphinxcontrib-openapi==0.9.0
     # via -r requirements/edx/doc.txt
 sphinxcontrib-qthelp==2.0.0
     # via
@@ -2059,11 +2067,11 @@ staff-graded-xblock==3.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-starlette==0.50.0
+starlette==0.52.1
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2109,9 +2117,9 @@ tomlkit==0.14.0
     #   openedx-core
     #   pylint
     #   snowflake-connector-python
-tox==4.34.1
+tox==4.47.0
     # via -r requirements/edx/testing.txt
-tqdm==4.67.1
+tqdm==4.67.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2121,7 +2129,7 @@ types-pyyaml==6.0.12.20250915
     #   django-stubs
     #   djangorestframework-stubs
 types-requests==2.32.4.20260107
-    # via djangorestframework-stubs
+    # via -r requirements/edx/development.in
 typing-extensions==4.15.0
     # via
     #   -r requirements/edx/doc.txt
@@ -2137,6 +2145,7 @@ typing-extensions==4.15.0
     #   fastapi
     #   grimp
     #   grpcio
+    #   icalendar
     #   import-linter
     #   jwcrypto
     #   mypy
@@ -2153,6 +2162,7 @@ typing-inspection==0.4.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    #   fastapi
     #   pydantic
 tzdata==2025.3
     # via
@@ -2192,9 +2202,10 @@ urllib3==2.6.3
     #   pact-python
     #   requests
     #   types-requests
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via
     #   -r requirements/edx/testing.txt
+    #   import-linter
     #   pact-python
 vine==5.1.0
     # via
@@ -2203,7 +2214,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.36.1
+virtualenv==21.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -2226,7 +2237,7 @@ wcmatch==10.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   pycasbin
-wcwidth==0.2.14
+wcwidth==0.6.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2252,14 +2263,14 @@ webob==1.8.9
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblock
-wheel==0.45.1
+wheel==0.46.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   -r requirements/pip-tools.txt
     #   django-pipeline
     #   pip-tools
-wrapt==2.0.1
+wrapt==2.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2298,7 +2309,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.11.0
+xblocks-contrib==0.11.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2312,7 +2323,7 @@ xss-utils==0.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-yarl==1.22.0
+yarl==1.23.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -45,7 +45,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.11.0
+asgiref==3.11.1
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -55,8 +55,10 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==4.0.3
-    # via sphinx-autoapi
+astroid==4.0.4
+    # via
+    #   -c requirements/constraints.txt
+    #   sphinx-autoapi
 attrs==25.4.0
     # via
     #   -r requirements/edx/base.txt
@@ -68,7 +70,7 @@ attrs==25.4.0
     #   openedx-core
     #   openedx-events
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar
@@ -102,14 +104,14 @@ bleach[css]==6.3.0
     #   ora2
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-boto3==1.42.30
+boto3==1.42.59
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.42.30
+botocore==1.42.59
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -125,7 +127,7 @@ cachecontrol==0.14.4
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-cachetools==6.2.4
+cachetools==7.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -148,7 +150,7 @@ celery==5.6.2
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-core
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -161,7 +163,7 @@ cffi==2.0.0
     #   -r requirements/edx/base.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
+chardet==6.0.0.post1
     # via
     #   -r requirements/edx/base.txt
     #   pysrt
@@ -210,6 +212,7 @@ cryptography==45.0.7
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
@@ -414,7 +417,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.6.0
+django-ses==4.7.2
     # via -r requirements/edx/base.txt
 django-simple-history==3.11.0
     # via
@@ -490,14 +493,14 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-spectacular==0.29.0
     # via -r requirements/edx/base.txt
-drf-yasg==1.21.14
+drf-yasg==1.21.15
     # via
     #   -r requirements/edx/base.txt
     #   django-user-tasks
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via -r requirements/edx/base.txt
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-authz
@@ -653,7 +656,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.44
+enterprise-integrated-channels==0.1.46
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via
@@ -665,11 +668,11 @@ fastavro==1.12.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.20.3
+filelock==3.25.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-firebase-admin==7.1.0
+firebase-admin==7.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -696,14 +699,14 @@ gitpython==3.1.46
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.29.0
+google-api-core[grpc]==2.30.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.47.0
+google-auth==2.48.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -719,7 +722,7 @@ google-cloud-firestore==2.23.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-cloud-storage==3.8.0
+google-cloud-storage==3.9.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -737,16 +740,16 @@ googleapis-common-protos==1.72.0
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.76.0
+grpcio==1.78.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.76.0
+grpcio-status==1.78.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
-gunicorn==23.0.0
+gunicorn==25.1.0
     # via -r requirements/edx/base.txt
 h11==0.16.0
     # via
@@ -778,7 +781,7 @@ hyperframe==6.1.0
     # via
     #   -r requirements/edx/base.txt
     #   h2
-icalendar==6.3.2
+icalendar==7.0.2
     # via -r requirements/edx/base.txt
 idna==3.11
     # via
@@ -814,7 +817,7 @@ jinja2==3.1.6
     #   code-annotations
     #   sphinx
     #   sphinx-autoapi
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -881,7 +884,7 @@ lxml[html-clean]==5.3.2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via
     #   -r requirements/edx/base.txt
     #   lxml
@@ -894,7 +897,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.10
+markdown==3.10.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -908,7 +911,7 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==3.0.0
+maxminddb==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -936,20 +939,20 @@ msgpack==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-nh3==0.3.2
+nh3==0.3.3
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.9.3
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1016,7 +1019,7 @@ optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
 ora2==6.17.2
     # via -r requirements/edx/base.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1025,6 +1028,7 @@ packaging==25.0
     #   pydata-sphinx-theme
     #   snowflake-connector-python
     #   sphinx
+    #   wheel
 paramiko==4.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -1049,13 +1053,13 @@ picobox==4.0.0
     # via sphinxcontrib-openapi
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==12.1.0
+pillow==12.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -1072,12 +1076,12 @@ propcache==0.4.1
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-proto-plus==1.27.0
+proto-plus==1.27.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -1085,11 +1089,11 @@ protobuf==6.33.4
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.2.1
+psutil==7.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
-psycopg2-binary==2.9.10
+psycopg2-binary==2.9.11
     # via -r requirements/edx/base.txt
 pyasn1==0.6.2
     # via
@@ -1101,14 +1105,14 @@ pyasn1-modules==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   google-auth
-pycasbin==2.7.1
+pycasbin==2.8.0
     # via
     #   -r requirements/edx/base.txt
     #   casbin-django-orm-adapter
     #   openedx-authz
-pycountry==24.6.1
+pycountry==26.2.16
     # via -r requirements/edx/base.txt
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r requirements/edx/base.txt
     #   cffi
@@ -1133,7 +1137,7 @@ pygments==2.19.2
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-mdinclude
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1173,7 +1177,7 @@ pyopenssl==25.3.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1207,7 +1211,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
-python-swiftclient==4.9.0
+python-swiftclient==4.10.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1251,7 +1255,7 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==3.1.0
     # via -r requirements/edx/base.txt
-redis==7.1.0
+redis==7.2.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
@@ -1260,7 +1264,7 @@ referencing==0.37.0
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.1.15
+regex==2026.2.28
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1320,7 +1324,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.17.0
+scipy==1.17.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1358,7 +1362,6 @@ six==1.17.0
     #   fs-s3fs
     #   html5lib
     #   python-dateutil
-    #   sphinxcontrib-httpdomain
 slumber==0.7.1
     # via
     #   -r requirements/edx/base.txt
@@ -1369,7 +1372,7 @@ smmap==5.0.2
     # via gitdb
 snowballstemmer==3.0.1
     # via sphinx
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1379,12 +1382,12 @@ social-auth-app-django==5.4.1
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
-social-auth-core==4.8.3
+social-auth-core==4.8.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -1426,11 +1429,11 @@ sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
-sphinxcontrib-httpdomain==1.8.1
+sphinxcontrib-httpdomain==2.0.0
     # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-openapi==0.8.4
+sphinxcontrib-openapi==0.9.0
     # via -r requirements/edx/doc.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
@@ -1444,7 +1447,7 @@ sqlparse==0.5.5
     #   django
 staff-graded-xblock==3.1.0
     # via -r requirements/edx/base.txt
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1481,7 +1484,7 @@ tomlkit==0.14.0
     #   -r requirements/edx/base.txt
     #   openedx-core
     #   snowflake-connector-python
-tqdm==4.67.1
+tqdm==4.67.3
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1494,6 +1497,7 @@ typing-extensions==4.15.0
     #   django-countries
     #   edx-opaque-keys
     #   grpcio
+    #   icalendar
     #   jwcrypto
     #   pydantic
     #   pydantic-core
@@ -1552,7 +1556,7 @@ wcmatch==10.1
     # via
     #   -r requirements/edx/base.txt
     #   pycasbin
-wcwidth==0.2.14
+wcwidth==0.6.0
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
@@ -1574,11 +1578,11 @@ webob==1.8.9
     # via
     #   -r requirements/edx/base.txt
     #   xblock
-wheel==0.45.1
+wheel==0.46.3
     # via
     #   -r requirements/edx/base.txt
     #   django-pipeline
-wrapt==2.0.1
+wrapt==2.1.1
     # via -r requirements/edx/base.txt
 xblock[django]==5.3.0
     # via
@@ -1607,7 +1611,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.11.0
+xblocks-contrib==0.11.1
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via
@@ -1616,7 +1620,7 @@ xmlsec==1.3.14
     #   python3-saml
 xss-utils==0.8.0
     # via -r requirements/edx/base.txt
-yarl==1.22.0
+yarl==1.23.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -25,7 +25,7 @@ boltons==21.0.0
     #   semgrep
 bracex==2.6
     # via wcmatch
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   httpcore
     #   httpx
@@ -49,9 +49,9 @@ cryptography==45.0.7
     #   pyjwt
 exceptiongroup==1.2.2
     # via semgrep
-face==24.0.0
+face==26.0.0
     # via glom
-glom==22.1.0
+glom==25.12.0
     # via semgrep
 googleapis-common-protos==1.72.0
     # via opentelemetry-exporter-otlp-proto-http
@@ -120,17 +120,17 @@ opentelemetry-semantic-conventions==0.58b0
     #   opentelemetry-sdk
 opentelemetry-util-http==0.58b0
     # via opentelemetry-instrumentation-requests
-packaging==25.0
+packaging==26.0
     # via
     #   opentelemetry-instrumentation
     #   semgrep
 peewee==3.19.0
     # via semgrep
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pydantic==2.12.5
     # via
@@ -138,15 +138,17 @@ pydantic==2.12.5
     #   pydantic-settings
 pydantic-core==2.41.5
     # via pydantic
-pydantic-settings==2.12.0
+pydantic-settings==2.13.1
     # via mcp
 pygments==2.19.2
     # via rich
-pyjwt[crypto]==2.10.1
-    # via mcp
-python-dotenv==1.2.1
+pyjwt[crypto]==2.11.0
+    # via
+    #   mcp
+    #   semgrep
+python-dotenv==1.2.2
     # via pydantic-settings
-python-multipart==0.0.21
+python-multipart==0.0.22
     # via mcp
 referencing==0.37.0
     # via
@@ -166,9 +168,11 @@ ruamel-yaml==0.19.1
     # via semgrep
 ruamel-yaml-clib==0.2.14
     # via semgrep
-semgrep==1.148.0
+semantic-version==2.10.0
+    # via semgrep
+semgrep==1.153.1
     # via -r requirements/edx/semgrep.in
-sse-starlette==3.2.0
+sse-starlette==3.3.2
     # via mcp
 starlette==0.52.1
     # via
@@ -199,7 +203,7 @@ urllib3==2.6.3
     # via
     #   requests
     #   semgrep
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via mcp
 wcmatch==8.5.2
     # via semgrep

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -44,7 +44,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-asgiref==3.11.0
+asgiref==3.11.1
     # via
     #   -r requirements/edx/base.txt
     #   django
@@ -54,8 +54,9 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-astroid==4.0.3
+astroid==4.0.4
     # via
+    #   -c requirements/constraints.txt
     #   pylint
     #   pylint-celery
 attrs==25.4.0
@@ -69,7 +70,7 @@ attrs==25.4.0
     #   openedx-core
     #   openedx-events
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar
@@ -101,14 +102,14 @@ bleach[css]==6.3.0
     #   ora2
     #   xblock-drag-and-drop-v2
     #   xblock-poll
-boto3==1.42.30
+boto3==1.42.59
     # via
     #   -r requirements/edx/base.txt
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.42.30
+botocore==1.42.59
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -124,7 +125,7 @@ cachecontrol==0.14.4
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-cachetools==6.2.4
+cachetools==7.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -148,7 +149,7 @@ celery==5.6.2
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-core
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -161,13 +162,12 @@ cffi==2.0.0
     #   -r requirements/edx/base.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
+chardet==6.0.0.post1
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
     #   diff-cover
     #   pysrt
-    #   tox
 charset-normalizer==3.4.4
     # via
     #   -r requirements/edx/base.txt
@@ -215,7 +215,7 @@ codejail-includes==2.0.0
     # via -r requirements/edx/base.txt
 colorama==0.4.6
     # via tox
-coverage[toml]==7.13.1
+coverage[toml]==7.13.4
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -227,13 +227,14 @@ cryptography==45.0.7
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
+    #   google-auth
     #   jwcrypto
     #   paramiko
     #   pgpy
     #   pyjwt
     #   pyopenssl
     #   snowflake-connector-python
-cssselect==1.3.0
+cssselect==1.4.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
@@ -441,7 +442,7 @@ django-sekizai==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
-django-ses==4.6.0
+django-ses==4.7.2
     # via -r requirements/edx/base.txt
 django-simple-history==3.11.0
     # via
@@ -512,14 +513,14 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-spectacular==0.29.0
     # via -r requirements/edx/base.txt
-drf-yasg==1.21.14
+drf-yasg==1.21.15
     # via
     #   -r requirements/edx/base.txt
     #   django-user-tasks
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via -r requirements/edx/base.txt
-edx-api-doc-tools==2.1.0
+edx-api-doc-tools==2.1.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-authz
@@ -677,7 +678,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/base.txt
-enterprise-integrated-channels==0.1.44
+enterprise-integrated-channels==0.1.46
     # via -r requirements/edx/base.txt
 event-tracking==3.3.0
     # via
@@ -689,21 +690,24 @@ execnet==2.1.2
     # via pytest-xdist
 factory-boy==3.3.3
     # via -r requirements/edx/testing.in
-faker==40.1.2
+faker==40.5.1
     # via factory-boy
-fastapi==0.128.0
-    # via pact-python
+fastapi==0.135.1
+    # via
+    #   import-linter
+    #   pact-python
 fastavro==1.12.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.20.3
+filelock==3.25.0
     # via
     #   -r requirements/edx/base.txt
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==7.1.0
+firebase-admin==7.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
@@ -728,14 +732,14 @@ geoip2==5.2.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
-google-api-core[grpc]==2.29.0
+google-api-core[grpc]==2.30.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-auth==2.47.0
+google-auth==2.48.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -751,7 +755,7 @@ google-cloud-firestore==2.23.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
-google-cloud-storage==3.8.0
+google-cloud-storage==3.9.0
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
@@ -771,16 +775,16 @@ googleapis-common-protos==1.72.0
     #   grpcio-status
 grimp==3.14
     # via import-linter
-grpcio==1.76.0
+grpcio==1.78.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.76.0
+grpcio-status==1.78.0
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
-gunicorn==23.0.0
+gunicorn==25.1.0
     # via -r requirements/edx/base.txt
 h11==0.16.0
     # via
@@ -815,7 +819,7 @@ hyperframe==6.1.0
     # via
     #   -r requirements/edx/base.txt
     #   h2
-icalendar==6.3.2
+icalendar==7.0.2
     # via -r requirements/edx/base.txt
 idna==3.11
     # via
@@ -826,7 +830,7 @@ idna==3.11
     #   requests
     #   snowflake-connector-python
     #   yarl
-import-linter==2.9
+import-linter==2.10
     # via -r requirements/edx/testing.in
 importlib-metadata==8.7.1
     # via -r requirements/edx/base.txt
@@ -847,7 +851,7 @@ isodate==0.7.2
     # via
     #   -r requirements/edx/base.txt
     #   python3-saml
-isort==7.0.0
+isort==8.0.1
     # via
     #   -r requirements/edx/testing.in
     #   pylint
@@ -857,7 +861,7 @@ jinja2==3.1.6
     #   -r requirements/edx/coverage.txt
     #   code-annotations
     #   diff-cover
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   boto3
@@ -924,7 +928,7 @@ lxml[html-clean]==5.3.2
     #   python3-saml
     #   xblock
     #   xmlsec
-lxml-html-clean==0.4.3
+lxml-html-clean==0.4.4
     # via
     #   -r requirements/edx/base.txt
     #   lxml
@@ -937,7 +941,7 @@ mako==1.3.10
     #   lti-consumer-xblock
     #   xblock
     #   xblock-utils
-markdown==3.10
+markdown==3.10.2
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -954,7 +958,7 @@ markupsafe==3.0.3
     #   mako
     #   openedx-calc
     #   xblock
-maxminddb==3.0.0
+maxminddb==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -986,20 +990,20 @@ msgpack==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   cachecontrol
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/edx/base.txt
     #   openedx-forum
-nh3==0.3.2
+nh3==0.3.3
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-nltk==3.9.2
+nltk==3.9.3
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1066,7 +1070,7 @@ optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
 ora2==6.17.2
     # via -r requirements/edx/base.txt
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1076,6 +1080,7 @@ packaging==25.0
     #   pytest
     #   snowflake-connector-python
     #   tox
+    #   wheel
 pact-python==1.6.0
     # via
     #   -c requirements/constraints.txt
@@ -1102,16 +1107,17 @@ pgpy==0.6.0
     #   edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==12.1.0
+pillow==12.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via
     #   -r requirements/edx/base.txt
     #   pylint
+    #   python-discovery
     #   snowflake-connector-python
     #   tox
     #   virtualenv
@@ -1136,12 +1142,12 @@ propcache==0.4.1
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-proto-plus==1.27.0
+proto-plus==1.27.1
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   -r requirements/edx/base.txt
     #   google-api-core
@@ -1149,13 +1155,13 @@ protobuf==6.33.4
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
-psutil==7.2.1
+psutil==7.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
     #   pact-python
     #   pytest-xdist
-psycopg2-binary==2.9.10
+psycopg2-binary==2.9.11
     # via -r requirements/edx/base.txt
 py==1.11.0
     # via -r requirements/edx/testing.in
@@ -1169,7 +1175,7 @@ pyasn1-modules==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   google-auth
-pycasbin==2.7.1
+pycasbin==2.8.0
     # via
     #   -r requirements/edx/base.txt
     #   casbin-django-orm-adapter
@@ -1178,9 +1184,9 @@ pycodestyle==2.8.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.in
-pycountry==24.6.1
+pycountry==26.2.16
     # via -r requirements/edx/base.txt
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r requirements/edx/base.txt
     #   cffi
@@ -1203,7 +1209,7 @@ pygments==2.19.2
     #   -r requirements/edx/coverage.txt
     #   diff-cover
     #   rich
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1220,7 +1226,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==4.0.4
+pylint==4.0.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -1260,7 +1266,7 @@ pyopenssl==25.3.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1292,7 +1298,7 @@ pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
 pytest-cov==7.0.0
     # via -r requirements/edx/testing.in
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/edx/testing.in
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.in
@@ -1318,6 +1324,8 @@ python-dateutil==2.9.0.post0
     #   olxcleaner
     #   ora2
     #   xblock
+python-discovery==1.1.0
+    # via virtualenv
 python-ipware==3.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -1326,7 +1334,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
-python-swiftclient==4.9.0
+python-swiftclient==4.10.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1368,7 +1376,7 @@ random2==1.0.2
     # via -r requirements/edx/base.txt
 recommender-xblock==3.1.0
     # via -r requirements/edx/base.txt
-redis==7.1.0
+redis==7.2.1
     # via
     #   -r requirements/edx/base.txt
     #   walrus
@@ -1377,7 +1385,7 @@ referencing==0.37.0
     #   -r requirements/edx/base.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.1.15
+regex==2026.2.28
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1412,7 +1420,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-rich==14.2.0
+rich==14.3.3
     # via import-linter
 rpds-py==0.30.0
     # via
@@ -1437,7 +1445,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.17.0
+scipy==1.17.1
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1485,7 +1493,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-snowflake-connector-python==4.2.0
+snowflake-connector-python==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1495,12 +1503,12 @@ social-auth-app-django==5.4.1
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
-social-auth-core==4.8.3
+social-auth-core==4.8.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sorl-thumbnail==12.11.0
+sorl-thumbnail==13.0.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-django-wiki
@@ -1518,9 +1526,9 @@ sqlparse==0.5.5
     #   django
 staff-graded-xblock==3.1.0
     # via -r requirements/edx/base.txt
-starlette==0.50.0
+starlette==0.52.1
     # via fastapi
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1559,9 +1567,9 @@ tomlkit==0.14.0
     #   openedx-core
     #   pylint
     #   snowflake-connector-python
-tox==4.34.1
+tox==4.47.0
     # via -r requirements/edx/testing.in
-tqdm==4.67.1
+tqdm==4.67.3
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1576,6 +1584,7 @@ typing-extensions==4.15.0
     #   fastapi
     #   grimp
     #   grpcio
+    #   icalendar
     #   import-linter
     #   jwcrypto
     #   pydantic
@@ -1589,6 +1598,7 @@ typing-extensions==4.15.0
 typing-inspection==0.4.2
     # via
     #   -r requirements/edx/base.txt
+    #   fastapi
     #   pydantic
 tzdata==2025.3
     # via
@@ -1620,15 +1630,17 @@ urllib3==2.6.3
     #   elasticsearch
     #   pact-python
     #   requests
-uvicorn==0.40.0
-    # via pact-python
+uvicorn==0.41.0
+    # via
+    #   import-linter
+    #   pact-python
 vine==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.36.1
+virtualenv==21.1.0
     # via tox
 voluptuous==0.16.0
     # via
@@ -1642,7 +1654,7 @@ wcmatch==10.1
     # via
     #   -r requirements/edx/base.txt
     #   pycasbin
-wcwidth==0.2.14
+wcwidth==0.6.0
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
@@ -1664,11 +1676,11 @@ webob==1.8.9
     # via
     #   -r requirements/edx/base.txt
     #   xblock
-wheel==0.45.1
+wheel==0.46.3
     # via
     #   -r requirements/edx/base.txt
     #   django-pipeline
-wrapt==2.0.1
+wrapt==2.1.1
     # via -r requirements/edx/base.txt
 xblock[django]==5.3.0
     # via
@@ -1697,7 +1709,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.11.0
+xblocks-contrib==0.11.1
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via
@@ -1706,7 +1718,7 @@ xmlsec==1.3.14
     #   python3-saml
 xss-utils==0.8.0
     # via -r requirements/edx/base.txt
-yarl==1.22.0
+yarl==1.23.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,19 +8,23 @@ build==1.4.0
     # via pip-tools
 click==8.3.1
     # via pip-tools
-packaging==25.0
-    # via build
-pip-tools==7.5.2
+packaging==26.0
+    # via
+    #   build
+    #   wheel
+pip-tools==7.5.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==26.0.1
     # via pip-tools
-setuptools==80.9.0
-    # via pip-tools
+setuptools==81.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   pip-tools

--- a/scripts/structures_pruning/requirements/base.txt
+++ b/scripts/structures_pruning/requirements/base.txt
@@ -12,14 +12,14 @@ click-log==0.4.0
     # via -r scripts/structures_pruning/requirements/base.in
 dnspython==2.8.0
     # via pymongo
-edx-opaque-keys==3.0.0
+edx-opaque-keys==3.1.0
     # via -r scripts/structures_pruning/requirements/base.in
 pymongo==4.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r scripts/structures_pruning/requirements/base.in
     #   edx-opaque-keys
-stevedore==5.6.0
+stevedore==5.7.0
     # via edx-opaque-keys
 typing-extensions==4.15.0
     # via edx-opaque-keys

--- a/scripts/structures_pruning/requirements/testing.txt
+++ b/scripts/structures_pruning/requirements/testing.txt
@@ -16,11 +16,11 @@ dnspython==2.8.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   pymongo
-edx-opaque-keys==3.0.0
+edx-opaque-keys==3.1.0
     # via -r scripts/structures_pruning/requirements/base.txt
 iniconfig==2.3.0
     # via pytest
-packaging==25.0
+packaging==26.0
     # via pytest
 pluggy==1.6.0
     # via pytest
@@ -32,7 +32,7 @@ pymongo==4.4.0
     #   edx-opaque-keys
 pytest==9.0.2
     # via -r scripts/structures_pruning/requirements/testing.in
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   -r scripts/structures_pruning/requirements/base.txt
     #   edx-opaque-keys

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -4,19 +4,19 @@
 #
 #    make upgrade
 #
-asgiref==3.11.0
+asgiref==3.11.1
     # via django
 attrs==25.4.0
     # via zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.in
-boto3==1.42.30
+boto3==1.42.59
     # via -r scripts/user_retirement/requirements/base.in
-botocore==1.42.30
+botocore==1.42.59
     # via
     #   boto3
     #   s3transfer
-certifi==2026.1.4
+certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via
@@ -31,6 +31,7 @@ click==8.3.1
 cryptography==45.0.7
     # via
     #   -c requirements/constraints.txt
+    #   google-auth
     #   pyjwt
 django==5.2.11
     # via
@@ -47,11 +48,11 @@ edx-django-utils==8.0.1
     # via edx-rest-api-client
 edx-rest-api-client==6.2.0
     # via -r scripts/user_retirement/requirements/base.in
-google-api-core==2.29.0
+google-api-core==2.30.0
     # via google-api-python-client
-google-api-python-client==2.188.0
+google-api-python-client==2.191.0
     # via -r scripts/user_retirement/requirements/base.in
-google-auth==2.47.0
+google-auth==2.48.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -60,7 +61,7 @@ google-auth-httplib2==0.3.0
     # via google-api-python-client
 googleapis-common-protos==1.72.0
     # via google-api-core
-httplib2==0.31.1
+httplib2==0.31.2
     # via
     #   google-api-python-client
     #   google-auth-httplib2
@@ -68,9 +69,9 @@ idna==3.11
     # via requests
 isodate==0.7.2
     # via zeep
-jenkinsapi==0.3.17
+jenkinsapi==0.3.21
     # via -r scripts/user_retirement/requirements/base.in
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
@@ -80,16 +81,16 @@ lxml==5.3.2
     #   zeep
 more-itertools==10.8.0
     # via simple-salesforce
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via zeep
-proto-plus==1.27.0
+proto-plus==1.27.1
     # via google-api-core
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
-psutil==7.2.1
+psutil==7.2.2
     # via edx-django-utils
 pyasn1==0.6.2
     # via
@@ -97,15 +98,15 @@ pyasn1==0.6.2
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==2.23
+pycparser==3.0
     # via cffi
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via
     #   edx-rest-api-client
     #   simple-salesforce
 pynacl==1.6.2
     # via edx-django-utils
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via httplib2
 python-dateutil==2.9.0.post0
     # via botocore
@@ -141,7 +142,7 @@ six==1.17.0
     # via python-dateutil
 sqlparse==0.5.5
     # via django
-stevedore==5.6.0
+stevedore==5.7.0
     # via edx-django-utils
 typing-extensions==4.15.0
     # via simple-salesforce

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.11.0
+asgiref==3.11.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
@@ -14,17 +14,17 @@ attrs==25.4.0
     #   zeep
 backoff==2.2.1
     # via -r scripts/user_retirement/requirements/base.txt
-boto3==1.42.30
+boto3==1.42.59
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   moto
-botocore==1.42.30
+botocore==1.42.59
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
@@ -44,6 +44,7 @@ click==8.3.1
 cryptography==45.0.7
     # via
     #   -r scripts/user_retirement/requirements/base.txt
+    #   google-auth
     #   moto
     #   pyjwt
 ddt==1.7.2
@@ -68,13 +69,13 @@ edx-django-utils==8.0.1
     #   edx-rest-api-client
 edx-rest-api-client==6.2.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-api-core==2.29.0
+google-api-core==2.30.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.188.0
+google-api-python-client==2.191.0
     # via -r scripts/user_retirement/requirements/base.txt
-google-auth==2.47.0
+google-auth==2.48.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
@@ -88,7 +89,7 @@ googleapis-common-protos==1.72.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
-httplib2==0.31.1
+httplib2==0.31.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-python-client
@@ -103,11 +104,11 @@ isodate==0.7.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-jenkinsapi==0.3.17
+jenkinsapi==0.3.21
     # via -r scripts/user_retirement/requirements/base.txt
 jinja2==3.1.6
     # via moto
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   boto3
@@ -126,27 +127,27 @@ more-itertools==10.8.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   simple-salesforce
-moto==5.1.20
+moto==5.1.21
     # via -r scripts/user_retirement/requirements/testing.in
-packaging==25.0
+packaging==26.0
     # via pytest
-platformdirs==4.5.1
+platformdirs==4.9.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
 pluggy==1.6.0
     # via pytest
-proto-plus==1.27.0
+proto-plus==1.27.1
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
-psutil==7.2.1
+psutil==7.2.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
@@ -159,13 +160,13 @@ pyasn1-modules==0.4.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth
-pycparser==2.23
+pycparser==3.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   cffi
 pygments==2.19.2
     # via pytest
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.11.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-rest-api-client
@@ -174,7 +175,7 @@ pynacl==1.6.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   httplib2
@@ -217,7 +218,7 @@ requests-toolbelt==1.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   zeep
-responses==0.25.8
+responses==0.26.0
     # via
     #   -r scripts/user_retirement/requirements/testing.in
     #   moto
@@ -241,7 +242,7 @@ sqlparse==0.5.5
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
@@ -262,9 +263,9 @@ urllib3==2.6.3
     #   botocore
     #   requests
     #   responses
-werkzeug==3.1.5
+werkzeug==3.1.6
     # via moto
-xmltodict==1.0.2
+xmltodict==1.0.4
     # via moto
 zeep==4.3.2
     # via

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2026.1.4
+certifi==2026.2.25
     # via requests
 charset-normalizer==3.4.4
     # via requests


### PR DESCRIPTION
## Summary

`make upgrade` was failing due to dependency issues that required fixes:

1. **astroid**: The latest pylint pins back astroid to an older version (`4.0.4`), but this conflict wasn't caught in the docs requirements file. Since both docs and testing requirements are included in `development.in`, compiling `development.txt` failed due to conflicting astroid version requirements. Holding back until pylint releases a compatible version.
   - Tracking issue: https://github.com/openedx/openedx-platform/issues/38066

2. **setuptools**: `setuptools==82.0.0` removed `pkg_resources` from its distribution. The `fs` (pyfilesystem2) package still uses `pkg_resources` for namespace package declarations, causing `ModuleNotFoundError: No module named 'pkg_resources'` across all CI checks that import `fs`. Constraining `setuptools<82` until pyfilesystem2 drops its `pkg_resources` usage.
   - Upstream issue: https://github.com/PyFilesystem/pyfilesystem2/issues/577
   - Tracking issue: https://github.com/openedx/openedx-platform/issues/38068

3. **types-requests**: `djangorestframework-stubs==3.16.8` dropped `types-requests` as a transitive dependency. Since edx-platform uses the `requests` library directly, it is now pinned explicitly in `development.in`.