### PR TITLE
feat: decouple enterprise from courseware view redirects, course start-date validation, and course access checks

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
+from openedx_filters.learning.filters import CoursewareAccessChecksRequested
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
@@ -26,10 +27,6 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
 )
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerUserFactory,
-)
 
 
 @ddt.ddt
@@ -162,7 +159,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': True,
             'instructor_role': False,
             'masquerade_role': None,
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': True,
             'error_code': None,
         },
@@ -171,7 +168,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': False,
             'instructor_role': False,
             'masquerade_role': None,
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': False,
             'error_code': 'enrollment_required'
         },
@@ -180,7 +177,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': False,
             'instructor_role': True,
             'masquerade_role': None,
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': True,
             'error_code': None
         },
@@ -189,32 +186,32 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'enroll_user': False,
             'instructor_role': True,
             'masquerade_role': 'student',
-            'dsc_required': False,
+            'filter_denies_access': False,
             'expect_course_access': True,
             'error_code': None
         },
         {
-            # Data sharing Consent required learners should Not have access.
+            # Learners denied by an access-checks pipeline step should NOT have access.
             'enroll_user': True,
             'instructor_role': False,
             'masquerade_role': None,
-            'dsc_required': True,
+            'filter_denies_access': True,
             'expect_course_access': False,
-            'error_code': 'data_sharing_access_required'
+            'error_code': 'access_denied_by_filter'
         },
         {
-            # Data sharing Consent required staff should Not have access.
+            # Staff denied by an access-checks pipeline step should NOT have access.
             'enroll_user': True,
             'instructor_role': True,
             'masquerade_role': None,
-            'dsc_required': True,
+            'filter_denies_access': True,
             'expect_course_access': False,
-            'error_code': 'data_sharing_access_required'
+            'error_code': 'access_denied_by_filter'
         }
     )
     @ddt.unpack
     def test_course_access(
-        self, enroll_user, instructor_role, masquerade_role, dsc_required, expect_course_access, error_code
+        self, enroll_user, instructor_role, masquerade_role, filter_denies_access, expect_course_access, error_code
     ):
         """
         Test that course_access is calculated correctly based on
@@ -227,50 +224,22 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         if masquerade_role:
             self.update_masquerade(role=masquerade_role)
 
-        consent_url = 'dump/consent/url' if dsc_required else None
-        with patch('openedx.features.enterprise_support.api.get_enterprise_consent_url', return_value=consent_url):
+        if filter_denies_access:
+            mock_side_effect = CoursewareAccessChecksRequested.PreventCoursewareAccess(
+                message='Access denied by a courseware access-checks pipeline step',
+                error_code='access_denied_by_filter',
+                developer_message='https://example.com/redirect',
+                user_message='You are not allowed to access this course',
+            )
+            with patch(
+                'openedx_filters.learning.filters.CoursewareAccessChecksRequested.run_filter',
+                side_effect=mock_side_effect,
+            ):
+                response = self.client.get(self.url)
+        else:
             response = self.client.get(self.url)
 
         self._assert_course_access_response(response, expect_course_access, error_code)
-
-    @ddt.data(True, False)
-    def test_course_access_with_correct_active_enterprise(self, instructor_role):
-        """
-        Test that course_access is calculated correctly based on
-        access to MFE and access to the course itself.
-        """
-        if instructor_role:
-            CourseInstructorRole(self.course.id).add_users(self.user)
-
-        # Test with no EnterpriseCourseEnrollment
-        course_enrollment = CourseEnrollment.enroll(self.user, self.course.id, 'audit')
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, True, None)
-
-        # Test with EnterpriseCourseEnrollment and having correct active enterprise
-        course = course_enrollment.course
-        enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=self.user.id)
-        EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, True, None)
-
-        # Test with incorrect active enterprise
-        enterprise_customer_user_2 = EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
-        enterprise_customer_user.refresh_from_db()
-        assert not enterprise_customer_user.active
-        assert enterprise_customer_user_2.active
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, False, 'incorrect_active_enterprise')
-
-        # test when no active enterprise at all (ideally this should never happen)
-        enterprise_customer_user_2.active = False
-        enterprise_customer_user_2.save()
-        enterprise_customer_user.refresh_from_db()
-        enterprise_customer_user_2.refresh_from_db()
-        assert not enterprise_customer_user.active
-        assert not enterprise_customer_user_2.active
-        response = self.client.get(self.url)
-        self._assert_course_access_response(response, False, 'incorrect_active_enterprise')
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     @ddt.data(True, False)

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -102,7 +102,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'load',
             check_if_enrolled=True,
             check_if_authenticated=True,
-            apply_enterprise_checks=True,
+            apply_priority_access_checks=True,
         )
 
         _, request.user = setup_masquerade(

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -8,13 +8,13 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.deprecation import MiddlewareMixin
+from openedx_filters.learning.filters import CoursewareViewStarted
 from wiki.models import reverse
 
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_overview_with_access, get_course_with_access
 from openedx.core.lib.request_utils import course_id_from_url
-from openedx.features.enterprise_support.api import get_enterprise_consent_url
 from xmodule.modulestore.django import modulestore
 
 
@@ -96,10 +96,11 @@ class WikiAccessMiddleware(MiddlewareMixin):
                     # we'll redirect them to the course about page
                     return redirect('about_course', str(course_id))
 
-                # If we need enterprise data sharing consent for this course, then redirect to the form.
-                consent_url = get_enterprise_consent_url(request, str(course_id), source='WikiAccessMiddleware')
-                if consent_url:
-                    return redirect(consent_url)
+                # If a plugin requires a redirect for this course, redirect now.
+                try:
+                    CoursewareViewStarted.run_filter(course_key=course_id, view_name='WikiAccessMiddleware')
+                except CoursewareViewStarted.RedirectToUrl as exc:
+                    return redirect(exc.redirect_to)
 
             # set the course onto here so that the wiki template can show the course navigation
             request.course = course

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -2,19 +2,19 @@
 
 
 from urllib.parse import urlparse
+
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.deprecation import MiddlewareMixin
+from openedx_filters.learning.filters import CoursewareViewRedirectURL
 from wiki.models import reverse
 
+from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_overview_with_access, get_course_with_access
 from openedx.core.lib.request_utils import course_id_from_url
-from openedx.features.enterprise_support.api import get_enterprise_consent_url
-from common.djangoapps.student.models import CourseEnrollment
-
 from xmodule.modulestore.django import modulestore
 
 
@@ -96,10 +96,14 @@ class WikiAccessMiddleware(MiddlewareMixin):
                     # we'll redirect them to the course about page
                     return redirect('about_course', str(course_id))
 
-                # If we need enterprise data sharing consent for this course, then redirect to the form.
-                consent_url = get_enterprise_consent_url(request, str(course_id), source='WikiAccessMiddleware')
-                if consent_url:
-                    return redirect(consent_url)
+                # If a plugin requires a redirect for this course, redirect now.
+                redirect_urls, _, _ = CoursewareViewRedirectURL.run_filter(
+                    redirect_urls=[],
+                    request=request,
+                    course_key=course_id,
+                )
+                if redirect_urls:
+                    return redirect(redirect_urls[0])
 
             # set the course onto here so that the wiki template can show the course navigation
             request.course = course

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -3,17 +3,16 @@ Tests for course wiki
 """
 
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from django.urls import reverse
 
 from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
 from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase, ModuleStoreTestCase):
+class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for wiki course redirection.
     """
@@ -202,27 +201,33 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         assert resp.status_code == 200
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    def test_consent_required(self, mock_enterprise_customer_for_request):
+    @patch('openedx_filters.learning.filters.CoursewareViewRedirectURL.run_filter')
+    def test_consent_required(self, mock_run_filter):
         """
-        Test that enterprise data sharing consent is required when enabled for the various courseware views.
+        Test that wiki views redirect when the CoursewareViewRedirectURL filter provides a URL.
         """
-        # ENT-924: Temporary solution to replace sensitive SSO usernames.
-        mock_enterprise_customer_for_request.return_value = None
+        redirect_url = 'http://example.com/grant_consent'
+        mock_run_filter.return_value = ([redirect_url], MagicMock(), MagicMock())
 
         # Public wikis can be accessed by non-enrolled users, and so direct access is not gated by the consent page
         course = CourseFactory.create()
         course.allow_public_wiki_access = False
         course.save()
 
-        # However, for private wikis, enrolled users must pass through the consent gate
+        # However, for private wikis, enrolled users must pass through the filter redirect gate
         # (Unenrolled users are redirected to course/about)
         course_id = str(course.id)
         self.login(self.student, self.password)
         self.enroll(course)
 
-        for (url, status_code) in (
-                (reverse('course_wiki', kwargs={'course_id': course_id}), 302),
-                (f'/courses/{course_id}/wiki/', 200),
-        ):
-            self.verify_consent_required(self.client, url, status_code=status_code)  # lint-amnesty, pylint: disable=no-value-for-parameter
+        # The course_wiki view is decorated with courseware_view_redirect which calls the filter
+        url = reverse('course_wiki', kwargs={'course_id': course_id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], redirect_url)
+
+        # The wiki middleware (/courses/.../wiki/) also calls the filter
+        url = f'/courses/{course_id}/wiki/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], redirect_url)

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -6,17 +6,17 @@ Tests for course wiki
 from unittest.mock import patch
 
 from django.urls import reverse
+from openedx_filters.learning.filters import CoursewareViewStarted
 
 from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
 from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,  # pylint: disable=wrong-import-order
 )
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
 
-class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase, ModuleStoreTestCase):
+class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for wiki course redirection.
     """
@@ -205,27 +205,33 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         assert resp.status_code == 200
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    def test_consent_required(self, mock_enterprise_customer_for_request):
+    @patch('openedx_filters.learning.filters.CoursewareViewStarted.run_filter')
+    def test_filter_redirect(self, mock_run_filter):
         """
-        Test that enterprise data sharing consent is required when enabled for the various courseware views.
+        Test that wiki views redirect when the CoursewareViewStarted filter provides a URL.
         """
-        # ENT-924: Temporary solution to replace sensitive SSO usernames.
-        mock_enterprise_customer_for_request.return_value = None
+        redirect_url = 'http://example.com/redirect'
+        mock_run_filter.side_effect = CoursewareViewStarted.RedirectToUrl(message="redirect", redirect_to=redirect_url)
 
-        # Public wikis can be accessed by non-enrolled users, and so direct access is not gated by the consent page
+        # Public wikis can be accessed by non-enrolled users, and so direct access is not gated by the redirect
         course = CourseFactory.create()
         course.allow_public_wiki_access = False
         course.save()
 
-        # However, for private wikis, enrolled users must pass through the consent gate
+        # However, for private wikis, enrolled users must pass through the filter redirect gate
         # (Unenrolled users are redirected to course/about)
         course_id = str(course.id)
         self.login(self.student, self.password)
         self.enroll(course)
 
-        for (url, status_code) in (
-                (reverse('course_wiki', kwargs={'course_id': course_id}), 302),
-                (f'/courses/{course_id}/wiki/', 200),
-        ):
-            self.verify_consent_required(self.client, url, status_code=status_code)  # pylint: disable=no-value-for-parameter
+        # The course_wiki view is decorated with courseware_view_hooks which calls the filter
+        url = reverse('course_wiki', kwargs={'course_id': course_id})
+        response = self.client.get(url)
+        assert response.status_code == 302
+        assert response['Location'] == redirect_url
+
+        # The wiki middleware (/courses/.../wiki/) also calls the filter
+        url = f'/courses/{course_id}/wiki/'
+        response = self.client.get(url)
+        assert response.status_code == 302
+        assert response['Location'] == redirect_url

