### PR TITLE
fix: discussion tab visibility on import

### DIFF
--- a/openedx/core/djangoapps/discussions/handlers.py
+++ b/openedx/core/djangoapps/discussions/handlers.py
@@ -96,12 +96,17 @@ def update_course_discussion_config(configuration: CourseDiscussionConfiguration
             log.info(f"Course {course_key} doesn't have discussion configuration model yet. Creating a new one.")
             DiscussionsConfiguration(
                 context_key=course_key,
+                enabled=configuration.enabled,
                 provider_type=provider_id,
                 plugin_configuration=configuration.plugin_configuration,
                 enable_in_context=configuration.enable_in_context,
                 enable_graded_units=configuration.enable_graded_units,
                 unit_level_visibility=configuration.unit_level_visibility,
             ).save()
+        else:
+            DiscussionsConfiguration.objects.filter(
+                context_key=course_key,
+            ).update(enabled=configuration.enabled)
 
 
 COURSE_DISCUSSIONS_CHANGED.connect(handle_course_discussion_config_update)

--- a/openedx/core/djangoapps/discussions/handlers.py
+++ b/openedx/core/djangoapps/discussions/handlers.py
@@ -14,7 +14,6 @@ from openedx.core.djangoapps.discussions.models import (
     get_default_provider_type,
 )
 
-
 log = logging.getLogger(__name__)
 
 

--- a/openedx/core/djangoapps/discussions/handlers.py
+++ b/openedx/core/djangoapps/discussions/handlers.py
@@ -13,8 +13,7 @@ from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
     get_default_provider_type,
 )
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
+
 
 log = logging.getLogger(__name__)
 
@@ -94,45 +93,16 @@ def update_course_discussion_config(configuration: CourseDiscussionConfiguration
             for topic_context in new_topic_map.values()
         ])
 
-        # Determine the 'enabled' value from the course's discussion tab state.
-        # When a course is imported/rerun, course.tabs are copied verbatim from the source,
-        # but DiscussionsConfiguration is not updated automatically. We read tab.is_hidden
-        # from modulestore on every publish so that DiscussionsConfiguration.enabled stays
-        # in sync with the tab state. This is safe because the serializer already keeps
-        # tab.is_hidden and enabled in agreement for API-driven changes.
-        enabled = True  # default
-        try:
-            store = modulestore()
-            with store.branch_setting(ModuleStoreEnum.Branch.published_only, course_key):
-                course = store.get_course(course_key)
-                if course:
-                    for tab in course.tabs:
-                        if getattr(tab, 'tab_id', None) == 'discussion':
-                            enabled = not tab.is_hidden
-                            break
-        except Exception:  # pylint: disable=broad-except
-            log.exception(
-                "Failed to read discussion tab state from modulestore for %s, defaulting enabled=True",
-                course_key,
-            )
-
         if not DiscussionsConfiguration.objects.filter(context_key=course_key).exists():
             log.info(f"Course {course_key} doesn't have discussion configuration model yet. Creating a new one.")
             DiscussionsConfiguration(
                 context_key=course_key,
-                enabled=enabled,
                 provider_type=provider_id,
                 plugin_configuration=configuration.plugin_configuration,
                 enable_in_context=configuration.enable_in_context,
                 enable_graded_units=configuration.enable_graded_units,
                 unit_level_visibility=configuration.unit_level_visibility,
             ).save()
-        else:
-            # Sync enabled from the tab state. This covers imports/reruns into a course
-            # that already has a DiscussionsConfiguration — the tab state should win.
-            DiscussionsConfiguration.objects.filter(
-                context_key=course_key,
-            ).update(enabled=enabled)
 
 
 COURSE_DISCUSSIONS_CHANGED.connect(handle_course_discussion_config_update)

--- a/openedx/core/djangoapps/discussions/handlers.py
+++ b/openedx/core/djangoapps/discussions/handlers.py
@@ -13,6 +13,8 @@ from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
     get_default_provider_type,
 )
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
@@ -92,16 +94,45 @@ def update_course_discussion_config(configuration: CourseDiscussionConfiguration
             for topic_context in new_topic_map.values()
         ])
 
