### PR TITLE
Enable Extracted Video Block | Sandbox - 2

### DIFF
--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2105,6 +2105,7 @@ USE_EXTRACTED_PROBLEM_BLOCK = False
 # .. toggle_target_removal_date: 2025-06-01
 USE_EXTRACTED_VIDEO_BLOCK = True
 
+
 ############################## Marketing Site ##############################
 
 EDXMKTG_LOGGED_IN_COOKIE_NAME = 'edxloggedin'

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2103,7 +2103,7 @@ USE_EXTRACTED_PROBLEM_BLOCK = False
 # .. toggle_warning: Not production-ready until relevant subtask https://github.com/openedx/edx-platform/issues/34827 is done.
 # .. toggle_creation_date: 2024-11-10
 # .. toggle_target_removal_date: 2025-06-01
-USE_EXTRACTED_VIDEO_BLOCK = False
+USE_EXTRACTED_VIDEO_BLOCK = True
 
 ############################## Marketing Site ##############################
 


### PR DESCRIPTION
fPurpose of this test PR is to create a sanbox on Extracted Video Block.
Once all testing is done, we can merge this PR to enable the extracted video block

[Main ticket](https://github.com/openedx/openedx-platform/issues/34827)

-----

### Sandbox details for this PR:
[sandbox-details](https://github.com/openedx/openedx-platform/pull/38153/checks?check_run_id=66750027809)

-----

## Manual Test cases document created by Aximprovements team: 
[word-document](https://docs.google.com/document/d/1dAy2JLRlxdAu1ZP-KUza4j6Numc0LtIb9ucPQZ1_Bug/edit?usp=sharing)

#### Test data / Sample online video urls for the testing

- [Simple youtube video](https://youtu.be/7mx4dPlSKx0)
- [Youtube video with the transcripts](https://youtu.be/3E7hkPZ-HTk)
   - These transcripts files can be used for the this video [transcripts.zip](https://github.com/user-attachments/files/25792704/transcripts.zip)
- [MP4 video ](http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4)
- [HLS/m3u8 video](https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8)
- [webm video](https://dl11.webmfiles.org/big-buck-bunny_trailer-.webm)

-----   

## Other details

### PR for creating the sandbox for the Built-In Video Block:
Purpose of this sandbox is to compare the behaviour between extracted and built-in video block
https://github.com/openedx/openedx-platform/pull/38158

### Past testing:
Some testing has already been done in the past, here is the [comment](https://github.com/openedx/openedx-platform/pull/37851#issuecomment-3760331580)

### Known Issues:
- Course Import/Export feature is not working on the sandboxes