### PR TITLE
feat: add authz permission for the course authoring list

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -34,12 +34,12 @@ from common.djangoapps.student.roles import (
     UserBasedRole,
 )
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core import toggles as core_toggles
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.testing.utils import AUTHZ_TABLES
-from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
-from openedx.core import toggles as core_toggles
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,  # lint-amnesty, pylint: disable=wrong-import-order
@@ -489,7 +489,7 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
 
         self.assertEqual(len(courses), 1)
         self.assertEqual(courses[0].id, course1.id)
-        self.assertEqual(course2.id, course_key_2)
+        self.assertNotIn(course_key_2, {c.id for c in courses})
 
     def test_course_listing_with_course_editor_authz_permission(self):
         """
@@ -518,7 +518,7 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
 
         self.assertEqual(len(courses), 1)
         self.assertEqual(courses[0].id, course1.id)
-        self.assertEqual(course2.id, course_key_2)
+        self.assertNotIn(course_key_2, {c.id for c in courses})
 
     def test_course_listing_without_permissions(self):
         """

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -6,12 +6,12 @@ by reversing group name formats.
 import random
 from unittest.mock import Mock, patch
 
-import casbin
-import pkg_resources
 import ddt
 from ccx_keys.locator import CCXLocator
 from django.test import RequestFactory
 from opaque_keys.edx.locations import CourseLocator
+from openedx_authz.api.users import assign_role_to_user_in_scope
+from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_EDITOR, COURSE_STAFF
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
 from cms.djangoapps.contentstore.utils import delete_course
@@ -34,11 +34,12 @@ from common.djangoapps.student.roles import (
     UserBasedRole,
 )
 from common.djangoapps.student.tests.factories import UserFactory
-from common.djangoapps.util import course
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.testing.utils import AUTHZ_TABLES
+from openedx.core.djangoapps.authz.tests.mixins import AuthzTestMixin
+from openedx.core import toggles as core_toggles
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,  # lint-amnesty, pylint: disable=wrong-import-order
@@ -50,81 +51,6 @@ USER_COURSES_COUNT = 1
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES + AUTHZ_TABLES
 
-from rest_framework.test import APIClient
-from openedx_authz.api.users import assign_role_to_user_in_scope
-from openedx_authz.constants.roles import COURSE_STAFF, COURSE_EDITOR, COURSE_DATA_RESEARCHER
-from openedx_authz.engine.enforcer import AuthzEnforcer
-from openedx_authz.engine.utils import migrate_policy_between_enforcers
-
-from openedx.core import toggles as core_toggles
-
-
-class AuthzTestMixin:
-    """
-    Minimal reusable mixin for AuthZ-enabled tests.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.toggle_patcher = patch.object(
-            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
-            "is_enabled",
-            return_value=True,
-        )
-        cls.toggle_patcher.start()
-        super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.toggle_patcher.stop()
-        super().tearDownClass()
-
-    def setUp(self):
-        super().setUp()
-
-        self._seed_policies()
-
-        self.authorized_user = UserFactory()
-        self.unauthorized_user = UserFactory()
-
-        self.authorized_client = APIClient()
-        self.authorized_client.force_authenticate(user=self.authorized_user)
-
-        self.unauthorized_client = APIClient()
-        self.unauthorized_client.force_authenticate(user=self.unauthorized_user)
-
-    def tearDown(self):
-        super().tearDown()
-        AuthzEnforcer.get_enforcer().clear_policy()
-
-    def add_user_to_role(self, user, role, course_key):
-        """Helper method to add a user to a role for the course."""
-        assign_role_to_user_in_scope(
-            user.username,
-            role,
-            str(course_key)
-        )
-        AuthzEnforcer.get_enforcer().load_policy()
-
-    @classmethod
-    def _seed_policies(cls):
-        global_enforcer = AuthzEnforcer.get_enforcer()
-        global_enforcer.load_policy()
-
-        model_path = pkg_resources.resource_filename(
-            "openedx_authz.engine",
-            "config/model.conf",
-        )
-
-        policy_path = pkg_resources.resource_filename(
-            "openedx_authz.engine",
-            "config/authz.policy",
-        )
-
-        migrate_policy_between_enforcers(
-            source_enforcer=casbin.Enforcer(model_path, policy_path),
-            target_enforcer=global_enforcer,
-        )
 
 @ddt.ddt
 class TestCourseListing(ModuleStoreTestCase):
@@ -499,6 +425,7 @@ class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
         self.factory = RequestFactory()
 
     def _create_course(self, course_key):
+        """Helper method to create a course and its overview."""
         course = CourseFactory.create(
             org=course_key.org,
             number=course_key.course,
@@ -665,7 +592,11 @@ class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
             # so these three courses should be returned in the course listing even if the toggle is enabled
             # for authz_enable_course_3 but no role is assigned for it.
             self.assertEqual(len(courses), 3)
-            self.assertTrue(all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, legacy_course_1.id] for course in courses))
+            self.assertTrue(
+                all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, legacy_course_1.id]
+                    for course in courses
+                )
+            )
 
             # Case 2: Staff user should have access to all courses regardless of authz permissions.
             # Pending authz_course_3 to check as staff
@@ -673,7 +604,14 @@ class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
             courses_list, _ = get_courses_accessible_to_user(request)
             courses = list(courses_list)
             self.assertEqual(len(courses), 6)
-            self.assertTrue(all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id, legacy_course_1.id, legacy_course_2.id, legacy_course_3.id] for course in courses))
+            self.assertTrue(
+                all(
+                    course.id in
+                    [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id,
+                     legacy_course_1.id, legacy_course_2.id, legacy_course_3.id]
+                    for course in courses
+                )
+            )
 
             # Case 3: Superuser should have access to all courses regardless of authz permissions.
             superuser = UserFactory(is_superuser=True)
@@ -681,4 +619,11 @@ class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
             courses_list, _ = get_courses_accessible_to_user(request)
             courses = list(courses_list)
             self.assertEqual(len(courses), 6)
-            self.assertTrue(all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id, legacy_course_1.id, legacy_course_2.id, legacy_course_3.id] for course in courses))
+            self.assertTrue(
+                all(
+                    course.id in
+                    [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id,
+                     legacy_course_1.id, legacy_course_2.id, legacy_course_3.id]
+                    for course in courses
+                )
+            )

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -6,6 +6,8 @@ by reversing group name formats.
 import random
 from unittest.mock import Mock, patch
 
+import casbin
+import pkg_resources
 import ddt
 from ccx_keys.locator import CCXLocator
 from django.test import RequestFactory
@@ -47,6 +49,81 @@ USER_COURSES_COUNT = 1
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES + AUTHZ_TABLES
 
+from rest_framework.test import APIClient
+from openedx_authz.api.users import assign_role_to_user_in_scope
+from openedx_authz.constants.roles import COURSE_STAFF, COURSE_EDITOR, COURSE_DATA_RESEARCHER
+from openedx_authz.engine.enforcer import AuthzEnforcer
+from openedx_authz.engine.utils import migrate_policy_between_enforcers
+
+from openedx.core import toggles as core_toggles
+
+
+class AuthzTestMixin:
+    """
+    Minimal reusable mixin for AuthZ-enabled tests.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.toggle_patcher = patch.object(
+            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
+            "is_enabled",
+            return_value=True,
+        )
+        cls.toggle_patcher.start()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.toggle_patcher.stop()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+
+        self._seed_policies()
+
+        self.authorized_user = UserFactory()
+        self.unauthorized_user = UserFactory()
+
+        self.authorized_client = APIClient()
+        self.authorized_client.force_authenticate(user=self.authorized_user)
+
+        self.unauthorized_client = APIClient()
+        self.unauthorized_client.force_authenticate(user=self.unauthorized_user)
+
+    def tearDown(self):
+        super().tearDown()
+        AuthzEnforcer.get_enforcer().clear_policy()
+
+    def add_user_to_role(self, user, role, course_key):
+        """Helper method to add a user to a role for the course."""
+        assign_role_to_user_in_scope(
+            user.username,
+            role,
+            str(course_key)
+        )
+        AuthzEnforcer.get_enforcer().load_policy()
+
+    @classmethod
+    def _seed_policies(cls):
+        global_enforcer = AuthzEnforcer.get_enforcer()
+        global_enforcer.load_policy()
+
+        model_path = pkg_resources.resource_filename(
+            "openedx_authz.engine",
+            "config/model.conf",
+        )
+
+        policy_path = pkg_resources.resource_filename(
+            "openedx_authz.engine",
+            "config/authz.policy",
+        )
+
+        migrate_policy_between_enforcers(
+            source_enforcer=casbin.Enforcer(model_path, policy_path),
+            target_enforcer=global_enforcer,
+        )
 
 @ddt.ddt
 class TestCourseListing(ModuleStoreTestCase):