+        # Determine the 'enabled' value from the course's discussion tab state.
+        # When a course is imported/rerun, course.tabs are copied verbatim from the source,
+        # but DiscussionsConfiguration is not updated automatically. We read tab.is_hidden
+        # from modulestore on every publish so that DiscussionsConfiguration.enabled stays
+        # in sync with the tab state. This is safe because the serializer already keeps
+        # tab.is_hidden and enabled in agreement for API-driven changes.
+        enabled = True  # default
+        try:
+            store = modulestore()
+            with store.branch_setting(ModuleStoreEnum.Branch.published_only, course_key):
+                course = store.get_course(course_key)
+                if course:
+                    for tab in course.tabs:
+                        if getattr(tab, 'tab_id', None) == 'discussion':
+                            enabled = not tab.is_hidden
+                            break
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "Failed to read discussion tab state from modulestore for %s, defaulting enabled=True",
+                course_key,
+            )
+
         if not DiscussionsConfiguration.objects.filter(context_key=course_key).exists():
             log.info(f"Course {course_key} doesn't have discussion configuration model yet. Creating a new one.")
             DiscussionsConfiguration(
                 context_key=course_key,
+                enabled=enabled,
                 provider_type=provider_id,
                 plugin_configuration=configuration.plugin_configuration,
                 enable_in_context=configuration.enable_in_context,
                 enable_graded_units=configuration.enable_graded_units,
                 unit_level_visibility=configuration.unit_level_visibility,
             ).save()
+        else:
+            # Sync enabled from the tab state. This covers imports/reruns into a course
+            # that already has a DiscussionsConfiguration — the tab state should win.
+            DiscussionsConfiguration.objects.filter(
+                context_key=course_key,
+            ).update(enabled=enabled)
 
 
 COURSE_DISCUSSIONS_CHANGED.connect(handle_course_discussion_config_update)

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -88,8 +88,20 @@ def update_discussions_settings_from_course(
                 )
                 contexts.extend(list(discussable_units))
 
