### PR TITLE
refactor: Reference top-level settings instead of FEATURES

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     runs-on: ${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.11"

--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -254,7 +254,7 @@ class TestUserTaskStopped(APITestCase):
             *self.olx_validations['warnings']
         ]
 
-        with patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=True):
+        with override_settings(ENABLE_COURSE_OLX_VALIDATION=True):
             user_task_stopped.send(sender=UserTaskStatus, status=self.status)
             msg = mail.outbox[0]
 
@@ -277,12 +277,12 @@ class TestUserTaskStopped(APITestCase):
         msg = mail.outbox[0]
 
         # Verify olx validation is not enabled out of the box.
-        self.assertFalse(settings.FEATURES.get('ENABLE_COURSE_OLX_VALIDATION'))
+        self.assertFalse(settings.ENABLE_COURSE_OLX_VALIDATION)
         self.assertEqual(len(mail.outbox), 1)
         self.assert_msg_subject(msg)
         self.assert_msg_body_fragments(msg, body_fragments)
 
-    @patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=True)
+    @override_settings(ENABLE_COURSE_OLX_VALIDATION=True)
     @override_waffle_flag(BYPASS_OLX_FAILURE, active=True)
     def test_email_sent_with_olx_validations_with_bypass_flag(self):
         """

--- a/cms/djangoapps/course_creators/admin.py
+++ b/cms/djangoapps/course_creators/admin.py
@@ -142,7 +142,7 @@ def send_user_notification_callback(sender, **kwargs):  # pylint: disable=unused
     user = kwargs['user']
     updated_state = kwargs['state']
 
-    studio_request_email = settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')
+    studio_request_email = settings.STUDIO_REQUEST_EMAIL
     context = {'studio_request_email': studio_request_email}
 
     subject = render_to_string('emails/course_creator_subject.txt', context)
@@ -169,7 +169,7 @@ def send_admin_notification_callback(sender, **kwargs):  # pylint: disable=unuse
     """
     user = kwargs['user']
 
-    studio_request_email = settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')
+    studio_request_email = settings.STUDIO_REQUEST_EMAIL
     context = {'user_name': user.username, 'user_email': user.email}
 
     subject = render_to_string('emails/course_creator_admin_subject.txt', context)

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -8,7 +8,7 @@ from unittest import mock
 from django.contrib.admin.sites import AdminSite
 from django.core import mail
 from django.http import HttpRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from cms.djangoapps.course_creators.admin import CourseCreatorAdmin
 from cms.djangoapps.course_creators.models import CourseCreator
@@ -51,10 +51,6 @@ class CourseCreatorAdminTest(TestCase):
         self.creator_admin = CourseCreatorAdmin(self.table_entry, AdminSite())
 
         self.studio_request_email = 'mark@marky.mark'
-        self.enable_creator_group_patch = {
-            "ENABLE_CREATOR_GROUP": True,
-            "STUDIO_REQUEST_EMAIL": self.studio_request_email
-        }
 
     @mock.patch(
         'cms.djangoapps.course_creators.admin.render_to_string',
@@ -84,7 +80,7 @@ class CourseCreatorAdminTest(TestCase):
                 self.studio_request_email
             )
 
-        with mock.patch.dict('django.conf.settings.FEATURES', self.enable_creator_group_patch):
+        with override_settings(ENABLE_CREATOR_GROUP=True, STUDIO_REQUEST_EMAIL=self.studio_request_email):
 
             # User is initially unrequested.
             self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))
@@ -138,7 +134,7 @@ class CourseCreatorAdminTest(TestCase):
             else:
                 self.assertEqual(base_num_emails, len(mail.outbox))
 
-        with mock.patch.dict('django.conf.settings.FEATURES', self.enable_creator_group_patch):
+        with override_settings(ENABLE_CREATOR_GROUP=True, STUDIO_REQUEST_EMAIL=self.studio_request_email):
             # E-mail message should be sent to admin only when new state is PENDING, regardless of what
             # previous state was (unless previous state was already PENDING).
             # E-mail message sent to user only on transition into and out of GRANTED state.

--- a/cms/djangoapps/course_creators/tests/test_views.py
+++ b/cms/djangoapps/course_creators/tests/test_views.py
@@ -6,7 +6,7 @@ Tests course_creators.views.py.
 from unittest import mock
 
 from django.core.exceptions import PermissionDenied
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from cms.djangoapps.course_creators.views import (
@@ -65,7 +65,7 @@ class CourseCreatorView(TestCase):
         self.assertEqual('unrequested', get_course_creator_status(self.user))
 
     def test_add_granted(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             # Calling add_user_with_status_granted impacts is_user_in_course_group_role.
             self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))
 
@@ -79,7 +79,7 @@ class CourseCreatorView(TestCase):
             self.assertTrue(auth.user_has_role(self.user, CourseCreatorRole()))
 
     def test_update_creator_group(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))
             update_course_creator_group(self.admin, self.user, True)
             self.assertTrue(auth.user_has_role(self.user, CourseCreatorRole()))
@@ -87,7 +87,7 @@ class CourseCreatorView(TestCase):
             self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))
 
     def test_update_org_content_creator_role(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             self.assertFalse(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))
             update_org_content_creator_role(self.admin, self.user, [self.org])
             self.assertTrue(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -103,19 +103,19 @@ class CourseMetadata:
             exclude_list.append('giturl')
 
         # Do not show edxnotes if the feature is disabled.
-        if not settings.FEATURES.get('ENABLE_EDXNOTES'):
+        if not settings.ENABLE_EDXNOTES:
             exclude_list.append('edxnotes')
 
         # Do not show video auto advance if the feature is disabled
-        if not settings.FEATURES.get('ENABLE_OTHER_COURSE_SETTINGS'):
+        if not settings.ENABLE_OTHER_COURSE_SETTINGS:
             exclude_list.append('other_course_settings')
 
         # Do not show video_upload_pipeline if the feature is disabled.
-        if not settings.FEATURES.get('ENABLE_VIDEO_UPLOAD_PIPELINE'):
+        if not settings.ENABLE_VIDEO_UPLOAD_PIPELINE:
             exclude_list.append('video_upload_pipeline')
 
         # Do not show video auto advance if the feature is disabled
-        if not settings.FEATURES.get('ENABLE_AUTOADVANCE_VIDEOS'):
+        if not settings.ENABLE_AUTOADVANCE_VIDEOS:
             exclude_list.append('video_auto_advance')
 
         # Do not show social sharing url field if the feature is disabled.
@@ -124,14 +124,14 @@ class CourseMetadata:
             exclude_list.append('social_sharing_url')
 
         # Do not show teams configuration if feature is disabled.
-        if not settings.FEATURES.get('ENABLE_TEAMS'):
+        if not settings.ENABLE_TEAMS:
             exclude_list.append('teams_configuration')
 
-        if not settings.FEATURES.get('ENABLE_VIDEO_BUMPER'):
+        if not settings.ENABLE_VIDEO_BUMPER:
             exclude_list.append('video_bumper')
 
         # Do not show enable_ccx if feature is not enabled.
-        if not settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+        if not settings.CUSTOM_COURSES_EDX:
             exclude_list.append('enable_ccx')
             exclude_list.append('ccx_connector')
 

--- a/cms/lib/xblock/test/test_authoring_mixin.py
+++ b/cms/lib/xblock/test/test_authoring_mixin.py
@@ -32,9 +32,6 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
     ENROLLMENT_GROUPS_TITLE = "Enrollment Track Groups"
     STAFF_LOCKED = 'The unit that contains this component is hidden from learners'
 
-    FEATURES_WITH_ENROLLMENT_TRACK_DISABLED = settings.FEATURES.copy()
-    FEATURES_WITH_ENROLLMENT_TRACK_DISABLED['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = False
-
     @XBlock.register_temp_plugin(PureXBlock, 'pure')
     def setUp(self):
         """
@@ -170,7 +167,7 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
             [self.STAFF_LOCKED]
         )
 
-    @override_settings(FEATURES=FEATURES_WITH_ENROLLMENT_TRACK_DISABLED)
+    @override_settings(ENABLE_ENROLLMENT_TRACK_USER_PARTITION=False)
     def test_enrollment_tracks_disabled(self):
         """
         Test that the "no groups" messages doesn't reference enrollment tracks if

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -245,12 +245,12 @@ if toggles.EXPORT_GIT.is_enabled():
                 name='export_git')
     ]
 
-if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
+if settings.ENABLE_SERVICE_STATUS:
     urlpatterns.append(path('status/', include('openedx.core.djangoapps.service_status.urls')))
 
 # The password pages in the admin tool are disabled so that all password
 # changes go through our user portal and follow complexity requirements.