@@ -407,3 +484,112 @@ class TestCourseListing(ModuleStoreTestCase):
         self.assertSetEqual(
             _set_of_course_keys(courses_in_progress), _set_of_course_keys(unsucceeded_course_actions, 'course_key')
         )
+
+
+
+class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
+    """
+    Tests course listing using the new AuthZ authorization framework.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.factory = RequestFactory()
+
+    def _create_course(self, course_key):
+        course = CourseFactory.create(
+            org=course_key.org,
+            number=course_key.course,
+            run=course_key.run,
+        )
+
+        return CourseOverviewFactory.create(id=course.id, org=course_key.org)
+
+    def test_course_listing_with_course_staff_authz_permission(self):
+        # Create courses and assign access to only some of them to the user.
+        # Verify that only those courses are returned in the course listing.
+        # Using COURSE_STAFF role here.
+
+        course_key_1 = CourseLocator("Org1", "Course1", "Run1")
+        course1 = self._create_course(course_key_1)
+
+        course_key_2 = CourseLocator("Org1", "Course2", "Run1")
+        course2 = self._create_course(course_key_2)
+
+        assign_role_to_user_in_scope(
+            self.authorized_user.username,
+            COURSE_STAFF.external_key,
+            str(course_key_1),
+        )
+
+        request = self.factory.get("/course")
+        request.user = self.authorized_user
+
+        courses_list, _ = get_courses_accessible_to_user(request)
+
+        courses = list(courses_list)
+
+        self.assertEqual(len(courses), 1)
+        self.assertEqual(courses[0].id, course1.id)
+        self.assertEqual(course2.id, course_key_2)
+
+    def test_course_listing_with_course_editor_authz_permission(self):
+        # Create courses and assign access to only some of them to the user.
+        # Verify that only those courses are returned in the course listing.
+        # Using COURSE_EDITOR role here.
+
+        course_key_1 = CourseLocator("Org1", "Course1", "Run1")
+        course1 = self._create_course(course_key_1)
+
+        course_key_2 = CourseLocator("Org1", "Course2", "Run1")
+        course2 = self._create_course(course_key_2)
+
+        assign_role_to_user_in_scope(
+            self.authorized_user.username,
+            COURSE_EDITOR.external_key,
+            str(course_key_1),
+        )
+
+        request = self.factory.get("/course")
+        request.user = self.authorized_user
+
+        courses_list, _ = get_courses_accessible_to_user(request)
+
+        courses = list(courses_list)
+
+        self.assertEqual(len(courses), 1)
+        self.assertEqual(courses[0].id, course1.id)
+        self.assertEqual(course2.id, course_key_2)
+
+    def test_course_listing_without_permissions(self):
+        # Create a course but do not assign access to the user.
+        # Verify that no courses are returned in the course listing.
+
+        course_key = CourseLocator("Org1", "Course1", "Run1")
+
+        self._create_course(course_key)
+
+        request = self.factory.get("/course")
+        request.user = self.unauthorized_user
+
+        courses_list, _ = get_courses_accessible_to_user(request)
+
+        self.assertEqual(len(list(courses_list)), 0)
+
+    def test_non_staff_user_cannot_access(self):
+        """
+        Create a course and assign a non-staff role to the user.
+        Verify that the course is not returned in the course listing.
+        """
+        non_staff_user = UserFactory()
+        course_key = CourseLocator("Org1", "Course1", "Run1")
+        self._create_course(course_key)
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key, course_key)
+
+        request = self.factory.get("/course")
+        request.user = non_staff_user
+
+        courses_list, _ = get_courses_accessible_to_user(request)
+
+        self.assertEqual(len(list(courses_list)), 0)

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -34,6 +34,7 @@ from common.djangoapps.student.roles import (
     UserBasedRole,
 )
 from common.djangoapps.student.tests.factories import UserFactory
+from common.djangoapps.util import course
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
@@ -593,3 +594,91 @@ class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
         courses_list, _ = get_courses_accessible_to_user(request)
 
         self.assertEqual(len(list(courses_list)), 0)
+
+    def test_course_listing_with_mix_authz_and_legacy_permissions(self):
+        authz_courses_keys = {
+            "course-v1:Org1+Course1+AuthzRun",
+            "course-v1:Org1+Course2+AuthzRun",
+            "course-v1:Org1+Course3+AuthzRun",
+        }
+
+        authz_courses = []
+        legacy_courses = []
+
+        def mock_is_enabled(*args, **kwargs):
+            # Extract course key from context (depends on how it's passed)
+            course_key = kwargs.get("context") or (args[0] if args else None)
+            return str(course_key) in authz_courses_keys
+
+        with patch.object(
+            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
+            "is_enabled",
+            side_effect=mock_is_enabled,
+        ):
+            # Courses with authz flag enabled
+            authz_enable_course_key_1 = CourseLocator("Org1", "Course1", "AuthzRun")
+            authz_enable_course_1 = self._create_course(authz_enable_course_key_1)
+
+            authz_enable_course_key_2 = CourseLocator("Org1", "Course2", "AuthzRun")
+            authz_enable_course_2 = self._create_course(authz_enable_course_key_2)
+
+            authz_enable_course_key_3 = CourseLocator("Org1", "Course3", "AuthzRun")
+            authz_enable_course_3 = self._create_course(authz_enable_course_key_3)
+
+            authz_courses.extend([authz_enable_course_1, authz_enable_course_2, authz_enable_course_3])
+
+            # Courses without authz flag enabled (legacy courses)
+            legacy_course_key_1 = CourseLocator("Org1", "Course1", "LegacyRun")
+            legacy_course_1 = self._create_course(legacy_course_key_1)
+
+            legacy_course_key_2 = CourseLocator("Org1", "Course2", "LegacyRun")
+            legacy_course_2 = self._create_course(legacy_course_key_2)
+
+            legacy_course_key_3 = CourseLocator("Org1", "Course3", "LegacyRun")
+            legacy_course_3 = self._create_course(legacy_course_key_3)
+
+            legacy_courses.extend([legacy_course_1, legacy_course_2, legacy_course_3])
+
+            # Assign roles
+            assign_role_to_user_in_scope(
+                self.authorized_user.username,
+                COURSE_STAFF.external_key,
+                str(authz_enable_course_key_1),
+            )
+
+            assign_role_to_user_in_scope(
+                self.authorized_user.username,
+                COURSE_STAFF.external_key,
+                str(authz_enable_course_key_2),
+            )
+
+            CourseInstructorRole(legacy_course_key_1).add_users(self.authorized_user)
+
+            request = self.factory.get("/course")
+            request.user = self.authorized_user
+
+            courses_list, _ = get_courses_accessible_to_user(request)
+            courses = list(courses_list)
+
+            # Case 1: authorized user is added as a CourseStaff role is assigned for authz_enable_course_1,
+            # authz_enable_course_2 and CourseInstructor role is assigned for legacy_course_1,
+            # so these three courses should be returned in the course listing even if the toggle is enabled
+            # for authz_enable_course_3 but no role is assigned for it.
+            self.assertEqual(len(courses), 3)
+            self.assertTrue(all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, legacy_course_1.id] for course in courses))
+
+            # Case 2: Staff user should have access to all courses regardless of authz permissions.
+            # Pending authz_course_3 to check as staff
+            GlobalStaff().add_users(self.authorized_user)
+            courses_list, _ = get_courses_accessible_to_user(request)
+            courses = list(courses_list)
+            self.assertEqual(len(courses), 6)
+            self.assertTrue(all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id, legacy_course_1.id, legacy_course_2.id, legacy_course_3.id] for course in courses))
+
+            # Case 3: Superuser should have access to all courses regardless of authz permissions.
+            superuser = UserFactory(is_superuser=True)
+            request.user = superuser
+            courses_list, _ = get_courses_accessible_to_user(request)
+            courses = list(courses_list)
+            self.assertEqual(len(courses), 6)
+            self.assertTrue(all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id, legacy_course_1.id, legacy_course_2.id, legacy_course_3.id] for course in courses))

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -413,7 +413,6 @@ class TestCourseListing(ModuleStoreTestCase):
         )
 
 
-@ddt.ddt
 class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase):
     """
     Tests course listing using the new AuthZ authorization framework.
@@ -433,94 +432,6 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         )
 
         return CourseOverviewFactory.create(id=course.id, org=course_key.org)