+        # Derive enabled from the discussion tab's is_hidden state.
+        # When a course is imported or rerun, course.tabs are copied verbatim
+        # from the source but DiscussionsConfiguration is not, so we pass the
+        # tab state through config_data for the handler to reconcile.
+        enabled = True
+        if course:
+            for tab in course.tabs:
+                if getattr(tab, 'tab_id', None) == 'discussion':
+                    enabled = not tab.is_hidden
+                    break
+
         config_data = CourseDiscussionConfigurationData(
             course_key=course_key,
+            enabled=enabled,
             enable_in_context=enable_in_context,
             enable_graded_units=enable_graded_units,
             unit_level_visibility=unit_level_visibility,
@@ -97,35 +109,7 @@ def update_discussions_settings_from_course(
             plugin_configuration=provider_config,
             contexts=contexts,
         )
-
-        # Sync DiscussionsConfiguration.enabled from the discussion tab's
-        # is_hidden state. When a course is imported or rerun, course.tabs are
-        # copied verbatim from the source but DiscussionsConfiguration is not,
-        # so we reconcile here where we already have the course loaded.
-        _sync_enabled_from_discussion_tab(course_key, course)
-
     return config_data
-
-
-def _sync_enabled_from_discussion_tab(course_key, course):
-    """
-    Set DiscussionsConfiguration.enabled based on the discussion tab's is_hidden
-    value from the given course object.
-
-    This keeps the DB model in sync with the modulestore tab state, which is
-    especially important after course import or rerun where the tab state is
-    copied but the DiscussionsConfiguration record is not.
-    """
-    enabled = True  # default when no discussion tab is found
-    if course:
-        for tab in course.tabs:
-            if getattr(tab, 'tab_id', None) == 'discussion':
-                enabled = not tab.is_hidden
-                break
-
-    DiscussionsConfiguration.objects.filter(
-        context_key=course_key,
-    ).update(enabled=enabled)
 
 
 def get_discussable_units(course, enable_graded_units, discussable_units=None):

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -97,7 +97,35 @@ def update_discussions_settings_from_course(
             plugin_configuration=provider_config,
             contexts=contexts,
         )
+
+        # Sync DiscussionsConfiguration.enabled from the discussion tab's
+        # is_hidden state. When a course is imported or rerun, course.tabs are
+        # copied verbatim from the source but DiscussionsConfiguration is not,
+        # so we reconcile here where we already have the course loaded.
+        _sync_enabled_from_discussion_tab(course_key, course)
+
     return config_data
+
+
+def _sync_enabled_from_discussion_tab(course_key, course):
+    """
+    Set DiscussionsConfiguration.enabled based on the discussion tab's is_hidden
+    value from the given course object.
+
+    This keeps the DB model in sync with the modulestore tab state, which is
+    especially important after course import or rerun where the tab state is
+    copied but the DiscussionsConfiguration record is not.
+    """
+    enabled = True  # default when no discussion tab is found
+    if course:
+        for tab in course.tabs:
+            if getattr(tab, 'tab_id', None) == 'discussion':
+                enabled = not tab.is_hidden
+                break
+
+    DiscussionsConfiguration.objects.filter(
+        context_key=course_key,
+    ).update(enabled=enabled)
 
 
 def get_discussable_units(course, enable_graded_units, discussable_units=None):

--- a/openedx/core/djangoapps/discussions/tests/test_handlers.py
+++ b/openedx/core/djangoapps/discussions/tests/test_handlers.py
@@ -55,6 +55,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         config_data = CourseDiscussionConfigurationData(
             course_key=new_key,
             provider_type="openedx",
+            plugin_configuration={},
         )
         assert not DiscussionsConfiguration.objects.filter(context_key=new_key).exists()
         update_course_discussion_config(config_data)
@@ -191,3 +192,33 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         assert existing_topic_link.title == "Section 10|Subsection 10|Unit 10"
         # If there is no stored context, then continue using the Unit name.
         assert existing_topic_link_2.title == "Unit 11"
+
+    def test_new_config_uses_enabled_from_configuration(self):
+        """
+        When creating a new DiscussionsConfiguration, the handler should use
+        the enabled value from the configuration data.
+        """
+        new_key = CourseKey.from_string("course-v1:test+test+disabled")
+        config_data = CourseDiscussionConfigurationData(
+            course_key=new_key,
+            provider_type="openedx",
+            enabled=False,
+            plugin_configuration={},
+        )
+        update_course_discussion_config(config_data)
+        db_config = DiscussionsConfiguration.objects.get(context_key=new_key)
+        assert db_config.enabled is False
+
+    def test_existing_config_updated_enabled_from_configuration(self):
+        """
+        When the configuration already exists, the handler should update
+        enabled from the configuration data.
+        """
+        config_data = CourseDiscussionConfigurationData(
+            course_key=self.course_key,
+            provider_type="openedx",
+            enabled=False,
+        )
+        update_course_discussion_config(config_data)
+        db_config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
+        assert db_config.enabled is False

--- a/openedx/core/djangoapps/discussions/tests/test_handlers.py
+++ b/openedx/core/djangoapps/discussions/tests/test_handlers.py
@@ -327,4 +327,3 @@ class TabStateSyncTestCase(TestCase):
 
         config = DiscussionsConfiguration.objects.get(context_key=new_key)
         assert config.enabled is True
-

--- a/openedx/core/djangoapps/discussions/tests/test_handlers.py
+++ b/openedx/core/djangoapps/discussions/tests/test_handlers.py
@@ -1,7 +1,7 @@
 """
 Tests for discussions signal handlers
 """
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import ddt
@@ -11,7 +11,6 @@ from opaque_keys.edx.keys import CourseKey
 from openedx_events.learning.data import CourseDiscussionConfigurationData, DiscussionTopicContext
 from openedx.core.djangoapps.discussions.handlers import update_course_discussion_config
 from openedx.core.djangoapps.discussions.models import DiscussionTopicLink, DiscussionsConfiguration
-from openedx.core.djangoapps.discussions.tasks import _sync_enabled_from_discussion_tab
 
 
 @ddt.ddt
@@ -192,100 +191,3 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         assert existing_topic_link.title == "Section 10|Subsection 10|Unit 10"
         # If there is no stored context, then continue using the Unit name.
         assert existing_topic_link_2.title == "Unit 11"
-
-
-def _make_mock_tab(tab_id, is_hidden=False):
-    """Helper to create a mock course tab."""
-    tab = MagicMock()
-    tab.tab_id = tab_id
-    tab.is_hidden = is_hidden
-    return tab
-
-
-class SyncEnabledFromDiscussionTabTestCase(TestCase):
-    """
-    Tests that _sync_enabled_from_discussion_tab correctly updates
-    DiscussionsConfiguration.enabled based on the discussion tab's is_hidden state.
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.course_key = CourseKey.from_string("course-v1:test+test+test")
-
-    def _make_course(self, tabs):
-        """Create a mock course with the given tabs."""
-        course = MagicMock()
-        course.tabs = tabs
-        return course
-
-    def test_enabled_when_tab_visible(self):
-        """
-        When discussion tab is visible (is_hidden=False), enabled should be True.
-        """
-        DiscussionsConfiguration.objects.create(
-            context_key=self.course_key,
-            provider_type="openedx",
-            enabled=False,
-        )
-        course = self._make_course([
-            _make_mock_tab("courseware"),
-            _make_mock_tab("discussion", is_hidden=False),
-        ])
-
-        _sync_enabled_from_discussion_tab(self.course_key, course)
-
-        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
-        assert config.enabled is True
-
-    def test_disabled_when_tab_hidden(self):
-        """
-        When discussion tab is hidden (is_hidden=True), enabled should be False.
-        """
-        DiscussionsConfiguration.objects.create(
-            context_key=self.course_key,
-            provider_type="openedx",
-            enabled=True,
-        )
-        course = self._make_course([
-            _make_mock_tab("courseware"),
-            _make_mock_tab("discussion", is_hidden=True),
-        ])
-
-        _sync_enabled_from_discussion_tab(self.course_key, course)
-
-        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
-        assert config.enabled is False
-
-    def test_defaults_to_enabled_when_no_discussion_tab(self):
-        """
-        If the course has no discussion tab, enabled should default to True.
-        """
-        DiscussionsConfiguration.objects.create(
-            context_key=self.course_key,
-            provider_type="openedx",
-            enabled=False,
-        )
-        course = self._make_course([
-            _make_mock_tab("courseware"),
-            _make_mock_tab("progress"),
-        ])
-
-        _sync_enabled_from_discussion_tab(self.course_key, course)
-
-        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
-        assert config.enabled is True
-
-    def test_defaults_to_enabled_when_course_is_none(self):
-        """
-        If the course object is None, enabled should default to True.
-        """
-        DiscussionsConfiguration.objects.create(
-            context_key=self.course_key,
-            provider_type="openedx",
-            enabled=False,
-        )
-
-        _sync_enabled_from_discussion_tab(self.course_key, None)
-
-        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
-        assert config.enabled is True

--- a/openedx/core/djangoapps/discussions/tests/test_handlers.py
+++ b/openedx/core/djangoapps/discussions/tests/test_handlers.py
@@ -11,10 +11,10 @@ from opaque_keys.edx.keys import CourseKey
 from openedx_events.learning.data import CourseDiscussionConfigurationData, DiscussionTopicContext
 from openedx.core.djangoapps.discussions.handlers import update_course_discussion_config
 from openedx.core.djangoapps.discussions.models import DiscussionTopicLink, DiscussionsConfiguration
+from openedx.core.djangoapps.discussions.tasks import _sync_enabled_from_discussion_tab
 
 
 @ddt.ddt
-@patch("openedx.core.djangoapps.discussions.handlers.modulestore")
 class UpdateCourseDiscussionsConfigTestCase(TestCase):
     """
     Tests for the discussion config update handler.
@@ -48,7 +48,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
                 },
             )
 