-if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+if not settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN:
     urlpatterns.append(re_path(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(path('admin/password_change/', handler404))
 urlpatterns.append(
@@ -264,7 +264,7 @@ if core_toggles.ENTRANCE_EXAMS.is_enabled():
                        contentstore_views.entrance_exam))
 
 # Enable Web/HTML Certificates
-if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
+if settings.CERTIFICATES_HTML_VIEW:
     from cms.djangoapps.contentstore.views.certificates import (
         CertificateActivationAPIView,
         CertificateDetailAPIView,

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -826,7 +826,7 @@ class CourseMode(models.Model):
         """
         ineligible_modes = [cls.AUDIT]
 
-        if settings.FEATURES.get('DISABLE_HONOR_CERTIFICATES', False):
+        if settings.DISABLE_HONOR_CERTIFICATES:
             # Adding check so that we can regenerate the certificate for learners who have
             # already earned the certificate using honor mode
             from lms.djangoapps.certificates.data import CertificateStatuses

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -442,7 +442,7 @@ class CourseModeModelTest(TestCase):
     @ddt.unpack
     def test_eligible_for_cert(self, disable_honor_cert, mode_slug, expected_eligibility):
         """Verify that non-audit modes are eligible for a cert."""
-        with override_settings(FEATURES={'DISABLE_HONOR_CERTIFICATES': disable_honor_cert}):
+        with override_settings(DISABLE_HONOR_CERTIFICATES=disable_honor_cert):
             assert CourseMode.is_eligible_for_certificate(mode_slug) == expected_eligibility
 
     @ddt.data(

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -47,7 +47,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
     """
     URLCONF_MODULES = ['common.djangoapps.course_modes.urls']
 
-    @patch.dict(settings.FEATURES, {'MODE_CREATION_FOR_TESTING': True})
+    @override_settings(MODE_CREATION_FOR_TESTING=True)
     def setUp(self):
         super().setUp()
         now = datetime.now(ZoneInfo("UTC"))
@@ -640,7 +640,7 @@ class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def setUp(self):
         super().setUp()
 
@@ -656,7 +656,7 @@ class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
         # Construct the URL for the track selection page
         self.url = reverse('course_modes_choose', args=[str(self.course.id)])
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_restrict(self):
         with restrict_course(self.course.id) as redirect_url:
             response = self.client.get(self.url)

--- a/common/djangoapps/course_modes/urls.py
+++ b/common/djangoapps/course_modes/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
 ]
 
 # Enable verified mode creation
-if settings.FEATURES.get('MODE_CREATION_FOR_TESTING'):
+if settings.MODE_CREATION_FOR_TESTING:
     urlpatterns.append(
         re_path(fr'^create_mode/{settings.COURSE_ID_PATTERN}/$',
                 views.create_mode,

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -381,7 +381,7 @@ class ChooseModeView(View):
 def create_mode(request, course_id):
     """Add a mode to the course corresponding to the given course ID.
 
-    Only available when settings.FEATURES['MODE_CREATION_FOR_TESTING'] is True.
+    Only available when settings.MODE_CREATION_FOR_TESTING is True.
 
     Attempts to use the following querystring parameters from the request:
         `mode_slug` (str): The mode to add, either 'honor', 'verified', or 'professional'

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -45,7 +45,7 @@ def marketing_link(name):
     link_map = settings.MKTG_URL_LINK_MAP
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        settings.ENABLE_MKTG_SITE
     )
     marketing_urls = configuration_helpers.get_value(
         'MKTG_URLS',
@@ -115,7 +115,7 @@ def is_marketing_link_set(name):
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        settings.ENABLE_MKTG_SITE
     )
     marketing_urls = configuration_helpers.get_value(
         'MKTG_URLS',

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -35,12 +35,12 @@ class ShortcutsTests(UrlResetMixin, TestCase):
     def test_marketing_link(self):
         with override_settings(MKTG_URL_LINK_MAP={'ABOUT': self._get_test_url_name()}):
             # test marketing site on
-            with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+            with override_settings(ENABLE_MKTG_SITE=True):
                 expected_link = 'https://dummy-root/about-us'
                 link = marketing_link('ABOUT')
                 assert link == expected_link
             # test marketing site off
-            with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+            with override_settings(ENABLE_MKTG_SITE=False):
                 expected_link = reverse(self._get_test_url_name())
                 link = marketing_link('ABOUT')
                 assert link == expected_link
@@ -49,11 +49,11 @@ class ShortcutsTests(UrlResetMixin, TestCase):
     def test_is_marketing_link_set(self):
         with override_settings(MKTG_URL_LINK_MAP={'ABOUT': self._get_test_url_name()}):
             # test marketing site on
-            with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+            with override_settings(ENABLE_MKTG_SITE=True):
                 assert is_marketing_link_set('ABOUT')
                 assert not is_marketing_link_set('NOT_CONFIGURED')
             # test marketing site off
-            with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+            with override_settings(ENABLE_MKTG_SITE=False):
                 assert is_marketing_link_set('ABOUT')
                 assert not is_marketing_link_set('NOT_CONFIGURED')
 
@@ -61,12 +61,12 @@ class ShortcutsTests(UrlResetMixin, TestCase):
     def test_is_any_marketing_link_set(self):
         with override_settings(MKTG_URL_LINK_MAP={'ABOUT': self._get_test_url_name()}):
             # test marketing site on
-            with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+            with override_settings(ENABLE_MKTG_SITE=True):
                 assert is_any_marketing_link_set(['ABOUT'])
                 assert is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED'])
                 assert not is_any_marketing_link_set(['NOT_CONFIGURED'])
             # test marketing site off
-            with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+            with override_settings(ENABLE_MKTG_SITE=False):
                 assert is_any_marketing_link_set(['ABOUT'])
                 assert is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED'])
                 assert not is_any_marketing_link_set(['NOT_CONFIGURED'])
@@ -84,11 +84,11 @@ class ShortcutsTests(UrlResetMixin, TestCase):
     def test_override_marketing_link_valid(self):
         expected_link = 'https://edx.org'
         # test marketing site on
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+        with override_settings(ENABLE_MKTG_SITE=True):
             link = marketing_link('TOS')
             assert link == expected_link
         # test marketing site off
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+        with override_settings(ENABLE_MKTG_SITE=False):
             link = marketing_link('TOS')
             assert link == expected_link
 
@@ -97,11 +97,11 @@ class ShortcutsTests(UrlResetMixin, TestCase):
     def test_override_marketing_link_invalid(self):
         expected_link = '#'
         # test marketing site on
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+        with override_settings(ENABLE_MKTG_SITE=True):
             link = marketing_link('TOS')
             assert link == expected_link
         # test marketing site off
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+        with override_settings(ENABLE_MKTG_SITE=False):
             link = marketing_link('TOS')
             assert link == expected_link
 
@@ -112,7 +112,7 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             'BAD_URL': 'foobarbaz',
         }
 
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+        with override_settings(ENABLE_MKTG_SITE=False):
             with override_settings(MKTG_URL_LINK_MAP=url_link_map):
                 link = marketing_link('ABOUT')
                 assert link == '/dashboard'

--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -12,5 +12,5 @@ def is_enabled():
 
     return configuration_helpers.get_value(
         "ENABLE_THIRD_PARTY_AUTH",
-        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH")
+        settings.ENABLE_THIRD_PARTY_AUTH
     )

--- a/common/djangoapps/third_party_auth/apps.py
+++ b/common/djangoapps/third_party_auth/apps.py
@@ -13,7 +13,7 @@ class ThirdPartyAuthConfig(AppConfig):  # lint-amnesty, pylint: disable=missing-
         from .signals import handlers  # noqa: F401 pylint: disable=unused-import
 
         # To override the settings before loading social_django.
-        if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
+        if settings.ENABLE_THIRD_PARTY_AUTH:
             self._enable_third_party_auth()
 
     def _enable_third_party_auth(self):

--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -21,7 +21,7 @@ def xframe_allow_whitelisted(view_func):
         """ Modify the response with the correct X-Frame-Options. """
         resp = view_func(request, *args, **kwargs)
         x_frame_option = settings.X_FRAME_OPTIONS
-        if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
+        if settings.ENABLE_THIRD_PARTY_AUTH:
             referer = request.META.get('HTTP_REFERER')
             if referer is not None:
                 parsed_url = urlparse(referer)

--- a/common/djangoapps/third_party_auth/management/commands/remove_social_auth_users.py
+++ b/common/djangoapps/third_party_auth/management/commands/remove_social_auth_users.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         slug = options['IDP']
 
-        if not settings.FEATURES.get('ENABLE_ENROLLMENT_RESET'):
+        if not settings.ENABLE_ENROLLMENT_RESET:
             raise CommandError('ENABLE_ENROLLMENT_RESET feature not enabled on this enviroment')
 
         try:

--- a/common/djangoapps/third_party_auth/management/commands/tests/test_remove_social_auth_users.py
+++ b/common/djangoapps/third_party_auth/management/commands/tests/test_remove_social_auth_users.py
@@ -20,10 +20,6 @@ from common.djangoapps.third_party_auth.management.commands import remove_social
 from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
-FEATURES_WITH_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_ENABLED['ENABLE_ENROLLMENT_RESET'] = True
-
-
 @skip_unless_lms
 class TestRemoveSocialAuthUsersCommand(TestCase):
     """
@@ -64,7 +60,7 @@ class TestRemoveSocialAuthUsersCommand(TestCase):
     def find_user_social_auth_entry(self, username):
         UserSocialAuth.objects.get(user__username=username)
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_remove_users(self):
         call_command(self.command, self.provider_hogwarts.slug, force=True)
 
@@ -83,14 +79,14 @@ class TestRemoveSocialAuthUsersCommand(TestCase):
         # other social auth intact
         self.find_user_social_auth_entry(self.user_viktor.username)
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_invalid_idp(self):
         invalid_slug = 'jedi-academy'
         err_string = f'No SAML provider found for slug {invalid_slug}'
         with self.assertRaisesRegex(CommandError, err_string):
             call_command(self.command, invalid_slug)
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_confirmation_required(self):
         """ By default this command will require user input to confirm """
         with self._replace_stdin('confirm'):
@@ -101,7 +97,7 @@ class TestRemoveSocialAuthUsersCommand(TestCase):
         with pytest.raises(UserSocialAuth.DoesNotExist):
             self.find_user_social_auth_entry('harry')
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_confirmation_failure(self):
         err_string = 'User confirmation required.  No records have been modified'
         with self.assertRaisesRegex(CommandError, err_string):

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -70,7 +70,7 @@ def clean_username(username=''):
     """
     Simple helper method to ensure a username is compatible with our system requirements.
     """
-    if settings.FEATURES.get("ENABLE_UNICODE_USERNAME"):
+    if settings.ENABLE_UNICODE_USERNAME:
         return ('_').join(re.findall(settings.USERNAME_REGEX_PARTIAL, username))[:USERNAME_MAX_LENGTH]
     else:
         return ('_').join(re.findall(r'[a-zA-Z0-9\-]+', username))[:USERNAME_MAX_LENGTH]

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -43,7 +43,7 @@ def apply_settings(django_settings):
     django_settings.SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = {'msafed': 0}
 
     # Avoid default username check to allow non-ascii characters
-    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = not settings.FEATURES.get("ENABLE_UNICODE_USERNAME")
+    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = not settings.ENABLE_UNICODE_USERNAME
 
     # Inject our customized auth pipeline. All auth backends must work with
     # this pipeline.

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -15,7 +15,7 @@ from django.contrib.auth import models as auth_models
 from django.contrib.messages.storage import fallback
 from django.contrib.sessions.backends import cache
 from django.urls import reverse
-from django.test import utils as django_utils
+from django.test import override_settings, utils as django_utils
 from django.conf import settings as django_settings  # lint-amnesty, pylint: disable=reimported
 from social_core import actions, exceptions
 from social_django import utils as social_utils
@@ -150,12 +150,12 @@ class HelperMixin:
         partial_unicode_username = unicode_username + ascii_substring
         pipeline_kwargs = pipeline.get(request)["kwargs"]
 
-        assert settings.FEATURES["ENABLE_UNICODE_USERNAME"] is False
+        assert settings.ENABLE_UNICODE_USERNAME is False
 
         self._check_registration_form_username(pipeline_kwargs, unicode_username, "")
         self._check_registration_form_username(pipeline_kwargs, partial_unicode_username, ascii_substring)
 
-        with mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_UNICODE_USERNAME": True}):
+        with override_settings(ENABLE_UNICODE_USERNAME=True):
             self._check_registration_form_username(pipeline_kwargs, unicode_username, unicode_username)
 
     def assert_exception_redirect_looks_correct(self, expected_uri, auth_entry=None):
@@ -577,7 +577,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
 
 
 @unittest.skipUnless(
-    testutil.AUTH_FEATURES_KEY in django_settings.FEATURES, testutil.AUTH_FEATURES_KEY + " not in settings.FEATURES"
+    django_settings.ENABLE_THIRD_PARTY_AUTH, testutil.AUTH_FEATURES_KEY + " not in settings.FEATURES"
 )
 @django_utils.override_settings()  # For settings reversion on a method-by-method basis.
 class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -13,6 +13,7 @@ import ddt
 import httpretty
 from django.conf import settings
 from django.contrib import auth
+from django.test import override_settings
 from enterprise.models import EnterpriseCustomerIdentityProvider, EnterpriseCustomerUser
 from freezegun import freeze_time
 from social_core import actions
@@ -285,9 +286,7 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
         # First we expect that we're in the linked state, with a backend entry.
         self.assert_social_auth_exists_for_user(request.user, strategy)
 
-        FEATURES_WITH_ENTERPRISE_ENABLED = settings.FEATURES.copy()
-        FEATURES_WITH_ENTERPRISE_ENABLED["ENABLE_ENTERPRISE_INTEGRATION"] = True
-        with patch.dict("django.conf.settings.FEATURES", FEATURES_WITH_ENTERPRISE_ENABLED):
+        with override_settings(ENABLE_ENTERPRISE_INTEGRATION=True):
             # Fire off the disconnect pipeline without the user information.
             actions.do_disconnect(
                 request.backend, None, None, redirect_field_name=auth.REDIRECT_FIELD_NAME, request=request

--- a/common/djangoapps/third_party_auth/tests/test_decorators.py
+++ b/common/djangoapps/third_party_auth/tests/test_decorators.py
@@ -48,7 +48,7 @@ class TestXFrameWhitelistDecorator(TestCase):
 
     @ddt.data('http://localhost/login', 'http://not-a-real-domain.com', None)
     def test_feature_flag_off(self, url):
-        with self.settings(FEATURES={'ENABLE_THIRD_PARTY_AUTH': False}):
+        with self.settings(ENABLE_THIRD_PARTY_AUTH=False):
             request = self.construct_request(url)
             response = mock_view(request)
             assert response['X-Frame-Options'] == 'DENY'

--- a/common/djangoapps/third_party_auth/tests/test_models.py
+++ b/common/djangoapps/third_party_auth/tests/test_models.py
@@ -40,14 +40,14 @@ class TestSamlProviderConfigModel(TestCase, unittest.TestCase):
             bad_config.save()
         assert ctx.records[0].msg == f'Entity ID: {self.saml_provider_config.entity_id} already in use'
 
-    @override_settings(FEATURES={'ENABLE_UNICODE_USERNAME': False})
+    @override_settings(ENABLE_UNICODE_USERNAME=False)
     def test_clean_username_unicode_disabled(self):
         """
         Test the username cleaner function with unicode disabled
         """
         assert clean_username('ItJüstWòrks™') == 'ItJ_stW_rks'
 
-    @override_settings(FEATURES={'ENABLE_UNICODE_USERNAME': True})
+    @override_settings(ENABLE_UNICODE_USERNAME=True)
     def test_clean_username_unicode_enabled(self):
         """
         Test the username cleaner function with unicode enabled

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -1,6 +1,7 @@
 """Unit tests for settings.py."""
 
 from unittest.mock import patch
+from django.test import override_settings
 from common.djangoapps.third_party_auth import provider, settings
 from common.djangoapps.third_party_auth.tests import testutil
 from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
@@ -62,6 +63,6 @@ class SettingsUnitTest(testutil.TestCase):
         settings.apply_settings(self.settings)
         assert self.settings.SOCIAL_AUTH_CLEAN_USERNAMES
         # verify default behavior
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_UNICODE_USERNAME': True}):
+        with override_settings(ENABLE_UNICODE_USERNAME=True):
             settings.apply_settings(self.settings)
             assert not self.settings.SOCIAL_AUTH_CLEAN_USERNAMES

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -27,7 +27,7 @@ from openedx.core.djangolib.testing.utils import CacheIsolationMixin
 from openedx.core.storage import OverwriteStorage
 
 AUTH_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
-AUTH_FEATURE_ENABLED = AUTH_FEATURES_KEY in settings.FEATURES
+AUTH_FEATURE_ENABLED = settings.ENABLE_THIRD_PARTY_AUTH
 
 
 def patch_mako_templates():

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -59,7 +59,7 @@ def get_link_for_about_page(course):
 
     if is_social_sharing_enabled and course.social_sharing_url:
         course_about_url = course.social_sharing_url
-    elif settings.FEATURES.get('ENABLE_MKTG_SITE') and getattr(course, 'marketing_url', None):
+    elif settings.ENABLE_MKTG_SITE and getattr(course, 'marketing_url', None):
         course_about_url = course.marketing_url
     else:
         course_about_url = f'{about_base_url}/courses/{course.id}/about'
@@ -80,7 +80,7 @@ def has_certificates_enabled(course):
         course: This can be either a course overview object or a course block.
     Returns a boolean if the course has enabled certificates
     """
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return False
     return course.cert_html_view_enabled
 

--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -115,10 +115,7 @@ def course_filename_prefix_generator(course_id, separator='_'):
         course_id.run
     ])
 
-    enable_course_filename_ccx_suffix = settings.FEATURES.get(
-        'ENABLE_COURSE_FILENAME_CCX_SUFFIX',
-        False
-    )
+    enable_course_filename_ccx_suffix = settings.ENABLE_COURSE_FILENAME_CCX_SUFFIX
 
     if enable_course_filename_ccx_suffix and getattr(course_id, 'ccx', None):
         filename = separator.join([filename, 'ccx', course_id.ccx])

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -45,7 +45,7 @@ def is_prerequisite_courses_enabled():
     """
     Returns boolean indicating prerequisite courses enabled system wide or not.
     """
-    return settings.FEATURES.get('ENABLE_PREREQUISITE_COURSES') and ENABLE_MILESTONES_APP.is_enabled()
+    return settings.ENABLE_PREREQUISITE_COURSES and ENABLE_MILESTONES_APP.is_enabled()
 
 
 def add_prerequisite_course(course_key, prerequisite_course_key):

--- a/common/djangoapps/util/tests/test_course.py
+++ b/common/djangoapps/util/tests/test_course.py
@@ -51,9 +51,7 @@ class TestCourseSharingLinks(ModuleStoreTestCase):
         Returns course sharing url.
         """
         mock_settings = {
-            'FEATURES': {
-                'ENABLE_MKTG_SITE': enable_mktg_site,
-            },
+            'ENABLE_MKTG_SITE': enable_mktg_site,
             'SOCIAL_SHARING_SETTINGS': {
                 'CUSTOM_COURSE_URLS': enable_social_sharing
             }

--- a/common/djangoapps/util/tests/test_file.py
+++ b/common/djangoapps/util/tests/test_file.py
@@ -57,7 +57,7 @@ class FilenamePrefixGeneratorTestCase(TestCase):
         [CCXLocator.from_course_locator(CourseLocator(org='foo', course='bar', run='baz'), '1'), 'foo_bar_baz_ccx_1'],
     )
     @ddt.unpack
-    @override_settings(FEATURES={'ENABLE_COURSE_FILENAME_CCX_SUFFIX': True})
+    @override_settings(ENABLE_COURSE_FILENAME_CCX_SUFFIX=True)
     def test_include_ccx_id(self, course_key, expected_filename):
         """
         Test filename prefix genaration from multiple course key formats.
@@ -83,7 +83,7 @@ class FilenamePrefixGeneratorTestCase(TestCase):
         [CCXLocator.from_course_locator(CourseLocator(org='foo', course='bar', run='baz'), '1'), 'foo-bar-baz-ccx-1'],
     )
     @ddt.unpack
-    @override_settings(FEATURES={'ENABLE_COURSE_FILENAME_CCX_SUFFIX': True})
+    @override_settings(ENABLE_COURSE_FILENAME_CCX_SUFFIX=True)
     def test_custom_separator_including_ccx_id(self, course_key, expected_filename):
         """
         Test filename prefix is generated with a custom separator.

--- a/common/djangoapps/util/tests/test_milestones_helpers.py
+++ b/common/djangoapps/util/tests/test_milestones_helpers.py
@@ -59,9 +59,7 @@ class MilestonesHelpersTestCase(ModuleStoreTestCase):
         ENABLE_PREREQUISITE_COURSES and MILESTONES_APP feature flags.
         """
 
-        with patch.dict("django.conf.settings.FEATURES", {
-            'ENABLE_PREREQUISITE_COURSES': feature_flags[0],
-        }), override_settings(MILESTONES_APP=feature_flags[1]):
+        with override_settings(ENABLE_PREREQUISITE_COURSES=feature_flags[0], MILESTONES_APP=feature_flags[1]):
             assert feature_flags[2] == milestones_helpers.is_prerequisite_courses_enabled()
 
     def test_add_milestone_returns_none_when_app_disabled(self):

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -431,7 +431,7 @@ def _footer_mobile_links(is_secure):
     platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
 
     mobile_links = []
-    if settings.FEATURES.get('ENABLE_FOOTER_MOBILE_APP_LINKS'):
+    if settings.ENABLE_FOOTER_MOBILE_APP_LINKS:
         mobile_links = [
             {
                 "name": "apple",

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -46,7 +46,7 @@ class TestFooter(TestCase):
     """Test retrieving the footer. """
     maxDiff = None
 
-    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
+    @override_settings(ENABLE_MKTG_SITE=True)
     @mock.patch.dict('django.conf.settings.MKTG_URLS', {
         "ROOT": "https://edx.org",
         "ENTERPRISE": "/enterprise"
@@ -62,7 +62,7 @@ class TestFooter(TestCase):
         business_links = _footer_business_links()
         assert business_links[0]['url'] == 'https://edx.org/enterprise'
 
-    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
+    @override_settings(ENABLE_MKTG_SITE=True)
     @mock.patch.dict('django.conf.settings.MKTG_URLS', {
         "ROOT": "https://edx.org",
         "ABOUT": "/about-us",

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -24,12 +24,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-a
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.course_block import CATALOG_VISIBILITY_ABOUT, CATALOG_VISIBILITY_NONE
 
-FEATURES_WITH_STARTDATE = settings.FEATURES.copy()
-FEATURES_WITH_STARTDATE['DISABLE_START_DATES'] = False
-FEATURES_WO_STARTDATE = settings.FEATURES.copy()
-FEATURES_WO_STARTDATE['DISABLE_START_DATES'] = True
-
-
 def mock_render_to_response(*args, **kwargs):
     """
     Mock the render_to_response function
@@ -65,7 +59,7 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
 
         return headers
 
-    @override_settings(FEATURES=FEATURES_WITH_STARTDATE)
+    @override_settings(DISABLE_START_DATES=False)
     def test_none_user_index_access_with_startdate_fails(self):
         """
         This is a regression test for a bug where the incoming user is
@@ -76,12 +70,12 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
         response = self.client.get(reverse('root'))
         assert response.status_code == 200
 
-    @override_settings(FEATURES=FEATURES_WITH_STARTDATE)
+    @override_settings(DISABLE_START_DATES=False)
     def test_anon_user_with_startdate_index(self):
         response = self.client.get('/')
         assert response.status_code == 200
 
-    @override_settings(FEATURES=FEATURES_WO_STARTDATE)
+    @override_settings(DISABLE_START_DATES=True)
     def test_anon_user_no_startdate_index(self):
         response = self.client.get('/')
         assert response.status_code == 200
@@ -131,7 +125,7 @@ class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase, Mi
     """
     ENABLED_SIGNALS = ['course_published']
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_course_with_prereq(self):
         """
         Simulate having a course which has closed enrollments that has
@@ -220,7 +214,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': False})
+    @override_settings(ENABLE_COURSE_DISCOVERY=False)
     def test_course_discovery_off(self):
         """
         Asserts that the Course Discovery UI elements follow the
@@ -244,7 +238,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': True})
+    @override_settings(ENABLE_COURSE_DISCOVERY=True)
     def test_course_discovery_on(self):
         """
         Asserts that the Course Discovery UI elements follow the
@@ -266,7 +260,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': False})
+    @override_settings(ENABLE_COURSE_DISCOVERY=False)
     def test_course_cards_sorted_by_default_sorting(self):
         response = self.client.get('/')
         assert response.status_code == 200
@@ -291,8 +285,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_SORTING_BY_START_DATE': False})
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': False})
+    @override_settings(ENABLE_COURSE_SORTING_BY_START_DATE=False, ENABLE_COURSE_DISCOVERY=False)
     def test_course_cards_sorted_by_start_date_disabled(self):
         response = self.client.get('/')
         assert response.status_code == 200

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -46,7 +46,7 @@ class TestFooter(CacheIsolationTestCase):
         assert resp['Content-Type'] == content_type
         self.assertContains(resp, content)
 
-    @mock.patch.dict(settings.FEATURES, {'ENABLE_FOOTER_MOBILE_APP_LINKS': True})
+    @override_settings(ENABLE_FOOTER_MOBILE_APP_LINKS=True)
     def test_footer_json(self):
         self._set_feature_flag(True)
         with with_comprehensive_theme_context(None):

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -98,13 +98,13 @@ def courses(request):
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        settings.ENABLE_MKTG_SITE
     )
 
     if enable_mktg_site:
         return redirect(marketing_link('COURSES'), permanent=True)
 
-    if not settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+    if not settings.COURSES_ARE_BROWSABLE:
         raise Http404
 
     #  we do not expect this case to be reached in cases where

--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -28,7 +28,7 @@ class CcxCourseTab(CourseTab):
         """
         Returns true if CCX has been enabled and the specified user is a coach
         """
-        if not settings.FEATURES.get('CUSTOM_COURSES_EDX', False) or not course.enable_ccx:
+        if not settings.CUSTOM_COURSES_EDX or not course.enable_ccx:
             # If ccx is not enable do not show ccx coach tab.
             return False
 

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -37,12 +37,7 @@ from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
 
 
-@mock.patch.dict(
-    'django.conf.settings.FEATURES',
-    {
-        'ENABLE_XBLOCK_VIEW_ENDPOINT': True,
-    }
-)
+@override_settings(ENABLE_XBLOCK_VIEW_ENDPOINT=True)
 @ddt.ddt
 class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseTestMixin, ModuleStoreTestCase):
     """

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -229,7 +229,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
 
     @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', intercept_renderer)
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     def test_edit_schedule(self):
         """
         Get CCX schedule, modify it, save it.
@@ -1118,7 +1118,7 @@ class CCXCoachTabTestCase(CcxTestCase):
         """
         Test ccx coach tab state (visible or hidden) depending on the value of enable_ccx flag, ccx feature flag.
         """
-        with self.settings(FEATURES={'CUSTOM_COURSES_EDX': ccx_feature_flag}):
+        with self.settings(CUSTOM_COURSES_EDX=ccx_feature_flag):
             course = self.ccx_enabled_course if enable_ccx else self.ccx_disabled_course
             assert expected_result == self.check_ccx_tab(course, self.user)
 

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -6,7 +6,7 @@ Tests for the Certificate REST APIs.
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -380,7 +380,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             assert resp.status_code == status.HTTP_200_OK
             assert len(resp.data) == 2
 
-    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_with_no_certificate_configuration(self):
         """
         Verify that certificates are not returned until there is an active

--- a/lms/djangoapps/certificates/apps.py
+++ b/lms/djangoapps/certificates/apps.py
@@ -23,6 +23,6 @@ class CertificatesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from lms.djangoapps.certificates import signals  # pylint: disable=unused-import
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from lms.djangoapps.certificates.services import CertificateService
             set_runtime_service('certificates', CertificateService())

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -454,5 +454,4 @@ def _id_verification_enforced_and_missing(user):
     """
     Return true if IDV is required for this course and the user does not have it
     """
-    return settings.FEATURES.get(
-        'ENABLE_CERTIFICATES_IDV_REQUIREMENT') and not IDVerificationService.user_is_verified(user)
+    return settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT and not IDVerificationService.user_is_verified(user)

--- a/lms/djangoapps/certificates/management/commands/tests/test_regenerate_noidv_cert.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_regenerate_noidv_cert.py
@@ -5,8 +5,8 @@ Tests for the cert_generation command
 from unittest import mock
 
 import pytest
-from django.conf import settings
 from django.core.management import CommandError, call_command
+from django.test import override_settings
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -23,7 +23,7 @@ WEB_CERTS_METHOD = 'lms.djangoapps.certificates.generation_handler.has_html_cert
 
 # base setup is unverified users, Enable certificates IDV requirements turned off,
 # and normal passing grade certificates for convenience
-@mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
+@override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=False))
 @mock.patch(PASSING_GRADE_METHOD, mock.Mock(return_value=True))
 @mock.patch(WEB_CERTS_METHOD, mock.Mock(return_value=True))

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import ddt
 import pytz
 from config_models.models import cache
-from django.conf import settings
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -76,10 +75,6 @@ CAN_GENERATE_METHOD = "lms.djangoapps.certificates.generation_handler._can_gener
 BETA_TESTER_METHOD = "lms.djangoapps.certificates.api.access.is_beta_tester"
 CERTS_VIEWABLE_METHOD = "lms.djangoapps.certificates.api.certificates_viewable_for_course"
 PASSED_OR_ALLOWLISTED_METHOD = "lms.djangoapps.certificates.api._has_passed_or_is_allowlisted"
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED["CERTIFICATES_HTML_VIEW"] = True
-
-
 class WebCertificateTestMixin:
     """
     Mixin with helpers for testing Web Certificates.
@@ -191,14 +186,14 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             "uuid": cert.verify_uuid,
         }
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_pdf_cert_with_html_enabled(self):
         self.verify_downloadable_pdf_cert()
 
     def test_pdf_cert_with_html_disabled(self):
         self.verify_downloadable_pdf_cert()
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_with_downloadable_web_cert(self):
         cert_status = certificate_status_for_student(self.student, self.course.id)
         assert certificate_downloadable_status(self.student, self.course.id) == {
@@ -221,7 +216,7 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
         (False, timedelta(days=2), CertificatesDisplayBehaviors.END_WITH_DATE, False, None, True),
     )
     @ddt.unpack
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_cert_api_return(
         self,
         self_paced,
@@ -476,7 +471,7 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         """
         assert not get_certificates_for_user(self.student_no_cert.username)
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_get_web_certificate_url(self):
         """
         Test the get_certificate_url with a web cert course
@@ -490,7 +485,7 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         cert_url = get_certificate_url(user_id=self.student.id, course_id=self.web_cert_course.id, uuid=self.uuid)
         assert expected_url == cert_url
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_get_pdf_certificate_url(self):
         """
         Test the get_certificate_url with a pdf cert course
@@ -522,7 +517,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
             mode=CourseMode.VERIFIED,
         )
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": False})
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_cert_url_empty_with_invalid_certificate(self):
         """
         Test certificate url is empty if html view is not enabled and certificate is not yet generated
@@ -530,7 +525,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
         url = get_certificate_url(self.user.id, self.course_run_key)
         assert url == ""
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_generation(self):
         """
         Test that a cert is successfully generated
@@ -546,7 +541,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
                 assert cert.status == CertificateStatuses.downloadable
                 assert cert.mode == CourseMode.VERIFIED
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(True, False)
     def test_generation_unverified(self, enable_idv_requirement):
         """
@@ -557,7 +552,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
 
         with mock.patch(PASSING_GRADE_METHOD, return_value=True):
             with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-                with mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                with override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
                     generate_certificate_task(self.user, self.course_run_key)
 
                     cert = get_certificate_for_user_id(self.user.id, self.course_run_key)
@@ -567,7 +562,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
                     else:
                         assert cert.status == CertificateStatuses.downloadable
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_generation_notpassing(self):
         """
         Test that a cert is successfully generated with a status of notpassing
@@ -652,7 +647,7 @@ class CertificateGenerationEnabledTest(EventTestMixin, TestCase):
         assert expect_enabled == actual_enabled
 
 
-@override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+@override_settings(CERTIFICATES_HTML_VIEW=True)
 class CertificatesBrandingTest(ModuleStoreTestCase):
     """Test certificates branding."""
 

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -207,7 +207,7 @@ class AllowlistTests(ModuleStoreTestCase):
         Test handling when the user's id is not verified
         """
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
             self.assertNotEqual(
                 enable_idv_requirement,
                 _can_generate_allowlist_certificate(self.user, self.course_run_key, self.enrollment_mode))
@@ -350,15 +350,15 @@ class AllowlistTests(ModuleStoreTestCase):
         CertificateAllowlistFactory.create(course_id=course_run_key, user=self.user)
 
         # Enable Honor Certificates and verify we can generate an AllowList certificate
-        with override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': False}):
+        with override_settings(DISABLE_HONOR_CERTIFICATES=False):
             assert _can_generate_allowlist_certificate(self.user, course_run_key, enrollment_mode)
 
         # Disable Honor Certificates and verify we cannot generate an AllowList certificate
-        with override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': True}):
+        with override_settings(DISABLE_HONOR_CERTIFICATES=True):
             assert not _can_generate_allowlist_certificate(self.user, course_run_key, enrollment_mode)
 
 
-@mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
+@override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=True))
 @mock.patch(CCX_COURSE_METHOD, mock.Mock(return_value=False))
 @mock.patch(PASSING_GRADE_METHOD, mock.Mock(return_value=True))
@@ -535,7 +535,7 @@ class CertificateTests(ModuleStoreTestCase):
         )
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
             self.assertNotEqual(
                 enable_idv_requirement,
                 _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
@@ -557,7 +557,7 @@ class CertificateTests(ModuleStoreTestCase):
         )
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
             self.assertNotEqual(
                 enable_idv_requirement,
                 _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
@@ -585,7 +585,7 @@ class CertificateTests(ModuleStoreTestCase):
         )
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=False):
             assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
             if enable_idv_requirement:
@@ -615,7 +615,7 @@ class CertificateTests(ModuleStoreTestCase):
         CertificateAllowlistFactory(course_id=self.course_run_key, user=u)
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=False):
             assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
             if enable_idv_requirement:
