### PR TITLE
refactor: Reference top-level settings instead of FEATURES

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     runs-on: ${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.11"

--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -277,7 +277,7 @@ class TestUserTaskStopped(APITestCase):
         msg = mail.outbox[0]
 
         # Verify olx validation is not enabled out of the box.
-        self.assertFalse(settings.FEATURES.get('ENABLE_COURSE_OLX_VALIDATION'))
+        self.assertFalse(settings.ENABLE_COURSE_OLX_VALIDATION)
         self.assertEqual(len(mail.outbox), 1)
         self.assert_msg_subject(msg)
         self.assert_msg_body_fragments(msg, body_fragments)

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -49,7 +49,7 @@ def indexing_is_enabled():
     """
     Checks to see if the indexing feature is enabled
     """
-    return settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False)
+    return settings.ENABLE_COURSEWARE_INDEX
 
 
 class SearchIndexingError(Exception):

--- a/cms/djangoapps/contentstore/exams.py
+++ b/cms/djangoapps/contentstore/exams.py
@@ -27,7 +27,7 @@ def register_exams(course_key):
     Likewise, if formerly registered exams are not included in the payload they will
     be marked inactive by the exam service.
     """
-    if not settings.FEATURES.get('ENABLE_SPECIAL_EXAMS') or not exams_ida_enabled(course_key):
+    if not settings.ENABLE_SPECIAL_EXAMS or not exams_ida_enabled(course_key):
         # if feature is not enabled then do a quick exit
         return
 

--- a/cms/djangoapps/contentstore/management/commands/reindex_course.py
+++ b/cms/djangoapps/contentstore/management/commands/reindex_course.py
@@ -143,7 +143,7 @@ class Command(BaseCommand):
             all_courses = modulestore().get_courses()
 
             inclusion_date = datetime.strptime(
-                settings.FEATURES.get('COURSEWARE_SEARCH_INCLUSION_DATE', '2020-01-01'),
+                settings.FEATURES.get('COURSEWARE_SEARCH_INCLUSION_DATE') or '2020-01-01',
                 '%Y-%m-%d'
             )
 

--- a/cms/djangoapps/contentstore/management/commands/reindex_course.py
+++ b/cms/djangoapps/contentstore/management/commands/reindex_course.py
@@ -143,7 +143,7 @@ class Command(BaseCommand):
             all_courses = modulestore().get_courses()
 
             inclusion_date = datetime.strptime(
-                settings.FEATURES.get('COURSEWARE_SEARCH_INCLUSION_DATE') or '2020-01-01',
+                settings.COURSEWARE_SEARCH_INCLUSION_DATE or '2020-01-01',
                 '%Y-%m-%d'
             )
 

--- a/cms/djangoapps/contentstore/proctoring.py
+++ b/cms/djangoapps/contentstore/proctoring.py
@@ -35,7 +35,7 @@ def register_special_exams(course_key):
     subsystem. Likewise, if formerly registered exams are unmarked, then those
     registered exams are marked as inactive
     """
-    if not settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+    if not settings.ENABLE_SPECIAL_EXAMS:
         # if feature is not enabled then do a quick exit
         return
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
@@ -96,7 +96,7 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
             self.permission_denied(request)
 
         with modulestore().bulk_operations(course_key):
-            credit_eligibility_enabled = settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False)
+            credit_eligibility_enabled = settings.ENABLE_CREDIT_ELIGIBILITY
             show_credit_eligibility = is_credit_course(course_key) and credit_eligibility_enabled
 
             grading_context = get_course_grading(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/home.py
@@ -90,7 +90,7 @@ class HomePageView(APIView):
             ),
             'studio_name': settings.STUDIO_NAME,
             'studio_short_name': settings.STUDIO_SHORT_NAME,
-            'studio_request_email': settings.FEATURES.get('STUDIO_REQUEST_EMAIL', ''),
+            'studio_request_email': settings.STUDIO_REQUEST_EMAIL,
             'tech_support_email': settings.TECH_SUPPORT_EMAIL,
             'platform_name': settings.PLATFORM_NAME,
             'user_is_active': request.user.is_active,

--- a/cms/djangoapps/contentstore/rest_api/v1/views/proctoring.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/proctoring.py
@@ -266,7 +266,7 @@ class ProctoringErrorsView(DeveloperErrorViewMixin, APIView):
 
         course_block = modulestore().get_course(course_key)
         advanced_dict = CourseMetadata.fetch(course_block)
-        if settings.FEATURES.get('DISABLE_MOBILE_COURSE_AVAILABLE', False):
+        if settings.DISABLE_MOBILE_COURSE_AVAILABLE:
             advanced_dict.get('mobile_available')['deprecated'] = True
 
         proctoring_errors = CourseMetadata.validate_proctoring_settings(course_block, advanced_dict, request.user)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
@@ -110,7 +110,7 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
                 'course_display_name': course_block.display_name,
                 'course_display_name_with_default': course_block.display_name_with_default,
                 'platform_name': settings.PLATFORM_NAME,
-                'licensing_enabled': settings.FEATURES.get("LICENSING", False),
+                'licensing_enabled': settings.LICENSING,
             })
 
             serializer = CourseSettingsSerializer(settings_context)

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -437,7 +437,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
             self.assertNotContains(response, "Course Banner Image")
             self.assertNotContains(response, "Course Video Thumbnail Image")
 
-    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @unittest.skipUnless(settings.ENTRANCE_EXAMS, True)
     def test_entrance_exam_created_updated_and_deleted_successfully(self):
         """
         This tests both of the entrance exam settings and the `any_unfulfilled_milestones` helper.
@@ -503,7 +503,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
                          msg='The entrance exam should not be required anymore')
 
-    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @unittest.skipUnless(settings.ENTRANCE_EXAMS, True)
     def test_entrance_exam_store_default_min_score(self):
         """
         test that creating an entrance exam should store the default value, if key missing in json request
@@ -557,7 +557,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertTrue(course.entrance_exam_enabled)
         self.assertEqual(course.entrance_exam_minimum_score_pct, .5)
 
-    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @unittest.skipUnless(settings.ENTRANCE_EXAMS, True)
     @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
     def test_entrance_after_changing_other_setting(self):
         """

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -1,7 +1,9 @@
 """
 CMS feature toggles.
 """
+from django.conf import settings
 from edx_toggles.toggles import SettingToggle, WaffleFlag
+
 from openedx.core.djangoapps.content.search import api as search_api
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
@@ -409,25 +411,11 @@ def default_enable_flexible_peer_openassessments(course_key):
     return DEFAULT_ENABLE_FLEXIBLE_PEER_OPENASSESSMENTS.is_enabled(course_key)
 
 
-# .. toggle_name: ENABLE_CONTENT_LIBRARIES
-# .. toggle_implementation: SettingToggle
-# .. toggle_default: True
-# .. toggle_description: Enables use of the legacy and v2 libraries waffle flags.
-#    Note that legacy content libraries are only supported in courses using split mongo.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2015-03-06
-# .. toggle_target_removal_date: 2025-04-09
-# .. toggle_warning: This flag is deprecated in Sumac, and will be removed in favor of the disable_legacy_libraries and
-#    disable_new_libraries waffle flags.
-ENABLE_CONTENT_LIBRARIES = SettingToggle(
-    "ENABLE_CONTENT_LIBRARIES", default=True, module_name=__name__
-)
-
 # .. toggle_name: contentstore.new_studio_mfe.disable_legacy_libraries
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Hides legacy (v1) Libraries tab in Authoring MFE.
-#    This toggle interacts with ENABLE_CONTENT_LIBRARIES toggle: if this is disabled, then legacy libraries are also
+#    This toggle interacts with ENABLE_CONTENT_LIBRARIES setting: if this is disabled, then legacy libraries are also
 #    disabled.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2024-10-02
@@ -446,7 +434,7 @@ def libraries_v1_enabled():
     Returns a boolean if Libraries V2 is enabled in the new Studio Home.
     """
     return (
-        ENABLE_CONTENT_LIBRARIES.is_enabled() and
+        settings.ENABLE_CONTENT_LIBRARIES and
         not DISABLE_LEGACY_LIBRARIES.is_enabled()
     )
 
@@ -476,7 +464,7 @@ def libraries_v2_enabled():
     Requires the ENABLE_CONTENT_LIBRARIES feature flag to be enabled, plus Meilisearch.
     """
     return (
-        ENABLE_CONTENT_LIBRARIES.is_enabled() and
+        settings.ENABLE_CONTENT_LIBRARIES and
         search_api.is_meilisearch_enabled() and
         not DISABLE_NEW_LIBRARIES.is_enabled()
     )

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -571,7 +571,7 @@ def course_import_olx_validation_is_enabled():
     """
     Check if course olx validation is enabled on course import.
     """
-    return settings.FEATURES.get('ENABLE_COURSE_OLX_VALIDATION', False)
+    return settings.ENABLE_COURSE_OLX_VALIDATION
 
 
 # pylint: disable=invalid-name
@@ -1409,7 +1409,7 @@ def get_course_settings(request, course_key, course_block):
 
     from .views.course import get_courses_accessible_to_user, _process_courses_list
 
-    credit_eligibility_enabled = settings.FEATURES.get('ENABLE_CREDIT_ELIGIBILITY', False)
+    credit_eligibility_enabled = settings.ENABLE_CREDIT_ELIGIBILITY
     upload_asset_url = reverse_course_url('assets_handler', course_key)
 
     # see if the ORG of this course can be attributed to a defined configuration . In that case, the
@@ -1417,17 +1417,17 @@ def get_course_settings(request, course_key, course_block):
     publisher_enabled = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'ENABLE_PUBLISHER',
-        settings.FEATURES.get('ENABLE_PUBLISHER', False)
+        settings.ENABLE_PUBLISHER
     )
     marketing_enabled = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        settings.ENABLE_MKTG_SITE
     )
     enable_extended_course_details = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'ENABLE_EXTENDED_COURSE_DETAILS',
-        settings.FEATURES.get('ENABLE_EXTENDED_COURSE_DETAILS', False)
+        settings.ENABLE_EXTENDED_COURSE_DETAILS
     )
 
     about_page_editable = not publisher_enabled
@@ -1435,7 +1435,7 @@ def get_course_settings(request, course_key, course_block):
     short_description_editable = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'EDITABLE_SHORT_DESCRIPTION',
-        settings.FEATURES.get('EDITABLE_SHORT_DESCRIPTION', True)
+        settings.EDITABLE_SHORT_DESCRIPTION
     )
     sidebar_html_enabled = ENABLE_COURSE_ABOUT_SIDEBAR_HTML.is_enabled()
 
@@ -1623,9 +1623,9 @@ def get_library_context(request, request_is_json=False):
             'user': request.user,
             'request_course_creator_url': reverse('request_course_creator'),
             'course_creator_status': _get_course_creator_status(request.user),
-            'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
+            'allow_unicode_course_id': settings.ALLOW_UNICODE_COURSE_ID,
             'archived_courses': True,
-            'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
+            'allow_course_reruns': settings.ALLOW_COURSE_RERUNS,
             'rerun_creator_status': GlobalStaff().has_user(request.user),
             'split_studio_home': split_library_view_on_dashboard(),
             'active_tab': 'libraries',
@@ -1670,7 +1670,7 @@ def get_course_context(request):
         }
 
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request)
-    split_archived = settings.FEATURES.get('ENABLE_SEPARATE_ARCHIVED_COURSES', False)
+    split_archived = settings.ENABLE_SEPARATE_ARCHIVED_COURSES
     active_courses, archived_courses = _process_courses_list(courses_iter, in_process_course_actions, split_archived)
     in_process_course_actions = [format_in_process_course_view(uca) for uca in in_process_course_actions]
     return active_courses, archived_courses, in_process_course_actions
@@ -1763,8 +1763,8 @@ def get_home_context(request, no_course=False):
         'request_course_creator_url': reverse('request_course_creator'),
         'course_creator_status': _get_course_creator_status(user),
         'rerun_creator_status': GlobalStaff().has_user(user),
-        'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
-        'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
+        'allow_unicode_course_id': settings.ALLOW_UNICODE_COURSE_ID,
+        'allow_course_reruns': settings.ALLOW_COURSE_RERUNS,
         'active_tab': 'courses',
         'allowed_organizations': get_allowed_organizations(user),
         'allowed_organizations_for_libraries': get_allowed_organizations_for_libraries(user),
@@ -1788,7 +1788,7 @@ def get_course_rerun_context(course_key, course_block, user):
         'display_name': course_block.display_name,
         'user': user,
         'course_creator_status': _get_course_creator_status(user),
-        'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False)
+        'allow_unicode_course_id': settings.ALLOW_UNICODE_COURSE_ID
     }
 
     return course_rerun_context
@@ -1910,7 +1910,7 @@ def _get_course_index_context(request, course_key, course_block):
 
     lms_link = get_lms_link_for_item(course_block.location)
     reindex_link = None
-    if settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False):
+    if settings.ENABLE_COURSEWARE_INDEX:
         if GlobalStaff().has_user(request.user):
             reindex_link = f"/course/{str(course_key)}/search_reindex"
     sections = course_block.get_children()
@@ -1936,7 +1936,7 @@ def _get_course_index_context(request, course_key, course_block):
     frontend_app_publisher_url = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'FRONTEND_APP_PUBLISHER_URL',
-        settings.FEATURES.get('FRONTEND_APP_PUBLISHER_URL', False)
+        settings.FRONTEND_APP_PUBLISHER_URL
     )
     # gather any errors in the currently stored proctoring settings.
     advanced_dict = CourseMetadata.fetch(course_block)

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -577,7 +577,7 @@ def _get_and_validate_course(course_key_string, user):
     course = get_course_and_check_access(course_key, user)
 
     if (
-        settings.FEATURES["ENABLE_VIDEO_UPLOAD_PIPELINE"] and
+        settings.ENABLE_VIDEO_UPLOAD_PIPELINE and
         getattr(settings, "VIDEO_UPLOAD_PIPELINE", None) and
         course and
         course.video_pipeline_configured

--- a/cms/djangoapps/contentstore/views/certificate_manager.py
+++ b/cms/djangoapps/contentstore/views/certificate_manager.py
@@ -122,7 +122,7 @@ class CertificateManager:
         """
         is_active = False
         certificates = []
-        if settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+        if settings.CERTIFICATES_HTML_VIEW:
             certificates = CertificateManager.get_certificates(course)
             # we are assuming only one certificate in certificates collection.
             for certificate in certificates:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -883,7 +883,7 @@ def _create_or_rerun_course(request):
             raise PermissionDenied()
 
         # allow/disable unicode characters in course_id according to settings
-        if not settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID'):
+        if not settings.ALLOW_UNICODE_COURSE_ID:
             if _has_non_ascii_characters(org) or _has_non_ascii_characters(course) or _has_non_ascii_characters(run):
                 return JsonResponse(
                     {'error': _('Special characters not allowed in organization, course number, and course run.')},
@@ -1285,7 +1285,7 @@ def advanced_settings_handler(request, course_key_string):
         course_block = get_course_and_check_access(course_key, request.user)
 
         advanced_dict = CourseMetadata.fetch(course_block)
-        if settings.FEATURES.get('DISABLE_MOBILE_COURSE_AVAILABLE', False):
+        if settings.DISABLE_MOBILE_COURSE_AVAILABLE:
             advanced_dict.get('mobile_available')['deprecated'] = True
 
         if 'text/html' in request.META.get('HTTP_ACCEPT', '') and request.method == 'GET':
@@ -1294,7 +1294,7 @@ def advanced_settings_handler(request, course_key_string):
             publisher_enabled = configuration_helpers.get_value_for_org(
                 course_block.location.org,
                 'ENABLE_PUBLISHER',
-                settings.FEATURES.get('ENABLE_PUBLISHER', False)
+                settings.ENABLE_PUBLISHER
             )
             # gather any errors in the currently stored proctoring settings.
             proctoring_errors = CourseMetadata.validate_proctoring_settings(course_block, advanced_dict, request.user)
@@ -1803,9 +1803,9 @@ def _get_course_creator_status(user):
 
     if user.is_staff:
         course_creator_status = 'granted'
-    elif settings.FEATURES.get('DISABLE_COURSE_CREATION', False):
+    elif settings.DISABLE_COURSE_CREATION:
         course_creator_status = 'disallowed_for_this_site'
-    elif settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    elif settings.ENABLE_CREATOR_GROUP:
         course_creator_status = get_course_creator_status(user)
         if course_creator_status is None:
             # User not grandfathered in as an existing user, has not previously visited the dashboard page.
@@ -1822,7 +1822,7 @@ def get_allowed_organizations(user):
     """
     Helper method for returning the list of organizations for which the user is allowed to create courses.
     """
-    if settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    if settings.ENABLE_CREATOR_GROUP:
         return get_organizations(user)
     else:
         return []
@@ -1837,12 +1837,12 @@ def get_allowed_organizations_for_libraries(user):
     # This allows org-level staff to create libraries. We should re-evaluate
     # whether this is necessary and try to normalize course and library creation
     # authorization behavior.
-    if settings.FEATURES.get('ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES', False):
+    if settings.ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES:
         organizations_set.update(get_organizations_for_non_course_creators(user))
 
     # This allows people in the course creator group for an org to create
     # libraries, which mimics course behavior.
-    if settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    if settings.ENABLE_CREATOR_GROUP:
         organizations_set.update(get_organizations(user))
 
     return sorted(organizations_set)
@@ -1852,7 +1852,7 @@ def user_can_create_organizations(user):
     """
     Returns True if the user can create organizations.
     """
-    return user.is_staff or not settings.FEATURES.get('ENABLE_CREATOR_GROUP', False)
+    return user.is_staff or not settings.ENABLE_CREATOR_GROUP
 
 
 def get_organizations_for_non_course_creators(user):

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -72,7 +72,7 @@ def _user_can_create_library_for_org(user, org=None):
         return False
     elif user.is_staff:
         return True
-    elif settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    elif settings.ENABLE_CREATOR_GROUP:
         org_filter_params = {}
         if org:
             org_filter_params['org'] = org
@@ -93,8 +93,8 @@ def _user_can_create_library_for_org(user, org=None):
         return is_course_creator or has_org_staff_role or has_course_staff_role or has_course_admin_role
     else:
         # EDUCATOR-1924: DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
-        disable_library_creation = settings.FEATURES.get('DISABLE_LIBRARY_CREATION', None)
-        disable_course_creation = settings.FEATURES.get('DISABLE_COURSE_CREATION', False)
+        disable_library_creation = settings.DISABLE_LIBRARY_CREATION
+        disable_course_creation = settings.DISABLE_COURSE_CREATION
         if disable_library_creation is not None:
             return not disable_library_creation
         else:

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -191,7 +191,7 @@ def _prepare_runtime_for_preview(request, block):
     ]
 
     mako_service = MakoService(namespace_prefix='lms.')