-
-    def test_course_listing_with_course_staff_authz_permission(self):
-        # Create courses and assign access to only some of them to the user.
-        # Verify that only those courses are returned in the course listing.
-        # Using COURSE_STAFF role here.
-
-        course_key_1 = CourseLocator("Org1", "Course1", "Run1")
-        course1 = self._create_course(course_key_1)
-
-        course_key_2 = CourseLocator("Org1", "Course2", "Run1")
-        course2 = self._create_course(course_key_2)
-
-        assign_role_to_user_in_scope(
-            self.authorized_user.username,
-            COURSE_STAFF.external_key,
-            str(course_key_1),
-        )
-
-        request = self.factory.get("/course")
-        request.user = self.authorized_user
-
-        courses_list, _ = get_courses_accessible_to_user(request)
-
-        courses = list(courses_list)
-
-        self.assertEqual(len(courses), 1)
-        self.assertEqual(courses[0].id, course1.id)
-        self.assertEqual(course2.id, course_key_2)
-
-    def test_course_listing_with_course_editor_authz_permission(self):
-        # Create courses and assign access to only some of them to the user.
-        # Verify that only those courses are returned in the course listing.
-        # Using COURSE_EDITOR role here.
-
-        course_key_1 = CourseLocator("Org1", "Course1", "Run1")
-        course1 = self._create_course(course_key_1)
-
-        course_key_2 = CourseLocator("Org1", "Course2", "Run1")
-        course2 = self._create_course(course_key_2)
-
-        assign_role_to_user_in_scope(
-            self.authorized_user.username,
-            COURSE_EDITOR.external_key,
-            str(course_key_1),
-        )
-
-        request = self.factory.get("/course")
-        request.user = self.authorized_user
-
-        courses_list, _ = get_courses_accessible_to_user(request)
-
-        courses = list(courses_list)
-
-        self.assertEqual(len(courses), 1)
-        self.assertEqual(courses[0].id, course1.id)
-        self.assertEqual(course2.id, course_key_2)
-
-    def test_course_listing_without_permissions(self):
-        # Create a course but do not assign access to the user.
-        # Verify that no courses are returned in the course listing.
-
-        course_key = CourseLocator("Org1", "Course1", "Run1")
-
-        self._create_course(course_key)
-
-        request = self.factory.get("/course")
-        request.user = self.unauthorized_user
-
-        courses_list, _ = get_courses_accessible_to_user(request)
-
-        self.assertEqual(len(list(courses_list)), 0)
-
-    def test_non_staff_user_cannot_access(self):
-        """
-        Create a course and assign a non-staff role to the user.
-        Verify that the course is not returned in the course listing.
-        """
-        non_staff_user = UserFactory()
-        course_key = CourseLocator("Org1", "Course1", "Run1")
-        self._create_course(course_key)
-        self.add_user_to_role_in_course(non_staff_user, COURSE_DATA_RESEARCHER.external_key, course_key)
-
-        request = self.factory.get("/course")
-        request.user = non_staff_user
-
-        courses_list, _ = get_courses_accessible_to_user(request)
-
-        self.assertEqual(len(list(courses_list)), 0)
 
     def _mock_authz_toggle(self, enabled_keys):
         def _is_enabled(course_key=None, **_):
@@ -551,133 +462,256 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
 
         return authz_keys, legacy_keys, authz_courses, legacy_courses
 
-    @ddt.data(
-        {
-            "name": "authz_and_legacy_basic",
-            "is_staff": False,
-            "is_superuser": False,
-            "authz_enabled": [0, 2],  # toggle ON for Course1, Course3
+    def test_course_listing_with_course_staff_authz_permission(self):
+        """
+        Create courses and assign access to only some of them to the user.
+        Verify that only those courses are returned in the course listing.
+        Using COURSE_STAFF role here.
+        """
+        course_key_1 = CourseLocator("Org1", "Course1", "Run1")
+        course1 = self._create_course(course_key_1)
 
-            "authz_roles": [
-                {"index": 0, "role": COURSE_STAFF},   # valid (toggle ON)
-                {"index": 1, "role": COURSE_EDITOR},  # ignored (toggle OFF)
-            ],
-            "legacy_roles": [0],
+        course_key_2 = CourseLocator("Org1", "Course2", "Run1")
+        course2 = self._create_course(course_key_2)
 
-            "expected": [("authz", 0), ("legacy", 0)],
-        },
-        {
-            "name": "authz_role_but_toggle_off",
-            "is_staff": False,
-            "is_superuser": False,
-            "authz_enabled": [2],  # only Course3 enabled
+        assign_role_to_user_in_scope(
+            self.authorized_user.username,
+            COURSE_STAFF.external_key,
+            str(course_key_1),
+        )
 
-            "authz_roles": [
-                {"index": 1, "role": COURSE_EDITOR},  # should NOT appear
-            ],
-            "legacy_roles": [],
+        request = self.factory.get("/course")
+        request.user = self.authorized_user
 
-            "expected": [],
-        },
-        {
-            "name": "multiple_roles_mixed",
-            "is_staff": False,
-            "is_superuser": False,
-            "authz_enabled": [0, 1, 2],
+        courses_list, _ = get_courses_accessible_to_user(request)
 
-            "authz_roles": [
-                {"index": 0, "role": COURSE_STAFF},
-                {"index": 1, "role": COURSE_EDITOR},
-            ],
-            "legacy_roles": [2],
+        courses = list(courses_list)
 
-            "expected": [("authz", 0), ("authz", 1), ("legacy", 2)],
-        },
-        {
-            "name": "staff_gets_all",
-            "is_staff": True,
-            "is_superuser": False,
-            "authz_enabled": [],
+        self.assertEqual(len(courses), 1)
+        self.assertEqual(courses[0].id, course1.id)
+        self.assertEqual(course2.id, course_key_2)
 
-            "authz_roles": [],
-            "legacy_roles": [],
+    def test_course_listing_with_course_editor_authz_permission(self):
+        """
+        Create courses and assign access to only some of them to the user.
+        Verify that only those courses are returned in the course listing.
+        Using COURSE_EDITOR role here.
+        """
+        course_key_1 = CourseLocator("Org1", "Course1", "Run1")
+        course1 = self._create_course(course_key_1)
 
-            "expected": [
-                ("authz", 0), ("authz", 1), ("authz", 2),
-                ("legacy", 0), ("legacy", 1), ("legacy", 2),
-            ],
-        },
-        {
-            "name": "superuser_gets_all",
-            "is_staff": False,
-            "is_superuser": True,
-            "authz_enabled": [],
+        course_key_2 = CourseLocator("Org1", "Course2", "Run1")
+        course2 = self._create_course(course_key_2)
 
-            "authz_roles": [],
-            "legacy_roles": [],
+        assign_role_to_user_in_scope(
+            self.authorized_user.username,
+            COURSE_EDITOR.external_key,
+            str(course_key_1),
+        )
 
-            "expected": [
-                ("authz", 0), ("authz", 1), ("authz", 2),
-                ("legacy", 0), ("legacy", 1), ("legacy", 2),
-            ],
-        },
-    )
-    @ddt.unpack
-    def test_course_access_matrix(
-        self,
-        name,
-        is_staff,
-        is_superuser,
-        authz_enabled,
-        authz_roles,
-        legacy_roles,
-        expected,
-    ):
-        # --- Setup toggle ---
-        enabled_keys = set()
+        request = self.factory.get("/course")
+        request.user = self.authorized_user
 
+        courses_list, _ = get_courses_accessible_to_user(request)
+
+        courses = list(courses_list)
+
+        self.assertEqual(len(courses), 1)
+        self.assertEqual(courses[0].id, course1.id)
+        self.assertEqual(course2.id, course_key_2)
+
+    def test_course_listing_without_permissions(self):
+        """
+        Create a course but do not assign access to the user.
+        Verify that no courses are returned in the course listing.
+        """
+        course_key = CourseLocator("Org1", "Course1", "Run1")
+
+        self._create_course(course_key)
+
+        request = self.factory.get("/course")
+        request.user = self.unauthorized_user
+
+        courses_list, _ = get_courses_accessible_to_user(request)
+
+        self.assertEqual(len(list(courses_list)), 0)
+
+    def test_non_staff_user_cannot_access(self):
+        """
+        Create a course and assign a non-staff role to the user.
+        Verify that the course is not returned in the course listing.
+        """
+        non_staff_user = UserFactory()
+        course_key = CourseLocator("Org1", "Course1", "Run1")
+        self._create_course(course_key)
+        self.add_user_to_role_in_course(non_staff_user, COURSE_DATA_RESEARCHER.external_key, course_key)
+
+        request = self.factory.get("/course")
+        request.user = non_staff_user
+
+        courses_list, _ = get_courses_accessible_to_user(request)
+
+        self.assertEqual(len(list(courses_list)), 0)
+
+    def test_authz_and_legacy_basic(self):
+        """
+        AuthZ roles should only apply when toggle is enabled.
+        Legacy roles should still grant access.
+        """
         authz_keys, legacy_keys, authz_courses, legacy_courses = self._create_courses()
 