@@ -792,11 +792,11 @@ class CertificateTests(ModuleStoreTestCase):
         # Enable Honor Certificates and verify we can generate a certificate
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=True), \
-                override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': False}):
+                override_settings(DISABLE_HONOR_CERTIFICATES=False):
             assert _can_generate_regular_certificate(self.user, course_run_key, enrollment_mode, grade)
 
         # Disable Honor Certificates and verify we cannot generate a certificate
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=True), \
-                override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': True}):
+                override_settings(DISABLE_HONOR_CERTIFICATES=True):
             assert not _can_generate_regular_certificate(self.user, course_run_key, enrollment_mode, grade)

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -7,7 +7,6 @@ from unittest import mock, skipUnless
 
 import ddt
 import pytest
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
@@ -43,9 +42,6 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 
 ENROLLMENT_METHOD = 'common.djangoapps.student.models.course_enrollment.CourseEnrollment.enrollment_mode_for_user'
 PROFILE_METHOD = 'common.djangoapps.student.models_api.get_name'
-
-FEATURES_INVALID_FILE_PATH = settings.FEATURES.copy()
-FEATURES_INVALID_FILE_PATH['CERTS_HTML_VIEW_CONFIG_PATH'] = 'invalid/path/to/config.json'
 
 TEST_DIR = path(__file__).dirname()
 TEST_DATA_DIR = 'common/test/data/'
@@ -195,7 +191,6 @@ class CertificateHtmlViewConfigurationTest(TestCase, OpenEdxEventsTestMixin):
         self.config.save()
         assert len(self.config.get_config()) == 0
 
-    @override_settings(FEATURES=FEATURES_INVALID_FILE_PATH)
     def test_get_no_database_no_file(self):
         """
         Tests get configuration that is not enabled.

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -8,7 +8,6 @@ from unittest import mock
 from uuid import uuid4
 
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
@@ -23,8 +22,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-a
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 CAN_GENERATE_METHOD = 'lms.djangoapps.certificates.generation_handler._can_generate_regular_certificate'
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
 
 
 class CertificateSupportTestCase(ModuleStoreTestCase):
@@ -211,7 +208,7 @@ class CertificateSearchTests(CertificateSupportTestCase):
         assert retrieved_cert['download_url'] == self.CERT_DOWNLOAD_URL
         assert not retrieved_cert['regenerate']
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_download_link(self):
         self.cert.course_id = self.course_key
         self.cert.download_url = ''

--- a/lms/djangoapps/certificates/tests/test_utils.py
+++ b/lms/djangoapps/certificates/tests/test_utils.py
@@ -2,10 +2,8 @@
 Tests for Certificates app utility functions
 """
 from datetime import datetime, timedelta
-from unittest.mock import patch
-
 import ddt
-from django.test import TestCase
+from django.test import override_settings, TestCase
 from pytz import utc
 
 from lms.djangoapps.certificates.utils import has_html_certificates_enabled, should_certificate_be_visible
@@ -27,14 +25,14 @@ class CertificateUtilityTests(TestCase):
         super().setUp()
         self.course_overview = CourseOverviewFactory.create()
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_has_html_certificates_enabled_from_course_overview_cert_html_view_disabled(self):
         """
         Test to ensure we return the correct value when the `CERTIFICATES_HTML_VIEW` setting is disabled.
         """
         assert not has_html_certificates_enabled(self.course_overview)
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_has_html_certificates_enabled_from_course_overview_enabled(self):
         """
         Test to ensure we return the correct value when the HTML certificates are enabled in a course-run.
@@ -44,7 +42,7 @@ class CertificateUtilityTests(TestCase):
 
         assert has_html_certificates_enabled(self.course_overview)
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_has_html_certificates_enabled_from_course_overview_disabled(self):
         """
         Test to ensure we return the correct value when the HTML certificates are disabled in a course-run.

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -4,7 +4,6 @@
 import datetime
 from uuid import uuid4
 
-from django.conf import settings
 from django.test.client import Client
 from django.test.utils import override_settings
 
@@ -19,18 +18,6 @@ from openedx.core.djangoapps.site_configuration.tests.test_util import with_site
 from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
-
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
-
-FEATURES_WITH_CERTS_DISABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_DISABLED['CERTIFICATES_HTML_VIEW'] = False
-
-FEATURES_WITH_CUSTOM_CERTS_ENABLED = {
-    "CUSTOM_CERTIFICATE_TEMPLATES_ENABLED": True
-}
-FEATURES_WITH_CUSTOM_CERTS_ENABLED.update(FEATURES_WITH_CERTS_ENABLED)
-
 
 class CertificatesViewsSiteTests(ModuleStoreTestCase):
     """
@@ -130,7 +117,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         self.course.save()
         self.store.update_item(self.course, self.user.id)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @with_site_configuration(configuration={'platform_name': 'My Platform Site'})
     def test_html_view_for_site(self):
         test_url = get_certificate_url(
@@ -150,7 +137,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         )
         self.assertContains(response, 'About My Platform Site')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_view_site_configuration_missing(self):
         test_url = get_certificate_url(
             user_id=self.user.id,
@@ -166,7 +153,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
             'This should not survive being overwritten by static content',
         )
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, GOOGLE_ANALYTICS_4_ID='GA-abc')
+    @override_settings(CERTIFICATES_HTML_VIEW=True, GOOGLE_ANALYTICS_4_ID='GA-abc')
     @with_site_configuration(configuration={'platform_name': 'My Platform Site'})
     def test_html_view_with_g4(self):
         test_url = get_certificate_url(

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -51,15 +51,6 @@ from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
-
-FEATURES_WITH_CERTS_DISABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_DISABLED['CERTIFICATES_HTML_VIEW'] = False
-
-FEATURES_WITH_CUSTOM_CERTS_ENABLED = FEATURES_WITH_CERTS_ENABLED.copy()
-FEATURES_WITH_CUSTOM_CERTS_ENABLED['CUSTOM_CERTIFICATE_TEMPLATES_ENABLED'] = True
-
 name_affirmation_service = get_name_affirmation_service()
 
 
@@ -289,7 +280,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             'max_effort': '10'
         }
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_linkedin_share_url(self):
         """
         Test: LinkedIn share URL.
@@ -314,7 +305,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             js_escaped_string(self.linkedin_url.format(params=urlencode(params))),
         )
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @with_site_configuration(
         configuration={
             'platform_name': 'My Platform Site', 'LINKEDIN_COMPANY_ID': 2448,
@@ -348,7 +339,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         "CERTIFICATE_FACEBOOK": True,
         "CERTIFICATE_FACEBOOK_TEXT": "test FB text"
     })
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_certificate_html_view_with_facebook_meta_tags(self):
         """
         Test view html certificate if share to FB is enabled.
@@ -381,7 +372,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
     @patch.dict("django.conf.settings.SOCIAL_SHARING_SETTINGS", {
         "CERTIFICATE_FACEBOOK": False,
     })
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_certificate_html_view_without_facebook_meta_tags(self):
         """
         Test view html certificate if share to FB is disabled.
@@ -408,7 +399,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, '<meta property="og:image" ')
         self.assertNotContains(response, '<meta property="og:description" ')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @patch.dict("django.conf.settings.SOCIAL_SHARING_SETTINGS", {"CERTIFICATE_FACEBOOK": True})
     @with_site_configuration(
         configuration={'FACEBOOK_APP_ID': 'test_facebook_my_site'},
@@ -424,7 +415,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, "Post on Facebook")
         self.assertContains(response, 'test_facebook_my_site')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         (False, False, False),
         (False, False, True),
@@ -456,7 +447,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert ('Share on Twitter' in response.content.decode('utf-8')) == twitter_sharing
             assert ('Add to LinkedIn Profile' in response.content.decode('utf-8')) == linkedin_sharing
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_facebook_default_text_site(self):
         """
         Test: Facebook sharing default text for sites.
@@ -476,7 +467,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             response = self.client.get(test_url, HTTP_HOST='test.localhost')
             self.assertContains(response, facebook_text)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_twitter_default_text_site(self):
         """
         Test: Twitter sharing default text for sites.
@@ -496,7 +487,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             response = self.client.get(test_url, HTTP_HOST='test.localhost')
             self.assertContains(response, twitter_text)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_rendering_course_organization_data(self):
         """
         Test: organization data should render on certificate web view if course has organization.
@@ -525,7 +516,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, f'<title>test_organization {self.course.number} Certificate |')
         self.assertContains(response, 'logo_test1.png')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @patch.dict("django.conf.settings.SOCIAL_SHARING_SETTINGS", {
         "CERTIFICATE_TWITTER": True,
         "CERTIFICATE_FACEBOOK": True,
@@ -597,7 +588,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # Test course overrides
         self.assertContains(response, "/static/certificates/images/course_override_logo.png")
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_valid_certificate(self):
         self._add_course_certificates(count=1, signatory_count=2)
         test_url = get_certificate_url(
@@ -620,7 +611,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         self.assertContains(response, str(self.cert.verify_uuid))
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_certificate_only_for_downloadable_status(self):
         """
         Tests that Certificate HTML Web View returns Certificate only if certificate status is 'downloadable',
