### PR TITLE
feat: Add marketing_emails_opt_in_optional field to SAMLProviderConfig

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0015_samlproviderconfig_marketing_emails_optional.py
+++ b/common/djangoapps/third_party_auth/migrations/0015_samlproviderconfig_marketing_emails_optional.py
@@ -1,0 +1,27 @@
+# Generated migration for adding marketing emails opt-in optional configuration field
+
+from django.db import migrations, models
+import django.utils.translation
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0014_samlproviderconfig_optional_email_checkboxes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='marketing_emails_opt_in_optional',
+            field=models.BooleanField(
+                default=True,
+                help_text=django.utils.translation.gettext_lazy(
+                    "If enabled, the marketing emails opt-in checkbox will be optional (not required) "
+                    "and will default to unchecked (False) during registration for users authenticating "
+                    "via this provider. This gives users explicit control over marketing email preferences "
+                    "without forcing them to opt-in."
+                ),
+            ),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -753,6 +753,15 @@ class SAMLProviderConfig(ProviderConfig):
             "are skipped, their values are inferred as False (opted out)."
         ),
     )
+    marketing_emails_opt_in_optional = models.BooleanField(
+        default=True,
+        help_text=_(
+            "If enabled, the marketing emails opt-in checkbox will be optional (not required) "
+            "and will default to unchecked (False) during registration for users authenticating "
+            "via this provider. This gives users explicit control over marketing email preferences "
+            "without forcing them to opt-in."
+        ),
+    )
     other_settings = models.TextField(
         verbose_name="Advanced settings", blank=True,
         help_text=(


### PR DESCRIPTION
- Add marketing_emails_opt_in_optional BooleanField to SAMLProviderConfig model with default=True
- When enabled, marketing checkbox will be optional and default to unchecked (False) during SAML registration
- Gives users explicit control over marketing email preferences without forcing opt-in
- Create migration 0015 to add the new field to database

Related: ENT-11617