-        for i in authz_enabled:
-            enabled_keys.add(str(authz_keys[i]))
+        enabled_keys = {str(authz_keys[0]), str(authz_keys[2])}
 
         with patch.object(
             core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
             "is_enabled",
             side_effect=self._mock_authz_toggle(enabled_keys),
         ):
-            # --- Create user ---
-            user = UserFactory(is_superuser=is_superuser)
+            user = UserFactory()
 
-            if is_staff:
-                GlobalStaff().add_users(user)
+            # AuthZ roles
+            assign_role_to_user_in_scope(
+                user.username,
+                COURSE_STAFF.external_key,
+                str(authz_keys[0]),  # toggle ON → valid
+            )
+            assign_role_to_user_in_scope(
+                user.username,
+                COURSE_EDITOR.external_key,
+                str(authz_keys[1]),  # toggle OFF → ignored
+            )
 
-            # --- Assign AUTHZ roles ---
-            for r in authz_roles:
-                assign_role_to_user_in_scope(
-                    user.username,
-                    r["role"].external_key,
-                    str(authz_keys[r["index"]]),
-                )
+            # Legacy role
+            CourseInstructorRole(legacy_keys[0]).add_users(user)
 
-            # --- Assign LEGACY roles ---
-            for i in legacy_roles:
-                CourseInstructorRole(legacy_keys[i]).add_users(user)
+            courses, _ = get_courses_accessible_to_user(self._make_request(user))
 
-            # --- Execute ---
-            request = self._make_request(user)
-            courses, _ = get_courses_accessible_to_user(request)
+            result_ids = {c.id for c in courses}
 
-            # --- Expected set ---
             expected_ids = {
-                (authz_courses[i].id if group == "authz" else legacy_courses[i].id)
-                for group, i in expected
+                authz_courses[0].id,
+                legacy_courses[0].id,
             }
 
-            result_ids = {course.id for course in courses}
+            self.assertEqual(result_ids, expected_ids)
 
-            self.assertEqual(
-                result_ids,
-                expected_ids,
-                msg=f"Failed scenario: {name}",
+    def test_authz_role_ignored_when_toggle_off(self):
+        """
+        AuthZ role should not grant access if toggle is disabled for that course.
+        """
+        authz_keys, _, authz_courses, _ = self._create_courses()
+
+        enabled_keys = {str(authz_keys[2])}  # only Course3 enabled
+
+        with patch.object(
+            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
+            "is_enabled",
+            side_effect=self._mock_authz_toggle(enabled_keys),
+        ):
+            user = UserFactory()
+
+            assign_role_to_user_in_scope(
+                user.username,
+                COURSE_EDITOR.external_key,
+                str(authz_keys[1]),  # toggle OFF → ignored
             )
+
+            courses, _ = get_courses_accessible_to_user(self._make_request(user))
+
+            result_ids = {c.id for c in courses}
+            expected_ids = set()  # no access since toggle is off
+
+            self.assertEqual(result_ids, expected_ids)
+
+    def test_multiple_roles_mixed_authz_and_legacy(self):
+        """
+        User should receive:
+        - AuthZ courses when toggle is enabled
+        - Legacy courses independently
+        """
+        authz_keys, legacy_keys, authz_courses, legacy_courses = self._create_courses()
+
+        enabled_keys = {str(k) for k in authz_keys}  # all enabled
+
+        with patch.object(
+            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
+            "is_enabled",
+            side_effect=self._mock_authz_toggle(enabled_keys),
+        ):
+            user = UserFactory()
+
+            # AuthZ roles
+            assign_role_to_user_in_scope(
+                user.username,
+                COURSE_STAFF.external_key,
+                str(authz_keys[0]),
+            )
+            assign_role_to_user_in_scope(
+                user.username,
+                COURSE_EDITOR.external_key,
+                str(authz_keys[1]),
+            )
+
+            # Legacy role
+            CourseInstructorRole(legacy_keys[2]).add_users(user)
+
+            courses, _ = get_courses_accessible_to_user(self._make_request(user))
+
+            result_ids = {c.id for c in courses}
+
+            expected_ids = {
+                authz_courses[0].id,
+                authz_courses[1].id,
+                legacy_courses[2].id,
+            }
+
+            self.assertEqual(result_ids, expected_ids)
+
+    def test_staff_gets_all_courses(self):
+        """
+        Global staff should bypass AuthZ/legacy restrictions and get all courses.
+        """
+        authz_keys, legacy_keys, authz_courses, legacy_courses = self._create_courses()
+
+        with patch.object(
+            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
+            "is_enabled",
+            return_value=False,  # irrelevant for staff
+        ):
+            user = UserFactory()
+            GlobalStaff().add_users(user)
+
+            courses, _ = get_courses_accessible_to_user(self._make_request(user))
+
+            result_ids = {c.id for c in courses}
+
+            expected_ids = {
+                *(c.id for c in authz_courses),
+                *(c.id for c in legacy_courses),
+            }
+
+            self.assertEqual(result_ids, expected_ids)
+
+    def test_superuser_gets_all_courses(self):
+        """
+        Superuser should bypass all permission checks and get all courses.
+        """
+        _, _, authz_courses, legacy_courses = self._create_courses()
+
+        with patch.object(
+            core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
+            "is_enabled",
+            return_value=False,  # irrelevant for superuser
+        ):
+            user = UserFactory(is_superuser=True)
+
+            courses, _ = get_courses_accessible_to_user(self._make_request(user))
+
+            result_ids = {c.id for c in courses}
+
+            expected_ids = {
+                *(c.id for c in authz_courses),
+                *(c.id for c in legacy_courses),
+            }
+
+            self.assertEqual(result_ids, expected_ids)

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -38,7 +38,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.testing.utils import AUTHZ_TABLES
-from openedx.core.djangoapps.authz.tests.mixins import AuthzTestMixin
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
 from openedx.core import toggles as core_toggles
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import (
@@ -414,7 +414,7 @@ class TestCourseListing(ModuleStoreTestCase):
 
 
 @ddt.ddt
-class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
+class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase):
     """
     Tests course listing using the new AuthZ authorization framework.
     """
@@ -513,7 +513,7 @@ class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
         non_staff_user = UserFactory()
         course_key = CourseLocator("Org1", "Course1", "Run1")
         self._create_course(course_key)
-        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key, course_key)
+        self.add_user_to_role_in_course(non_staff_user, COURSE_DATA_RESEARCHER.external_key, course_key)
 
         request = self.factory.get("/course")
         request.user = non_staff_user

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -413,7 +413,7 @@ class TestCourseListing(ModuleStoreTestCase):
         )
 
 