@@ -649,7 +640,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         (CertificateStatuses.audit_notpassing, False),
     )
     @ddt.unpack
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_audit_certificate_display(self, status, eligible_for_certificate):
         """
         Ensure that audit-mode certs are only shown in the web view if they
@@ -672,7 +663,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         else:
             assert response.status_code == 404
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_view_returns_404_for_invalid_certificate(self):
         """
         Tests that Certificate HTML Web View successfully retrieves certificate only
@@ -694,7 +685,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         assert response.status_code == 404
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_lang_attribute_is_dynamic_for_certificate_html_view(self):
         """
         Tests that Certificate HTML Web View's lang attribute is based on user language.
@@ -717,7 +708,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, '<html class="no-js" lang="ar">')
 
     @ddt.data(False, True)
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_view_for_non_viewable_certificate_and_for_student_user(self, date_override):
         """
         Tests that Certificate HTML Web View returns "Cannot Find Certificate"
@@ -755,7 +746,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, "Cannot Find Certificate")
         self.assertContains(response, "We cannot find a certificate with this URL or ID number.")
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_with_valid_signatories(self):
         self._add_course_certificates(count=1, signatory_count=2)
         test_url = get_certificate_url(
@@ -771,7 +762,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'Signatory_Organization 0')
         self.assertContains(response, '/static/certificates/images/demo-sig0.png')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_course_display_name_not_override_with_course_title(self):
         # if certificate in block has not course_title then course name should not be overridden with this title.
         test_certificates = [
@@ -798,7 +789,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, 'test_course_title_0')
         self.assertContains(response, 'refundable course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_course_display_overrides(self):
         """
         Tests if `Course Number Display String` or `Course Organization Display` is set for a course
@@ -821,7 +812,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'overridden_number')
         self.assertContains(response, 'overridden_org')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_certificate_view_without_org_logo(self):
         test_certificates = [
             {
@@ -846,7 +837,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # make sure response html has only one organization logo container for edX
         self.assertContains(response, "<li class=\"wrapper-organization\">", 1)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_without_signatories(self):
         self._add_course_certificates(count=1, signatory_count=0)
         test_url = get_certificate_url(
@@ -858,7 +849,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, 'Signatory_Name 0')
         self.assertNotContains(response, 'Signatory_Title 0')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_is_html_escaped(self):
         test_certificates = [
             {
@@ -887,7 +878,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, '<script>')
         self.assertContains(response, '&lt;script&gt;course_title&lt;/script&gt;')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_DISABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_render_html_view_disabled_feature_flag_returns_static_url(self):
         test_url = get_certificate_url(
             user_id=self.user.id,
@@ -896,7 +887,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         assert str(self.cert.download_url) in test_url
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_invalid_course(self):
         test_url = "/certificates/user/{user_id}/course/{course_id}".format(
             user_id=self.user.id,
@@ -905,7 +896,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         self.assertContains(response, 'invalid')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_invalid_user_certificate(self):
         self._add_course_certificates(count=1, signatory_count=0)
         test_url = get_certificate_url(
@@ -919,7 +910,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         assert response.status_code == 404
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, PLATFORM_NAME='Űńíćődé Űńívéŕśítӳ')
+    @override_settings(CERTIFICATES_HTML_VIEW=True, PLATFORM_NAME='Űńíćődé Űńívéŕśítӳ')
     def test_render_html_view_with_unicode_platform_name(self):
         self._add_course_certificates(count=1, signatory_count=0)
 
@@ -931,7 +922,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         assert response.status_code == 200
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_user_id_cert_url_not_supported(self):
         """
         tests the user id based certificate url is no longer supported
@@ -944,7 +935,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # staff or instructor access should show invalid certificate
         self.assertContains(response, 'URL Not Supported')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_with_preview_mode(self):
         """
         test certificate web view should render properly along with its signatories information when accessing it in
@@ -967,7 +958,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course_title_0')
         self.assertContains(response, 'Signatory_Title 0')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_with_preview_mode_when_user_already_has_cert(self):
         """
         test certificate web view should render properly in
@@ -989,7 +980,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course_title_0')
         self.assertContains(response, 'Signatory_Title 0')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         (-2, True),
         (-2, False)
@@ -1024,7 +1015,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         self.assertContains(response, date)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         (True, False),
         (False, False),
@@ -1072,7 +1063,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
         self.assertContains(response, date)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_invalid_certificate_configuration(self):
         self.course.cert_html_view_enabled = True
         self.course.save()
@@ -1087,7 +1078,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, "Invalid Certificate")
 
     # TEMPLATES WITHOUT LANGUAGE TESTS
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @override_settings(LANGUAGE_CODE='fr')
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org_mode_and_course_key(self, mock_get_course_run_details):
@@ -1122,7 +1113,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, 'lang: fr')
             self.assertContains(response, 'course name: test_template_3_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org_and_mode(self, mock_get_course_run_details):
         """
@@ -1157,7 +1148,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org(self, mock_get_course_run_details):
         """
@@ -1181,7 +1172,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_mode(self, mock_get_course_run_details):
         """
@@ -1209,7 +1200,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     # Templates With Language tests
     # 1
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @override_settings(LANGUAGE_CODE='fr')
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
@@ -1294,7 +1285,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 2
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_org_and_mode(self, mock_get_org_id, mock_get_course_run_details):
@@ -1354,7 +1345,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 3
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_org(self, mock_get_org_id, mock_get_course_run_details):
@@ -1412,7 +1403,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 4
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_mode(self, mock_get_org_id, mock_get_course_run_details):
@@ -1470,7 +1461,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_locale_language_from_catalogue(
@@ -1532,7 +1523,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @ddt.data(True, False)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
@@ -1578,10 +1569,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         mode = 'honor'
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(mode=mode)
-        with patch.dict("django.conf.settings.FEATURES", {
-            "CERTIFICATES_HTML_VIEW": True,
-            "CUSTOM_CERTIFICATE_TEMPLATES_ENABLED": custom_certs_enabled
-        }):
+        with override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=custom_certs_enabled):
             test_url = get_certificate_url(
                 user_id=self.user.id,
                 course_id=str(self.course.id),
@@ -1603,7 +1591,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
                             self.assertContains(response, "Tweet this Accomplishment")
                         self.assertContains(response, 'https://twitter.com/intent/tweet')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_asset_by_slug(self, mock_get_course_run_details):
         """
@@ -1642,7 +1630,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             )
 
     @skipUnless(name_affirmation_service is not None, 'Requires Name Affirmation')
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data((True, 'approved'),
               (True, 'denied'),
               (False, 'pending'))
