### PR TITLE
feat: add authz permission checks for the course group configuration endpoints

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/group_configurations.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/group_configurations.py
@@ -5,12 +5,14 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from openedx_authz.constants.permissions import COURSES_MANAGE_GROUP_CONFIGURATIONS
 
 from cms.djangoapps.contentstore.utils import get_group_configurations_context
 from cms.djangoapps.contentstore.rest_api.v1.serializers import (
     CourseGroupConfigurationsSerializer,
 )
-from common.djangoapps.student.auth import has_studio_read_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import authz_permission_required
 from openedx.core.lib.api.view_utils import (
     DeveloperErrorViewMixin,
     verify_course_exists,
@@ -39,7 +41,11 @@ class CourseGroupConfigurationsView(DeveloperErrorViewMixin, APIView):
         },
     )
     @verify_course_exists()
-    def get(self, request: Request, course_id: str):
+    @authz_permission_required(
+        authz_permission=COURSES_MANAGE_GROUP_CONFIGURATIONS.identifier,
+        legacy_permission=LegacyAuthoringPermission.READ
+    )
+    def get(self, request: Request, course_key: CourseKey):
         """
         Get an object containing course's settings group configurations.
 
@@ -139,11 +145,7 @@ class CourseGroupConfigurationsView(DeveloperErrorViewMixin, APIView):
         }
         ```
         """
-        course_key = CourseKey.from_string(course_id)
         store = modulestore()
