### PR TITLE
feat: add new content library enforcement points

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -9,8 +9,9 @@ to decide whether to check course creator role, and other such functions.
 from ccx_keys.locator import CCXBlockUsageLocator, CCXLocator
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from opaque_keys.edx.locator import LibraryLocator
+from opaque_keys.edx.locator import LibraryLocator, LibraryLocatorV2
 from openedx_authz import api as authz_api
+from openedx_authz.constants import permissions as authz_permissions
 from openedx_authz.constants.permissions import COURSES_MANAGE_ADVANCED_SETTINGS
 
 from common.djangoapps.student.roles import (
@@ -178,6 +179,32 @@ def has_studio_read_access(user, course_key):
     there is read-only access to content libraries.
     """
     return bool(STUDIO_VIEW_CONTENT & get_user_permissions(user, course_key))
+
+
+def has_library_tagging_access(user, library_key: LibraryLocatorV2) -> bool:
+    """
+    Check if user has permission to tag content in the specified library.
+
+    Note: `MANAGE_LIBRARY_TAGS` implies `EDIT_LIBRARY_CONTENT` via authz policies (g2),
+    so users with tagging permission also have edit permission automatically.
+
+    Args:
+        user (User): Django user object
+        library_key (LibraryLocatorV2): Key for the library
+
+    Returns:
+        bool: True if user has permission to tag content in the library, False otherwise
+    """
+    # Import here to avoid circular import
+    from openedx.core.djangoapps.content_libraries.api import libraries as lib_api
+
+    try:
+        library_obj = lib_api.ContentLibrary.objects.get_by_key(library_key)
+        return lib_api.user_has_permission_across_lib_authz_systems(
+            user, authz_permissions.MANAGE_LIBRARY_TAGS, library_obj
+        )
+    except lib_api.ContentLibrary.DoesNotExist:
+        return False
 
 
 def check_course_advanced_settings_access(user, course_key, access_type='read'):

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -9,9 +9,8 @@ to decide whether to check course creator role, and other such functions.
 from ccx_keys.locator import CCXBlockUsageLocator, CCXLocator
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from opaque_keys.edx.locator import LibraryLocator, LibraryLocatorV2
+from opaque_keys.edx.locator import LibraryLocator
 from openedx_authz import api as authz_api
-from openedx_authz.constants import permissions as authz_permissions
 from openedx_authz.constants.permissions import COURSES_MANAGE_ADVANCED_SETTINGS
 
 from common.djangoapps.student.roles import (
@@ -179,32 +178,6 @@ def has_studio_read_access(user, course_key):
     there is read-only access to content libraries.
     """
     return bool(STUDIO_VIEW_CONTENT & get_user_permissions(user, course_key))
-
-
-def has_library_tagging_access(user, library_key: LibraryLocatorV2) -> bool:
-    """
-    Check if user has permission to tag content in the specified library.
-
-    Note: `MANAGE_LIBRARY_TAGS` implies `EDIT_LIBRARY_CONTENT` via authz policies (g2),
-    so users with tagging permission also have edit permission automatically.
-
-    Args:
-        user (User): Django user object
-        library_key (LibraryLocatorV2): Key for the library
-
-    Returns:
-        bool: True if user has permission to tag content in the library, False otherwise
-    """
-    # Import here to avoid circular import
-    from openedx.core.djangoapps.content_libraries.api import libraries as lib_api
-
-    try:
-        library_obj = lib_api.ContentLibrary.objects.get_by_key(library_key)
-        return lib_api.user_has_permission_across_lib_authz_systems(
-            user, authz_permissions.MANAGE_LIBRARY_TAGS, library_obj
-        )
-    except lib_api.ContentLibrary.DoesNotExist:
-        return False
 
 
 def check_course_advanced_settings_access(user, course_key, access_type='read'):

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -837,6 +837,7 @@ def _transform_authz_permission_to_legacy_lib_permission(permission: str) -> str
         authz_permissions.CREATE_LIBRARY_COLLECTION.identifier: permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
         authz_permissions.EDIT_LIBRARY_COLLECTION.identifier: permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
         authz_permissions.DELETE_LIBRARY_COLLECTION.identifier: permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
+        authz_permissions.MANAGE_LIBRARY_TAGS.identifier: permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
         authz_permissions.REUSE_LIBRARY_CONTENT.identifier: permissions.CAN_VIEW_THIS_CONTENT_LIBRARY,
     }.get(permission, permission)
 

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -336,15 +336,24 @@ def get_metadata(queryset: QuerySet[ContentLibrary], text_search: str | None = N
     return libraries
 
 
-def require_permission_for_library_key(library_key: LibraryLocatorV2, user: UserType, permission) -> ContentLibrary:
+def require_permission_for_library_key(
+    library_key: LibraryLocatorV2, user: UserType, permission: str | authz_api.data.PermissionData
+) -> ContentLibrary:
     """
-    Given any of the content library permission strings defined in
-    openedx.core.djangoapps.content_libraries.permissions,
-    check if the given user has that permission for the library with the
-    specified library ID.
+    Check if the user has the specified permission for a content library.
 
-    Raises django.core.exceptions.PermissionDenied if the user doesn't have
-    permission.
+    Args:
+        library_key: The library key identifying the content library
+        user: The user whose permissions are being checked
+        permission: Either a permission string from content_libraries.permissions
+                   or a PermissionData instance from the authz API
+
+    Returns:
+        ContentLibrary: The library object if permission check passes
+
+    Raises:
+        ContentLibraryNotFound: If the library with the given key doesn't exist
+        PermissionDenied: If the user doesn't have the required permission
     """
     library_obj = ContentLibrary.objects.get_by_key(library_key)
     # obj should be able to read any valid model object but mypy thinks it can only be

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -837,6 +837,7 @@ def _transform_authz_permission_to_legacy_lib_permission(permission: str) -> str
         authz_permissions.CREATE_LIBRARY_COLLECTION.identifier: permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
         authz_permissions.EDIT_LIBRARY_COLLECTION.identifier: permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
         authz_permissions.DELETE_LIBRARY_COLLECTION.identifier: permissions.CAN_EDIT_THIS_CONTENT_LIBRARY,
+        authz_permissions.REUSE_LIBRARY_CONTENT.identifier: permissions.CAN_VIEW_THIS_CONTENT_LIBRARY,
     }.get(permission, permission)
 
 

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -572,7 +572,9 @@ class LibraryPasteClipboardView(GenericAPIView):
         Import the contents of the user's clipboard and paste them into the Library
         """
         library_key = LibraryLocatorV2.from_string(lib_key_str)
-        api.require_permission_for_library_key(library_key, request.user, permissions.CAN_EDIT_THIS_CONTENT_LIBRARY)
+        api.require_permission_for_library_key(
+            library_key, request.user, authz_permissions.REUSE_LIBRARY_CONTENT
+        )
 
         try:
             result = api.import_staged_content_from_user_clipboard(library_key, request.user)

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -572,9 +572,7 @@ class LibraryPasteClipboardView(GenericAPIView):
         Import the contents of the user's clipboard and paste them into the Library
         """
         library_key = LibraryLocatorV2.from_string(lib_key_str)