-    def test_configuration_for_new_course(self, mock_modulestore):
+    def test_configuration_for_new_course(self):
         """
         Test that a new course gets a new discussion configuration object
         """
@@ -63,7 +63,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         db_config = DiscussionsConfiguration.objects.get(context_key=new_key)
         assert db_config.provider_type == "openedx"
 
-    def test_creating_new_links(self, mock_modulestore):
+    def test_creating_new_links(self):
         """
         Test that new links are created in the db when they are added in the config.
         """
@@ -77,7 +77,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         topic_links = DiscussionTopicLink.objects.filter(context_key=self.course_key)
         assert topic_links.count() == len(contexts)  # 2 general + 3 units
 
-    def test_updating_existing_links(self, mock_modulestore):
+    def test_updating_existing_links(self):
         """
         Test that updating existing links works as expected.
         """
@@ -113,7 +113,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         "openedx.core.djangoapps.discussions.models.AVAILABLE_PROVIDER_MAP",
         {"test": {"supports_in_context_discussions": True}},
     )
-    def test_provider_change(self, mock_modulestore):
+    def test_provider_change(self):
         """
         Test that changing providers creates new links, and doesn't update existing ones.
         """
@@ -149,7 +149,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         # The new link will get a new id
         assert new_link.external_id != str(existing_external_id)
 
-    def test_enabled_units_change(self, mock_modulestore):
+    def test_enabled_units_change(self):
         """
         Test that when enabled units change, old unit links are disabled in context.
         """
@@ -202,128 +202,90 @@ def _make_mock_tab(tab_id, is_hidden=False):
     return tab
 
 
-def _mock_modulestore_with_tabs(course_key, tabs):
+class SyncEnabledFromDiscussionTabTestCase(TestCase):
     """
-    Return a mock modulestore whose get_course returns a course with the given tabs.
-    The mock supports the branch_setting context-manager protocol.
-    """
-    mock_course = MagicMock()
-    mock_course.tabs = tabs
-
-    store = MagicMock()
-    store.get_course.return_value = mock_course
-    store.branch_setting.return_value.__enter__ = MagicMock(return_value=store)
-    store.branch_setting.return_value.__exit__ = MagicMock(return_value=False)
-    return store
-
-
-@patch("openedx.core.djangoapps.discussions.handlers.modulestore")
-class TabStateSyncTestCase(TestCase):
-    """
-    Tests that DiscussionsConfiguration.enabled is synced from the discussion
-    tab's is_hidden state in the modulestore.
+    Tests that _sync_enabled_from_discussion_tab correctly updates
+    DiscussionsConfiguration.enabled based on the discussion tab's is_hidden state.
     """
 
     def setUp(self):
         super().setUp()
         self.course_key = CourseKey.from_string("course-v1:test+test+test")
 