--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -14,10 +14,10 @@ from wiki.core.exceptions import NoRootURL
 from wiki.models import Article, URLPath
 
 from lms.djangoapps.course_wiki.utils import course_wiki_slug
+from lms.djangoapps.courseware.decorators import courseware_view_redirect
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import Text
 from openedx.core.lib.courses import get_course_by_id
-from openedx.features.enterprise_support.api import data_sharing_consent_required
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def root_create(request):
     return redirect('wiki:get', path=root.path)
 
 
-@data_sharing_consent_required
+@courseware_view_redirect
 def course_wiki_redirect(request, course_id, wiki_path=""):
     """
     This redirects to whatever page on the wiki that the course designates

--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -14,10 +14,10 @@ from wiki.core.exceptions import NoRootURL
 from wiki.models import Article, URLPath
 
 from lms.djangoapps.course_wiki.utils import course_wiki_slug
+from lms.djangoapps.courseware.decorators import courseware_view_hooks
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import Text
 from openedx.core.lib.courses import get_course_by_id
-from openedx.features.enterprise_support.api import data_sharing_consent_required
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def root_create(request):
     return redirect('wiki:get', path=root.path)
 
 
-@data_sharing_consent_required
+@courseware_view_hooks
 def course_wiki_redirect(request, course_id, wiki_path=""):
     """
     This redirects to whatever page on the wiki that the course designates

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -259,31 +259,13 @@ class EnrollmentRequiredAccessError(AccessError):
         super().__init__(error_code, developer_message, user_message)
 
 
-class IncorrectActiveEnterpriseAccessError(AccessError):
+class PriorityAccessFiltersError(AccessError):
     """
-    Access denied because the user must login with correct enterprise.
-    """
-    def __init__(self, enrollment_enterprise_name, active_enterprise_name):
-        error_code = "incorrect_active_enterprise"
-        developer_message = "User active enterprise should be same as EnterpriseCourseEnrollment enterprise."
-        user_message = _("You are enrolled in this course with '{enrollment_enterprise_name}'. However, you are "
-                         "currently logged in as a '{active_enterprise_name}' user. Please log in with "
-                         "'{enrollment_enterprise_name}' to access this course.")
-        user_message = user_message.format(
-            enrollment_enterprise_name=enrollment_enterprise_name, active_enterprise_name=active_enterprise_name
-        )
-        super().__init__(error_code, developer_message, user_message)
+    Access denied by a plugin via the CoursewareAccessChecksRequested filter.
 
-
-class DataSharingConsentRequiredAccessError(AccessError):
+    Priority — non-bypassable by staff. The error_code, developer_message,
+    and user_message are supplied by the pipeline step that denied access.
     """
-    Access denied because the user must give Data sharing consent before access it.
-    """
-    def __init__(self, consent_url):
-        error_code = "data_sharing_access_required"
-        developer_message = consent_url
-        user_message = _("You must give Data Sharing Consent for the course")
-        super().__init__(error_code, developer_message, user_message)
 
 
 class AuthenticationRequiredAccessError(AccessError):

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -1,7 +1,7 @@
 """
 This file contains all the classes used by has_access for error handling
 """
-
+from datetime import datetime
 
 from django.utils.translation import gettext as _
 
@@ -124,12 +124,23 @@ class StartDateError(AccessError):
     Access denied because the course has not started yet and the user
     is not staff
     """
-    def __init__(self, start_date, display_error_to_user=True):
+    def __init__(
+        self,
+        start_date: datetime,
+        display_error_to_user=True,
+        error_code_override: str | None = None,
+        developer_message_override: str | None = None,
+        user_message_override: str | None = None,
+    ):
         """
         Arguments:
+            start_date: The future start date of the course, used for messaging.
             display_error_to_user: If True, display this error to users in the UI.
+            error_code_override: Optional override error_code.
+            developer_message_override: Optional override developer_message.
+            user_message_override: Optional override user_message.
         """
-        error_code = "course_not_started"
+        error_code = error_code_override or "course_not_started"
         if start_date == DEFAULT_START_DATE:
             developer_message = "Course has not started"
             user_message = _("Course has not started")
@@ -137,33 +148,11 @@ class StartDateError(AccessError):
             developer_message = f"Course does not start until {start_date}"
             user_message = _("Course does not start until {}"  # pylint: disable=translation-of-non-string
                              .format(f"{start_date:%B %d, %Y}"))
-        super().__init__(
-            error_code,
-            developer_message,
-            user_message if display_error_to_user else None
-        )
 
+        # Use override message if available.
+        developer_message = developer_message_override or developer_message
+        user_message = user_message_override or user_message
 
-class StartDateEnterpriseLearnerError(AccessError):
-    """
-    Access denied because the course has not started yet and the user is not staff.  Use this error when this user is
-    also an enterprise learner and enrolled in the requested course.
-    """
-    def __init__(self, start_date, display_error_to_user=True):
-        """
-        Arguments:
-            display_error_to_user: If True, display this error to users in the UI.
-        """
-        error_code = "course_not_started_enterprise_learner"
-        if start_date == DEFAULT_START_DATE:
-            developer_message = "Course has not started, and the learner is enrolled via an enterprise subsidy."
-            user_message = _("Course has not started")
-        else:
-            developer_message = (
-                f"Course does not start until {start_date}, and the learner is enrolled via an enterprise subsidy."
-            )
-            user_message = _("Course does not start until {}"  # pylint: disable=translation-of-non-string
-                             .format(f"{start_date:%B %d, %Y}"))
         super().__init__(
             error_code,
             developer_message,

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -8,7 +8,6 @@ from logging import getLogger
 
 from crum import get_current_request
 from django.conf import settings
-from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
 from pytz import UTC
 
 from common.djangoapps.student.models import CourseEnrollment
@@ -20,13 +19,13 @@ from lms.djangoapps.courseware.access_response import (
     EnrollmentRequiredAccessError,
     IncorrectActiveEnterpriseAccessError,
     StartDateEnterpriseLearnerError,
-    StartDateError,
+    StartDateError
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
 from openedx.features.course_experience import (
     COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
     COURSE_PRE_START_ACCESS_FLAG,
-    ENFORCE_MASQUERADE_START_DATES,
+    ENFORCE_MASQUERADE_START_DATES
 )
 from xmodule.course_block import COURSE_VISIBILITY_PUBLIC  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -70,58 +69,22 @@ def adjust_start_date(user, days_early_for_beta, start, course_key):
     return start
 
 
-def enterprise_learner_enrolled(request, user, course_key):
+def _get_courseware_redirect_url(request, course_key):
     """
-    Determine if the learner should be redirected to the enterprise learner portal by checking their enterprise
-    memberships/enrollments.  If all of the following are true, then we are safe to redirect the learner:
-
-    * The learner is linked to an enterprise customer,
-    * The enterprise customer has subsidized the learner's enrollment in the requested course,
-    * The enterprise customer has the learner portal enabled.
-
-    NOTE: This function MUST be called from a view, or it will throw an exception.
+    Return the first courseware redirect URL provided by plugins, or None.
 
     Args:
-        request (django.http.HttpRequest): The current request being handled.  Must not be None.
-        user (User): The requesting enter, potentially an enterprise learner.
-        course_key (str): The requested course to check for enrollment.
+        request (django.http.HttpRequest): The current request.
+        course_key: The course key for the view being accessed.
 
     Returns:
-        bool: True if the learner is enrolled via a linked enterprise customer and can safely be redirected to the
-        enterprise learner dashboard.
+        str or None: The first redirect URL returned by plugins, or None if no redirect is needed.
     """
-    from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
-
-    if not user.is_authenticated:
-        return False
-
-    # enterprise_customer_data is either None (if learner is not linked to any customer) or a serialized
-    # EnterpriseCustomer representing the learner's active linked customer.
-    enterprise_customer_data = enterprise_customer_from_session_or_learner_data(request)
-    learner_portal_enabled = enterprise_customer_data and enterprise_customer_data["enable_learner_portal"]
-    if not learner_portal_enabled:
-        return False
-
-    # Additionally make sure the enterprise learner is actually enrolled in the requested course, subsidized
-    # via the discovered customer.
-    enterprise_enrollments = EnterpriseCourseEnrollment.objects.filter(
-        course_id=course_key,
-        enterprise_customer_user__user_id=user.id,
-        enterprise_customer_user__enterprise_customer__uuid=enterprise_customer_data["uuid"],
+    from openedx_filters.learning.filters import CoursewareViewRedirectURL
+    redirect_urls, _, _ = CoursewareViewRedirectURL.run_filter(
+        redirect_urls=[], request=request, course_key=course_key
     )
-    enterprise_enrollment_exists = enterprise_enrollments.exists()
-    log.info(
-        (
-            "[enterprise_learner_enrolled] Checking for an enterprise enrollment for "
-            "lms_user_id=%s in course_key=%s via enterprise_customer_uuid=%s. "
-            "Exists: %s"
-        ),
-        user.id,
-        course_key,
-        enterprise_customer_data["uuid"],
-        enterprise_enrollment_exists,
-    )
-    return enterprise_enrollment_exists
+    return redirect_urls[0] if redirect_urls else None
 
 
 def check_start_date(user, days_early_for_beta, start, course_key, display_error_to_user=True, now=None):
@@ -155,10 +118,10 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
         if should_grant_access:
             return ACCESS_GRANTED
 
-        # Before returning a StartDateError, determine if the learner should be redirected to the enterprise learner
-        # portal by returning StartDateEnterpriseLearnerError instead.
+        # Before returning a StartDateError, determine if a plugin requires a redirect (e.g. enterprise learner
+        # portal), and if so return StartDateEnterpriseLearnerError instead.
         request = get_current_request()
-        if request and enterprise_learner_enrolled(request, user, course_key):
+        if request and _get_courseware_redirect_url(request, course_key):
             return StartDateEnterpriseLearnerError(start, display_error_to_user=display_error_to_user)
 
         return StartDateError(start, display_error_to_user=display_error_to_user)
@@ -232,22 +195,17 @@ def check_public_access(course, visibilities):
 
 def check_data_sharing_consent(course_id):
     """
-    Grants access if the user is do not need DataSharing consent, otherwise returns data sharing link.
+    Grants access if no courseware redirect is pending for this course; otherwise returns an access error.
 
     Returns:
         AccessResponse: Either ACCESS_GRANTED or DataSharingConsentRequiredAccessError
     """
-    from openedx.features.enterprise_support.api import get_enterprise_consent_url
-
-    consent_url = get_enterprise_consent_url(
-        request=get_current_request(),
-        course_id=str(course_id),
-        return_to="courseware",
-        enrollment_exists=True,
-        source="CoursewareAccess",
-    )
-    if consent_url:
-        return DataSharingConsentRequiredAccessError(consent_url=consent_url)
+    request = get_current_request()
+    if not request:
+        return ACCESS_GRANTED
+    redirect_url = _get_courseware_redirect_url(request, course_id)
+    if redirect_url:
+        return DataSharingConsentRequiredAccessError(consent_url=redirect_url)
     return ACCESS_GRANTED
 
 
@@ -259,6 +217,7 @@ def check_correct_active_enterprise_customer(user, course_id):
     Returns:
         AccessResponse: Either ACCESS_GRANTED or IncorrectActiveEnterpriseAccessError
     """