@@ -1679,7 +1667,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, self.user.profile.name)
             self.assertNotContains(response, verified_name)
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True)
     @ddt.data(
         True,
         False
@@ -1688,7 +1676,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         """
         Test that for a verified cert, the correct language is used when the integrity signature feature is enabled.
         """
-        with patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
+        with override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
             self._add_course_certificates(count=1, signatory_count=2, is_active=True)
             self._create_custom_template_with_verified_description()
             self.cert.mode = 'verified'
@@ -1823,7 +1811,7 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
     Test events emitted by certificate handling.
     """
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_certificate_evidence_event_emitted(self):
         self.client.logout()
         self._add_course_certificates(count=1, signatory_count=2)

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -4,10 +4,8 @@ Tests for the certificates models.
 
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
-
 from ddt import data, ddt, unpack
-from django.conf import settings
+from django.test import override_settings
 from milestones.tests.utils import MilestonesTestCaseMixin
 from pytz import UTC
 
@@ -182,7 +180,7 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
             {course_1.id, course_2.id}
         )
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_course_milestone_collected(self):
         student = UserFactory()
         course = CourseFactory.create(org='edx', number='998', display_name='Test Course')

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -87,7 +87,7 @@ def has_html_certificates_enabled(course_overview):
     """
     Returns True if HTML certificates are enabled in a course run.
     """
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return False
     return course_overview.cert_html_view_enabled
 

--- a/lms/djangoapps/certificates/views/tests/test_filters.py
+++ b/lms/djangoapps/certificates/views/tests/test_filters.py
@@ -1,7 +1,6 @@
 """
 Test that various filters are fired for views in the certificates app.
 """
-from django.conf import settings
 from django.http import HttpResponse
 from django.test import override_settings
 from openedx_filters import PipelineStep
@@ -14,10 +13,6 @@ from lms.djangoapps.certificates.tests.test_webview_views import CommonCertifica
 from lms.djangoapps.certificates.utils import get_certificate_url
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
-
 
 class TestStopCertificateRenderStep(PipelineStep):
     """
@@ -120,7 +115,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_render_filter_executed(self):
         """
@@ -154,7 +149,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_render_invalid(self):
         """
@@ -186,7 +181,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_redirect(self):
         """
@@ -217,7 +212,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_render_custom_response(self):
         """
@@ -240,7 +235,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
 
     @override_settings(
         OPEN_EDX_FILTERS_CONFIG={},
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     @with_site_configuration(
         configuration={

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -82,7 +82,7 @@ def get_certificate_description(mode, certificate_type, platform_name, course_ke
                                          "{platform_name} and has completed all of the required tasks for this course "
                                          "under its guidelines. ").format(cert_type=certificate_type,
                                                                           platform_name=platform_name)
-        if settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT'):
+        if settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT:
             certificate_type_description += _("A {cert_type} certificate also indicates that the "
                                               "identity of the learner has been checked and "
                                               "is valid.").format(cert_type=certificate_type)
@@ -250,7 +250,7 @@ def _update_course_context(request, context, course, platform_name):
     context['accomplishment_copy_course_name'] = accomplishment_copy_course_name
     course_number = course.display_coursenumber if course.display_coursenumber else course.number
     context['course_number'] = course_number
-    context['idv_enabled_for_certificates'] = settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT')
+    context['idv_enabled_for_certificates'] = settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT
     if context['organization_long_name']:
         # Translators:  This text represents the description of course
         context['accomplishment_copy_course_description'] = _('a course of study offered by {partner_short_name}, '
@@ -476,7 +476,7 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
     configuration = CertificateHtmlViewConfiguration.get_config()
 
     # Kick the user back to the "Invalid" screen if the feature is disabled globally
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Load the course and user objects
@@ -532,7 +532,7 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
     # Determine whether to use the standard or custom template to render the certificate.
     custom_template = None
     custom_template_language = None
-    if settings.FEATURES.get('CUSTOM_CERTIFICATE_TEMPLATES_ENABLED', False):
+    if settings.CUSTOM_CERTIFICATE_TEMPLATES_ENABLED:
         log.info("Custom certificate for course %s", course_id)
         custom_template, custom_template_language = _get_custom_template_and_language(
             course.id,

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 
 import ddt
 import pytz
-from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
@@ -84,7 +83,7 @@ class BasketsViewTests(UserMixin, ModuleStoreTestCase):
                 bulk_sku=f'BULK-{sku_string}'
             )
 
-    @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_restriction(self):
         """
         The view should return HTTP 403 status if the course is embargoed.

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -86,7 +86,7 @@ def _filter_by_search(course_queryset, search_term, mobile_search=False):
     """
     Filters a course queryset by the specified search term.
     """
-    if not settings.FEATURES['ENABLE_COURSEWARE_SEARCH'] or not search_term:
+    if not settings.ENABLE_COURSEWARE_SEARCH or not search_term:
         return course_queryset
 
     # Return all the results, 10K is the maximum allowed value for ElasticSearch.

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -174,7 +174,7 @@ class BlockSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
             ),
         }
 
-        if settings.FEATURES.get("ENABLE_LTI_PROVIDER") and 'lti_url' in self.context['requested_fields']:
+        if settings.ENABLE_LTI_PROVIDER and 'lti_url' in self.context['requested_fields']:
             data['lti_url'] = reverse(
                 'lti_provider_launch',
                 kwargs={'course_id': str(block_key.course_key), 'usage_id': str(block_key)},

--- a/lms/djangoapps/course_api/blocks/transformers/milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/milestones.py
@@ -73,7 +73,7 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
                 return True
             elif not self.include_gated_sections and self.has_pending_milestones_for_user(block_key, usage_info):
                 return True
-            elif (settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+            elif (settings.ENABLE_SPECIAL_EXAMS and
                   (self.is_special_exam(block_key, block_structure) and
                    not self.include_special_exams)):
                 return True

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -6,6 +6,7 @@ Tests for ProctoredExamTransformer.
 from unittest.mock import Mock, patch
 
 import ddt
+from django.test.utils import override_settings
 from milestones.tests.utils import MilestonesTestCaseMixin
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
@@ -22,7 +23,7 @@ from ..milestones import MilestonesAndSpecialExamsTransformer
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseMixin):
     """
     Test behavior of ProctoredExamTransformer

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -4,9 +4,9 @@ Tests for StartDateTransformer.
 
 
 from datetime import timedelta
-from unittest.mock import patch
 
 import ddt
+from django.test.utils import override_settings
 from django.utils.timezone import now
 
 from common.djangoapps.student.tests.factories import BetaTesterFactory
@@ -63,7 +63,7 @@ class StartDateTransformerTestCase(BlockParentsMapTestCase):
     #  3   4   /   5
     #       \ /
     #        6
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     @ddt.data(
         (STUDENT, {}, {}, {}),
         (STUDENT, {0: StartDateType.default}, {}, {}),

--- a/lms/djangoapps/course_goals/tests/test_user_activity.py
+++ b/lms/djangoapps/course_goals/tests/test_user_activity.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 import ddt
 from django.contrib.auth import get_user_model
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 from django.urls import reverse
 from edx_django_utils.cache import TieredCache
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -31,7 +32,7 @@ class UserActivityTests(UrlResetMixin, ModuleStoreTestCase):
     """
     Testing Course Goals User Activity
     """
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(
@@ -168,7 +169,7 @@ class UserActivityTests(UrlResetMixin, ModuleStoreTestCase):
     def test_mobile_app_user_activity_calls(self, url):
         url = url.replace('{COURSE_ID}', str(self.course.id))
         with patch.object(UserActivity, 'record_user_activity') as record_user_activity_mock:
-            with patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}):
+            with override_settings(ENABLE_DISCUSSION_SERVICE=True):
                 self.client.get(url)
                 record_user_activity_mock.assert_called_once()
 

--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import ddt
 from django.db import transaction
+from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 
@@ -235,7 +236,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         response = self.client.get(self.url)
         self._assert_course_access_response(response, False, 'incorrect_active_enterprise')
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @ddt.data(True, False)
     def test_discussion_tab_visible(self, visible):
         """

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -257,7 +257,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         }
         assert course_goals == expected_course_goals
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
     def test_proctored_exam(self, mock_summary):
         course = CourseFactory.create(
@@ -612,7 +612,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         response = self.client.get(url)
         assert response.status_code == 404
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
     def test_proctored_exam(self, mock_summary):
         """
@@ -802,9 +802,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         self.create_completion(problem, int(problem_complete))
         self.create_completion(library, int(library_complete))
 
-        with override_settings(
-            FEATURES={**settings.FEATURES, 'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': library_complete_on_view}
-        ):
+        with override_settings(MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW=library_complete_on_view):
             response = self.client.get(reverse('course-home:course-navigation', args=[self.course.id]))
 
         sequence_data = response.data['blocks'][str(self.sequential.location)]

--- a/lms/djangoapps/course_home_api/progress/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_views.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import dateutil
 import ddt
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -117,7 +118,7 @@ class ProgressTabTestViews(BaseCourseHomeTests):
         self.update_masquerade(username=verified_user.username)
         assert self.client.get(self.url).data.get('enrollment_mode') == 'verified'
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_has_scheduled_content_data(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         future = now() + timedelta(days=30)

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -108,7 +108,7 @@ class WikiAccessMiddleware(MiddlewareMixin):
 
             # Check to see if we don't allow top-level access to the wiki via the /wiki/xxxx/yyy/zzz URLs
             # this will help prevent people from writing pell-mell to the Wiki in an unstructured way
-            if not settings.FEATURES.get('ALLOW_WIKI_ROOT_ACCESS', False):
+            if not settings.ALLOW_WIKI_ROOT_ACCESS:
                 raise PermissionDenied()
 
             return self._redirect_from_referrer(request, wiki_path)

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -4,6 +4,7 @@ Tests for course wiki
 
 
 from unittest.mock import patch
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
@@ -31,7 +32,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
             self.activate_user(email)
             self.logout()
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_wiki_redirect(self):
         """
         Test that requesting wiki URLs redirect properly to or out of classes.
@@ -67,7 +68,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         assert resp.status_code == 302
         assert resp['Location'] == destination
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': False})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=False)
     def test_wiki_no_root_access(self):
         """
         Test to verify that normally Wiki's cannot be browsed from the /wiki/xxxx/yyy/zz URLs
@@ -111,7 +112,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         self.assertContains(resp, "Home")
         self.assertContains(resp, "Course")
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_course_navigator(self):
         """"
         Test that going from a course page to a wiki page contains the course navigator.
@@ -128,7 +129,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
 
         self.has_course_navigator(resp)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_wiki_not_accessible_when_not_enrolled(self):
         """
         Test that going from a course page to a wiki page when not enrolled
@@ -153,7 +154,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         target_url, __ = resp.redirect_chain[-1]
         assert target_url.endswith(reverse('about_course', args=[str(self.toy.id)]))
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_redirect_when_not_logged_in(self):
         """
         Test that attempting to reach a course wiki page when not logged in
@@ -171,7 +172,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         target_url, __ = resp.redirect_chain[-1]
         assert reverse('signin_user') in target_url
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_create_wiki_with_long_course_id(self):
         """
         Tests that the wiki is successfully created for courses that have
@@ -201,7 +202,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         resp = self.client.get(course_wiki_page, follow=True, HTTP_REFERER=referer)
         assert resp.status_code == 200
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
     def test_consent_required(self, mock_enterprise_customer_for_request):
         """

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -282,7 +282,7 @@ def _can_enroll_courselike(user, courselike):
             # DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED flag is used to disable enrollment for user invited
             # to a course if user is registering when the course enrollment is closed
             if (
-                settings.FEATURES.get('DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED') and
+                settings.DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED and
                 not course_enrollment_open and
                 not user_has_staff_access
             ):

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -135,7 +135,7 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
     Returns:
         AccessResponse: Either ACCESS_GRANTED or StartDateError.
     """
-    start_dates_disabled = settings.FEATURES["DISABLE_START_DATES"]
+    start_dates_disabled = settings.DISABLE_START_DATES
     masquerading_as_student = is_masquerading_as_student(user, course_key)
 
     if start_dates_disabled and not masquerading_as_student:

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -259,7 +259,7 @@ def _add_timed_exam_info(user, course, section, section_context):
     """
     section_is_time_limited = (
         getattr(section, 'is_time_limited', False) and
-        settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False)
+        settings.ENABLE_SPECIAL_EXAMS
     )
     if section_is_time_limited:
         # call into edx_proctoring subsystem
@@ -555,7 +555,7 @@ def prepare_runtime_for_user(
         block_wrappers.append(filter_displayed_blocks)
 
     mako_service = MakoService()
-    if settings.FEATURES.get("LICENSING", False):
+    if settings.LICENSING:
         block_wrappers.append(partial(wrap_with_license, mako_service=mako_service))
 
     # Wrap the output display in a single div to allow for the XBlock
@@ -584,7 +584,7 @@ def prepare_runtime_for_user(
 
     user_is_staff = bool(has_access(user, 'staff', course_id))
 
-    if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):
+    if settings.DISPLAY_DEBUG_INFO_TO_STAFF:
         if user_is_staff or is_masquerading_as_specific_student(user, course_id):
             # When masquerading as a specific student, we want to show the debug button
             # unconditionally to enable resetting the state of the student we are masquerading as.
@@ -1004,9 +1004,9 @@ def xblock_view(request, course_id, usage_id, view_name):
         resources: A list of tuples where the first element is the resource hash, and
             the second is the resource description
     """
-    if not settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False):
+    if not settings.ENABLE_XBLOCK_VIEW_ENDPOINT:
         log.warning("Attempt to use deactivated XBlock view endpoint -"
-                    " see FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']")
+                    " see ENABLE_XBLOCK_VIEW_ENDPOINT")
         raise Http404
 
     try:

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -592,7 +592,7 @@ class VerificationDeadlineDate(DateSummary):
             is_active and
             mode == 'verified' and
             self.verification_status in ('expired', 'none', 'must_reverify') and
-            not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE')
+            not settings.ENABLE_INTEGRITY_SIGNATURE
         )
 
     @lazy

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -214,7 +214,7 @@ def setup_masquerade(request, course_key, staff_access=False, reset_masquerade_d
     """
     if (
         request.user is None or
-        not settings.FEATURES.get('ENABLE_MASQUERADE', False) or
+        not settings.ENABLE_MASQUERADE or
         not staff_access
     ):
         return None, request.user

--- a/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
+++ b/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
@@ -20,7 +20,7 @@ class CsmBigInt(AlterField):
         to_model = to_state.apps.get_model(app_label, self.model_name)
 
         if schema_editor.connection.alias == 'student_module_history':
-            if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+            if settings.ENABLE_CSMH_EXTENDED:
                 if schema_editor.connection.vendor == 'mysql':
                     schema_editor.execute("ALTER TABLE `coursewarehistoryextended_studentmodulehistoryextended` MODIFY `student_module_id` bigint UNSIGNED NOT NULL;")
                 elif schema_editor.connection.vendor == 'postgresql':
@@ -44,7 +44,7 @@ class Migration(migrations.Migration):
         ('courseware', '0010_auto_20190709_1559'),
     ]
 
-    if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+    if settings.ENABLE_CSMH_EXTENDED:
         dependencies.append(('coursewarehistoryextended', '0002_force_studentmodule_index'))
 
     operations = [

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -216,7 +216,7 @@ class BaseStudentModuleHistory(models.Model):
 
         history_entries = []
 
-        if settings.FEATURES.get('ENABLE_CSMH_EXTENDED'):
+        if settings.ENABLE_CSMH_EXTENDED:
             from lms.djangoapps.coursewarehistoryextended.models import StudentModuleHistoryExtended
             history_entries += StudentModuleHistoryExtended.objects.filter(
                 # Django will sometimes try to join to courseware_studentmodule
@@ -226,7 +226,7 @@ class BaseStudentModuleHistory(models.Model):
 
         # If we turn off reading from multiple history tables, then we don't want to read from
         # StudentModuleHistory anymore, we believe that all history is in the Extended table.
-        if settings.FEATURES.get('ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES'):
+        if settings.ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES:
             # we want to save later SQL queries on the model which allows us to prefetch
             history_entries += StudentModuleHistory.objects.prefetch_related('student_module').filter(
                 student_module__in=student_modules
@@ -315,7 +315,7 @@ class StudentModuleHistory(BaseStudentModuleHistory):
     # When the extended studentmodulehistory table exists, don't save
     # duplicate history into courseware_studentmodulehistory, just retain
     # data for reading.
-    if not settings.FEATURES.get('ENABLE_CSMH_EXTENDED'):
+    if not settings.ENABLE_CSMH_EXTENDED:
         post_save.connect(save_history, sender=StudentModule)
 
 

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -17,7 +17,7 @@ from openedx.core.lib.courses import get_course_by_id
 
 User = get_user_model()
 
-TEXTBOOK_ENABLED = settings.FEATURES.get("ENABLE_TEXTBOOK", False)
+TEXTBOOK_ENABLED = settings.ENABLE_TEXTBOOK
 
 
 class ProgressCourseApp(CourseApp):

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -134,7 +134,7 @@ class TextbookTabs(TextbookTabsBase):
     @classmethod
     def is_enabled(cls, course, user=None):
         parent_is_enabled = super().is_enabled(course, user)
-        return settings.FEATURES.get('ENABLE_TEXTBOOK') and parent_is_enabled
+        return settings.ENABLE_TEXTBOOK and parent_is_enabled
 
     @classmethod
     def items(cls, course):

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 import ddt
 import pytz
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
@@ -113,15 +112,15 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         resp = self.client.get(url)
         assert resp.status_code == 404
 
-    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
+    @override_settings(ENABLE_MKTG_SITE=True)
     def test_logged_in_marketing(self):
         self.setup_user()
         url = reverse('about_course', args=[str(self.course.id)])
         resp = self.client.get(url)
         self.assertRedirects(resp, course_home_url(self.course.id), fetch_redirect_response=False)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_COURSE_HOME_REDIRECT': False})
-    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
+    @override_settings(ENABLE_COURSE_HOME_REDIRECT=False)
+    @override_settings(ENABLE_MKTG_SITE=True)
     def test_logged_in_marketing_without_course_home_redirect(self):
         """
         Verify user is not redirected to course home page when
@@ -133,8 +132,8 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         # should not be redirected
         self.assertContains(resp, "OOGIE BLOOGIE")
 
-    @patch.dict(settings.FEATURES, {'ENABLE_COURSE_HOME_REDIRECT': True})
-    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': False})
+    @override_settings(ENABLE_COURSE_HOME_REDIRECT=True)
+    @override_settings(ENABLE_MKTG_SITE=False)
     def test_logged_in_marketing_without_mktg_site(self):
         """
         Verify user is not redirected to course home page when
@@ -146,7 +145,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         # should not be redirected
         self.assertContains(resp, "OOGIE BLOOGIE")
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_pre_requisite_course(self):
         pre_requisite_course = CourseFactory.create(org='edX', course='900', display_name='pre requisite course')
         course = CourseFactory.create(pre_requisite_courses=[str(pre_requisite_course.id)])
@@ -161,7 +160,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
             f'{pre_requisite_courses[0]["display"]}</a> before you begin this course.'
         ) in resp.content.decode(resp.charset).strip('\n')
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_about_page_unfulfilled_prereqs(self):
         pre_requisite_course = CourseFactory.create(
             org='edX',
@@ -252,14 +251,14 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         # common/test/data/2014/about/overview.html
         self.xml_data = "about page 463139"
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_logged_in_xml(self):
         self.setup_user()
         url = reverse('about_course', args=[str(self.xml_course_id)])
         resp = self.client.get(url)
         self.assertContains(resp, self.xml_data)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_anonymous_user_xml(self):
         url = reverse('about_course', args=[str(self.xml_course_id)])
         resp = self.client.get(url)

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -11,7 +11,6 @@ import pytest
 import ddt
 import pytz
 from ccx_keys.locator import CCXLocator
-from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -421,7 +420,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         (False, TOMORROW, access_response.StartDateError)
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test__has_access_to_block_staff_lock(self, visible_to_staff_only, start, expected_error_type=None):
         """
         Tests that "visible_to_staff_only" overrides start date.
@@ -451,7 +450,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         (YESTERDAY, None)
     )  # ddt throws an error if I don't put the None argument there
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test__has_access_to_block_with_start_date(self, start, expected_error_type):
         """
         Tests that block access follows start date rules.
@@ -480,7 +479,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         (True, True, TOMORROW, False),  # Masquerading, future start date - no access
     )
     @ddt.unpack
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_enforce_masquerade_start_dates_flag(self, flag_active, is_masquerading, start, expected_access=True):
         """
         Test that the ENFORCE_MASQUERADE_START_DATES flag controls whether masquerading bypasses start date
@@ -551,7 +550,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         course.save()
         assert not access._has_access_course(user, 'enroll', course)
 
-    @override_settings(FEATURES={**settings.FEATURES, 'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': True})
+    @override_settings(DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED=True)
     def test__has_access_course_with_disable_allowed_enrollment_flag(self):
         yesterday = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)
         tomorrow = datetime.datetime.now(pytz.utc) + datetime.timedelta(days=1)
@@ -681,7 +680,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         assert access._has_access_course(staff, 'see_in_catalog', course)
         assert access._has_access_course(staff, 'see_about_page', course)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     @override_settings(MILESTONES_APP=True)
     def test_access_on_course_with_pre_requisites(self):
         """
@@ -823,7 +822,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
 
     @ddt.data(*(COURSE_TEST_DATA + LOAD_MOBILE_TEST_DATA + PREREQUISITES_TEST_DATA))
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_overview_access(self, user_attr_name, action, course_attr_name):
         """
         Check that a user's access to a course is equal to the user's access to
@@ -863,7 +862,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
         )
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_catalog_access_num_queries_no_enterprise(self, user_attr_name, action, course_attr_name):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
 
@@ -911,7 +910,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
         )
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
+    @override_settings(DISABLE_START_DATES=False, ENABLE_ENTERPRISE_INTEGRATION=True)
     def test_course_catalog_access_num_queries_enterprise(self, user_attr_name, course_attr_name):
         """
         Similar to test_course_catalog_access_num_queries_no_enterprise, except enable enterprise features and make the

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -975,7 +975,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_XBLOCK_VIEW_ENDPOINT': True})
+@override_settings(ENABLE_XBLOCK_VIEW_ENDPOINT=True)
 class TestXBlockView(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test the handle_xblock_callback function
@@ -1123,7 +1123,7 @@ class TestTOC(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class TestProctoringRendering(ModuleStoreTestCase):
     """Check the Table of Contents for a course"""
     def setUp(self):
@@ -1708,7 +1708,7 @@ class DetachedXBlock(XBlock):
         return frag
 
 
-@patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True, 'DISPLAY_HISTOGRAMS_TO_STAFF': True})
+@override_settings(DISPLAY_DEBUG_INFO_TO_STAFF=True, DISPLAY_HISTOGRAMS_TO_STAFF=True)
 @patch('lms.djangoapps.courseware.block_render.has_access', Mock(return_value=True, autospec=True))
 class TestStaffDebugInfo(SharedModuleStoreTestCase):
     """Tests to verify that Staff Debug Info panel and histograms are displayed to staff."""
@@ -1746,7 +1746,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
             self.block
         )
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': False})
+    @override_settings(DISPLAY_DEBUG_INFO_TO_STAFF=False)
     def test_staff_debug_info_disabled(self):
         block = render.get_block(
             self.user,
@@ -1828,7 +1828,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
         result_fragment = block.render(STUDENT_VIEW)
         assert 'Staff Debug' not in result_fragment.content
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_HISTOGRAMS_TO_STAFF': False})
+    @override_settings(DISPLAY_HISTOGRAMS_TO_STAFF=False)
     def test_histogram_disabled(self):
         block = render.get_block(
             self.user,

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -3,9 +3,8 @@ Tests for credit requirement display on the progress page.
 """
 
 
-from unittest.mock import patch
 import ddt
-from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -16,7 +15,7 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # 
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-@patch.dict(settings.FEATURES, {"ENABLE_CREDIT_ELIGIBILITY": True})
+@override_settings(ENABLE_CREDIT_ELIGIBILITY=True)
 @ddt.ddt
 class ProgressPageCreditRequirementsTest(SharedModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -3,12 +3,11 @@
 
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
 import crum
 import ddt
-from django.conf import settings
 from django.test import RequestFactory
+from django.test.utils import override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from freezegun import freeze_time
 from pytz import utc
@@ -570,7 +569,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         block = VerificationDeadlineDate(course, user)
         assert not block.is_allowed
 
-    @patch.dict(settings.FEATURES, {'ENABLE_INTEGRITY_SIGNATURE': True})
+    @override_settings(ENABLE_INTEGRITY_SIGNATURE=True)
     def test_verification_deadline_with_integrity_signature(self):
         course = create_course_run(days_till_start=-1)
         user = create_user()

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -13,7 +13,6 @@ import uuid
 from unittest import mock
 from unittest.mock import patch
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
@@ -171,7 +170,7 @@ class TestViews(TestDiscussionXBlock):
             }
         )
 