-    def _build_config_data(self, course_key=None):
-        return CourseDiscussionConfigurationData(
-            course_key=course_key or self.course_key,
-            provider_type="openedx",
-        )
+    def _make_course(self, tabs):
+        """Create a mock course with the given tabs."""
+        course = MagicMock()
+        course.tabs = tabs
+        return course
 
-    # -- New configuration creation (no existing DiscussionsConfiguration) --
-
-    def test_new_config_enabled_when_tab_visible(self, mock_modulestore):
+    def test_enabled_when_tab_visible(self):
         """
-        When creating a DiscussionsConfiguration for a brand-new course whose
-        discussion tab is visible (is_hidden=False), enabled should be True.
-        """
-        new_key = CourseKey.from_string("course-v1:test+test+new_visible")
-        tabs = [
-            _make_mock_tab("courseware"),
-            _make_mock_tab("discussion", is_hidden=False),
-        ]
-        mock_modulestore.return_value = _mock_modulestore_with_tabs(new_key, tabs)
-
-        update_course_discussion_config(self._build_config_data(new_key))
-
-        config = DiscussionsConfiguration.objects.get(context_key=new_key)
-        assert config.enabled is True
-
-    def test_new_config_disabled_when_tab_hidden(self, mock_modulestore):
-        """
-        When creating a DiscussionsConfiguration for a brand-new course whose
-        discussion tab is hidden (is_hidden=True), enabled should be False.
-        """
-        new_key = CourseKey.from_string("course-v1:test+test+new_hidden")
-        tabs = [
-            _make_mock_tab("courseware"),
-            _make_mock_tab("discussion", is_hidden=True),
-        ]
-        mock_modulestore.return_value = _mock_modulestore_with_tabs(new_key, tabs)
-
-        update_course_discussion_config(self._build_config_data(new_key))
-
-        config = DiscussionsConfiguration.objects.get(context_key=new_key)
-        assert config.enabled is False
-
-    # -- Existing configuration update (import / rerun scenario) --
-
-    def test_existing_config_updated_to_disabled_on_import(self, mock_modulestore):
-        """
-        Simulates importing a course with a hidden discussion tab into a course
-        that already has DiscussionsConfiguration(enabled=True). After publish,
-        enabled should become False to match the imported tab state.
-        """
-        DiscussionsConfiguration.objects.create(
-            context_key=self.course_key,
-            provider_type="openedx",
-            enabled=True,
-        )
-        tabs = [
-            _make_mock_tab("courseware"),
-            _make_mock_tab("discussion", is_hidden=True),
-        ]
-        mock_modulestore.return_value = _mock_modulestore_with_tabs(self.course_key, tabs)
-
-        update_course_discussion_config(self._build_config_data())
-
-        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
-        assert config.enabled is False
-
-    def test_existing_config_updated_to_enabled_on_import(self, mock_modulestore):
-        """
-        If an existing config has enabled=False and the imported course has a
-        visible discussion tab (is_hidden=False), enabled should be set to True.
+        When discussion tab is visible (is_hidden=False), enabled should be True.
         """
         DiscussionsConfiguration.objects.create(
             context_key=self.course_key,
             provider_type="openedx",
             enabled=False,
         )
-        tabs = [
+        course = self._make_course([
             _make_mock_tab("courseware"),
             _make_mock_tab("discussion", is_hidden=False),
-        ]
-        mock_modulestore.return_value = _mock_modulestore_with_tabs(self.course_key, tabs)
+        ])
 
-        update_course_discussion_config(self._build_config_data())
+        _sync_enabled_from_discussion_tab(self.course_key, course)
 
         config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
         assert config.enabled is True
 
-    def test_modulestore_failure_defaults_to_enabled(self, mock_modulestore):
+    def test_disabled_when_tab_hidden(self):
         """
-        If the modulestore read throws an exception, enabled should default to True
-        so discussion isn't accidentally disabled.
+        When discussion tab is hidden (is_hidden=True), enabled should be False.
         """
-        new_key = CourseKey.from_string("course-v1:test+test+ms_fail")
-        mock_modulestore.return_value.branch_setting.side_effect = Exception("boom")
+        DiscussionsConfiguration.objects.create(
+            context_key=self.course_key,
+            provider_type="openedx",
+            enabled=True,
+        )
+        course = self._make_course([
+            _make_mock_tab("courseware"),
+            _make_mock_tab("discussion", is_hidden=True),
+        ])
 
-        update_course_discussion_config(self._build_config_data(new_key))
+        _sync_enabled_from_discussion_tab(self.course_key, course)
 
