### PR TITLE
feat: add pre-item-delete signal

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -724,7 +724,7 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==10.0.1
+lti-consumer-xblock @ git+https://github.com/open-craft/xblock-lti-consumer@navin/fal-4318/split-config
     # via -r requirements/edx/kernel.in
 lxml[html-clean]==5.3.2
     # via
@@ -846,6 +846,7 @@ openedx-events==11.1.0
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
     #   event-tracking
+    #   lti-consumer-xblock
     #   ora2
 openedx-filters==2.1.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1203,7 +1203,7 @@ libsass==0.10.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.txt
-lti-consumer-xblock==10.0.1
+lti-consumer-xblock @ git+https://github.com/open-craft/xblock-lti-consumer@navin/fal-4318/split-config
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1408,6 +1408,7 @@ openedx-events==11.1.0
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
     #   event-tracking
+    #   lti-consumer-xblock
     #   ora2
 openedx-filters==2.1.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -883,7 +883,7 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==10.0.1
+lti-consumer-xblock @ git+https://github.com/open-craft/xblock-lti-consumer@navin/fal-4318/split-config
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via
@@ -1026,6 +1026,7 @@ openedx-events==11.1.0
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
     #   event-tracking
+    #   lti-consumer-xblock
     #   ora2
 openedx-filters==2.1.0
     # via

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -101,7 +101,7 @@ jsonfield                           # Django model field for validated JSON; use
 laboratory                          # Library for testing that code refactors/infrastructure changes produce identical results
 importlib_metadata                  # Used to access entry_points in i18n_api plugin
 lxml[html_clean]                    # XML parser
-lti-consumer-xblock>=9.14.2
+lti-consumer-xblock @ git+https://github.com/open-craft/xblock-lti-consumer@navin/fal-4318/split-config
 mako                                # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis
 meilisearch                         # Library to access Meilisearch search engine (will replace ElasticSearch)

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -922,7 +922,7 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==10.0.1
+lti-consumer-xblock @ git+https://github.com/open-craft/xblock-lti-consumer@navin/fal-4318/split-config
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via
@@ -1073,6 +1073,7 @@ openedx-events==11.1.0
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
     #   event-tracking
+    #   lti-consumer-xblock
     #   ora2
 openedx-filters==2.1.0
     # via

--- a/xmodule/modulestore/__init__.py
+++ b/xmodule/modulestore/__init__.py
@@ -1425,3 +1425,10 @@ class ModuleStoreWriteBase(ModuleStoreReadBase, ModuleStoreWrite):
         """
         if self.signal_handler:
             self.signal_handler.send("item_deleted", usage_key=usage_key, user_id=user_id)
+
+    def _emit_pre_item_delete_signal(self, usage_key, user_id):
+        """
+        Helper method used to emit the pre_item_delete signal.
+        """
+        if self.signal_handler:
+            self.signal_handler.send("pre_item_delete", usage_key=usage_key, user_id=user_id)

--- a/xmodule/modulestore/django.py
+++ b/xmodule/modulestore/django.py
@@ -195,11 +195,19 @@ class SignalHandler:
     course_deleted = SwitchedSignal("course_deleted")
     library_updated = SwitchedSignal("library_updated")
     item_deleted = SwitchedSignal("item_deleted")
+    pre_item_delete = SwitchedSignal("pre_item_delete")
 
     _mapping = {
         signal.name: signal
         for signal
-        in [pre_publish, course_published, course_deleted, library_updated, item_deleted]
+        in [
+            pre_publish,
+            course_published,
+            course_deleted,
+            library_updated,
+            item_deleted,
+            pre_item_delete,
+        ]
     }
 
     def __init__(self, modulestore_class):

--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -2517,6 +2517,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             # The supplied UsageKey is of the wrong type, so it can't possibly be stored in this modulestore.
             raise ItemNotFoundError(usage_locator)
 
+        # Send pre delete event signal before deleting any item
+        self._emit_pre_item_delete_signal(usage_locator, user_id)
+
         with self.bulk_operations(usage_locator.course_key):
             original_structure = self._lookup_course(usage_locator.course_key).structure
             block_key = BlockKey.from_usage_key(usage_locator)

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -1123,7 +1123,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
     #          check CONTENT_TAGGING_AUTO CourseWaffleFlag
     #   Find: active_versions, 2 structures (published & draft), definition (unnecessary)
     #   Sends: updated draft and published structures and active_versions
-    @ddt.data((ModuleStoreEnum.Type.split, 5, 2, 3))
+    @ddt.data((ModuleStoreEnum.Type.split, 11, 2, 3))
     @ddt.unpack
     def test_delete_item(self, default_ms, num_mysql, max_find, max_send):
         """
@@ -1146,7 +1146,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
     #           check CONTENT_TAGGING_AUTO CourseWaffleFlag
     #    find: draft and published structures, definition (unnecessary)
     #    sends: update published (why?), draft, and active_versions
-    @ddt.data((ModuleStoreEnum.Type.split, 5, 3, 3))
+    @ddt.data((ModuleStoreEnum.Type.split, 11, 3, 3))
     @ddt.unpack
     def test_delete_private_vertical(self, default_ms, num_mysql, max_find, max_send):
         """
@@ -1196,7 +1196,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
     #          check CONTENT_TAGGING_AUTO CourseWaffleFlag
     #   find: structure (cached)
     #   send: update structure and active_versions
-    @ddt.data((ModuleStoreEnum.Type.split, 5, 1, 2))
+    @ddt.data((ModuleStoreEnum.Type.split, 11, 1, 2))
     @ddt.unpack
     def test_delete_draft_vertical(self, default_ms, num_mysql, max_find, max_send):
         """


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This is required in cases where we want to be able to delete or update database rows related to children blocks on the deleted block. Fetching children after deletion is not possible, which is why this signal is useful


Useful information to include:

- Which edX user roles will this change impact? "Developer"

## Supporting information

* Related to: https://github.com/openedx/xblock-lti-consumer/issues/594

## Testing instructions

See PR: https://github.com/openedx/xblock-lti-consumer/pull/627

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
