### PR TITLE
feat: Implement AuthZ checks on assets endpoints

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -135,7 +135,7 @@ def _authz_enforce_file_permissions(request, course_key):
                 LegacyAuthoringPermission.WRITE
             ):
                 raise PermissionDenied()
-        
+
         if request.method == 'DELETE' and not user_has_course_permission(
             request.user,
             COURSES_DELETE_FILES.identifier,

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -128,7 +128,7 @@ def _authz_enforce_file_permissions(request, course_key):
             ):
                 raise PermissionDenied()
             # When we get a PUT or POST and no file, it's an edit
-            elif request.method in ('PUT', 'POST') and not user_has_course_permission(
+            if request.method in ('PUT', 'POST') and not user_has_course_permission(
                 request.user,
                 COURSES_EDIT_FILES.identifier,
                 course_key,

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -17,6 +17,8 @@ from django.utils.translation import gettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods, require_POST
 from opaque_keys.edx.keys import AssetKey, CourseKey
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from pymongo import ASCENDING, DESCENDING
 
 from common.djangoapps.student.auth import has_course_author_access
@@ -25,6 +27,7 @@ from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.models import UserPreference
+from openedx_authz.constants.permissions import COURSES_VIEW_FILES, COURSES_CREATE_FILES, COURSES_DELETE_FILES, COURSES_EDIT_FILES
 from openedx_filters.content_authoring.filters import LMSPageURLRequested
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -73,13 +76,45 @@ def handle_assets(request, course_key_string=None, asset_key_string=None):
         json: delete an asset
     '''
     course_key = CourseKey.from_string(course_key_string)
-    if not has_course_author_access(request.user, course_key):
+    # Everyone should have at least view access to proceedd.
+    if not user_has_course_permission(
+        request.user,
+        COURSES_VIEW_FILES.identifier,
+        course_key,
+        LegacyAuthoringPermission.WRITE
+    ):
         raise PermissionDenied()
 
     response_format = get_response_format(request)
     if request_response_format_is_json(request, response_format):
         if request.method == 'GET':
             return _assets_json(request, course_key)
+
+        # Check create, edit and delete permissions for AuthZ-enabled courses.
+        # When we get a PUT or POST that includes a file, it's a create.
+        if request.method in ('PUT', 'POST') and 'file' in request.FILES and not user_has_course_permission(
+            request.user,
+            COURSES_CREATE_FILES.identifier,
+            course_key,
+            LegacyAuthoringPermission.WRITE
+        ):
+            raise PermissionDenied()
+        # When we get a PUT or POST and no file, it's an edit
+        if request.method in ('PUT', 'POST') and not user_has_course_permission(
+            request.user,
+            COURSES_EDIT_FILES.identifier,
+            course_key,
+            LegacyAuthoringPermission.WRITE
+        ):
+            raise PermissionDenied()
+
+        if request.method == 'DELETE' and not user_has_course_permission(
+            request.user,
+            COURSES_DELETE_FILES.identifier,
+            course_key,
+            LegacyAuthoringPermission.WRITE
+        ):
+            raise PermissionDenied()
 
         # POST, PUT, DELETE typically invoke this
         asset_key = AssetKey.from_string(asset_key_string) if asset_key_string else None
@@ -96,7 +131,12 @@ def get_asset_usage_path_json(request, course_key, asset_key_string):
     Get a list of units with ancestors that use given asset.
     """
     course_key = CourseKey.from_string(course_key)
-    if not has_course_author_access(request.user, course_key):
+    if not user_has_course_permission(
+        request.user,
+        COURSES_VIEW_FILES.identifier,
+        course_key,
+        LegacyAuthoringPermission.WRITE
+    ):
         raise PermissionDenied()
     asset_location = AssetKey.from_string(asset_key_string) if asset_key_string else None
     usage_locations = _get_asset_usage_path(course_key, [{'asset_key': asset_location}])

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -103,7 +103,7 @@ def _authz_enforce_file_permissions(request, course_key):
     """
     Enforce permissions for file operations in asset handler.
     When the authz.enable_course_authoring flag is enabled for the specified course,
-    This function enforces the appropiate file permission depending on request content.
+    This function enforces the appropriate file permission depending on request content.
     When the flag is disabled, it enforces the legacy has_studio_write_access permission.
     """
     # Enforce permission to view files.

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -98,6 +98,7 @@ def handle_assets(request, course_key_string=None, asset_key_string=None):
 
     return HttpResponseNotFound()
 
+
 def _authz_enforce_file_permissions(request, course_key):
     """
     Enforce permissions for file operations in asset handler.
@@ -105,7 +106,7 @@ def _authz_enforce_file_permissions(request, course_key):
     This function enforces the appropiate file permission depending on request content.
     When the flag is disabled, it enforces the legacy has_studio_write_access permission.
     """
-    # Enforce permisison to view files.
+    # Enforce permission to view files.
     # This is the minimum permission needed for handling assets.
     if not user_has_course_permission(
         request.user,
@@ -117,23 +118,24 @@ def _authz_enforce_file_permissions(request, course_key):
 
     if enable_authz_course_authoring(course_key):
         # Check create, edit and delete permissions for AuthZ-enabled courses.
-        # When we get a PUT or POST that includes a file, it's a create.
-        if request.method in ('PUT', 'POST') and 'file' in request.FILES and not user_has_course_permission(
-            request.user,
-            COURSES_CREATE_FILES.identifier,
-            course_key,
-            LegacyAuthoringPermission.WRITE
-        ):
-            raise PermissionDenied()
-        # When we get a PUT or POST and no file, it's an edit
-        if request.method in ('PUT', 'POST') and not user_has_course_permission(
-            request.user,
-            COURSES_EDIT_FILES.identifier,
-            course_key,
-            LegacyAuthoringPermission.WRITE
-        ):
-            raise PermissionDenied()
-
+        if request.method in ('PUT', 'POST'):
+            # When we get a PUT or POST that includes a file, it's a create.
+            if 'file' in request.FILES and not user_has_course_permission(
+                request.user,
+                COURSES_CREATE_FILES.identifier,
+                course_key,
+                LegacyAuthoringPermission.WRITE
+            ):
+                raise PermissionDenied()
+            # When we get a PUT or POST and no file, it's an edit
+            elif request.method in ('PUT', 'POST') and not user_has_course_permission(
+                request.user,
+                COURSES_EDIT_FILES.identifier,
+                course_key,
+                LegacyAuthoringPermission.WRITE
+            ):
+                raise PermissionDenied()
+        
         if request.method == 'DELETE' and not user_has_course_permission(
             request.user,
             COURSES_DELETE_FILES.identifier,
@@ -141,6 +143,7 @@ def _authz_enforce_file_permissions(request, course_key):
             LegacyAuthoringPermission.WRITE
         ):
             raise PermissionDenied()
+
 
 def get_asset_usage_path_json(request, course_key, asset_key_string):
     """

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -119,18 +119,15 @@ def _authz_enforce_file_permissions(request, course_key):
     if enable_authz_course_authoring(course_key):
         # Check create, edit and delete permissions for AuthZ-enabled courses.
         if request.method in ('PUT', 'POST'):
-            # When we get a PUT or POST that includes a file, it's a create.
-            if 'file' in request.FILES and not user_has_course_permission(
+            permission = (
+                COURSES_CREATE_FILES.identifier
+                if 'file' in request.FILES
+                else COURSES_EDIT_FILES.identifier
+            )
+        
+            if not user_has_course_permission(
                 request.user,
-                COURSES_CREATE_FILES.identifier,
-                course_key,
-                LegacyAuthoringPermission.WRITE
-            ):
-                raise PermissionDenied()
-            # When we get a PUT or POST and no file, it's an edit
-            if request.method in ('PUT', 'POST') and not user_has_course_permission(
-                request.user,
-                COURSES_EDIT_FILES.identifier,
+                permission,
                 course_key,
                 LegacyAuthoringPermission.WRITE
             ):

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -33,6 +33,7 @@ from openedx_authz.constants.permissions import (
     COURSES_EDIT_FILES,
 )
 from openedx_filters.content_authoring.filters import LMSPageURLRequested
+from openedx.core.toggles import enable_authz_course_authoring
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.exceptions import NotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -80,7 +81,32 @@ def handle_assets(request, course_key_string=None, asset_key_string=None):
         json: delete an asset
     '''
     course_key = CourseKey.from_string(course_key_string)
-    # Everyone should have at least view access to proceedd.
+    # Enforce file permissions.
+    _authz_enforce_file_permissions(request, course_key)
+
+    response_format = get_response_format(request)
+    if request_response_format_is_json(request, response_format):
+        if request.method == 'GET':
+            return _assets_json(request, course_key)
+
+        # POST, PUT, DELETE typically invoke this
+        asset_key = AssetKey.from_string(asset_key_string) if asset_key_string else None
+        return update_asset(request, course_key, asset_key)
+
+    elif request.method == 'GET':  # assume html
+        return _asset_index(request, course_key)
+
+    return HttpResponseNotFound()
+
+def _authz_enforce_file_permissions(request, course_key):
+    """
+    Enforce permissions for file operations in asset handler.
+    When the authz.enable_course_authoring flag is enabled for the specified course,
+    This function enforces the appropiate file permission depending on request content.
+    When the flag is disabled, it enforces the legacy has_studio_write_access permission.
+    """
+    # Enforce permisison to view files.
+    # This is the minimum permission needed for handling assets.
     if not user_has_course_permission(
         request.user,
         COURSES_VIEW_FILES.identifier,
@@ -89,11 +115,7 @@ def handle_assets(request, course_key_string=None, asset_key_string=None):
     ):
         raise PermissionDenied()
 
-    response_format = get_response_format(request)
-    if request_response_format_is_json(request, response_format):
-        if request.method == 'GET':
-            return _assets_json(request, course_key)
-
+    if enable_authz_course_authoring(course_key):
         # Check create, edit and delete permissions for AuthZ-enabled courses.
         # When we get a PUT or POST that includes a file, it's a create.
         if request.method in ('PUT', 'POST') and 'file' in request.FILES and not user_has_course_permission(
@@ -119,16 +141,6 @@ def handle_assets(request, course_key_string=None, asset_key_string=None):
             LegacyAuthoringPermission.WRITE
         ):
             raise PermissionDenied()
-
-        # POST, PUT, DELETE typically invoke this
-        asset_key = AssetKey.from_string(asset_key_string) if asset_key_string else None
-        return update_asset(request, course_key, asset_key)
-
-    elif request.method == 'GET':  # assume html
-        return _asset_index(request, course_key)
-
-    return HttpResponseNotFound()
-
 
 def get_asset_usage_path_json(request, course_key, asset_key_string):
     """

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -124,7 +124,7 @@ def _authz_enforce_file_permissions(request, course_key):
                 if 'file' in request.FILES
                 else COURSES_EDIT_FILES.identifier
             )
-        
+
             if not user_has_course_permission(
                 request.user,
                 permission,

--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -21,13 +21,17 @@ from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
 from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from pymongo import ASCENDING, DESCENDING
 
-from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.util.date_utils import get_default_time_display
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.models import UserPreference
-from openedx_authz.constants.permissions import COURSES_VIEW_FILES, COURSES_CREATE_FILES, COURSES_DELETE_FILES, COURSES_EDIT_FILES
+from openedx_authz.constants.permissions import (
+    COURSES_VIEW_FILES,
+    COURSES_CREATE_FILES,
+    COURSES_DELETE_FILES,
+    COURSES_EDIT_FILES,
+)
 from openedx_filters.content_authoring.filters import LMSPageURLRequested
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -594,7 +594,7 @@ class DeleteAssetTestCase(AssetsTestCase):
         self.assertEqual(resp.status_code, 204)
 
 
-class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
+class AssetsEndpointsAuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
     """
     Unit tests for validating authorization on Assets endpoints when AuthZ is enabled.
     """
@@ -657,13 +657,11 @@ class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
 
         # PUT assets_handler forbidden
         resp = self._put_asset(client)
-        if resp is not None:
-            self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
         # DELETE assets_handler forbidden
         resp = self._delete_asset(client)
-        if resp is not None:
-            self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
     def test_editor_permissions(self):
         """Editor: read/create/edit allowed, delete forbidden."""
@@ -686,13 +684,11 @@ class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
 
         # PUT assets_handler allowed
         resp = self._put_asset(client)
-        if resp is not None:
-            self.assertIn(resp.status_code, [200, 201])
+        self.assertIn(resp.status_code, [200, 201])
 
         # DELETE assets_handler forbidden
         resp = self._delete_asset(client)
-        if resp is not None:
-            self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
     def test_admin_permissions(self):
         """Admin: full access."""
@@ -715,13 +711,11 @@ class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
 
         # PUT assets_handler allowed
         resp = self._put_asset(client)
-        if resp is not None:
-            self.assertIn(resp.status_code, [200, 201])
+        self.assertIn(resp.status_code, [200, 201])
 
         # DELETE assets_handler allowed
         resp = self._delete_asset(client)
-        if resp is not None:
-            self.assertEqual(resp.status_code, 204)
+        self.assertEqual(resp.status_code, 204)
 
     def test_no_role_permissions(self):
         """No role: all forbidden."""
@@ -743,10 +737,8 @@ class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
 
         # PUT assets_handler forbidden
         resp = self._put_asset(client)
-        if resp is not None:
-            self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
         # DELETE assets_handler forbidden
         resp = self._delete_asset(client)
-        if resp is not None:
-            self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -14,13 +14,18 @@ from django.conf import settings
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import AssetKey
 from opaque_keys.edx.locator import CourseLocator
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_EDITOR, COURSE_ADMIN
+from rest_framework.test import APIClient
+
 from PIL import Image
 from pytz import UTC
 
+from common.djangoapps.student.tests.factories import UserFactory
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
 from cms.djangoapps.contentstore.views import assets
 from common.djangoapps.static_replace import replace_static_urls
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthzTestMixin
 from xmodule.assetstore import AssetMetadata  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -587,3 +592,151 @@ class DeleteAssetTestCase(AssetsTestCase):
         contentstore().save(self.content)
         resp = self.client.delete(test_url, HTTP_ACCEPT="application/json")
         self.assertEqual(resp.status_code, 204)
+
+
+class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
+    """
+    Unit tests for validating authorization on Assets endpoints when AuthZ is enabled.
+    """
+
+    authz_roles_to_assign = []
+
+    def setUp(self):
+        super().setUp()
+
+        self.course_key = self.course.id
+
+        # Upload a file for GET/PUT/DELETE tests
+        r = self.upload_asset('authz_test_file')
+
+        if r.status_code == 200:
+            sample_asset_key = json.loads(r.content.decode('utf-8'))['asset']['id']
+            self.asset_url = reverse_course_url('assets_handler', self.course.id, kwargs={'asset_key_string': sample_asset_key})
+            self.asset_usage_url = reverse_course_url('asset_usage_path_handler', self.course.id, kwargs={'asset_key_string': sample_asset_key})
+
+    def _put_asset(self, client):
+        # Simulate a PUT (edit) request with a JSON body
+        return client.put(
+            self.asset_url,
+            data=json.dumps({"locked": True}),
+            content_type="application/json"
+        )
+
+    def _delete_asset(self, client):
+        return client.delete(self.asset_url, HTTP_ACCEPT="application/json")
+
+    def test_auditor_permissions(self):
+        """Auditor: read allowed, write/edit/delete forbidden."""
+        user = UserFactory(password=self.user_password)
+        self.add_user_to_role(user, COURSE_AUDITOR.external_key)
+
+        client = APIClient()
+        client.login(username=user.username, password=self.user_password)
+
+        # GET assets_handler allowed
+        resp = client.get(self.asset_url)
+        self.assertEqual(resp.status_code, 200)
+
+        # GET asset_usage_path_handler allowed
+        resp = client.get(self.asset_usage_url)
+        self.assertEqual(resp.status_code, 200)
+
+        # POST assets_handler forbidden
+        resp = client.post(self.url, {"name": "file", "file": self.get_sample_asset('file')})
+        self.assertEqual(resp.status_code, 403)
+
+        # PUT assets_handler forbidden
+        resp = self._put_asset(client)
+        if resp is not None:
+            self.assertEqual(resp.status_code, 403)
+
+        # DELETE assets_handler forbidden
+        resp = self._delete_asset(client)
+        if resp is not None:
+            self.assertEqual(resp.status_code, 403)
+
+    def test_editor_permissions(self):
+        """Editor: read/create/edit allowed, delete forbidden."""
+        user = UserFactory(password=self.user_password)
+        self.add_user_to_role(user, COURSE_EDITOR.external_key)
+        client = APIClient()
+        client.login(username=user.username, password=self.user_password)
+
+        # GET assets_handler allowed
+        resp = client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+
+        # GET asset_usage_path_handler allowed
+        resp = client.get(self.asset_usage_url)
+        self.assertEqual(resp.status_code, 200)
+
+        # POST assets_handler allowed
+        resp = client.post(self.url, {"name": "file", "file": self.get_sample_asset('file')})
+        self.assertEqual(resp.status_code, 200)
+
+        # PUT assets_handler allowed
+        resp = self._put_asset(client)
+        if resp is not None:
+            self.assertIn(resp.status_code, [200, 201])
+
+        # DELETE assets_handler forbidden
+        resp = self._delete_asset(client)
+        if resp is not None:
+            self.assertEqual(resp.status_code, 403)
+
+    def test_admin_permissions(self):
+        """Admin: full access."""
+        user = UserFactory(password=self.user_password)
+        self.add_user_to_role(user, COURSE_ADMIN.external_key)
+        client = APIClient()
+        client.login(username=user.username, password=self.user_password)
+
+        # GET assets_handler allowed
+        resp = client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+
+        # GET asset_usage_path_handler allowed
+        resp = client.get(self.asset_usage_url)
+        self.assertEqual(resp.status_code, 200)
+
+        # POST assets_handler allowed
+        resp = client.post(self.url, {"name": "file", "file": self.get_sample_asset('file')})
+        self.assertEqual(resp.status_code, 200)
+
+        # PUT assets_handler allowed
+        resp = self._put_asset(client)
+        if resp is not None:
+            self.assertIn(resp.status_code, [200, 201])
+
+        # DELETE assets_handler allowed
+        resp = self._delete_asset(client)
+        if resp is not None:
+            self.assertEqual(resp.status_code, 204)
+
+    def test_no_role_permissions(self):
+        """No role: all forbidden."""
+        user = UserFactory(password=self.user_password)
+        client = APIClient()
+        client.login(username=user.username, password=self.user_password)
+
+        # GET assets_handler forbidden
+        resp = client.get(self.url)
+        self.assertEqual(resp.status_code, 403)
+
+        # GET asset_usage_path_handler forbidden
+        resp = client.get(self.asset_usage_url)
+        self.assertEqual(resp.status_code, 403)
+
+        # POST assets_handler forbidden
+        resp = client.post(self.url, {"name": "file", "file": self.get_sample_asset('file')})
+        self.assertEqual(resp.status_code, 403)
+
+        # PUT assets_handler forbidden
+        resp = self._put_asset(client)
+        if resp is not None:
+            self.assertEqual(resp.status_code, 403)
+
+        # DELETE assets_handler forbidden
+        resp = self._delete_asset(client)
+        if resp is not None:
+            self.assertEqual(resp.status_code, 403)

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -601,10 +601,12 @@ class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
 
     authz_roles_to_assign = []
 
+    @property
+    def course_key(self):
+        return self.course.id
+
     def setUp(self):
         super().setUp()
-
-        self.course_key = self.course.id
 
         # Upload a file for GET/PUT/DELETE tests
         r = self.upload_asset('authz_test_file')

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -611,8 +611,16 @@ class AuthzTestCase(CourseAuthzTestMixin, AssetsTestCase):
 
         if r.status_code == 200:
             sample_asset_key = json.loads(r.content.decode('utf-8'))['asset']['id']
-            self.asset_url = reverse_course_url('assets_handler', self.course.id, kwargs={'asset_key_string': sample_asset_key})
-            self.asset_usage_url = reverse_course_url('asset_usage_path_handler', self.course.id, kwargs={'asset_key_string': sample_asset_key})
+            self.asset_url = reverse_course_url(
+                'assets_handler',
+                self.course.id,
+                kwargs={'asset_key_string': sample_asset_key}
+            )
+            self.asset_usage_url = reverse_course_url(
+                'asset_usage_path_handler',
+                self.course.id,
+                kwargs={'asset_key_string': sample_asset_key}
+            )
 
     def _put_asset(self, client):
         # Simulate a PUT (edit) request with a JSON body

--- a/openedx/core/djangoapps/authz/tests/mixins.py
+++ b/openedx/core/djangoapps/authz/tests/mixins.py
@@ -45,8 +45,8 @@ class CourseAuthoringAuthzTestMixin:
 
         self._seed_policies()
 
-        self.authorized_user = UserFactory()
-        self.unauthorized_user = UserFactory()
+        self.authorized_user = UserFactory(password=self.password) if hasattr(self, 'password') else UserFactory()
+        self.unauthorized_user = UserFactory(password=self.password) if hasattr(self, 'password') else UserFactory()
 
         self.authorized_client = APIClient()
         self.authorized_client.force_authenticate(user=self.authorized_user)

--- a/openedx/core/djangoapps/authz/tests/mixins.py
+++ b/openedx/core/djangoapps/authz/tests/mixins.py
@@ -45,8 +45,8 @@ class CourseAuthoringAuthzTestMixin:
 
         self._seed_policies()
 
-        self.authorized_user = UserFactory(password=self.password) if hasattr(self, 'password') else UserFactory()
-        self.unauthorized_user = UserFactory(password=self.password) if hasattr(self, 'password') else UserFactory()
+        self.authorized_user = UserFactory()
+        self.unauthorized_user = UserFactory()
 
         self.authorized_client = APIClient()
         self.authorized_client.force_authenticate(user=self.authorized_user)


### PR DESCRIPTION
## Description

Implement new AuthZ permission checks over endpoints related with file assets handling in course authoring.

The new AuthZ permission checks only apply when the enable_authz_course_authoring feature flag is enabled for the specific course, or globally, otherwise existing behavior persist.

The following AuthZ permissions are being used:

- courses.view_files
- courses.create_files
- courses.edit_files
- courses.delete_files

The following endpoints were updated:

- GET /assets/(courseid)/: List Filles, Permission: courses.view_files
- GET /assets/(courseid)/(assetid)/usage: Get file info, Permission: courses.view_files
- POST /assets/(courseid)/: Upload file, Permission: courses.create_files
- PUT /assets/(courseid)/(assetid)/: Lock file, Permission: courses.edit_files
- DELETE /assets/(courseid)/(assetid)/: Delete file, Permission: courses.delete_files

## Supporting information

Closes https://github.com/openedx/openedx-authz/issues/193

## Testing

Verified that:

- Authorized users can access the endpoints.
- Unauthorized users receive a 403 response.
- Legacy permission fallback works as expected.

Running relevant tests manually:

On a cms container (run with `tutor dev exec cms bash`), do:

```bash
pytest -p no:randomly --ds=cms.envs.test cms/djangoapps/contentstore/views/tests/test_assets.py
```

## Deadline

Verawood