+    from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
     enterprise_enrollments = EnterpriseCourseEnrollment.objects.filter(
         course_id=course_id, enterprise_customer_user__user_id=user.id
     )

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -9,6 +9,7 @@ from logging import getLogger
 from crum import get_current_request
 from django.conf import settings
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
+from openedx_filters.learning.filters import CourseStartDateValidationFailed
 from pytz import UTC
 
 from common.djangoapps.student.models import CourseEnrollment
@@ -19,7 +20,6 @@ from lms.djangoapps.courseware.access_response import (
     DataSharingConsentRequiredAccessError,
     EnrollmentRequiredAccessError,
     IncorrectActiveEnterpriseAccessError,
-    StartDateEnterpriseLearnerError,
     StartDateError,
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
@@ -70,60 +70,6 @@ def adjust_start_date(user, days_early_for_beta, start, course_key):
     return start
 
 
-def enterprise_learner_enrolled(request, user, course_key):
-    """
-    Determine if the learner should be redirected to the enterprise learner portal by checking their enterprise
-    memberships/enrollments.  If all of the following are true, then we are safe to redirect the learner:
-
-    * The learner is linked to an enterprise customer,
-    * The enterprise customer has subsidized the learner's enrollment in the requested course,
-    * The enterprise customer has the learner portal enabled.
-
-    NOTE: This function MUST be called from a view, or it will throw an exception.
-
-    Args:
-        request (django.http.HttpRequest): The current request being handled.  Must not be None.
-        user (User): The requesting enter, potentially an enterprise learner.
-        course_key (str): The requested course to check for enrollment.
-
-    Returns:
-        bool: True if the learner is enrolled via a linked enterprise customer and can safely be redirected to the
-        enterprise learner dashboard.
-    """
-    from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
-
-    if not user.is_authenticated:
-        return False
-
-    # enterprise_customer_data is either None (if learner is not linked to any customer) or a serialized
-    # EnterpriseCustomer representing the learner's active linked customer.
-    enterprise_customer_data = enterprise_customer_from_session_or_learner_data(request)
-    learner_portal_enabled = enterprise_customer_data and enterprise_customer_data["enable_learner_portal"]
-    if not learner_portal_enabled:
-        return False
-
-    # Additionally make sure the enterprise learner is actually enrolled in the requested course, subsidized
-    # via the discovered customer.
-    enterprise_enrollments = EnterpriseCourseEnrollment.objects.filter(
-        course_id=course_key,
-        enterprise_customer_user__user_id=user.id,
-        enterprise_customer_user__enterprise_customer__uuid=enterprise_customer_data["uuid"],
-    )
-    enterprise_enrollment_exists = enterprise_enrollments.exists()
-    log.info(
-        (
-            "[enterprise_learner_enrolled] Checking for an enterprise enrollment for "
-            "lms_user_id=%s in course_key=%s via enterprise_customer_uuid=%s. "
-            "Exists: %s"
-        ),
-        user.id,
-        course_key,
-        enterprise_customer_data["uuid"],
-        enterprise_enrollment_exists,
-    )
-    return enterprise_enrollment_exists
-
-
 def check_start_date(user, days_early_for_beta, start, course_key, display_error_to_user=True, now=None):
     """
     Verifies whether the given user is allowed access given the
@@ -155,11 +101,20 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
         if should_grant_access:
             return ACCESS_GRANTED
 
-        # Before returning a StartDateError, determine if the learner should be redirected to the enterprise learner
-        # portal by returning StartDateEnterpriseLearnerError instead.
-        request = get_current_request()
-        if request and enterprise_learner_enrolled(request, user, course_key):
-            return StartDateEnterpriseLearnerError(start, display_error_to_user=display_error_to_user)
+        # Before returning a StartDateError, give plugins a chance to substitute a more specific access-error payload.
+        try:
+            CourseStartDateValidationFailed.run_filter(
+                course_key=course_key,
+                start_date=start,
+            )
+        except CourseStartDateValidationFailed.OverrideStartDateError as exc:
+            return StartDateError(
+                start_date=start,
+                display_error_to_user=display_error_to_user,
+                error_code_override=exc.error_code,
+                developer_message_override=exc.developer_message,
+                user_message_override=exc.user_message,
+            )
 
         return StartDateError(start, display_error_to_user=display_error_to_user)
 

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -6,9 +6,7 @@ It allows us to share code between access.py and block transformers.
 from datetime import datetime, timedelta
 from logging import getLogger
 
-from crum import get_current_request
 from django.conf import settings
-from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
 from openedx_filters.learning.filters import CourseStartDateValidationFailed
 from pytz import UTC
 
@@ -17,9 +15,7 @@ from common.djangoapps.student.roles import CourseBetaTesterRole
 from lms.djangoapps.courseware.access_response import (
     AccessResponse,
     AuthenticationRequiredAccessError,
-    DataSharingConsentRequiredAccessError,
     EnrollmentRequiredAccessError,
-    IncorrectActiveEnterpriseAccessError,
     StartDateError,
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
@@ -183,68 +179,3 @@ def check_public_access(course, visibilities):
         return ACCESS_GRANTED
 
     return ACCESS_DENIED
-
-
-def check_data_sharing_consent(course_id):
-    """
-    Grants access if the user is do not need DataSharing consent, otherwise returns data sharing link.
-
-    Returns:
-        AccessResponse: Either ACCESS_GRANTED or DataSharingConsentRequiredAccessError
-    """
-    from openedx.features.enterprise_support.api import get_enterprise_consent_url
-
-    consent_url = get_enterprise_consent_url(
-        request=get_current_request(),
-        course_id=str(course_id),
-        return_to="courseware",
-        enrollment_exists=True,
-        source="CoursewareAccess",
-    )
-    if consent_url:
-        return DataSharingConsentRequiredAccessError(consent_url=consent_url)
-    return ACCESS_GRANTED
-
-
-def check_correct_active_enterprise_customer(user, course_id):
-    """
-    Grants access if the user's active enterprise customer is same as  EnterpriseCourseEnrollment's Enterprise.
-    Also, Grant access if enrollment is not Enterprise
-
-    Returns:
-        AccessResponse: Either ACCESS_GRANTED or IncorrectActiveEnterpriseAccessError
-    """
-    enterprise_enrollments = EnterpriseCourseEnrollment.objects.filter(
-        course_id=course_id, enterprise_customer_user__user_id=user.id
-    )
-    if not enterprise_enrollments.exists():
-        return ACCESS_GRANTED
-
-    try:
-        active_enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
-        if enterprise_enrollments.filter(enterprise_customer_user=active_enterprise_customer_user).exists():
-            return ACCESS_GRANTED
-
-        active_enterprise_name = active_enterprise_customer_user.enterprise_customer.name
-    except (EnterpriseCustomerUser.DoesNotExist, EnterpriseCustomerUser.MultipleObjectsReturned):
-        # Ideally this should not happen. As there should be only 1 active enterprise customer in our system
-        log.error("Multiple or No Active Enterprise found for the user %s.", user.id)
-        active_enterprise_name = "Incorrect"
-
-    enrollment_enterprise_name = enterprise_enrollments.first().enterprise_customer_user.enterprise_customer.name
-    return IncorrectActiveEnterpriseAccessError(enrollment_enterprise_name, active_enterprise_name)
-
-
-def is_priority_access_error(access_error):
-    """
-    Check if given access error is a priority Access Error or not.
-    Priority Access Error can not be bypassed by staff users.
-    """
-    priority_access_errors = [
-        DataSharingConsentRequiredAccessError,
-        IncorrectActiveEnterpriseAccessError,
-    ]
-    for priority_access_error in priority_access_errors:
-        if isinstance(access_error, priority_access_error):
-            return True
-    return False

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -20,6 +20,7 @@ from django.utils.translation import gettext as _
 from edx_django_utils.monitoring import function_trace, set_custom_attribute
 from fs.errors import ResourceNotFound
 from opaque_keys.edx.keys import UsageKey
+from openedx_filters.learning.filters import CoursewareAccessChecksRequested
 from path import Path as path
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
@@ -34,14 +35,12 @@ from lms.djangoapps.courseware.access_response import (
     EnrollmentRequiredAccessError,
     MilestoneAccessError,
     OldMongoAccessError,
+    PriorityAccessFiltersError,
     StartDateError,
 )
 from lms.djangoapps.courseware.access_utils import (
     check_authentication,
-    check_correct_active_enterprise_customer,
-    check_data_sharing_consent,
     check_enrollment,
-    is_priority_access_error,
 )
 from lms.djangoapps.courseware.block_render import get_block
 from lms.djangoapps.courseware.context_processor import get_user_timezone_or_last_seen_timezone_or_utc
@@ -168,7 +167,7 @@ def check_course_access(
     check_if_enrolled=False,
     check_survey_complete=True,
     check_if_authenticated=False,
-    apply_enterprise_checks=False,
+    apply_priority_access_checks=False,
 ):
     """
     Check that the user has the access to perform the specified action
@@ -176,6 +175,11 @@ def check_course_access(
 
     check_if_enrolled: If true, additionally verifies that the user is enrolled.
     check_survey_complete: If true, additionally verifies that the user has completed the survey.
+    apply_priority_access_checks: If true, run the CoursewareAccessChecksRequested
+        filter pipeline so plugins can deny access with priority (non-bypassable)
+        errors. Used by views that surface the access error directly to the
+        client (e.g. course-home metadata) rather than relying on the redirect
+        machinery in ``check_course_access_with_redirect``.
     """
     def _check_nonstaff_access():
         # Below is a series of checks that must all pass for a user to be granted access
@@ -195,14 +199,13 @@ def check_course_access(
             if not enrollment_access_response:
                 return enrollment_access_response
 
-        if apply_enterprise_checks:
-            correct_active_enterprise_response = check_correct_active_enterprise_customer(user, course.id)
-            if not correct_active_enterprise_response:
-                return correct_active_enterprise_response
-
-            data_sharing_consent_response = check_data_sharing_consent(course.id)
-            if not data_sharing_consent_response:
-                return data_sharing_consent_response
+        if apply_priority_access_checks:
+            try:
+                CoursewareAccessChecksRequested.run_filter(user=user, course_key=course.id)
+            except CoursewareAccessChecksRequested.PreventCoursewareAccess as exc:
+                return PriorityAccessFiltersError(
+                    exc.error_code, exc.developer_message, exc.user_message,
+                )
 
         # Redirect if the user must answer a survey before entering the course.
         if check_survey_complete and action == 'load':
@@ -216,7 +219,7 @@ def check_course_access(
     non_staff_access_response = _check_nonstaff_access()
 
     # User has course access OR access error is a priority error
-    if non_staff_access_response or is_priority_access_error(non_staff_access_response):
+    if non_staff_access_response or isinstance(non_staff_access_response, PriorityAccessFiltersError):
         return non_staff_access_response
 
     # Allow staff full access to the course even if other checks fail

--- a/lms/djangoapps/courseware/decorators.py
+++ b/lms/djangoapps/courseware/decorators.py
@@ -1,0 +1,55 @@
+"""
+Decorators for courseware views.
+"""
+import functools
+
+from django.shortcuts import redirect
+from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CoursewareViewRedirectURL
+
+
+def courseware_view_redirect(view_func):
+    """
+    Decorator that calls the CoursewareViewRedirectURL filter before rendering a courseware view.
+
+    If any pipeline step returns a non-empty list of redirect URLs, the user is redirected
+    to the first URL in the list. Otherwise, the original view is rendered normally.
+
+    Usage::
+
+        @courseware_view_redirect
+        def my_view(request, course_id, ...):
+            ...
+
+    Works with both function-based views and ``method_decorator``-wrapped class-based views.
+    The decorator extracts the ``course_id`` or ``course_key`` from the view arguments.
+    """
+    @functools.wraps(view_func)
+    def _wrapper(request_or_self, *args, **kwargs):
+        # Support both function views (request as first arg) and method views
+        # (self as first arg, request as second arg).
+        if hasattr(request_or_self, 'method'):
+            # Function-based view: first arg is request
+            request = request_or_self
+        else:
+            # Class-based view via method_decorator: first arg is self, second is request
+            request = args[0] if args else kwargs.get('request')
+
+        course_id = kwargs.get('course_id') or (args[0] if args and not hasattr(request_or_self, 'method') else None)
+        try:
+            course_key = CourseKey.from_string(str(course_id)) if course_id else None
+        except Exception:  # pylint: disable=broad-except
+            course_key = None
+
+        if course_key is not None:
+            redirect_urls, _request, _course_key = CoursewareViewRedirectURL.run_filter(
+                redirect_urls=[],
+                request=request,
+                course_key=course_key,
+            )
+            if redirect_urls:
+                return redirect(redirect_urls[0])
+
+        return view_func(request_or_self, *args, **kwargs)
+
+    return _wrapper

--- a/lms/djangoapps/courseware/decorators.py
+++ b/lms/djangoapps/courseware/decorators.py
@@ -1,0 +1,46 @@
+"""
+Decorators for courseware views.
+"""
+import functools
+
+from django.shortcuts import redirect
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CoursewareViewStarted
+
+
+def courseware_view_hooks(view_func):
+    """
+    Decorator that calls the CoursewareViewStarted filter before rendering a courseware view.
+
+    If any pipeline step raises ``CoursewareViewStarted.RedirectToUrl``, the user is
+    redirected to that URL. Otherwise, the original view is rendered normally.
+
+    Usage::
+
+        @courseware_view_hooks
+        def my_view(request, course_id, ...):
+            ...
+
+    Works with both function-based views and ``method_decorator``-wrapped class-based views.
+    The wrapped view must accept ``course_id`` as its first argument after ``request``, which
+    binds whether callers pass it positionally or as a URL keyword argument.
+    """
+    @functools.wraps(view_func)
+    def _wrapper(request, course_id, *args, **kwargs):
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            # Skip bad request which contains a malformed course_id; let the view logic raise an error.
+            return view_func(request, course_id, *args, **kwargs)
+
+        try:
+            view_name = getattr(view_func, '__name__', '')
+            CoursewareViewStarted.run_filter(course_key=course_key, view_name=view_name)
+        except CoursewareViewStarted.RedirectToUrl as exc:
+            # One of the pipeline steps wants us to block view execution and redirect to a specific URL.
+            return redirect(exc.redirect_to)
+
+        return view_func(request, course_id, *args, **kwargs)
+
+    return _wrapper

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -952,15 +952,15 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
                 # read: CourseAccessRole + django_comment_client.Role
                 num_queries = 2
             else:
-                # read: CourseAccessRole + EnterpriseCourseEnrollment
-                num_queries = 2
+                # read: CourseAccessRole
+                num_queries = 1
         elif user_attr_name == 'user_normal':
             if course_attr_name == 'course_started':
                 # read: CourseAccessRole + django_comment_client.Role + FBEEnrollmentExclusion + CourseMode
                 num_queries = 4
             else:
-                # read: CourseAccessRole + CourseEnrollmentAllowed + EnterpriseCourseEnrollment
-                num_queries = 3
+                # read: CourseAccessRole + CourseEnrollmentAllowed
+                num_queries = 2
         elif user_attr_name == 'user_anonymous':
             if course_attr_name == 'course_started':
                 # read: CourseMode

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -11,7 +11,6 @@ import ddt
 import pytest
 import pytz
 from ccx_keys.locator import CCXLocator
-from crum import set_current_request
 from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.test import TestCase
@@ -19,7 +18,6 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
-from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
 from milestones.tests.utils import MilestonesTestCaseMixin
 from opaque_keys.edx.locator import CourseLocator
 
@@ -50,12 +48,6 @@ from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.testing.utils import AUTHZ_TABLES
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_experience import ENFORCE_MASQUERADE_START_DATES
-from openedx.features.enterprise_support.api import add_enterprise_customer_to_session
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerFactory,
-    EnterpriseCustomerUserFactory,
-)
 from xmodule.course_block import (  # pylint: disable=wrong-import-order
     CATALOG_VISIBILITY_ABOUT,
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
@@ -913,7 +905,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
     )
     @ddt.unpack
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    def test_course_catalog_access_num_queries_no_enterprise(self, user_attr_name, action, course_attr_name):
+    def test_course_catalog_access_num_queries(self, user_attr_name, action, course_attr_name):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
 
         course = getattr(self, course_attr_name)
@@ -952,74 +944,6 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
         course_overview = CourseOverview.get_from_id(course.id)
         with self.assertNumQueries(num_queries, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             bool(access.has_access(user, action, course_overview, course_key=course.id))
-
-    @ddt.data(
-        *itertools.product(
-            ['user_normal', 'user_staff', 'user_anonymous'],
-            ['course_started', 'course_not_started'],
-        )
-    )
-    @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
-    def test_course_catalog_access_num_queries_enterprise(self, user_attr_name, course_attr_name):
-        """
-        Similar to test_course_catalog_access_num_queries_no_enterprise, except enable enterprise features and make the
-        basic enrollment look like an enterprise-subsidized enrollment, setting up one of each:
-
-        * EnterpriseCustomer
-        * EnterpriseCustomerUser
-        * EnterpriseCourseEnrollment
-        * A mock request session to pre-cache the enterprise customer data.
-        """
-        ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
-
-        course = getattr(self, course_attr_name)
-
-        request = RequestFactory().get('/')
-        request.session = {}
-
-        # get a fresh user object that won't have any cached role information
-        if user_attr_name == 'user_anonymous':
-            user = AnonymousUserFactory()
-            request.user = user
-        else:
-            user = getattr(self, user_attr_name)
-            user = User.objects.get(id=user.id)
-            request.user = user
-            course_enrollment = CourseEnrollmentFactory(user=user, course_id=course.id)  # noqa: F841
-            enterprise_customer = EnterpriseCustomerFactory(enable_learner_portal=True)
-            add_enterprise_customer_to_session(request, EnterpriseCustomerSerializer(enterprise_customer).data)
-            enterprise_customer_user = EnterpriseCustomerUserFactory(
-                user_id=user.id,
-                enterprise_customer=enterprise_customer,
-            )
-            EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
-        set_current_request(request)
-
-        if user_attr_name == 'user_staff':
-            if course_attr_name == 'course_started':
-                # read: CourseAccessRole + django_comment_client.Role
-                num_queries = 4
-            else:
-                # read: CourseAccessRole + EnterpriseCourseEnrollment
-                num_queries = 4
-        elif user_attr_name == 'user_normal':
-            if course_attr_name == 'course_started':
-                # read: CourseAccessRole + django_comment_client.Role + FBEEnrollmentExclusion + CourseMode
-                num_queries = 6
-            else:
-                # read: CourseAccessRole + CourseEnrollmentAllowed + EnterpriseCourseEnrollment
-                num_queries = 5
-        elif user_attr_name == 'user_anonymous':
-            if course_attr_name == 'course_started':
-                # read: CourseMode
-                num_queries = 1
-            else:
-                num_queries = 0
-
-        course_overview = CourseOverview.get_from_id(course.id)
-        with self.assertNumQueries(num_queries, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
-            bool(access.has_access(user, 'see_exists', course_overview, course_key=course.id))
 
 
 class AuthzSeeAboutPageAccessTestCase(CourseAuthoringAuthzTestMixin, SharedModuleStoreTestCase):

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -23,13 +23,12 @@ from common.djangoapps.student.tests.factories import (
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.tests.helpers import CourseAccessTestMixin, LoginEnrollmentTestCase
 from lms.djangoapps.instructor.toggles import LEGACY_INSTRUCTOR_DASHBOARD
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 
-class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnrollmentTestCase):
+class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that view authentication works properly.
     """

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -28,6 +28,7 @@ from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_
 from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
 from freezegun import freeze_time
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from openedx_filters.learning.filters import CoursewareViewStarted
 from pytz import UTC
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -98,7 +99,6 @@ from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCustomerFactory,
     EnterpriseCustomerUserFactory,
 )
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -1646,6 +1646,19 @@ class ProgressPageTests(ProgressPageBaseTests):
             'earned_but_not_available': earned_but_not_available,
         }
 
