### PR TITLE
fix: authz compat layer was failing on libraries v2 keys

### DIFF
--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -88,7 +88,7 @@ def authz_get_all_course_assignments_for_user(user: User) -> list[RoleAssignment
 
 def get_org_from_key(key: str) -> str:
     """
-    Get the org from a course or library key.
+    Get the org from a course key.
     """
     parsed_key = CourseKey.from_string(key)
     return parsed_key.org

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -13,11 +13,10 @@ from dataclasses import dataclass
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from common.djangoapps.student.signals.signals import emit_course_access_role_added, emit_course_access_role_removed
 from opaque_keys.edx.django.models import CourseKeyField
-from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locator import CourseLocator, LibraryLocatorV2
+from opaque_keys.edx.locator import CourseLocator
 from openedx_authz.api import users as authz_api
-from openedx_authz.api.data import RoleAssignmentData
+from openedx_authz.api.data import RoleAssignmentData, CourseOverviewData
 from openedx_authz.constants import roles as authz_roles
 
 from common.djangoapps.student.models import CourseAccessRole
@@ -81,17 +80,17 @@ def authz_get_all_course_assignments_for_user(user: User) -> list[RoleAssignment
     """
     assignments = authz_api.get_user_role_assignments(user_external_key=user.username)
     # filter courses only
-    filtered_assignments = [assignment for assignment in assignments if assignment.scope.NAMESPACE == 'course-v1']
+    filtered_assignments = [
+        assignment for assignment in assignments
+        if isinstance(assignment.scope, CourseOverviewData)
+    ]
     return filtered_assignments
 
 def get_org_from_key(key: str) -> str:
     """
     Get the org from a course or library key.
     """
-    try:
-        parsed_key = CourseKey.from_string(key)
-    except InvalidKeyError:
-        parsed_key = LibraryLocatorV2.from_string(key)
+    parsed_key = CourseKey.from_string(key)
     return parsed_key.org
 
 def register_access_role(cls):

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -18,6 +18,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocatorV2
 from openedx_authz.api import users as authz_api
 from openedx_authz.constants import roles as authz_roles
+from openedx_authz.models import RoleAssignmentData
 
 from common.djangoapps.student.models import CourseAccessRole
 from openedx.core.lib.cache_utils import get_cache
@@ -73,6 +74,15 @@ def authz_add_role(user: User, authz_role: str, course_key: str):
     )
     legacy_role = get_legacy_role_from_authz_role(authz_role)
     emit_course_access_role_added(user, course_locator, course_locator.org, legacy_role)
+
+def authz_get_all_course_assignments_for_user(user: User) -> list[RoleAssignmentData]:
+    """
+    Get all course assignments for a user.
+    """
+    assignments = authz_api.get_user_role_assignments(user_external_key=user.username)
+    # filter courses only
+    filtered_assignments = [assignment for assignment in assignments if assignment.scope.NAMESPACE == 'course-v1']
+    return filtered_assignments
 
 def get_org_from_key(key: str) -> str:
     """
@@ -146,7 +156,7 @@ def get_authz_compat_course_access_roles_for_user(user: User) -> set[AuthzCompat
     Retrieve all CourseAccessRole objects for a given user and convert them to AuthzCompatCourseAccessRole objects.
     """
     compat_role_assignments = set()
-    assignments = authz_api.get_user_role_assignments(user_external_key=user.username)
+    assignments = authz_get_all_course_assignments_for_user(user)
     for assignment in assignments:
         for role in assignment.roles:
             legacy_role = get_legacy_role_from_authz_role(authz_role=role.external_key)
@@ -834,9 +844,7 @@ class UserBasedRole:
 
         # Get all assignments for a user to a role
         new_authz_roles = [get_authz_role_from_legacy_role(role) for role in roles]
-        all_authz_user_assignments = authz_api.get_user_role_assignments(
-            user_external_key=self.user.username
-        )
+        all_authz_user_assignments = authz_get_all_course_assignments_for_user(self.user)
 
         all_assignments = set()
 
@@ -888,9 +896,7 @@ class UserBasedRole:
 
         # Then check for authz assignments
         new_authz_roles = [get_authz_role_from_legacy_role(role) for role in roles]
-        all_authz_user_assignments = authz_api.get_user_role_assignments(
-            user_external_key=self.user.username
-        )
+        all_authz_user_assignments = authz_get_all_course_assignments_for_user(self.user)
 
         for assignment in all_authz_user_assignments:
             for role in assignment.roles:

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -17,8 +17,8 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocatorV2
 from openedx_authz.api import users as authz_api
+from openedx_authz.api.data import RoleAssignmentData
 from openedx_authz.constants import roles as authz_roles
-from openedx_authz.models import RoleAssignmentData
 
 from common.djangoapps.student.models import CourseAccessRole
 from openedx.core.lib.cache_utils import get_cache

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -13,8 +13,9 @@ from dataclasses import dataclass
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from common.djangoapps.student.signals.signals import emit_course_access_role_added, emit_course_access_role_removed
 from opaque_keys.edx.django.models import CourseKeyField
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locator import CourseLocator
+from opaque_keys.edx.locator import CourseLocator, LibraryLocatorV2
 from openedx_authz.api import users as authz_api
 from openedx_authz.constants import roles as authz_roles
 
@@ -73,6 +74,15 @@ def authz_add_role(user: User, authz_role: str, course_key: str):
     legacy_role = get_legacy_role_from_authz_role(authz_role)
     emit_course_access_role_added(user, course_locator, course_locator.org, legacy_role)
 
+def get_org_from_key(key: str) -> str:
+    """
+    Get the org from a course or library key.
+    """
+    try:
+        parsed_key = CourseKey.from_string(key)
+    except InvalidKeyError:
+        parsed_key = LibraryLocatorV2.from_string(key)
+    return parsed_key.org
 
 def register_access_role(cls):
     """
@@ -141,8 +151,7 @@ def get_authz_compat_course_access_roles_for_user(user: User) -> set[AuthzCompat
         for role in assignment.roles:
             legacy_role = get_legacy_role_from_authz_role(authz_role=role.external_key)
             course_key = assignment.scope.external_key
-            parsed_key = CourseKey.from_string(course_key)
-            org = parsed_key.org
+            org = get_org_from_key(course_key)
             compat_role = AuthzCompatCourseAccessRole(
                 user_id=user.id,
                 username=user.username,
@@ -847,8 +856,7 @@ class UserBasedRole:
                     continue
                 legacy_role = get_legacy_role_from_authz_role(authz_role=role.external_key)
                 course_key = assignment.scope.external_key
-                parsed_key = CourseKey.from_string(course_key)
-                org = parsed_key.org
+                org = get_org_from_key(course_key)
                 all_assignments.add(AuthzCompatCourseAccessRole(
                     user_id=self.user.id,
                     username=self.user.username,
@@ -892,7 +900,7 @@ class UserBasedRole:
                     # There is at least one assignment, short circuit
                     return True
                 course_key = assignment.scope.external_key
-                parsed_key = CourseKey.from_string(course_key)
-                if org == parsed_key.org:
+                parsed_org = get_org_from_key(course_key)
+                if org == parsed_org:
                     return True
         return False

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -4,6 +4,7 @@ Tests of student.roles
 
 
 import ddt
+from unittest.mock import patch
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -235,6 +236,26 @@ class RolesTestCase(TestCase):
         role_second_org = OrgContentCreatorRole(org=self.orgs[1])
         role_second_org.add_users(self.student)
         assert len(role.get_orgs_for_user(self.student)) == 2
+
+    def test_get_authz_compat_course_access_roles_for_user(self):
+        """
+        Thest that get_authz_compat_course_access_roles_for_user doesn't crash when the user
+        has Libraries V2 or other non-course roles in their assignments.
+        """
+        from openedx_authz.api.data import ContentLibraryData, RoleAssignmentData, RoleData, UserData
+        from common.djangoapps.student.roles import get_authz_compat_course_access_roles_for_user
+
+        lib_assignment = RoleAssignmentData(
+            subject=UserData(external_key=self.student.username),
+            roles=[RoleData(external_key='test-role')],
+            scope=ContentLibraryData(external_key='lib:edX:test-lib'),
+        )
+        with patch(
+            'openedx_authz.api.users.get_subject_role_assignments',
+            return_value=[lib_assignment],
+        ):
+            result = get_authz_compat_course_access_roles_for_user(self.student)
+        assert result == set()
 
 
 @ddt.ddt

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -12,6 +12,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
 
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx_authz.api.data import ContentLibraryData, RoleAssignmentData, RoleData, UserData
 from openedx_authz.engine.enforcer import AuthzEnforcer
 
 from common.djangoapps.student.admin import CourseAccessRoleHistoryAdmin
@@ -33,6 +34,7 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgStaffRole,
     RoleCache,
+    get_authz_compat_course_access_roles_for_user,
     get_role_cache_key_for_course,
     ROLE_CACHE_UNGROUPED_ROLES__KEY
 )
@@ -242,9 +244,6 @@ class RolesTestCase(TestCase):
         Thest that get_authz_compat_course_access_roles_for_user doesn't crash when the user
         has Libraries V2 or other non-course roles in their assignments.
         """
-        from openedx_authz.api.data import ContentLibraryData, RoleAssignmentData, RoleData, UserData
-        from common.djangoapps.student.roles import get_authz_compat_course_access_roles_for_user
-
         lib_assignment = RoleAssignmentData(
             subject=UserData(external_key=self.student.username),
             roles=[RoleData(external_key='test-role')],


### PR DESCRIPTION
## Description

Follow up on https://github.com/openedx/openedx-platform/pull/38013

The code on the RBAC AuthZ compatibility layer for course authoring was querying for all roles assigned to a user, which also included library v2 permissions, which the CourseKey class was not expecting and causing an exception.

Added filtering so only courses-v1 role assignments are returned.

## Supporting information

Bug reported by @BryanttV

## Testing instructions

1. Create a new non-admin user
2. Create a new empty library
3. As an admin, go to the library > Manage Library Team and add the non-admin user as a "Library Contributor"
4. Before applying the fix, login as the non-admin user in studio and try to go to the library, the library contents won't load and you should see the following error in the CMS logs:

```
cms-1  | 2026-03-10 21:19:39,333 INFO 35 [tracking] [user 5] [ip 140.82.114.4] logger.py:41 - {"name": "/api/content_search/v2/studio/", "context": {"user_id": 5, "path": "/api/content_search/v2/studio/", "course_id": "", "org_id": "", "enterprise_uuid": ""}, "username": "contributor", "session": "052e9ad37a2b4d793827c130992a3ff9", "ip": "140.82.114.4", "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36", "host": "studio.local.openedx.io:8001", "referer": "http://apps.local.openedx.io:2001/", "accept_language": "en-US,en;q=0.9", "event": "{\"GET\": {}, \"POST\": {}}", "time": "2026-03-10T21:19:39.333686+00:00", "event_type": "/api/content_search/v2/studio/", "event_source": "server", "page": null}
cms-1  | 2026-03-10 21:19:39,356 ERROR 35 [root] [user None] [ip None] signals.py:22 - Uncaught exception from None
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 234, in __init__
cms-1  |     self._roles_by_course_id = BulkRoleCache.get_user_roles(user)
cms-1  |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 215, in get_user_roles
cms-1  |     return get_cache(cls.CACHE_NAMESPACE)[cls.CACHE_KEY][user.id]
cms-1  |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
cms-1  | KeyError: 'roles_by_user'
cms-1  |
cms-1  | During handling of the above exception, another exception occurred:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 238, in get_namespace_plugin
cms-1  |     return drivers[namespace].plugin
cms-1  |            ~~~~~~~^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/stevedore/extension.py", line 452, in __getitem__
cms-1  |     return self._extensions_by_name[name]
cms-1  |            ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
cms-1  | KeyError: 'lib'
cms-1  |
cms-1  | The above exception was the direct cause of the following exception:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 190, in from_string
cms-1  |     key_class = cls.get_namespace_plugin(namespace)
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 243, in get_namespace_plugin
cms-1  |     raise InvalidKeyError(cls, f'{namespace}:*') from error
cms-1  | opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.keys.CourseKey'>: lib:*
cms-1  |
cms-1  | During handling of the above exception, another exception occurred:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
cms-1  |     response = get_response(request)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
cms-1  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/opt/pyenv/versions/3.12.12/lib/python3.12/contextlib.py", line 81, in inner
cms-1  |     return func(*args, **kwds)
cms-1  |            ^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
cms-1  |     return view_func(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/views/generic/base.py", line 105, in view
cms-1  |     return self.dispatch(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
cms-1  |     response = self.handle_exception(exc)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
cms-1  |     self.raise_uncaught_exception(exc)
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
cms-1  |     raise exc
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
cms-1  |     response = handler(request, *args, **kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/views.py", line 34, in get
cms-1  |     response_data = api.generate_user_token_for_studio_search(request)
cms-1  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 973, in generate_user_token_for_studio_search
cms-1  |     STUDIO_INDEX_NAME: _get_meili_access_filter(request),
cms-1  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 957, in _get_meili_access_filter
cms-1  |     user_orgs = _get_user_orgs(request)[:MAX_ORGS_IN_FILTER]
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 940, in _get_user_orgs
cms-1  |     course_roles = get_course_roles(request.user)
cms-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
cms-1  |     result = wrapped(*args, **kwargs)
cms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/role_helpers.py", line 77, in get_course_roles
cms-1  |     role_cache = get_role_cache(user)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
cms-1  |     result = wrapped(*args, **kwargs)
cms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/role_helpers.py", line 64, in get_role_cache
cms-1  |     user._roles = RoleCache(user)
cms-1  |                   ^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 239, in __init__
cms-1  |     compat_roles = get_authz_compat_course_access_roles_for_user(user)
cms-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 144, in get_authz_compat_course_access_roles_for_user
cms-1  |     parsed_key = CourseKey.from_string(course_key)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 198, in from_string
cms-1  |     return cls.deprecated_fallback._from_deprecated_string(serialized)  # type: ignore
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/edx/locator.py", line 403, in _from_deprecated_string
cms-1  |     raise InvalidKeyError(cls, serialized)
cms-1  | opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.locator.CourseLocator'>: lib:WGU:CSPROB
cms-1  | Internal Server Error: /api/content_search/v2/studio/
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 234, in __init__
cms-1  |     self._roles_by_course_id = BulkRoleCache.get_user_roles(user)
cms-1  |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 215, in get_user_roles
cms-1  |     return get_cache(cls.CACHE_NAMESPACE)[cls.CACHE_KEY][user.id]
cms-1  |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
cms-1  | KeyError: 'roles_by_user'
cms-1  |
cms-1  | During handling of the above exception, another exception occurred:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 238, in get_namespace_plugin
cms-1  |     return drivers[namespace].plugin
cms-1  |            ~~~~~~~^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/stevedore/extension.py", line 452, in __getitem__
cms-1  |     return self._extensions_by_name[name]
cms-1  |            ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
cms-1  | KeyError: 'lib'
cms-1  |
cms-1  | The above exception was the direct cause of the following exception:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 190, in from_string
cms-1  |     key_class = cls.get_namespace_plugin(namespace)
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 243, in get_namespace_plugin
cms-1  |     raise InvalidKeyError(cls, f'{namespace}:*') from error
cms-1  | opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.keys.CourseKey'>: lib:*
cms-1  |
cms-1  | During handling of the above exception, another exception occurred:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
cms-1  |     response = get_response(request)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
cms-1  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/opt/pyenv/versions/3.12.12/lib/python3.12/contextlib.py", line 81, in inner
cms-1  |     return func(*args, **kwds)
cms-1  |            ^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
cms-1  |     return view_func(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/views/generic/base.py", line 105, in view
cms-1  |     return self.dispatch(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
cms-1  |     response = self.handle_exception(exc)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
cms-1  |     self.raise_uncaught_exception(exc)
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
cms-1  |     raise exc
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
cms-1  |     response = handler(request, *args, **kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/views.py", line 34, in get
cms-1  |     response_data = api.generate_user_token_for_studio_search(request)
cms-1  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 973, in generate_user_token_for_studio_search
cms-1  |     STUDIO_INDEX_NAME: _get_meili_access_filter(request),
cms-1  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 957, in _get_meili_access_filter
cms-1  |     user_orgs = _get_user_orgs(request)[:MAX_ORGS_IN_FILTER]
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 940, in _get_user_orgs
cms-1  |     course_roles = get_course_roles(request.user)
cms-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
cms-1  |     result = wrapped(*args, **kwargs)
cms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/role_helpers.py", line 77, in get_course_roles
cms-1  |     role_cache = get_role_cache(user)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
cms-1  |     result = wrapped(*args, **kwargs)
cms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/role_helpers.py", line 64, in get_role_cache
cms-1  |     user._roles = RoleCache(user)
cms-1  |                   ^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 239, in __init__
cms-1  |     compat_roles = get_authz_compat_course_access_roles_for_user(user)
cms-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 144, in get_authz_compat_course_access_roles_for_user
cms-1  |     parsed_key = CourseKey.from_string(course_key)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 198, in from_string
cms-1  |     return cls.deprecated_fallback._from_deprecated_string(serialized)  # type: ignore
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/edx/locator.py", line 403, in _from_deprecated_string
cms-1  |     raise InvalidKeyError(cls, serialized)
cms-1  | opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.locator.CourseLocator'>: lib:WGU:CSPROB
cms-1  | 2026-03-10 21:19:39,399 ERROR 35 [django.request] [user None] [ip None] log.py:253 - Internal Server Error: /api/content_search/v2/studio/
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 234, in __init__
cms-1  |     self._roles_by_course_id = BulkRoleCache.get_user_roles(user)
cms-1  |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 215, in get_user_roles
cms-1  |     return get_cache(cls.CACHE_NAMESPACE)[cls.CACHE_KEY][user.id]
cms-1  |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
cms-1  | KeyError: 'roles_by_user'
cms-1  |
cms-1  | During handling of the above exception, another exception occurred:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 238, in get_namespace_plugin
cms-1  |     return drivers[namespace].plugin
cms-1  |            ~~~~~~~^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/stevedore/extension.py", line 452, in __getitem__
cms-1  |     return self._extensions_by_name[name]
cms-1  |            ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
cms-1  | KeyError: 'lib'
cms-1  |
cms-1  | The above exception was the direct cause of the following exception:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 190, in from_string
cms-1  |     key_class = cls.get_namespace_plugin(namespace)
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 243, in get_namespace_plugin
cms-1  |     raise InvalidKeyError(cls, f'{namespace}:*') from error
cms-1  | opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.keys.CourseKey'>: lib:*
cms-1  |
cms-1  | During handling of the above exception, another exception occurred:
cms-1  |
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
cms-1  |     response = get_response(request)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
cms-1  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/opt/pyenv/versions/3.12.12/lib/python3.12/contextlib.py", line 81, in inner
cms-1  |     return func(*args, **kwds)
cms-1  |            ^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
cms-1  |     return view_func(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/django/views/generic/base.py", line 105, in view
cms-1  |     return self.dispatch(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
cms-1  |     response = self.handle_exception(exc)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
cms-1  |     self.raise_uncaught_exception(exc)
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
cms-1  |     raise exc
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
cms-1  |     response = handler(request, *args, **kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/views.py", line 34, in get
cms-1  |     response_data = api.generate_user_token_for_studio_search(request)
cms-1  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 973, in generate_user_token_for_studio_search
cms-1  |     STUDIO_INDEX_NAME: _get_meili_access_filter(request),
cms-1  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 957, in _get_meili_access_filter
cms-1  |     user_orgs = _get_user_orgs(request)[:MAX_ORGS_IN_FILTER]
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 940, in _get_user_orgs
cms-1  |     course_roles = get_course_roles(request.user)
cms-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
cms-1  |     result = wrapped(*args, **kwargs)
cms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/role_helpers.py", line 77, in get_course_roles
cms-1  |     role_cache = get_role_cache(user)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
cms-1  |     result = wrapped(*args, **kwargs)
cms-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/role_helpers.py", line 64, in get_role_cache
cms-1  |     user._roles = RoleCache(user)
cms-1  |                   ^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 239, in __init__
cms-1  |     compat_roles = get_authz_compat_course_access_roles_for_user(user)
cms-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 144, in get_authz_compat_course_access_roles_for_user
cms-1  |     parsed_key = CourseKey.from_string(course_key)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/__init__.py", line 198, in from_string
cms-1  |     return cls.deprecated_fallback._from_deprecated_string(serialized)  # type: ignore
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.12/site-packages/opaque_keys/edx/locator.py", line 403, in _from_deprecated_string
cms-1  |     raise InvalidKeyError(cls, serialized)
cms-1  | opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.locator.CourseLocator'>: lib:WGU:CSPROB
cms-1  | [10/Mar/2026 21:19:39] "GET /api/contentstore/v1/course_waffle_flags/lib:WGU:CSPROB HTTP/1.1" 404 60130
cms-1  | [10/Mar/2026 21:19:39] "GET /api/content_search/v2/studio/ HTTP/1.1" 500 347472
```

5. Apply the fix, login as the non-admin user in studio and go to the library, the library will load normally and the CMS logs will look like:

```
cms-1  | 2026-03-10 21:22:44,472 INFO 149 [tracking] [user 5] [ip 140.82.114.4] logger.py:41 - {"name": "/api/content_search/v2/studio/", "context": {"user_id": 5, "path": "/api/content_search/v2/studio/", "course_id": "", "org_id": "", "enterprise_uuid": ""}, "username": "contributor", "session": "052e9ad37a2b4d793827c130992a3ff9", "ip": "140.82.114.4", "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36", "host": "studio.local.openedx.io:8001", "referer": "http://apps.local.openedx.io:2001/", "accept_language": "en-US,en;q=0.9", "event": "{\"GET\": {}, \"POST\": {}}", "time": "2026-03-10T21:22:44.472666+00:00", "event_type": "/api/content_search/v2/studio/", "event_source": "server", "page": null}
cms-1  | 2026-03-10 21:22:44,476 INFO 149 [tracking] [user 5] [ip 140.82.114.4] logger.py:41 - {"name": "/api/contentstore/v1/home", "context": {"user_id": 5, "path": "/api/contentstore/v1/home", "course_id": "", "org_id": "", "enterprise_uuid": ""}, "username": "contributor", "session": "052e9ad37a2b4d793827c130992a3ff9", "ip": "140.82.114.4", "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36", "host": "studio.local.openedx.io:8001", "referer": "http://apps.local.openedx.io:2001/", "accept_language": "en-US,en;q=0.9", "event": "{\"GET\": {}, \"POST\": {}}", "time": "2026-03-10T21:22:44.476090+00:00", "event_type": "/api/contentstore/v1/home", "event_source": "server", "page": null}
cms-1  | 2026-03-10 21:22:44,493 INFO 149 [tracking] [user 5] [ip 140.82.114.4] logger.py:41 - {"name": "/api/libraries/v2/lib:WGU:CSPROB/", "context": {"user_id": 5, "path": "/api/libraries/v2/lib:WGU:CSPROB/", "course_id": "", "org_id": "", "enterprise_uuid": ""}, "username": "contributor", "session": "052e9ad37a2b4d793827c130992a3ff9", "ip": "140.82.114.4", "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36", "host": "studio.local.openedx.io:8001", "referer": "http://apps.local.openedx.io:2001/", "accept_language": "en-US,en;q=0.9", "event": "{\"GET\": {}, \"POST\": {}}", "time": "2026-03-10T21:22:44.493144+00:00", "event_type": "/api/libraries/v2/lib:WGU:CSPROB/", "event_source": "server", "page": null}
cms-1  | [10/Mar/2026 21:22:44] "GET /api/content_search/v2/studio/ HTTP/1.1" 200 382
cms-1  | [10/Mar/2026 21:22:44] "GET /api/contentstore/v1/home HTTP/1.1" 200 905
cms-1  | [10/Mar/2026 21:22:44] "GET /api/libraries/v2/lib:WGU:CSPROB/ HTTP/1.1" 200 453
```

## Deadline

Verawood release
