### PR TITLE
fix: fix multiple COURSE_PUBLISHED signals being fired when saving

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details.py
@@ -2,7 +2,7 @@
 Unit tests for course details views.
 """
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import ddt
 from django.urls import reverse
@@ -13,6 +13,7 @@ from rest_framework.test import APIClient
 from cms.djangoapps.contentstore.rest_api.v1.views.course_details import _classify_update
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
+from xmodule.modulestore.django import SignalHandler
 
 from ...mixins import PermissionAccessMixin
 
@@ -121,6 +122,38 @@ class CourseDetailsViewTest(CourseTestCase, PermissionAccessMixin):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+
+    def test_put_emits_course_published_signal_once(self):
+        """
+        Verify that a single PUT to the course details API emits the
+        course_published signal exactly once.
+
+        The bulk_operations context inside update_from_json coalesces all
+        individual update_item / delete_item calls into a single signal
+        emission.  Without it, each call would fire its own signal.
+        """
+        signal_handler = MagicMock()
+        SignalHandler.course_published.connect(signal_handler)
+        try:
+            request_data = {
+                "overview": "<p>Updated overview</p>",
+                "short_description": "Updated short description",
+                "effort": "3 hours/week",
+                "language": "en",
+                "intro_video": None,
+            }
+            # ModuleStoreTestCase disables all signals by default; re-enable
+            # course_published for this test so we can assert on its emission.
+            with SignalHandler.course_published.for_state(is_enabled=True):
+                response = self.client.put(
+                    path=self.url,
+                    data=json.dumps(request_data),
+                    content_type="application/json",
+                )
+            assert response.status_code == status.HTTP_200_OK
+            signal_handler.assert_called_once()
+        finally:
+            SignalHandler.course_published.disconnect(signal_handler)
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -201,8 +201,8 @@ class CourseDetails:
         only one ``course_published`` signal is emitted per call, regardless of how
         many individual fields were updated.  Without this, every ``update_item`` /
         ``delete_item`` call inside ``update_about_item`` (and the top-level block
-        update) each fire their own signal, causing downstream tasks (e.g. git
-        auto-export) to run multiple times for a single user action.
+        update) each fire their own signal, causing downstream tasks to run
+        multiple times for a single user action.
         """
         module_store = modulestore()
 

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -195,126 +195,135 @@ class CourseDetails:
     @classmethod
     def update_from_json(cls, course_key, jsondict, user):  # pylint: disable=too-many-statements
         """
-        Decode the json into CourseDetails and save any changed attrs to the db
+        Decode the json into CourseDetails and save any changed attrs to the db.
+
+        All writes are batched inside a single ``bulk_operations`` context so that
+        only one ``course_published`` signal is emitted per call, regardless of how
+        many individual fields were updated.  Without this, every ``update_item`` /
+        ``delete_item`` call inside ``update_about_item`` (and the top-level block
+        update) each fire their own signal, causing downstream tasks (e.g. git
+        auto-export) to run multiple times for a single user action.
         """
         module_store = modulestore()
-        block = module_store.get_course(course_key)
 
-        dirty = False
+        with module_store.bulk_operations(course_key):
+            block = module_store.get_course(course_key)
 
-        # In the block's setter, the date is converted to JSON
-        # using Date's to_json method. Calling to_json on something that
-        # is already JSON doesn't work. Since reaching directly into the
-        # model is nasty, convert the JSON Date to a Python date, which
-        # is what the setter expects as input.
-        date = Date()
+            dirty = False
 
-        if jsondict['overview'] == '':
-            jsondict['overview'] = '<p>&nbsp;</p>'
+            # In the block's setter, the date is converted to JSON
+            # using Date's to_json method. Calling to_json on something that
+            # is already JSON doesn't work. Since reaching directly into the
+            # model is nasty, convert the JSON Date to a Python date, which
+            # is what the setter expects as input.
+            date = Date()
 
-        if 'start_date' in jsondict:
-            converted = date.from_json(jsondict['start_date'])
-        else:
-            converted = None
-        if converted != block.start:
-            dirty = True
-            block.start = converted
+            if jsondict['overview'] == '':
+                jsondict['overview'] = '<p>&nbsp;</p>'
 
-        if 'end_date' in jsondict:
-            converted = date.from_json(jsondict['end_date'])
-        else:
-            converted = None
+            if 'start_date' in jsondict:
+                converted = date.from_json(jsondict['start_date'])
+            else:
+                converted = None
+            if converted != block.start:
+                dirty = True
+                block.start = converted
 
