### PR TITLE
feat: Add sort order to cohorts endpoint

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -345,9 +345,10 @@ def get_course_cohorts(course=None, course_id=None, assignment_type=None, orderi
         group_type=CourseUserGroup.COHORT
     )
     query_set = query_set.filter(cohort__assignment_type=assignment_type) if assignment_type else query_set
-    sort_field = 'name'
-    if ordering == 'desc':
-        sort_field = '-name'
+    ordering = ordering.lower()
+    if ordering not in ('asc', 'desc'):
+        raise ValueError(f"Invalid ordering value '{ordering}'. Must be 'asc' or 'desc'.")
+    sort_field = '-name' if ordering == 'desc' else 'name'
     query_set = query_set.order_by(sort_field)
     return list(query_set)
 

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -327,7 +327,8 @@ def get_course_cohorts(course=None, course_id=None, assignment_type=None, orderi
     Arguments:
         course: the course for which cohorts should be returned
         assignment_type: cohort assignment type
-        ordering: sort direction for results by name ('asc' or 'desc'), defaults to 'asc'
+        ordering: sort direction for results by name. Use 'desc' for descending order.
+            Any other value (including the default 'asc') results in ascending order.
 
     Returns:
         A list of CourseUserGroup objects. Empty if there are no cohorts. Does

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -319,7 +319,7 @@ def migrate_cohort_settings(course):
     return cohort_settings
 
 
-def get_course_cohorts(course=None, course_id=None, assignment_type=None):
+def get_course_cohorts(course=None, course_id=None, assignment_type=None, ordering='asc'):
     """
     Get a list of all the cohorts in the given course. This will include auto cohorts,
     regardless of whether or not the auto cohorts include any users.
@@ -327,6 +327,7 @@ def get_course_cohorts(course=None, course_id=None, assignment_type=None):
     Arguments:
         course: the course for which cohorts should be returned
         assignment_type: cohort assignment type
+        ordering: sort direction for results by name ('asc' or 'desc'), defaults to 'asc'
 
     Returns:
         A list of CourseUserGroup objects. Empty if there are no cohorts. Does
@@ -343,6 +344,10 @@ def get_course_cohorts(course=None, course_id=None, assignment_type=None):
         group_type=CourseUserGroup.COHORT
     )
     query_set = query_set.filter(cohort__assignment_type=assignment_type) if assignment_type else query_set
+    sort_field = 'name'
+    if ordering == 'desc':
+        sort_field = '-name'
+    query_set = query_set.order_by(sort_field)
     return list(query_set)
 
 

--- a/openedx/core/djangoapps/course_groups/tests/test_api_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_api_views.py
@@ -624,6 +624,7 @@ class TestCohortApi(SharedModuleStoreTestCase):
         response = self.client.get(path=path, data={'ordering': 'invalid'})
 
         assert response.status_code == 400
+        assert response.json().get('error_code') == 'invalid-ordering-value'
 
     def test_patch_cohort_with_name_only(self):
         """

--- a/openedx/core/djangoapps/course_groups/tests/test_api_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_api_views.py
@@ -583,6 +583,48 @@ class TestCohortApi(SharedModuleStoreTestCase):
         assert data['developer_message'] == 'If group_id is specified, user_partition_id must also be specified.'
         assert data['error_code'] == 'missing-user-partition-id'
 
+    def test_get_cohorts_default_ordering(self):
+        """
+        Test that cohorts are returned in ascending alphabetical order by default.
+        """
+        cohorts.add_cohort(self.course_key, "Zebra", "manual")
+        cohorts.add_cohort(self.course_key, "Alpha", "manual")
+        cohorts.add_cohort(self.course_key, "Mango", "manual")
+
+        path = reverse('api_cohorts:cohort_handler', kwargs={'course_key_string': self.course_str})
+        self.client.login(username=self.staff_user.username, password=self.password)
+        response = self.client.get(path=path)
+
+        assert response.status_code == 200
+        names = [c['name'] for c in response.json()]
+        assert names == ['Alpha', 'Mango', 'Zebra']
+
+    def test_get_cohorts_desc_ordering(self):
+        """
+        Test that cohorts are returned in descending alphabetical order when ordering=desc.
+        """
+        cohorts.add_cohort(self.course_key, "Zebra", "manual")
+        cohorts.add_cohort(self.course_key, "Alpha", "manual")
+        cohorts.add_cohort(self.course_key, "Mango", "manual")
+
+        path = reverse('api_cohorts:cohort_handler', kwargs={'course_key_string': self.course_str})
+        self.client.login(username=self.staff_user.username, password=self.password)
+        response = self.client.get(path=path, data={'ordering': 'desc'})
+
+        assert response.status_code == 200
+        names = [c['name'] for c in response.json()]
+        assert names == ['Zebra', 'Mango', 'Alpha']
+
+    def test_get_cohorts_invalid_ordering(self):
+        """
+        Test that an invalid ordering value returns a 400 error.
+        """
+        path = reverse('api_cohorts:cohort_handler', kwargs={'course_key_string': self.course_str})
+        self.client.login(username=self.staff_user.username, password=self.password)
+        response = self.client.get(path=path, data={'ordering': 'invalid'})
+
+        assert response.status_code == 400
+
     def test_patch_cohort_with_name_only(self):
         """
         Test that PATCH with only name is now valid (previously required assignment_type too).

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -532,10 +532,10 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
 
     **Example Requests**:
 
-        GET /api/cohorts/v1/courses/{course_id}/cohorts
-        GET /api/cohorts/v1/courses/{course_id}/cohorts?ordering=asc
-        GET /api/cohorts/v1/courses/{course_id}/cohorts?ordering=desc
-        POST /api/cohorts/v1/courses/{course_id}/cohorts
+        GET /api/cohorts/v1/courses/{course_id}/cohorts/
+        GET /api/cohorts/v1/courses/{course_id}/cohorts/?ordering=asc
+        GET /api/cohorts/v1/courses/{course_id}/cohorts/?ordering=desc
+        POST /api/cohorts/v1/courses/{course_id}/cohorts/
         GET /api/cohorts/v1/courses/{course_id}/cohorts/{cohort_id}
         PATCH /api/cohorts/v1/courses/{course_id}/cohorts/{cohort_id}
 

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -575,7 +575,14 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
         """
         course_key, course = _get_course_with_access(request, course_key_string, 'load')
         if not cohort_id:
-            all_cohorts = cohorts.get_course_cohorts(course)
+            ordering = request.query_params.get('ordering', 'asc').lower()
+            if ordering not in ('asc', 'desc'):
+                raise self.api_error(
+                    status.HTTP_400_BAD_REQUEST,
+                    'Invalid ordering value. Must be "asc" or "desc".',
+                    'invalid-ordering-value'
+                )
+            all_cohorts = cohorts.get_course_cohorts(course, ordering=ordering)
             paginator = NamespacedPageNumberPagination()
             paginator.max_page_size = MAX_PAGE_SIZE
             page = paginator.paginate_queryset(all_cohorts, request)

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -533,9 +533,16 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
     **Example Requests**:
 
         GET /api/cohorts/v1/courses/{course_id}/cohorts
+        GET /api/cohorts/v1/courses/{course_id}/cohorts?ordering=asc
+        GET /api/cohorts/v1/courses/{course_id}/cohorts?ordering=desc
         POST /api/cohorts/v1/courses/{course_id}/cohorts
         GET /api/cohorts/v1/courses/{course_id}/cohorts/{cohort_id}
         PATCH /api/cohorts/v1/courses/{course_id}/cohorts/{cohort_id}
+
+    **GET Query Parameters**
+
+        * ordering (optional): Sort direction for the cohort list by name. Accepted values are
+          "asc" (ascending, default) and "desc" (descending). Returns HTTP 400 for invalid values.
 
     **POST Request Values**
 


### PR DESCRIPTION
## Description

  Adds alphabetical ordering to the `GET /api/cohorts/v1/courses/{course_id}/cohorts/` endpoint. Previously, the response order was non-deterministic (database insertion order). Cohorts are now returned in ascending alphabetical order by name by default, with an optional `ordering` query parameter to control sort direction.

  **Changes:**
  - `get_course_cohorts()` now accepts an `ordering` parameter (`'asc'` or `'desc'`, default `'asc'`) and applies `ORDER BY name` to the queryset. All callers benefit from deterministic ordering.
  - `CohortHandler.GET` reads the `?ordering=asc|desc` query parameter, validates it, and passes it through. Returns HTTP 400 for invalid values.

  **User roles impacted:** Developers and Operators consuming the cohorts API. No UI changes.

  ## Supporting information

  - GitHub Issue: https://github.com/openedx/edx-platform/issues/38119
  - Related frontend ticket: https://github.com/openedx/frontend-app-instruct/issues/52

  ## Testing instructions

  1. Create a course with several cohorts whose names are out of alphabetical order.
  2. `GET /api/cohorts/v1/courses/{course_id}/cohorts/` — verify cohorts are returned A→Z.
  3. `GET /api/cohorts/v1/courses/{course_id}/cohorts/?ordering=desc` — verify cohorts are returned Z→A.
  4. `GET /api/cohorts/v1/courses/{course_id}/cohorts/?ordering=invalid` — verify HTTP 400 is returned.

  ## Deadline

  None

  ## Other information

  - No database migrations required.
  - This is a non-breaking change. Existing callers without the `ordering` param will now receive cohorts in ascending alphabetical order, which is an improvement over the previous non-deterministic ordering. No response schema changes.
  - A v2 endpoint was considered but deemed unnecessary since this is purely an ordering improvement with no schema changes.