### PR TITLE
feat: add authz permission for certificates

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/certificates.py
@@ -6,11 +6,14 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from openedx_authz.constants.permissions import COURSES_MANAGE_CERTIFICATES
+
 from cms.djangoapps.contentstore.utils import get_certificates_context
 from cms.djangoapps.contentstore.rest_api.v1.serializers import (
     CourseCertificatesSerializer,
 )
-from common.djangoapps.student.auth import has_studio_write_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.lib.api.view_utils import (
     DeveloperErrorViewMixin,
     verify_course_exists,
@@ -96,7 +99,12 @@ class CourseCertificatesView(DeveloperErrorViewMixin, APIView):
         course_key = CourseKey.from_string(course_id)
         store = modulestore()
 
-        if not has_studio_write_access(request.user, course_key):
+        if not user_has_course_permission(
+            request.user,
+            COURSES_MANAGE_CERTIFICATES.identifier,
+            course_key,
+            LegacyAuthoringPermission.READ
+        ):
             self.permission_denied(request)
 
         with store.bulk_operations(course_key):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/certificates.py
@@ -103,7 +103,7 @@ class CourseCertificatesView(DeveloperErrorViewMixin, APIView):
             request.user,
             COURSES_MANAGE_CERTIFICATES.identifier,
             course_key,
-            LegacyAuthoringPermission.READ
+            LegacyAuthoringPermission.WRITE
         ):
             self.permission_denied(request)
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
@@ -56,7 +56,7 @@ class CourseCertificatesAuthzViewTest(AuthzTestMixin, CourseTestCase, Permission
     def test_authorized_user_can_access(self):
         """User with COURSE_STAFF role can access."""
         self._add_course_certificates(count=2, signatory_count=2)
-        self.add_user_to_role(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
         resp = self.authorized_client.get(self.url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
@@ -66,6 +66,6 @@ class CourseCertificatesAuthzViewTest(AuthzTestMixin, CourseTestCase, Permission
         This case validates that a non-staff user cannot access.
         """
         self._add_course_certificates(count=2, signatory_count=2)
-        self.add_user_to_role(self.authorized_user, COURSE_EDITOR.external_key, self.course.id)
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_EDITOR.external_key, self.course.id)
         resp = self.authorized_client.get(self.url)
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
@@ -4,8 +4,11 @@ Unit tests for the course's certificate.
 from django.urls import reverse
 from rest_framework import status
 
+from openedx_authz.constants.roles import COURSE_STAFF, COURSE_EDITOR
+
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.views.tests.test_certificates import HelperMethods
+from openedx.core.djangoapps.authz.tests.mixins import AuthzTestMixin
 
 from ...mixins import PermissionAccessMixin
 
@@ -36,3 +39,35 @@ class CourseCertificatesViewTest(CourseTestCase, PermissionAccessMixin, HelperMe
         self.assertEqual(response_data["course_number_override"], self.course.display_coursenumber)
         self.assertEqual(response_data["course_title"], self.course.display_name_with_default)
         self.assertEqual(response_data["course_number"], self.course.number)
+
+
+class CourseCertificatesAuthzViewTest(AuthzTestMixin, CourseTestCase, PermissionAccessMixin, HelperMethods):
+    """
+    Tests for CourseCertificatesView with AuthZ enabled.
+    """
+
+    authz_roles_to_assign = [COURSE_STAFF.external_key]
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(
+            "cms.djangoapps.contentstore:v1:certificates",
+            kwargs={"course_id": self.course.id},
+        )
+
+    def test_authorized_user_can_access(self):
+        """User with COURSE_STAFF role can access."""
+        self._add_course_certificates(count=2, signatory_count=2)
+        self.add_user_to_role(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_non_staff_user_cannot_access(self):
+        """
+        User without permissions should be denied.
+        This case validates that a non-staff user cannot access.
+        """
+        self._add_course_certificates(count=2, signatory_count=2)
+        self.add_user_to_role(self.authorized_user, COURSE_EDITOR.external_key, self.course.id)
+        resp = self.authorized_client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
@@ -46,8 +46,6 @@ class CourseCertificatesAuthzViewTest(AuthzTestMixin, CourseTestCase, Permission
     Tests for CourseCertificatesView with AuthZ enabled.
     """
 
-    authz_roles_to_assign = [COURSE_STAFF.external_key]
-
     def setUp(self):
         super().setUp()
         self.url = reverse(

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
@@ -8,7 +8,7 @@ from openedx_authz.constants.roles import COURSE_STAFF, COURSE_EDITOR
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.views.tests.test_certificates import HelperMethods
-from openedx.core.djangoapps.authz.tests.mixins import AuthzTestMixin
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
 
 from ...mixins import PermissionAccessMixin
 
@@ -41,7 +41,9 @@ class CourseCertificatesViewTest(CourseTestCase, PermissionAccessMixin, HelperMe
         self.assertEqual(response_data["course_number"], self.course.number)
 
 
-class CourseCertificatesAuthzViewTest(AuthzTestMixin, CourseTestCase, PermissionAccessMixin, HelperMethods):
+class CourseCertificatesAuthzViewTest(
+        CourseAuthoringAuthzTestMixin, CourseTestCase, PermissionAccessMixin, HelperMethods
+    ):
     """
     Tests for CourseCertificatesView with AuthZ enabled.
     """

--- a/openedx/core/djangoapps/authz/tests/mixins.py
+++ b/openedx/core/djangoapps/authz/tests/mixins.py
@@ -14,6 +14,75 @@ from openedx.core import toggles as core_toggles
 from common.djangoapps.student.tests.factories import UserFactory
 
 
+class AuthzTestMixin:
+    """
+    Minimal reusable mixin for AuthZ-enabled tests.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.toggle_patcher = patch.object(
+            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
+            "is_enabled",
+            return_value=True,
+        )
+        cls.toggle_patcher.start()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.toggle_patcher.stop()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+
+        self._seed_policies()
+
+        self.authorized_user = UserFactory()
+        self.unauthorized_user = UserFactory()
+
+        self.authorized_client = APIClient()
+        self.authorized_client.force_authenticate(user=self.authorized_user)
+
+        self.unauthorized_client = APIClient()
+        self.unauthorized_client.force_authenticate(user=self.unauthorized_user)
+
+    def tearDown(self):
+        super().tearDown()
+        AuthzEnforcer.get_enforcer().clear_policy()
+
+    def add_user_to_role(self, user, role, course_key):
+        """Helper method to add a user to a role for the course."""
+        assign_role_to_user_in_scope(
+            user.username,
+            role,
+            str(course_key)
+        )
+        AuthzEnforcer.get_enforcer().load_policy()
+
+    @classmethod
+    def _seed_policies(cls):
+        """Seed the database with AuthZ policies."""
+        global_enforcer = AuthzEnforcer.get_enforcer()
+        global_enforcer.load_policy()
+
+        model_path = pkg_resources.resource_filename(
+            "openedx_authz.engine",
+            "config/model.conf",
+        )
+
+        policy_path = pkg_resources.resource_filename(
+            "openedx_authz.engine",
+            "config/authz.policy",
+        )
+
+        migrate_policy_between_enforcers(
+            source_enforcer=casbin.Enforcer(model_path, policy_path),
+            target_enforcer=global_enforcer,
+        )
+
+
 class CourseAuthzTestMixin:
     """
     Reusable mixin for testing course-scoped AuthZ endpoints.

--- a/openedx/core/djangoapps/authz/tests/mixins.py
+++ b/openedx/core/djangoapps/authz/tests/mixins.py
@@ -16,7 +16,9 @@ from common.djangoapps.student.tests.factories import UserFactory
 
 class AuthzTestMixin:
     """
-    Minimal reusable mixin for AuthZ-enabled tests.
+    Base mixin for testing AuthZ endpoints.
+    Provides setup and helper methods for testing
+    AuthZ policies and permissions.
     """
 
     @classmethod
@@ -52,7 +54,7 @@ class AuthzTestMixin:
         super().tearDown()
         AuthzEnforcer.get_enforcer().clear_policy()
 
-    def add_user_to_role(self, user, role, course_key):
+    def add_user_to_role_in_course(self, user, role, course_key):
         """Helper method to add a user to a role for the course."""
         assign_role_to_user_in_scope(
             user.username,
@@ -83,37 +85,16 @@ class AuthzTestMixin:
         )
 
 
-class CourseAuthzTestMixin:
+class CourseAuthzTestMixin(AuthzTestMixin):
     """
     Reusable mixin for testing course-scoped AuthZ endpoints.
     """
 
     authz_roles_to_assign = [COURSE_STAFF.external_key]
-
-    @classmethod
-    def setUpClass(cls):
-        cls.toggle_patcher = patch.object(
-            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
-            "is_enabled",
-            return_value=True
-        )
-        cls.toggle_patcher.start()
-
-        super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.toggle_patcher.stop()
-        super().tearDownClass()
+    course_key = None
 
     def setUp(self):
         super().setUp()
-
-        self._seed_database_with_policies()
-
-        self.authorized_user = UserFactory()
-        self.unauthorized_user = UserFactory()
-
         for role in self.authz_roles_to_assign:
             assign_role_to_user_in_scope(
                 self.authorized_user.username,
@@ -123,42 +104,6 @@ class CourseAuthzTestMixin:
 
         AuthzEnforcer.get_enforcer().load_policy()
 
-        self.authorized_client = APIClient()
-        self.authorized_client.force_authenticate(user=self.authorized_user)
-
-        self.unauthorized_client = APIClient()
-        self.unauthorized_client.force_authenticate(user=self.unauthorized_user)
-
     def add_user_to_role(self, user, role):
         """Helper method to add a user to a role for the course."""
-        assign_role_to_user_in_scope(
-            user.username,
-            role,
-            str(self.course_key)
-        )
-        AuthzEnforcer.get_enforcer().load_policy()
-
-    def tearDown(self):
-        super().tearDown()
-        AuthzEnforcer.get_enforcer().clear_policy()
-
-    @classmethod
-    def _seed_database_with_policies(cls):
-        """Seed the database with AuthZ policies."""
-        global_enforcer = AuthzEnforcer.get_enforcer()
-        global_enforcer.load_policy()
-
-        model_path = pkg_resources.resource_filename(
-            "openedx_authz.engine",
-            "config/model.conf"
-        )
-
-        policy_path = pkg_resources.resource_filename(
-            "openedx_authz.engine",
-            "config/authz.policy"
-        )
-
-        migrate_policy_between_enforcers(
-            source_enforcer=casbin.Enforcer(model_path, policy_path),
-            target_enforcer=global_enforcer,
-        )
+        self.add_user_to_role_in_course(user, role, self.course_key)

--- a/openedx/core/djangoapps/authz/tests/mixins.py
+++ b/openedx/core/djangoapps/authz/tests/mixins.py
@@ -14,11 +14,15 @@ from openedx.core import toggles as core_toggles
 from common.djangoapps.student.tests.factories import UserFactory
 
 
-class AuthzTestMixin:
+class CourseAuthoringAuthzTestMixin:
     """
-    Base mixin for testing AuthZ endpoints.
-    Provides setup and helper methods for testing
-    AuthZ policies and permissions.
+    Base mixin for testing AuthZ in the course authoring context.
+
+    Responsibilities:
+    - Enable course authoring AuthZ feature flag
+    - Seed policies into the AuthZ enforcer
+    - Provide authenticated test clients
+    - Provide helpers for assigning roles within a course scope
     """
 
     @classmethod
@@ -85,13 +89,19 @@ class AuthzTestMixin:
         )
 
 
-class CourseAuthzTestMixin(AuthzTestMixin):
+class CourseAuthzTestMixin(CourseAuthoringAuthzTestMixin):
     """
     Reusable mixin for testing course-scoped AuthZ endpoints.
     """
 
     authz_roles_to_assign = [COURSE_STAFF.external_key]
-    course_key = None
+
+    @property
+    def course_key(self):
+        """
+        Must be defined by subclasses.
+        """
+        raise NotImplementedError("Tests using CourseAuthzTestMixin must define 'course_key'")
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->
Resolves: https://github.com/openedx/openedx-authz/issues/199
## Description

This PR introduces a new authorization permission for certificates and integrates it into the certificates endpoint behind a feature flag.

The goal is to align certificate access with the new AuthZ framework while maintaining backward compatibility through the flag.

## Changes

- Implement courses.manage_certificates permission
- Add permission checks to the certificates endpoint handler (guarded by feature flag)
- Extend test coverage:
      - Validate access for course staff
      - Validate access for course editor (non-staff)
- Introduce a reusable test mixin for AuthZ certificate scenarios

## Endpoint Affected

`GET /api/contentstore/v1/certificates/<course_id>/`

Now enforces courses.manage_certificates when the feature flag is enabled

## Testing instructions

Verified that:

- Authorized users can access the endpoints.
- Unauthorized users receive a 403 response.
- Legacy permission fallback works as expected.

Running relevant tests manually:
On a cms container (run with tutor dev exec cms bash), do:

`pytest -p no:randomly --ds=cms.envs.test cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
`
## Deadline

Verawood