+    @patch('openedx_filters.learning.filters.CoursewareViewStarted.run_filter')
+    def test_redirects_when_courseware_view_filter_raises(self, mock_run_filter):
+        """
+        Redirects to the URL raised by the CoursewareViewStarted filter on progress page URLs.
+        """
+        redirect_url = 'http://example.com/redirect'
+        mock_run_filter.side_effect = CoursewareViewStarted.RedirectToUrl(message="redirect", redirect_to=redirect_url)
+
+        resp = self._get_progress_page(expected_status_code=302)
+        assert resp['Location'] == redirect_url
+        resp = self._get_student_progress_page(expected_status_code=302)
+        assert resp['Location'] == redirect_url
+
 
 @ddt.ddt
 class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
@@ -2665,35 +2678,6 @@ class TestRenderXBlockSelfPaced(TestRenderXBlock):  # pylint: disable=test-inher
         options = super().course_options()
         options['self_paced'] = True
         return options
-
-
-class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCase):
-    """
-    Ensure that the Enterprise Data Consent redirects are in place only when consent is required.
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.user = UserFactory.create()
-        assert self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        self.course = CourseFactory.create()
-        CourseOverview.load_from_module_store(self.course.id)
-        CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
-
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    def test_consent_required(self, mock_enterprise_customer_for_request):
-        """
-        Test that enterprise data sharing consent is required when enabled for the various courseware views.
-        """
-        # ENT-924: Temporary solution to replace sensitive SSO usernames.
-        mock_enterprise_customer_for_request.return_value = None
-
-        course_id = str(self.course.id)
-        for url in (
-                reverse("progress", kwargs=dict(course_id=course_id)),
-                reverse("student_progress", kwargs=dict(course_id=course_id, student_id=str(self.user.id))),
-        ):
-            self.verify_consent_required(self.client, url)  # pylint: disable=no-value-for-parameter
 
 
 @ddt.ddt

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -104,7 +104,6 @@ from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCustomerUserFactory,
     EnterpriseCustomerFactory
 )
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from openedx.features.enterprise_support.api import add_enterprise_customer_to_session
 from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
 
@@ -2670,9 +2669,9 @@ class TestRenderXBlockSelfPaced(TestRenderXBlock):  # lint-amnesty, pylint: disa
         return options
 
 
-class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCase):
+class EnterpriseConsentTestCase(ModuleStoreTestCase):
     """