-
+@ddt.ddt
 class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
     """
     Tests course listing using the new AuthZ authorization framework.
@@ -522,108 +522,162 @@ class TestCourseListingAuthz(AuthzTestMixin, ModuleStoreTestCase):
 
         self.assertEqual(len(list(courses_list)), 0)
 
-    def test_course_listing_with_mix_authz_and_legacy_permissions(self):
-        authz_courses_keys = {
-            "course-v1:Org1+Course1+AuthzRun",
-            "course-v1:Org1+Course2+AuthzRun",
-            "course-v1:Org1+Course3+AuthzRun",
-        }
+    def _mock_authz_toggle(self, enabled_keys):
+        def _is_enabled(course_key=None, **_):
+            return str(course_key) in enabled_keys
+        return _is_enabled
 
-        authz_courses = []
-        legacy_courses = []
+    def _make_request(self, user):
+        request = self.factory.get("/course")
+        request.user = user
+        return request
 
-        def mock_is_enabled(*args, **kwargs):
-            # Extract course key from context (depends on how it's passed)
-            course_key = kwargs.get("context") or (args[0] if args else None)
-            return str(course_key) in authz_courses_keys
+    def _create_courses(self):
+        """Helper method to create multiple courses for testing."""
+        authz_keys = [
+            CourseLocator("Org1", "Course1", "AuthzRun"),
+            CourseLocator("Org1", "Course2", "AuthzRun"),
+            CourseLocator("Org1", "Course3", "AuthzRun"),
+        ]
+
+        legacy_keys = [
+            CourseLocator("Org1", "Course1", "LegacyRun"),
+            CourseLocator("Org1", "Course2", "LegacyRun"),
+            CourseLocator("Org1", "Course3", "LegacyRun"),
+        ]
+
+        authz_courses = [self._create_course(k) for k in authz_keys]
+        legacy_courses = [self._create_course(k) for k in legacy_keys]
+
+        return authz_keys, legacy_keys, authz_courses, legacy_courses
+
+    @ddt.data(
+        {
+            "name": "authz_and_legacy_basic",
+            "is_staff": False,
+            "is_superuser": False,
+            "authz_enabled": [0, 2],  # toggle ON for Course1, Course3
+
+            "authz_roles": [
+                {"index": 0, "role": COURSE_STAFF},   # valid (toggle ON)
+                {"index": 1, "role": COURSE_EDITOR},  # ignored (toggle OFF)
+            ],
+            "legacy_roles": [0],
+
+            "expected": [("authz", 0), ("legacy", 0)],
+        },
+        {
+            "name": "authz_role_but_toggle_off",
+            "is_staff": False,
+            "is_superuser": False,
+            "authz_enabled": [2],  # only Course3 enabled
+
+            "authz_roles": [
+                {"index": 1, "role": COURSE_EDITOR},  # should NOT appear
+            ],
+            "legacy_roles": [],
+
+            "expected": [],
+        },
+        {
+            "name": "multiple_roles_mixed",
+            "is_staff": False,
+            "is_superuser": False,
+            "authz_enabled": [0, 1, 2],
+
+            "authz_roles": [
+                {"index": 0, "role": COURSE_STAFF},
+                {"index": 1, "role": COURSE_EDITOR},
+            ],
+            "legacy_roles": [2],
+
+            "expected": [("authz", 0), ("authz", 1), ("legacy", 2)],
+        },
+        {
+            "name": "staff_gets_all",
+            "is_staff": True,
+            "is_superuser": False,
+            "authz_enabled": [],
+
+            "authz_roles": [],
+            "legacy_roles": [],
+
+            "expected": [
+                ("authz", 0), ("authz", 1), ("authz", 2),
+                ("legacy", 0), ("legacy", 1), ("legacy", 2),
+            ],
+        },
+        {
+            "name": "superuser_gets_all",
+            "is_staff": False,
+            "is_superuser": True,
+            "authz_enabled": [],
+
+            "authz_roles": [],
+            "legacy_roles": [],
+
+            "expected": [
+                ("authz", 0), ("authz", 1), ("authz", 2),
+                ("legacy", 0), ("legacy", 1), ("legacy", 2),
+            ],
+        },
+    )
+    @ddt.unpack
+    def test_course_access_matrix(
+        self,
+        name,
+        is_staff,
+        is_superuser,
+        authz_enabled,
+        authz_roles,
+        legacy_roles,
+        expected,
+    ):
+        # --- Setup toggle ---
+        enabled_keys = set()
+
+        authz_keys, legacy_keys, authz_courses, legacy_courses = self._create_courses()
+
+        for i in authz_enabled:
+            enabled_keys.add(str(authz_keys[i]))
 
         with patch.object(
             core_toggles.AUTHZ_COURSE_AUTHORING_FLAG,
             "is_enabled",
-            side_effect=mock_is_enabled,
+            side_effect=self._mock_authz_toggle(enabled_keys),
         ):
-            # Courses with authz flag enabled
-            authz_enable_course_key_1 = CourseLocator("Org1", "Course1", "AuthzRun")
-            authz_enable_course_1 = self._create_course(authz_enable_course_key_1)
+            # --- Create user ---
+            user = UserFactory(is_superuser=is_superuser)
 
-            authz_enable_course_key_2 = CourseLocator("Org1", "Course2", "AuthzRun")
-            authz_enable_course_2 = self._create_course(authz_enable_course_key_2)
+            if is_staff:
+                GlobalStaff().add_users(user)
 
-            authz_enable_course_key_3 = CourseLocator("Org1", "Course3", "AuthzRun")
-            authz_enable_course_3 = self._create_course(authz_enable_course_key_3)
-
-            authz_courses.extend([authz_enable_course_1, authz_enable_course_2, authz_enable_course_3])
-
-            # Courses without authz flag enabled (legacy courses)
-            legacy_course_key_1 = CourseLocator("Org1", "Course1", "LegacyRun")
-            legacy_course_1 = self._create_course(legacy_course_key_1)
-
-            legacy_course_key_2 = CourseLocator("Org1", "Course2", "LegacyRun")
-            legacy_course_2 = self._create_course(legacy_course_key_2)
-
-            legacy_course_key_3 = CourseLocator("Org1", "Course3", "LegacyRun")
-            legacy_course_3 = self._create_course(legacy_course_key_3)
-
-            legacy_courses.extend([legacy_course_1, legacy_course_2, legacy_course_3])
-
-            # Assign roles
-            assign_role_to_user_in_scope(
-                self.authorized_user.username,
-                COURSE_STAFF.external_key,
-                str(authz_enable_course_key_1),
-            )
-
-            assign_role_to_user_in_scope(
-                self.authorized_user.username,
-                COURSE_STAFF.external_key,
-                str(authz_enable_course_key_2),
-            )
-
-            CourseInstructorRole(legacy_course_key_1).add_users(self.authorized_user)
-
-            request = self.factory.get("/course")
-            request.user = self.authorized_user
-
-            courses_list, _ = get_courses_accessible_to_user(request)
-            courses = list(courses_list)
-
-            # Case 1: authorized user is added as a CourseStaff role is assigned for authz_enable_course_1,
-            # authz_enable_course_2 and CourseInstructor role is assigned for legacy_course_1,
-            # so these three courses should be returned in the course listing even if the toggle is enabled
-            # for authz_enable_course_3 but no role is assigned for it.
-            self.assertEqual(len(courses), 3)
-            self.assertTrue(
-                all(course.id in [authz_enable_course_1.id, authz_enable_course_2.id, legacy_course_1.id]
-                    for course in courses
+            # --- Assign AUTHZ roles ---
+            for r in authz_roles:
+                assign_role_to_user_in_scope(
+                    user.username,
+                    r["role"].external_key,
+                    str(authz_keys[r["index"]]),
                 )
-            )
 
-            # Case 2: Staff user should have access to all courses regardless of authz permissions.
-            # Pending authz_course_3 to check as staff
-            GlobalStaff().add_users(self.authorized_user)
-            courses_list, _ = get_courses_accessible_to_user(request)
-            courses = list(courses_list)
-            self.assertEqual(len(courses), 6)
-            self.assertTrue(
-                all(
-                    course.id in
-                    [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id,
-                     legacy_course_1.id, legacy_course_2.id, legacy_course_3.id]
-                    for course in courses
-                )
-            )
+            # --- Assign LEGACY roles ---
+            for i in legacy_roles:
+                CourseInstructorRole(legacy_keys[i]).add_users(user)
 
-            # Case 3: Superuser should have access to all courses regardless of authz permissions.
-            superuser = UserFactory(is_superuser=True)
-            request.user = superuser
-            courses_list, _ = get_courses_accessible_to_user(request)
-            courses = list(courses_list)
-            self.assertEqual(len(courses), 6)
-            self.assertTrue(
-                all(
-                    course.id in
-                    [authz_enable_course_1.id, authz_enable_course_2.id, authz_enable_course_3.id,
-                     legacy_course_1.id, legacy_course_2.id, legacy_course_3.id]
-                    for course in courses
-                )
+            # --- Execute ---
+            request = self._make_request(user)
+            courses, _ = get_courses_accessible_to_user(request)
+
+            # --- Expected set ---
+            expected_ids = {
+                (authz_courses[i].id if group == "authz" else legacy_courses[i].id)
+                for group, i in expected
+            }
+
+            result_ids = {course.id for course in courses}
+
+            self.assertEqual(
+                result_ids,
+                expected_ids,
+                msg=f"Failed scenario: {name}",
             )

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -902,17 +902,20 @@ def get_courses_accessible_to_user(request):
     is_staff_user = GlobalStaff().has_user(user) or user.is_superuser
     authz_scopes = None
     legacy_accesses = None
+    in_process_actions = []
 
     # Step 1: Determine candidate keys
     if is_staff_user:
         # unavoidable full scan
         candidate_courses = CourseOverview.get_all_courses()
         candidate_keys = [c.id for c in candidate_courses]
+        # Compute actions once for staff users since they have access to all courses
+        in_process_actions = get_in_process_course_actions(request)
     else:
         candidate_keys, authz_scopes, legacy_accesses = _get_candidate_course_keys(request)
 
     if not candidate_keys:
-        return [], []
+        return [], in_process_actions
 
     # Step 2: Single-pass decision → collect valid keys
     valid_course_keys = set()
@@ -926,7 +929,7 @@ def get_courses_accessible_to_user(request):
                 valid_course_keys.add(course_key)
 
     if not valid_course_keys:
-        return [], []
+        return [], in_process_actions
 
     # Step 3: Batch fetch (key optimization)
     courses = CourseOverview.get_all_courses(
@@ -935,9 +938,6 @@ def get_courses_accessible_to_user(request):
 
     # Step 4: Apply filters once
     courses = _apply_query_filters(request, courses)
-
-    # Step 5: Compute actions once
-    in_process_actions = get_in_process_course_actions(request)
 
     return list(courses), in_process_actions
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -854,7 +854,6 @@ def _get_legacy_accessible_courses_list(request):
         if access.course_id is not None:
             course_key = access.course_id
             if not isinstance(course_key, CourseKey):
-                # CCX courses cannot be edited in Studio and should not be shown in this dashboard.
                 course_key = CourseKey.from_string(str(course_key))
             group_keys.add(course_key)
         elif access.org:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -829,6 +829,7 @@ def _get_authz_accessible_courses_list(request):
         access.course_key
         for access in authz_scopes
         if isinstance(access, CourseOverviewData) and access.course_key
+        and core_toggles.enable_authz_course_authoring(access.course_key)
     }
     return authz_keys
 
@@ -944,15 +945,7 @@ def get_courses_accessible_to_user(request):
         candidate_keys = _get_candidate_course_keys(request)
 
     # Step 2: Single-pass decision → collect valid keys
-    valid_course_keys = set()
-    for course_key in candidate_keys:
-        if is_staff_user or user_has_course_permission(
-            user,
-            COURSES_VIEW_COURSE.identifier,
-            course_key,
-            LegacyAuthoringPermission.READ,
-        ):
-            valid_course_keys.add(course_key)
+    valid_course_keys = set(candidate_keys)
 
     if not valid_course_keys:
         return [], in_process_actions

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -778,34 +778,7 @@ def course_index(request, course_key):
     block_to_show = request.GET.get("show")
     return redirect(get_course_outline_url(course_key, block_to_show))
 
-
-def _has_authz_access(course_key, is_staff_user, authz_scopes):
-    """Returns True if the user has access to the course based on authz scopes, False otherwise."""
-    if is_staff_user:
-        return True
-
-    for access in authz_scopes:
-        if access.course_id == course_key:
-            return True
-
-    return False
-
-
-def _has_legacy_access(course_key, is_staff_user, legacy_accesses):
-    """Returns True if the user has access to the course based on legacy accesses, False otherwise."""
-    if is_staff_user:
-        return True
-
-    for access in legacy_accesses:
-        if access.course_id and access.course_id == course_key:
-            return True
-        elif access.org and access.course_id is None and access.org == course_key.org:
-            return True
-
-    return False
-
-
-def _apply_query_filters(request, courses):
+def _apply_course_query_filters(request, courses):
     """Applies all query filters to the given courses queryset.
     This includes filtering by active/archived status, search query, ordering
     and any special filters (e.g. CCX courses, template courses). The filters are applied in the following order:
