### PR TITLE
refactor: Extract get_additional_student_profile_attributes function

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1459,10 +1459,7 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
                 'enrollment_date',
             ]
 
-        additional_attributes = configuration_helpers.get_value_for_org(
-            course_key.org,
-            "additional_student_profile_attributes"
-        )
+        additional_attributes = instructor_analytics_basic.get_additional_student_profile_attributes(course_key)
         if additional_attributes:
             # Fail fast: must be list/tuple of strings.
             if not isinstance(additional_attributes, (list, tuple)):

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -893,10 +893,7 @@ class GenerateReportView(DeveloperErrorViewMixin, APIView):
                 'enrollment_date',
             ]
 
-        additional_attributes = configuration_helpers.get_value_for_org(
-            course_key.org,
-            "additional_student_profile_attributes"
-        )
+        additional_attributes = instructor_analytics_basic.get_additional_student_profile_attributes(course_key)
         if additional_attributes:
             # Fail fast: must be list/tuple of strings.
             if not isinstance(additional_attributes, (list, tuple)):

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -144,15 +144,33 @@ def get_student_features_with_custom(course_key):
     Returns:
         tuple: Combined tuple of standard STUDENT_FEATURES and custom attributes
     """
-    additional_attributes = configuration_helpers.get_value_for_org(
-        course_key.org,
-        "additional_student_profile_attributes"
-    )
+    additional_attributes = get_additional_student_profile_attributes(course_key)
 
     if additional_attributes:
         return STUDENT_FEATURES + tuple(additional_attributes)
 
     return STUDENT_FEATURES
+
+
+def get_additional_student_profile_attributes(course_key):
+    """
+    Return list of additional student profile attributes configured for the course organization.
+
+    This function retrieves any custom student profile attributes that have been configured for
+    a specific course organization. These attributes can be used to extend the standard set of
+    student features included in analytics exports.
+
+    Args:
+        course_key: CourseKey object for the course
+
+    Returns:
+        list: List of additional student profile attributes configured for the course organization
+    """
+    return configuration_helpers.get_value_for_org(
+        course_key.org,
+        "additional_student_profile_attributes",
+        default=[]
+    )
 
 
 def get_available_features(course_key):


### PR DESCRIPTION
Extract the configuration_helpers.get_value_for_org() call for fetching additional student profile attributes into a dedicated function to eliminate code duplication.

## Description

This PR refactors the retrieval of additional student profile attributes to eliminate code duplication and improve maintainability.

### Problem

The code for fetching `additional_student_profile_attributes` from site configuration was duplicated in two locations:
1. `lms/djangoapps/instructor_analytics/basic.py` in the `get_student_features_with_custom()` function
2. `lms/djangoapps/instructor/views/api.py` in the `GetStudentsFeatures` view
3. 2. `lms/djangoapps/instructor/views/api_v2.py` in the `GenerateReportView` view

This duplication made the code harder to maintain and increased the risk of inconsistencies.

### Solution

Extracted the duplicated configuration retrieval logic into a dedicated function `get_additional_student_profile_attributes()` in the `instructor_analytics.basic` module. Both call sites now use this shared function.

### Business requirement

It allows to monkey patch the new function `get_additional_student_profile_attributes()` for better extensibility.

For example on [NAU](https://lms.nau.edu.pt/login) installation to have a per course configuration to better align with our GDPR compliance of custom fields.