-    Ensure that the Enterprise Data Consent redirects are in place only when consent is required.
+    Ensure that courseware views redirect when the CoursewareViewRedirectURL filter provides a URL.
     """
 
     def setUp(self):
@@ -2683,20 +2682,22 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCa
         CourseOverview.load_from_module_store(self.course.id)
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
 
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    def test_consent_required(self, mock_enterprise_customer_for_request):
+    @patch('openedx_filters.learning.filters.CoursewareViewRedirectURL.run_filter')
+    def test_consent_required(self, mock_run_filter):
         """
-        Test that enterprise data sharing consent is required when enabled for the various courseware views.
+        Test that courseware views redirect to the URL returned by the CoursewareViewRedirectURL filter.
         """
-        # ENT-924: Temporary solution to replace sensitive SSO usernames.
-        mock_enterprise_customer_for_request.return_value = None
+        redirect_url = 'http://example.com/grant_consent'
+        mock_run_filter.return_value = ([redirect_url], MagicMock(), MagicMock())
 
         course_id = str(self.course.id)
         for url in (
                 reverse("progress", kwargs=dict(course_id=course_id)),
                 reverse("student_progress", kwargs=dict(course_id=course_id, student_id=str(self.user.id))),
         ):
-            self.verify_consent_required(self.client, url)  # lint-amnesty, pylint: disable=no-value-for-parameter
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response['Location'], redirect_url)
 
 
 @ddt.ddt
@@ -2766,7 +2767,13 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
             EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
         set_current_request(request)
 
-        access_response = check_course_open_for_learner(staff_user, course)
+        if setup_enterprise_enrollment:
+            # Mock the filter to simulate an enterprise plugin redirecting the learner.
+            with patch('openedx_filters.learning.filters.CoursewareViewRedirectURL.run_filter') as mock_filter:
+                mock_filter.return_value = (['http://enterprise-portal.example.com/'], MagicMock(), MagicMock())
+                access_response = check_course_open_for_learner(staff_user, course)
+        else:
+            access_response = check_course_open_for_learner(staff_user, course)
         assert bool(access_response) == expected_has_access
         assert access_response.error_code == expected_error_code
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -25,10 +25,9 @@ from django.test.client import Client
 from django.urls import reverse, reverse_lazy
 from edx_django_utils.cache.utils import RequestCache
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
-from enterprise.api.v1.serializers import EnterpriseCustomerSerializer
 from freezegun import freeze_time
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from openedx_filters.learning.filters import CoursewareViewStarted
+from openedx_filters.learning.filters import CourseStartDateValidationFailed, CoursewareViewStarted
 from pytz import UTC
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -93,12 +92,6 @@ from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url, make_learning_mfe_courseware_url
-from openedx.features.enterprise_support.api import add_enterprise_customer_to_session
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerFactory,
-    EnterpriseCustomerUserFactory,
-)
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -2688,27 +2681,21 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
     @ddt.data(
         {
             'start_date_modifier': 1,  # course starts in future
-            'setup_enterprise_enrollment': False,
+            'filter_raises_override': False,
             'expected_has_access': False,
             'expected_error_code': 'course_not_started',
         },
         {
             'start_date_modifier': -1,  # course already started
-            'setup_enterprise_enrollment': False,
+            'filter_raises_override': False,
             'expected_has_access': True,
             'expected_error_code': None,
         },
         {
-            'start_date_modifier': 1,  # course starts in future
-            'setup_enterprise_enrollment': True,
+            'start_date_modifier': 1,  # course starts in future, filter overrides error
+            'filter_raises_override': True,
             'expected_has_access': False,
             'expected_error_code': 'course_not_started_enterprise_learner',
-        },
-        {
-            'start_date_modifier': -1,  # course already started
-            'setup_enterprise_enrollment': True,
-            'expected_has_access': True,
-            'expected_error_code': None,
         },
     )
     @ddt.unpack
@@ -2716,38 +2703,33 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
     def test_is_course_open_for_learner(
         self,
         start_date_modifier,
-        setup_enterprise_enrollment,
+        filter_raises_override,
         expected_has_access,
         expected_error_code,
     ):
-        """
-        Test is_course_open_for_learner().
-
-        When setup_enterprise_enrollment == True, make an enterprise-subsidized enrollment, setting up one of each:
-        * CourseEnrollment
-        * EnterpriseCustomer
-        * EnterpriseCustomerUser
-        * EnterpriseCourseEnrollment
-        * A mock request session to pre-cache the enterprise customer data.
-        """
+        """Test is_course_open_for_learner()."""
         staff_user = AdminFactory()
         start_date = datetime.now(UTC) + timedelta(days=start_date_modifier)
         course = CourseFactory.create(start=start_date)
         request = RequestFactory().get('/')
         request.user = staff_user
         request.session = {}
-        if setup_enterprise_enrollment:
-            course_enrollment = CourseEnrollmentFactory(mode=CourseMode.VERIFIED, user=staff_user, course_id=course.id)  # noqa: F841  # pylint: disable=line-too-long
-            enterprise_customer = EnterpriseCustomerFactory(enable_learner_portal=True)
-            add_enterprise_customer_to_session(request, EnterpriseCustomerSerializer(enterprise_customer).data)
-            enterprise_customer_user = EnterpriseCustomerUserFactory(
-                user_id=staff_user.id,
-                enterprise_customer=enterprise_customer,
-            )
-            EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
         set_current_request(request)
 
-        access_response = check_course_open_for_learner(staff_user, course)
+        if filter_raises_override:
+            # Mock the filter to simulate a plugin substituting the start-date error payload.
+            with patch(
+                'openedx_filters.learning.filters.CourseStartDateValidationFailed.run_filter'
+            ) as mock_filter:
+                mock_filter.side_effect = CourseStartDateValidationFailed.OverrideStartDateError(
+                    message='message',
+                    error_code='course_not_started_enterprise_learner',
+                    developer_message='developer message',
+                    user_message='user message',
+                )
+                access_response = check_course_open_for_learner(staff_user, course)
+        else:
+            access_response = check_course_open_for_learner(staff_user, course)
         assert bool(access_response) == expected_has_access
         assert access_response.error_code == expected_error_code
 

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -17,11 +17,11 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from common.djangoapps.util.views import ensure_valid_course_key
+from lms.djangoapps.courseware.decorators import courseware_view_hooks
 from lms.djangoapps.courseware.exceptions import Redirect
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
-from openedx.features.enterprise_support.api import data_sharing_consent_required
 from xmodule.modulestore.django import modulestore
 
 from ..block_render import get_block_for_descriptor
@@ -43,7 +43,7 @@ class CoursewareIndex(View):
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True))
     @method_decorator(ensure_valid_course_key)
-    @method_decorator(data_sharing_consent_required)
+    @method_decorator(courseware_view_hooks)
     def get(self, request, course_id, section=None, subsection=None, position=None):
         """
         Instead of loading the legacy courseware sequences pages, load the equivalent URL

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -9,21 +9,20 @@ import logging
 
 from django.contrib.auth.views import redirect_to_login
 from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.utils.functional import cached_property
 from django.views.generic import View
-
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from xmodule.modulestore.django import modulestore
 
 from common.djangoapps.util.views import ensure_valid_course_key
+from lms.djangoapps.courseware.decorators import courseware_view_redirect
 from lms.djangoapps.courseware.exceptions import Redirect
 from lms.djangoapps.courseware.masquerade import setup_masquerade
-from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
-from openedx.features.enterprise_support.api import data_sharing_consent_required
+from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
+from xmodule.modulestore.django import modulestore
 
 from ..block_render import get_block_for_descriptor
 from ..courses import get_course_with_access
@@ -44,7 +43,7 @@ class CoursewareIndex(View):
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True))
     @method_decorator(ensure_valid_course_key)