@@ -841,24 +814,12 @@ def _apply_query_filters(request, courses):
     return filter(filter_course, filtered_courses)
 
 
-def _get_candidate_course_keys(request):
+def _get_authz_accessible_courses_list(request):
     """
-    Return candidate course keys the user may have access to, combining:
-
-    - Authz scopes:
-    Collects course keys from the user's scopes for the
-    `COURSES_VIEW_COURSE` permission.
-
-    - Legacy access:
-    Collects course keys based on Django group roles
-    (`CourseInstructorRole`, `CourseStaffRole`) and org-level access.
-    If the user has org-level access, all courses within those orgs
-    are included.
+    List all courses available to the logged in user by
+    evaluating Authz scopes for course access.
     """
     user = request.user
-
-    # Authz start --------------------------------------
-    # Recolecting all course keys from authz scopes
     authz_scopes = get_scopes_for_user_and_permission(
         user.username,
         COURSES_VIEW_COURSE.identifier
@@ -869,10 +830,14 @@ def _get_candidate_course_keys(request):
         for access in authz_scopes
         if isinstance(access, CourseOverviewData) and access.course_key
     }
-    # Authz end -----------------------------------------
+    return authz_keys
 
-    # Legacy start --------------------------------------
-    # Recolecting all course keys from django groups
+def _get_legacy_accessible_courses_list(request):
+    """
+    List all courses available to the logged in user by
+    evaluating legacy Django group roles and organization-level access.
+    """
+    user = request.user
     instructor_courses = UserBasedRole(user, CourseInstructorRole.ROLE).courses_with_role()
 
     with strict_role_checking():
@@ -899,10 +864,40 @@ def _get_candidate_course_keys(request):
         # Getting courses from user global orgs
         all_courses_give_an_org = CourseOverview.get_all_courses(orgs=org_accesses).values_list("id", flat=True)
         group_keys.update(all_courses_give_an_org)
-    # Legacy end ----------------------------------------
+    return group_keys
+
+def _get_candidate_course_keys(request):
+    """
+    Resolve accessible course keys by merging Authz scope evaluation with
+    legacy permission checks.
+
+    Why merge Authz and legacy checks?
+    At the time of implementation, the system is in a transition phase where
+    both Authz scopes and legacy permission checks are required to determine
+    course access. Combining both approaches allows us to leverage the
+    efficiency of Authz scopes while still capturing access granted through
+    legacy mechanisms.
+
+    This produces a comprehensive and performant set of candidate course keys,
+    combining:
+
+    - Authz scopes:
+      Collects course keys from the user's scopes for the
+      `COURSES_VIEW_COURSE` permission.
+
+    - Legacy access:
+      Collects course keys based on Django group roles
+      (`CourseInstructorRole`, `CourseStaffRole`) and
+      organization-level access. If the user has organization-level access,
+      all courses within those organizations are included.
+    """
+    # Recolecting all course keys from authz scopes
+    authz_keys = _get_authz_accessible_courses_list(request)
+
+    # Recolecting all course keys from django groups and org access
+    group_keys = _get_legacy_accessible_courses_list(request)
 
     return authz_keys | group_keys
-
 
 @function_trace('get_courses_accessible_to_user')
 def get_courses_accessible_to_user(request):
@@ -941,6 +936,11 @@ def get_courses_accessible_to_user(request):
         # Compute actions once for staff users since they have access to all courses
         in_process_actions = get_in_process_course_actions(request)
     else:
+        # For non-staff users, we can get a more targeted list of candidate course keys
+        # by combining AuthZ scopes and legacy access.
+        # Why? Because non-staff users typically have access to a smaller subset of courses,
+        # so this can significantly reduce the number of courses we need to check for access
+        # in the next step.
         candidate_keys = _get_candidate_course_keys(request)
 
     # Step 2: Single-pass decision → collect valid keys
@@ -963,7 +963,7 @@ def get_courses_accessible_to_user(request):
     ).order_by('created')  # default ordering is by created date
 
     # Step 4: Apply filters (e.g. search, active/archived status, ordering)
-    courses = _apply_query_filters(request, courses)
+    courses = _apply_course_query_filters(request, courses)
 
     return courses, in_process_actions
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -778,6 +778,7 @@ def course_index(request, course_key):
     block_to_show = request.GET.get("show")
     return redirect(get_course_outline_url(course_key, block_to_show))
 
+
 def _apply_course_query_filters(request, courses):
     """Applies all query filters to the given courses queryset.
     This includes filtering by active/archived status, search query, ordering
@@ -833,6 +834,7 @@ def _get_authz_accessible_courses_list(request):
     }
     return authz_keys
 
+
 def _get_legacy_accessible_courses_list(request):
     """
     List all courses available to the logged in user by
@@ -863,9 +865,10 @@ def _get_legacy_accessible_courses_list(request):
 
     if org_accesses:
         # Getting courses from user global orgs
-        all_courses_give_an_org = CourseOverview.get_all_courses(orgs=org_accesses).values_list("id", flat=True)
-        group_keys.update(all_courses_give_an_org)
+        org_course_keys = CourseOverview.get_all_courses(orgs=org_accesses).values_list("id", flat=True)
+        group_keys.update(org_course_keys)
     return group_keys