-        api.require_permission_for_library_key(
-            library_key, request.user, authz_permissions.REUSE_LIBRARY_CONTENT
-        )
+        api.require_permission_for_library_key(library_key, request.user, authz_permissions.EDIT_LIBRARY_CONTENT)
 
         try:
             result = api.import_staged_content_from_user_clipboard(library_key, request.user)

--- a/openedx/core/djangoapps/content_staging/views.py
+++ b/openedx/core/djangoapps/content_staging/views.py
@@ -11,6 +11,7 @@ from django.utils.decorators import method_decorator
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocatorV2
+from openedx_authz.constants import permissions as authz_permissions
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -114,7 +115,7 @@ class ClipboardEndpoint(APIView):
                 lib_api.require_permission_for_library_key(
                     course_key,
                     request.user,
-                    lib_api.permissions.CAN_VIEW_THIS_CONTENT_LIBRARY
+                    authz_permissions.REUSE_LIBRARY_CONTENT
                 )
                 block = xblock_api.load_block(usage_key, user=None)
                 version_num = lib_api.get_library_block(usage_key).draft_version_num

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1950,15 +1950,15 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
 
     @ddt.data(
         ('staff', 'courseA', 8),
-        ('staff', 'libraryA', 11),
-        ('staff', 'collection_key', 11),
+        ('staff', 'libraryA', 17),
+        ('staff', 'collection_key', 17),
         ("content_creatorA", 'courseA', 18, False),
-        ("content_creatorA", 'libraryA', 32, False),
-        ("content_creatorA", 'collection_key', 32, False),
-        ("library_staffA", 'libraryA', 32, False),  # Library users can only view objecttags, not change them?
-        ("library_staffA", 'collection_key', 32, False),
-        ("library_userA", 'libraryA', 32, False),
-        ("library_userA", 'collection_key', 32, False),
+        ("content_creatorA", 'libraryA', 23, False),
+        ("content_creatorA", 'collection_key', 23, False),
+        ("library_staffA", 'libraryA', 23, False),  # Library users can only view objecttags, not change them?
+        ("library_staffA", 'collection_key', 23, False),
+        ("library_userA", 'libraryA', 23, False),
+        ("library_userA", 'collection_key', 23, False),
         ("instructorA", 'courseA', 18),
         ("course_instructorA", 'courseA', 18),
         ("course_staffA", 'courseA', 18),

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1633,7 +1633,12 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
     @ddt.data("libraryA", "collection_key", "container_key")
     @patch("openedx_authz.api.is_user_allowed")
     @patch("openedx.core.djangoapps.content_tagging.rules.has_studio_write_access")
-    def test_tag_library_objects_with_manage_library_tags_permission(self, object_attr, mock_has_studio_write_access, mock_is_user_allowed):
+    def test_tag_library_objects_with_manage_library_tags_permission(
+        self,
+        object_attr,
+        mock_has_studio_write_access,
+        mock_is_user_allowed,
+    ):
         """
         Users with MANAGE_LIBRARY_TAGS permission should be able to tag:
         - the library itself

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import abc
 import json
 from io import BytesIO
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import ddt
@@ -16,6 +16,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator, LibraryCollectionLocator, LibraryContainerLocator
+from openedx_authz.constants import permissions as authz_permissions
 from openedx_authz.constants.roles import COURSE_STAFF
 from openedx_tagging.models import Tag, Taxonomy
 from openedx_tagging.models.system_defined import SystemDefinedTaxonomy
@@ -1628,6 +1629,30 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
             new_response = self.client.get(url, format="json")
             assert status.is_success(new_response.status_code)
             assert new_response.data == response.data
+
+    @ddt.data("libraryA", "collection_key", "container_key")
+    @patch("openedx_authz.api.is_user_allowed")
+    @patch("openedx.core.djangoapps.content_tagging.rules.has_studio_write_access")
+    def test_tag_library_objects_with_manage_library_tags_permission(self, object_attr, mock_has_studio_write_access, mock_is_user_allowed):
+        """
+        Users with MANAGE_LIBRARY_TAGS permission should be able to tag:
+        - the library itself
+        - collections in the library
+        - containers in the library
+        """
+        mock_is_user_allowed.return_value = True
+        object_id = getattr(self, object_attr)
+
+        self.client.force_authenticate(user=self.library_userA)
+        response = self._call_put_request(object_id, self.tA1.pk, ["Tag 1"])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_is_user_allowed.assert_called_with(
+            self.library_userA.username,
+            authz_permissions.MANAGE_LIBRARY_TAGS.identifier,
+            self.libraryA,
+        )
+        mock_has_studio_write_access.assert_not_called()
 
     @ddt.data(
         "staffA",

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1950,15 +1950,15 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
 
     @ddt.data(
         ('staff', 'courseA', 8),
-        ('staff', 'libraryA', 23),
-        ('staff', 'collection_key', 23),
+        ('staff', 'libraryA', 17),
+        ('staff', 'collection_key', 17),
         ("content_creatorA", 'courseA', 17, False),
-        ("content_creatorA", 'libraryA', 28, False),
-        ("content_creatorA", 'collection_key', 28, False),
-        ("library_staffA", 'libraryA', 28, False),  # Library users can only view objecttags, not change them?
-        ("library_staffA", 'collection_key', 28, False),
-        ("library_userA", 'libraryA', 28, False),
-        ("library_userA", 'collection_key', 28, False),
+        ("content_creatorA", 'libraryA', 22, False),
+        ("content_creatorA", 'collection_key', 22, False),
+        ("library_staffA", 'libraryA', 22, False),  # Library users can only view objecttags, not change them?
+        ("library_staffA", 'collection_key', 22, False),
+        ("library_userA", 'libraryA', 22, False),
+        ("library_userA", 'collection_key', 22, False),
         ("instructorA", 'courseA', 17),
         ("course_instructorA", 'courseA', 17),
         ("course_staffA", 'courseA', 17),

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1950,18 +1950,18 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
 
     @ddt.data(
         ('staff', 'courseA', 8),
-        ('staff', 'libraryA', 8),
-        ('staff', 'collection_key', 8),
-        ("content_creatorA", 'courseA', 18, False),
-        ("content_creatorA", 'libraryA', 18, False),
-        ("content_creatorA", 'collection_key', 18, False),
-        ("library_staffA", 'libraryA', 18, False),  # Library users can only view objecttags, not change them?
-        ("library_staffA", 'collection_key', 18, False),
-        ("library_userA", 'libraryA', 18, False),
-        ("library_userA", 'collection_key', 18, False),
-        ("instructorA", 'courseA', 18),
-        ("course_instructorA", 'courseA', 18),
-        ("course_staffA", 'courseA', 18),
+        ('staff', 'libraryA', 23),
+        ('staff', 'collection_key', 23),
+        ("content_creatorA", 'courseA', 17, False),
+        ("content_creatorA", 'libraryA', 28, False),
+        ("content_creatorA", 'collection_key', 28, False),
+        ("library_staffA", 'libraryA', 28, False),  # Library users can only view objecttags, not change them?
+        ("library_staffA", 'collection_key', 28, False),
+        ("library_userA", 'libraryA', 28, False),
+        ("library_userA", 'collection_key', 28, False),
+        ("instructorA", 'courseA', 17),
+        ("course_instructorA", 'courseA', 17),
+        ("course_staffA", 'courseA', 17),
     )
     @ddt.unpack
     def test_object_tags_query_count(

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1950,18 +1950,18 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
 
     @ddt.data(
         ('staff', 'courseA', 8),
-        ('staff', 'libraryA', 17),
-        ('staff', 'collection_key', 17),
-        ("content_creatorA", 'courseA', 17, False),
-        ("content_creatorA", 'libraryA', 22, False),
-        ("content_creatorA", 'collection_key', 22, False),
-        ("library_staffA", 'libraryA', 22, False),  # Library users can only view objecttags, not change them?
-        ("library_staffA", 'collection_key', 22, False),
-        ("library_userA", 'libraryA', 22, False),
-        ("library_userA", 'collection_key', 22, False),
-        ("instructorA", 'courseA', 17),
-        ("course_instructorA", 'courseA', 17),
-        ("course_staffA", 'courseA', 17),
+        ('staff', 'libraryA', 9),
+        ('staff', 'collection_key', 9),
+        ("content_creatorA", 'courseA', 18, False),
+        ("content_creatorA", 'libraryA', 24, False),
+        ("content_creatorA", 'collection_key', 24, False),
+        ("library_staffA", 'libraryA', 24, False),  # Library users can only view objecttags, not change them?
+        ("library_staffA", 'collection_key', 24, False),
+        ("library_userA", 'libraryA', 24, False),
+        ("library_userA", 'collection_key', 24, False),
+        ("instructorA", 'courseA', 18),
+        ("course_instructorA", 'courseA', 18),
+        ("course_staffA", 'courseA', 18),
     )
     @ddt.unpack
     def test_object_tags_query_count(

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -1950,15 +1950,15 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
 
     @ddt.data(
         ('staff', 'courseA', 8),
-        ('staff', 'libraryA', 9),
-        ('staff', 'collection_key', 9),
+        ('staff', 'libraryA', 11),
+        ('staff', 'collection_key', 11),
         ("content_creatorA", 'courseA', 18, False),
-        ("content_creatorA", 'libraryA', 24, False),
-        ("content_creatorA", 'collection_key', 24, False),
-        ("library_staffA", 'libraryA', 24, False),  # Library users can only view objecttags, not change them?
-        ("library_staffA", 'collection_key', 24, False),
-        ("library_userA", 'libraryA', 24, False),
-        ("library_userA", 'collection_key', 24, False),
+        ("content_creatorA", 'libraryA', 32, False),
+        ("content_creatorA", 'collection_key', 32, False),
+        ("library_staffA", 'libraryA', 32, False),  # Library users can only view objecttags, not change them?
+        ("library_staffA", 'collection_key', 32, False),
+        ("library_userA", 'libraryA', 32, False),
+        ("library_userA", 'collection_key', 32, False),
         ("instructorA", 'courseA', 18),
         ("course_instructorA", 'courseA', 18),
         ("course_staffA", 'courseA', 18),

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -298,6 +298,11 @@ def can_remove_object_tag_objectid(user: UserType, object_id: str) -> bool:
     except (ValueError, AssertionError):
         return False
 
+    # For Content Libraries V2, check specific tagging permission
+    if isinstance(context_key, LibraryLocatorV2) and has_library_tagging_access(user, context_key):
+        return True
+
+    # For other contexts (courses, xblocks, etc.), use general write access
     if has_studio_write_access(user, context_key):
         return True
 

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -7,9 +7,10 @@ from typing import Union
 import django.contrib.auth.models
 import openedx_tagging.rules as oel_tagging
 import rules
+from opaque_keys.edx.locator import LibraryLocatorV2
 from organizations.models import Organization
 
-from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
+from common.djangoapps.student.auth import has_library_tagging_access, has_studio_read_access, has_studio_write_access
 from common.djangoapps.student.role_helpers import get_course_roles, get_role_cache
 from common.djangoapps.student.roles import (
     CourseInstructorRole,
@@ -217,7 +218,10 @@ def can_change_taxonomy(user: UserType, taxonomy: oel_tagging.Taxonomy) -> bool:
 @rules.predicate
 def can_change_object_tag_objectid(user: UserType, object_id: str) -> bool:
     """
-    Everyone that has permission to edit the object should be able to tag it.
+    Check if user has permission to tag the object.
+
+    For Content Libraries V2: requires MANAGE_LIBRARY_TAGS permission.
+    For other contexts (courses, etc.): requires edit/write access.
     """
     if not object_id:
         return True
@@ -228,6 +232,11 @@ def can_change_object_tag_objectid(user: UserType, object_id: str) -> bool:
     except (ValueError, AssertionError):
         return False
 
+    # For Content Libraries V2, check specific tagging permission
+    if isinstance(context_key, LibraryLocatorV2) and has_library_tagging_access(user, context_key):
+        return True
+
+    # For other contexts (courses, xblocks, etc.), use general write access
     if has_studio_write_access(user, context_key):
         return True
 

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -8,9 +8,11 @@ import django.contrib.auth.models
 import openedx_tagging.rules as oel_tagging
 import rules
 from opaque_keys.edx.locator import LibraryLocatorV2
+from openedx_authz import api as authz_api
+from openedx_authz.constants import permissions as authz_permissions
 from organizations.models import Organization
 
-from common.djangoapps.student.auth import has_library_tagging_access, has_studio_read_access, has_studio_write_access
+from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
 from common.djangoapps.student.role_helpers import get_course_roles, get_role_cache
 from common.djangoapps.student.roles import (
     CourseInstructorRole,
@@ -237,7 +239,11 @@ def can_change_object_tag_objectid(user: UserType, object_id: str) -> bool:
 
     # For Content Libraries V2, prefer explicit library tagging permission,
     # but fall back to org-level admin access for backwards compatibility.
-    if isinstance(context_key, LibraryLocatorV2) and has_library_tagging_access(user, context_key):
+    if isinstance(context_key, LibraryLocatorV2) and authz_api.is_user_allowed(
+        user.username,
+        authz_permissions.MANAGE_LIBRARY_TAGS.identifier,
+        str(context_key),
+    ):
         return True
 
     # For other contexts (courses, xblocks, etc.), use general write or org-admin access
@@ -310,7 +316,11 @@ def can_remove_object_tag_objectid(user: UserType, object_id: str) -> bool:
 
     # For Content Libraries V2, prefer explicit library tagging permission,
     # but fall back to org-level admin access for backwards compatibility.
-    if isinstance(context_key, LibraryLocatorV2) and has_library_tagging_access(user, context_key):
+    if isinstance(context_key, LibraryLocatorV2) and authz_api.is_user_allowed(
+        user.username,
+        authz_permissions.MANAGE_LIBRARY_TAGS.identifier,
+        str(context_key),
+    ):
         return True
 
     # For other contexts (courses, xblocks, etc.), use general write or org-admin access

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -238,7 +238,7 @@ def can_change_object_tag_objectid(user: UserType, object_id: str) -> bool:
         return False
 
     # For Content Libraries V2, prefer explicit library tagging permission,
-    # but fall back to org-level admin access for backwards compatibility.
+    # however, org-level admins are also allowed to perform these operations.
     if isinstance(context_key, LibraryLocatorV2) and authz_api.is_user_allowed(
         user.username,
         authz_permissions.MANAGE_LIBRARY_TAGS.identifier,
@@ -315,7 +315,7 @@ def can_remove_object_tag_objectid(user: UserType, object_id: str) -> bool:
         return False
 
     # For Content Libraries V2, prefer explicit library tagging permission,
-    # but fall back to org-level admin access for backwards compatibility.
+    # however, org-level admins are also allowed to perform these operations.
     if isinstance(context_key, LibraryLocatorV2) and authz_api.is_user_allowed(
         user.username,
         authz_permissions.MANAGE_LIBRARY_TAGS.identifier,

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -218,10 +218,13 @@ def can_change_taxonomy(user: UserType, taxonomy: oel_tagging.Taxonomy) -> bool:
 @rules.predicate
 def can_change_object_tag_objectid(user: UserType, object_id: str) -> bool:
     """
-    Check if user has permission to tag the object.
+    Return True if the user may add or modify tags on the given object.
 
-    For Content Libraries V2: requires MANAGE_LIBRARY_TAGS permission.
-    For other contexts (courses, etc.): requires edit/write access.
+    For Content Libraries V2, this requires either explicit library tagging permission
+    (MANAGE_LIBRARY_TAGS) or org-level admin access for the library's org.
+
+    For other contexts (courses, xblocks, etc.), this requires studio write access or
+    org-level admin access for the object's org.
     """
     if not object_id:
         return True
@@ -285,7 +288,13 @@ def can_view_object_tag_objectid(user: UserType, object_id: str) -> bool:
 @rules.predicate
 def can_remove_object_tag_objectid(user: UserType, object_id: str) -> bool:
     """
-    Everyone that has permission to edit the object should be able remove tags from it.
+    Return True if the user may remove tags from the given object.
+
+    For Content Libraries V2, this requires either explicit library tagging permission
+    (MANAGE_LIBRARY_TAGS) or org-level admin access for the library's org.
+
+    For other contexts (courses, xblocks, etc.), this requires studio write access or
+    org-level admin access for the object's org.
     """
     if not object_id:
         raise ValueError("object_id must be provided")

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -232,11 +232,12 @@ def can_change_object_tag_objectid(user: UserType, object_id: str) -> bool:
     except (ValueError, AssertionError):
         return False
 
-    # For Content Libraries V2, check specific tagging permission
+    # For Content Libraries V2, prefer explicit library tagging permission,
+    # but fall back to org-level admin access for backwards compatibility.
     if isinstance(context_key, LibraryLocatorV2) and has_library_tagging_access(user, context_key):
         return True
 
-    # For other contexts (courses, xblocks, etc.), use general write access
+    # For other contexts (courses, xblocks, etc.), use general write or org-admin access
     if has_studio_write_access(user, context_key):
         return True
 
@@ -298,11 +299,12 @@ def can_remove_object_tag_objectid(user: UserType, object_id: str) -> bool:
     except (ValueError, AssertionError):
         return False
 
-    # For Content Libraries V2, check specific tagging permission
+    # For Content Libraries V2, prefer explicit library tagging permission,
+    # but fall back to org-level admin access for backwards compatibility.
     if isinstance(context_key, LibraryLocatorV2) and has_library_tagging_access(user, context_key):
         return True
 
-    # For other contexts (courses, xblocks, etc.), use general write access
+    # For other contexts (courses, xblocks, etc.), use general write or org-admin access
     if has_studio_write_access(user, context_key):
         return True
 

--- a/openedx/core/djangoapps/content_tagging/tests/test_rules.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_rules.py
@@ -1,16 +1,28 @@
 """Tests content_tagging rules-based permissions"""
 
+from unittest.mock import patch
+
 import ddt
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+<<<<<<< HEAD
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from openedx_tagging.models import Tag, UserSystemDefinedTaxonomy
+=======
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator, LibraryLocatorV2
+from openedx_authz.constants import permissions as authz_permissions
+from openedx_tagging.models import (
+    Tag,
+    UserSystemDefinedTaxonomy,
+)
+>>>>>>> 473bf5f071 (test: add unit tests for MANAGE_LIBRARY_TAGS permission)
 from openedx_tagging.rules import ObjectTagPermissionItem
 
 from common.djangoapps.student.auth import add_users, update_org_role
 from common.djangoapps.student.roles import CourseStaffRole, OrgStaffRole
 
 from .. import api
+from ..rules import can_change_object_tag_objectid, can_remove_object_tag_objectid
 from .test_api import TestTaxonomyMixin
 
 User = get_user_model()
@@ -605,3 +617,137 @@ class TestRulesTaxonomy(TestTaxonomyMixin, TestCase):
         assert not self.user_both_orgs.has_perm(perm, self.disabled_course_tag)
         assert not self.user_org2.has_perm(perm, self.disabled_course_tag)
         assert not self.learner.has_perm(perm, self.disabled_course_tag)
+
+
+class TestRulesLibraryV2Permissions(TestTaxonomyMixin, TestCase):
+    """
+    Tests for Content Library V2 permissions with MANAGE_LIBRARY_TAGS.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.library_user = User.objects.create(
+            username="library_user",
+            email="library_user@example.com",
+        )
+        self.org_admin = User.objects.create(
+            username="org_admin",
+            email="org_admin@example.com",
+        )
+        self.regular_user = User.objects.create(
+            username="regular_user",
+            email="regular_user@example.com",
+        )
+        self.superuser = User.objects.create(
+            username="superuser",
+            email="superuser@example.com",
+            is_superuser=True,
+        )
+
+        # Make org_admin an OrgStaffRole for org1
+        update_org_role(
+            self.superuser,
+            OrgStaffRole,
+            self.org_admin,
+            [self.org1.short_name],
+        )
+
+        self.library_key = LibraryLocatorV2.from_string(f"lib:{self.org1.short_name}:test_library")
+
+    @patch("openedx_authz.api.is_user_allowed")
+    def test_change_objecttag_objectid_with_manage_library_tags_permission(self, mock_is_user_allowed):
+        """
+        Test that a user with MANAGE_LIBRARY_TAGS permission can change tags on a library.
+        """
+        mock_is_user_allowed.return_value = True
+
+        result = can_change_object_tag_objectid(self.library_user, str(self.library_key))
+
+        self.assertTrue(result)
+        mock_is_user_allowed.assert_called_once_with(
+            self.library_user.username,
+            authz_permissions.MANAGE_LIBRARY_TAGS.identifier,
+            str(self.library_key),
+        )
+
+    @patch("openedx_authz.api.is_user_allowed")
+    def test_change_objecttag_objectid_without_manage_library_tags_but_org_admin(self, mock_is_user_allowed):
+        """
+        Test that an org admin can change tags on a library even without
+        explicit MANAGE_LIBRARY_TAGS permission.
+        """
+        mock_is_user_allowed.return_value = False
+
+        result = can_change_object_tag_objectid(self.org_admin, str(self.library_key))
+
+        self.assertTrue(result)
+
+    @patch("openedx_authz.api.is_user_allowed")
+    def test_change_objecttag_objectid_without_permissions(self, mock_is_user_allowed):
+        """
+        Test that a regular user without MANAGE_LIBRARY_TAGS permission and
+        without org admin access cannot change tags.
+        """
+        mock_is_user_allowed.return_value = False
+
+        result = can_change_object_tag_objectid(self.regular_user, str(self.library_key))
+
+        self.assertFalse(result)
+
+    @patch("openedx_authz.api.is_user_allowed")
+    def test_remove_objecttag_objectid_with_manage_library_tags_permission(self, mock_is_user_allowed):
+        """
+        Test that a user with MANAGE_LIBRARY_TAGS permission can remove tags
+        from a library.
+        """
+        mock_is_user_allowed.return_value = True
+
+        result = can_remove_object_tag_objectid(self.library_user, str(self.library_key))
+
+        self.assertTrue(result)
+        mock_is_user_allowed.assert_called_once_with(
+            self.library_user.username,
+            authz_permissions.MANAGE_LIBRARY_TAGS.identifier,
+            str(self.library_key),
+        )
+
+    @patch("openedx_authz.api.is_user_allowed")
+    def test_remove_objecttag_objectid_without_manage_library_tags_but_org_admin(self, mock_is_user_allowed):
+        """
+        Test that an org admin can remove tags from a library even without
+        explicit MANAGE_LIBRARY_TAGS permission.
+        """
+        mock_is_user_allowed.return_value = False
+
+        result = can_remove_object_tag_objectid(self.org_admin, str(self.library_key))
+
+        self.assertTrue(result)
+
+    @patch("openedx_authz.api.is_user_allowed")
+    def test_remove_objecttag_objectid_without_permissions(self, mock_is_user_allowed):
+        """
+        Test that a regular user without MANAGE_LIBRARY_TAGS permission and
+        without org admin access cannot remove tags.
+        """
+        mock_is_user_allowed.return_value = False
+
+        result = can_remove_object_tag_objectid(self.regular_user, str(self.library_key))
+
+        self.assertFalse(result)
+
+    def test_invalid_library_key(self):
+        """
+        Test that invalid library keys return False.
+        """
+        self.assertFalse(can_change_object_tag_objectid(self.library_user, "invalid_key"))
+        self.assertFalse(can_remove_object_tag_objectid(self.library_user, "invalid_key"))
+
+    def test_empty_object_id(self):
+        """
+        Test behavior with empty object_id.
+        """
+        self.assertTrue(can_change_object_tag_objectid(self.library_user, ""))
+
+        with self.assertRaises(ValueError):
+            can_remove_object_tag_objectid(self.library_user, "")

--- a/openedx/core/djangoapps/content_tagging/tests/test_rules.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_rules.py
@@ -5,17 +5,9 @@ from unittest.mock import patch
 import ddt
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-<<<<<<< HEAD
-from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
-from openedx_tagging.models import Tag, UserSystemDefinedTaxonomy
-=======
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator, LibraryLocatorV2
 from openedx_authz.constants import permissions as authz_permissions
-from openedx_tagging.models import (
-    Tag,
-    UserSystemDefinedTaxonomy,
-)
->>>>>>> 473bf5f071 (test: add unit tests for MANAGE_LIBRARY_TAGS permission)
+from openedx_tagging.models import Tag, UserSystemDefinedTaxonomy
 from openedx_tagging.rules import ObjectTagPermissionItem
 
 from common.djangoapps.student.auth import add_users, update_org_role


### PR DESCRIPTION
## Description

This PR adds missing authorization enforcement points for Content Libraries v2, aligning tagging and reuse operations with the new granular authz permissions (notably `MANAGE_LIBRARY_TAGS` and `REUSE_LIBRARY_CONTENT`). Currently, some operations on Content Libraries v2 rely on **generic edit/view permissions** instead of the more specific g2 authz permissions

### What This PR Changes

- **New helper for library tagging access**
  - Adds `has_library_tagging_access(user, library_key)`. This helper looks up the `ContentLibrary` object and checks `MANAGE_LIBRARY_TAGS` via `user_has_permission_across_lib_authz_systems`.

- **Updated tagging rules for library content**
  - Updates `can_change_object_tag_objectid` and `can_remove_object_tag_objectid`. If the context is a `LibraryLocatorV2`, it now uses `has_library_tagging_access` and therefore requires `MANAGE_LIBRARY_TAGS`. For other contexts (courses, XBlocks, etc.), it still falls back to `has_studio_write_access` as before.

- **New enforcement for content reuse flows**
  - The `LibraryPasteClipboardView` now requires `authz_permissions.EDIT_LIBRARY_CONTENT` instead of the legacy `CAN_EDIT_THIS_CONTENT_LIBRARY` permission.
  - The `ClipboardEndpoint` now requires `REUSE_LIBRARY_CONTENT` (rather than `CAN_VIEW_THIS_CONTENT_LIBRARY`) when bringing content from a library into a course.

- **Authz-to-legacy permission mapping updates**
  - In `_transform_authz_permission_to_legacy_lib_permission` is extended so that:
    - `MANAGE_LIBRARY_TAGS` → `CAN_EDIT_THIS_CONTENT_LIBRARY`
    - `REUSE_LIBRARY_CONTENT` → `CAN_VIEW_THIS_CONTENT_LIBRARY`
  - This keeps the **legacy permission layer in sync** with the new authz permissions.

## Supporting information

- https://github.com/openedx/openedx-authz/issues/154

## Testing instructions

You can test the following endpoints:

### `REUSE_LIBRARY_CONTENT`

All library roles (**Library Admin, Library Author, Library Contributor, and Library User**) can reuse library content:

- **POST** `{studio_domain}/api/content-staging/v1/clipboard/`: Copy content to the clipboard.

### `MANAGE_LIBRARY_TAGS`

All library roles (except **Library User**) can manage (add or remove) tags for content in a library:

- **PUT** `{studio_domain}/api/content_tagging/v1/object_tags/{object_key}/`: Add or remove tags from library content.

You can use the following [Postman Collection](https://github.com/user-attachments/files/25800309/pr-38071-endpoints.postman_collection.json).

## Deadline
None