-    @method_decorator(data_sharing_consent_required)
+    @method_decorator(courseware_view_redirect)
     def get(self, request, course_id, section=None, subsection=None, position=None):
         """
         Instead of loading the legacy courseware sequences pages, load the equivalent URL

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -82,6 +82,7 @@ from lms.djangoapps.courseware.courses import (
     sort_by_start_date,
 )
 from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link
+from lms.djangoapps.courseware.decorators import courseware_view_hooks
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, Redirect
 from lms.djangoapps.courseware.masquerade import is_masquerading_as_specific_student, setup_masquerade
 from lms.djangoapps.courseware.model_data import FieldDataCache
@@ -137,7 +138,6 @@ from openedx.features.course_experience.url_helpers import (
 )
 from openedx.features.course_experience.utils import dates_banner_should_display
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
-from openedx.features.enterprise_support.api import data_sharing_consent_required
 from xmodule.course_block import (
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
     COURSE_VISIBILITY_PUBLIC,
@@ -521,7 +521,7 @@ class CourseTabView(EdxFragmentView):
     """
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(ensure_valid_course_key)
-    @method_decorator(data_sharing_consent_required)
+    @method_decorator(courseware_view_hooks)
     def get(self, request, course_id, tab_type, **kwargs):  # pylint: disable=arguments-differ
         """
         Displays a course tab page that contains a web fragment.
@@ -970,7 +970,7 @@ def dates(request, course_id):
 @login_required
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @ensure_valid_course_key
-@data_sharing_consent_required
+@courseware_view_hooks
 def progress(request, course_id, student_id=None):
     """ Display the progress page. """
     course_key = CourseKey.from_string(course_id)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -12,14 +12,15 @@ from urllib.parse import quote_plus, urlencode, urljoin, urlparse, urlunparse
 
 import nh3
 import requests
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Q, prefetch_related_objects
+from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
 from django.shortcuts import redirect
-from django.http import JsonResponse, Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.template.context_processors import csrf
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -34,37 +35,25 @@ from django.views.generic import View
 from edx_django_utils.monitoring import set_custom_attribute, set_custom_attributes_for_course_key
 from edx_django_utils.plugins import pluggable_override
 from ipware.ip import get_client_ip
-from xblock.core import XBlock
-
-from lms.djangoapps.static_template_view.views import render_500
 from markupsafe import escape
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from openedx_filters.learning.filters import CourseAboutRenderStarted, RenderXBlockStarted
-from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from pytz import UTC
+from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from rest_framework import status
 from rest_framework.decorators import api_view, throttle_classes
+from rest_framework.fields import BooleanField
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
-from rest_framework.fields import BooleanField
 from web_fragments.fragment import Fragment
-from xmodule.course_block import (
-    COURSE_VISIBILITY_PUBLIC,
-    COURSE_VISIBILITY_PUBLIC_OUTLINE,
-    CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
-)
-from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
-from xmodule.tabs import CourseTabList
-from xmodule.x_module import STUDENT_VIEW
+from xblock.core import XBlock
 
 from common.djangoapps.course_modes.models import CourseMode, get_course_prices
 from common.djangoapps.edxmako.shortcuts import marketing_link, render_to_response, render_to_string
 from common.djangoapps.student import auth
-from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.models import CourseEnrollment, UserTestGroup
+from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.util.cache import cache, cache_if_anonymous
 from common.djangoapps.util.course import course_location_from_key, get_link_for_about_page
 from common.djangoapps.util.db import outer_atomic
@@ -93,16 +82,13 @@ from lms.djangoapps.courseware.courses import (
     sort_by_start_date
 )
 from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link
+from lms.djangoapps.courseware.decorators import courseware_view_redirect
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, Redirect
 from lms.djangoapps.courseware.masquerade import is_masquerading_as_specific_student, setup_masquerade
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
 from lms.djangoapps.courseware.permissions import MASQUERADE_AS_STUDENT, VIEW_COURSE_HOME, VIEW_COURSEWARE
-from lms.djangoapps.courseware.toggles import (
-    course_is_invitation_only,
-    courseware_mfe_search_is_enabled,
-)
-from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
+from lms.djangoapps.courseware.toggles import course_is_invitation_only, courseware_mfe_search_is_enabled
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.courseware.utils import (
     _use_new_financial_assistance_flow,
@@ -114,6 +100,7 @@ from lms.djangoapps.experiments.utils import get_experiment_user_metadata_contex
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.instructor.enrollment import uses_shib
 from lms.djangoapps.instructor.views.api import require_global_staff
+from lms.djangoapps.static_template_view.views import render_500
 from lms.djangoapps.survey import views as survey_views
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.catalog.utils import (
@@ -135,8 +122,8 @@ from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.programs.utils import ProgramMarketingDataExtender
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
-from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
 from openedx.core.djangoapps.video_config.sharing import is_public_sharing_enabled
+from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
 from openedx.core.djangoapps.zendesk_proxy.utils import create_zendesk_ticket
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.courses import get_course_by_id
@@ -151,14 +138,20 @@ from openedx.features.course_experience.url_helpers import (
 )
 from openedx.features.course_experience.utils import dates_banner_should_display
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
-from openedx.features.enterprise_support.api import data_sharing_consent_required
+from xmodule.course_block import (
+    CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
+    COURSE_VISIBILITY_PUBLIC,
+    COURSE_VISIBILITY_PUBLIC_OUTLINE
+)
+from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
+from xmodule.tabs import CourseTabList
+from xmodule.x_module import STUDENT_VIEW
 
 from ..block_render import get_block, get_block_by_usage_id, get_block_for_descriptor
 from ..tabs import _get_dynamic_tabs
-from ..toggles import (
-    COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
-    ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER,
-)
+from ..toggles import COURSEWARE_OPTIMIZED_RENDER_XBLOCK, ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER
 
 log = logging.getLogger("edx.courseware")
 
@@ -528,7 +521,7 @@ class CourseTabView(EdxFragmentView):
     """
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(ensure_valid_course_key)
-    @method_decorator(data_sharing_consent_required)
+    @method_decorator(courseware_view_redirect)
     def get(self, request, course_id, tab_type, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
         """
         Displays a course tab page that contains a web fragment.
@@ -977,7 +970,7 @@ def dates(request, course_id):
 @login_required
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @ensure_valid_course_key
-@data_sharing_consent_required
+@courseware_view_redirect
 def progress(request, course_id, student_id=None):
     """ Display the progress page. """
     course_key = CourseKey.from_string(course_id)

--- a/lms/djangoapps/discussion/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/tests/test_views_v2.py
@@ -16,7 +16,6 @@ from django.http import Http404
 from django.test.client import Client, RequestFactory  # noqa: F401
 from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils import translation
 from edx_django_utils.cache import RequestCache  # noqa: F401
 from edx_toggles.toggles.testutils import override_waffle_flag
 
@@ -63,7 +62,6 @@ from openedx.core.djangoapps.util.testing import ContentGroupTestCase
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.lib.teams_config import TeamsConfig
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig  # noqa: F401
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.modulestore import ModuleStoreEnum  # noqa: F401
 from xmodule.modulestore.django import modulestore  # noqa: F401
 from xmodule.modulestore.tests.django_utils import (
@@ -1046,75 +1044,6 @@ class ForumFormDiscussionUnicodeTestCase(
         response_data = json.loads(response.content.decode("utf-8"))
         assert response_data["discussion_data"][0]["title"] == text
         assert response_data["discussion_data"][0]["body"] == text
-
-
-class EnterpriseConsentTestCase(
-    EnterpriseTestConsentRequired,
-    UrlResetMixin,
-    ModuleStoreTestCase,
-    ForumViewsUtilsMixin,
-):
-    """
-    Ensure that the Enterprise Data Consent redirects are in place only when consent is required.
-    """
-
-    CREATE_USER = False
-
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
-    def setUp(self):
-        # Invoke UrlResetMixin setUp
-        super().setUp()
-        username = "foo"
-        password = "bar"
-
-        self.discussion_id = "dummy_discussion_id"
-        self.course = CourseFactory.create(
-            discussion_topics={"dummy discussion": {"id": self.discussion_id}}
-        )
-        self.student = UserFactory.create(username=username, password=password)
-        CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
-        assert self.client.login(username=username, password=password)
-
-        self.addCleanup(translation.deactivate)
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        super().setUpClassAndForumMock()
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        super().disposeForumMocks()
-
-    @patch("openedx.features.enterprise_support.api.enterprise_customer_for_request")
-    def test_consent_required(self, mock_enterprise_customer_for_request):
-        """
-        Test that enterprise data sharing consent is required when enabled for the various discussion views.
-        """
-        # ENT-924: Temporary solution to replace sensitive SSO usernames.
-        mock_enterprise_customer_for_request.return_value = None
-
-        thread_id = "dummy"
-        course_id = str(self.course.id)
-        self._configure_mock_responses(
-            course=self.course, text="dummy", thread_id=thread_id
-        )
-
-        for url in (
-            reverse("forum_form_discussion", kwargs=dict(course_id=course_id)),
-            reverse(
-                "single_thread",
-                kwargs=dict(
-                    course_id=course_id,
-                    discussion_id=self.discussion_id,
-                    thread_id=thread_id,
-                ),
-            ),
-        ):
-            self.verify_consent_required(  # pylint: disable=no-value-for-parameter
-                self.client, url
-            )
 
 
 class InlineDiscussionGroupIdTestCase(  # pylint: disable=missing-class-docstring

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3172,3 +3172,15 @@ SSL_AUTH_EMAIL_DOMAIN = "MIT.EDU"
 SSL_AUTH_DN_FORMAT_STRING = (
     "/C=US/ST=Massachusetts/O=Massachusetts Institute of Technology/OU=Client CA v1/CN={0}/emailAddress={1}"
 )
+
+########################## OpenEdX Filters Configuration ####################
+
+OPEN_EDX_FILTERS_CONFIG = {
+    "org.openedx.learning.courseware.view.redirect_url.requested.v1": {
+        "fail_silently": True,
+        "pipeline": [
+            "enterprise.filters.courseware.ConsentRedirectStep",
+            "enterprise.filters.courseware.LearnerPortalRedirectStep",
+        ],
+    },
+}

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -66,9 +66,9 @@ def safe_get_host(request):
         return configuration_helpers.get_value('site_domain', settings.SITE_NAME)
 
 
-def course_id_from_url(url):
+def course_id_from_url(url: str | None) -> CourseKey | None:
     """
-    Extracts the course_id from the given `url`.
+    Extracts and parses the course_id from the given `url` and returns a CourseKey.
     """
     if not url:
         return None

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -11,13 +11,10 @@ from crum import get_current_request
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
-from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.template.loader import render_to_string
-from django.urls import reverse
-from django.utils.http import urlencode
 from django.utils.translation import gettext as _
-from edx_django_utils.cache import TieredCache, get_cache_key
+from edx_django_utils.cache import get_cache_key
 from edx_rest_api_client.auth import SuppliedJwtAuth
 from requests.exceptions import HTTPError
 
@@ -26,7 +23,6 @@ from common.djangoapps.third_party_auth.provider import Registry
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.features.enterprise_support.utils import get_data_consent_share_cache_key
 
 try:
     from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
@@ -556,170 +552,6 @@ def enterprise_customer_for_request(request):
     return enterprise_customer
 
 
-@enterprise_is_enabled(otherwise=False)
-def consent_needed_for_course(request, user, course_id, enrollment_exists=False):
-    """
-    Wraps the enterprise app check to determine if the user needs to grant
-    data sharing permissions before accessing a course.
-    """
-    LOGGER.info(
-        "[ENTERPRISE DSC] Determining if user [{username}] must consent to data sharing for course"  # noqa: UP032
-        " [{course_id}]".format(
-            username=user.username,
-            course_id=course_id
-        )
-    )
-
-    active_enterprise_learner_info = get_active_enterprise_customer_user(user)
-    if not active_enterprise_learner_info:
-        # user is not linked to any enterprise so return False
-        LOGGER.info(
-            "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]."  # noqa: UP032
-            " The user is not linked to an enterprise.".format(
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        return False
-
-    active_enterprise_customer = active_enterprise_learner_info['enterprise_customer']
-
-    # Check if DSC required from cache
-    consent_cache_key = get_data_consent_share_cache_key(user.id, course_id, active_enterprise_customer['uuid'])
-    data_sharing_consent_needed_cache = TieredCache.get_cached_response(consent_cache_key)
-    if data_sharing_consent_needed_cache.is_found and data_sharing_consent_needed_cache.value == 0:
-        LOGGER.info(
-            "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. "  # noqa: UP032
-            "The DSC cache was checked and the value was 0.".format(
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        return False
-
-    # Check if DSC enabled by the enterprise customer
-    enable_data_sharing_consent = active_enterprise_customer['enable_data_sharing_consent']
-    if not enable_data_sharing_consent:
-        # enterprise has disabled DSC so no need to move forward
-        LOGGER.info(
-            "[ENTERPRISE DSC] DSC is disabled for enterprise customer [{slug}]. Consent from user [{username}] is not "
-            "needed for course [{course_id}]".format(
-                slug=active_enterprise_customer['slug'],
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    # check if the request enterprise and learner's active enterprise matches
-    current_enterprise_uuid = enterprise_customer_uuid_for_request(request)
-    active_enterprise_match = str(current_enterprise_uuid) == str(active_enterprise_customer['uuid'])
-    if not active_enterprise_match:
-        LOGGER.info(
-            '[ENTERPRISE DSC] Enterprise mismatch. USER: [{username}], RequestEnterprise: [{current_enterprise_uuid}], '
-            'LearnerEnterprise: [{active_enterprise_customer}]'.format(
-                username=user.username,
-                current_enterprise_uuid=current_enterprise_uuid,
-                active_enterprise_customer=active_enterprise_customer['uuid'],
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    # check if the enterprise and learner's site matches
-    enterprise_domain = Site.objects.get(domain=active_enterprise_customer['site']['domain'])
-    enterprise_and_learner_have_same_domain = enterprise_domain == request.site
-    if not enterprise_and_learner_have_same_domain:
-        LOGGER.info(
-            '[ENTERPRISE DSC] Site mismatch. USER: [{username}], RequestSite: [{request_site}], '  # noqa: UP032
-            'LearnerEnterpriseDomain: [{enterprise_domain}]'.format(
-                username=user.username,
-                request_site=request.site,
-                enterprise_domain=enterprise_domain
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    # check if consent required
-    client = ConsentApiClient(user=request.user)
-    consent_required = client.consent_required(
-        username=user.username,
-        course_id=course_id,
-        enterprise_customer_uuid=current_enterprise_uuid,
-        enrollment_exists=enrollment_exists,
-    )
-    if not consent_required:
-        LOGGER.info(
-            "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. The user's current"  # noqa: UP032  # pylint: disable=line-too-long
-            " enterprise does not require data sharing consent.".format(
-                username=user.username,
-                course_id=course_id
-            )
-        )
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-        return False
-
-    LOGGER.info(
-        "[ENTERPRISE DSC] Consent from user [{username}] is needed for course [{course_id}]. The user's "  # noqa: UP032
-        "current enterprise requires data sharing consent, and it has not been given.".format(
-            username=user.username,
-            course_id=course_id
-        )
-    )
-    return True
-
-
-@enterprise_is_enabled(otherwise='')
-def get_enterprise_consent_url(request, course_id, user=None, return_to=None, enrollment_exists=False, source='lms'):
-    """
-    Build a URL to redirect the user to the Enterprise app to provide data sharing
-    consent for a specific course ID.
-
-    Arguments:
-    * request: Request object
-    * course_id: Course key/identifier string.
-    * user: user to check for consent. If None, uses request.user
-    * return_to: url name label for the page to return to after consent is granted.
-                 If None, return to request.path instead.
-    """
-    user = user or request.user
-
-    LOGGER.info(
-        'Getting enterprise consent url for user [{username}] and course [{course_id}].'.format(  # noqa: UP032
-            username=user.username,
-            course_id=course_id
-        )
-    )
-
-    if not consent_needed_for_course(request, user, course_id, enrollment_exists=enrollment_exists):
-        return None
-
-    if return_to is None:
-        return_path = request.path
-    else:
-        return_path = reverse(return_to, args=(course_id,))
-
-    url_params = {
-        'enterprise_customer_uuid': enterprise_customer_uuid_for_request(request),
-        'course_id': course_id,
-        'source': source,
-        'next': request.build_absolute_uri(return_path),
-        'failure_url': request.build_absolute_uri(
-            reverse('dashboard') + '?' + urlencode(
-                {
-                    CONSENT_FAILED_PARAMETER: course_id
-                }
-            )
-        ),
-    }
-    querystring = urlencode(url_params)
-    full_url = reverse('grant_data_sharing_permissions') + '?' + querystring
-    LOGGER.info('Redirecting to %s to complete data sharing consent', full_url)
-    return full_url
-
-
 @enterprise_is_enabled()
 def get_enterprise_learner_data_from_api(user):
     """
@@ -740,23 +572,6 @@ def get_enterprise_learner_data_from_db(user):
         queryset = EnterpriseCustomerUser.objects.filter(user_id=user.id)
         serializer = EnterpriseCustomerUserReadOnlySerializer(queryset, many=True)
         return serializer.data
-
-
-@enterprise_is_enabled(otherwise=None)
-def get_active_enterprise_customer_user(user):
-    """
-    Query the database to return active enterprise customer user and serialize the result. There can only be one active
-    EnterpriseCustomerUser instance against a user_id.
-    """
-    if user.is_authenticated:
-        try:
-            enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
-        except EnterpriseCustomerUser.DoesNotExist:
-            LOGGER.info(
-                "Active EnterpriseCustomerUser for user [{username}] does not exist".format(username=user.username)  # noqa: UP032  # pylint: disable=line-too-long
-            )
-            return None
-        return EnterpriseCustomerUserReadOnlySerializer(instance=enterprise_customer_user).data
 
 
 @enterprise_is_enabled(otherwise=[])

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -4,7 +4,6 @@ APIs providing support for enterprise functionality.
 
 import logging
 import traceback
-from functools import wraps
 from urllib.parse import urljoin
 
 import requests
@@ -14,7 +13,6 @@ from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
 from django.core.cache import cache
-from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -328,44 +326,6 @@ def activate_learner_enterprise(request, user, enterprise_customer):
         return True
 
     return False
-
-
-def data_sharing_consent_required(view_func):
-    """
-    Decorator which makes a view method redirect to the Data Sharing Consent form if:
-
-    * The wrapped method is passed request, course_id as the first two arguments.
-    * Enterprise integration is enabled
-    * Data sharing consent is required before accessing this course view.
-    * The request.user has not yet given data sharing consent for this course.
-
-    After granting consent, the user will be redirected back to the original request.path.
-
-    """
-
-    @wraps(view_func)
-    def inner(request, course_id, *args, **kwargs):
-        """
-        Redirect to the consent page if the request.user must consent to data sharing before viewing course_id.
-
-        Otherwise, just call the wrapped view function.
-        """
-        # Redirect to the consent URL, if consent is required.
-        source = getattr(view_func, '__name__', '')
-        consent_url = get_enterprise_consent_url(request, course_id, enrollment_exists=True, source=source)
-        if consent_url:
-            real_user = getattr(request.user, 'real_user', request.user)
-            LOGGER.info(
-                'User %s cannot access the course %s because they have not granted consent',
-                real_user,
-                course_id,
-            )
-            return redirect(consent_url)
-
-        # Otherwise, drop through to wrapped view
-        return view_func(request, course_id, *args, **kwargs)
-
-    return inner
 
 
 def enterprise_enabled():

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -4,15 +4,10 @@ Mixins for the EnterpriseApiClient.
 
 
 import json
-from unittest import mock
 
 import httpretty
 from django.conf import settings
 from django.core.cache import cache
-from django.test import SimpleTestCase
-from django.urls import reverse
-
-from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
 
 
 class EnterpriseServiceMockMixin:
@@ -282,62 +277,3 @@ class EnterpriseServiceMockMixin:
             body=enterprise_learner_api_response_json,
             content_type='application/json'
         )