-        if converted != block.end:
-            dirty = True
-            block.end = converted
+            if 'end_date' in jsondict:
+                converted = date.from_json(jsondict['end_date'])
+            else:
+                converted = None
 
-        if 'enrollment_start' in jsondict:
-            converted = date.from_json(jsondict['enrollment_start'])
-        else:
-            converted = None
+            if converted != block.end:
+                dirty = True
+                block.end = converted
 
-        if converted != block.enrollment_start:
-            dirty = True
-            block.enrollment_start = converted
+            if 'enrollment_start' in jsondict:
+                converted = date.from_json(jsondict['enrollment_start'])
+            else:
+                converted = None
 
-        if 'enrollment_end' in jsondict:
-            converted = date.from_json(jsondict['enrollment_end'])
-        else:
-            converted = None
+            if converted != block.enrollment_start:
+                dirty = True
+                block.enrollment_start = converted
 
-        if converted != block.enrollment_end:
-            dirty = True
-            block.enrollment_end = converted
+            if 'enrollment_end' in jsondict:
+                converted = date.from_json(jsondict['enrollment_end'])
+            else:
+                converted = None
 
-        if 'certificate_available_date' in jsondict:
-            converted = date.from_json(jsondict['certificate_available_date'])
-        else:
-            converted = None
+            if converted != block.enrollment_end:
+                dirty = True
+                block.enrollment_end = converted
 
-        if converted != block.certificate_available_date:
-            dirty = True
-            block.certificate_available_date = converted
+            if 'certificate_available_date' in jsondict:
+                converted = date.from_json(jsondict['certificate_available_date'])
+            else:
+                converted = None
 
-        if (
-            'certificates_display_behavior' in jsondict
-            and jsondict['certificates_display_behavior'] != block.certificates_display_behavior
-        ):
-            block.certificates_display_behavior = jsondict['certificates_display_behavior']
-            dirty = True
+            if converted != block.certificate_available_date:
+                dirty = True
+                block.certificate_available_date = converted
 
-        if 'course_image_name' in jsondict and jsondict['course_image_name'] != block.course_image:
-            block.course_image = jsondict['course_image_name']
-            dirty = True
+            if (
+                'certificates_display_behavior' in jsondict
+                and jsondict['certificates_display_behavior'] != block.certificates_display_behavior
+            ):
+                block.certificates_display_behavior = jsondict['certificates_display_behavior']
+                dirty = True
 
-        if 'banner_image_name' in jsondict and jsondict['banner_image_name'] != block.banner_image:
-            block.banner_image = jsondict['banner_image_name']
-            dirty = True
+            if 'course_image_name' in jsondict and jsondict['course_image_name'] != block.course_image:
+                block.course_image = jsondict['course_image_name']
+                dirty = True
 
-        if 'video_thumbnail_image_name' in jsondict \
-                and jsondict['video_thumbnail_image_name'] != block.video_thumbnail_image:
-            block.video_thumbnail_image = jsondict['video_thumbnail_image_name']
-            dirty = True
+            if 'banner_image_name' in jsondict and jsondict['banner_image_name'] != block.banner_image:
+                block.banner_image = jsondict['banner_image_name']
+                dirty = True
 
-        if 'pre_requisite_courses' in jsondict \
-                and sorted(jsondict['pre_requisite_courses']) != sorted(block.pre_requisite_courses):
-            block.pre_requisite_courses = jsondict['pre_requisite_courses']
-            dirty = True
+            if 'video_thumbnail_image_name' in jsondict \
+                    and jsondict['video_thumbnail_image_name'] != block.video_thumbnail_image:
+                block.video_thumbnail_image = jsondict['video_thumbnail_image_name']
+                dirty = True
 
-        if 'license' in jsondict:
-            block.license = jsondict['license']
-            dirty = True
+            if 'pre_requisite_courses' in jsondict \
+                    and sorted(jsondict['pre_requisite_courses']) != sorted(block.pre_requisite_courses):
+                block.pre_requisite_courses = jsondict['pre_requisite_courses']
+                dirty = True
 
-        if 'learning_info' in jsondict:
-            block.learning_info = jsondict['learning_info']
-            dirty = True
+            if 'license' in jsondict:
+                block.license = jsondict['license']
+                dirty = True
 
-        if 'instructor_info' in jsondict:
-            block.instructor_info = jsondict['instructor_info']
-            dirty = True
+            if 'learning_info' in jsondict:
+                block.learning_info = jsondict['learning_info']
+                dirty = True
 