-    if settings.FEATURES.get("LICENSING", False):
+    if settings.LICENSING:
         # stick the license wrapper in front
         wrappers.insert(0, partial(wrap_with_license, mako_service=mako_service))
 

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -217,7 +217,7 @@ class VideoPipelineStudioAccessTestsMixin:
     Access tests for video views that rely on the video pipeline
     """
     def test_video_pipeline_not_enabled(self):
-        settings.FEATURES["ENABLE_VIDEO_UPLOAD_PIPELINE"] = False
+        settings.ENABLE_VIDEO_UPLOAD_PIPELINE = False
         self.assertEqual(self.client.get(self.url).status_code, 404)
 
     def test_video_pipeline_not_configured(self):

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1230,7 +1230,7 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
                 "user_partitions": user_partitions,
                 "show_correctness": xblock.show_correctness,
                 "hide_from_toc": xblock.hide_from_toc,
-                "enable_hide_from_toc_ui": settings.FEATURES.get("ENABLE_HIDE_FROM_TOC_UI", False),
+                "enable_hide_from_toc_ui": settings.ENABLE_HIDE_FROM_TOC_UI,
                 "xblock_type": get_icon(xblock),
             }
         )
@@ -1268,7 +1268,7 @@ def create_xblock_info(  # lint-amnesty, pylint: disable=too-many-statements
             )
 
         # update xblock_info with special exam information if the feature flag is enabled
-        if settings.FEATURES.get("ENABLE_SPECIAL_EXAMS"):
+        if settings.ENABLE_SPECIAL_EXAMS:
             if xblock.category == "course":
                 xblock_info.update(
                     {

--- a/cms/djangoapps/course_creators/admin.py
+++ b/cms/djangoapps/course_creators/admin.py
@@ -142,7 +142,7 @@ def send_user_notification_callback(sender, **kwargs):  # pylint: disable=unused
     user = kwargs['user']
     updated_state = kwargs['state']
 
-    studio_request_email = settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')
+    studio_request_email = settings.STUDIO_REQUEST_EMAIL
     context = {'studio_request_email': studio_request_email}
 
     subject = render_to_string('emails/course_creator_subject.txt', context)
@@ -169,7 +169,7 @@ def send_admin_notification_callback(sender, **kwargs):  # pylint: disable=unuse
     """
     user = kwargs['user']
 
-    studio_request_email = settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')
+    studio_request_email = settings.STUDIO_REQUEST_EMAIL
     context = {'user_name': user.username, 'user_email': user.email}
 
     subject = render_to_string('emails/course_creator_admin_subject.txt', context)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -103,19 +103,19 @@ class CourseMetadata:
             exclude_list.append('giturl')
 
         # Do not show edxnotes if the feature is disabled.
-        if not settings.FEATURES.get('ENABLE_EDXNOTES'):
+        if not settings.ENABLE_EDXNOTES:
             exclude_list.append('edxnotes')
 
         # Do not show video auto advance if the feature is disabled
-        if not settings.FEATURES.get('ENABLE_OTHER_COURSE_SETTINGS'):
+        if not settings.ENABLE_OTHER_COURSE_SETTINGS:
             exclude_list.append('other_course_settings')
 
         # Do not show video_upload_pipeline if the feature is disabled.
-        if not settings.FEATURES.get('ENABLE_VIDEO_UPLOAD_PIPELINE'):
+        if not settings.ENABLE_VIDEO_UPLOAD_PIPELINE:
             exclude_list.append('video_upload_pipeline')
 
         # Do not show video auto advance if the feature is disabled
-        if not settings.FEATURES.get('ENABLE_AUTOADVANCE_VIDEOS'):
+        if not settings.ENABLE_AUTOADVANCE_VIDEOS:
             exclude_list.append('video_auto_advance')
 
         # Do not show social sharing url field if the feature is disabled.
@@ -124,14 +124,14 @@ class CourseMetadata:
             exclude_list.append('social_sharing_url')
 
         # Do not show teams configuration if feature is disabled.
-        if not settings.FEATURES.get('ENABLE_TEAMS'):
+        if not settings.ENABLE_TEAMS:
             exclude_list.append('teams_configuration')
 
-        if not settings.FEATURES.get('ENABLE_VIDEO_BUMPER'):
+        if not settings.ENABLE_VIDEO_BUMPER:
             exclude_list.append('video_bumper')
 
         # Do not show enable_ccx if feature is not enabled.
-        if not settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+        if not settings.CUSTOM_COURSES_EDX:
             exclude_list.append('enable_ccx')
             exclude_list.append('ccx_connector')
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -120,15 +120,6 @@ ENABLE_VIDEO_UPLOAD_PIPELINE = False
 # course and that can be read from themes
 ENABLE_OTHER_COURSE_SETTINGS = False
 
-# .. toggle_name: settings.ENABLE_CONTENT_LIBRARIES_LTI_TOOL
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: When set to True, Content Libraries in
-#    Studio can be used as an LTI 1.3 tool by external LTI platforms.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-08-17
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/27411
-ENABLE_CONTENT_LIBRARIES_LTI_TOOL = False
 
 # Toggle course entrance exams feature
 ENTRANCE_EXAMS = False

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -82,10 +82,6 @@ STUDIO_REQUEST_EMAIL = ''
 # Segment - must explicitly turn it on for production
 CMS_SEGMENT_KEY = None
 
-# If set to True, new Studio users won't be able to author courses unless
-# an Open edX admin has added them to the course creator group.
-ENABLE_CREATOR_GROUP = True
-
 # If set to True, organization staff members can create libraries for their specific
 # organization and no other organizations. They do not need to be course creators,
 # even when ENABLE_CREATOR_GROUP is True.

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -120,10 +120,6 @@ ENABLE_VIDEO_UPLOAD_PIPELINE = False
 # course and that can be read from themes
 ENABLE_OTHER_COURSE_SETTINGS = False
 
-# Enable support for content libraries. Note that content libraries are
-# only supported in courses using split mongo.
-ENABLE_CONTENT_LIBRARIES = True
-
 # .. toggle_name: settings.ENABLE_CONTENT_LIBRARIES_LTI_TOOL
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -221,14 +221,6 @@ ENABLE_SEND_XBLOCK_LIFECYCLE_EVENTS_OVER_BUS = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33952
 ENABLE_HIDE_FROM_TOC_UI = False
 
-# .. toggle_name: settings.IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Set to False to disable in-context discussion for units by default.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2024-09-02
-IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT = True
-
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -154,7 +154,7 @@
   </section>
 </div>
 
-% if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True):
+% if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.ALLOW_PUBLIC_ACCOUNT_CREATION) and settings.SHOW_REGISTRATION_LINKS:
 <div class="wrapper-content-cta wrapper">
   <section class="content content-cta">
     <header>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -664,7 +664,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             </div>
           % endif
 
-          % if settings.FEATURES.get("LICENSING", False):
+          % if settings.LICENSING:
             <hr class="divide" />
 
             <div class="group-settings license">

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -91,7 +91,7 @@
         </section>
         <hr class="divide" />
 
-        % if settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False) and is_credit_course:
+        % if settings.ENABLE_CREDIT_ELIGIBILITY and is_credit_course:
           <section class="group-settings grade-rules">
             <header>
               <h2 class="title-2">${_("Credit Eligibility")}</h2>

--- a/cms/templates/visibility_editor.html
+++ b/cms/templates/visibility_editor.html
@@ -24,7 +24,7 @@ block_is_unit = is_unit(xblock)
                 % else:
                     <p>${_('Access to this component is not restricted, but visibility might be affected by inherited settings.')}</p>
                 %endif
-                % if settings.FEATURES.get('ENABLE_ENROLLMENT_TRACK_USER_PARTITION'):
+                % if settings.ENABLE_ENROLLMENT_TRACK_USER_PARTITION:
                     % if block_is_unit:
                         <p>${_('You can restrict access to this unit to learners in specific enrollment tracks or content groups.')}</p>
                     % else:

--- a/cms/templates/widgets/deprecated-course-key-warning.html
+++ b/cms/templates/widgets/deprecated-course-key-warning.html
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _
 from openedx.core.djangolib.translation_utils import translate_date
 
 DEFAULT_LANGUAGE = getattr(settings, 'LANGUAGE_CODE', 'en')
-IS_ENABLED = settings.FEATURES.get('DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO', True)
+IS_ENABLED = settings.DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO
 %>
 <%
 is_visible = IS_ENABLED and course and course.id.deprecated

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -42,7 +42,7 @@
             advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': str(course_key)})
             tabs_url = reverse('tabs_handler', kwargs={'course_key_string': str(course_key)})
             certificates_url = ''
-            if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
+            if settings.CERTIFICATES_HTML_VIEW and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': str(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
             pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
@@ -309,7 +309,7 @@
       <nav class="nav-account nav-is-signedin nav-dd ui-right" aria-label="${_('Account')}">
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
-          % if settings.FEATURES.get('ENABLE_HELP_LINK'):
+          % if settings.ENABLE_HELP_LINK:
             <li class="nav-item nav-account-help">
               <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a></span></h3>
             </li>
@@ -324,12 +324,12 @@
       <nav class="nav-not-signedin nav-pitch" aria-label="${_('Account')}">
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
-          % if settings.FEATURES.get('ENABLE_HELP_LINK'):
+          % if settings.ENABLE_HELP_LINK:
           <li class="nav-item nav-not-signedin-help">
             <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a>
           </li>
           % endif
-          % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True):
+          % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.ALLOW_PUBLIC_ACCOUNT_CREATION) and settings.SHOW_REGISTRATION_LINKS:
               <li class="nav-item nav-not-signedin-signup">
                 <a class="action action-signup" href="${settings.FRONTEND_REGISTER_URL}?next=${quote_plus(request.build_absolute_uri(settings.LOGIN_URL))}">${_("Sign Up")}</a>
               </li>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -245,12 +245,12 @@ if toggles.EXPORT_GIT.is_enabled():
                 name='export_git')
     ]
 
-if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
+if settings.ENABLE_SERVICE_STATUS:
     urlpatterns.append(path('status/', include('openedx.core.djangoapps.service_status.urls')))
 
 # The password pages in the admin tool are disabled so that all password
 # changes go through our user portal and follow complexity requirements.