-
-
-class EnterpriseTestConsentRequired(SimpleTestCase):
-    """
-    Mixin to help test the data_sharing_consent_required decorator.
-    """
-
-    @mock.patch('openedx.features.enterprise_support.utils.get_enterprise_learner_generic_name')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    @mock.patch('openedx.features.enterprise_support.api.reverse')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
-    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
-    def verify_consent_required(
-            self,
-            client,
-            url,
-            mock_consent_necessary,
-            mock_enterprise_enabled,
-            mock_reverse,
-            mock_enterprise_customer_uuid_for_request,
-            mock_enterprise_customer_from_api,
-            mock_get_enterprise_learner_generic_name,
-            status_code=200,
-    ):
-        """
-        Verify that the given URL redirects to the consent page when consent is required,
-        and doesn't redirect to the consent page when consent is not required.
-        """
-
-        def mock_consent_reverse(*args, **kwargs):
-            if args[0] == 'grant_data_sharing_permissions':
-                return '/enterprise/grant_data_sharing_permissions'
-            return reverse(*args, **kwargs)
-
-        # ENT-924: Temporary solution to replace sensitive SSO usernames.
-        mock_get_enterprise_learner_generic_name.return_value = ''
-
-        mock_reverse.side_effect = mock_consent_reverse
-        mock_enterprise_enabled.return_value = True
-        mock_enterprise_customer_uuid_for_request.return_value = 'fake-uuid'
-        mock_enterprise_customer_from_api.return_value = FAKE_ENTERPRISE_CUSTOMER
-        # Ensure that when consent is necessary, the user is redirected to the consent page.
-        mock_consent_necessary.return_value = True
-        response = client.get(url)
-        while(response.status_code == 302 and 'grant_data_sharing_permissions' not in response.url):
-            response = client.get(response.url)
-        assert response.status_code == 302
-        assert 'grant_data_sharing_permissions' in response.url
-
-        # Ensure that when consent is not necessary, the user continues through to the requested page.
-        mock_consent_necessary.return_value = False
-        response = client.get(url)
-        assert response.status_code == status_code
-
-        # If we were expecting a redirect, ensure it's not to the data sharing permission page
-        if status_code == 302:
-            assert 'grant_data_sharing_permissions' not in response.url
-        return response

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -11,14 +11,10 @@ from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.cache import cache
 from django.test.utils import override_settings
-from django.urls import reverse
-from edx_django_utils.cache import TieredCache, get_cache_key
+from edx_django_utils.cache import get_cache_key
 from requests.exceptions import HTTPError
-from six.moves.urllib.parse import parse_qs
-from testfixtures import LogCapture
 
 from common.djangoapps.student.tests.factories import UserFactory
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.features.enterprise_support.api import (
     _CACHE_MISS,
@@ -30,18 +26,15 @@ from openedx.features.enterprise_support.api import (
     EnterpriseApiServiceClient,
     activate_learner_enterprise,
     add_enterprise_customer_to_session,
-    consent_needed_for_course,
     enterprise_customer_for_request,
     enterprise_customer_from_api,
     enterprise_customer_from_session,
     enterprise_customer_from_session_or_learner_data,
     enterprise_customer_uuid_for_request,
     enterprise_enabled,
-    get_active_enterprise_customer_user,
     get_consent_notification_data,
     get_dashboard_consent_notification,
     get_data_sharing_consents,
-    get_enterprise_consent_url,
     get_enterprise_course_enrollments,
     get_enterprise_learner_data_from_api,
     get_enterprise_learner_data_from_db,
@@ -54,9 +47,6 @@ from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCustomerUserFactory,
 )
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
-from openedx.features.enterprise_support.utils import clear_data_consent_share_cache, get_data_consent_share_cache_key
-
-LOGGER_NAME = "edx.enterprise_helpers"
 
 
 class MockEnrollment(mock.MagicMock):
@@ -242,291 +232,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         mock_client.post.assert_called_once_with(consent_client.consent_endpoint, json=kwargs)
         mock_client.delete.assert_called_once_with(consent_client.consent_endpoint, json=kwargs)
 
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    def test_consent_needed_for_course_no_active_enterprise_user(self, mock_get_active_enterprise_customer_user):
-        """Tests that consent is not needed for non-enterprise user."""
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        course_id = 'fake-course'
-        mock_get_active_enterprise_customer_user.return_value = None
-
-        # test that consent is not required for a non-enterprise learner and appropriate message is logged
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]." \
-                           " The user is not linked to an enterprise."
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id),
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    def test_consent_needed_for_course_dsc_cache_found(self, mock_get_active_enterprise_customer_user):
-        """
-        Tests that a consent is not needed when a DSC record is already found in cache and it is equal to 0.
-        """
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-        )
-
-        # store a DSC record value in cache
-        consent_cache_key = get_data_consent_share_cache_key(user.id, course_id, ec_uuid)
-        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
-
-        # test that consent is not required if DSC record is already found in cache.
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. " \
-                           "The DSC cache was checked and the value was 0."
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id),
-                )
-            )
-        # clearing up
-        clear_data_consent_share_cache(user.id, course_id, ec_uuid)
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    def test_consent_needed_for_course_dsc_not_enabled(self, mock_get_active_enterprise_customer_user):
-        """
-        Tests that a consent is not needed when enterprise customer has disabled DSC.
-        """
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        ent_slug = 'test-slug'
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-            enable_data_sharing_consent=False,
-            slug=ent_slug
-        )
-
-        # test that consent is not required if DSC is disabled for the enterprise.
-        expected_message = "[ENTERPRISE DSC] DSC is disabled for enterprise customer [{slug}]. " \
-                           "Consent from user [{username}] is not needed for course [{course_id}]"
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(slug=ent_slug, username=user.username, course_id=course_id)
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_enterprise_mismatch(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_get_active_enterprise_customer_user
-    ):
-        """
-        Tests that a consent is not needed when current request enterprise and learner's active
-        enterprise does not match.
-        """
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain='example.com'),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-
-        learner_enterprise = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        current_request_enterprise = '1234-23434-vfdfa-242sdczz'
-        course_id = 'fake-course'
-        enterprise_customer_uuid_for_request_mock.return_value = current_request_enterprise
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=learner_enterprise,
-        )
-
-        expected_message = '[ENTERPRISE DSC] Enterprise mismatch. USER: [{username}], RequestEnterprise: ' \
-                           '[{current_enterprise_uuid}], LearnerEnterprise: [{active_enterprise_customer}]'
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(
-                        username=user.username,
-                        current_enterprise_uuid=current_request_enterprise,
-                        active_enterprise_customer=learner_enterprise
-                    )
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_site_mismatch(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_get_active_enterprise_customer_user,
-    ):
-        """
-        Tests that a consent is not needed when enterprise customer and learner's site domain does not match.
-        """
-        user = UserFactory(username='janedoe')
-        request_site_domain = 'site-mismatch.com'
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain=request_site_domain),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        ent_site = SiteFactory(domain='ent-site.com')
-        enterprise_customer_uuid_for_request_mock.return_value = ec_uuid
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-            site_domain=str(ent_site.domain),
-        )
-
-        expected_message = "[ENTERPRISE DSC] Site mismatch. USER: [{username}], RequestSite: [{request_site}], " \
-                           "LearnerEnterpriseDomain: [{enterprise_domain}]"
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(
-                        username=user.username,
-                        request_site=request_site_domain,
-                        enterprise_domain=ent_site.domain
-                    )
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.ConsentApiClient.consent_required')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_when_consent_is_not_required(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_consent_required,
-        mock_get_active_enterprise_customer_user
-    ):
-        """
-        Tests that a consent is not needed when learner is not already enrolled and the enterprise requires consent.
-        """
-        mock_consent_required.return_value = False
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        enterprise_customer_uuid_for_request_mock.return_value = ec_uuid
-
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-        )
-
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is not needed for course [{course_id}]. " \
-                           "The user's current enterprise does not require data sharing consent."
-        with LogCapture(LOGGER_NAME) as log:
-            assert not consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id)
-                )
-            )
-
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_active_enterprise_customer_user')
-    @mock.patch('openedx.features.enterprise_support.api.ConsentApiClient.consent_required')
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    def test_consent_needed_for_course_when_consent_is_required(
-        self,
-        enterprise_customer_uuid_for_request_mock,
-        mock_consent_required,
-        mock_get_active_enterprise_customer_user
-    ):
-        """
-        Tests that a consent is needed when learner is not already enrolled and the enterprise requires consent.
-        """
-        mock_consent_required.return_value = True
-        user = UserFactory(username='janedoe')
-        request = mock.MagicMock(
-            user=user,
-            site=SiteFactory(domain="example.com"),
-            session={},
-            COOKIES={},
-            GET={},
-        )
-        ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        course_id = 'fake-course'
-        enterprise_customer_uuid_for_request_mock.return_value = ec_uuid
-
-        mock_get_active_enterprise_customer_user.return_value = self.get_mock_active_enterprise_learner_details(
-            learner_id=user.id,
-            enterprise_customer_uuid=ec_uuid,
-        )
-
-        expected_message = "[ENTERPRISE DSC] Consent from user [{username}] is needed for course [{course_id}]. " \
-                           "The user's current enterprise requires data sharing consent, and it has not been given."
-        with LogCapture(LOGGER_NAME) as log:
-            assert consent_needed_for_course(request, user, course_id)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_message.format(username=user.username, course_id=course_id)
-                )
-            )
-
     @mock.patch('openedx.features.enterprise_support.api.create_jwt_for_user')
     def test_fetch_enterprise_learner_data_unauthenticated(self, mock_jwt_builder):
         api_client = self._assert_api_client_with_user(EnterpriseApiClient, mock_jwt_builder)