-        if 'language' in jsondict and jsondict['language'] != block.language:
-            block.language = jsondict['language']
-            dirty = True
+            if 'instructor_info' in jsondict:
+                block.instructor_info = jsondict['instructor_info']
+                dirty = True
 
-        if (block.can_toggle_course_pacing
-                and 'self_paced' in jsondict
-                and jsondict['self_paced'] != block.self_paced):
-            block.self_paced = jsondict['self_paced']
-            dirty = True
+            if 'language' in jsondict and jsondict['language'] != block.language:
+                block.language = jsondict['language']
+                dirty = True
 
-        if dirty:
-            module_store.update_item(block, user.id)
+            if (block.can_toggle_course_pacing
+                    and 'self_paced' in jsondict
+                    and jsondict['self_paced'] != block.self_paced):
+                block.self_paced = jsondict['self_paced']
+                dirty = True
 
-        # NOTE: below auto writes to the db w/o verifying that any of
-        # the fields actually changed to make faster, could compare
-        # against db or could have client send over a list of which
-        # fields changed.
-        for attribute in ABOUT_ATTRIBUTES:
-            if attribute in jsondict:
-                cls.update_about_item(block, attribute, jsondict[attribute], user.id)
+            if dirty:
+                module_store.update_item(block, user.id)
 
-        cls.update_about_video(block, jsondict['intro_video'], user.id)
+            # NOTE: below auto writes to the db w/o verifying that any of
+            # the fields actually changed to make faster, could compare
+            # against db or could have client send over a list of which
+            # fields changed.
+            for attribute in ABOUT_ATTRIBUTES:
+                if attribute in jsondict:
+                    cls.update_about_item(block, attribute, jsondict[attribute], user.id)
+
+            cls.update_about_video(block, jsondict['intro_video'], user.id)
 
         # Could just return jsondict w/o doing any db reads, but I put
         # the reads in as a means to confirm it persisted correctly

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -4,6 +4,7 @@ Tests for CourseDetails
 
 
 import datetime
+from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
 import ddt
@@ -13,6 +14,7 @@ from django.test import override_settings
 from openedx.core.djangoapps.models.course_details import ABOUT_ATTRIBUTES, CourseDetails
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import SignalHandler
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -211,3 +213,32 @@ class CourseDetailsTestCase(ModuleStoreTestCase):
         assert CourseDetails.validate_certificate_settings(
             stored_date, stored_behavior
         ) == (expected_date, expected_behavior)
+
+    def test_update_from_json_emits_course_published_signal_once(self):
+        """
+        Verify that update_from_json emits the course_published signal exactly
+        once per call.
+
+        The bulk_operations context wrapping all writes inside update_from_json
+        coalesces every update_item / delete_item call into a single
+        course_published signal emission.
+        """
+        signal_handler = MagicMock()
+        SignalHandler.course_published.connect(signal_handler)
+        try:
+            jsondetails = CourseDetails.fetch(self.course.id)
+            jsondetails.overview = "<p>Updated overview</p>"
+            jsondetails.short_description = "Updated short description"
+            jsondetails.effort = "2 hours/week"
+            jsondetails.language = "en"
+            jsondetails.intro_video = None
+
+            # ModuleStoreTestCase disables all signals by default; re-enable
+            # course_published for this test so we can assert on its emission.
+            with SignalHandler.course_published.for_state(is_enabled=True):
+                with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+                    CourseDetails.update_from_json(self.course.id, jsondetails.__dict__, self.user)
+
+            signal_handler.assert_called_once()
+        finally:
+            SignalHandler.course_published.disconnect(signal_handler)


### PR DESCRIPTION
### Related ticket (MIT Internal)
https://github.com/mitodl/hq/issues/10266

### Issue
When saving changes from "Schedule & details" course page, `COURSE_PUBLISHED` signal is fired multiple times

## Description
This pull request improves the efficiency of the `update_from_json` method in the `CourseDetails` model by batching all database writes into a single bulk operation. This ensures that only one `course_published` signal is emitted per update, preventing redundant downstream processing such as multiple git auto-exports for a single user action.

**Signal emission and efficiency improvements:**

* Wrapped all writes in `update_from_json` inside a single `bulk_operations` context on the module store, so only one `course_published` signal is emitted per call, reducing unnecessary downstream tasks.

## Testing instructions

1. Checkout to this branch and make sure the setup is restarted
2. Make any changes in the course "Schedule & details" page and press save.
3. Monitor the logs and you should not see multiple `COURSE_PUBLISHED` signals to  be fired.
4. To confirm the issue, you can checkout to master and repeat the above steps.

**NOTE**: you might get 2 signals locally as frontend sends two requests in development mode.