+
 
 def _get_candidate_course_keys(request):
     """

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -842,9 +842,19 @@ def _apply_query_filters(request, courses):
 
 
 def _get_candidate_course_keys(request):
-    """Returns a list of candidate course keys that the user may have access to,
-    based on both authz scopes and legacy group-based access.
-    Also returns the authz scopes and legacy accesses for further processing."""
+    """
+    Return candidate course keys the user may have access to, combining:
+
+    - Authz scopes:
+    Collects course keys from the user's scopes for the
+    `COURSES_VIEW_COURSE` permission.
+
+    - Legacy access:
+    Collects course keys based on Django group roles
+    (`CourseInstructorRole`, `CourseStaffRole`) and org-level access.
+    If the user has org-level access, all courses within those orgs
+    are included.
+    """
     user = request.user
 
     # Authz start --------------------------------------
@@ -855,9 +865,9 @@ def _get_candidate_course_keys(request):
     )
 
     authz_keys = {
-        access.course_id
+        access.course_key
         for access in authz_scopes
-        if access.course_id is not None and isinstance(access, CourseOverviewData)
+        if isinstance(access, CourseOverviewData) and access.course_key
     }
     # Authz end -----------------------------------------
 
@@ -874,7 +884,11 @@ def _get_candidate_course_keys(request):
 
     for access in legacy_accesses:
         if access.course_id is not None:
-            group_keys.add(access.course_id)
+            course_key = access.course_id
+            if not isinstance(course_key, CourseKey):
+                # CCX courses cannot be edited in Studio and should not be shown in this dashboard.
+                course_key = CourseKey.from_string(str(course_key))
+            group_keys.add(course_key)
         elif access.org:
             org_accesses.add(access.org)
         else:
@@ -883,63 +897,75 @@ def _get_candidate_course_keys(request):
 
     if org_accesses:
         # Getting courses from user global orgs
-        all_courses_give_an_org = CourseOverview.get_all_courses(orgs=list(org_accesses))
-        org_course_keys = {overview.id for overview in all_courses_give_an_org}
-        group_keys.update(org_course_keys)
+        all_courses_give_an_org = CourseOverview.get_all_courses(orgs=org_accesses).values_list("id", flat=True)
+        group_keys.update(all_courses_give_an_org)
     # Legacy end ----------------------------------------
 
-    return list(authz_keys | group_keys), authz_scopes, legacy_accesses
+    return authz_keys | group_keys
 
 
 @function_trace('get_courses_accessible_to_user')
 def get_courses_accessible_to_user(request):
     """
-    Hybrid approach:
-    - Single-pass decision per course (authz vs legacy)
-    - Batch DB fetch for performance
+    Return courses accessible to the user using a hybrid AuthZ + legacy approach.
+
+    Flow:
+        1. Determine candidate course keys:
+           - Staff: all courses (full scan).
+           - Non-staff: derived from AuthZ scopes and legacy access.
+
+        2. Single-pass access evaluation:
+           - Use AuthZ or legacy checks per course (based on feature flags).
+           - Collect only accessible course keys.
+
+        3. Batch fetch courses:
+           - Retrieve all valid courses in one query (ordered by creation date).
+
+        4. Apply request-based filters.
+
+    Returns:
+        tuple:
+            - list[CourseOverview]: Accessible courses.
+            - list: In-process course actions (staff only).
     """
     user = request.user
     is_staff_user = GlobalStaff().has_user(user) or user.is_superuser
-    authz_scopes = None
-    legacy_accesses = None
     in_process_actions = []
 
     # Step 1: Determine candidate keys
     if is_staff_user:
-        # unavoidable full scan
-        candidate_courses = CourseOverview.get_all_courses()
-        candidate_keys = [c.id for c in candidate_courses]
+        # Unavoidable full scan
+        # however, we only fetch the course keys here for the access check,
+        # and defer fetching the full course objects until after filtering by access
+        candidate_keys = CourseOverview.get_all_courses().values_list("id", flat=True)
         # Compute actions once for staff users since they have access to all courses
         in_process_actions = get_in_process_course_actions(request)
     else:
-        candidate_keys, authz_scopes, legacy_accesses = _get_candidate_course_keys(request)
-
-    if not candidate_keys:
-        return [], in_process_actions
+        candidate_keys = _get_candidate_course_keys(request)
 
     # Step 2: Single-pass decision → collect valid keys
     valid_course_keys = set()
-
     for course_key in candidate_keys:
-        if core_toggles.enable_authz_course_authoring(course_key):
-            if _has_authz_access(course_key, is_staff_user, authz_scopes):
-                valid_course_keys.add(course_key)
-        else:
-            if _has_legacy_access(course_key, is_staff_user, legacy_accesses):
-                valid_course_keys.add(course_key)
+        if is_staff_user or user_has_course_permission(
+            user,
+            COURSES_VIEW_COURSE.identifier,
+            course_key,
+            LegacyAuthoringPermission.READ,
+        ):
+            valid_course_keys.add(course_key)
 
     if not valid_course_keys:
         return [], in_process_actions
 
-    # Step 3: Batch fetch (key optimization)
+    # Step 3: Batch fetch valid courses with a single query, ordered by creation date
     courses = CourseOverview.get_all_courses(
         filter_={'id__in': list(valid_course_keys)}
-    ).order_by('created')  # default ordering is by last modified date, descending
+    ).order_by('created')  # default ordering is by created date
 
-    # Step 4: Apply filters once
+    # Step 4: Apply filters (e.g. search, active/archived status, ordering)
     courses = _apply_query_filters(request, courses)
 
-    return list(courses), in_process_actions
+    return courses, in_process_actions
 
 
 def _process_courses_list(courses_iter, in_process_course_actions, split_archived=False):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -931,7 +931,7 @@ def get_courses_accessible_to_user(request):
     # Step 3: Batch fetch (key optimization)
     courses = CourseOverview.get_all_courses(
         filter_={'id__in': list(valid_course_keys)}
-    )
+    ).order_by('created')  # default ordering is by last modified date, descending
 
     # Step 4: Apply filters once
     courses = _apply_query_filters(request, courses)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -28,9 +28,12 @@ from edx_django_utils.monitoring import function_trace
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import BlockUsageLocator
+from openedx_authz.api import get_scopes_for_user_and_permission
+from openedx_authz.api.data import CourseOverviewData
 from openedx_authz.constants.permissions import (
     COURSES_MANAGE_COURSE_UPDATES,
     COURSES_MANAGE_GROUP_CONFIGURATIONS,
+    COURSES_VIEW_COURSE,
     COURSES_VIEW_COURSE_UPDATES,
 )
 from organizations.api import add_organization_course, ensure_organization
@@ -67,6 +70,7 @@ from common.djangoapps.student.roles import (
 )
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
+from openedx.core import toggles as core_toggles
 from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
 from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -408,7 +412,9 @@ def get_in_process_course_actions(request):
             exclude_args={'state': CourseRerunUIStateManager.State.SUCCEEDED},
             should_display=True,
         )
-        if has_studio_read_access(request.user, course.course_key)
+        if user_has_course_permission(
+            request.user, COURSES_VIEW_COURSE.identifier, course.course_key, LegacyAuthoringPermission.READ
+        )
     ]
 
 
@@ -773,26 +779,166 @@ def course_index(request, course_key):
     return redirect(get_course_outline_url(course_key, block_to_show))
 
 
+def _has_authz_access(course_key, is_staff_user, authz_scopes):
+    """Returns True if the user has access to the course based on authz scopes, False otherwise."""
+    if is_staff_user:
+        return True
+
+    for access in authz_scopes:
+        if access.course_id == course_key:
+            return True
+
+    return False
+
+
+def _has_legacy_access(course_key, is_staff_user, legacy_accesses):
+    """Returns True if the user has access to the course based on legacy accesses, False otherwise."""
+    if is_staff_user:
+        return True
+
+    for access in legacy_accesses:
+        if access.course_id and access.course_id == course_key:
+            return True
+        elif access.org and access.course_id is None and access.org == course_key.org:
+            return True
+
+    return False
+
+
+def _apply_query_filters(request, courses):
+    """Applies all query filters to the given courses queryset.
+    This includes filtering by active/archived status, search query, ordering
+    and any special filters (e.g. CCX courses, template courses). The filters are applied in the following order:
+    1. Special filters (e.g. CCX courses, template courses)
+    2. Active/archived status
+    3. Search query
+    4. Ordering
+    """
+
+    def filter_course(course):
+        """
+        Special filters
+        """
+        # CCXs cannot be edited in Studio (aka cms) and should not be shown in this dashboard.
+        include_course = not isinstance(course.id, CCXLocator)
+
+         # TODO remove this condition when templates purged from db
+        include_course = include_course and course.location.course != 'templates'
+
+        return include_course
+
+    filtered_courses = filter(filter_course, courses)
+
+    search_query, order, active_only, archived_only = get_query_params_if_present(request)
+
+    return get_filtered_and_ordered_courses(
+        filtered_courses,
+        active_only,
+        archived_only,
+        search_query,
+        order,
+    )
+
+
+def _get_candidate_course_keys(request):
+    """Returns a list of candidate course keys that the user may have access to,
+    based on both authz scopes and legacy group-based access.
+    Also returns the authz scopes and legacy accesses for further processing."""
+    user = request.user
+
+    # Authz start --------------------------------------
+    # Recolecting all course keys from authz scopes
+    authz_scopes = get_scopes_for_user_and_permission(
+        user.username,
+        COURSES_VIEW_COURSE.identifier
+    )
+
+    authz_keys = {
+        access.course_id
+        for access in authz_scopes
+        if access.course_id is not None and isinstance(access, CourseOverviewData)
+    }
+    # Authz end -----------------------------------------
+
+    # Legacy start --------------------------------------
+    # Recolecting all course keys from django groups
+    instructor_courses = UserBasedRole(user, CourseInstructorRole.ROLE).courses_with_role()
+
+    with strict_role_checking():
+        staff_courses = UserBasedRole(user, CourseStaffRole.ROLE).courses_with_role()
+
+    group_keys = set()
+    org_accesses = set()
+    legacy_accesses = instructor_courses | staff_courses
+
+    for access in legacy_accesses:
+        if access.course_id is not None:
+            group_keys.add(access.course_id)
+        elif access.org:
+            org_accesses.add(access.org)
+        else:
+            # No course_id or org is associated with this access.
+            pass
+
+    if org_accesses:
+        # Getting courses from user global orgs
+        all_courses_give_an_org = CourseOverview.get_all_courses(orgs=list(org_accesses))
+        org_course_keys = {overview.id for overview in all_courses_give_an_org}
+        group_keys.update(org_course_keys)
+    # Legacy end ----------------------------------------
+
+    return list(authz_keys | group_keys), authz_scopes, legacy_accesses
+
+
 @function_trace('get_courses_accessible_to_user')
 def get_courses_accessible_to_user(request):
     """