-
-        if not has_studio_read_access(request.user, course_key):
-            self.permission_denied(request)
 
         with store.bulk_operations(course_key):
             course = modulestore().get_course(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_group_configurations.py
@@ -106,9 +106,8 @@ class CourseGroupConfigurationsAuthzTest(CourseAuthzTestMixin, BaseCourseViewTes
 
     def test_non_staff_user_cannot_access(self):
         """
-        User without permissions should be denied.
-        This case validates that a non-staff user cannot access even
-        if they have course author access to the course.
+        User without required permissions should be denied.
+        This case validates that a non-staff user doesn't get access.
         """
         non_staff_user = UserFactory()
         non_staff_client = APIClient()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_group_configurations.py
@@ -3,11 +3,16 @@ Unit tests for the course's setting group configuration.
 """
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APIClient
 
+from cms.djangoapps.contentstore.api.tests.base import BaseCourseViewTest
 from cms.djangoapps.contentstore.course_group_config import (
     CONTENT_GROUP_CONFIGURATION_NAME,
 )
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthzTestMixin
 from xmodule.partitions.partitions import (
     Group,
     UserPartition,
@@ -53,3 +58,62 @@ class CourseGroupConfigurationsViewTest(CourseTestCase, PermissionAccessMixin):
         self.assertContains(response, "Group C")
         self.assertContains(response, CONTENT_GROUP_CONFIGURATION_NAME)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+class CourseGroupConfigurationsAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
+    """
+    Tests Course Group Configuration API authorization using openedx-authz.
+    The endpoint uses COURSES_MANAGE_GROUP_CONFIGURATIONS permission.
+    """
+
+    view_name = "cms.djangoapps.contentstore:v1:group_configurations"
+    authz_roles_to_assign = [COURSE_STAFF.external_key]
+
+    def test_authorized_user_can_access(self):
+        """User with COURSE_STAFF role can access."""
+        resp = self.authorized_client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_unauthorized_user_cannot_access(self):
+        """User without role cannot access."""
+        resp = self.unauthorized_client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_role_scoped_to_course(self):
+        """Authorization should only apply to the assigned course."""
+        other_course = self.store.create_course("OtherOrg", "OtherCourse", "Run", self.staff.id)
+
+        resp = self.authorized_client.get(self.get_url(other_course.id))
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user_allowed_via_legacy(self):
+        """
+        Staff users should still pass through legacy fallback.
+        """
+        self.client.login(username=self.staff.username, password=self.password)
+
+        resp = self.client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_superuser_allowed(self):
+        """Superusers should always be allowed."""
+        superuser = UserFactory(is_superuser=True)
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+
+        resp = client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_non_staff_user_cannot_access(self):
+        """
+        User without permissions should be denied.
+        This case validates that a non-staff user cannot access even
+        if they have course author access to the course.
+        """
+        non_staff_user = UserFactory()
+        non_staff_client = APIClient()
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key)
+        non_staff_client.force_authenticate(user=non_staff_user)
+
+        resp = non_staff_client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -36,10 +36,7 @@ from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 from rest_framework.exceptions import ValidationError
 from rest_framework.decorators import api_view
-from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
-from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.lib.api.view_utils import view_auth_classes
-from openedx_authz.constants.permissions import COURSES_MANAGE_GROUP_CONFIGURATIONS
 
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import create_xblock_info
 from cms.djangoapps.course_creators.views import add_user_with_status_unrequested, get_course_creator_status
@@ -61,7 +58,11 @@ from common.djangoapps.student.auth import (
 )
 from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
 from openedx.core.djangoapps.authz.decorators import user_has_course_permission
-from openedx_authz.constants.permissions import COURSES_MANAGE_COURSE_UPDATES, COURSES_VIEW_COURSE_UPDATES
+from openedx_authz.constants.permissions import (
+    COURSES_MANAGE_COURSE_UPDATES,
+    COURSES_VIEW_COURSE_UPDATES,
+    COURSES_MANAGE_GROUP_CONFIGURATIONS,
+)
 from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseStaffRole,

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -36,7 +36,10 @@ from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 from rest_framework.exceptions import ValidationError
 from rest_framework.decorators import api_view
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.lib.api.view_utils import view_auth_classes
+from openedx_authz.constants.permissions import COURSES_MANAGE_GROUP_CONFIGURATIONS
 
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import create_xblock_info
 from cms.djangoapps.course_creators.views import add_user_with_status_unrequested, get_course_creator_status
@@ -150,15 +153,36 @@ class AccessListFallback(Exception):
     pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
-def get_course_and_check_access(course_key, user, depth=0):
+def _get_course_block(course_key, depth=0):
     """
     Function used to calculate and return the locator and course block
     for the view functions in this file.
     """
-    if not has_studio_read_access(user, course_key):
-        raise PermissionDenied()
     course_block = modulestore().get_course(course_key, depth=depth)
     return course_block
+
+def get_course_and_check_access(course_key, user, depth=0):
+    """
+    Function used to validate permission and return a course block
+    for the view functions in this file.
+    """
+    if not has_studio_read_access(user, course_key):
+        raise PermissionDenied()
+    return _get_course_block(course_key, depth)
+
+def get_course_and_check_manage_group_configurations_access(course_key, user, depth=0):
+    """
+    Function used to validate permission and return a course block
+    for the view functions for group configurations in this file.
+    """
+    if not user_has_course_permission(
+        user=user,
+        authz_permission=COURSES_MANAGE_GROUP_CONFIGURATIONS.identifier,
+        course_key=course_key,
+        legacy_permission=LegacyAuthoringPermission.READ
+    ):
+        raise PermissionDenied()
+    return _get_course_block(course_key, depth)
 
 
 def reindex_course_and_check_access(course_key, user):
@@ -1628,7 +1652,7 @@ def group_configurations_list_handler(request, course_key_string):
     course_key = CourseKey.from_string(course_key_string)
     store = modulestore()
     with store.bulk_operations(course_key):
-        course = get_course_and_check_access(course_key, request.user)
+        course = get_course_and_check_manage_group_configurations_access(course_key, request.user)
 
         if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
             if use_new_group_configurations_page(course_key):
@@ -1671,7 +1695,7 @@ def group_configurations_detail_handler(request, course_key_string, group_config
     course_key = CourseKey.from_string(course_key_string)
     store = modulestore()
     with store.bulk_operations(course_key):
-        course = get_course_and_check_access(course_key, request.user)
+        course = get_course_and_check_manage_group_configurations_access(course_key, request.user)
         matching_id = [p for p in course.user_partitions
                        if str(p.id) == str(group_configuration_id)]
         if matching_id:

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -7,6 +7,7 @@ import json
 from operator import itemgetter
 from unittest.mock import patch
 from edx_toggles.toggles.testutils import override_waffle_flag
+from rest_framework import status
 
 import ddt
 
@@ -16,8 +17,13 @@ from cms.djangoapps.contentstore.course_group_config import (
     ENROLLMENT_SCHEME,
     GroupConfiguration
 )
+from django.test import Client
+from cms.djangoapps.contentstore.api.tests.base import BaseCourseViewTest
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from common.djangoapps.student.tests.factories import UserFactory
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
+from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthzTestMixin
 from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITION_ID
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
@@ -1236,3 +1242,306 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
         Tests if validation message is not present when updating usage info.
         """
         self.verify_validation_update_usage_info(None, None)  # pylint: disable=no-value-for-parameter
+
+class PostGroupConfigurationsListHandlerAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
+    """
+    Tests endpoint used to create new Course Group Configurations
+    (group_configurations_list_handler) authorization using openedx-authz.
+    The endpoint uses COURSES_MANAGE_GROUP_CONFIGURATIONS permission.
+    """
+
+    view_name = "group_configurations_list_handler"
+    authz_roles_to_assign = [COURSE_STAFF.external_key]
+    course_key_arg_name = 'course_key_string'
+
+    def setUp(self):
+        super().setUp()
+        # Function-based views require session auth, not DRF force_authenticate.
+        # Re-initialize clients using Django's test Client with login().
+        self.authorized_client = Client()
+        self.authorized_client.login(
+            username=self.authorized_user.username, password=self.password
+        )
+        self.unauthorized_client = Client()
+        self.unauthorized_client.login(
+            username=self.unauthorized_user.username, password=self.password
+        )
+
+    def test_authorized_user_can_access(self):
+        """User with COURSE_STAFF role can access."""
+        resp = self.authorized_client.post(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_unauthorized_user_cannot_access(self):
+        """User without role cannot access."""
+        resp = self.unauthorized_client.post(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_role_scoped_to_course(self):
+        """Authorization should only apply to the assigned course."""
+        other_course = self.store.create_course("OtherOrg", "OtherCourse", "Run", self.staff.id)
+
+        resp = self.authorized_client.post(
+            self.get_url(other_course.id),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user_allowed_via_legacy(self):
+        """
+        Staff users should still pass through legacy fallback.
+        """
+        self.client.login(username=self.staff.username, password=self.password)
+
+        resp = self.client.post(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_superuser_allowed(self):
+        """Superusers should always be allowed."""
+        superuser = UserFactory(is_superuser=True, password=self.password)
+
+        client = Client()
+        client.login(
+            username=superuser.username, password=self.password
+        )
+
+        resp = client.post(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_non_staff_user_cannot_access(self):
+        """
+        User without permissions should be denied.
+        This case validates that a non-staff user cannot access even
+        if they have course author access to the course.
+        """
+        non_staff_user = UserFactory(password=self.password)
+        non_staff_client = Client()
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key)
+        non_staff_client.login(
+            username=non_staff_user.username, password=self.password
+        )
+
+        resp = non_staff_client.post(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class PutGroupConfigurationsDetailHandlerAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
+    """
+    Tests endpoint used to update Course Group Configurations
+    (group_configurations_detail_handler) authorization using openedx-authz.
+    The endpoint uses COURSES_MANAGE_GROUP_CONFIGURATIONS permission.
+    """
+
+    view_name = "group_configurations_detail_handler"
+    authz_roles_to_assign = [COURSE_STAFF.external_key]
+    course_key_arg_name = 'course_key_string'
+    extra_request_args = {'group_configuration_id': 999}
+
+    def setUp(self):
+        super().setUp()
+        self.authorized_client = Client()
+        self.authorized_client.login(
+            username=self.authorized_user.username, password=self.password
+        )
+        self.unauthorized_client = Client()
+        self.unauthorized_client.login(
+            username=self.unauthorized_user.username, password=self.password
+        )
+
+    def test_authorized_user_can_access(self):
+        """User with COURSE_STAFF role can access."""
+        resp = self.authorized_client.put(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_unauthorized_user_cannot_access(self):
+        """User without role cannot access."""
+        resp = self.unauthorized_client.put(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_role_scoped_to_course(self):
+        """Authorization should only apply to the assigned course."""
+        other_course = self.store.create_course("OtherOrg", "OtherCourse", "Run2", self.staff.id)
+
+        resp = self.authorized_client.put(
+            self.get_url(other_course.id),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user_allowed_via_legacy(self):
+        """Staff users should still pass through legacy fallback."""
+        self.client.login(username=self.staff.username, password=self.password)
+
+        resp = self.client.put(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_superuser_allowed(self):
+        """Superusers should always be allowed."""
+        superuser = UserFactory(is_superuser=True, password=self.password)
+
+        client = Client()
+        client.login(username=superuser.username, password=self.password)
+
+        resp = client.put(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+    def test_non_staff_user_cannot_access(self):
+        """User without permissions should be denied."""
+        non_staff_user = UserFactory(password=self.password)
+        non_staff_client = Client()
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key)
+        non_staff_client.login(username=non_staff_user.username, password=self.password)
+
+        resp = non_staff_client.put(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class DeleteGroupConfigurationsDetailHandlerAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
+    """
+    Tests DELETE on group_configurations_detail_handler authorization using openedx-authz.
+    The endpoint uses COURSES_MANAGE_GROUP_CONFIGURATIONS permission.
+    """
+
+    PARTITION_ID = 999
+
+    view_name = "group_configurations_detail_handler"
+    authz_roles_to_assign = [COURSE_STAFF.external_key]
+    course_key_arg_name = 'course_key_string'
+    extra_request_args = {'group_configuration_id': PARTITION_ID}
+
+    def setUp(self):
+        super().setUp()
+        # Seed a random-scheme partition so DELETE finds a configuration to remove.
+        self.course.user_partitions = [
+            UserPartition(
+                self.PARTITION_ID, 'Test Config', 'Test description',
+                [Group(0, 'Group A'), Group(1, 'Group B')],
+                scheme=None, scheme_id='random',
+            )
+        ]
+        self.store.update_item(self.course, self.staff.id)
+
+        self.authorized_client = Client()
+        self.authorized_client.login(
+            username=self.authorized_user.username, password=self.password
+        )
+        self.unauthorized_client = Client()
+        self.unauthorized_client.login(
+            username=self.unauthorized_user.username, password=self.password
+        )
+
+    def test_authorized_user_can_access(self):
+        """User with COURSE_STAFF role can delete."""
+        resp = self.authorized_client.delete(
+            self.get_url(self.course_key),
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_unauthorized_user_cannot_access(self):
+        """User without role cannot delete."""
+        resp = self.unauthorized_client.delete(
+            self.get_url(self.course_key),
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_role_scoped_to_course(self):
+        """Authorization should only apply to the assigned course."""
+        other_course = self.store.create_course("OtherOrg", "OtherCourse", "Run3", self.staff.id)
+
+        resp = self.authorized_client.delete(
+            self.get_url(other_course.id),
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user_allowed_via_legacy(self):
+        """Staff users should still pass through legacy fallback."""
+        self.client.login(username=self.staff.username, password=self.password)
+
+        resp = self.client.delete(
+            self.get_url(self.course_key),
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_superuser_allowed(self):
+        """Superusers should always be allowed."""
+        superuser = UserFactory(is_superuser=True, password=self.password)
+
+        client = Client()
+        client.login(username=superuser.username, password=self.password)
+
+        resp = client.delete(
+            self.get_url(self.course_key),
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_non_staff_user_cannot_access(self):
+        """User without permissions should be denied."""
+        non_staff_user = UserFactory(password=self.password)
+        non_staff_client = Client()
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key)
+        non_staff_client.login(username=non_staff_user.username, password=self.password)
+
+        resp = non_staff_client.delete(
+            self.get_url(self.course_key),
+            HTTP_ACCEPT='application/json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
## Description

Implement new AuthZ permission checks over endpoints related with course group configuration in course authoring.

The new AuthZ permission checks only apply when the enable_authz_course_authoring feature flag is enabled for the specific course, or globally, otherwise existing behavior persist.

The following AuthZ permission is being used:

- courses.manage_group_configurations

The following endpoints were updated:

- GET /api/contentstore/v1/group_configurations/(courseid)/: Get group configurations
- POST /group_configurations/(courseid)/: Create new group
- POST/PUT /group_configurations/(courseid)/(configurationid)/: Edit group
- DELETE /group_configurations/(courseid)/(configurationid)/(itemid)/: Delete group

## Supporting information

Closes https://github.com/openedx/openedx-authz/issues/197

## Testing

Verified that:

- Authorized users can access the endpoints.
- Unauthorized users receive a 403 response.
- Legacy permission fallback works as expected.

Running relevant tests manually:

On a cms container (run with `tutor dev exec cms bash`), do:

```bash
pytest -p no:randomly --ds=cms.envs.test cms/djangoapps/contentstore/rest_api/v1/views/tests/test_group_configurations.py

pytest -p no:randomly --ds=cms.envs.test cms/djangoapps/contentstore/views/tests/test_group_configurations.py
```

## Deadline

Verawood
