### PR TITLE
feat: remove enterprise enrollment imports and adds CourseEnrollmentViewStarted filter

### DIFF
--- a/openedx/core/djangoapps/enrollments/tests/test_filters.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_filters.py
@@ -1,0 +1,168 @@
+"""
+Test for CourseEnrollmentViewStarted filter in enrollment views.
+"""
+import json
+
+from django.test import override_settings
+from django.urls import reverse
+from openedx_filters import PipelineStep
+from openedx_filters.learning.filters import CourseEnrollmentViewStarted
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+TEST_STEP_PATH = "openedx.core.djangoapps.enrollments.tests.test_filters.TestCourseEnrollmentViewStartedPipelineStep"
+
+
+class TestCourseEnrollmentViewStartedPipelineStep(PipelineStep):
+    """
+    Utility pipeline step that prevents enrollment via CourseEnrollmentViewStarted filter.
+    """
+
+    def run_filter(self, user, course_key, requester_is_backend_service):  # pylint: disable=arguments-differ
+        """Pipeline step that prevents enrollment for specific users or conditions."""
+        if user.username == "blocked_user":
+            raise CourseEnrollmentViewStarted.PreventEnrollment(
+                "User is not allowed to enroll in this course."
+            )
+        # Set a side effect on the user to verify the filter was executed
+        user.profile.set_meta({"enrollment_filter_executed": True})
+        user.profile.save()
+        return {
+            "user": user,
+            "course_key": course_key,
+            "requester_is_backend_service": requester_is_backend_service,
+        }
+
+
+@skip_unless_lms
+class CourseEnrollmentViewStartedFilterTest(APITestCase, ModuleStoreTestCase):
+    """
+    Tests for the CourseEnrollmentViewStarted filter in the enrollment view.
+
+    This class guarantees that the following filters are triggered when attempting
+    to enroll a user through the enrollment API endpoint:
+
+    - CourseEnrollmentViewStarted
+    """
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create(emit_signals=True)
+        self.user = UserFactory.create(
+            username="test_user",
+            email="test@example.com",
+            password="password",
+        )
+        self.blocked_user = UserFactory.create(
+            username="blocked_user",
+            email="blocked@example.com",
+            password="password",
+        )
+        UserProfileFactory.create(user=self.user, name="Test User")
+        UserProfileFactory.create(user=self.blocked_user, name="Blocked User")
+
+        # Create course modes
+        CourseModeFactory.create(
+            course_id=self.course.id,
+            mode_slug='audit',
+            mode_display_name='Audit'
+        )
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course.enrollment.view.started.v1": {
+                "pipeline": [
+                    TEST_STEP_PATH,
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_course_enrollment_view_started_filter_executed(self):
+        """
+        Test that the CourseEnrollmentViewStarted filter is executed when enrolling through the view.
+
+        Expected result:
+            - CourseEnrollmentViewStarted is triggered and executes the pipeline step.
+            - The enrollment is created successfully if the filter allows it.
+            - The filter pipeline step sets a side effect on the user's profile.
+        """
+        self.client.login(username=self.user.username, password="password")
+
+        response = self.client.post(
+            reverse('courseenrollments'),
+            {
+                "course_details": {"course_id": str(self.course.id)},
+                "mode": "audit",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        # Verify the filter was executed by checking the side effect
+        self.user.profile.refresh_from_db()
+        meta = self.user.profile.get_meta()
+        assert meta.get("enrollment_filter_executed") is True
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course.enrollment.view.started.v1": {
+                "pipeline": [
+                    TEST_STEP_PATH,
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_course_enrollment_view_started_filter_prevent_enrollment(self):
+        """
+        Test that enrollment is prevented when filter raises PreventEnrollment.
+
+        Expected result:
+            - CourseEnrollmentViewStarted is triggered and executes the pipeline step.
+            - The pipeline step raises PreventEnrollment for blocked_user.
+            - The endpoint returns HTTP 400 Bad Request.
+        """
+        self.client.login(username=self.blocked_user.username, password="password")
+
+        response = self.client.post(
+            reverse('courseenrollments'),
+            {
+                "course_details": {"course_id": str(self.course.id)},
+                "mode": "audit",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = json.loads(response.content.decode('utf-8'))
+        assert "message" in response_data
+        assert "An error occurred while creating the new course enrollment" in response_data["message"]
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_course_enrollment_view_started_without_filter_configuration(self):
+        """
+        Test enrollment without filter configuration (no filter interference).
+
+        Expected result:
+            - CourseEnrollmentViewStarted does not have any effect.
+            - The enrollment process succeeds without filter intervention.
+        """
+        self.client.login(username=self.user.username, password="password")
+
+        response = self.client.post(
+            reverse('courseenrollments'),
+            {
+                "course_details": {"course_id": str(self.course.id)},
+                "mode": "audit",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -8,11 +8,10 @@ import itertools
 import json
 from unittest.mock import patch
 from urllib.parse import quote
+from zoneinfo import ZoneInfo
 
 import ddt
-import httpretty
 import pytest
-from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
@@ -44,8 +43,6 @@ from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.user_api.models import RetirementState, UserOrgTag, UserRetirementStatus
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.core.lib.django_test_client_utils import get_absolute_url
-from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
@@ -158,7 +155,7 @@ class EnrollmentTestMixin:
 @override_waffle_flag(ENABLE_NOTIFICATIONS, True)
 @ddt.ddt
 @skip_unless_lms
-class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, EnterpriseServiceMockMixin):
+class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
     """
     Test user enrollment, especially with different course modes.
     """
@@ -1237,40 +1234,6 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             assert is_active
             assert course_mode == CourseMode.VERIFIED
         self.client.logout()
-
-    @httpretty.activate
-    @override_settings(ENTERPRISE_SERVICE_WORKER_USERNAME='enterprise_worker',
-                       FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
-    def test_enterprise_course_enrollment_with_ec_uuid(self, mock_enterprise_customer_from_api):
-        """Verify that the enrollment completes when the EnterpriseCourseEnrollment creation succeeds. """
-        UserFactory.create(
-            username='enterprise_worker',
-            email=self.EMAIL,
-            password=self.PASSWORD,
-        )
-        CourseModeFactory.create(
-            course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
-        )
-        consent_kwargs = {
-            'username': self.user.username,
-            'course_id': str(self.course.id),
-            'ec_uuid': 'this-is-a-real-uuid'
-        }
-        mock_enterprise_customer_from_api.return_value = FAKE_ENTERPRISE_CUSTOMER
-        self.mock_enterprise_course_enrollment_post_api()
-        self.mock_consent_missing(**consent_kwargs)
-        self.mock_consent_post(**consent_kwargs)
-        self.assert_enrollment_status(
-            expected_status=status.HTTP_200_OK,
-            as_server=True,
-            username='enterprise_worker',
-            linked_enterprise_customer='this-is-a-real-uuid',
-        )
-        assert httpretty.last_request().path == '/consent/api/v1/data_sharing_consent'  # pylint: disable=no-member
-        assert httpretty.last_request().method == httpretty.POST
 
     def test_enrollment_attributes_always_written(self):
         """ Enrollment attributes should always be written, regardless of whether

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -11,7 +11,6 @@ from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 import ddt
-import httpretty
 import pytest
 from django.conf import settings
 from django.core.cache import cache
@@ -42,8 +41,6 @@ from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.user_api.models import RetirementState, UserOrgTag, UserRetirementStatus
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.core.lib.django_test_client_utils import get_absolute_url
-from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
-from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
@@ -155,7 +152,7 @@ class EnrollmentTestMixin:
 @override_settings(EDX_API_KEY="i am a key")
 @ddt.ddt
 @skip_unless_lms
-class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, EnterpriseServiceMockMixin):
+class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
     """
     Test user enrollment, especially with different course modes.
     """
@@ -1234,40 +1231,6 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             assert is_active
             assert course_mode == CourseMode.VERIFIED
         self.client.logout()
-
-    @httpretty.activate
-    @override_settings(ENTERPRISE_SERVICE_WORKER_USERNAME='enterprise_worker',
-                       FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
-    def test_enterprise_course_enrollment_with_ec_uuid(self, mock_enterprise_customer_from_api):
-        """Verify that the enrollment completes when the EnterpriseCourseEnrollment creation succeeds. """
-        UserFactory.create(
-            username='enterprise_worker',
-            email=self.EMAIL,
-            password=self.PASSWORD,
-        )
-        CourseModeFactory.create(
-            course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
-        )
-        consent_kwargs = {
-            'username': self.user.username,
-            'course_id': str(self.course.id),
-            'ec_uuid': 'this-is-a-real-uuid'
-        }
-        mock_enterprise_customer_from_api.return_value = FAKE_ENTERPRISE_CUSTOMER
-        self.mock_enterprise_course_enrollment_post_api()
-        self.mock_consent_missing(**consent_kwargs)
-        self.mock_consent_post(**consent_kwargs)
-        self.assert_enrollment_status(
-            expected_status=status.HTTP_200_OK,
-            as_server=True,
-            username='enterprise_worker',
-            linked_enterprise_customer='this-is-a-real-uuid',
-        )
-        assert httpretty.last_request().path == '/consent/api/v1/data_sharing_consent'  # pylint: disable=no-member
-        assert httpretty.last_request().method == httpretty.POST
 
     def test_enrollment_attributes_always_written(self):
         """ Enrollment attributes should always be written, regardless of whether

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -21,6 +21,7 @@ from edx_rest_framework_extensions.auth.session.authentication import (  # pylin
 )
 from opaque_keys import InvalidKeyError  # pylint: disable=wrong-import-order
 from opaque_keys.edx.keys import CourseKey  # pylint: disable=wrong-import-order
+from openedx_filters.learning.filters import CourseEnrollmentViewStarted
 from rest_framework import permissions, status  # pylint: disable=wrong-import-order
 from rest_framework.generics import ListAPIView  # pylint: disable=wrong-import-order
 from rest_framework.response import Response  # pylint: disable=wrong-import-order
@@ -57,12 +58,6 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeade
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.lib.exceptions import CourseNotFoundError
 from openedx.core.lib.log_utils import audit_log
-from openedx.features.enterprise_support.api import (
-    ConsentApiServiceClient,
-    EnterpriseApiException,
-    EnterpriseApiServiceClient,
-    enterprise_enabled,
-)
 
 log = logging.getLogger(__name__)
 REQUIRED_ATTRIBUTES = {
@@ -774,26 +769,18 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     data={"message": ("'{value}' is an invalid enrollment activation status.").format(value=is_active)},  # noqa: UP032  # pylint: disable=line-too-long
                 )
 
-            explicit_linked_enterprise = request.data.get("linked_enterprise_customer")
-            if explicit_linked_enterprise and has_api_key_permissions and enterprise_enabled():
-                enterprise_api_client = EnterpriseApiServiceClient()
-                consent_client = ConsentApiServiceClient()
-                try:
-                    enterprise_api_client.post_enterprise_course_enrollment(username, str(course_id))
-                except EnterpriseApiException as error:
-                    log.exception(
-                        "An unexpected error occurred while creating the new EnterpriseCourseEnrollment "
-                        "for user [%s] in course run [%s]",
-                        username,
-                        course_id,
-                    )
-                    raise CourseEnrollmentError(str(error))  # pylint: disable=raise-missing-from  # noqa: B904
-                kwargs = {
-                    "username": username,
-                    "course_id": str(course_id),
-                    "enterprise_customer_uuid": explicit_linked_enterprise,
-                }
-                consent_client.provide_consent(**kwargs)
+            # Filter hook that allows plugins (e.g., Enterprise) to run enrollment-related logic
+            # and optionally prevent enrollment via CourseEnrollmentViewStarted.PreventEnrollment.
+            try:
+                # .. filter_implemented_name: CourseEnrollmentViewStarted
+                # .. filter_type: org.openedx.learning.course.enrollment.view.started.v1
+                CourseEnrollmentViewStarted.run_filter(
+                    user=user,
+                    course_key=course_id,
+                    requester_is_backend_service=has_api_key_permissions,
+                )
+            except CourseEnrollmentViewStarted.PreventEnrollment as exc:
+                raise CourseEnrollmentError(str(exc)) from exc
 
             enrollment_attributes = request.data.get("enrollment_attributes")
             force_enrollment = request.data.get("force_enrollment")

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -8,17 +8,17 @@ import logging
 
 from django.core.exceptions import (  # lint-amnesty, pylint: disable=wrong-import-order
     ObjectDoesNotExist,
-    ValidationError,
+    ValidationError
 )
 from django.db import IntegrityError  # lint-amnesty, pylint: disable=wrong-import-order
 from django.db.models import Q  # lint-amnesty, pylint: disable=wrong-import-order
 from django.utils.decorators import method_decorator  # lint-amnesty, pylint: disable=wrong-import-order
-from edx_rest_framework_extensions.auth.jwt.authentication import (
-    JwtAuthentication,
-)  # lint-amnesty, pylint: disable=wrong-import-order
-from edx_rest_framework_extensions.auth.session.authentication import (
-    SessionAuthenticationAllowInactiveUser,
-)  # lint-amnesty, pylint: disable=wrong-import-order
+from edx_rest_framework_extensions.auth.jwt.authentication import (  # lint-amnesty, pylint: disable=wrong-import-order
+    JwtAuthentication
+)
+from edx_rest_framework_extensions.auth.session.authentication import (  # lint-amnesty, pylint: disable=wrong-import-order
+    SessionAuthenticationAllowInactiveUser
+)
 from opaque_keys import InvalidKeyError  # lint-amnesty, pylint: disable=wrong-import-order
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework import permissions, status  # lint-amnesty, pylint: disable=wrong-import-order
@@ -41,13 +41,13 @@ from openedx.core.djangoapps.enrollments.errors import (
     CourseEnrollmentError,
     CourseEnrollmentExistsError,
     CourseModeNotFoundError,
-    InvalidEnrollmentAttribute,
+    InvalidEnrollmentAttribute
 )
 from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm
 from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
 from openedx.core.djangoapps.enrollments.serializers import (
     CourseEnrollmentAllowedSerializer,
-    CourseEnrollmentsApiListSerializer,
+    CourseEnrollmentsApiListSerializer
 )
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
@@ -57,12 +57,6 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeade
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.lib.exceptions import CourseNotFoundError
 from openedx.core.lib.log_utils import audit_log
-from openedx.features.enterprise_support.api import (
-    ConsentApiServiceClient,
-    EnterpriseApiException,
-    EnterpriseApiServiceClient,
-    enterprise_enabled,
-)
 
 log = logging.getLogger(__name__)
 REQUIRED_ATTRIBUTES = {
@@ -773,27 +767,6 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     status=status.HTTP_400_BAD_REQUEST,
                     data={"message": ("'{value}' is an invalid enrollment activation status.").format(value=is_active)},
                 )
-
-            explicit_linked_enterprise = request.data.get("linked_enterprise_customer")
-            if explicit_linked_enterprise and has_api_key_permissions and enterprise_enabled():
-                enterprise_api_client = EnterpriseApiServiceClient()
-                consent_client = ConsentApiServiceClient()
-                try:
-                    enterprise_api_client.post_enterprise_course_enrollment(username, str(course_id))
-                except EnterpriseApiException as error:
-                    log.exception(
-                        "An unexpected error occurred while creating the new EnterpriseCourseEnrollment "
-                        "for user [%s] in course run [%s]",
-                        username,
-                        course_id,
-                    )
-                    raise CourseEnrollmentError(str(error))  # lint-amnesty, pylint: disable=raise-missing-from
-                kwargs = {
-                    "username": username,
-                    "course_id": str(course_id),
-                    "enterprise_customer_uuid": explicit_linked_enterprise,
-                }
-                consent_client.provide_consent(**kwargs)
 
             enrollment_attributes = request.data.get("enrollment_attributes")
             force_enrollment = request.data.get("force_enrollment")

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -44,7 +44,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==8.3.0
+edx-enterprise==8.7.0
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -483,7 +483,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==8.3.0
+edx-enterprise==8.7.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
@@ -861,7 +861,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -756,7 +756,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==8.3.0
+edx-enterprise==8.7.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
@@ -1413,7 +1413,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -573,7 +573,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==8.3.0
+edx-enterprise==8.7.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -1041,7 +1041,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -589,7 +589,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==8.3.0
+edx-enterprise==8.7.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
@@ -1081,7 +1081,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.7.0
+openedx-filters==3.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
## Description
This PR removes those enterprise imports and the conditional block from the enrollment view, then runs the CourseModeCheckoutStarted filter to handle the enterprise-specific enrollment logic separately and outside of edx-platform. This is part of an ongoing initiative to leverage openedx-filters to allow enterprise to customize logic and remove it from edx-platform code.

[ENT-11570](https://2u-internal.atlassian.net/browse/ENT-11570)

## Supporting information
This is the https://github.com/openedx/openedx-filters/pull/363
This is https://github.com/openedx/edx-enterprise/pull/2553
And this is the corresponding [https://github.com/openedx/openedx-platform/pull/38106](https://github.com/edx/edx-platform/pull/306)

## Testing instructions
Testing instructions in the https://github.com/openedx/edx-enterprise/pull/2553.