### PR TITLE
chore: bumped edx-enterprise version to 6.6.7

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -44,7 +44,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -480,7 +480,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -761,7 +761,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -573,7 +573,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -592,7 +592,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.6.5
+edx-enterprise==6.6.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
### Description
Updates the `edx-enterprise` package version in the base requirements file.

### Changes Made
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/base.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/constraints.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/testing.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/development.txt`
- Bumped `edx-enterprise` from `6.6.5` to `6.6.7` in `requirements/edx/doc.txt`