-if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+if not settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN:
     urlpatterns.append(re_path(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(path('admin/password_change/', handler404))
 urlpatterns.append(
@@ -264,7 +264,7 @@ if core_toggles.ENTRANCE_EXAMS.is_enabled():
                        contentstore_views.entrance_exam))
 
 # Enable Web/HTML Certificates
-if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
+if settings.CERTIFICATES_HTML_VIEW:
     from cms.djangoapps.contentstore.views.certificates import (
         CertificateActivationAPIView,
         CertificateDetailAPIView,

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -230,7 +230,7 @@ urlpatterns += [
     path('openassessment/fileupload/', include('openassessment.fileupload.urls')),
 ]
 
-if toggles.ENABLE_CONTENT_LIBRARIES:
+if settings.ENABLE_CONTENT_LIBRARIES:
     urlpatterns += [
         re_path(fr'^library/{LIBRARY_KEY_PATTERN}?$',
                 contentstore_views.library_handler, name='library_handler'),

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -826,7 +826,7 @@ class CourseMode(models.Model):
         """
         ineligible_modes = [cls.AUDIT]
 
-        if settings.FEATURES.get('DISABLE_HONOR_CERTIFICATES', False):
+        if settings.DISABLE_HONOR_CERTIFICATES:
             # Adding check so that we can regenerate the certificate for learners who have
             # already earned the certificate using honor mode
             from lms.djangoapps.certificates.data import CertificateStatuses

--- a/common/djangoapps/course_modes/urls.py
+++ b/common/djangoapps/course_modes/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
 ]
 
 # Enable verified mode creation
-if settings.FEATURES.get('MODE_CREATION_FOR_TESTING'):
+if settings.MODE_CREATION_FOR_TESTING:
     urlpatterns.append(
         re_path(fr'^create_mode/{settings.COURSE_ID_PATTERN}/$',
                 views.create_mode,

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -381,7 +381,7 @@ class ChooseModeView(View):
 def create_mode(request, course_id):
     """Add a mode to the course corresponding to the given course ID.
 
-    Only available when settings.FEATURES['MODE_CREATION_FOR_TESTING'] is True.
+    Only available when settings.MODE_CREATION_FOR_TESTING is True.
 
     Attempts to use the following querystring parameters from the request:
         `mode_slug` (str): The mode to add, either 'honor', 'verified', or 'professional'

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -45,7 +45,7 @@ def marketing_link(name):
     link_map = settings.MKTG_URL_LINK_MAP
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        settings.ENABLE_MKTG_SITE
     )
     marketing_urls = configuration_helpers.get_value(
         'MKTG_URLS',
@@ -115,7 +115,7 @@ def is_marketing_link_set(name):
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        settings.ENABLE_MKTG_SITE
     )
     marketing_urls = configuration_helpers.get_value(
         'MKTG_URLS',

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -538,7 +538,7 @@ class UserChangeForm(BaseUserChangeForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+        if not settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN:
             self.fields["password"] = ReadOnlyPasswordHashField(
                 label=_("Password"),
                 help_text=_(

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -61,10 +61,10 @@ def user_has_role(user, role):
     # CourseCreator is odd b/c it can be disabled via config
     if isinstance(role, CourseCreatorRole):
         # completely shut down course creation setting
-        if settings.FEATURES.get('DISABLE_COURSE_CREATION', False):
+        if settings.DISABLE_COURSE_CREATION:
             return False
         # wide open course creation setting
-        if not settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+        if not settings.ENABLE_CREATOR_GROUP:
             return True
 
     if role.has_user(user):
@@ -163,7 +163,7 @@ def has_studio_advanced_settings_access(user):
     By default, this feature is disabled.
     """
     return (
-        not settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
+        not settings.DISABLE_ADVANCED_SETTINGS
         or user.is_staff
         or user.is_superuser
     )
@@ -205,7 +205,7 @@ def check_course_advanced_settings_access(user, course_key, access_type='read'):
         # For feature_restricted access type, check DISABLE_ADVANCED_SETTINGS feature
         if (
             access_type == 'feature_restricted'
-            and settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
+            and settings.DISABLE_ADVANCED_SETTINGS
         ):
             # When feature is disabled, only staff/superuser can access (bypass authz)
             return user.is_staff or user.is_superuser

--- a/common/djangoapps/student/email_helpers.py
+++ b/common/djangoapps/student/email_helpers.py
@@ -57,7 +57,7 @@ def generate_proctoring_requirements_email_context(user, course_id):
         'course_name': course_block.display_name,
         'proctoring_provider': capwords(course_block.proctoring_provider.replace('_', ' ')),
         'proctoring_requirements_url': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('faq', ''),
-        'idv_required': not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'),
+        'idv_required': not settings.ENABLE_INTEGRITY_SIGNATURE,
         'id_verification_url': IDVerificationService.get_verify_location(),
     }
 

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -122,7 +122,7 @@ def check_verify_status_by_course(user, course_enrollments):
     status_by_course = {}
 
     # If integrity signature is enabled, this is a no-op because IDV is not required
-    if settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+    if settings.ENABLE_INTEGRITY_SIGNATURE:
         return status_by_course
 
     # Retrieve all verifications for the user, sorted in descending
@@ -316,7 +316,7 @@ def get_next_url_for_login_page(request, include_host=False):
     # Append a tpa_hint query parameter, if one is configured
     tpa_hint = configuration_helpers.get_value(
         "THIRD_PARTY_AUTH_HINT",
-        settings.FEATURES.get("THIRD_PARTY_AUTH_HINT", '')
+        settings.THIRD_PARTY_AUTH_HINT
     )
     if tpa_hint:
         # Don't add tpa_hint if we're already in the TPA pipeline (prevent infinite loop),
@@ -676,7 +676,7 @@ def do_create_account(form, custom_form=None):
     # Check if ALLOW_PUBLIC_ACCOUNT_CREATION flag turned off to restrict user account creation
     if not configuration_helpers.get_value(
             'ALLOW_PUBLIC_ACCOUNT_CREATION',
-            settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)
+            settings.ALLOW_PUBLIC_ACCOUNT_CREATION
     ):
         raise PermissionDenied()
 

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -199,7 +199,7 @@ class CourseEnrollmentManager(models.Manager):
 
         'course_id' is the course_id to return enrollments
         """
-        max_enrollments = settings.FEATURES.get("MAX_ENROLLMENT_INSTR_BUTTONS")
+        max_enrollments = settings.MAX_ENROLLMENT_INSTR_BUTTONS
 
         enrollment_number = super().get_queryset().filter(
             course_id=course_id,

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -1310,7 +1310,7 @@ def enforce_single_login(sender, request, user, signal, **kwargs):  # pylint: di
     Sets the current session id in the user profile,
     to prevent concurrent logins.
     """
-    if settings.FEATURES.get('PREVENT_CONCURRENT_LOGINS', False):
+    if settings.PREVENT_CONCURRENT_LOGINS:
         if signal == user_logged_in:
             key = request.session.session_key
         else:

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -971,7 +971,7 @@ class LoginFailures(models.Model):
         """
         Returns whether the feature flag around this functionality has been set
         """
-        return settings.FEATURES['ENABLE_MAX_FAILED_LOGIN_ATTEMPTS']
+        return settings.ENABLE_MAX_FAILED_LOGIN_ATTEMPTS
 
     @classmethod
     def is_user_locked_out(cls, user):
@@ -1249,7 +1249,7 @@ def add_user_to_default_group(user, group):  # lint-amnesty, pylint: disable=mis
 
 
 def create_comments_service_user(user):  # lint-amnesty, pylint: disable=missing-function-docstring
-    if not settings.FEATURES['ENABLE_DISCUSSION_SERVICE']:
+    if not settings.ENABLE_DISCUSSION_SERVICE:
         # Don't try--it won't work, and it will fill the logs with lots of errors
         return
     try:
@@ -1278,7 +1278,7 @@ def log_successful_login(sender, request, user, **kwargs):  # lint-amnesty, pyli
             'event_type': "login",
         }
     )
-    if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+    if settings.SQUELCH_PII_IN_LOGS:
         AUDIT_LOG.info(f"Login success - user.id: {user.id}")
     else:
         AUDIT_LOG.info(f"Login success - {user.username} ({user.email})")
@@ -1295,7 +1295,7 @@ def log_successful_logout(sender, request, user, **kwargs):  # lint-amnesty, pyl
                 'event_type': "logout",
             }
         )
-        if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+        if settings.SQUELCH_PII_IN_LOGS:
             AUDIT_LOG.info(f'Logout - user.id: {request.user.id}')  # pylint: disable=logging-format-interpolation
         else:
             AUDIT_LOG.info(f'Logout - {request.user}')  # pylint: disable=logging-format-interpolation

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -530,7 +530,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
         assert len(mail.outbox) == 2
 
         use_https = self.request.is_secure()
-        if settings.FEATURES['ENABLE_MKTG_SITE']:
+        if settings.ENABLE_MKTG_SITE:
             contact_link = marketing_link('CONTACT')
         else:
             contact_link = '{protocol}://{site}{link}'.format(

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -1009,7 +1009,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
 
 
 @skip_unless_lms
-@unittest.skipUnless(settings.FEATURES.get("ENABLE_NOTICES"), 'Notices plugin is not enabled')
+@unittest.skipUnless(settings.ENABLE_NOTICES, 'Notices plugin is not enabled')
 class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
     """
     Tests for the Dashboard redirect functionality introduced via the Notices plugin.

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -386,7 +386,7 @@ def credit_statuses(user, course_enrollments):
     from openedx.core.djangoapps.credit import api as credit_api
 
     # Feature flag off
-    if not settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY"):
+    if not settings.ENABLE_CREDIT_ELIGIBILITY:
         return {}
 
     request_status_by_course = {
@@ -541,25 +541,25 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
 
     enable_verified_certificates = configuration_helpers.get_value(
         'ENABLE_VERIFIED_CERTIFICATES',
-        settings.FEATURES.get('ENABLE_VERIFIED_CERTIFICATES')
+        settings.ENABLE_VERIFIED_CERTIFICATES
     )
     display_course_modes_on_dashboard = configuration_helpers.get_value(
         'DISPLAY_COURSE_MODES_ON_DASHBOARD',
-        settings.FEATURES.get('DISPLAY_COURSE_MODES_ON_DASHBOARD', True)
+        settings.DISPLAY_COURSE_MODES_ON_DASHBOARD
     )
     activation_email_support_link = configuration_helpers.get_value(
         'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK
     ) or settings.SUPPORT_SITE_LINK
     hide_dashboard_courses_until_activated = configuration_helpers.get_value(
         'HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED',
-        settings.FEATURES.get('HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED', False)
+        settings.HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED
     )
     empty_dashboard_message = configuration_helpers.get_value(
         'EMPTY_DASHBOARD_MESSAGE', None
     )
     disable_unenrollment = configuration_helpers.get_value(
         'DISABLE_UNENROLLMENT',
-        settings.FEATURES.get('DISABLE_UNENROLLMENT')
+        settings.DISABLE_UNENROLLMENT
     )
 
     disable_course_limit = request and 'course_limit' in request.GET

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -266,7 +266,7 @@ def compose_and_send_activation_email(
         redirect_url: The URL to redirect to after successful activation
         registration_flow: Is the request coming from registration workflow
     """
-    route_enabled = bool(settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'))
+    route_enabled = bool(settings.REROUTE_ACTIVATION_EMAIL)
 
     msg = compose_activation_email(
         user, user_registration, route_enabled, profile.name, redirect_url, registration_flow
@@ -395,7 +395,7 @@ def change_enrollment(request, check_access=True):
             return HttpResponseBadRequest(_("Course id is invalid"))
 
         # Record the user's email opt-in preference
-        if settings.FEATURES.get('ENABLE_MKTG_EMAIL_OPT_IN'):
+        if settings.ENABLE_MKTG_EMAIL_OPT_IN:
             _update_email_opt_in(request, course_id.org)
 
         available_modes = CourseMode.modes_for_course_dict(course_id)
@@ -445,7 +445,7 @@ def change_enrollment(request, check_access=True):
     elif action == "unenroll":
         if configuration_helpers.get_value(
             "DISABLE_UNENROLLMENT",
-            settings.FEATURES.get("DISABLE_UNENROLLMENT")
+            settings.DISABLE_UNENROLLMENT
         ):
             return HttpResponseBadRequest(_("Unenrollment is currently disabled"))
 

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -139,7 +139,7 @@ def index(request, extra_context=None, user=AnonymousUser()):
 
     if configuration_helpers.get_value(
         "ENABLE_COURSE_SORTING_BY_START_DATE",
-        settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"],
+        settings.ENABLE_COURSE_SORTING_BY_START_DATE,
     ):
         courses = sort_by_start_date(courses)
     else:
@@ -220,7 +220,7 @@ def compose_activation_email(
     })
 
     if route_enabled:
-        dest_addr = settings.FEATURES['REROUTE_ACTIVATION_EMAIL']
+        dest_addr = settings.REROUTE_ACTIVATION_EMAIL
     else:
         dest_addr = user.email
 
@@ -893,7 +893,7 @@ def confirm_email_change(request, key):
             return response
 
         use_https = request.is_secure()
-        if settings.FEATURES['ENABLE_MKTG_SITE']:
+        if settings.ENABLE_MKTG_SITE:
             contact_link = marketing_link('CONTACT')
         else:
             contact_link = '{protocol}://{site}{link}'.format(

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -266,7 +266,7 @@ def compose_and_send_activation_email(
         redirect_url: The URL to redirect to after successful activation
         registration_flow: Is the request coming from registration workflow
     """
-    route_enabled = settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL')
+    route_enabled = bool(settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'))
 
     msg = compose_activation_email(
         user, user_registration, route_enabled, profile.name, redirect_url, registration_flow

--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -12,5 +12,5 @@ def is_enabled():
 
     return configuration_helpers.get_value(
         "ENABLE_THIRD_PARTY_AUTH",
-        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH")
+        settings.ENABLE_THIRD_PARTY_AUTH
     )

--- a/common/djangoapps/third_party_auth/apps.py
+++ b/common/djangoapps/third_party_auth/apps.py
@@ -13,7 +13,7 @@ class ThirdPartyAuthConfig(AppConfig):  # lint-amnesty, pylint: disable=missing-
         from .signals import handlers  # noqa: F401 pylint: disable=unused-import
 
         # To override the settings before loading social_django.
-        if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
+        if settings.ENABLE_THIRD_PARTY_AUTH:
             self._enable_third_party_auth()
 
     def _enable_third_party_auth(self):

--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -21,7 +21,7 @@ def xframe_allow_whitelisted(view_func):
         """ Modify the response with the correct X-Frame-Options. """
         resp = view_func(request, *args, **kwargs)
         x_frame_option = settings.X_FRAME_OPTIONS
-        if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
+        if settings.ENABLE_THIRD_PARTY_AUTH:
             referer = request.META.get('HTTP_REFERER')
             if referer is not None:
                 parsed_url = urlparse(referer)

--- a/common/djangoapps/third_party_auth/management/commands/remove_social_auth_users.py
+++ b/common/djangoapps/third_party_auth/management/commands/remove_social_auth_users.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         slug = options['IDP']
 
-        if not settings.FEATURES.get('ENABLE_ENROLLMENT_RESET'):
+        if not settings.ENABLE_ENROLLMENT_RESET:
             raise CommandError('ENABLE_ENROLLMENT_RESET feature not enabled on this enviroment')
 
         try:

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -70,7 +70,7 @@ def clean_username(username=''):
     """
     Simple helper method to ensure a username is compatible with our system requirements.
     """
-    if settings.FEATURES.get("ENABLE_UNICODE_USERNAME"):
+    if settings.ENABLE_UNICODE_USERNAME:
         return ('_').join(re.findall(settings.USERNAME_REGEX_PARTIAL, username))[:USERNAME_MAX_LENGTH]
     else:
         return ('_').join(re.findall(r'[a-zA-Z0-9\-]+', username))[:USERNAME_MAX_LENGTH]

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -43,7 +43,7 @@ def apply_settings(django_settings):
     django_settings.SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = {'msafed': 0}
 
     # Avoid default username check to allow non-ascii characters
-    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = not settings.FEATURES.get("ENABLE_UNICODE_USERNAME")
+    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = not settings.ENABLE_UNICODE_USERNAME
 
     # Inject our customized auth pipeline. All auth backends must work with
     # this pipeline.

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -576,9 +576,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
         return reverse("social:complete", kwargs={"backend": self.PROVIDER_BACKEND})
 
 
-@unittest.skipUnless(
-    testutil.AUTH_FEATURES_KEY in django_settings.FEATURES, testutil.AUTH_FEATURES_KEY + " not in settings.FEATURES"
-)
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 @django_utils.override_settings()  # For settings reversion on a method-by-method basis.
 class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
     """Abstract base class for provider integration tests."""

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -150,7 +150,7 @@ class HelperMixin:
         partial_unicode_username = unicode_username + ascii_substring
         pipeline_kwargs = pipeline.get(request)["kwargs"]
 
-        assert settings.FEATURES["ENABLE_UNICODE_USERNAME"] is False
+        assert settings.ENABLE_UNICODE_USERNAME is False
 
         self._check_registration_form_username(pipeline_kwargs, unicode_username, "")
         self._check_registration_form_username(pipeline_kwargs, partial_unicode_username, ascii_substring)

--- a/common/djangoapps/third_party_auth/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/tests/test_views.py
@@ -22,12 +22,12 @@ from common.djangoapps.third_party_auth import pipeline
 from common.djangoapps.third_party_auth.utils import SAML_XML_NS
 from common.djangoapps.third_party_auth.views import inactive_user_view
 
-from .testutil import AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY, SAMLTestCase
+from .testutil import SAMLTestCase
 
 XMLDSIG_XML_NS = 'http://www.w3.org/2000/09/xmldsig#'
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 @ddt.ddt
 class SAMLMetadataTest(SAMLTestCase):
     """
@@ -145,7 +145,7 @@ class SAMLMetadataTest(SAMLTestCase):
         assert support_email_node.text == support_email
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 class SAMLAuthTest(SAMLTestCase):
     """
     Test the SAML auth views
@@ -165,7 +165,7 @@ class SAMLAuthTest(SAMLTestCase):
         assert response.status_code == 404
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 class IdPRedirectViewTest(SAMLTestCase):
     """
         Test IdPRedirectView.
@@ -205,7 +205,7 @@ class IdPRedirectViewTest(SAMLTestCase):
         )
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 class InactiveUserViewTests(TestCase):
     """Test inactive user view """
     @patch('common.djangoapps.third_party_auth.views.redirect')

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -26,9 +26,6 @@ from common.djangoapps.third_party_auth.models import cache as config_cache
 from openedx.core.djangolib.testing.utils import CacheIsolationMixin
 from openedx.core.storage import OverwriteStorage
 
-AUTH_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
-AUTH_FEATURE_ENABLED = AUTH_FEATURES_KEY in settings.FEATURES
-
 
 def patch_mako_templates():
     """ Patch mako so the django test client can access template context """

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -6,6 +6,7 @@ from base64 import b64encode
 from unittest import skip
 
 import httpretty
+from django.conf import settings
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from oauth2_provider.models import Application
 from social_core.backends.facebook import API_VERSION as FACEBOOK_API_VERSION
@@ -14,7 +15,7 @@ from social_django.models import Partial, UserSocialAuth
 
 from common.djangoapps.student.tests.factories import UserFactory
 
-from .testutil import ThirdPartyAuthTestMixin, AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY
+from .testutil import ThirdPartyAuthTestMixin
 
 
 @httpretty.activate
@@ -150,6 +151,6 @@ def skip_unless_thirdpartyauth():
     """
     Wraps unittest.skip in consistent logic to skip certain third_party_auth tests in CMS.
     """
-    if AUTH_FEATURE_ENABLED:
+    if settings.ENABLE_THIRD_PARTY_AUTH:
         return lambda func: func
-    return skip("%s not enabled" % AUTH_FEATURES_KEY)
+    return skip("%s not enabled" % "ENABLE_THIRD_PARTY_AUTH")

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -59,7 +59,7 @@ def get_link_for_about_page(course):
 
     if is_social_sharing_enabled and course.social_sharing_url:
         course_about_url = course.social_sharing_url
-    elif settings.FEATURES.get('ENABLE_MKTG_SITE') and getattr(course, 'marketing_url', None):
+    elif settings.ENABLE_MKTG_SITE and getattr(course, 'marketing_url', None):
         course_about_url = course.marketing_url
     else:
         course_about_url = f'{about_base_url}/courses/{course.id}/about'
@@ -80,7 +80,7 @@ def has_certificates_enabled(course):
         course: This can be either a course overview object or a course block.
     Returns a boolean if the course has enabled certificates
     """
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return False
     return course.cert_html_view_enabled
 

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -45,7 +45,7 @@ def is_prerequisite_courses_enabled():
     """
     Returns boolean indicating prerequisite courses enabled system wide or not.
     """
-    return settings.FEATURES.get('ENABLE_PREREQUISITE_COURSES') and ENABLE_MILESTONES_APP.is_enabled()
+    return settings.ENABLE_PREREQUISITE_COURSES and ENABLE_MILESTONES_APP.is_enabled()
 
 
 def add_prerequisite_course(course_key, prerequisite_course_key):

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -431,7 +431,7 @@ def _footer_mobile_links(is_secure):
     platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
 
     mobile_links = []
-    if settings.FEATURES.get('ENABLE_FOOTER_MOBILE_APP_LINKS'):
+    if settings.ENABLE_FOOTER_MOBILE_APP_LINKS:
         mobile_links = [
             {
                 "name": "apple",

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -98,13 +98,13 @@ def courses(request):
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
-        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+        settings.ENABLE_MKTG_SITE
     )
 
     if enable_mktg_site:
         return redirect(marketing_link('COURSES'), permanent=True)
 
-    if not settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+    if not settings.COURSES_ARE_BROWSABLE:
         raise Http404
 
     #  we do not expect this case to be reached in cases where

--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -28,7 +28,7 @@ class CcxCourseTab(CourseTab):
         """
         Returns true if CCX has been enabled and the specified user is a coach
         """
-        if not settings.FEATURES.get('CUSTOM_COURSES_EDX', False) or not course.enable_ccx:
+        if not settings.CUSTOM_COURSES_EDX or not course.enable_ccx:
             # If ccx is not enable do not show ccx coach tab.
             return False
 

--- a/lms/djangoapps/certificates/apps.py
+++ b/lms/djangoapps/certificates/apps.py
@@ -23,6 +23,6 @@ class CertificatesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from lms.djangoapps.certificates import signals  # pylint: disable=unused-import
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from lms.djangoapps.certificates.services import CertificateService
             set_runtime_service('certificates', CertificateService())

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -87,7 +87,7 @@ def has_html_certificates_enabled(course_overview):
     """
     Returns True if HTML certificates are enabled in a course run.
     """
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return False
     return course_overview.cert_html_view_enabled
 

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -82,7 +82,7 @@ def get_certificate_description(mode, certificate_type, platform_name, course_ke
                                          "{platform_name} and has completed all of the required tasks for this course "
                                          "under its guidelines. ").format(cert_type=certificate_type,
                                                                           platform_name=platform_name)
-        if settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT'):
+        if settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT:
             certificate_type_description += _("A {cert_type} certificate also indicates that the "
                                               "identity of the learner has been checked and "
                                               "is valid.").format(cert_type=certificate_type)
@@ -250,7 +250,7 @@ def _update_course_context(request, context, course, platform_name):
     context['accomplishment_copy_course_name'] = accomplishment_copy_course_name
     course_number = course.display_coursenumber if course.display_coursenumber else course.number
     context['course_number'] = course_number
-    context['idv_enabled_for_certificates'] = settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT')
+    context['idv_enabled_for_certificates'] = settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT
     if context['organization_long_name']:
         # Translators:  This text represents the description of course
         context['accomplishment_copy_course_description'] = _('a course of study offered by {partner_short_name}, '
@@ -476,7 +476,7 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
     configuration = CertificateHtmlViewConfiguration.get_config()
 
     # Kick the user back to the "Invalid" screen if the feature is disabled globally
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Load the course and user objects
@@ -532,7 +532,7 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
     # Determine whether to use the standard or custom template to render the certificate.
     custom_template = None
     custom_template_language = None
-    if settings.FEATURES.get('CUSTOM_CERTIFICATE_TEMPLATES_ENABLED', False):
+    if settings.CUSTOM_CERTIFICATE_TEMPLATES_ENABLED:
         log.info("Custom certificate for course %s", course_id)
         custom_template, custom_template_language = _get_custom_template_and_language(
             course.id,

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -86,7 +86,7 @@ def _filter_by_search(course_queryset, search_term, mobile_search=False):
     """
     Filters a course queryset by the specified search term.
     """
-    if not settings.FEATURES['ENABLE_COURSEWARE_SEARCH'] or not search_term:
+    if not settings.ENABLE_COURSEWARE_SEARCH or not search_term:
         return course_queryset
 
     # Return all the results, 10K is the maximum allowed value for ElasticSearch.

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -174,7 +174,7 @@ class BlockSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
             ),
         }
 
-        if settings.FEATURES.get("ENABLE_LTI_PROVIDER") and 'lti_url' in self.context['requested_fields']:
+        if settings.ENABLE_LTI_PROVIDER and 'lti_url' in self.context['requested_fields']:
             data['lti_url'] = reverse(
                 'lti_provider_launch',
                 kwargs={'course_id': str(block_key.course_key), 'usage_id': str(block_key)},

--- a/lms/djangoapps/course_api/blocks/transformers/milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/milestones.py
@@ -73,7 +73,7 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
                 return True
             elif not self.include_gated_sections and self.has_pending_milestones_for_user(block_key, usage_info):
                 return True
-            elif (settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+            elif (settings.ENABLE_SPECIAL_EXAMS and
                   (self.is_special_exam(block_key, block_structure) and
                    not self.include_special_exams)):
                 return True

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -108,7 +108,7 @@ class WikiAccessMiddleware(MiddlewareMixin):
 
             # Check to see if we don't allow top-level access to the wiki via the /wiki/xxxx/yyy/zzz URLs
             # this will help prevent people from writing pell-mell to the Wiki in an unstructured way
-            if not settings.FEATURES.get('ALLOW_WIKI_ROOT_ACCESS', False):
+            if not settings.ALLOW_WIKI_ROOT_ACCESS:
                 raise PermissionDenied()
 
             return self._redirect_from_referrer(request, wiki_path)

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -282,7 +282,7 @@ def _can_enroll_courselike(user, courselike):
             # DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED flag is used to disable enrollment for user invited
             # to a course if user is registering when the course enrollment is closed
             if (
-                settings.FEATURES.get('DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED') and
+                settings.DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED and
                 not course_enrollment_open and
                 not user_has_staff_access
             ):

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -135,7 +135,7 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
     Returns:
         AccessResponse: Either ACCESS_GRANTED or StartDateError.
     """
-    start_dates_disabled = settings.FEATURES["DISABLE_START_DATES"]
+    start_dates_disabled = settings.DISABLE_START_DATES
     masquerading_as_student = is_masquerading_as_student(user, course_key)
 
     if start_dates_disabled and not masquerading_as_student:

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -259,7 +259,7 @@ def _add_timed_exam_info(user, course, section, section_context):
     """
     section_is_time_limited = (
         getattr(section, 'is_time_limited', False) and
-        settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False)
+        settings.ENABLE_SPECIAL_EXAMS
     )
     if section_is_time_limited:
         # call into edx_proctoring subsystem
@@ -555,7 +555,7 @@ def prepare_runtime_for_user(
         block_wrappers.append(filter_displayed_blocks)
 
     mako_service = MakoService()
-    if settings.FEATURES.get("LICENSING", False):
+    if settings.LICENSING:
         block_wrappers.append(partial(wrap_with_license, mako_service=mako_service))
 
     # Wrap the output display in a single div to allow for the XBlock
@@ -584,7 +584,7 @@ def prepare_runtime_for_user(
 
     user_is_staff = bool(has_access(user, 'staff', course_id))
 
-    if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):
+    if settings.DISPLAY_DEBUG_INFO_TO_STAFF:
         if user_is_staff or is_masquerading_as_specific_student(user, course_id):
             # When masquerading as a specific student, we want to show the debug button
             # unconditionally to enable resetting the state of the student we are masquerading as.
@@ -1004,7 +1004,7 @@ def xblock_view(request, course_id, usage_id, view_name):
         resources: A list of tuples where the first element is the resource hash, and
             the second is the resource description
     """
-    if not settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False):
+    if not settings.ENABLE_XBLOCK_VIEW_ENDPOINT:
         log.warning("Attempt to use deactivated XBlock view endpoint -"
                     " see FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']")
         raise Http404

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -592,7 +592,7 @@ class VerificationDeadlineDate(DateSummary):
             is_active and
             mode == 'verified' and
             self.verification_status in ('expired', 'none', 'must_reverify') and
-            not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE')
+            not settings.ENABLE_INTEGRITY_SIGNATURE
         )
 
     @lazy

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -214,7 +214,7 @@ def setup_masquerade(request, course_key, staff_access=False, reset_masquerade_d
     """
     if (
         request.user is None or
-        not settings.FEATURES.get('ENABLE_MASQUERADE', False) or
+        not settings.ENABLE_MASQUERADE or
         not staff_access
     ):
         return None, request.user

--- a/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
+++ b/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
@@ -20,7 +20,7 @@ class CsmBigInt(AlterField):
         to_model = to_state.apps.get_model(app_label, self.model_name)
 
         if schema_editor.connection.alias == 'student_module_history':
-            if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+            if settings.ENABLE_CSMH_EXTENDED:
                 if schema_editor.connection.vendor == 'mysql':
                     schema_editor.execute("ALTER TABLE `coursewarehistoryextended_studentmodulehistoryextended` MODIFY `student_module_id` bigint UNSIGNED NOT NULL;")
                 elif schema_editor.connection.vendor == 'postgresql':
@@ -44,7 +44,7 @@ class Migration(migrations.Migration):
         ('courseware', '0010_auto_20190709_1559'),
     ]
 
-    if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+    if settings.ENABLE_CSMH_EXTENDED:
         dependencies.append(('coursewarehistoryextended', '0002_force_studentmodule_index'))
 
     operations = [

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -216,7 +216,7 @@ class BaseStudentModuleHistory(models.Model):
 
         history_entries = []
 
-        if settings.FEATURES.get('ENABLE_CSMH_EXTENDED'):
+        if settings.ENABLE_CSMH_EXTENDED:
             from lms.djangoapps.coursewarehistoryextended.models import StudentModuleHistoryExtended
             history_entries += StudentModuleHistoryExtended.objects.filter(
                 # Django will sometimes try to join to courseware_studentmodule
@@ -226,7 +226,7 @@ class BaseStudentModuleHistory(models.Model):
 
         # If we turn off reading from multiple history tables, then we don't want to read from
         # StudentModuleHistory anymore, we believe that all history is in the Extended table.
-        if settings.FEATURES.get('ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES'):
+        if settings.ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES:
             # we want to save later SQL queries on the model which allows us to prefetch
             history_entries += StudentModuleHistory.objects.prefetch_related('student_module').filter(
                 student_module__in=student_modules
@@ -315,7 +315,7 @@ class StudentModuleHistory(BaseStudentModuleHistory):
     # When the extended studentmodulehistory table exists, don't save
     # duplicate history into courseware_studentmodulehistory, just retain
     # data for reading.
-    if not settings.FEATURES.get('ENABLE_CSMH_EXTENDED'):
+    if not settings.ENABLE_CSMH_EXTENDED:
         post_save.connect(save_history, sender=StudentModule)
 
 

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -17,7 +17,7 @@ from openedx.core.lib.courses import get_course_by_id
 
 User = get_user_model()
 
-TEXTBOOK_ENABLED = settings.FEATURES.get("ENABLE_TEXTBOOK", False)
+TEXTBOOK_ENABLED = settings.ENABLE_TEXTBOOK
 
 
 class ProgressCourseApp(CourseApp):
@@ -237,7 +237,7 @@ class ProctoringCourseApp(CourseApp):
         """
         Returns true if the proctoring app is available for all courses.
         """
-        return settings.FEATURES.get('ENABLE_PROCTORED_EXAMS')
+        return settings.ENABLE_PROCTORED_EXAMS
 
     @classmethod
     def is_enabled(cls, course_key: CourseKey) -> bool:

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -134,7 +134,7 @@ class TextbookTabs(TextbookTabsBase):
     @classmethod
     def is_enabled(cls, course, user=None):
         parent_is_enabled = super().is_enabled(course, user)
-        return settings.FEATURES.get('ENABLE_TEXTBOOK') and parent_is_enabled
+        return settings.ENABLE_TEXTBOOK and parent_is_enabled
 
     @classmethod
     def items(cls, course):

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -365,7 +365,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'autoAdvance': False,
             'saveStateEnabled': True,
             'saveStateUrl': '',
-            'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', True),
+            'autoplay': settings.AUTOPLAY_VIDEOS,
             'streams': '1.00:3_yD_cEKoCk',
             'sources': '[]',
             'duration': 111.0,

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -310,7 +310,7 @@ def courses(request):
     courses_list = []
     course_discovery_meanings = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
     set_default_filter = ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER.is_enabled()
-    if not settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+    if not settings.ENABLE_COURSE_DISCOVERY:
         courses_list = get_courses(
             request.user,
             filter_={"catalog_visibility": CATALOG_VISIBILITY_CATALOG_AND_ABOUT},
@@ -557,7 +557,7 @@ class CourseTabView(EdxFragmentView):
         Returns the URL to use to enroll in the specified course.
         """
         url_to_enroll = reverse('about_course', args=[str(course_key)])
-        if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+        if settings.ENABLE_MKTG_SITE:
             url_to_enroll = marketing_link('COURSES')
         return url_to_enroll
 
@@ -840,7 +840,7 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
         show_courseware_link = bool(
             (
                 request.user.has_perm(VIEW_COURSEWARE, course)
-            ) or settings.FEATURES.get('ENABLE_LMS_MIGRATION')
+            ) or settings.ENABLE_LMS_MIGRATION
         )
 
         # If the ecommerce checkout flow is enabled and the mode of the course is
@@ -899,7 +899,7 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
             'studio_url': studio_url,
             'registered': registered,
             'course_target': course_target,
-            'is_cosmetic_price_enabled': settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_PRICE'),
+            'is_cosmetic_price_enabled': settings.ENABLE_COSMETIC_DISPLAY_PRICE,
             'course_price': course_price,
             'ecommerce_checkout': ecommerce_checkout,
             'ecommerce_checkout_link': ecommerce_checkout_link,
@@ -1098,7 +1098,7 @@ def _downloadable_certificate_message(course, cert_downloadable_status):  # lint
 
 
 def _missing_required_verification(student, enrollment_mode):
-    return settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT') and (
+    return settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT and (
         enrollment_mode in CourseMode.VERIFIED_MODES and not IDVerificationService.user_is_verified(student)
     )
 
@@ -1171,7 +1171,7 @@ def credit_course_requirements(course_key, student):
     # If credit eligibility is not enabled or this is not a credit course,
     # short-circuit and return `None`.  This indicates that credit requirements
     # should NOT be displayed on the progress page.
-    if not (settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False) and is_credit_course(course_key)):
+    if not (settings.ENABLE_CREDIT_ELIGIBILITY and is_credit_course(course_key)):
         return None
 
     # This indicates that credit requirements should NOT be displayed on the progress page.
@@ -1226,9 +1226,9 @@ def _course_home_redirect_enabled():
     Returns: boolean True or False
     """
     if configuration_helpers.get_value(
-            'ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+            'ENABLE_MKTG_SITE', settings.ENABLE_MKTG_SITE
     ) and configuration_helpers.get_value(
-        'ENABLE_COURSE_HOME_REDIRECT', settings.FEATURES.get('ENABLE_COURSE_HOME_REDIRECT', True)
+        'ENABLE_COURSE_HOME_REDIRECT', settings.ENABLE_COURSE_HOME_REDIRECT
     ):
         return True
 
@@ -1713,7 +1713,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
                 'enable_completion_on_view_service': enable_completion_on_view_service,
                 'edx_notes_enabled': is_feature_enabled(course, request.user),
                 'staff_access': staff_access,
-                'xqa_server': settings.FEATURES.get('XQA_SERVER', 'http://your_xqa_server.com'),
+                'xqa_server': settings.XQA_SERVER,
                 'missed_deadlines': missed_deadlines,
                 'missed_gated_content': missed_gated_content,
                 'has_ended': course.has_ended(),
@@ -2360,7 +2360,7 @@ def courseware_mfe_search_enabled(request, course_id=None):
     user = request.user
 
     has_required_enrollment = False
-    if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED'):
+    if settings.ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED:
         enrollment_mode, _ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
         if (
             auth.user_has_role(user, CourseStaffRole(CourseKey.from_string(course_id)))
@@ -2370,7 +2370,7 @@ def courseware_mfe_search_enabled(request, course_id=None):
     else:
         has_required_enrollment = True
 
-    inclusion_date = settings.FEATURES.get('COURSEWARE_SEARCH_INCLUSION_DATE')
+    inclusion_date = settings.COURSEWARE_SEARCH_INCLUSION_DATE
     start_date = CourseOverview.get_from_id(course_key).start
     has_valid_inclusion_date = False
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -317,7 +317,7 @@ def courses(request):
         )
 
         if configuration_helpers.get_value("ENABLE_COURSE_SORTING_BY_START_DATE",
-                                           settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]):
+                                           settings.ENABLE_COURSE_SORTING_BY_START_DATE):
             courses_list = sort_by_start_date(courses_list)
         else:
             courses_list = sort_by_announcement(courses_list)

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -20,7 +20,7 @@ from lms.djangoapps.courseware.tests.factories import LOCATION
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 
 
-@skipUnless(settings.FEATURES["ENABLE_CSMH_EXTENDED"], "CSMH Extended needs to be enabled")
+@skipUnless(settings.ENABLE_CSMH_EXTENDED, "CSMH Extended needs to be enabled")
 class TestStudentModuleHistoryBackends(TestCase):
     """ Tests of data in CSMH and CSMHE """
     # Tell Django to clean out all databases, not just default

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -20,7 +20,7 @@ ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
 
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""
-    return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST', False)
+    return settings.ENABLE_FORUM_DAILY_DIGEST
 
 # .. toggle_name: discussion.enable_captcha
 # .. toggle_implementation: CourseWaffleFlag

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -7,16 +7,6 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'discussion'
 
-# .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Settings for forums/discussions to on/off daily digest
-#   feature. Set this to True if you want to enable users to subscribe and unsubscribe
-#   for daily digest. This setting enables deprecation of daily digest.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-03-09
-ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
-
 
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -1018,7 +1018,7 @@ def is_discussion_enabled(course_id):
     """
     Return True if discussions are enabled; else False
     """
-    return settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE')
+    return settings.ENABLE_DISCUSSION_SERVICE
 
 
 def is_content_authored_by(content, user):

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -28,7 +28,7 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
     priority = 40
     view_name = 'forum_form_discussion'
     fragment_view_name = 'lms.djangoapps.discussion.views.DiscussionBoardFragmentView'
-    is_hideable = settings.FEATURES.get('ALLOW_HIDING_DISCUSSION_TAB', False)
+    is_hideable = settings.ALLOW_HIDING_DISCUSSION_TAB
     is_default = False
     body_class = 'discussion'
     online_help_token = 'discussions'

--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -26,7 +26,7 @@ def edxnotes(cls):
             generate_uid, get_edxnotes_id_token, get_public_endpoint, get_token_url, is_feature_enabled
         )
 
-        if not settings.FEATURES.get("ENABLE_EDXNOTES"):
+        if not settings.ENABLE_EDXNOTES:
             return original_get_html(self, *args, **kwargs)
 
         runtime = getattr(self, 'block', self).runtime

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -39,7 +39,7 @@ class EdxNotesTab(EnrolledTab):
         if not super().is_enabled(course, user=user):
             return False
 
-        if not settings.FEATURES.get("ENABLE_EDXNOTES"):
+        if not settings.ENABLE_EDXNOTES:
             return False
 
         if user and not user.is_authenticated:
@@ -65,7 +65,7 @@ class EdxNotesCourseApp(CourseApp):
         """
         EdX notes availability is currently globally controlled via a feature setting.
         """
-        return settings.FEATURES.get("ENABLE_EDXNOTES", False)
+        return settings.ENABLE_EDXNOTES
 
     @classmethod
     def is_enabled(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -93,7 +93,7 @@ class TestProblem:
         return "original_get_html"
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 class EdxNotesDecoratorTest(ModuleStoreTestCase):
     """
     Tests for edxnotes decorator.
@@ -190,7 +190,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         assert problem.get_html() == "original_get_html"
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesHelpersTest(ModuleStoreTestCase):
     """
@@ -939,7 +939,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         verify_url(previous_url, previous_api_url)
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesViewsTest(ModuleStoreTestCase):
     """
@@ -1251,7 +1251,7 @@ class EdxNotesRetireAPITest(ModuleStoreTestCase):
         assert response.status_code == 500
 
 
-@skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
+@skipUnless(settings.ENABLE_EDXNOTES, "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesPluginTest(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/grades/apps.py
+++ b/lms/djangoapps/grades/apps.py
@@ -43,6 +43,6 @@ class GradesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from .signals import handlers  # pylint: disable=unused-import
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import GradesService
             set_runtime_service('grades', GradesService())

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -104,7 +104,7 @@ class SubsectionGradeFactory:
             )
             self._update_saved_subsection_grade(subsection.location, grade_model)
 
-            if settings.FEATURES.get('ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL'):
+            if settings.ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL:
                 COURSE_ASSESSMENT_GRADE_CHANGED.send(
                     sender=self,
                     course_id=self.course_data.course_key,

--- a/lms/djangoapps/instructor/apps.py
+++ b/lms/djangoapps/instructor/apps.py
@@ -37,6 +37,6 @@ class InstructorConfig(AppConfig):
 
     def ready(self):
         from . import handlers  # pylint: disable=unused-import,import-outside-toplevel
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import InstructorService
             set_runtime_service('instructor', InstructorService())

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -492,7 +492,7 @@ def get_email_params(course, auto_enroll, secure=True, course_key=None, display_
 
     # We can't get the url to the course's About page if the marketing site is enabled.
     course_about_url = None
-    if not settings.FEATURES.get('ENABLE_MKTG_SITE', False):
+    if not settings.ENABLE_MKTG_SITE:
         course_about_url = '{proto}://{site}{path}'.format(
             proto=protocol,
             site=stripped_site_name,

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -9,7 +9,7 @@ def plugin_settings(settings):
     ### Analytics Dashboard (Insights) settings
     settings.ANALYTICS_DASHBOARD_URL = ""
     settings.ANALYTICS_DASHBOARD_NAME = _('Your Platform Insights')
-    # .. toggle_name: FEATURES['DISPLAY_ANALYTICS_ENROLLMENTS']
+    # .. toggle_name: DISPLAY_ANALYTICS_ENROLLMENTS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
     # .. toggle_description: Enable display of enrollment counts in instructor dashboard and
@@ -19,7 +19,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/5838
     settings.DISPLAY_ANALYTICS_ENROLLMENTS = True
 
-    # .. toggle_name: FEATURES['ENABLE_CCX_ANALYTICS_DASHBOARD_URL']
+    # .. toggle_name: ENABLE_CCX_ANALYTICS_DASHBOARD_URL
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Display the 'Analytics' tab in the instructor dashboard for CCX courses.
@@ -30,7 +30,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/13196
     settings.ENABLE_CCX_ANALYTICS_DASHBOARD_URL = False
 
-    # .. setting_name: FEATURES['MAX_ENROLLMENT_INSTR_BUTTONS']
+    # .. setting_name: MAX_ENROLLMENT_INSTR_BUTTONS
     # .. setting_default: 200
     # .. setting_description: Disable instructor dashboard buttons for downloading course data
     #   when enrollment exceeds this number. The number indicates the maximum allowed enrollments
@@ -38,7 +38,7 @@ def plugin_settings(settings):
     #   courses will have disabled buttons at the instructor dashboard.
     settings.MAX_ENROLLMENT_INSTR_BUTTONS = 200
 
-    # .. toggle_name: FEATURES['ENABLE_GRADE_DOWNLOADS']
+    # .. toggle_name: ENABLE_GRADE_DOWNLOADS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable grade CSV downloads from the instructor dashboard. Grade
@@ -49,7 +49,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/11286
     settings.ENABLE_GRADE_DOWNLOADS = False
 
-    # .. toggle_name: FEATURES['ALLOW_COURSE_STAFF_GRADE_DOWNLOADS']
+    # .. toggle_name: ALLOW_COURSE_STAFF_GRADE_DOWNLOADS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable to give course staff unrestricted access to grade downloads;
@@ -59,7 +59,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/1750
     settings.ALLOW_COURSE_STAFF_GRADE_DOWNLOADS = False
 
-    # .. toggle_name: FEATURES['ALLOW_AUTOMATED_SIGNUPS']
+    # .. toggle_name: ALLOW_AUTOMATED_SIGNUPS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable to show a section in the membership tab of the instructor
@@ -70,7 +70,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/5670
     settings.ALLOW_AUTOMATED_SIGNUPS = False
 
-    # .. toggle_name: FEATURES['ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS']
+    # .. toggle_name: ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: When True, the CSV file that contains a list of
@@ -82,7 +82,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/21260
     settings.ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS = False
 
-    # .. toggle_name: FEATURES['CERTIFICATES_INSTRUCTOR_GENERATION']  # lint-amnesty, pylint: disable=annotation-missing-token
+    # .. toggle_name: CERTIFICATES_INSTRUCTOR_GENERATION  # lint-amnesty, pylint: disable=annotation-missing-token
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable to allow batch generation of certificates from the instructor dashboard.
@@ -98,7 +98,7 @@ def plugin_settings(settings):
     # .. toggle_use_cases: opt_in
     settings.ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE = False
 
-    # .. toggle_name: FEATURES['BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT']
+    # .. toggle_name: BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
     # .. toggle_description: Controls if the "Notify users by email" checkbox in the batch

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -285,7 +285,7 @@ class RegisterAndEnrollStudents(APIView):
         """
         if not configuration_helpers.get_value(
             'ALLOW_AUTOMATED_SIGNUPS',
-            settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False),
+            settings.ALLOW_AUTOMATED_SIGNUPS,
         ):
             return HttpResponseForbidden()
 
@@ -341,7 +341,7 @@ class RegisterAndEnrollStudents(APIView):
             already_warned_not_cohorted = False
             extra_fields_is_enabled = configuration_helpers.get_value(
                 'ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS',
-                settings.FEATURES.get('ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS', False),
+                settings.ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS,
             )
 
             # Iterate each student in the uploaded csv file.

--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -106,7 +106,7 @@ def get_grade_book_page(request, course, course_key):
 def spoc_gradebook(request, course_id):
     """
     Show the gradebook for this course:
-    - Only shown for courses with enrollment < settings.FEATURES.get("MAX_ENROLLMENT_INSTR_BUTTONS")
+    - Only shown for courses with enrollment < settings.MAX_ENROLLMENT_INSTR_BUTTONS
     - Only displayed to course staff
     """
     course_key = CourseKey.from_string(course_id)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -92,7 +92,7 @@ def show_analytics_dashboard_message(course_key):
         course_key (CourseLocator): The course locator to display the analytics dashboard message on.
     """
     if hasattr(course_key, 'ccx'):
-        ccx_analytics_enabled = settings.FEATURES.get('ENABLE_CCX_ANALYTICS_DASHBOARD_URL', False)
+        ccx_analytics_enabled = settings.ENABLE_CCX_ANALYTICS_DASHBOARD_URL
         return settings.ANALYTICS_DASHBOARD_URL and ccx_analytics_enabled
 
     return settings.ANALYTICS_DASHBOARD_URL
@@ -208,7 +208,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
     # and enable self-generated certificates for a course.
     # Note: This is hidden for all CCXs
     certs_enabled = certs_api.is_certificate_generation_enabled() and not hasattr(course_key, 'ccx')
-    certs_instructor_enabled = settings.FEATURES.get('ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE', False)
+    certs_instructor_enabled = settings.ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE
 
     if certs_enabled and (access['admin'] or (access['instructor'] and certs_instructor_enabled)):
         sections.append(_section_certificates(course))
@@ -258,7 +258,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'generate_bulk_certificate_exceptions_url': generate_bulk_certificate_exceptions_url,
         'certificate_exception_view_url': certificate_exception_view_url,
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
-        'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
+        'xqa_server': settings.XQA_SERVER,
     }
 
     context_from_plugins = get_plugins_view_context(
@@ -366,7 +366,7 @@ def _section_certificates(course):
                 for cert_status in example_cert_status
             )
         )
-    instructor_generation_enabled = settings.FEATURES.get('CERTIFICATES_INSTRUCTOR_GENERATION', False)
+    instructor_generation_enabled = settings.CERTIFICATES_INSTRUCTOR_GENERATION
     certificate_statuses_with_count = {
         certificate['status']: certificate['count']
         for certificate in certs_api.get_unique_certificate_statuses(course.id)
@@ -463,7 +463,7 @@ def _section_course_info(course, access):
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': str(course_key)}),
     }
 
-    if settings.FEATURES.get('DISPLAY_ANALYTICS_ENROLLMENTS'):
+    if settings.DISPLAY_ANALYTICS_ENROLLMENTS:
         section_data['enrollment_count'] = CourseEnrollment.objects.enrollment_counts(course_key)
 
     if show_analytics_dashboard_message(course_key):
@@ -494,7 +494,7 @@ def _section_course_info(course, access):
 def _section_membership(course, access):
     """ Provide data for the corresponding dashboard section """
     course_key = course.id
-    ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
+    ccx_enabled = settings.CUSTOM_COURSES_EDX and course.enable_ccx
 
     section_data = {
         'section_key': 'membership',
@@ -635,7 +635,7 @@ def _section_data_download(course, access):
     course_key = course.id
 
     show_proctored_report_button = (
-        settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+        settings.ENABLE_SPECIAL_EXAMS and
         course.enable_proctored_exams
     )
     section_key = 'data_download_2' if data_download_v2_is_enabled() else 'data_download'
@@ -734,7 +734,7 @@ def _section_send_email(course, access):
             'list_email_content', kwargs={'course_id': str(course_key)}
         ),
     }
-    if settings.FEATURES.get("ENABLE_NEW_BULK_EMAIL_EXPERIENCE", False) is not False:
+    if settings.ENABLE_NEW_BULK_EMAIL_EXPERIENCE is not False:
         section_data[
             "communications_mfe_url"
         ] = f"{settings.COMMUNICATIONS_MICROFRONTEND_URL}/courses/{str(course_key)}/bulk_email"
@@ -799,7 +799,7 @@ def _section_open_response_assessment(request, course, openassessment_blocks, ac
     section_data = {
         'fragment': block.render('ora_blocks_listing_view', context={
             'ora_items': ora_items,
-            'ora_item_view_enabled': settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False)
+            'ora_item_view_enabled': settings.ENABLE_XBLOCK_VIEW_ENDPOINT
         }),
         'section_key': 'open_response_assessment',
         'section_display_name': _('Open Responses'),

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -172,7 +172,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
 
         # Note: This is hidden for all CCXs
         certs_enabled = CertificateGenerationConfiguration.current().enabled and not hasattr(course_key, 'ccx')
-        certs_instructor_enabled = settings.FEATURES.get('ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE', False)
+        certs_instructor_enabled = settings.ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE
 
         if certs_enabled and access['admin'] or (access['instructor'] and certs_instructor_enabled):
             tabs.append({

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -911,7 +911,7 @@ class ProblemResponses:
         ])
 
         student_data = []
-        max_count = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT')
+        max_count = settings.MAX_PROBLEM_RESPONSES_COUNT
 
         store = modulestore()
         user_state_client = DjangoXBlockUserStateClient()

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -55,7 +55,7 @@ def lti_launch(request, course_id, usage_id):
         - The launch data is correctly signed using a known client key/secret
           pair
     """
-    if not settings.FEATURES['ENABLE_LTI_PROVIDER']:
+    if not settings.ENABLE_LTI_PROVIDER:
         log.info('LTI provider feature is disabled.')
         return HttpResponseForbidden()
 

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -101,7 +101,7 @@ class MFEConfigView(APIView):
         return {
             "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
                 "ENABLE_COURSE_SORTING_BY_START_DATE",
-                settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]
+                settings.ENABLE_COURSE_SORTING_BY_START_DATE
             ),
             "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
                 "homepage_promo_video_youtube_id",
@@ -116,5 +116,5 @@ class MFEConfigView(APIView):
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
             "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
-            "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
+            "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
         }

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -115,6 +115,6 @@ class MFEConfigView(APIView):
                 "course_about_twitter_account",
                 settings.PLATFORM_TWITTER_ACCOUNT
             ),
-            "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
+            "NON_BROWSABLE_COURSES": not settings.COURSES_ARE_BROWSABLE,
             "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
         }

--- a/lms/djangoapps/teams/__init__.py
+++ b/lms/djangoapps/teams/__init__.py
@@ -12,4 +12,4 @@ def is_feature_enabled(course):
     """
     Returns True if the teams feature is enabled.
     """
-    return settings.FEATURES.get('ENABLE_TEAMS', False) and course.teams_enabled
+    return settings.ENABLE_TEAMS and course.teams_enabled

--- a/lms/djangoapps/teams/management/commands/reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/reindex_course_team.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
             if not options['course_team_ids']:
                 raise CommandError('At least one course_team_id or --all needs to be specified')
 
-        if not settings.FEATURES.get('ENABLE_TEAMS', False):
+        if not settings.ENABLE_TEAMS:
             raise CommandError('ENABLE_TEAMS must be enabled to use course team indexing')
 
         if options['all']:

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -63,7 +63,7 @@ class TeamsCourseApp(CourseApp):
         """
         if not ENABLE_TEAMS_APP.is_enabled():
             return False
-        return settings.FEATURES.get("ENABLE_TEAMS", False)
+        return settings.ENABLE_TEAMS
 
     @classmethod
     def is_enabled(cls, course_key: CourseKey) -> bool:

--- a/lms/djangoapps/verify_student/urls.py
+++ b/lms/djangoapps/verify_student/urls.py
@@ -121,7 +121,7 @@ urlpatterns = [
 ]
 
 # Fake response page for incourse reverification ( software secure )
-if settings.FEATURES.get('ENABLE_SOFTWARE_SECURE_FAKE'):
+if settings.ENABLE_SOFTWARE_SECURE_FAKE:
     from lms.djangoapps.verify_student.tests.fake_software_secure import SoftwareSecureFakeView
     urlpatterns += [
         path('software-secure-fake-response', SoftwareSecureFakeView.as_view()),

--- a/lms/djangoapps/verify_student/utils.py
+++ b/lms/djangoapps/verify_student/utils.py
@@ -136,7 +136,7 @@ def auto_verify_for_testing_enabled(override=None):
     """
     if override is not None:
         return override
-    return settings.FEATURES.get('AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING')
+    return settings.AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING
 
 
 def can_verify_now(verification_status, expiration_datetime):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -95,7 +95,7 @@ DISPLAY_DEBUG_INFO_TO_STAFF = True
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2425
 DISPLAY_HISTOGRAMS_TO_STAFF = False  # For large courses this slows down courseware access for staff.
 
-REROUTE_ACTIVATION_EMAIL = False  # nonempty string = address for all activation emails
+REROUTE_ACTIVATION_EMAIL = None  # nonempty string = address for all activation emails
 
 ENABLE_DISCUSSION_HOME_PANEL = False
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3134,3 +3134,17 @@ SSL_AUTH_EMAIL_DOMAIN = "MIT.EDU"
 SSL_AUTH_DN_FORMAT_STRING = (
     "/C=US/ST=Massachusetts/O=Massachusetts Institute of Technology/OU=Client CA v1/CN={0}/emailAddress={1}"
 )
+
+
+# .. toggle_name: ENABLE_FORUM_DAILY_DIGEST
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Set to True to enable forum notification features.
+# .. toggle_category: discussion
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-03-09
+# .. toggle_expiration_date: None
+# .. toggle_tickets: None
+# .. toggle_status: supported
+# .. toggle_warnings: None
+ENABLE_FORUM_DAILY_DIGEST = True

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -84,16 +84,6 @@ CC_MERCHANT_NAME = Derived(lambda settings: settings.PLATFORM_NAME)
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2425
 DISPLAY_DEBUG_INFO_TO_STAFF = True
 
-# .. toggle_name: settings.DISPLAY_HISTOGRAMS_TO_STAFF
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: This displays histograms in the Staff Debug Info panel to course staff.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-02-13
-# .. toggle_warning: Generating histograms requires scanning the courseware_studentmodule table on each view. This
-#   can make staff access to courseware very slow on large courses.
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2425
-DISPLAY_HISTOGRAMS_TO_STAFF = False  # For large courses this slows down courseware access for staff.
 
 REROUTE_ACTIVATION_EMAIL = None  # nonempty string = address for all activation emails
 
@@ -135,7 +125,6 @@ ENABLE_UNICODE_USERNAME = False
 #  Django's admin site and will be inaccessible to the superuser.
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/829
 ENABLE_DJANGO_ADMIN_SITE = True
-ENABLE_LMS_MIGRATION = False
 
 # .. toggle_name: settings.ENABLE_MASQUERADE
 # .. toggle_implementation: DjangoSetting
@@ -290,16 +279,6 @@ SQUELCH_PII_IN_LOGS = True
 # defaults, so that we maintain current behavior
 ALLOW_WIKI_ROOT_ACCESS = True
 
-# .. toggle_name: settings.ENABLE_THIRD_PARTY_AUTH
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Turn on third-party auth. Disabled for now because full implementations are not yet
-#   available. Remember to run migrations if you enable this; we don't create tables by default. This feature can
-#   be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication
-#   backends with the AUTHENTICATION_BACKENDS setting.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2014-09-15
-ENABLE_THIRD_PARTY_AUTH = False
 
 # Prevent concurrent logins per user
 PREVENT_CONCURRENT_LOGINS = True
@@ -362,12 +341,6 @@ ENABLE_MKTG_EMAIL_OPT_IN = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/6588
 ENABLE_FOOTER_MOBILE_APP_LINKS = False
 
-# For easily adding modes to courses during acceptance testing
-MODE_CREATION_FOR_TESTING = False
-
-# For caching programs in contexts where the LMS can only
-# be reached over HTTP.
-EXPOSE_CACHE_PROGRAMS_ENDPOINT = False
 
 # Courseware search feature
 # .. toggle_name: settings.ENABLE_COURSEWARE_SEARCH
@@ -544,17 +517,6 @@ UNSUPPORTED_BROWSER_ALERT_VERSIONS = "{i:10,f:-3,o:-3,s:-3,c:-3}"
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/18298
 ENABLE_ACCOUNT_DELETION = True
 
-# .. toggle_name: settings.ENABLE_AUTHN_MICROFRONTEND
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the logistration.
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2020-09-08
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/24908'
-# .. toggle_warning: Also set settings.AUTHN_MICROFRONTEND_URL for rollout. This temporary feature
-#   toggle does not have a target removal date.
-ENABLE_AUTHN_MICROFRONTEND = os.environ.get("EDXAPP_ENABLE_AUTHN_MFE", False)
 
 # .. toggle_name: settings.ENABLE_CATALOG_MICROFRONTEND
 # .. toggle_implementation: DjangoSetting

--- a/lms/templates/courses_list.html
+++ b/lms/templates/courses_list.html
@@ -5,7 +5,7 @@
 <section class="courses-container">
   <section class="highlighted-courses">
 
-    % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+    % if settings.COURSES_ARE_BROWSABLE:
       <section class="courses">
         <ul class="courses-listing">
           ## limiting the course number by using HOMEPAGE_COURSE_MAX as the maximum number of courses

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -21,7 +21,7 @@ if active_page is None and active_page_context is not UNDEFINED:
 if course is not None:
     include_special_exams = (
     request.user.is_authenticated and
-    settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+    settings.ENABLE_SPECIAL_EXAMS and
     (course.enable_proctored_exams or course.enable_timed_exams)
     )
 

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -6,7 +6,7 @@
 %>
 <%inherit file="../main.html" />
 <%
-  course_discovery_enabled = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  course_discovery_enabled = settings.ENABLE_COURSE_DISCOVERY
 %>
 
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -75,7 +75,7 @@ from common.djangoapps.student.models import CourseEnrollment
       });
     });
   </%static:webpack>
-  % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
+  % if settings.ENABLE_DASHBOARD_SEARCH:
     <%static:require_module module_name="course_search/js/dashboard_search_factory" class_name="DashboardSearchFactory">
         DashboardSearchFactory();
     </%static:require_module>
@@ -240,7 +240,7 @@ from common.djangoapps.student.models import CourseEnrollment
                 % if empty_dashboard_message:
                   <p class="custom-message">${empty_dashboard_message | n, decode.utf8}</p>
                 %endif
-                % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+                % if settings.COURSES_ARE_BROWSABLE:
                   <a class="btn btn-primary" href="${marketing_link('COURSES')}">
                     ${_("Explore courses")}
                   </a>
@@ -277,7 +277,7 @@ from common.djangoapps.student.models import CourseEnrollment
           </div>
         %endif
 
-        % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
+        % if settings.ENABLE_DASHBOARD_SEARCH:
           <div id="dashboard-search-bar" class="search-bar dashboard-search-bar" role="search" aria-label="Dashboard">
             <form class="search-form">
               <label for="dashboard-search-input">${_('Search Your Courses')}</label>

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -23,7 +23,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 <%block name="navigation_top" />
 
 <%
-  unsupported_browser_alert_versions = configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS'))
+  unsupported_browser_alert_versions = configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.UNSUPPORTED_BROWSER_ALERT_VERSIONS)
 %>
 % if waffle.switch_is_active('enable_unsupported_browser_alert'):
   <script>
@@ -43,7 +43,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 % endif
 
 <header class="global-header ${'slim' if course else ''}">
-    % if settings.FEATURES.get('ENABLE_COOKIE_POLICY_BANNER', use_cookie_banner):
+    % if settings.ENABLE_COOKIE_POLICY_BANNER:
         ${static.renderReact(
             component="CookiePolicyBanner",
             id="frontend-component-cookie-policy-banner",
@@ -78,7 +78,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 <![endif]-->
 % endif
 
-% if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
+% if settings.ENABLE_COOKIE_CONSENT:
   <%include file="../widgets/cookie-consent.html" />
 % endif
 

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -11,9 +11,9 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 %>
 
 <%
-  show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  show_explore_courses = settings.COURSES_ARE_BROWSABLE
   self.real_user = getattr(user, 'real_user', user)
-  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+  enable_help_link = settings.ENABLE_HELP_LINK
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -42,7 +42,7 @@ enterprise_customer_link = get_enterprise_learner_portal(request)
       <span class="course-number">${course.display_number_with_default}</span>
       <%
       display_name = course.display_name_with_default
-      if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
+      if settings.CUSTOM_COURSES_EDX:
         ccx = get_current_ccx(course.id)
         if ccx:
           display_name = ccx.display_name

--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -14,11 +14,11 @@ from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_
 %>
 
 <%
-  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
-  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.ENABLE_MKTG_SITE)
+  courses_are_browsable = settings.COURSES_ARE_BROWSABLE
   allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
-  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
-  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True)
+  can_discover_courses = settings.ENABLE_COURSE_DISCOVERY
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.ALLOW_PUBLIC_ACCOUNT_CREATION) and settings.SHOW_REGISTRATION_LINKS
   should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
 %>
 <nav class="nav-links" aria-label=${_("Supplemental Links")}>

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -20,7 +20,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 <%include file="index_overlay.html" />
               % endif
             </div>
-            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+            % if settings.ENABLE_COURSE_DISCOVERY:
               <div class="course-search">
                 <form method="get" action="/courses">
                   <label><span class="sr">${_("Search for a course")}</span>

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -98,7 +98,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         <div class="certificate-generation-status"></div>
     </div>
 
-        %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+        %if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
         <div class="running-tasks-container action-type-container">
             <hr>
             <h3 class="hd hd-3"> ${_("Pending Tasks")} </h3>

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -4,10 +4,10 @@ from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
-%if settings.FEATURES.get('DISPLAY_ANALYTICS_ENROLLMENTS') or section_data.get('enrollment_message'):
+%if settings.DISPLAY_ANALYTICS_ENROLLMENTS or section_data.get('enrollment_message'):
   <h4 class="hd hd-4">${_("Enrollment Information")}</h4>
   <div class="enrollment-wrapper">
-    %if settings.FEATURES.get('DISPLAY_ANALYTICS_ENROLLMENTS'):
+    %if settings.DISPLAY_ANALYTICS_ENROLLMENTS:
       ## Translators: 'track' refers to the enrollment type ('honor', 'verified', or 'audit')
       <% modes = section_data['enrollment_count'] %>
         <table>
@@ -136,7 +136,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
 </div>
 
-%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+%if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
   <div class="running-tasks-container action-type-container">
     <hr>
     <h4 class="hd hd-4"> ${_("Pending Tasks")} </h4>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -20,7 +20,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
  </div>
 
-%if settings.FEATURES.get('ENABLE_GRADE_DOWNLOADS'):
+%if settings.ENABLE_GRADE_DOWNLOADS:
   <div class="reports-download-container action-type-container">
     <hr>
     <h3 class="hd hd-3">${_("Reports")}</h3>
@@ -55,7 +55,7 @@ from openedx.core.djangolib.markup import HTML, Text
     %endif
 
     <p>${_("Select a problem to generate a CSV file that lists all student answers to the problem. You also select a section or chapter to include results of all problems in that section or chapter.")}</p>
-    <% max_entries = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT') %>
+    <% max_entries = settings.MAX_PROBLEM_RESPONSES_COUNT %>
     %if max_entries is not None:
       <p>
         <strong>${_("NOTE")}: </strong>
@@ -96,7 +96,7 @@ from openedx.core.djangolib.markup import HTML, Text
   %endif
   <div class="data-display-table profile-data-display-table" id="data-student-profiles-table"></div>
 
-  %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
+  %if settings.ALLOW_COURSE_STAFF_GRADE_DOWNLOADS or section_data['access']['admin']:
     <p>${_("Click to generate a CSV grade report for all currently enrolled students.")}</p>
     <p>
       <input type="button" name="calculate-grades-csv" class="async-report-btn" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/>
@@ -120,7 +120,7 @@ from openedx.core.djangolib.markup import HTML, Text
       ${_("The reports listed below are available for download, identified by UTC date and time of generation.")}
     </p>
 
-  %if settings.FEATURES.get('ENABLE_ASYNC_ANSWER_DISTRIBUTION'):
+  %if settings.ENABLE_ASYNC_ANSWER_DISTRIBUTION:
     <p>
       ${_("The answer distribution report listed below is generated periodically by an automated background process. The report is cumulative, so answers submitted after the process starts are included in a subsequent report. The report is generated several times per day.")}
     </p>
@@ -142,7 +142,7 @@ from openedx.core.djangolib.markup import HTML, Text
   </div>
 %endif
 
-%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+%if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
   <div class="running-tasks-container action-type-container">
     <hr>
     <h3 class="hd hd-3">${_("Pending Tasks")}</h3>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2.html
@@ -11,14 +11,14 @@ from openedx.core.djangolib.markup import HTML, Text
         <li class="nav-item ">
             <button type="button" class="btn-link reports  active-section" data-section="reports">Reports</button>
         </li>
-        %if settings.FEATURES.get('ENABLE_GRADE_DOWNLOADS'):
+        %if settings.ENABLE_GRADE_DOWNLOADS:
         <li class="nav-item">
             <button type="button" class="btn-link problem-report" data-section="problem">Problem Report</button>
         </li>
         <li class="nav-item">
             <button type="button" class="btn-link certificates" data-section="certificate">Certificates</button>
         </li>
-        %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
+        %if settings.ALLOW_COURSE_STAFF_GRADE_DOWNLOADS or section_data['access']['admin']:
         <li class="nav-item">
             <button type="button" class="btn-link grading" data-section="grading">Grading</button>
         </li>
@@ -30,7 +30,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
     <%include file="./data_download_2/grading.html" args="section_data=section_data, **context.kwargs" />
 
-    %if settings.FEATURES.get('ENABLE_GRADE_DOWNLOADS'):
+    %if settings.ENABLE_GRADE_DOWNLOADS:
       <%include file="./data_download_2/certificates.html" args="section_data=section_data, **context.kwargs" />
       <%include file="./data_download_2/problem_report.html" args="section_data=section_data, **context.kwargs" />
     %endif
@@ -50,7 +50,7 @@ from openedx.core.djangolib.markup import HTML, Text
         ${_("The reports listed below are available for download, identified by UTC date and time of generation.")}
     </p>
 
-    %if settings.FEATURES.get('ENABLE_ASYNC_ANSWER_DISTRIBUTION'):
+    %if settings.ENABLE_ASYNC_ANSWER_DISTRIBUTION:
     <p>
         ${_("The answer distribution report listed below is generated periodically by an automated background process. \
         The report is cumulative, so answers submitted after the process starts are included in a subsequent report. \
@@ -78,7 +78,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
 </div>
 
-%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+%if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
 <div class="running-tasks-container action-type-container">
     <hr>
     <h3 class="hd hd-3">${_("Pending Tasks")}</h3>
@@ -90,4 +90,3 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="no-pending-tasks-message"></div>
 </div>
 %endif
-

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/grading.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/grading.html
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
-%if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
+%if settings.ALLOW_COURSE_STAFF_GRADE_DOWNLOADS or section_data['access']['admin']:
 <section id="grading" class="idash-section tab-data" aria-labelledby="header-grading">
     <h6 class="mb-15 font-size-100" id="header-grading">
         <strong>${_("Note")}: </strong>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/problem_report.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/problem_report.html
@@ -36,7 +36,7 @@ from openedx.core.djangolib.markup import HTML, Text
            class="download-report mb-20 hidden"
            style="margin-left: 0">
 
-    <% max_entries = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT') %>
+    <% max_entries = settings.MAX_PROBLEM_RESPONSES_COUNT %>
     %if max_entries is not None:
     <p class="mb-15">
         <strong>${_("NOTE")}: </strong>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download_2/reports.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download_2/reports.html
@@ -24,7 +24,7 @@ from openedx.core.djangolib.markup import HTML, Text
                             class="${'is-disabled' if disable_buttons else ''}"
                             aria-disabled="${'true' if disable_buttons else 'false'}">Anonymized Student IDs
                     </option>
-                    %if settings.FEATURES.get('ENABLE_GRADE_DOWNLOADS'):
+                    %if settings.ENABLE_GRADE_DOWNLOADS:
                     <option value="profileInformation"
                             data-endpoint="${ section_data['get_students_features_url'] + '/csv' }"
                             data-csv="true">Profile Information
@@ -54,7 +54,7 @@ from openedx.core.djangolib.markup import HTML, Text
                         Survey Result report
                     </option>
                     %endif
-                    %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
+                    %if settings.ALLOW_COURSE_STAFF_GRADE_DOWNLOADS or section_data['access']['admin']:
                     <option value="ORADataReport" data-graderelated="true"
                             data-endpoint="${ section_data['export_ora2_data_url'] }">ORA Data
                         report

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -39,7 +39,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="enroll-option">
         <label class="has-hint">
           <input type="checkbox" name="email-students" id="email-students" value="Notify-students-by-email" aria-describedby="heading-batch-enrollment"
-                 ${'checked="yes"' if settings.FEATURES.get('BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT') else ''}>
+                 ${'checked="yes"' if settings.BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT else ''}>
             <span class="label-text">${_("Notify users by email")}</span>
             <div class="hint email-students-hint">
                 <span class="hint-caret"></span>
@@ -57,7 +57,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="request-response-error"></div>
 </fieldset>
 
-%if static.get_value('ALLOW_AUTOMATED_SIGNUPS', settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False)):
+%if static.get_value('ALLOW_AUTOMATED_SIGNUPS', settings.ALLOW_AUTOMATED_SIGNUPS):
 <hr class="divider" />
 
   <div class="auto_enroll auto_enroll_csv membership-section">
@@ -76,7 +76,7 @@ from openedx.core.djangolib.markup import HTML, Text
       <div class="enroll-option">
           <label class="has-hint">
             <input type="checkbox" name="email-students" id="csv-email-students" value="Notify-students-by-email" aria-describedby="heading-batch-enrollment"
-                   ${'checked="yes"' if settings.FEATURES.get('BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT') else ''}>
+                   ${'checked="yes"' if settings.BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT else ''}>
               <span class="label-text">${_("Notify users by email")}</span>
               <div class="hint email-students-hint">
                   <span class="hint-caret"></span>
@@ -119,7 +119,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="enroll-option">
         <label class="has-hint">
             <input type="checkbox" name="email-students-beta" id="email-students-beta" value="Notify-students-by-email" aria-describedby="heading-batch-beta-testers"
-                   ${'checked="yes"' if settings.FEATURES.get('BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT') else ''}>
+                   ${'checked="yes"' if settings.BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT else ''}>
             <span class="label-text">${_("Notify users by email")}</span>
             <div class="hint email-students-beta-hint">
                 <span class="hint-caret"></span>

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -111,7 +111,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <input type="button" name="send" value="${_("Send Email")}" data-endpoint="${ section_data['send_email'] }" >
     <div class="request-response-error"></div>
 
-    %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+    %if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
     <div class="running-tasks-container action-type-container">
         <hr>
         <h3 class="hd hd-3">${_("Pending Tasks")}</h3>

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -85,7 +85,7 @@
 
     <br><br>
 
-    %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+    %if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
         <h5 class="hd hd-5">${_("Rescore")}</h5>
         <label for="rescore-actions-single">${_("For the specified problem, rescore the learner's responses. The 'Rescore Only If Score Improves' option updates the learner's score only if it improves in the learner's favor.")}</label>
         <br>
@@ -97,7 +97,7 @@
 
     <br><br>
 
-    %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+    %if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
         <h5 class="hd hd-5">${_("Score Override")}</h5>
         <label for="override-problem-score-single">${_("For the specified problem, override the learner's score.")}</label>
         <br><br>
@@ -121,7 +121,7 @@
 
     <br><br>
 
-    %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+    %if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
         <h5 class="hd hd-5">${_("Task Status")}</h5>
         <label for="task-history-single">${_("Show the status for the rescoring tasks that you submitted for this learner and problem.")}</label>
         <br>
@@ -155,7 +155,7 @@
     <input type="button" name="skip-entrance-exam" value="${_('Let Learner Skip Entrance Exam')}" data-endpoint="${ section_data['student_can_skip_entrance_exam_url'] }">
     <br><br>
 
-    %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS') and section_data['access']['instructor']:
+    %if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS and section_data['access']['instructor']:
         <h5 class="hd hd-5">${_("Rescore")}</h5>
         <label for="rescore-actions-entrance-exam">
             ${_("Rescore any responses that have been submitted. The 'Rescore All Problems Only If Score Improves' option updates the learner's scores only if it improves in the learner's favor.")}
@@ -177,7 +177,7 @@
     <br><br>
 
 
-    %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+    %if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
         <h5 class="hd hd-5">${_("Task Status")}</h5>
         <label for="entrance-exam-task-history">
             ${_("Show the status for the rescoring tasks that you submitted for this learner and entrance exam.")}
@@ -193,7 +193,7 @@
 %endif
 
 %if section_data['access']['instructor']:
-%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+%if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
 <div class="course-specific-container action-type-container">
     <h4 class="hd hd-4">${_("Adjust all enrolled learners' grades for a specific problem")}</h4>
     <div class="request-response-error"></div>
@@ -231,7 +231,7 @@
 %endif
 %endif
 
-%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+%if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
 <div class="running-tasks-container action-type-container">
     <h4 class="hd hd-4">${_("Pending Tasks")}</h4>
     <div class="running-tasks-section">

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -17,7 +17,7 @@ from django.utils.translation import gettext as _
         <span class="course-number">${course.display_number_with_default}</span>
         <%
         display_name = course.display_name_with_default
-        if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
+        if settings.CUSTOM_COURSES_EDX:
           ccx = get_current_ccx(course.id)
           if ccx:
             display_name = ccx.display_name
@@ -27,7 +27,7 @@ from django.utils.translation import gettext as _
     % endif
 
 
-    % if settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing:
+    % if settings.COURSES_ARE_BROWSABLE and not show_program_listing:
       <li class="nav-item mt-2 nav-item-open-collapsed">
         <a class="nav-link" href="${marketing_link('COURSES')}">${_('Explore courses')}</a>
       </li>
@@ -50,7 +50,7 @@ from django.utils.translation import gettext as _
   </ul>
 
   <ul class="navbar-nav navbar-right">
-    % if settings.FEATURES.get('ENABLE_HELP_LINK'):
+    % if settings.ENABLE_HELP_LINK:
       <li class="nav-item mt-2 nav-item-open-collapsed">
         <a href="${get_online_help_info(online_help_token)['doc_url']}"
         rel="noopener"

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -11,7 +11,7 @@ from django.utils.translation import gettext as _
 
 <ol class="left nav-global list-inline authenticated">
   <%block name="navigation_global_links_authenticated">
-    % if settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing:
+    % if settings.COURSES_ARE_BROWSABLE and not show_program_listing:
       <li class="item nav-global-01">
         <a class="btn" href="${marketing_link('COURSES')}">${_('Explore courses')}</a>
       </li>
@@ -35,7 +35,7 @@ from django.utils.translation import gettext as _
 
 <%include file="../user_dropdown.html"/>
 
-% if settings.FEATURES.get('ENABLE_HELP_LINK'):
+% if settings.ENABLE_HELP_LINK:
   <a href="${get_online_help_info(online_help_token)['doc_url']}"
           rel="noopener"
            target="_blank"

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -27,7 +27,7 @@ from lms.djangoapps.branding import api as branding_api
       <span class="course-number">${course.display_number_with_default}</span>
       <%
       display_name = course.display_name_with_default
-      if settings.FEATURES.get('CUSTOM_COURSES_EDX', False):
+      if settings.CUSTOM_COURSES_EDX:
         ccx = get_current_ccx(course.id)
         if ccx:
           display_name = ccx.display_name

--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -11,11 +11,11 @@ from django.utils.translation import gettext as _
 
 <ol class="left list-inline nav-global">
   <%block name="navigation_global_links">
-    % if static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
+    % if static.get_value('ENABLE_MKTG_SITE', settings.ENABLE_MKTG_SITE):
       <li class="item nav-global-01">
         <a class="btn" href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
       </li>
-      % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+      % if settings.COURSES_ARE_BROWSABLE:
         <li class="item nav-global-02">
           <a class="btn" href="${marketing_link('COURSES')}">${_("Courses")}</a>
         </li>
@@ -28,12 +28,12 @@ from django.utils.translation import gettext as _
 
   <%block name="navigation_other_global_links">
     % if not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register:
-      % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+      % if settings.ENABLE_COURSE_DISCOVERY:
         <li class="item nav-global-05">
           <a class="btn" href="/courses">${_("Explore Courses")}</a>
         </li>
       %endif
-      % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True):
+      % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.ALLOW_PUBLIC_ACCOUNT_CREATION) and settings.SHOW_REGISTRATION_LINKS:
         <li class="item nav-global-04">
           <a class="btn btn-neutral btn-register" href="/register${login_query()}">${_("Register")}</a>
         </li>

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -90,6 +90,6 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
 <![endif]-->
 % endif
 
-% if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
+% if settings.ENABLE_COOKIE_CONSENT:
   <%include file="../widgets/cookie-consent.html" />
 % endif

--- a/lms/templates/seq_block.html
+++ b/lms/templates/seq_block.html
@@ -132,7 +132,7 @@
     ${gated_sequence_paywall | n, decode.utf8}
   % else:
   <div class="sr-is-focusable" tabindex="-1"></div>
-  % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False) and getattr(settings, 'COMPLETION_AGGREGATOR_URL', ''):
+  % if settings.SHOW_PROGRESS_BAR and getattr(settings, 'COMPLETION_AGGREGATOR_URL', ''):
     <div class="progress-container">
       <iframe id="progress-frame" style="border: none; width: 100%; height: 70px;" src="${chapter_completion_aggregator_url}"></iframe>
     </div>

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -26,7 +26,7 @@ ${block_content | n, decode.utf8}
 <div class="wrap-instructor-info">
   <a class="instructor-info-action" href="#${element_id}_debug" rel="leanModal" id="${element_id}_trig">${_("Staff Debug Info")}</a>
 
-  %  if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW') and \
+  %  if settings.ENABLE_STUDENT_HISTORY_VIEW and \
     location.block_type == 'problem':
     <a class="instructor-info-action" href="#${element_id}_history" rel="leanModal" id="${element_id}_history_trig">${_("Submission history")}</a>
   %  endif

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -57,7 +57,7 @@ RENDER_VIDEO_XBLOCK_NAME = 'render_public_video_xblock'
 RENDER_VIDEO_XBLOCK_EMBED_NAME = 'render_public_video_xblock_embed'
 COURSE_PROGRESS_NAME = 'progress'
 
-if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
+if settings.DEBUG or settings.ENABLE_DJANGO_ADMIN_SITE:
     django_autodiscover()
     admin.site.site_header = _('LMS Administration')
     admin.site.site_title = admin.site.site_header
@@ -216,7 +216,7 @@ urlpatterns = [
     path('500', handler500, name='render_500'),
 ]
 
-if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
+if settings.ENABLE_MOBILE_REST_API:
     urlpatterns += [
         re_path(r'^api/mobile/(?P<api_version>v(4|3|2|1|0.5))/', include('lms.djangoapps.mobile_api.urls')),
     ]
@@ -681,7 +681,7 @@ urlpatterns += [
     ),
 ]
 