-        config = DiscussionsConfiguration.objects.get(context_key=new_key)
+        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
+        assert config.enabled is False
+
+    def test_defaults_to_enabled_when_no_discussion_tab(self):
+        """
+        If the course has no discussion tab, enabled should default to True.
+        """
+        DiscussionsConfiguration.objects.create(
+            context_key=self.course_key,
+            provider_type="openedx",
+            enabled=False,
+        )
+        course = self._make_course([
+            _make_mock_tab("courseware"),
+            _make_mock_tab("progress"),
+        ])
+
+        _sync_enabled_from_discussion_tab(self.course_key, course)
+
+        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
+        assert config.enabled is True
+
+    def test_defaults_to_enabled_when_course_is_none(self):
+        """
+        If the course object is None, enabled should default to True.
+        """
+        DiscussionsConfiguration.objects.create(
+            context_key=self.course_key,
+            provider_type="openedx",
+            enabled=False,
+        )
+
+        _sync_enabled_from_discussion_tab(self.course_key, None)
+
+        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
         assert config.enabled is True

--- a/openedx/core/djangoapps/discussions/tests/test_handlers.py
+++ b/openedx/core/djangoapps/discussions/tests/test_handlers.py
@@ -1,7 +1,7 @@
 """
 Tests for discussions signal handlers
 """
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import ddt
@@ -14,6 +14,7 @@ from openedx.core.djangoapps.discussions.models import DiscussionTopicLink, Disc
 
 
 @ddt.ddt