@@ -609,35 +314,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         EnterpriseCustomerUserFactory(user_id=self.user.id)
         user_data = get_enterprise_learner_data_from_db(self.user)[0]['user']
         assert user_data['username'] == self.user.username
-
-    @ddt.data(True, False)
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
-    def test_get_active_enterprise_customer_user(self, is_enterprise_enabled, mock_enterprise_enabled):
-        """Tests that get_active_enterprise_customer_user utility returns correct user."""
-        mock_enterprise_enabled.return_value = is_enterprise_enabled
-        EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
-        if not is_enterprise_enabled:
-            assert not get_active_enterprise_customer_user(self.user)
-        else:
-            user_data = get_active_enterprise_customer_user(self.user)
-            assert user_data['user']['username'] == self.user.username
-            assert user_data['active']
-
-    def test_get_active_enterprise_customer_user_no_user_found(self):
-        """
-        Test that get_active_enterprise_customer_user utility returns None if active user not found.
-        And logs the appropriate message.
-        """
-        expected_logger_message = "Active EnterpriseCustomerUser for user [{username}] does not exist"
-        with LogCapture(LOGGER_NAME) as log:
-            assert not get_active_enterprise_customer_user(self.user)
-            log.check_present(
-                (
-                    LOGGER_NAME,
-                    'INFO',
-                    expected_logger_message.format(username=self.user.username),
-                )
-            )
 
     @ddt.data(True, False)
     @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
@@ -816,55 +492,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
             assert enterprise_customer == enterprise_data
             assert mock_enterprise_customer_from_api.called is False
             assert mock_enterprise_customer_from_session.called is True
-
-    @ddt.data(True, False)
-    @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
-    @mock.patch('openedx.features.enterprise_support.api.reverse')
-    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
-    def test_get_enterprise_consent_url(
-            self,
-            is_return_to_null,
-            needed_for_course_mock,
-            reverse_mock,
-            enterprise_customer_uuid_for_request_mock,
-    ):
-        """
-        Verify that get_enterprise_consent_url correctly builds URLs.
-        """
-
-        def fake_reverse(*args, **kwargs):
-            if args[0] == 'grant_data_sharing_permissions':
-                return '/enterprise/grant_data_sharing_permissions'
-            return reverse(*args, **kwargs)
-
-        enterprise_customer_uuid_for_request_mock.return_value = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
-        reverse_mock.side_effect = fake_reverse
-        needed_for_course_mock.return_value = True
-        request_mock = mock.MagicMock(
-            user=self.user,
-            path='/request_path',
-            build_absolute_uri=lambda x: 'http://localhost:8000' + x  # Don't do it like this in prod. Ever.
-        )
-
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-        return_to = None if is_return_to_null else 'courseware'
-
-        if is_return_to_null:
-            expected_path = request_mock.path
-        else:
-            expected_path = '/courses/course-v1:edX+DemoX+Demo_Course/courseware'
-        expected_url_args = {
-            'course_id': ['course-v1:edX+DemoX+Demo_Course'],
-            'source': ['lms'],
-            'failure_url': ['http://localhost:8000/dashboard?consent_failed=course-v1%3AedX%2BDemoX%2BDemo_Course'],
-            'enterprise_customer_uuid': ['cf246b88-d5f6-4908-a522-fc307e0b0c59'],
-            'next': [f'http://localhost:8000{expected_path}']
-        }
-
-        actual_url = get_enterprise_consent_url(request_mock, course_id, return_to=return_to)
-        actual_url_args = parse_qs(actual_url.split('/enterprise/grant_data_sharing_permissions?')[1])
-        assert actual_url_args == expected_url_args
 
     @ddt.data(
         (False, {'real': 'enterprise', 'uuid': ''}, 'course', [], [], "", ""),

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -10,7 +10,6 @@ from consent.models import DataSharingConsent
 from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.cache import cache
-from django.http import HttpResponseRedirect
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_django_utils.cache import TieredCache, get_cache_key
@@ -32,7 +31,6 @@ from openedx.features.enterprise_support.api import (
     activate_learner_enterprise,
     add_enterprise_customer_to_session,
     consent_needed_for_course,
-    data_sharing_consent_required,
     enterprise_customer_for_request,
     enterprise_customer_from_api,
     enterprise_customer_from_session,
@@ -818,84 +816,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
             assert enterprise_customer == enterprise_data
             assert mock_enterprise_customer_from_api.called is False
             assert mock_enterprise_customer_from_session.called is True
-
-    def check_data_sharing_consent(self, consent_required=False, consent_url=None):
-        """
-        Used to test the data_sharing_consent_required view decorator.
-        """
-
-        # Test by wrapping a function that has the expected signature
-        @data_sharing_consent_required
-        def view_func(request, course_id, *args, **kwargs):
-            """
-            Return the function arguments, so they can be tested.
-            """
-            return ((request, course_id,) + args, kwargs)
-
-        # Call the wrapped function
-        args = (mock.MagicMock(), 'course-id', 'another arg', 'and another')
-        kwargs = dict(a=1, b=2, c=3)
-        response = view_func(*args, **kwargs)
-
-        # If consent required, then the response should be a redirect to the consent URL, and the view function would
-        # not be called.
-        if consent_required:
-            assert isinstance(response, HttpResponseRedirect)
-            assert response.url == consent_url  # pylint: disable=no-member
-
-        # Otherwise, the view function should have been called with the expected arguments.
-        else:
-            assert response == (args, kwargs)
-
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
-    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
-    def test_data_consent_required_enterprise_disabled(self,
-                                                       mock_consent_necessary,
-                                                       mock_enterprise_enabled):
-        """
-        Verify that the wrapped view is called directly when enterprise integration is disabled,
-        without checking for course consent necessary.
-        """
-        mock_enterprise_enabled.return_value = False
-
-        self.check_data_sharing_consent(consent_required=False)
-
-        mock_enterprise_enabled.assert_called_once()
-        mock_consent_necessary.assert_not_called()
-
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
-    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
-    def test_no_course_data_consent_required(self,
-                                             mock_consent_necessary,
-                                             mock_enterprise_enabled):
-        """
-        Verify that the wrapped view is called directly when enterprise integration is enabled,
-        and no course consent is required.
-        """
-        mock_enterprise_enabled.return_value = True
-        mock_consent_necessary.return_value = False
-
-        self.check_data_sharing_consent(consent_required=False)
-
-        mock_enterprise_enabled.assert_called_once()
-        mock_consent_necessary.assert_called_once()
-
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
-    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
-    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_consent_url')
-    def test_data_consent_required(self, mock_get_consent_url, mock_consent_necessary, mock_enterprise_enabled):
-        """
-        Verify that the wrapped function returns a redirect to the consent URL when enterprise integration is enabled,
-        and course consent is required.
-        """
-        mock_enterprise_enabled.return_value = True
-        mock_consent_necessary.return_value = True
-        consent_url = '/abc/def'
-        mock_get_consent_url.return_value = consent_url
-
-        self.check_data_sharing_consent(consent_required=True, consent_url=consent_url)
-
-        mock_get_consent_url.assert_called_once()
 
     @ddt.data(True, False)
     @httpretty.activate

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -862,7 +862,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1414,7 +1414,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1042,7 +1042,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1082,7 +1082,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
* Instead of an enterprise-specific view decorator conditionally redirecting learners to a consent view, plugins can now hook into the **CoursewareViewStarted** filter to redirect anywhere.
* Instead of enterprise-specific logic throwing an enterprise-specific start date validation error, **CourseStartDateValidationFailed** filter can now be used by plugins to throw a custom start date error.
* Instead of enterprise/consent-specific access checks baked into check_course_access, the **CoursewareAccessChecksRequested** filter lets plugins deny courseware access with a generic priority access error.

ENT-11544

---

Blocked by:
* https://github.com/openedx/openedx-filters/pull/336
* https://github.com/openedx/edx-enterprise/pull/2548
* https://github.com/edx/edx-platform/pull/338
* https://github.com/edx/edx-platform/pull/339
* https://github.com/edx/edx-platform/pull/340