-    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
+    @override_settings(ENABLE_DISCUSSION_SERVICE='True')
     @ddt.data(
         (False, False, False),
         (True, False, False),
@@ -242,7 +241,7 @@ class TestTemplates(TestDiscussionXBlock):
         fragment = self.block.author_view({})
         assert f'data-discussion-id="{self.discussion_id}"' in fragment.content
 
-    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
+    @override_settings(ENABLE_DISCUSSION_SERVICE='True')
     @ddt.data(
         (True, False, False),
         (False, True, False),

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -3,7 +3,6 @@ Tests use cases related to LMS Entrance Exam behavior, such as gated content acc
 """
 
 
-from unittest.mock import patch
 from crum import set_current_request
 from django.test import override_settings
 from django.urls import reverse
@@ -312,7 +311,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         )
         assert user_has_passed_entrance_exam(self.request.user, course)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_MASQUERADE': False})
+    @override_settings(ENABLE_MASQUERADE=False)
     def test_entrance_exam_xblock_response(self):
         """
         Tests entrance exam xblock has `entrance_exam_passed` key in json response.

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -6,12 +6,12 @@ import json
 import pickle
 from datetime import datetime
 from importlib import import_module
-from unittest.mock import patch
 import pytest
 import ddt
 from operator import itemgetter  # lint-amnesty, pylint: disable=wrong-import-order
 from django.conf import settings
 from django.test import TestCase, RequestFactory
+from django.test.utils import override_settings
 from django.urls import reverse
 from pytz import UTC
 from xblock.runtime import DictKeyValueStore
@@ -193,13 +193,12 @@ class TestMasqueradeLearnerOptions(StaffMasqueradeTestCase):
     """
 
     @ddt.data(True, False)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_MASQUERADE': True})
+    @override_settings(ENABLE_MASQUERADE=True)
     def test_masquerade_options_for_learner(self, partitions_enabled):
         """
         If there are partitions, then the View as Learner should NOT be available
         """
-        with patch.dict('django.conf.settings.FEATURES',
-                        {'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': partitions_enabled}):
+        with override_settings(ENABLE_ENROLLMENT_TRACK_USER_PARTITION=partitions_enabled):
             response = self.get_available_masquerade_identities()
             is_learner_available = 'Learner' in map(itemgetter('name'), response.json()['available'])
             assert partitions_enabled != is_learner_available
@@ -232,7 +231,7 @@ class TestMasqueradeOptionsNoContentGroups(StaffMasqueradeTestCase):
 
     @ddt.data(['Cohort Group 1', True], ['Content Group 1', False])
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_MASQUERADE': True})
+    @override_settings(ENABLE_MASQUERADE=True)
     def testMasqueradeCohortAvailable(self, target, expected):
         """
         Args:
@@ -301,7 +300,7 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         'john',  # Non-unicode username
         'fôô@bar',  # Unicode username with @, which is what the ENABLE_UNICODE_USERNAME feature allows
     )
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_masquerade_as_specific_student(self, username):
         """
         Test masquerading as a specific user.
@@ -407,7 +406,7 @@ class TestGetMasqueradingGroupId(StaffMasqueradeTestCase):
         self.course.user_partitions.append(self.user_partition)
         modulestore().update_item(self.course, self.test_user.id)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_get_masquerade_group(self):
         """
         Tests that a staff member can masquerade as being in a group in a user partition

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -2,7 +2,6 @@
 
 import datetime
 
-from unittest.mock import patch
 import pytz
 from django.test.utils import override_settings
 
@@ -83,7 +82,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         __, sp_section = self.setup_course(display_name="Self-Paced Course", self_paced=True)
         assert sp_section.due is None
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_access_to_beta_users(self):
         """
         Test that beta testers can access `self_paced` course prior to start date.
@@ -111,7 +110,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         assert has_access(beta_tester, 'load', self_paced_course)
         assert has_access(beta_tester, 'load', self_paced_section, self_paced_course.id)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_instructor_paced_discussion_xblock_visibility(self):
         """
         Verify that discussion xblocks scheduled for release in the future are
@@ -124,7 +123,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         xblocks = get_accessible_discussion_xblocks(course, self.non_staff_user)
         assert all((xblock.display_name == 'released') for xblock in xblocks)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_self_paced_discussion_xblock_visibility(self):
         """
         Regression test. Verify that discussion xblocks scheduled for release

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -215,7 +215,7 @@ class TextbooksTestCase(TabTestCase):
         ])
         self.num_textbooks = self.num_textbook_tabs * len(self.books)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_TEXTBOOK": True})
+    @override_settings(ENABLE_TEXTBOOK=True)
     def test_textbooks_enabled(self):
 
         type_to_reverse_name = {'textbook': 'book', 'pdftextbook': 'pdf_book', 'htmltextbook': 'html_book'}
@@ -320,14 +320,14 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.xml_data = "static 463139"
         self.xml_url = "8e4cce2b4aaf4ba28b1220804619e41f"
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_logged_in_xml(self):
         self.setup_user()
         url = reverse('static_tab', args=[str(self.xml_course_key), self.xml_url])
         resp = self.client.get(url)
         self.assertContains(resp, self.xml_data)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_anonymous_user_xml(self):
         url = reverse('static_tab', args=[str(self.xml_course_key), self.xml_url])
         resp = self.client.get(url)
@@ -484,7 +484,7 @@ class TextBookCourseViewsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
                 num_of_textbooks_found += 1
         assert num_of_textbooks_found == self.num_textbooks
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_TEXTBOOK": False})
+    @override_settings(ENABLE_TEXTBOOK=False)
     def test_textbooks_disabled(self):
         tab = xmodule_tabs.CourseTab.load('textbooks')
         assert not tab.is_enabled(self.course, self.user)
@@ -613,11 +613,7 @@ class CourseTabListTestCase(TabListTestCase):
         assert not self.has_tab(self.course.tabs, 'external_discussion')
         assert self.has_tab(self.course.tabs, 'discussion')
 
-    @patch.dict("django.conf.settings.FEATURES", {
-        "ENABLE_TEXTBOOK": True,
-        "ENABLE_DISCUSSION_SERVICE": True,
-        "ENABLE_EDXNOTES": True,
-    })
+    @override_settings(ENABLE_TEXTBOOK=True, ENABLE_DISCUSSION_SERVICE=True, ENABLE_EDXNOTES=True)
     def test_iterate_displayable(self):
         self.course.hide_progress_tab = False
 
@@ -773,7 +769,7 @@ class DiscussionLinkTestCase(TabTestCase):
                     (discussion_tab.link_func(self.course, reverse)
                      == expected_discussion_link)) == expected_can_display_value
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": False})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=False)
     def test_explicit_discussion_link(self):
         """Test that setting discussion_link overrides everything else"""
         self.check_discussion(
@@ -783,7 +779,7 @@ class DiscussionLinkTestCase(TabTestCase):
             expected_can_display_value=True,
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": False})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=False)
     def test_discussions_disabled(self):
         """Test that other cases return None with discussions disabled"""
         for tab_list in [[], self.tabs_with_discussion, self.tabs_without_discussion]:
@@ -793,7 +789,7 @@ class DiscussionLinkTestCase(TabTestCase):
                 expected_can_display_value=False,
             )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_with_discussion(self):
         """Test a course with a discussion tab configured"""
         self.check_discussion(
@@ -802,7 +798,7 @@ class DiscussionLinkTestCase(TabTestCase):
             expected_can_display_value=True,
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_without_discussion(self):
         """Test a course with tabs configured but without a discussion tab"""
         self.check_discussion(
@@ -811,7 +807,7 @@ class DiscussionLinkTestCase(TabTestCase):
             expected_can_display_value=False,
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_enrolled_or_staff(self):
         for is_enrolled, is_staff in [(True, False), (False, True)]:
             self.check_discussion(
@@ -822,7 +818,7 @@ class DiscussionLinkTestCase(TabTestCase):
                 is_staff=is_staff
             )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_not_enrolled_or_staff(self):
         is_enrolled = is_staff = False
         self.check_discussion(
@@ -840,7 +836,7 @@ class DiscussionLinkTestCase(TabTestCase):
         else:
             expected_link = reverse("forum_form_discussion", args=[str(self.course.id)])
 
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True}):
+        with self.settings(ENABLE_DISCUSSION_SERVICE=True):
             with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, toggle_enabled):
                 self.check_discussion(
                     tab_list=self.tabs_with_discussion,

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -365,7 +365,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'autoAdvance': False,
             'saveStateEnabled': True,
             'saveStateUrl': '',
-            'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', True),
+            'autoplay': settings.AUTOPLAY_VIDEOS,
             'streams': '1.00:3_yD_cEKoCk',
             'sources': '[]',
             'duration': 111.0,
@@ -2320,8 +2320,6 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
     """
     CATEGORY = "video"
     METADATA = {}
-    # Use temporary FEATURES in this test without affecting the original
-    FEATURES = dict(settings.FEATURES)
 
     @patch('xmodule.video_block.bumper_utils.get_bumper_settings')
     def test_is_bumper_enabled(self, get_bumper_settings):
@@ -2330,21 +2328,14 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
 
         Assume that bumper settings are correct.
         """
-        self.FEATURES.update({
-            "SHOW_BUMPER_PERIODICITY": 1,
-            "ENABLE_VIDEO_BUMPER": True,
-        })
-
         get_bumper_settings.return_value = {
             "video_id": "edx_video_id",
             "transcripts": {},
         }
-        with override_settings(FEATURES=self.FEATURES):
+        with override_settings(SHOW_BUMPER_PERIODICITY=1, ENABLE_VIDEO_BUMPER=True):
             assert bumper_utils.is_bumper_enabled(self.block)
 
-        self.FEATURES.update({"ENABLE_VIDEO_BUMPER": False})
-
-        with override_settings(FEATURES=self.FEATURES):
+        with override_settings(ENABLE_VIDEO_BUMPER=False):
             assert not bumper_utils.is_bumper_enabled(self.block)
 
     @patch('xblock.utils.resources.ResourceLoader.render_django_template', side_effect=mock_render_template)
@@ -2464,8 +2455,6 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
     maxDiff = None
     CATEGORY = "video"
     METADATA = {}
-    # Use temporary FEATURES in this test without affecting the original
-    FEATURES = dict(settings.FEATURES)
 
     def prepare_expected_context(self, autoadvanceenabled_flag, autoadvance_flag):
         """
@@ -2537,7 +2526,7 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
         return context
 
     def assert_content_matches_expectations(
-        self, autoadvanceenabled_must_be, autoadvance_must_be, mock_render_django_template
+        self, autoadvanceenabled_must_be, autoadvance_must_be, mock_render_django_template, global_setting=False
     ):
         """
         Check (assert) that loading video.html produces content that corresponds
@@ -2545,7 +2534,7 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
         Helper function to avoid code repetition.
         """
 
-        with override_settings(FEATURES=self.FEATURES):
+        with override_settings(ENABLE_AUTOADVANCE_VIDEOS=global_setting):
             self.block.student_view(None)
 
         expected_context = self.prepare_expected_context(
@@ -2590,11 +2579,11 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
         - in that case (when the controls are visible) the video will autoadvance
           (because that's the default), in other cases it won't
         """
-        self.FEATURES.update({"ENABLE_AUTOADVANCE_VIDEOS": global_setting})
         self.change_course_setting_autoadvance(new_value=course_setting)
 
         self.assert_content_matches_expectations(
             autoadvanceenabled_must_be=(global_setting and course_setting),
             autoadvance_must_be=(global_setting and course_setting),
             mock_render_django_template=mock_render_django_template,
+            global_setting=global_setting,
         )

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -5,8 +5,8 @@ Check that view authentication works properly.
 
 import datetime
 
-from unittest.mock import patch
 import pytz
+from django.test.utils import override_settings
 from django.urls import reverse
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -245,7 +245,7 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         for url in urls:
             self.assert_request_status_code(200, url)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_enrolled_student(self):
         """
         Make sure that before course start, students can't access course
@@ -272,7 +272,7 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         self._check_non_staff_light(self.test_course)
         self._check_non_staff_dark(self.test_course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_instructor(self):
         """
         Make sure that before course start instructors can access the
@@ -295,7 +295,7 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         self._check_non_staff_light(self.test_course)
         self._check_non_staff_dark(self.test_course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_global_staff(self):
         """
         Make sure that before course start staff can access
@@ -317,7 +317,7 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         self._check_staff(self.course)
         self._check_staff(self.test_course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_enrollment_period(self):
         """
         Check that enrollment periods work.
@@ -370,7 +370,7 @@ class TestBetatesterAccess(ModuleStoreTestCase, CourseAccessTestMixin):
         self.normal_student = UserFactory()
         self.beta_tester = BetaTesterFactory(course_key=self.course.id)  # lint-amnesty, pylint: disable=no-member
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_beta_period(self):
         """
         Check that beta-test access works for courses.
@@ -379,7 +379,7 @@ class TestBetatesterAccess(ModuleStoreTestCase, CourseAccessTestMixin):
         self.assertCannotAccessCourse(self.normal_student, 'load', self.course)
         self.assertCanAccessCourse(self.beta_tester, 'load', self.course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_content_beta_period(self):
         """
         Check that beta-test access works for content.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -110,9 +110,6 @@ from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
 
-FEATURES_WITH_DISABLE_HONOR_CERTIFICATE = settings.FEATURES.copy()
-FEATURES_WITH_DISABLE_HONOR_CERTIFICATE['DISABLE_HONOR_CERTIFICATES'] = True
-
 
 @ddt.ddt
 class TestJumpTo(ModuleStoreTestCase):
@@ -1191,7 +1188,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         resp = self._get_progress_page()
         self.assertNotContains(resp, 'Request Certificate')
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_view_certificate_for_unverified_student(self):
         """
         If user has already generated a certificate, it should be visible in case of user being
@@ -1222,7 +1219,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.assertNotContains(resp, "Certificate unavailable")
             self.assertContains(resp, "Your certificate is available")
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_view_certificate_link(self):
         """
         If certificate web view is enabled then certificate web view button should appear for user who certificate is
@@ -1309,7 +1306,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             ), check_mongo_calls(2):
                 self._get_progress_page()
 
-    @patch.dict(settings.FEATURES, {'ENABLE_CERTIFICATES_IDV_REQUIREMENT': True})
+    @override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=True)
     @ddt.data(
         *itertools.product(
             (
@@ -1347,7 +1344,7 @@ class ProgressPageTests(ProgressPageBaseTests):
 
                 assert cert_button_hidden == ('Request Certificate' not in resp.content.decode('utf-8'))
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_page_with_invalidated_certificate_with_html_view(self):
         """
         Verify that for html certs if certificate is marked as invalidated than
@@ -1383,7 +1380,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.assertContains(resp, "View Certificate")
             self.assert_invalidate_certificate(generated_certificate)
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_page_with_allowlisted_certificate_with_html_view(self):
         """
         Verify that view certificate appears for an allowlisted user
@@ -1487,7 +1484,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         self.assertNotContains(response, bannerText, html=True)
 
     @patch('lms.djangoapps.courseware.views.views.is_course_passed', PropertyMock(return_value=True))
-    @override_settings(FEATURES=FEATURES_WITH_DISABLE_HONOR_CERTIFICATE)
+    @override_settings(DISABLE_HONOR_CERTIFICATES=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.HONOR)
     def test_message_for_ineligible_mode(self, course_mode):
         """ Verify that message appears on progress page, if learner is enrolled
@@ -1524,7 +1521,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         assert response.cert_status == 'invalidated'
         assert response.title == 'Your certificate has been invalidated'
 
-    @override_settings(FEATURES=FEATURES_WITH_DISABLE_HONOR_CERTIFICATE)
+    @override_settings(DISABLE_HONOR_CERTIFICATES=True)
     def test_downloadable_get_cert_data(self):
         """
         Verify that downloadable cert data is returned if cert is downloadable even
@@ -1594,7 +1591,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         """
         certs_api.set_certificate_generation_config(enabled=True)
         certs_api.set_cert_generation_enabled(self.course.id, True)
-        with patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
+        with override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
             with patch(
                 'lms.djangoapps.certificates.api.certificate_downloadable_status',
                 return_value=self.mock_certificate_downloadable_status()
@@ -2731,7 +2728,7 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
         },
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
+    @override_settings(DISABLE_START_DATES=False, ENABLE_ENTERPRISE_INTEGRATION=True)
     def test_is_course_open_for_learner(
         self,
         start_date_modifier,
@@ -3220,7 +3217,7 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
         (CourseMode.MASTERS, True),
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': True})
+    @override_settings(ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED=True)
     def test_courseware_mfe_search_verified_only(self, mode, expected_enabled):
         """
         Only verified enrollees may use Courseware Search if ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED
@@ -3236,7 +3233,7 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body, {'enabled': expected_enabled})
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': True})
+    @override_settings(ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED=True)
     def test_courseware_mfe_search_staff_access(self):
         """
         Staff users may use Courseware Search regardless of their enrollment status.

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -5,7 +5,7 @@ Common test utilities for courseware functionality
 
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from django.test.utils import override_settings
 from urllib.parse import urlencode
 
 import ddt
@@ -201,7 +201,7 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
         self.setup_user(admin=False, enroll=False, login=True)
         self.verify_response(expected_response_code=404)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_fail_block_unreleased(self):
         self.setup_course()
         self.setup_user(admin=False, enroll=True, login=True)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -310,14 +310,14 @@ def courses(request):
     courses_list = []
     course_discovery_meanings = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
     set_default_filter = ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER.is_enabled()
-    if not settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+    if not settings.ENABLE_COURSE_DISCOVERY:
         courses_list = get_courses(
             request.user,
             filter_={"catalog_visibility": CATALOG_VISIBILITY_CATALOG_AND_ABOUT},
         )
 
         if configuration_helpers.get_value("ENABLE_COURSE_SORTING_BY_START_DATE",
-                                           settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]):
+                                           settings.ENABLE_COURSE_SORTING_BY_START_DATE):
             courses_list = sort_by_start_date(courses_list)
         else:
             courses_list = sort_by_announcement(courses_list)
@@ -557,7 +557,7 @@ class CourseTabView(EdxFragmentView):
         Returns the URL to use to enroll in the specified course.
         """
         url_to_enroll = reverse('about_course', args=[str(course_key)])
-        if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+        if settings.ENABLE_MKTG_SITE:
             url_to_enroll = marketing_link('COURSES')
         return url_to_enroll
 
@@ -840,7 +840,7 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
         show_courseware_link = bool(
             (
                 request.user.has_perm(VIEW_COURSEWARE, course)
-            ) or settings.FEATURES.get('ENABLE_LMS_MIGRATION')
+            ) or settings.ENABLE_LMS_MIGRATION
         )
 
         # If the ecommerce checkout flow is enabled and the mode of the course is
@@ -899,7 +899,7 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
             'studio_url': studio_url,
             'registered': registered,
             'course_target': course_target,
-            'is_cosmetic_price_enabled': settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_PRICE'),
+            'is_cosmetic_price_enabled': settings.ENABLE_COSMETIC_DISPLAY_PRICE,
             'course_price': course_price,
             'ecommerce_checkout': ecommerce_checkout,
             'ecommerce_checkout_link': ecommerce_checkout_link,
@@ -1098,7 +1098,7 @@ def _downloadable_certificate_message(course, cert_downloadable_status):  # lint
 
 
 def _missing_required_verification(student, enrollment_mode):
-    return settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT') and (
+    return settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT and (
         enrollment_mode in CourseMode.VERIFIED_MODES and not IDVerificationService.user_is_verified(student)
     )
 
@@ -1171,7 +1171,7 @@ def credit_course_requirements(course_key, student):
     # If credit eligibility is not enabled or this is not a credit course,
     # short-circuit and return `None`.  This indicates that credit requirements
     # should NOT be displayed on the progress page.
-    if not (settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False) and is_credit_course(course_key)):
+    if not (settings.ENABLE_CREDIT_ELIGIBILITY and is_credit_course(course_key)):
         return None
 
     # This indicates that credit requirements should NOT be displayed on the progress page.
@@ -1226,9 +1226,9 @@ def _course_home_redirect_enabled():
     Returns: boolean True or False
     """
     if configuration_helpers.get_value(
-            'ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+            'ENABLE_MKTG_SITE', settings.ENABLE_MKTG_SITE
     ) and configuration_helpers.get_value(
-        'ENABLE_COURSE_HOME_REDIRECT', settings.FEATURES.get('ENABLE_COURSE_HOME_REDIRECT', True)
+        'ENABLE_COURSE_HOME_REDIRECT', settings.ENABLE_COURSE_HOME_REDIRECT
     ):
         return True
 
@@ -2360,7 +2360,7 @@ def courseware_mfe_search_enabled(request, course_id=None):
     user = request.user
 
     has_required_enrollment = False
-    if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED'):
+    if settings.ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED:
         enrollment_mode, _ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
         if (
             auth.user_has_role(user, CourseStaffRole(CourseKey.from_string(course_id)))

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -8,11 +8,11 @@ backend tables.
 
 import json
 from unittest import skipUnless
-from unittest.mock import patch
 
 from django.conf import settings
 from django.db import connections
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule, StudentModuleHistory
 from lms.djangoapps.courseware.tests.factories import COURSE_KEY
@@ -20,7 +20,7 @@ from lms.djangoapps.courseware.tests.factories import LOCATION
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 
 
-@skipUnless(settings.FEATURES["ENABLE_CSMH_EXTENDED"], "CSMH Extended needs to be enabled")
+@skipUnless(settings.ENABLE_CSMH_EXTENDED, "CSMH Extended needs to be enabled")
 class TestStudentModuleHistoryBackends(TestCase):
     """ Tests of data in CSMH and CSMHE """
     # Tell Django to clean out all databases, not just default
@@ -44,8 +44,7 @@ class TestStudentModuleHistoryBackends(TestCase):
                                         max_grade=csm.max_grade)
             csmh.save()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": True})
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": True})
+    @override_settings(ENABLE_CSMH_EXTENDED=True, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=True)
     def test_get_history_true_true(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)
@@ -57,8 +56,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmh', 'order': 2} == json.loads(history[4].state)
         assert {'type': 'csmh', 'order': 1} == json.loads(history[5].state)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": True})
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": False})
+    @override_settings(ENABLE_CSMH_EXTENDED=True, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=False)
     def test_get_history_true_false(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)
@@ -67,8 +65,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmhe', 'order': 2} == json.loads(history[1].state)
         assert {'type': 'csmhe', 'order': 1} == json.loads(history[2].state)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": False})
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": True})
+    @override_settings(ENABLE_CSMH_EXTENDED=False, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=True)
     def test_get_history_false_true(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)
@@ -77,8 +74,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmh', 'order': 2} == json.loads(history[1].state)
         assert {'type': 'csmh', 'order': 1} == json.loads(history[2].state)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": False})
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": False})
+    @override_settings(ENABLE_CSMH_EXTENDED=False, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=False)
     def test_get_history_false_false(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)

--- a/lms/djangoapps/discussion/django_comment_client/base/tests_v2.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests_v2.py
@@ -12,6 +12,7 @@ import ddt
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 from django.urls import reverse
 from eventtracking.processors.exceptions import EventEmissionExit
 from opaque_keys.edx.keys import CourseKey
@@ -431,7 +432,7 @@ class ViewsTestCase(
         # seed the forums permissions and roles
         call_command("seed_permissions_roles", str(cls.course_id))
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         # Patching the ENABLE_DISCUSSION_SERVICE value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
@@ -1061,7 +1062,7 @@ class ViewPermissionsTestCase(
             Role.objects.get(name="Moderator", course_id=cls.course.id)
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         """Set up the test case."""
         super().setUp()
@@ -1355,9 +1356,7 @@ class TeamsPermissionsTestCase(
             users=[cls.group_moderator, cls.cohorted],
         )
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -2493,7 +2492,7 @@ class ForumThreadViewedEventTransformerTestCase(UrlResetMixin, ModuleStoreTestCa
     DUMMY_CATEGORY_ID = 'i4x-edx-dummy-commentable-id'
     DUMMY_THREAD_ID = 'dummy_thread_id'
 
-    @mock.patch.dict("common.djangoapps.student.models.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -1165,7 +1165,7 @@ class DiscussionTabTestCase(ModuleStoreTestCase):
         return any(tab.type == 'discussion' for tab in all_tabs)
 
     def test_tab_access(self):
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True}):
+        with self.settings(ENABLE_DISCUSSION_SERVICE=True):
             assert self.discussion_tab_present(self.staff_user)
             assert self.discussion_tab_present(self.enrolled_user)
             assert not self.discussion_tab_present(self.unenrolled_user)
@@ -1173,10 +1173,10 @@ class DiscussionTabTestCase(ModuleStoreTestCase):
     @mock.patch('lms.djangoapps.ccx.overrides.get_current_ccx')
     def test_tab_settings(self, mock_get_ccx):
         mock_get_ccx.return_value = True
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': False}):
+        with self.settings(ENABLE_DISCUSSION_SERVICE=False):
             assert not self.discussion_tab_present(self.enrolled_user)
 
-        with self.settings(FEATURES={'CUSTOM_COURSES_EDX': True}):
+        with self.settings(CUSTOM_COURSES_EDX=True):
             assert not self.discussion_tab_present(self.enrolled_user)
 
 

--- a/lms/djangoapps/discussion/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/utils.py
@@ -3,7 +3,7 @@ Utilities for tests within the django_comment_client module.
 """
 
 
-from unittest.mock import patch
+from django.test.utils import override_settings
 
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -23,7 +23,7 @@ class CohortedTestCase(UrlResetMixin, SharedModuleStoreTestCase):
     Sets up a course with a student, a moderator and their cohorts.
     """
     @classmethod
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create(
@@ -44,7 +44,7 @@ class CohortedTestCase(UrlResetMixin, SharedModuleStoreTestCase):
         fake_user_id = 1
         cls.store.update_item(cls.course, fake_user_id)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -1018,7 +1018,7 @@ def is_discussion_enabled(course_id):
     """
     Return True if discussions are enabled; else False
     """
-    return settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE')
+    return settings.ENABLE_DISCUSSION_SERVICE
 
 
 def is_content_authored_by(content, user):

--- a/lms/djangoapps/discussion/notification_prefs/tests.py
+++ b/lms/djangoapps/discussion/notification_prefs/tests.py
@@ -27,7 +27,7 @@ from openedx.core.djangoapps.user_api.models import UserPreference
 class NotificationPrefViewTest(UrlResetMixin, TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
     INITIALIZATION_VECTOR = b"\x00" * 16
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_FORUM_DAILY_DIGEST": True})
     def setUp(self):
         super().setUp()

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2,12 +2,11 @@
 Tests for Discussion API internal interface
 """
 
-from unittest import mock
-
 import ddt
 import pytest
 from django.contrib.auth import get_user_model
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
 
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -27,7 +26,7 @@ User = get_user_model()
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetUserCommentsTest(ForumMockUtilsMixin, SharedModuleStoreTestCase):
     """
     Tests for get_user_comments.
@@ -43,7 +42,7 @@ class GetUserCommentsTest(ForumMockUtilsMixin, SharedModuleStoreTestCase):
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
@@ -178,7 +178,7 @@ def _set_course_discussion_blackout(course, user_id):
 @ddt.ddt
 @disable_signal(api, "thread_created")
 @disable_signal(api, "thread_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CreateThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -237,9 +237,7 @@ class CreateThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
@@ -594,7 +592,7 @@ class CreateThreadTest(
 @ddt.ddt
 @disable_signal(api, "comment_created")
 @disable_signal(api, "comment_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @mock.patch(
     "lms.djangoapps.discussion.signals.handlers.send_response_notifications",
     new=mock.Mock(),
@@ -619,9 +617,7 @@ class CreateCommentTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -1037,7 +1033,7 @@ class CreateCommentTest(
 @ddt.ddt
 @disable_signal(api, "thread_edited")
 @disable_signal(api, "thread_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class UpdateThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -1058,9 +1054,7 @@ class UpdateThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -1697,7 +1691,7 @@ class UpdateThreadTest(
 @ddt.ddt
 @disable_signal(api, "comment_edited")
 @disable_signal(api, "comment_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class UpdateCommentTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -1718,9 +1712,7 @@ class UpdateCommentTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -2302,7 +2294,7 @@ class UpdateCommentTest(
 
 @ddt.ddt
 @disable_signal(api, "thread_deleted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class DeleteThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -2323,9 +2315,7 @@ class DeleteThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -2481,7 +2471,7 @@ class DeleteThreadTest(
 
 @ddt.ddt
 @disable_signal(api, "comment_deleted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class DeleteCommentTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -2502,9 +2492,7 @@ class DeleteCommentTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -2671,7 +2659,7 @@ class DeleteCommentTest(
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class RetrieveThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -2691,9 +2679,7 @@ class RetrieveThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -2827,7 +2813,7 @@ class RetrieveThreadTest(
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetThreadListTest(
         ForumMockUtilsMixin, UrlResetMixin, SharedModuleStoreTestCase
 ):
@@ -2845,9 +2831,7 @@ class GetThreadListTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -3462,7 +3446,7 @@ class GetThreadListTest(
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetCommentListTest(
         SharedModuleStoreTestCase, ForumMockUtilsMixin
 ):
@@ -3480,9 +3464,7 @@ class GetCommentListTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -4233,11 +4215,11 @@ class CourseTopicsV2Test(ModuleStoreTestCase):
             )
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(DISABLE_START_DATES=False)
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetCourseTopicsTest(ForumMockUtilsMixin, UrlResetMixin, ModuleStoreTestCase):
     """Test for get_course_topics"""
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         httpretty.reset()
         httpretty.enable()
@@ -4669,7 +4651,7 @@ class GetCourseTopicsTest(ForumMockUtilsMixin, UrlResetMixin, ModuleStoreTestCas
         }
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @override_settings(DISCUSSION_MODERATION_EDIT_REASON_CODES={"test-edit-reason": "Test Edit Reason"})
 @override_settings(DISCUSSION_MODERATION_CLOSE_REASON_CODES={"test-close-reason": "Test Close Reason"})
 @ddt.ddt
@@ -4680,7 +4662,7 @@ class GetCourseTest(UrlResetMixin, SharedModuleStoreTestCase):
         super().setUpClass()
         cls.course = CourseFactory.create(org="x", course="y", run="z")
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
@@ -4753,12 +4735,12 @@ class GetCourseTest(UrlResetMixin, SharedModuleStoreTestCase):
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetCourseTestBlackouts(UrlResetMixin, ModuleStoreTestCase):
     """
     Tests of get_course for courses that have blackout dates.
     """
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(org="x", course="y", run="z")

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
@@ -9,6 +9,7 @@ from unittest import mock
 import ddt
 import httpretty
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -392,7 +393,7 @@ class ThreadSerializerDeserializationTest(
 ):
     """Tests for ThreadSerializer deserialization."""
     @classmethod
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
@@ -404,7 +405,7 @@ class ThreadSerializerDeserializationTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -538,7 +539,7 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
     Test Mixin for Serializer tests
     """
     @classmethod
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
@@ -550,7 +551,7 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         httpretty.reset()

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import ddt
 import httpretty
 from django.conf import settings
+from django.test.utils import override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx_events.learning.signals import COURSE_NOTIFICATION_REQUESTED, USER_NOTIFICATION_REQUESTED
 
@@ -496,7 +497,7 @@ class TestSendCommentNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCas
 
 @ddt.ddt
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @override_waffle_flag(ENABLE_NOTIFICATIONS, active=True)
 class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -4,10 +4,10 @@ Tests for Discussion API views
 
 import json
 from datetime import datetime
-from unittest import mock
 from urllib.parse import urlencode
 
 import ddt
+from django.test.utils import override_settings
 from django.urls import reverse
 from pytz import UTC
 from rest_framework import status
@@ -29,7 +29,7 @@ from lms.djangoapps.discussion.rest_api.tests.utils import (
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CommentViewSetListByUserTest(
     ForumMockUtilsMixin,
     UrlResetMixin,
@@ -49,7 +49,7 @@ class CommentViewSetListByUserTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -81,9 +81,7 @@ class DiscussionAPIViewTestMixin(ForumMockUtilsMixin, UrlResetMixin):
 
     client_class = APIClient
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.maxDiff = None  # pylint: disable=invalid-name
@@ -176,7 +174,7 @@ class DiscussionAPIViewTestMixin(ForumMockUtilsMixin, UrlResetMixin):
 @ddt.ddt
 @httpretty.activate
 @disable_signal(api, "thread_edited")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ThreadViewSetPartialUpdateTest(
     DiscussionAPIViewTestMixin, ModuleStoreTestCase, PatchMediaTypeMixin
 ):
@@ -359,7 +357,7 @@ class ThreadViewSetPartialUpdateTest(
 
 @ddt.ddt
 @disable_signal(api, "comment_edited")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CommentViewSetPartialUpdateTest(
     DiscussionAPIViewTestMixin, ModuleStoreTestCase, PatchMediaTypeMixin
 ):
@@ -493,7 +491,7 @@ class CommentViewSetPartialUpdateTest(
 
 @ddt.ddt
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ThreadViewSetListTest(
     DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin
 ):
@@ -890,7 +888,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     Tests for the BulkDeleteUserPostsViewSet
     """
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self) -> None:
         super().setUp()
         self.course = CourseFactory.create()
@@ -935,7 +933,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_regular_user(self):
         """
         Tests that for a regular user stats are returned without flag counts
@@ -945,7 +943,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         data = response.json()
         assert data["results"] == self.stats_without_flags
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_moderator_user(self):
         """
         Tests that for a moderator user stats are returned with flag counts
@@ -965,7 +963,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         ("user", "recency", "recency"),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting(self, username, ordering_requested, ordering_performed):
         """
         Test valid sorting options and defaults
@@ -980,7 +978,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         assert params["sort_key"] == ordering_performed
 
     @ddt.data("flagged", "xyz")
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting_error_regular_user(self, order_by):
         """
         Test for invalid sorting options for regular users.
@@ -994,7 +992,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         ('moderator', 'moderator'),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param(self, username_search_string, comma_separated_usernames):
         """
         Test for endpoint with username param.
@@ -1006,7 +1004,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         params = self.get_mock_func_calls("get_user_course_stats")[-1][1]
         assert params["usernames"] == comma_separated_usernames
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_with_no_matches(self):
         """
         Test for endpoint with username param with no matches.
@@ -1024,7 +1022,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         'User-2',
         'UsEr-3'
     )
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_case(self, username_search_string):
         """
         Test user search function is case-insensitive.
@@ -1044,7 +1042,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @override_settings(DISCUSSION_MODERATION_EDIT_REASON_CODES={"test-edit-reason": "Test Edit Reason"})
 @override_settings(DISCUSSION_MODERATION_CLOSE_REASON_CODES={"test-close-reason": "Test Close Reason"})
 class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
@@ -1105,7 +1103,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 @ddt.ddt
 @httpretty.activate
 @mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for ReplaceUsernamesView"""
 
@@ -1199,7 +1197,7 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin, ModuleStoreTestCase):
     """
     Tests for CourseTopicsView
@@ -1409,7 +1407,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin,
 
 @ddt.ddt
 @mock.patch('lms.djangoapps.discussion.rest_api.api._get_course', mock.Mock())
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @override_waffle_flag(ENABLE_NEW_STRUCTURE_DISCUSSIONS, True)
 class CourseTopicsViewV3Test(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """
@@ -1501,7 +1499,7 @@ class CourseTopicsViewV3Test(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 
 @ddt.ddt
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for LearnerThreadView list"""
 
@@ -1819,7 +1817,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
     Tests for the course stats endpoint
     """
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self) -> None:
         super().setUp()
         self.course = CourseFactory.create()
@@ -1864,7 +1862,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_regular_user(self):
         """
         Tests that for a regular user stats are returned without flag counts
@@ -1874,7 +1872,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         data = response.json()
         assert data["results"] == self.stats_without_flags
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_moderator_user(self):
         """
         Tests that for a moderator user stats are returned with flag counts
@@ -1894,7 +1892,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         ("user", "recency", "recency"),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting(self, username, ordering_requested, ordering_performed):
         """
         Test valid sorting options and defaults
@@ -1909,7 +1907,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         assert params["sort_key"] == ordering_performed
 
     @ddt.data("flagged", "xyz")
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting_error_regular_user(self, order_by):
         """
         Test for invalid sorting options for regular users.
@@ -1923,7 +1921,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         ('moderator', 'moderator'),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param(self, username_search_string, comma_separated_usernames):
         """
         Test for endpoint with username param.
@@ -1935,7 +1933,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         params = self.get_mock_func_calls("get_user_course_stats")[-1][1]
         assert params["usernames"] == comma_separated_usernames
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_with_no_matches(self):
         """
         Test for endpoint with username param with no matches.
@@ -1953,7 +1951,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         'User-2',
         'UsEr-3'
     )
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_case(self, username_search_string):
         """
         Test user search function is case-insensitive.
@@ -1963,7 +1961,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
 
 
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for CourseView"""
 
@@ -2026,13 +2024,13 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class UploadFileViewTest(ForumMockUtilsMixin, UrlResetMixin, ModuleStoreTestCase):
     """
     Tests for UploadFileView.
     """
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.valid_file = {
@@ -2188,7 +2186,7 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
     """
     Test the course discussion settings handler API endpoint.
     """
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(
@@ -2487,7 +2485,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
     """
     Test the course discussion roles management endpoint.
     """
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(
@@ -2501,7 +2499,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
         course_key = CourseKey.from_string('course-v1:x+y+z')
         seed_permissions_roles(course_key)
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def path(self, course_id=None, role=None):
         """Return the URL path to the endpoint based on the provided arguments."""
         course_id = str(self.course.id) if course_id is None else course_id

--- a/lms/djangoapps/discussion/tests/test_tasks_v2.py
+++ b/lms/djangoapps/discussion/tests/test_tasks_v2.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import ddt
 from django.contrib.sites.models import Site
+from django.test.utils import override_settings
 from edx_ace.channel import ChannelType, get_channel_for_message
 from edx_ace.recipient import Recipient
 from edx_ace.renderers import EmailRenderer
@@ -78,9 +79,7 @@ class TaskTestCase(
 ):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUpClass(cls):
         super().setUpClass()
         super().setUpClassAndForumMock()

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -51,7 +51,7 @@ QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
 
 class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
 
         # Patching the ENABLE_DISCUSSION_SERVICE value affects the contents of urls.py,
@@ -316,7 +316,7 @@ class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
 
     CREATE_USER = False
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         patcher = mock.patch(
@@ -392,13 +392,13 @@ class EnrollmentTestCase(ModuleStoreTestCase):
     in the course
     """
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
     def test_unenrolled(self, mock_request):
         mock_request.side_effect = make_mock_request_impl(course=self.course, text='dummy')

--- a/lms/djangoapps/discussion/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/tests/test_views_v2.py
@@ -727,7 +727,7 @@ class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixinV2, For
 
 class SingleThreadContentGroupTestCase(UrlResetMixin, ContentGroupTestCase, ForumViewsUtilsMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -941,7 +941,7 @@ class ForumFormDiscussionContentGroupTestCase(
     beta_block => beta_group_discussion => beta_cohort => beta_user
     """
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.thread_list = [
@@ -1083,7 +1083,7 @@ class EnterpriseConsentTestCase(
 
     CREATE_USER = False
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         # Invoke UrlResetMixin setUp
         super().setUp()
@@ -1454,7 +1454,7 @@ class ForumDiscussionXSSTestCase(
         UrlResetMixin, ModuleStoreTestCase, ForumViewsUtilsMixin
 ):  # lint-amnesty, pylint: disable=missing-class-docstring
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -1745,7 +1745,7 @@ class UserProfileTestCase(
     TEST_THREAD_TEXT = "userprofile-test-text"
     TEST_THREAD_ID = "userprofile-test-thread-id"
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -1892,7 +1892,7 @@ class ThreadViewedEventTestCase(
     DUMMY_TITLE = 'Dummy title'
     DUMMY_URL = 'https://example.com/dummy/url/'
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp('lms.djangoapps.discussion.django_comment_client.base.views.tracker')
         self.course = CourseFactory.create(
@@ -1939,7 +1939,7 @@ class ThreadViewedEventTestCase(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_thread_viewed_event(self):
         self._configure_mock_responses(
             course=self.course,

--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -26,7 +26,7 @@ def edxnotes(cls):
             generate_uid, get_edxnotes_id_token, get_public_endpoint, get_token_url, is_feature_enabled
         )
 
-        if not settings.FEATURES.get("ENABLE_EDXNOTES"):
+        if not settings.ENABLE_EDXNOTES:
             return original_get_html(self, *args, **kwargs)
 
         runtime = getattr(self, 'block', self).runtime

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -39,7 +39,7 @@ class EdxNotesTab(EnrolledTab):
         if not super().is_enabled(course, user=user):
             return False
 
-        if not settings.FEATURES.get("ENABLE_EDXNOTES"):
+        if not settings.ENABLE_EDXNOTES:
             return False
 
         if user and not user.is_authenticated:
@@ -65,7 +65,7 @@ class EdxNotesCourseApp(CourseApp):
         """
         EdX notes availability is currently globally controlled via a feature setting.
         """
-        return settings.FEATURES.get("ENABLE_EDXNOTES", False)
+        return settings.ENABLE_EDXNOTES
 
     @classmethod
     def is_enabled(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -40,7 +40,6 @@ from .decorators import edxnotes
 from .exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
 from .plugins import EdxNotesTab
 
-FEATURES = settings.FEATURES.copy()
 
 NOTES_API_EMPTY_RESPONSE = {
     "total": 0,
@@ -93,7 +92,7 @@ class TestProblem:
         return "original_get_html"
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 class EdxNotesDecoratorTest(ModuleStoreTestCase):
     """
     Tests for edxnotes decorator.
@@ -108,7 +107,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         self.client.login(username=self.user.username, password=UserFactory._DEFAULT_PASSWORD)  # lint-amnesty, pylint: disable=protected-access
         self.problem = TestProblem(self.course, self.user)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_EDXNOTES': True})
+    @override_settings(ENABLE_EDXNOTES=True)
     @patch("lms.djangoapps.edxnotes.helpers.get_public_endpoint", autospec=True)
     @patch("lms.djangoapps.edxnotes.helpers.get_token_url", autospec=True)
     @patch("lms.djangoapps.edxnotes.helpers.get_edxnotes_id_token", autospec=True)
@@ -144,7 +143,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         }
         assert problem.get_html() == render_to_string('edxnotes_wrapper.html', expected_context)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     def test_edxnotes_disabled_if_edxnotes_flag_is_false(self):
         """
         Tests that get_html is wrapped when feature flag is on, but edxnotes are
@@ -153,7 +152,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         self.course.edxnotes = False
         assert 'original_get_html' == self.problem.get_html()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+    @override_settings(ENABLE_EDXNOTES=False)
     def test_edxnotes_disabled(self):
         """
         Tests that get_html is not wrapped when feature flag is off.
@@ -182,7 +181,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         enable_edxnotes_for_the_course(self.course, self.user.id)
         assert 'original_get_html' == self.problem.get_html()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     def test_anonymous_user(self):
         user = AnonymousUser()
         problem = TestProblem(self.course, user)
@@ -190,7 +189,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         assert problem.get_html() == "original_get_html"
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesHelpersTest(ModuleStoreTestCase):
     """
@@ -939,7 +938,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         verify_url(previous_url, previous_api_url)
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesViewsTest(ModuleStoreTestCase):
     """
@@ -986,7 +985,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         assert has_notes_tab(self.user, self.course)
 
     # pylint: disable=unused-argument
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     @patch("lms.djangoapps.edxnotes.views.get_notes", return_value={'results': []})
     def test_edxnotes_view_is_enabled(self, mock_get_notes):
         """
@@ -997,7 +996,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         self.assertContains(response, 'Highlights and notes you&#39;ve made in course content')
 
     # pylint: disable=unused-argument
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     @patch("lms.djangoapps.edxnotes.views.get_notes", return_value={'results': []})
     @patch("lms.djangoapps.edxnotes.views.get_course_position", return_value={
         'display_name': 'Section 1',
@@ -1014,7 +1013,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
             'Get started by making a note in something you just read, like <a href="test_url">Section 1</a>'
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+    @override_settings(ENABLE_EDXNOTES=False)
     def test_edxnotes_view_is_disabled(self):
         """
         Tests that 404 status code is received if EdxNotes feature is disabled.
@@ -1022,7 +1021,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         response = self.client.get(self.notes_page_url)
         assert response.status_code == 404
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     @patch("lms.djangoapps.edxnotes.views.get_notes", autospec=True)
     def test_search_notes_successfully_respond(self, mock_search):
         """
@@ -1034,7 +1033,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         assert json.loads(response.content.decode('utf-8')) == NOTES_VIEW_EMPTY_RESPONSE
         assert response.status_code == 200
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+    @override_settings(ENABLE_EDXNOTES=False)
     def test_search_notes_is_disabled(self):
         """
         Tests that 404 status code is received if EdxNotes feature is disabled.
@@ -1042,7 +1041,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         response = self.client.get(self.notes_url, {"text": "test"})
         assert response.status_code == 404
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     @patch("lms.djangoapps.edxnotes.views.get_notes", autospec=True)
     def test_search_500_service_unavailable(self, mock_search):
         """
@@ -1053,7 +1052,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         response = self.client.get(self.notes_url, {"text": "test"})
         self.assertContains(response, "error", status_code=500)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     @patch("lms.djangoapps.edxnotes.views.get_notes", autospec=True)
     def test_search_notes_exception(self, mock_search):
         """
@@ -1065,7 +1064,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         response = self.client.get(self.notes_url, {"text": "test"})
         self.assertContains(response, "error", status_code=500)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     def test_get_id_token(self):
         """
         Test generation of ID Token.
@@ -1080,7 +1079,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
             algorithms=[settings.JWT_AUTH['JWT_ALGORITHM']]
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     def test_get_id_token_anonymous(self):
         """
         Test that generation of ID Token does not work for anonymous user.
@@ -1103,7 +1102,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         course_block = self._get_course_block()
         assert not course_block.edxnotes_visibility
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
+    @override_settings(ENABLE_EDXNOTES=False)
     def test_edxnotes_visibility_if_feature_is_disabled(self):
         """
         Tests that 404 response is received if EdxNotes feature is disabled.
@@ -1111,7 +1110,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         response = self.client.post(self.visibility_url)
         assert response.status_code == 404
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     def test_edxnotes_visibility_invalid_json(self):
         """
         Tests that 400 response is received if invalid JSON is sent.
@@ -1124,7 +1123,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         )
         assert response.status_code == 400
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @override_settings(ENABLE_EDXNOTES=True)
     def test_edxnotes_visibility_key_error(self):
         """
         Tests that 400 response is received if invalid data structure is sent.
@@ -1251,7 +1250,7 @@ class EdxNotesRetireAPITest(ModuleStoreTestCase):
         assert response.status_code == 500
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesPluginTest(ModuleStoreTestCase):
     """
@@ -1273,6 +1272,5 @@ class EdxNotesPluginTest(ModuleStoreTestCase):
         """
         Verify EdxNotesTab visibility when ENABLE_EDXNOTES feature flag is enabled/disabled.
         """
-        FEATURES['ENABLE_EDXNOTES'] = enabled
-        with override_settings(FEATURES=FEATURES):
+        with override_settings(ENABLE_EDXNOTES=enabled):
             assert EdxNotesTab.is_enabled(self.course, self.user) == enabled

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -178,11 +178,9 @@ class ExperimentDataViewSetTests(APITestCase, ModuleStoreTestCase):  # lint-amne
 
 def cross_domain_config(func):
     """Decorator for configuring a cross-domain request. """
-    feature_flag_decorator = patch.dict(settings.FEATURES, {
-        'ENABLE_CORS_HEADERS': True,
-        'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True
-    })
     settings_decorator = override_settings(
+        ENABLE_CORS_HEADERS=True,
+        ENABLE_CROSS_DOMAIN_CSRF_COOKIE=True,
         CORS_ORIGIN_WHITELIST=['https://ecommerce.edx.org'],
         CSRF_COOKIE_NAME="prod-edx-csrftoken",
         CROSS_DOMAIN_CSRF_COOKIE_NAME="prod-edx-csrftoken",
@@ -190,10 +188,8 @@ def cross_domain_config(func):
     )
     is_secure_decorator = patch.object(WSGIRequest, 'is_secure', return_value=True)
 
-    return feature_flag_decorator(
-        settings_decorator(
-            is_secure_decorator(func)
-        )
+    return settings_decorator(
+        is_secure_decorator(func)
     )
 
 

--- a/lms/djangoapps/grades/apps.py
+++ b/lms/djangoapps/grades/apps.py
@@ -43,6 +43,6 @@ class GradesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from .signals import handlers  # pylint: disable=unused-import
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import GradesService
             set_runtime_service('grades', GradesService())

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -12,6 +12,7 @@ from common.djangoapps.student.models.course_enrollment import CourseEnrollment
 
 import ddt
 import pytest
+from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 from freezegun import freeze_time
@@ -2222,7 +2223,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
 
         assert status.HTTP_403_FORBIDDEN == resp.status_code
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_get_override_for_unreleased_block(self):
         self.login_course_staff()
         unreleased_subsection = BlockFactory.create(

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -104,7 +104,7 @@ class SubsectionGradeFactory:
             )
             self._update_saved_subsection_grade(subsection.location, grade_model)
 
-            if settings.FEATURES.get('ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL'):
+            if settings.ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL:
                 COURSE_ASSESSMENT_GRADE_CHANGED.send(
                     sender=self,
                     course_id=self.course_data.course_key,

--- a/lms/djangoapps/grades/tests/test_course_data.py
+++ b/lms/djangoapps/grades/tests/test_course_data.py
@@ -4,6 +4,7 @@ Tests for CourseData utility class.
 from unittest.mock import patch
 
 import pytest
+from django.test.utils import override_settings
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks
@@ -86,7 +87,7 @@ class CourseDataTest(ModuleStoreTestCase):
         with pytest.raises(ValueError):
             _ = CourseData(self.user)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_full_string(self):
         empty_structure = get_course_blocks(self.user, self.course.location)
         assert not empty_structure

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -6,7 +6,7 @@ Tests for the SubsectionGradeFactory class.
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
+from django.test.utils import override_settings
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
@@ -43,7 +43,7 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
         assert isinstance(grade, ZeroSubsectionGrade)
         self.assert_grade(grade, 0.0, 1.0)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL': True})
+    @override_settings(ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL=True)
     def test_update(self):
         """
         Assuming the underlying score reporting methods work,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -290,17 +290,6 @@ SQUELCH_PII_IN_LOGS = True
 # defaults, so that we maintain current behavior
 ALLOW_WIKI_ROOT_ACCESS = True
 
-# .. toggle_name: settings.ENABLE_THIRD_PARTY_AUTH
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Turn on third-party auth. Disabled for now because full implementations are not yet
-#   available. Remember to run migrations if you enable this; we don't create tables by default. This feature can
-#   be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication
-#   backends with the AUTHENTICATION_BACKENDS setting.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-09-15
-ENABLE_THIRD_PARTY_AUTH = False
-
 # Prevent concurrent logins per user
 PREVENT_CONCURRENT_LOGINS = True
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
@@ -35,7 +35,7 @@ class SpecialExamsOutlineProcessor(OutlineProcessor):
         """
         Check if special exams are enabled
         """
-        self.special_exams_enabled = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False)  # lint-amnesty, pylint: disable=attribute-defined-outside-init
+        self.special_exams_enabled = settings.ENABLE_SPECIAL_EXAMS  # lint-amnesty, pylint: disable=attribute-defined-outside-init
 
     def exam_data(self, pruned_course_outline: UserCourseOutlineData) -> SpecialExamAttemptData:
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -9,6 +9,7 @@ import unittest
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import signals
+from django.test import override_settings
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from edx_toggles.toggles.testutils import override_waffle_flag
 from edx_when.api import set_dates_for_course
@@ -998,7 +999,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
         # Enroll student in the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     def test_special_exams_enabled_all_sequences_visible(self):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # lint-amnesty, pylint: disable=unused-variable
 
@@ -1014,7 +1015,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
         assert len(student_details.outline.accessible_sequences) == 4
         assert len(student_details.outline.sequences) == 4
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False})
+    @override_settings(ENABLE_SPECIAL_EXAMS=False)
     def test_special_exams_disabled_preserves_exam_sequences(self):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # lint-amnesty, pylint: disable=unused-variable
 
@@ -1033,7 +1034,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
             assert key in student_details.outline.accessible_sequences
             assert key in student_details.outline.sequences
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
     def test_special_exam_attempt_data_in_details(self, mock_get_attempt_status_summary):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # lint-amnesty, pylint: disable=unused-variable
@@ -1067,7 +1068,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
             assert type(attempt_summary) == dict  # lint-amnesty, pylint: disable=unidiomatic-typecheck
             assert attempt_summary["summary"]["usage_key"] == str(sequence_key)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False})
+    @override_settings(ENABLE_SPECIAL_EXAMS=False)
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
     def test_special_exam_attempt_data_empty_when_disabled(self, mock_get_attempt_status_summary):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # lint-amnesty, pylint: disable=unused-variable
@@ -1081,7 +1082,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
         assert len(student_details.special_exam_attempts.sequences) == 0
 
     @override_waffle_flag(EXAMS_IDA, active=True)
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
     def test_special_exam_attempt_data_exams_ida_flag_on(self, mock_get_attempt_status_summary):
         _, student_details, _ = self.get_details(
@@ -1092,7 +1093,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
         assert mock_get_attempt_status_summary.call_count == 0
 
     @override_waffle_flag(EXAMS_IDA, active=True)
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     def test_special_exam_attempt_data_exam_type(self):
         _, student_details, _ = self.get_details(
             datetime(2020, 5, 25, tzinfo=timezone.utc)

--- a/openedx/core/djangoapps/content/learning_sequences/apps.py
+++ b/openedx/core/djangoapps/content/learning_sequences/apps.py
@@ -13,6 +13,6 @@ class LearningSequencesConfig(AppConfig):  # lint-amnesty, pylint: disable=missi
         # Register celery workers
         # from .tasks import ls_listen_for_course_publish  # pylint: disable=unused-variable
 
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import LearningSequencesRuntimeService
             set_runtime_service('learning_sequences', LearningSequencesRuntimeService())

--- a/openedx/core/djangoapps/content/learning_sequences/views.py
+++ b/openedx/core/djangoapps/content/learning_sequences/views.py
@@ -122,7 +122,7 @@ class CourseOutlineView(APIView):
             }
 
             # Only include this data if special exams are on
-            if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False):
+            if settings.ENABLE_SPECIAL_EXAMS:
                 sequence_representation["exam"] = sequence_exam
 
             return sequence_representation

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1302,6 +1302,17 @@ ENABLE_ORA_ALL_FILE_URLS = False
 # .. toggle_warning: This temporary feature toggle does not have a target removal date.
 ENABLE_ORA_USER_STATE_UPLOAD_DATA = False
 
+# .. toggle_name: settings.ENABLE_THIRD_PARTY_AUTH
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Turn on third-party auth. Disabled for now because full implementations are not yet
+#   available. Remember to run migrations if you enable this; we don't create tables by default. This feature can
+#   be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication
+#   backends with the AUTHENTICATION_BACKENDS setting.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-09-15
+ENABLE_THIRD_PARTY_AUTH = False
+
 # .. toggle_name: ENABLE_INTEGRITY_SIGNATURE
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False


### PR DESCRIPTION
## Description

Replace each reference to the FEATURES dictionary with the equivalent top-level Django settings reference.

## Supporting information

TBC

## Testing instructions

TBC

## Deadline

Verawood code freeze

## Other information

### A

I used claude code -- more TBC