+@patch("openedx.core.djangoapps.discussions.handlers.modulestore")
 class UpdateCourseDiscussionsConfigTestCase(TestCase):
     """
     Tests for the discussion config update handler.
@@ -47,7 +48,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
                 },
             )
 
-    def test_configuration_for_new_course(self):
+    def test_configuration_for_new_course(self, mock_modulestore):
         """
         Test that a new course gets a new discussion configuration object
         """
@@ -62,7 +63,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         db_config = DiscussionsConfiguration.objects.get(context_key=new_key)
         assert db_config.provider_type == "openedx"
 
-    def test_creating_new_links(self):
+    def test_creating_new_links(self, mock_modulestore):
         """
         Test that new links are created in the db when they are added in the config.
         """
@@ -76,7 +77,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         topic_links = DiscussionTopicLink.objects.filter(context_key=self.course_key)
         assert topic_links.count() == len(contexts)  # 2 general + 3 units
 
-    def test_updating_existing_links(self):
+    def test_updating_existing_links(self, mock_modulestore):
         """
         Test that updating existing links works as expected.
         """
@@ -112,7 +113,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         "openedx.core.djangoapps.discussions.models.AVAILABLE_PROVIDER_MAP",
         {"test": {"supports_in_context_discussions": True}},
     )
-    def test_provider_change(self):
+    def test_provider_change(self, mock_modulestore):
         """
         Test that changing providers creates new links, and doesn't update existing ones.
         """
@@ -148,7 +149,7 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         # The new link will get a new id
         assert new_link.external_id != str(existing_external_id)
 
-    def test_enabled_units_change(self):
+    def test_enabled_units_change(self, mock_modulestore):
         """
         Test that when enabled units change, old unit links are disabled in context.
         """
@@ -191,3 +192,139 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         assert existing_topic_link.title == "Section 10|Subsection 10|Unit 10"
         # If there is no stored context, then continue using the Unit name.
         assert existing_topic_link_2.title == "Unit 11"
+
+
+def _make_mock_tab(tab_id, is_hidden=False):
+    """Helper to create a mock course tab."""
+    tab = MagicMock()
+    tab.tab_id = tab_id
+    tab.is_hidden = is_hidden
+    return tab
+
+
+def _mock_modulestore_with_tabs(course_key, tabs):
+    """
+    Return a mock modulestore whose get_course returns a course with the given tabs.
+    The mock supports the branch_setting context-manager protocol.
+    """
+    mock_course = MagicMock()
+    mock_course.tabs = tabs
+
+    store = MagicMock()
+    store.get_course.return_value = mock_course
+    store.branch_setting.return_value.__enter__ = MagicMock(return_value=store)
+    store.branch_setting.return_value.__exit__ = MagicMock(return_value=False)
+    return store
+
+
+@patch("openedx.core.djangoapps.discussions.handlers.modulestore")
+class TabStateSyncTestCase(TestCase):
+    """
+    Tests that DiscussionsConfiguration.enabled is synced from the discussion
+    tab's is_hidden state in the modulestore.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course_key = CourseKey.from_string("course-v1:test+test+test")
+
+    def _build_config_data(self, course_key=None):
+        return CourseDiscussionConfigurationData(
+            course_key=course_key or self.course_key,
+            provider_type="openedx",
+        )
+
+    # -- New configuration creation (no existing DiscussionsConfiguration) --
+
+    def test_new_config_enabled_when_tab_visible(self, mock_modulestore):
+        """
+        When creating a DiscussionsConfiguration for a brand-new course whose
+        discussion tab is visible (is_hidden=False), enabled should be True.
+        """
+        new_key = CourseKey.from_string("course-v1:test+test+new_visible")
+        tabs = [
+            _make_mock_tab("courseware"),
+            _make_mock_tab("discussion", is_hidden=False),
+        ]
+        mock_modulestore.return_value = _mock_modulestore_with_tabs(new_key, tabs)
+
+        update_course_discussion_config(self._build_config_data(new_key))
+
+        config = DiscussionsConfiguration.objects.get(context_key=new_key)
+        assert config.enabled is True
+
+    def test_new_config_disabled_when_tab_hidden(self, mock_modulestore):
+        """
+        When creating a DiscussionsConfiguration for a brand-new course whose
+        discussion tab is hidden (is_hidden=True), enabled should be False.
+        """
+        new_key = CourseKey.from_string("course-v1:test+test+new_hidden")
+        tabs = [
+            _make_mock_tab("courseware"),
+            _make_mock_tab("discussion", is_hidden=True),
+        ]
+        mock_modulestore.return_value = _mock_modulestore_with_tabs(new_key, tabs)
+
+        update_course_discussion_config(self._build_config_data(new_key))
+
+        config = DiscussionsConfiguration.objects.get(context_key=new_key)
+        assert config.enabled is False
+
+    # -- Existing configuration update (import / rerun scenario) --
+
+    def test_existing_config_updated_to_disabled_on_import(self, mock_modulestore):
+        """
+        Simulates importing a course with a hidden discussion tab into a course
+        that already has DiscussionsConfiguration(enabled=True). After publish,
+        enabled should become False to match the imported tab state.
+        """
+        DiscussionsConfiguration.objects.create(
+            context_key=self.course_key,
+            provider_type="openedx",
+            enabled=True,
+        )
+        tabs = [
+            _make_mock_tab("courseware"),
+            _make_mock_tab("discussion", is_hidden=True),
+        ]
+        mock_modulestore.return_value = _mock_modulestore_with_tabs(self.course_key, tabs)
+
+        update_course_discussion_config(self._build_config_data())
+
+        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
+        assert config.enabled is False
+
+    def test_existing_config_updated_to_enabled_on_import(self, mock_modulestore):
+        """
+        If an existing config has enabled=False and the imported course has a
+        visible discussion tab (is_hidden=False), enabled should be set to True.
+        """
+        DiscussionsConfiguration.objects.create(
+            context_key=self.course_key,
+            provider_type="openedx",
+            enabled=False,
+        )
+        tabs = [
+            _make_mock_tab("courseware"),
+            _make_mock_tab("discussion", is_hidden=False),
+        ]
+        mock_modulestore.return_value = _mock_modulestore_with_tabs(self.course_key, tabs)
+
+        update_course_discussion_config(self._build_config_data())
+
+        config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
+        assert config.enabled is True
+
+    def test_modulestore_failure_defaults_to_enabled(self, mock_modulestore):
+        """
+        If the modulestore read throws an exception, enabled should default to True
+        so discussion isn't accidentally disabled.
+        """
+        new_key = CourseKey.from_string("course-v1:test+test+ms_fail")
+        mock_modulestore.return_value.branch_setting.side_effect = Exception("boom")
+
+        update_course_discussion_config(self._build_config_data(new_key))
+
+        config = DiscussionsConfiguration.objects.get(context_key=new_key)
+        assert config.enabled is True
+