-    Try to get all courses by first reversing django groups and fallback to old method if it fails
-    Note: overhead of pymongo reads will increase if getting courses from django groups fails
-
-    Arguments:
-        request: the request object
+    Hybrid approach:
+    - Single-pass decision per course (authz vs legacy)
+    - Batch DB fetch for performance
     """
-    if GlobalStaff().has_user(request.user):
-        # user has global access so no need to get courses from django groups
-        courses, in_process_course_actions = _accessible_courses_summary_iter(request)
+    user = request.user
+    is_staff_user = GlobalStaff().has_user(user) or user.is_superuser
+    authz_scopes = None
+    legacy_accesses = None
+
+    # Step 1: Determine candidate keys
+    if is_staff_user:
+        # unavoidable full scan
+        candidate_courses = CourseOverview.get_all_courses()
+        candidate_keys = [c.id for c in candidate_courses]
     else:
-        try:
-            courses, in_process_course_actions = _accessible_courses_list_from_groups(request)
-        except AccessListFallback:
-            # user have some old groups or there was some error getting courses from django groups
-            # so fallback to iterating through all courses
-            courses, in_process_course_actions = _accessible_courses_summary_iter(request)
-    return courses, in_process_course_actions
+        candidate_keys, authz_scopes, legacy_accesses = _get_candidate_course_keys(request)
+
+    if not candidate_keys:
+        return [], []
+
+    # Step 2: Single-pass decision → collect valid keys
+    valid_course_keys = set()
+
+    for course_key in candidate_keys:
+        if core_toggles.enable_authz_course_authoring(course_key):
+            if _has_authz_access(course_key, is_staff_user, authz_scopes):
+                valid_course_keys.add(course_key)
+        else:
+            if _has_legacy_access(course_key, is_staff_user, legacy_accesses):
+                valid_course_keys.add(course_key)
+
+    if not valid_course_keys:
+        return [], []
+
+    # Step 3: Batch fetch (key optimization)
+    courses = CourseOverview.get_all_courses(
+        filter_={'id__in': list(valid_course_keys)}
+    )
+
+    # Step 4: Apply filters once
+    courses = _apply_query_filters(request, courses)
+
+    # Step 5: Compute actions once
+    in_process_actions = get_in_process_course_actions(request)
+
+    return list(courses), in_process_actions
 
 
 def _process_courses_list(courses_iter, in_process_course_actions, split_archived=False):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -809,10 +809,12 @@ def _apply_query_filters(request, courses):
     """Applies all query filters to the given courses queryset.
     This includes filtering by active/archived status, search query, ordering
     and any special filters (e.g. CCX courses, template courses). The filters are applied in the following order:
-    1. Special filters (e.g. CCX courses, template courses)
-    2. Active/archived status
-    3. Search query
-    4. Ordering
+    1. Active/archived status
+    2. Search query
+    3. Ordering
+    4. Special filters (e.g. CCX courses, template courses)
+    The first 3 filters are applied using queryset methods, while the last filter is applied using a Python filter
+    function since it involves checking the course type (i.e. if it's a CCX course or a template course).
     """
 
     def filter_course(course):
@@ -827,17 +829,16 @@ def _apply_query_filters(request, courses):
 
         return include_course
 
-    filtered_courses = filter(filter_course, courses)
-
     search_query, order, active_only, archived_only = get_query_params_if_present(request)
 
-    return get_filtered_and_ordered_courses(
-        filtered_courses,
+    filtered_courses = get_filtered_and_ordered_courses(
+        courses,
         active_only,
         archived_only,
         search_query,
         order,
     )
+    return filter(filter_course, filtered_courses)
 
 
 def _get_candidate_course_keys(request):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -797,7 +797,7 @@ def _apply_course_query_filters(request, courses):
         # CCXs cannot be edited in Studio (aka cms) and should not be shown in this dashboard.
         include_course = not isinstance(course.id, CCXLocator)
 
-         # TODO remove this condition when templates purged from db
+        # TODO remove this condition when templates purged from db
         include_course = include_course and course.location.course != 'templates'
 
         return include_course
@@ -859,7 +859,7 @@ def _get_legacy_accessible_courses_list(request):
             org_accesses.add(access.org)
         else:
             # No course_id or org is associated with this access.
-            pass
+            raise AccessListFallback
 
     if org_accesses:
         # Getting courses from user global orgs
@@ -892,10 +892,10 @@ def _get_candidate_course_keys(request):
       organization-level access. If the user has organization-level access,
       all courses within those organizations are included.
     """
-    # Recolecting all course keys from authz scopes
+    # Collecting all course keys from authz scopes
     authz_keys = _get_authz_accessible_courses_list(request)
 
-    # Recolecting all course keys from django groups and org access
+    # Collecting all course keys from django groups and org access
     group_keys = _get_legacy_accessible_courses_list(request)
 
     return authz_keys | group_keys
@@ -942,7 +942,14 @@ def get_courses_accessible_to_user(request):
         # Why? Because non-staff users typically have access to a smaller subset of courses,
         # so this can significantly reduce the number of courses we need to check for access
         # in the next step.
-        candidate_keys = _get_candidate_course_keys(request)
+        try:
+            candidate_keys = _get_candidate_course_keys(request)
+        except AccessListFallback:
+            # This exception is raised when we cannot determine candidate course keys from legacy access.
+            # User have some old groups or there was some error getting courses from django groups
+            # so fallback to iterating through all courses
+            candidate_keys = CourseOverview.get_all_courses().values_list("id", flat=True)
+            in_process_actions = get_in_process_course_actions(request)
 
     # Step 2: Single-pass decision → collect valid keys
     valid_course_keys = set(candidate_keys)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Refactor course access listing to single-pass hybrid AuthZ + legacy approach

### Summary

This PR refactors get_courses_accessible_to_user to improve performance, readability, and maintainability by introducing a single-pass hybrid access evaluation model.

Instead of splitting courses into separate AuthZ and legacy pipelines and merging results afterward, this implementation evaluates access per course in a single pass, then performs a single batched query to retrieve the final course list.

## Key Improvements

**Single-pass access evaluation**
- Replaced the dual pipeline (AuthZ vs legacy) with a unified loop.
- Each course is evaluated once using:
      - `user_has_course_permission(...)`
- Eliminates duplicated logic and merging complexity.

**Scoped full scan to staff users only**
- Staff users still require evaluating all courses (expected behavior).
- Non-staff users now operate only on candidate course keys, avoiding unnecessary full table scans.

```
if is_staff_user:
    candidate_keys = CourseOverview.get_all_courses().values_list("id", flat=True)
else:
    candidate_keys = _get_candidate_course_keys(request)
```

**Deferred object fetching**
- Only fetch full CourseOverview objects after access filtering
- Reduces memory usage and DB overhead

**Centralized filtering and ordering**
- Filters (search, active/archived, ordering) are applied once at the end
- Ensures consistent behavior and avoids repeated processing

**Improved readability and maintainability**
- Clear step-based flow:
1. Determine candidate keys
2. Evaluate access
3. Batch fetch
4. Apply filters
- Reduced cognitive complexity and branching

## Testing Notes

- Existing tests should continue to pass without modification
- Recommended additional coverage:
    - Mixed AuthZ + legacy access scenarios
    - Staff vs non-staff behavior
    - Empty access cases

## Deadline

Verawood

## Other information

Resolves: https://github.com/openedx/openedx-authz/issues/190