-if settings.FEATURES.get('ENABLE_TEAMS'):
+if settings.ENABLE_TEAMS:
     # Teams endpoints
     urlpatterns += [
         path(
@@ -698,7 +698,7 @@ if settings.FEATURES.get('ENABLE_TEAMS'):
     ]
 
 # allow course staff to change to student view of courseware
-if settings.FEATURES.get('ENABLE_MASQUERADE'):
+if settings.ENABLE_MASQUERADE:
     urlpatterns += [
         re_path(
             r'^courses/{}/masquerade$'.format(
@@ -720,7 +720,7 @@ urlpatterns += [
 ]
 
 # discussion forums live within courseware, so courseware must be enabled first
-if settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE'):
+if settings.ENABLE_DISCUSSION_SERVICE:
     urlpatterns += [
         path(
             'api/discussion/',
@@ -788,7 +788,7 @@ urlpatterns += [
     ),
 ]
 
-if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW'):
+if settings.ENABLE_STUDENT_HISTORY_VIEW:
     urlpatterns += [
         re_path(
             r'^courses/{}/submission_history/(?P<learner_identifier>[^/]*)/(?P<location>.*?)$'.format(
@@ -799,14 +799,14 @@ if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW'):
         ),
     ]
 
-if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
+if settings.DEBUG or settings.ENABLE_DJANGO_ADMIN_SITE:
     # Jasmine and admin
 
     # The password pages in the admin tool are disabled so that all password
     # changes go through our user portal and follow complexity requirements.
     # The form to change another user's password is conditionally enabled
     # for backwards compatibility.
-    if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+    if not settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN:
         urlpatterns += [
             re_path(r'^admin/auth/user/\d+/password/$', handler404),
         ]
@@ -818,13 +818,13 @@ if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
         path('admin/', admin.site.urls),
     ]
 
-if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATURES.get('ENABLE_BULK_ENROLLMENT_VIEW')):
+if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.ENABLE_BULK_ENROLLMENT_VIEW):
     urlpatterns += [
         path('api/bulk_enroll/v1/', include('lms.djangoapps.bulk_enroll.urls')),
     ]
 
 # Embargo
-if settings.FEATURES.get('EMBARGO'):
+if settings.EMBARGO:
     urlpatterns += [
         path('embargo/', include(('openedx.core.djangoapps.embargo.urls', 'openedx.core.djangoapps.embargo'),
                                  namespace='embargo')),
@@ -847,12 +847,12 @@ urlpatterns += [
     path('_o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 ]
 
-if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
+if settings.ENABLE_SERVICE_STATUS:
     urlpatterns += [
         path('status/', include('openedx.core.djangoapps.service_status.urls')),
     ]
 
-if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
     urlpatterns += [
         path(
             'instructor_task_status/',
@@ -861,7 +861,7 @@ if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
         ),
     ]
 
-if settings.FEATURES.get('ENABLE_DEBUG_RUN_PYTHON'):
+if settings.ENABLE_DEBUG_RUN_PYTHON:
     urlpatterns += [
         path('debug/run_python', debug_views.run_python),
     ]
@@ -871,7 +871,7 @@ urlpatterns += [
 ]
 
 # Third-party auth.
-if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+if settings.ENABLE_THIRD_PARTY_AUTH:
     urlpatterns += [
         path('', include('common.djangoapps.third_party_auth.urls')),
         path('api/third_party_auth/', include('common.djangoapps.third_party_auth.api.urls')),
@@ -908,14 +908,14 @@ urlpatterns += [
 ]
 
 # Custom courses on edX (CCX) URLs
-if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+if settings.CUSTOM_COURSES_EDX:
     urlpatterns += [
         re_path(fr'^courses/{settings.COURSE_ID_PATTERN}/', include('lms.djangoapps.ccx.urls')),
         path('api/ccx/', include(('lms.djangoapps.ccx.api.urls', 'lms.djangoapps.ccx'), namespace='ccx_api')),
     ]
 
 # Access to courseware as an LTI provider
-if settings.FEATURES.get('ENABLE_LTI_PROVIDER'):
+if settings.ENABLE_LTI_PROVIDER:
     urlpatterns += [
         path('lti_provider/', include('lms.djangoapps.lti_provider.urls')),
     ]
@@ -946,7 +946,7 @@ if 'debug_toolbar' in settings.INSTALLED_APPS:
         path('__debug__/', include(debug_toolbar.urls)),
     ]
 
-if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
+if settings.ENABLE_FINANCIAL_ASSISTANCE_FORM:
     urlpatterns += [
         path(
             'financial-assistance/',
@@ -1027,7 +1027,7 @@ urlpatterns += [
 ]
 
 # Bulk User Retirement API urls
-if settings.FEATURES.get('ENABLE_BULK_USER_RETIREMENT'):
+if settings.ENABLE_BULK_USER_RETIREMENT:
     urlpatterns += [
         path('', include('lms.djangoapps.bulk_user_retirement.urls')),
     ]

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -65,7 +65,7 @@ class IntegritySignatureView(AuthenticatedAPIView):
         If a username is not given, it should default to the requesting user (or masqueraded user).
         Only staff should be able to access this endpoint for other users.
         """
-        if not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+        if not settings.ENABLE_INTEGRITY_SIGNATURE:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )
@@ -108,7 +108,7 @@ class IntegritySignatureView(AuthenticatedAPIView):
                 created_at: "2021-04-23T18:25:43.511Z"
             }
         """
-        if not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+        if not settings.ENABLE_INTEGRITY_SIGNATURE:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )
@@ -143,7 +143,7 @@ class LTIPIISignatureView(AuthenticatedAPIView):
                 created_at: "2021-04-23T18:25:43.511Z"
             }
         """
-        if not settings.FEATURES.get('ENABLE_LTI_PII_ACKNOWLEDGEMENT'):
+        if not settings.ENABLE_LTI_PII_ACKNOWLEDGEMENT:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )

--- a/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
@@ -8,6 +8,7 @@ import unittest
 
 import httpretty
 import social_django.utils as social_utils
+from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -17,7 +18,7 @@ from common.djangoapps.third_party_auth.tests.utils import ThirdPartyOAuthTestMi
 
 from ..forms import AccessTokenExchangeForm
 from .mixins import DOTAdapterMixin
-from .utils import TPA_FEATURE_ENABLED, TPA_FEATURES_KEY, AccessTokenExchangeTestMixin
+from .utils import AccessTokenExchangeTestMixin
 
 
 class AccessTokenExchangeFormTest(AccessTokenExchangeTestMixin):
@@ -50,7 +51,7 @@ class AccessTokenExchangeFormTest(AccessTokenExchangeTestMixin):
 
 
 # This is necessary because cms does not implement third party auth
-@unittest.skipUnless(TPA_FEATURE_ENABLED, TPA_FEATURES_KEY + " not enabled")
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 @httpretty.activate
 class DOTAccessTokenExchangeFormTestFacebook(
         DOTAdapterMixin,
@@ -66,7 +67,7 @@ class DOTAccessTokenExchangeFormTestFacebook(
 
 
 # This is necessary because cms does not implement third party auth
-@unittest.skipUnless(TPA_FEATURE_ENABLED, TPA_FEATURES_KEY + " not enabled")
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 @httpretty.activate
 class DOTAccessTokenExchangeFormTestGoogle(
         DOTAdapterMixin,

--- a/openedx/core/djangoapps/auth_exchange/tests/test_views.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_views.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 import ddt
 import httpretty
+from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -30,7 +31,7 @@ from common.djangoapps.third_party_auth.tests.utils import (
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from .mixins import DOTAdapterMixin
-from .utils import TPA_FEATURE_ENABLED, TPA_FEATURES_KEY, AccessTokenExchangeTestMixin
+from .utils import AccessTokenExchangeTestMixin
 
 
 @ddt.ddt
@@ -115,7 +116,7 @@ class AccessTokenExchangeViewTest(AccessTokenExchangeTestMixin):
         self._assert_error(self.data, "account_disabled", "user account is disabled", 403)
 
 
-@unittest.skipUnless(TPA_FEATURE_ENABLED, TPA_FEATURES_KEY + " not enabled")
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 @httpretty.activate
 class DOTAccessTokenExchangeViewTestFacebook(
         DOTAdapterMixin,
@@ -130,7 +131,7 @@ class DOTAccessTokenExchangeViewTestFacebook(
 
 
 # This is necessary because cms does not implement third party auth
-@unittest.skipUnless(TPA_FEATURE_ENABLED, TPA_FEATURES_KEY + " not enabled")
+@unittest.skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "Third party auth is disabled.")
 @httpretty.activate
 class DOTAccessTokenExchangeViewTestGoogle(
         DOTAdapterMixin,

--- a/openedx/core/djangoapps/auth_exchange/tests/utils.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/utils.py
@@ -8,9 +8,6 @@ from social_django.models import Partial, UserSocialAuth
 
 from common.djangoapps.third_party_auth.tests.utils import ThirdPartyOAuthTestMixin
 
-TPA_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
-TPA_FEATURE_ENABLED = TPA_FEATURES_KEY in settings.FEATURES
-
 
 class AccessTokenExchangeTestMixin(ThirdPartyOAuthTestMixin):
     """

--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -138,7 +138,7 @@ class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware, MiddlewareMi
         # security feature, we can turn it off when auto-auth is
         # enabled since auto-auth is highly insecure and only for
         # tests.
-        auto_auth_enabled = settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING', False)
+        auto_auth_enabled = settings.AUTOMATIC_AUTH_FOR_TESTING
         if not auto_auth_enabled and hasattr(request.user, 'get_session_auth_hash'):
             session_hash = request.session.get(HASH_SESSION_KEY)
             session_hash_verified = session_hash and constant_time_compare(

--- a/openedx/core/djangoapps/catalog/views.py
+++ b/openedx/core/djangoapps/catalog/views.py
@@ -18,7 +18,7 @@ def cache_programs(request):
     # checks that does site has configuration if not then
     # add a configuration with COURSE_CATALOG_API_URL parameter.
 
-    if settings.FEATURES.get('EXPOSE_CACHE_PROGRAMS_ENDPOINT'):
+    if settings.EXPOSE_CACHE_PROGRAMS_ENDPOINT:
         call_command('cache_programs')
 
         return HttpResponse('Programs cached.')

--- a/openedx/core/djangoapps/common_initialization/checks.py
+++ b/openedx/core/djangoapps/common_initialization/checks.py
@@ -33,7 +33,7 @@ def validate_marketing_site_setting(app_configs, **kwargs):  # lint-amnesty, pyl
     Validates marketing site related settings.
     """
     errors = []
-    if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+    if settings.ENABLE_MKTG_SITE:
         if not hasattr(settings, 'MKTG_URLS'):
             errors.append(
                 Error(

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -561,7 +561,7 @@ class CourseOverview(TimeStampedModel):
         """
         Returns whether the course has marketing url.
         """
-        return settings.FEATURES.get('ENABLE_MKTG_SITE') and bool(self.marketing_url)
+        return settings.ENABLE_MKTG_SITE and bool(self.marketing_url)
 
     def has_social_sharing_url(self):
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
@@ -35,7 +35,7 @@ class SpecialExamsOutlineProcessor(OutlineProcessor):
         """
         Check if special exams are enabled
         """
-        self.special_exams_enabled = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False)  # lint-amnesty, pylint: disable=attribute-defined-outside-init
+        self.special_exams_enabled = settings.ENABLE_SPECIAL_EXAMS  # lint-amnesty, pylint: disable=attribute-defined-outside-init
 
     def exam_data(self, pruned_course_outline: UserCourseOutlineData) -> SpecialExamAttemptData:
         """

--- a/openedx/core/djangoapps/content/learning_sequences/apps.py
+++ b/openedx/core/djangoapps/content/learning_sequences/apps.py
@@ -13,6 +13,6 @@ class LearningSequencesConfig(AppConfig):  # lint-amnesty, pylint: disable=missi
         # Register celery workers
         # from .tasks import ls_listen_for_course_publish  # pylint: disable=unused-variable
 
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import LearningSequencesRuntimeService
             set_runtime_service('learning_sequences', LearningSequencesRuntimeService())

--- a/openedx/core/djangoapps/content/learning_sequences/views.py
+++ b/openedx/core/djangoapps/content/learning_sequences/views.py
@@ -122,7 +122,7 @@ class CourseOutlineView(APIView):
             }
 
             # Only include this data if special exams are on
-            if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False):
+            if settings.ENABLE_SPECIAL_EXAMS:
                 sequence_representation["exam"] = sequence_exam
 
             return sequence_representation

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -229,7 +229,7 @@ perms[CAN_LEARN_FROM_THIS_CONTENT_LIBRARY] = (
 
 # Is the user allowed to create content libraries?
 CAN_CREATE_CONTENT_LIBRARY = 'content_libraries.create_library'
-if settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+if settings.ENABLE_CREATOR_GROUP:
     perms[CAN_CREATE_CONTENT_LIBRARY] = is_global_staff | (is_user_active & is_course_creator)
 else:
     perms[CAN_CREATE_CONTENT_LIBRARY] = is_global_staff

--- a/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/libraries.py
@@ -953,8 +953,8 @@ def requires_lti_enabled(view_func):
     enabled.
     """
     def wrapped_view(*args, **kwargs):
-        lti_enabled = (settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES')
-                       and settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES_LTI_TOOL'))
+        lti_enabled = (settings.ENABLE_CONTENT_LIBRARIES
+                       and settings.ENABLE_CONTENT_LIBRARIES_LTI_TOOL)
         if not lti_enabled:
             raise Http404()
         return view_func(*args, **kwargs)

--- a/openedx/core/djangoapps/content_libraries/signal_handlers.py
+++ b/openedx/core/djangoapps/content_libraries/signal_handlers.py
@@ -33,8 +33,8 @@ def score_changed_handler(sender, **kwargs):  # pylint: disable=unused-argument
     Match the score event to an LTI resource and update.
     """
 
-    lti_enabled = (settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES')
-                   and settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES_LTI_TOOL'))
+    lti_enabled = (settings.ENABLE_CONTENT_LIBRARIES
+                   and settings.ENABLE_CONTENT_LIBRARIES_LTI_TOOL)
     if not lti_enabled:
         return
 

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -63,7 +63,7 @@ class CorsCSRFMiddleware(CsrfViewMiddleware, MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature flag is disabled. """
-        if not settings.FEATURES.get('ENABLE_CORS_HEADERS'):
+        if not settings.ENABLE_CORS_HEADERS:
             raise MiddlewareNotUsed()
         super().__init__(*args, **kwargs)
 
@@ -96,7 +96,7 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature is not enabled. """
-        if not settings.FEATURES.get('ENABLE_CROSS_DOMAIN_CSRF_COOKIE'):
+        if not settings.ENABLE_CROSS_DOMAIN_CSRF_COOKIE:
             raise MiddlewareNotUsed()
 
         if not getattr(settings, 'CROSS_DOMAIN_CSRF_COOKIE_NAME', ''):

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -296,14 +296,14 @@ class CoursewareMeta:
         """
         Django setting for the integrity signature feature.
         """
-        return settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE', False)
+        return settings.ENABLE_INTEGRITY_SIGNATURE
 
     @property
     def user_needs_integrity_signature(self):
         """
         Boolean describing whether the user needs to sign the integrity agreement for a course.
         """
-        if not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+        if not settings.ENABLE_INTEGRITY_SIGNATURE:
             return False
 
         integrity_signature_required = (
@@ -396,7 +396,7 @@ class CoursewareMeta:
             course_with_access = get_course_with_access(self.request.user, permission, self.course_key)
             return bool(
                 self.request.user.has_perm(VIEW_COURSEWARE, course_with_access)
-                or settings.FEATURES.get('ENABLE_LMS_MIGRATION')
+                or settings.ENABLE_LMS_MIGRATION
             )
 
     @property

--- a/openedx/core/djangoapps/credit/apps.py
+++ b/openedx/core/djangoapps/credit/apps.py
@@ -16,6 +16,6 @@ class CreditConfig(AppConfig):
 
     def ready(self):
         from .signals import handlers  # lint-amnesty, pylint: disable=unused-import
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import CreditService
             set_runtime_service('credit', CreditService())

--- a/openedx/core/djangoapps/embargo/api.py
+++ b/openedx/core/djangoapps/embargo/api.py
@@ -47,7 +47,7 @@ def redirect_if_blocked(
     Returns:
         If blocked, a URL path to a page explaining why the user was blocked. Else None.
     """
-    if settings.FEATURES.get('EMBARGO'):
+    if settings.EMBARGO:
         client_ips = ip.get_all_client_ips(request)
         user = user or request.user
         is_blocked = not check_course_access(course_key, user=user, ip_addresses=client_ips, url=request.path)
@@ -79,7 +79,7 @@ def check_course_access(
 
     """
     # No-op if the country access feature is not enabled
-    if not settings.FEATURES.get('EMBARGO'):
+    if not settings.EMBARGO:
         return True
 
     # First, check whether there are any restrictions on the course.

--- a/openedx/core/djangoapps/embargo/middleware.py
+++ b/openedx/core/djangoapps/embargo/middleware.py
@@ -63,7 +63,7 @@ class EmbargoMiddleware(MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         # If embargoing is turned off, make this middleware do nothing
-        if not settings.FEATURES.get('EMBARGO'):
+        if not settings.EMBARGO:
             raise MiddlewareNotUsed()
         super().__init__(*args, **kwargs)
 

--- a/openedx/core/djangoapps/embargo/middleware.py
+++ b/openedx/core/djangoapps/embargo/middleware.py
@@ -16,7 +16,7 @@ Embargo can restrict by states and whitelist/blacklist (IP Addresses
 
 Usage:
 
-1) Enable embargo by setting `settings.FEATURES['EMBARGO']` to True.
+1) Enable embargo by setting `settings.EMBARGO` to True.
 
 2) In Django admin, create a new `IPFilter` model to block or whitelist
     an IP address from accessing the site.

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -573,7 +573,7 @@ def is_enrollment_valid_for_proctoring(username, course_id):
         * username (str): The user associated with the enrollment.
         * course_id (str): The course id associated with the enrollment.
     """
-    if not settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+    if not settings.ENABLE_SPECIAL_EXAMS:
         return False
 
     # Verify that the learner's enrollment is active

--- a/openedx/core/djangoapps/enrollments/apps.py
+++ b/openedx/core/djangoapps/enrollments/apps.py
@@ -20,6 +20,6 @@ class EnrollmentsConfig(AppConfig):
         """
         Connect handlers to fetch enrollments.
         """
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import EnrollmentsService
             set_runtime_service('enrollments', EnrollmentsService())

--- a/openedx/core/djangoapps/lang_pref/api.py
+++ b/openedx/core/djangoapps/lang_pref/api.py
@@ -16,17 +16,17 @@ Language = namedtuple('Language', 'code name')
 
 def header_language_selector_is_enabled():
     """Return true if the header language selector has been enabled via settings or site-specific configuration."""
-    setting = get_value('SHOW_HEADER_LANGUAGE_SELECTOR', settings.FEATURES.get('SHOW_HEADER_LANGUAGE_SELECTOR', False))
+    setting = get_value('SHOW_HEADER_LANGUAGE_SELECTOR', settings.SHOW_HEADER_LANGUAGE_SELECTOR)
 
     # The SHOW_LANGUAGE_SELECTOR setting is deprecated, but might still be in use on some installations.
-    deprecated_setting = get_value('SHOW_LANGUAGE_SELECTOR', settings.FEATURES.get('SHOW_LANGUAGE_SELECTOR', False))
+    deprecated_setting = get_value('SHOW_LANGUAGE_SELECTOR', settings.SHOW_LANGUAGE_SELECTOR)
 
     return setting or deprecated_setting
 
 
 def footer_language_selector_is_enabled():
     """Return true if the footer language selector has been enabled via settings or site-specific configuration."""
-    return get_value('SHOW_FOOTER_LANGUAGE_SELECTOR', settings.FEATURES.get('SHOW_FOOTER_LANGUAGE_SELECTOR', False))
+    return get_value('SHOW_FOOTER_LANGUAGE_SELECTOR', settings.SHOW_FOOTER_LANGUAGE_SELECTOR)
 
 
 def released_languages():

--- a/openedx/core/djangoapps/oauth_dispatch/urls.py
+++ b/openedx/core/djangoapps/oauth_dispatch/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     re_path(r'^revoke_token/?$', csrf_exempt(views.RevokeTokenView.as_view()), name='revoke_token'),
 ]
 
-if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+if settings.ENABLE_THIRD_PARTY_AUTH:
     urlpatterns += [
         path('exchange_access_token/<str:backend>/', csrf_exempt(views.AccessTokenExchangeView.as_view()),
              name='exchange_access_token',

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -154,7 +154,7 @@ def update_account_settings(requesting_user, update, username=None):
     _validate_email_change(user, update, field_errors)
     _validate_secondary_email(user, update, field_errors)
     if (
-        settings.FEATURES.get('EMBARGO', False) and
+        settings.EMBARGO and
         GlobalRestrictedCountry.is_country_restricted(update.get('country', ''))
     ):
         field_errors['country'] = {

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -214,7 +214,7 @@ def _validate_email_change(user, data, field_errors):
     if "email" not in data:
         return
 
-    if not settings.FEATURES['ALLOW_EMAIL_ADDRESS_CHANGE']:
+    if not settings.ALLOW_EMAIL_ADDRESS_CHANGE:
         raise AccountUpdateError("Email address changes have been disabled by the site operators.")
 
     new_email = data["email"]

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -557,7 +557,7 @@ class DeactivateLogoutView(APIView):
 
         # Ensure the account deletion is not disable
         enable_account_deletion = configuration_helpers.get_value(
-            "ENABLE_ACCOUNT_DELETION", settings.FEATURES.get("ENABLE_ACCOUNT_DELETION", False)
+            "ENABLE_ACCOUNT_DELETION", settings.ENABLE_ACCOUNT_DELETION
         )
 
         if not enable_account_deletion:

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -57,7 +57,7 @@ ALL_LOGGED_IN_COOKIE_NAMES = JWT_COOKIE_NAMES + DEPRECATED_LOGGED_IN_COOKIE_NAME
 
 def are_logged_in_cookies_set(request):
     """ Check whether the request has logged in cookies set. """
-    if settings.FEATURES.get('DISABLE_SET_JWT_COOKIES_FOR_TESTS', False):
+    if settings.DISABLE_SET_JWT_COOKIES_FOR_TESTS:
         cookies_that_should_exist = DEPRECATED_LOGGED_IN_COOKIE_NAMES
     else:
         cookies_that_should_exist = ALL_LOGGED_IN_COOKIE_NAMES
@@ -295,7 +295,7 @@ def _create_and_set_jwt_cookies(response, request, cookie_settings, user=None):
     # a login oauth client cannot be found in the database in ``_get_login_oauth_client``.
     # This solution is not ideal, but see https://github.com/openedx/edx-platform/pull/19180#issue-226706355
     # for a discussion of alternative solutions that did not work or were halted.
-    if settings.FEATURES.get('DISABLE_SET_JWT_COOKIES_FOR_TESTS', False):
+    if settings.DISABLE_SET_JWT_COOKIES_FOR_TESTS:
         return
 
     expires_in = settings.JWT_AUTH['JWT_IN_COOKIE_EXPIRATION']

--- a/openedx/core/djangoapps/user_authn/toggles.py
+++ b/openedx/core/djangoapps/user_authn/toggles.py
@@ -22,7 +22,7 @@ def should_redirect_to_authn_microfrontend():
     if request and request.GET.get('skip_authn_mfe'):
         return False
     return configuration_helpers.get_value(
-        'ENABLE_AUTHN_MICROFRONTEND', settings.FEATURES.get('ENABLE_AUTHN_MICROFRONTEND')
+        'ENABLE_AUTHN_MICROFRONTEND', settings.ENABLE_AUTHN_MICROFRONTEND
     )
 
 
@@ -40,5 +40,5 @@ def is_auto_generated_username_enabled():
     Checks if auto-generated username should be enabled.
     """
     return configuration_helpers.get_value(
-        'ENABLE_AUTO_GENERATED_USERNAME', settings.FEATURES.get('ENABLE_AUTO_GENERATED_USERNAME')
+        'ENABLE_AUTO_GENERATED_USERNAME', settings.ENABLE_AUTO_GENERATED_USERNAME
     )

--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -105,7 +105,7 @@ urlpatterns += [
 ]
 
 # enable automatic login
-if settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING'):
+if settings.AUTOMATIC_AUTH_FOR_TESTING:
     urlpatterns += [
         path('auto_auth', auto_auth.auto_auth),
     ]

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -44,7 +44,7 @@ def auto_auth(request):  # pylint: disable=too-many-statements
     Create or configure a user account, then log in as that user.
 
     Enabled only when
-    settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] is true.
+    settings.AUTOMATIC_AUTH_FOR_TESTING is true.
 
     Accepts the following querystring parameters:
     * `username`, `email`, and `password` for the user account

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -91,7 +91,7 @@ def auto_auth(request):  # pylint: disable=too-many-statements
     redirect_when_done = _str2bool(request.GET.get('redirect', '')) or redirect_to
     login_when_done = 'no_login' not in request.GET
 
-    restricted = settings.FEATURES.get('RESTRICT_AUTOMATIC_AUTH', True)
+    restricted = settings.RESTRICT_AUTOMATIC_AUTH
     if is_superuser and restricted:
         return HttpResponseForbidden(_('Superuser creation not allowed'))
 

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -257,8 +257,8 @@ def login_and_registration_form(request, initial_mode="login"):
             'registration_form_desc': json.loads(form_descriptions['registration']),
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
             'account_creation_allowed': configuration_helpers.get_value(
-                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)),
-            'register_links_allowed': settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True),
+                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.ALLOW_PUBLIC_ACCOUNT_CREATION),
+            'register_links_allowed': settings.SHOW_REGISTRATION_LINKS,
             'is_account_recovery_feature_enabled': is_secondary_email_feature_enabled(),
             'enterprise_slug_login_url': get_enterprise_slug_login_url(),
             'is_enterprise_enable': enterprise_enabled(),

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -273,7 +273,7 @@ def login_and_registration_form(request, initial_mode="login"):
         'combined_login_and_register': True,
         'disable_footer': not configuration_helpers.get_value(
             'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER',
-            settings.FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER']
+            settings.ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
         ),
     }
 

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -642,7 +642,7 @@ def password_change_request_handler(request):
             # If enabled, send an email saying that a password reset was attempted, but that there is
             # no user associated with the email
             if configuration_helpers.get_value('ENABLE_PASSWORD_RESET_FAILURE_EMAIL',
-                                               settings.FEATURES['ENABLE_PASSWORD_RESET_FAILURE_EMAIL']):
+                                               settings.ENABLE_PASSWORD_RESET_FAILURE_EMAIL):
                 site = get_current_site()
                 message_context = get_base_template_context(site)
 

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -253,7 +253,7 @@ def create_account_with_params(request, params):  # pylint: disable=too-many-sta
         redirect_url = get_redirect_url_with_host(root_url, redirect_to)
         compose_and_send_activation_email(user, profile, registration, redirect_url, True)
 
-    if settings.FEATURES.get('ENABLE_DISCUSSION_EMAIL_DIGEST'):
+    if settings.ENABLE_DISCUSSION_EMAIL_DIGEST:
         try:
             enable_notifications(user)
         except Exception:  # pylint: disable=broad-except
@@ -476,8 +476,8 @@ def _skip_activation_email(user, running_pipeline, third_party_provider):
         )
 
     return (
-        settings.FEATURES.get('SKIP_EMAIL_VALIDATION', None) or
-        settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING') or
+        settings.SKIP_EMAIL_VALIDATION or
+        settings.AUTOMATIC_AUTH_FOR_TESTING or
         (third_party_provider and third_party_provider.skip_email_verification and valid_email)
     )
 

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -71,7 +71,7 @@ def validate_username(username):
     flags = None
     message = accounts.USERNAME_INVALID_CHARS_ASCII
 
-    if settings.FEATURES.get("ENABLE_UNICODE_USERNAME"):
+    if settings.ENABLE_UNICODE_USERNAME:
         username_re = fr"^{settings.USERNAME_REGEX_PARTIAL}$"
         flags = re.UNICODE
         message = accounts.USERNAME_INVALID_CHARS_UNICODE
@@ -310,7 +310,7 @@ class AccountCreationForm(forms.Form):
         """
         country = self.cleaned_data.get("country")
         if (
-            settings.FEATURES.get('EMBARGO', False) and
+            settings.EMBARGO and
             country in GlobalRestrictedCountry.get_countries()
         ):
             raise ValidationError(_("Registration from this country is not allowed due to restrictions."))

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -45,7 +45,7 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {"AUTOMATIC_AUTH_FOR_TESTING": True})
     def setUp(self):
-        # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
+        # Patching the settings.AUTOMATIC_AUTH_FOR_TESTING
         # value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)
@@ -303,7 +303,7 @@ class AutoAuthDisabledTestCase(AutoAuthTestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {"AUTOMATIC_AUTH_FOR_TESTING": False})
     def setUp(self):
-        # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
+        # Patching the settings.AUTOMATIC_AUTH_FOR_TESTING
         # value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)
@@ -327,7 +327,7 @@ class AutoAuthRestrictedTestCase(AutoAuthTestCase):
 
     @patch.dict('django.conf.settings.FEATURES', {'AUTOMATIC_AUTH_FOR_TESTING': True})
     def setUp(self):
-        # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
+        # Patching the settings.AUTOMATIC_AUTH_FOR_TESTING
         # value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -425,7 +425,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
     )
     def test_settings_tpa_hinted_login(self, url_name):
         """
-        Ensure that settings.FEATURES['THIRD_PARTY_AUTH_HINT'] can set third_party_auth_hint.
+        Ensure that settings.THIRD_PARTY_AUTH_HINT can set third_party_auth_hint.
         """
         params = [("next", "/courses/something/")]
         response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -2729,7 +2729,7 @@ class ThirdPartyRegistrationTestMixin(
         self._verify_user_existence(user_exists=False, social_link_exists=False)
 
 
-@skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
+@skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "third party auth not enabled")
 class TestFacebookRegistrationView(
     ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase, OpenEdxEventsTestMixin
 ):
@@ -2761,7 +2761,7 @@ class TestFacebookRegistrationView(
         self._verify_user_existence(user_exists=False, social_link_exists=False)
 
 
-@skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
+@skipUnless(settings.ENABLE_THIRD_PARTY_AUTH, "third party auth not enabled")
 class TestGoogleRegistrationView(
     ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase, OpenEdxEventsTestMixin
 ):
@@ -2945,7 +2945,7 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestM
             {'username': str(USERNAME_BAD_LENGTH_MSG)}
         )
 
-    @skipUnless(settings.FEATURES.get("ENABLE_UNICODE_USERNAME"), "Unicode usernames disabled.")
+    @skipUnless(settings.ENABLE_UNICODE_USERNAME, "Unicode usernames disabled.")
     @ddt.data(*testutils.INVALID_USERNAMES_UNICODE)
     def test_username_invalid_unicode_validation_decision(self, username):
         self.assertValidationDecision(
@@ -2953,7 +2953,7 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestM
             {'username': str(USERNAME_INVALID_CHARS_UNICODE)}
         )
 
-    @skipIf(settings.FEATURES.get("ENABLE_UNICODE_USERNAME"), "Unicode usernames enabled.")
+    @skipIf(settings.ENABLE_UNICODE_USERNAME, "Unicode usernames enabled.")
     @ddt.data(*testutils.INVALID_USERNAMES_ASCII)
     def test_username_invalid_ascii_validation_decision(self, username):
         self.assertValidationDecision(

--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -199,7 +199,7 @@ def remove_disabled_country_from_list(countries: Dict) -> Dict:
     Returns:
     - dict: Dict of countries with disabled countries removed.
     """
-    if not settings.FEATURES.get("EMBARGO", False):
+    if not settings.EMBARGO:
         return countries
 
     for country_code in GlobalRestrictedCountry.get_countries():

--- a/openedx/core/djangoapps/video_config/services.py
+++ b/openedx/core/djangoapps/video_config/services.py
@@ -179,7 +179,7 @@ class VideoConfigService:
         """
         translations = []
         if verify_assets is None:
-            verify_assets = not settings.FEATURES.get('FALLBACK_TO_ENGLISH_TRANSCRIPTS')
+            verify_assets = not settings.FALLBACK_TO_ENGLISH_TRANSCRIPTS
 
         sub, other_langs = transcripts["sub"], transcripts["transcripts"]
 

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -282,14 +282,14 @@ def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context)
         return frag
 
     block_id = block.location
-    if block.has_score and settings.FEATURES.get('DISPLAY_HISTOGRAMS_TO_STAFF'):
+    if block.has_score and settings.DISPLAY_HISTOGRAMS_TO_STAFF:
         histogram = grade_histogram(block_id)
         render_histogram = len(histogram) > 0
     else:
         histogram = None
         render_histogram = False
 
-    if settings.FEATURES.get('ENABLE_LMS_MIGRATION') and hasattr(block.runtime, 'resources_fs'):
+    if settings.ENABLE_LMS_MIGRATION and hasattr(block.runtime, 'resources_fs'):
         [filepath, filename] = getattr(block, 'xml_attributes', {}).get('filename', ['', None])
         osfs = block.runtime.resources_fs
         if filename is not None and osfs.exists(filename):
@@ -337,7 +337,7 @@ def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context)
         'element_id': sanitize_html_id(block.location.html_id()),
         'edit_link': edit_link,
         'user': user,
-        'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
+        'xqa_server': settings.XQA_SERVER,
         'histogram': json.dumps(histogram),
         'render_histogram': render_histogram,
         'block_content': frag.content,

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -3099,11 +3099,6 @@ ENABLE_NOTICES = False
 # .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/38093
 ENABLE_PROCTORED_EXAMS = False
 
-# .. setting_name: MAX_ENROLLMENT_INSTR_BUTTONS
-# .. setting_default: False
-# .. setting_description: Maximum enrollment count for a course to show the instructor gradebook.
-MAX_ENROLLMENT_INSTR_BUTTONS = False
-
 # If set to True, new Studio users won't be able to author courses unless
 # an Open edX admin has added them to the course creator group.
 ENABLE_CREATOR_GROUP = True

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2983,3 +2983,15 @@ MAINTENANCE_BANNER_TEXT: str | None
 # .. setting_description: The name that will appear on the landing page of Studio, as well as in various emails and
 #   templates. (Note: set to 'Studio' by default in the LMS).
 STUDIO_NAME: str
+
+# .. toggle_name: ENABLE_CONTENT_LIBRARIES
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Enables use of the legacy and v2 libraries waffle flags.
+#    Note that legacy content libraries are only supported in courses using split mongo.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-03-06
+# .. toggle_target_removal_date: 2025-04-09
+# .. toggle_warning: This flag is deprecated in Sumac, and will be removed in favor of the disable_legacy_libraries and
+#    disable_new_libraries waffle flags.
+ENABLE_CONTENT_LIBRARIES =  True

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -3103,3 +3103,7 @@ ENABLE_PROCTORED_EXAMS = False
 # .. setting_default: False
 # .. setting_description: Maximum enrollment count for a course to show the instructor gradebook.
 MAX_ENROLLMENT_INSTR_BUTTONS = False
+
+# If set to True, new Studio users won't be able to author courses unless
+# an Open edX admin has added them to the course creator group.
+ENABLE_CREATOR_GROUP = True

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1401,6 +1401,49 @@ ENABLE_DISCUSSION_HOME_PANEL: bool
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2331
 ENABLE_MAX_FAILED_LOGIN_ATTEMPTS: bool
 
+# .. toggle_name: settings.DISPLAY_HISTOGRAMS_TO_STAFF
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: This displays histograms in the Staff Debug Info panel to course staff.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-02-13
+# .. toggle_warning: Generating histograms requires scanning the courseware_studentmodule table on each view. This
+#   can make staff access to courseware very slow on large courses.
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2425
+DISPLAY_HISTOGRAMS_TO_STAFF = False  # For large courses this slows down courseware access for staff.
+
+# .. toggle_name: settings.ENABLE_AUTHN_MICROFRONTEND
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the logistration.
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2020-09-08
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/24908'
+# .. toggle_warning: Also set settings.AUTHN_MICROFRONTEND_URL for rollout. This temporary feature
+#   toggle does not have a target removal date.
+ENABLE_AUTHN_MICROFRONTEND = os.environ.get("EDXAPP_ENABLE_AUTHN_MFE", False)
+
+ENABLE_LMS_MIGRATION = False
+
+# .. toggle_name: settings.ENABLE_THIRD_PARTY_AUTH
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Turn on third-party auth. Disabled for now because full implementations are not yet
+#   available. Remember to run migrations if you enable this; we don't create tables by default. This feature can
+#   be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication
+#   backends with the AUTHENTICATION_BACKENDS setting.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-09-15
+ENABLE_THIRD_PARTY_AUTH = False
+
+# For easily adding modes to courses during acceptance testing
+MODE_CREATION_FOR_TESTING = False
+
+# For caching programs in contexts where the LMS can only
+# be reached over HTTP.
+EXPOSE_CACHE_PROGRAMS_ENDPOINT = False
+
 ###################### CAPA External Code Evaluation #######################
 
 # Used with XQueue
@@ -2995,3 +3038,13 @@ STUDIO_NAME: str
 # .. toggle_warning: This flag is deprecated in Sumac, and will be removed in favor of the disable_legacy_libraries and
 #    disable_new_libraries waffle flags.
 ENABLE_CONTENT_LIBRARIES =  True
+
+# .. toggle_name: settings.ENABLE_CONTENT_LIBRARIES_LTI_TOOL
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When set to True, Content Libraries in
+#    Studio can be used as an LTI 1.3 tool by external LTI platforms.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-08-17
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/27411
+ENABLE_CONTENT_LIBRARIES_LTI_TOOL = False

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -3107,3 +3107,11 @@ MAX_ENROLLMENT_INSTR_BUTTONS = False
 # If set to True, new Studio users won't be able to author courses unless
 # an Open edX admin has added them to the course creator group.
 ENABLE_CREATOR_GROUP = True
+
+# .. toggle_name: settings.IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: Set to False to disable in-context discussion for units by default.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-09-02
+IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT = True

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -3048,3 +3048,58 @@ ENABLE_CONTENT_LIBRARIES =  True
 # .. toggle_creation_date: 2021-08-17
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/27411
 ENABLE_CONTENT_LIBRARIES_LTI_TOOL = False
+
+# .. setting_name: COURSEWARE_SEARCH_INCLUSION_DATE
+# .. setting_default: None
+# .. setting_description: Excludes courses with a start date before this value from courseware search.
+COURSEWARE_SEARCH_INCLUSION_DATE: str | None = None
+
+# .. toggle_name: DISPLAY_ANALYTICS_ENROLLMENTS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Shows enrollment counts on the instructor dashboard.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-01-01
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/38093
+DISPLAY_ANALYTICS_ENROLLMENTS = False
+
+# .. toggle_name: ENABLE_AUTO_GENERATED_USERNAME
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enables automatic username generation.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-01-01
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/38093
+ENABLE_AUTO_GENERATED_USERNAME = False
+
+# .. toggle_name: ENABLE_FINANCIAL_ASSISTANCE_FORM
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enables the financial assistance application form.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-01-01
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/38093
+ENABLE_FINANCIAL_ASSISTANCE_FORM = False
+
+# .. toggle_name: ENABLE_NOTICES
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enables the Notices plugin, which can redirect users from the dashboard.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-01-01
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/38093
+ENABLE_NOTICES = False
+
+# .. toggle_name: ENABLE_PROCTORED_EXAMS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enables proctored exam support.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2014-01-01
+# .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/38093
+ENABLE_PROCTORED_EXAMS = False
+
+# .. setting_name: MAX_ENROLLMENT_INSTR_BUTTONS
+# .. setting_default: False
+# .. setting_description: Maximum enrollment count for a course to show the instructor gradebook.
+MAX_ENROLLMENT_INSTR_BUTTONS = False

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -373,7 +373,7 @@ def enterprise_enabled():
     """
     Determines whether the Enterprise app is installed
     """
-    return 'enterprise' in settings.INSTALLED_APPS and settings.FEATURES.get('ENABLE_ENTERPRISE_INTEGRATION', False)
+    return 'enterprise' in settings.INSTALLED_APPS and settings.ENABLE_ENTERPRISE_INTEGRATION
 
 
 def enterprise_is_enabled(otherwise=None):

--- a/openedx/features/name_affirmation_api/apps.py
+++ b/openedx/features/name_affirmation_api/apps.py
@@ -20,7 +20,7 @@ class NameAffirmationApiConfig(AppConfig):
         """
         Connect services.
         """
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             name_affirmation_service = get_name_affirmation_service()
             if name_affirmation_service:
                 set_runtime_service('name_affirmation', name_affirmation_service)

--- a/themes/stanford-style/lms/templates/index.html
+++ b/themes/stanford-style/lms/templates/index.html
@@ -16,7 +16,7 @@ from openedx.core.djangolib.markup import HTML
             <p>${_("For anyone, anywhere, anytime")}</p>
           % endif
         </div>
-        % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+        % if settings.ENABLE_COURSE_DISCOVERY:
           <div class="course-search">
             <form method="get" action="/courses">
               <label><span class="sr">${_("Search for a course")}</span>

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -235,7 +235,7 @@ class ProctoringProvider(String):
         and include any inherited values from the platform default.
         """
         value = super().from_json(value)
-        if settings.FEATURES.get('ENABLE_PROCTORED_EXAMS'):
+        if settings.ENABLE_PROCTORED_EXAMS:
             # Only validate the provider value if ProctoredExams are enabled on the environment
             # Otherwise, the passed in provider does not matter. We should always return default
             if validate_providers:

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -221,7 +221,7 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
                 'can_create_subcomment': self.has_permission("create_sub_comment"),
                 'login_msg': login_msg,
                 'PLATFORM_NAME': settings.PLATFORM_NAME,
-                'enable_discussion_home_panel': settings.FEATURES.get("ENABLE_DISCUSSION_HOME_PANEL", False),
+                'enable_discussion_home_panel': settings.ENABLE_DISCUSSION_HOME_PANEL,
             }
             fragment.add_content(
                 render_to_string('discussion/_discussion_inline.html', context)

--- a/xmodule/item_bank_block.py
+++ b/xmodule/item_bank_block.py
@@ -92,7 +92,7 @@ class ItemBankMixin(
 
         This is a property, so it can be dynamically overridden in tests, as it is not evaluated at runtime.
         """
-        if settings.FEATURES.get('MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW', False):
+        if settings.MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW:
             return XBlockCompletionMode.COMPLETABLE
 
         return XBlockCompletionMode.AGGREGATOR

--- a/xmodule/modulestore/django.py
+++ b/xmodule/modulestore/django.py
@@ -341,7 +341,7 @@ def modulestore():
             settings.MODULESTORE['default'].get('OPTIONS', {})
         )
 
-        if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+        if settings.CUSTOM_COURSES_EDX:
             # TODO: This import prevents a circular import issue, but is
             # symptomatic of a lib having a dependency on code in lms.  This
             # should be updated to have a setting that enumerates modulestore

--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -1726,7 +1726,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
             parent = new_structure['blocks'][block_id]
 
-            # Originally added to support entrance exams (settings.FEATURES.get('ENTRANCE_EXAMS'))
+            # Originally added to support entrance exams (settings.ENTRANCE_EXAMS)
             if kwargs.get('position') is None:
                 parent.fields.setdefault('children', []).append(BlockKey.from_usage_key(xblock.location))
             else:

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -44,7 +44,7 @@ class VerticalFields:
     discussion_enabled = Boolean(
         display_name=_("Enable in-context discussions for the Unit"),
         help=_("Add discussion for the Unit."),
-        default=settings.FEATURES.get('IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT', True),
+        default=settings.IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT,
         scope=Scope.settings,
     )
 

--- a/xmodule/video_block/bumper_utils.py
+++ b/xmodule/video_block/bumper_utils.py
@@ -49,7 +49,7 @@ def is_bumper_enabled(video):
     """
     bumper_last_view_date = getattr(video, 'bumper_last_view_date', None)
     utc_now = datetime.now(ZoneInfo("UTC"))
-    periodicity = settings.FEATURES.get('SHOW_BUMPER_PERIODICITY', 0)
+    periodicity = settings.SHOW_BUMPER_PERIODICITY
     has_viewed = any([
         video.bumper_do_not_show_again,
         (bumper_last_view_date and bumper_last_view_date + timedelta(seconds=periodicity) > utc_now)
@@ -57,7 +57,7 @@ def is_bumper_enabled(video):
     is_studio = getattr(video.runtime, "is_author_mode", False)
     return bool(
         not is_studio and
-        settings.FEATURES.get('ENABLE_VIDEO_BUMPER') and
+        settings.ENABLE_VIDEO_BUMPER and
         get_bumper_settings(video) and
         edxval_api and
         not has_viewed

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -383,7 +383,7 @@ class _BuiltInVideoBlock(
         # video will autoadvance or not.
         # For autoadvance controls to be shown, both the feature flag and the course setting must be true.
         # This allows to enable the feature for certain courses only.
-        autoadvance_enabled = settings.FEATURES.get('ENABLE_AUTOADVANCE_VIDEOS', False) and \
+        autoadvance_enabled = settings.ENABLE_AUTOADVANCE_VIDEOS and \
             getattr(self, 'video_auto_advance', False)
 
         # This is the current status of auto-advance (not the control visibility).
@@ -407,7 +407,7 @@ class _BuiltInVideoBlock(
             # this option will have an effect if changed to "True". The code on
             # front-end exists.
             'autohideHtml5': False,
-            'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', False),
+            'autoplay': settings.AUTOPLAY_VIDEOS,
             # This won't work when we move to data that
             # isn't on the filesystem
             'captionDataDir': getattr(self, 'data_dir', None),


### PR DESCRIPTION
## Description

WIP

Replace each reference to the FEATURES dictionary with the equivalent top-level Django settings reference.

## Supporting information

TBC

## Testing instructions

TBC

## Deadline

Verawood code freeze

## Other information

### AI notes

I used claude code -- more TBC