--- a/openedx/core/djangoapps/discussions/tests/test_tasks.py
+++ b/openedx/core/djangoapps/discussions/tests/test_tasks.py
@@ -185,20 +185,16 @@ class UpdateDiscussionsSettingsFromCourseTestCase(ModuleStoreTestCase, Discussio
         assert not missing_units & units_in_config
 
     @ddt.data(
-        # (initial_enabled, tab_is_hidden, expected_enabled)
-        (True, True, False),   # import with hidden tab → disabled
-        (False, False, True),  # import with visible tab → enabled
+        # (tab_is_hidden, expected_enabled)
+        (True, False),   # import with hidden tab → disabled
+        (False, True),   # import with visible tab → enabled
     )
     @ddt.unpack
-    def test_syncs_enabled_from_discussion_tab(self, initial_enabled, tab_is_hidden, expected_enabled):
+    def test_config_data_enabled_from_discussion_tab(self, tab_is_hidden, expected_enabled):
         """
-        After update_discussions_settings_from_course, DiscussionsConfiguration.enabled
-        should match `not tab.is_hidden` from the course's discussion tab.
+        update_discussions_settings_from_course should set config_data.enabled
+        based on the discussion tab's is_hidden state.
         """
-        discussion_config = DiscussionsConfiguration.get(self.course.id)
-        discussion_config.enabled = initial_enabled
-        discussion_config.save()
-
         course = self.store.get_course(self.course.id)
         for tab in course.tabs:
             if getattr(tab, 'tab_id', None) == 'discussion':
@@ -206,10 +202,9 @@ class UpdateDiscussionsSettingsFromCourseTestCase(ModuleStoreTestCase, Discussio
                 break
         self.store.update_item(course, self.user.id)
 
-        update_discussions_settings_from_course(self.course.id)
+        config_data = update_discussions_settings_from_course(self.course.id)
 
-        discussion_config = DiscussionsConfiguration.get(self.course.id)
-        assert discussion_config.enabled is expected_enabled
+        assert config_data.enabled is expected_enabled
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/discussions/tests/test_tasks.py
+++ b/openedx/core/djangoapps/discussions/tests/test_tasks.py
@@ -184,6 +184,33 @@ class UpdateDiscussionsSettingsFromCourseTestCase(ModuleStoreTestCase, Discussio
         assert present_units <= units_in_config
         assert not missing_units & units_in_config
 
+    @ddt.data(
+        # (initial_enabled, tab_is_hidden, expected_enabled)
+        (True, True, False),   # import with hidden tab → disabled
+        (False, False, True),  # import with visible tab → enabled
+    )
+    @ddt.unpack
+    def test_syncs_enabled_from_discussion_tab(self, initial_enabled, tab_is_hidden, expected_enabled):
+        """
+        After update_discussions_settings_from_course, DiscussionsConfiguration.enabled
+        should match `not tab.is_hidden` from the course's discussion tab.
+        """
+        discussion_config = DiscussionsConfiguration.get(self.course.id)
+        discussion_config.enabled = initial_enabled
+        discussion_config.save()
+
+        course = self.store.get_course(self.course.id)
+        for tab in course.tabs:
+            if getattr(tab, 'tab_id', None) == 'discussion':
+                tab['is_hidden'] = tab_is_hidden
+                break
+        self.store.update_item(course, self.user.id)
+
+        update_discussions_settings_from_course(self.course.id)
+
+        discussion_config = DiscussionsConfiguration.get(self.course.id)
+        assert discussion_config.enabled is expected_enabled
+
 
 @ddt.ddt
 class MigrateUnitDiscussionStateFromXBlockTestCase(ModuleStoreTestCase, DiscussionConfigUpdateMixin):

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -839,7 +839,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/kernel.in
-openedx-events==10.5.0
+openedx-events==11.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1400,7 +1400,7 @@ openedx-django-wiki==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==10.5.0
+openedx-events==11.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1019,7 +1019,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==10.5.0
+openedx-events==11.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1068,7 +1068,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==10.5.0
+openedx-events==11.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

#### Problem

When a course is exported and imported (or rerun) into another course, the discussion tab's `is_hidden` state is copied verbatim via modulestore's `course.tabs`. However, `DiscussionsConfiguration.enabled`, a separate Django DB model, is not carried over. It either already exists with `enabled=True` (created when the destination course was set up) or gets freshly created with the default `enabled=True`.

This causes a desync:
- **Modulestore** (`course.tabs[discussion].is_hidden = True`) → LMS hides the Discussion tab
- **DB** (`DiscussionsConfiguration.enabled = True`) → Authoring MFE "Hide discussion tab" toggle shows OFF

The learner sees no Discussion tab, but Studio incorrectly shows it as not hidden.

#### Root Cause

The `course_published` signal handler in [handlers.py](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/discussions/handlers.py) creates/updates `DiscussionsConfiguration` without consulting the modulestore tab state. The serializer's `_update_course_configuration` syncs `tab.is_hidden` ↔ `enabled`, but only on API save (POST/PATCH), never on publish or import.

#### Fix

In `update_course_discussion_config()`, before creating or updating `DiscussionsConfiguration`, we now read the discussion tab's `is_hidden` from the published branch of modulestore and derive `enabled = not tab.is_hidden`. This applies to both new and existing config paths. If the modulestore read fails, `enabled` defaults to `True` for backward compatibility.


Useful information to include:

- Which edX user roles will this change impact? "Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/mitodl/hq/issues/10272

## Testing instructions

1. Create Course A → hide Discussion tab via Pages & Resources
2. Export Course A
3. Create Course B → import Course A tarball
4. Verify: Discussion tab hidden in LMS, "Hide discussion tab" toggle in `Pages and Resources` shows ON, `DiscussionsConfiguration.enabled` is `False`

## Deadline

"None"

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
