### PR TITLE
feat: replace enterprise imports in learner_home/views.py with pluggable_override

### DIFF
--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.urls import reverse
 from edx_django_utils import monitoring as monitoring_utils
 from edx_django_utils.monitoring import function_trace
+from edx_django_utils.plugins import pluggable_override
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import (
     SessionAuthenticationAllowInactiveUser,
@@ -59,10 +60,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_duration_limits.access import (
     get_user_course_expiration_date,
-)
-from openedx.features.enterprise_support.api import (
-    enterprise_customer_from_session_or_learner_data,
-    get_enterprise_learner_data_from_db,
 )
 
 logger = logging.getLogger(__name__)
@@ -208,17 +205,16 @@ def get_email_settings_info(user, course_enrollments):
     return show_email_settings_for, course_optouts
 
 
+@pluggable_override('OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER')
 @function_trace("get_enterprise_customer")
 def get_enterprise_customer(user, request, is_masquerading):
     """
-    If we are not masquerading, try to load the enterprise learner from session data, falling back to the db.
-    If we are masquerading, don't read or write to/from session data, go directly to db.
+    Return the enterprise customer dict for the given user, or None.
+
+    This function can be overridden by an installed plugin via the
+    OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER setting.
     """
-    if is_masquerading:
-        learner_data = get_enterprise_learner_data_from_db(user)
-        return learner_data[0]["enterprise_customer"] if learner_data else None
-    else:
-        return enterprise_customer_from_session_or_learner_data(request)
+    return None
 
 
 @function_trace("get_ecommerce_payment_page")


### PR DESCRIPTION
Remove enterprise_customer_from_session_or_learner_data and get_enterprise_learner_data_from_db imports. Replace get_enterprise_customer body with a default return None, decorated with @pluggable_override('OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER').

ENT-11571

---

Related:
* https://github.com/openedx/edx-enterprise/pull/2554
* https://github.com/openedx/openedx-platform/pull/38107
