### PR TITLE
feat: Add course team management v2 API for instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -12,6 +12,9 @@ TO DO sync instructor and staff flags
 
 import logging
 
+from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
+
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseCcxCoachRole,
@@ -21,7 +24,13 @@ from common.djangoapps.student.roles import (
     CourseStaffRole,
 )
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params
-from openedx.core.djangoapps.django_comment_common.models import Role
+from openedx.core.djangoapps.django_comment_common.models import (
+    FORUM_ROLE_ADMINISTRATOR,
+    FORUM_ROLE_COMMUNITY_TA,
+    FORUM_ROLE_GROUP_MODERATOR,
+    FORUM_ROLE_MODERATOR,
+    Role,
+)
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +42,47 @@ ROLES = {
     'ccx_coach': CourseCcxCoachRole,
     'data_researcher': CourseDataResearcherRole,
 }
+
+#: Forum/discussion roles managed through :func:`update_forum_role`.
+#: Stored separately from :data:`ROLES` because they use a different
+#: model (``Role`` from django_comment_common) and different helpers.
+FORUM_ROLES = (
+    FORUM_ROLE_ADMINISTRATOR,
+    FORUM_ROLE_MODERATOR,
+    FORUM_ROLE_GROUP_MODERATOR,
+    FORUM_ROLE_COMMUNITY_TA,
+)
+
+ROLE_DISPLAY_NAMES = {
+    'instructor': _('Admin'),
+    'staff': _('Staff'),
+    'limited_staff': _('Limited Staff'),
+    'beta': _('Beta Tester'),
+    'ccx_coach': _('CCX Coach'),
+    'data_researcher': _('Data Researcher'),
+    FORUM_ROLE_ADMINISTRATOR: _('Discussion Admin'),
+    FORUM_ROLE_MODERATOR: _('Discussion Moderator'),
+    FORUM_ROLE_GROUP_MODERATOR: _('Group Moderator'),
+    FORUM_ROLE_COMMUNITY_TA: _('Community TA'),
+}
+
+
+def is_forum_role(rolename):
+    """Return True if ``rolename`` is a forum/discussion role."""
+    return rolename in FORUM_ROLES
+
+
+def list_forum_members(course_id, rolename):
+    """
+    Return a User QuerySet of users holding ``rolename`` forum role for the course.
+
+    Returns an empty QuerySet if the role doesn't exist for the course.
+    """
+    try:
+        role = Role.objects.get(course_id=course_id, name=rolename)
+    except Role.DoesNotExist:
+        return get_user_model().objects.none()
+    return role.users.all()
 
 
 def list_with_level(course_id, level):

--- a/lms/djangoapps/instructor/docs/references/instructor-v2-course-team-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-course-team-api-spec.yaml
@@ -1,0 +1,612 @@
+swagger: '2.0'
+info:
+  title: Instructor Dashboard Course Team API
+  version: 2.0.0
+  description: |
+    Modern REST API for managing course team members (instructors, staff, beta testers,
+    CCX coaches, and discussion/forum roles) on the instructor dashboard.
+
+    **Design Principles:**
+    - RESTful resource-oriented URLs
+    - Query parameters for filtering operations
+    - Clear separation between read and write operations
+    - Consistent error handling
+
+    **Execution Model:**
+    - All operations execute synchronously
+    - Single-user modifications are immediate (~100-500ms)
+    - Bulk beta tester operations process each identifier and return aggregated results
+
+    **Authorization:**
+    - Listing and modifying course team members requires instructor-level access
+    - Bulk beta tester management requires beta test permission
+    - Instructors cannot remove their own instructor access
+
+host: courses.example.com
+basePath: /
+schemes:
+  - https
+
+securityDefinitions:
+  JWTAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+    description: JWT token authentication. Header format depends on JWT_AUTH['JWT_AUTH_HEADER_PREFIX'] setting (default is 'JWT <token>').
+
+security:
+  - JWTAuth: []
+
+tags:
+  - name: Course Team
+    description: Course team role membership management
+  - name: Beta Testers
+    description: Bulk beta tester management
+
+paths:
+  # ==================== COURSE TEAM ENDPOINTS ====================
+
+  /api/instructor/v2/courses/{course_key}/team:
+    get:
+      tags:
+        - Course Team
+      summary: List course team members
+      description: |
+        Retrieve a list of users who hold course team roles.
+
+        When `role` is provided, returns only members with that role.
+        When `role` is omitted, returns all team members across all roles.
+        Each result includes a `role` field so the caller knows which role
+        the user holds.
+
+        **Available Roles:**
+        - `instructor` — Full admin, can manage other roles
+        - `staff` — Can view/edit content, limited role management
+        - `limited_staff` — LMS-only staff
+        - `beta` — Beta testers
+        - `ccx_coach` — CCX coach (only when CCX is enabled)
+        - `data_researcher` — Data researcher
+        - `Administrator` — Discussion administrator (forum role)
+        - `Moderator` — Discussion moderator (forum role)
+        - `Group Moderator` — Group moderator (forum role)
+        - `Community TA` — Community TA (forum role)
+
+        The `email_or_username` query parameter performs a case-insensitive
+        substring match against username and email.
+
+        Results are paginated via `page` and `page_size`.
+
+        **Note:** This replaces the legacy `POST /courses/{course_id}/instructor/api/list_course_role_members` endpoint.
+      operationId: listCourseTeamMembers
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseKey'
+        - name: role
+          in: query
+          description: |
+            Filter by role. When omitted, members across all roles are returned.
+          required: false
+          type: string
+          enum:
+            - instructor
+            - staff
+            - limited_staff
+            - beta
+            - ccx_coach
+            - data_researcher
+            - Administrator
+            - Moderator
+            - Group Moderator
+            - Community TA
+          x-example: "staff"
+        - name: email_or_username
+          in: query
+          description: |
+            Case-insensitive substring filter applied to username and email.
+          required: false
+          type: string
+          x-example: "jane_doe"
+        - name: page
+          in: query
+          description: Page number (1-indexed).
+          required: false
+          type: integer
+          minimum: 1
+          default: 1
+        - name: page_size
+          in: query
+          description: Number of results per page.
+          required: false
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+      responses:
+        200:
+          description: Team members retrieved successfully
+          schema:
+            $ref: '#/definitions/CourseTeamMemberList'
+          examples:
+            application/json:
+              course_id: "course-v1:edX+DemoX+Demo_Course"
+              role: null
+              email_or_username: null
+              count: 2
+              num_pages: 1
+              current_page: 1
+              start: 0
+              next: null
+              previous: null
+              results:
+                - username: "jane_doe"
+                  email: "jane@example.com"
+                  first_name: "Diana"
+                  last_name: "Salas"
+                  roles:
+                    - role: "staff"
+                      display_name: "Staff"
+                    - role: "beta"
+                      display_name: "Beta Tester"
+                    - role: "ccx_coach"
+                      display_name: "CCX Coach"
+                - username: "staff_user2"
+                  email: "staff2@example.com"
+                  first_name: "Bob"
+                  last_name: "Jones"
+                  roles:
+                    - role: "staff"
+                      display_name: "Staff"
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        404:
+          $ref: '#/responses/NotFound'
+
+    post:
+      tags:
+        - Course Team
+      summary: Grant or revoke a course role for one or more users
+      description: |
+        Grant or revoke a specific course role for one or more users, identified by
+        username or email.
+
+        **Behavior (action=allow):**
+        - If a user is not already enrolled in the course, they will be auto-enrolled
+        - For `ccx_coach` role, an enrollment email is sent automatically
+
+        **Behavior (action=revoke):**
+        - Instructors cannot revoke their own instructor access (per-identifier error)
+
+        **Common:**
+        - Users must exist and be active; per-identifier errors are reported in the response
+
+        **Note:** This replaces the legacy
+        `POST /courses/{course_id}/instructor/api/modify_access` endpoint.
+      operationId: modifyCourseRole
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseKey'
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            required:
+              - identifiers
+              - role
+              - action
+            properties:
+              identifiers:
+                type: array
+                description: List of usernames or emails of users to modify
+                minItems: 1
+                items:
+                  type: string
+                example: ["jane_doe", "john@example.com"]
+              role:
+                type: string
+                description: The role to grant or revoke (course access role or forum role)
+                enum:
+                  - instructor
+                  - staff
+                  - limited_staff
+                  - beta
+                  - ccx_coach
+                  - data_researcher
+                  - Administrator
+                  - Moderator
+                  - Group Moderator
+                  - Community TA
+                example: "staff"
+              action:
+                type: string
+                description: Whether to grant ('allow') or revoke ('revoke') the role
+                enum:
+                  - allow
+                  - revoke
+                example: "allow"
+      responses:
+        200:
+          description: Role modification completed (per-identifier results)
+          schema:
+            $ref: '#/definitions/CourseTeamGrantResult'
+          examples:
+            application/json:
+              action: "allow"
+              role: "staff"
+              results:
+                - identifier: "jane_doe"
+                  error: false
+                  userDoesNotExist: false
+                  is_active: true
+                - identifier: "john@example.com"
+                  error: false
+                  userDoesNotExist: false
+                  is_active: true
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        404:
+          $ref: '#/responses/NotFound'
+
+  /api/instructor/v2/courses/{course_key}/team/{email_or_username}:
+    delete:
+      tags:
+        - Course Team
+      summary: Revoke one or more course roles from a user
+      description: |
+        Revoke one or more course roles from a user.
+
+        **Constraints:**
+        - Instructors cannot revoke their own instructor access
+        - The user must exist and be active
+
+        **Note:** This replaces the `action=revoke` path of the legacy
+        `POST /courses/{course_id}/instructor/api/modify_access` endpoint.
+      operationId: revokeCourseRole
+      produces:
+        - application/json
+      consumes:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseKey'
+        - name: email_or_username
+          in: path
+          description: Username or email of the user to revoke the role from
+          required: true
+          type: string
+          x-example: "jane_doe"
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            required:
+              - role
+            properties:
+              role:
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - instructor
+                    - staff
+                    - limited_staff
+                    - beta
+                    - ccx_coach
+                    - data_researcher
+                    - Administrator
+                    - Moderator
+                    - Group Moderator
+                    - Community TA
+                description: One or more roles to revoke (course access role or forum role)
+                minItems: 1
+                x-example: ["staff", "beta"]
+      responses:
+        200:
+          description: Role(s) revoked successfully
+          schema:
+            type: object
+            required:
+              - identifier
+              - roles
+              - action
+              - success
+            properties:
+              identifier:
+                type: string
+              roles:
+                type: array
+                items:
+                  type: string
+              action:
+                type: string
+                enum: ["revoke"]
+              success:
+                type: boolean
+          examples:
+            application/json:
+              identifier: "jane_doe"
+              roles: ["staff", "beta"]
+              action: "revoke"
+              success: true
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        404:
+          $ref: '#/responses/NotFound'
+        409:
+          description: Cannot remove own instructor access
+          schema:
+            type: object
+            required:
+              - error
+            properties:
+              error:
+                type: string
+                description: Error message explaining why the instructor role cannot be revoked
+          examples:
+            application/json:
+              error: "Instructors cannot remove their own instructor access."
+
+# ==================== COMPONENTS ====================
+
+parameters:
+  CourseKey:
+    name: course_key
+    in: path
+    required: true
+    description: Course identifier in format `course-v1:{org}+{course}+{run}`
+    type: string
+    pattern: '^course-v1:[^/+]+(\+[^/+]+)+(\+[^/]+)$'
+    x-example: "course-v1:edX+DemoX+Demo_Course"
+
+responses:
+  BadRequest:
+    description: Bad request - Invalid parameters or malformed request. Returns either
+      a simple error payload or serializer validation errors.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        error: "The role query parameter is required."
+
+  Unauthorized:
+    description: Unauthorized - Authentication required
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        detail: "Authentication credentials were not provided."
+
+  Forbidden:
+    description: Forbidden - Insufficient permissions
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        detail: "You do not have permission to perform this action."
+
+  NotFound:
+    description: Not found - Resource does not exist
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        error: "User 'unknown' not found."
+
+definitions:
+  CourseTeamMemberList:
+    type: object
+    description: Paginated list of course team members, optionally filtered by role and/or identity
+    required:
+      - course_id
+      - role
+      - email_or_username
+      - count
+      - num_pages
+      - current_page
+      - results
+    properties:
+      course_id:
+        type: string
+        description: Course identifier
+        example: "course-v1:edX+DemoX+Demo_Course"
+      role:
+        type: string
+        description: The role that was queried, or null when all roles were requested
+        x-nullable: true
+        example: "staff"
+      email_or_username:
+        type: string
+        description: The identity filter that was applied, or null when no filter was provided
+        x-nullable: true
+        example: "jane_doe"
+      count:
+        type: integer
+        description: Total number of matching team members across all pages
+        example: 150
+      num_pages:
+        type: integer
+        description: Total number of pages
+        example: 15
+      current_page:
+        type: integer
+        description: Current page number (1-indexed)
+        example: 1
+      start:
+        type: integer
+        description: Index (0-based) of the first result on this page in the overall result set
+        example: 0
+      next:
+        type: string
+        description: URL for the next page, or null if there is no next page
+        x-nullable: true
+        example: "http://example.com/api/instructor/v2/courses/.../team?page=2"
+      previous:
+        type: string
+        description: URL for the previous page, or null if there is no previous page
+        x-nullable: true
+        example: null
+      results:
+        type: array
+        description: List of team members on this page
+        items:
+          $ref: '#/definitions/CourseTeamMember'
+
+  CourseTeamMember:
+    type: object
+    description: A user with one or more course team roles, aggregated into a single record
+    required:
+      - username
+      - email
+      - first_name
+      - last_name
+      - roles
+    properties:
+      username:
+        type: string
+        description: User's username
+        example: "staff_user1"
+      email:
+        type: string
+        format: email
+        description: User's email address
+        example: "staff1@example.com"
+      first_name:
+        type: string
+        description: User's first name
+        example: "Alice"
+      last_name:
+        type: string
+        description: User's last name
+        example: "Smith"
+      roles:
+        type: array
+        description: All roles held by this user in the course
+        items:
+          $ref: '#/definitions/CourseTeamMemberRole'
+
+  CourseTeamMemberRole:
+    type: object
+    description: A role held by a team member, with its localized display name
+    required:
+      - role
+      - display_name
+    properties:
+      role:
+        type: string
+        description: Role identifier (course access role or forum role)
+        example: "staff"
+      display_name:
+        type: string
+        description: Localized display name for the role
+        example: "Staff"
+
+  CourseTeamModifyResult:
+    type: object
+    description: Result of granting or revoking a course role
+    required:
+      - identifier
+      - role
+      - action
+      - success
+    properties:
+      identifier:
+        type: string
+        description: Username of the affected user
+        example: "jane_doe"
+      role:
+        type: string
+        description: The role that was modified
+        example: "staff"
+      action:
+        type: string
+        enum: ["allow", "revoke"]
+        description: The action that was performed
+        example: "allow"
+      success:
+        type: boolean
+        description: Whether the operation succeeded
+        example: true
+
+  CourseTeamGrantResult:
+    type: object
+    description: Aggregated result of a course role modification operation
+    required:
+      - action
+      - role
+      - results
+    properties:
+      action:
+        type: string
+        enum: ["allow", "revoke"]
+        description: The action that was performed
+        example: "allow"
+      role:
+        type: string
+        description: The role that was modified
+        example: "staff"
+      results:
+        type: array
+        description: Per-identifier results
+        items:
+          $ref: '#/definitions/CourseTeamGrantItemResult'
+
+  CourseTeamGrantItemResult:
+    type: object
+    description: Result for a single identifier in a course role grant operation
+    required:
+      - identifier
+      - error
+      - userDoesNotExist
+      - is_active
+    properties:
+      identifier:
+        type: string
+        description: The email or username that was processed
+        example: "jane_doe"
+      error:
+        type: boolean
+        description: Whether an error occurred processing this identifier
+        example: false
+      userDoesNotExist:
+        type: boolean
+        description: Whether the user was not found
+        example: false
+      is_active:
+        type: boolean
+        description: Whether the user account is active (null if user does not exist)
+        x-nullable: true
+        example: true
+
+  Error:
+    type: object
+    description: |
+      Error response. The shape varies by error source:
+      - View-level errors return `{"error": "..."}` with a human-readable message.
+      - Serializer validation errors return field-keyed objects (e.g., `{"role": ["..."]}`).
+      - DRF permission/authentication errors return `{"detail": "..."}`.
+    properties:
+      error:
+        type: string
+        description: Human-readable error message (view-level errors)
+        example: "User 'unknown' not found."
+      detail:
+        type: string
+        description: Error message from DRF (authentication/permission errors)
+        example: "Authentication credentials were not provided."
+    additionalProperties: true

--- a/lms/djangoapps/instructor/docs/references/instructor-v2-course-team-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-course-team-api-spec.yaml
@@ -292,9 +292,9 @@ paths:
           schema:
             type: object
             required:
-              - role
+              - roles
             properties:
-              role:
+              roles:
                 type: array
                 items:
                   type: string

--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -3,6 +3,8 @@ Permissions for the instructor dashboard and associated actions
 """
 from bridgekeeper import perms
 from bridgekeeper.rules import is_staff
+from django.http import Http404
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission
@@ -83,7 +85,11 @@ perms[VIEW_FORUM_MEMBERS] = HasAccessRule('staff')
 class InstructorPermission(BasePermission):
     """Generic permissions"""
     def has_permission(self, request, view):
-        course = get_course_by_id(CourseKey.from_string(view.kwargs.get('course_id')))
+        try:
+            course_key = CourseKey.from_string(view.kwargs.get('course_id'))
+        except InvalidKeyError as exc:
+            raise Http404('Invalid course key') from exc
+        course = get_course_by_id(course_key)
         permission = getattr(view, 'permission_name', None)
         return request.user.has_perm(permission, course)
 

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -8,18 +8,25 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import ddt
+from django.contrib.auth import get_user_model
+from django.http import Http404
 from django.test import SimpleTestCase, override_settings
 from django.urls import NoReverseMatch, reverse
 from edx_when.api import set_date_for_block, set_dates_for_course
 from opaque_keys import InvalidKeyError
 from pytz import UTC
 from rest_framework import status
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APIClient, APIRequestFactory, APITestCase
 
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import ManualEnrollmentAudit
 from common.djangoapps.student.models.course_enrollment import CourseEnrollment, CourseEnrollmentAllowed
-from common.djangoapps.student.roles import CourseBetaTesterRole, CourseDataResearcherRole, CourseInstructorRole
+from common.djangoapps.student.roles import (
+    CourseBetaTesterRole,
+    CourseDataResearcherRole,
+    CourseInstructorRole,
+    CourseStaffRole,
+)
 from common.djangoapps.student.tests.factories import (
     AdminFactory,
     CourseEnrollmentFactory,
@@ -31,8 +38,12 @@ from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import CertificateGenerationHistory
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.courseware.models import StudentModule
+from lms.djangoapps.instructor.access import ROLE_DISPLAY_NAMES
+from lms.djangoapps.instructor.permissions import InstructorPermission
 from lms.djangoapps.instructor.views.serializers_v2 import CourseInformationSerializerV2
 from lms.djangoapps.instructor_task.tests.factories import InstructorTaskFactory
+from openedx.core.djangoapps.django_comment_common.models import Role
+from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
@@ -2624,3 +2635,563 @@ class BetaTesterModifyViewTest(SharedModuleStoreTestCase):
         assert len(results) == 2
         assert results[0]['error'] is False
         assert results[1]['error'] is True
+
+
+@ddt.ddt
+class CourseTeamViewTest(SharedModuleStoreTestCase):
+    """Tests for CourseTeamView (GET list and POST grant) endpoints."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course = CourseFactory.create(
+            org='edX',
+            number='TeamX',
+            run='2024',
+            display_name='Team Test Course',
+        )
+        cls.course_key = cls.course.id
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.instructor = InstructorFactory.create(course_key=self.course_key)
+        self.staff_user = StaffFactory.create(course_key=self.course_key)
+        self.student = UserFactory.create()
+        self.url = reverse('instructor_api_v2:course_team', kwargs={'course_id': str(self.course_key)})
+
+    # ---- GET tests ----
+
+    def test_list_staff_members(self):
+        """Instructors can list users with a given role."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'role': 'staff'})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['course_id'] == str(self.course_key)
+        assert response.data['role'] == 'staff'
+        usernames = [m['username'] for m in response.data['results']]
+        assert self.staff_user.username in usernames
+
+    def test_list_instructors(self):
+        """List instructor role members."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'role': 'instructor'})
+
+        assert response.status_code == status.HTTP_200_OK
+        usernames = [m['username'] for m in response.data['results']]
+        assert self.instructor.username in usernames
+
+    def test_list_all_roles_when_no_role_param(self):
+        """GET without role param returns all team members aggregated per user."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['role'] is None
+        usernames = [m['username'] for m in response.data['results']]
+        assert self.instructor.username in usernames
+        assert self.staff_user.username in usernames
+        for member in response.data['results']:
+            assert 'roles' in member
+            assert isinstance(member['roles'], list)
+            for role_entry in member['roles']:
+                assert 'role' in role_entry
+                assert 'display_name' in role_entry
+
+    def test_list_aggregates_user_with_multiple_roles(self):
+        """A user with multiple roles appears as a single record with all roles."""
+        multi_role_user = UserFactory.create(username='multirole')
+        CourseStaffRole(self.course_key).add_users(multi_role_user)
+        CourseBetaTesterRole(self.course_key).add_users(multi_role_user)
+
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        matches = [m for m in response.data['results'] if m['username'] == 'multirole']
+        assert len(matches) == 1
+        role_names = {r['role'] for r in matches[0]['roles']}
+        assert {'staff', 'beta'}.issubset(role_names)
+        for role_entry in matches[0]['roles']:
+            assert role_entry['display_name'] == str(ROLE_DISPLAY_NAMES[role_entry['role']])
+
+    def test_list_invalid_role(self):
+        """GET with invalid role returns 400."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'role': 'nonexistent'})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_list_unauthenticated(self):
+        """Unauthenticated request returns 401."""
+        response = self.client.get(self.url, {'role': 'staff'})
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_list_no_permission(self):
+        """Student without instructor access gets 403."""
+        self.client.force_authenticate(user=self.student)
+        response = self.client.get(self.url, {'role': 'staff'})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_response_fields(self):
+        """Verify response contains expected user fields and roles array."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'role': 'staff'})
+
+        assert response.status_code == status.HTTP_200_OK
+        for member in response.data['results']:
+            assert 'username' in member
+            assert 'email' in member
+            assert 'first_name' in member
+            assert 'last_name' in member
+            assert 'roles' in member
+            assert any(r['role'] == 'staff' for r in member['roles'])
+
+    @ddt.data('instructor', 'staff', 'limited_staff', 'beta', 'ccx_coach', 'data_researcher')
+    def test_list_all_valid_roles(self, role):
+        """GET with any valid role returns 200."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'role': role})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['role'] == role
+        assert 'results' in response.data
+
+    # ---- POST grant tests ----
+
+    def test_grant_staff_role(self):
+        """Grant staff role to one or more users via array."""
+        new_user = UserFactory.create()
+        other_user = UserFactory.create()
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [new_user.username, other_user.email],
+            'role': 'staff',
+            'action': 'allow',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['action'] == 'allow'
+        assert response.data['role'] == 'staff'
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id[new_user.username]['error'] is False
+        assert results_by_id[new_user.username]['userDoesNotExist'] is False
+        assert results_by_id[new_user.username]['is_active'] is True
+        assert results_by_id[other_user.email]['error'] is False
+        assert CourseStaffRole(self.course_key).has_user(new_user)
+        assert CourseStaffRole(self.course_key).has_user(other_user)
+
+    def test_grant_role_auto_enrolls(self):
+        """Granting a role also enrolls the user if not already enrolled."""
+        new_user = UserFactory.create()
+        self.client.force_authenticate(user=self.instructor)
+        self.client.post(self.url, {
+            'identifiers': [new_user.username],
+            'role': 'staff',
+            'action': 'allow',
+        }, format='json')
+
+        assert CourseEnrollment.is_enrolled(new_user, self.course_key)
+
+    def test_grant_role_user_not_found(self):
+        """Granting a role to a non-existent user reports per-identifier error."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': ['nonexistent_user_12345'],
+            'role': 'staff',
+            'action': 'allow',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id['nonexistent_user_12345']['error'] is True
+        assert results_by_id['nonexistent_user_12345']['userDoesNotExist'] is True
+        assert results_by_id['nonexistent_user_12345']['is_active'] is None
+
+    def test_grant_role_invalid_role(self):
+        """Granting an invalid role returns 400."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [self.student.username],
+            'role': 'nonexistent',
+            'action': 'allow',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_grant_role_inactive_user(self):
+        """Granting a role to an inactive user reports per-identifier error."""
+        inactive_user = UserFactory.create(is_active=False)
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [inactive_user.username],
+            'role': 'staff',
+            'action': 'allow',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id[inactive_user.username]['error'] is True
+        assert results_by_id[inactive_user.username]['userDoesNotExist'] is False
+        assert results_by_id[inactive_user.username]['is_active'] is False
+        assert not CourseStaffRole(self.course_key).has_user(inactive_user)
+
+    def test_grant_role_empty_identifiers(self):
+        """POST with empty identifiers array returns 400."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [],
+            'role': 'staff',
+            'action': 'allow',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_post_missing_action_returns_400(self):
+        """POST without action field returns 400."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [self.student.username],
+            'role': 'staff',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    # ---- POST revoke tests ----
+
+    def test_revoke_staff_role(self):
+        """Revoke staff role from one or more users via array."""
+        user_a = UserFactory.create()
+        user_b = UserFactory.create()
+        CourseStaffRole(self.course_key).add_users(user_a, user_b)
+        assert CourseStaffRole(self.course_key).has_user(user_a)
+        assert CourseStaffRole(self.course_key).has_user(user_b)
+
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [user_a.username, user_b.username],
+            'role': 'staff',
+            'action': 'revoke',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['action'] == 'revoke'
+        assert response.data['role'] == 'staff'
+        for result in response.data['results']:
+            assert result['error'] is False
+        fresh_a = get_user_model().objects.get(pk=user_a.pk)
+        fresh_b = get_user_model().objects.get(pk=user_b.pk)
+        assert not CourseStaffRole(self.course_key).has_user(fresh_a)
+        assert not CourseStaffRole(self.course_key).has_user(fresh_b)
+
+    def test_revoke_own_instructor_role_errors(self):
+        """Instructors cannot revoke their own instructor access."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [self.instructor.username],
+            'role': 'instructor',
+            'action': 'revoke',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id[self.instructor.username]['error'] is True
+        assert CourseInstructorRole(self.course_key).has_user(self.instructor)
+
+    def test_revoke_role_user_not_found(self):
+        """Revoking a role from a non-existent user reports per-identifier error."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': ['ghost_user_xyz'],
+            'role': 'staff',
+            'action': 'revoke',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id['ghost_user_xyz']['error'] is True
+        assert results_by_id['ghost_user_xyz']['userDoesNotExist'] is True
+
+    def test_revoke_inactive_user_errors(self):
+        """Revoking a role from an inactive user reports per-identifier error."""
+        inactive_user = UserFactory.create(is_active=False)
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [inactive_user.username],
+            'role': 'staff',
+            'action': 'revoke',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id[inactive_user.username]['error'] is True
+        assert results_by_id[inactive_user.username]['is_active'] is False
+
+    # ---- email_or_username filter tests ----
+
+    def test_list_email_or_username_filters_by_username(self):
+        """email_or_username filters by username substring (case-insensitive)."""
+        target = UserFactory.create(username='alicelookup', email='alice@example.com')
+        CourseStaffRole(self.course_key).add_users(target)
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'email_or_username': 'ALICELOOK'})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['email_or_username'] == 'ALICELOOK'
+        usernames = [m['username'] for m in response.data['results']]
+        assert target.username in usernames
+        assert self.staff_user.username not in usernames
+
+    def test_list_email_or_username_filters_by_email(self):
+        """email_or_username filters by email substring."""
+        target = UserFactory.create(email='needle@example.com')
+        CourseStaffRole(self.course_key).add_users(target)
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'email_or_username': 'needle'})
+
+        assert response.status_code == status.HTTP_200_OK
+        emails = [m['email'] for m in response.data['results']]
+        assert target.email in emails
+
+    def test_list_email_or_username_no_match_returns_empty(self):
+        """email_or_username that matches nothing returns an empty results list."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'email_or_username': 'zzz_no_match_zzz'})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['results'] == []
+        assert response.data['count'] == 0
+
+    def test_list_email_or_username_null_when_omitted(self):
+        """email_or_username is null in response when no filter is provided."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['email_or_username'] is None
+
+    # ---- Pagination tests ----
+
+    def test_list_pagination_fields_present(self):
+        """Paginated response includes DRF pagination fields."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        for field in ('count', 'num_pages', 'current_page', 'next', 'previous', 'results'):
+            assert field in response.data
+
+    def test_list_page_size_limits_results(self):
+        """page_size limits the number of returned results per page."""
+        for i in range(5):
+            user = UserFactory.create(username=f'extra_staff_{i}')
+            CourseStaffRole(self.course_key).add_users(user)
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'role': 'staff', 'page_size': 2})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data['results']) == 2
+        assert response.data['count'] >= 5
+        assert response.data['num_pages'] >= 3
+
+    def test_list_page_navigation(self):
+        """Second page returns different results than the first."""
+        for i in range(5):
+            user = UserFactory.create(username=f'paged_staff_{i:02d}')
+            CourseStaffRole(self.course_key).add_users(user)
+        self.client.force_authenticate(user=self.instructor)
+
+        page1 = self.client.get(self.url, {'role': 'staff', 'page_size': 2, 'page': 1})
+        page2 = self.client.get(self.url, {'role': 'staff', 'page_size': 2, 'page': 2})
+
+        assert page1.status_code == status.HTTP_200_OK
+        assert page2.status_code == status.HTTP_200_OK
+        page1_users = {m['username'] for m in page1.data['results']}
+        page2_users = {m['username'] for m in page2.data['results']}
+        assert page1_users.isdisjoint(page2_users)
+
+    # ---- Forum role tests ----
+
+    def test_grant_forum_role(self):
+        """POST with a forum role grants the role via the forum role system."""
+        seed_permissions_roles(self.course_key)
+
+        new_user = UserFactory.create()
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [new_user.username],
+            'role': 'Moderator',
+            'action': 'allow',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['role'] == 'Moderator'
+        assert response.data['action'] == 'allow'
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id[new_user.username]['error'] is False
+        role = Role.objects.get(course_id=self.course_key, name='Moderator')
+        assert role.users.filter(pk=new_user.pk).exists()
+
+    def test_list_forum_role(self):
+        """GET with a forum role query lists forum role holders."""
+        seed_permissions_roles(self.course_key)
+
+        target = UserFactory.create()
+        role = Role.objects.get(course_id=self.course_key, name='Community TA')
+        role.users.add(target)
+
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url, {'role': 'Community TA'})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['role'] == 'Community TA'
+        usernames = [m['username'] for m in response.data['results']]
+        assert target.username in usernames
+        for member in response.data['results']:
+            assert any(r['role'] == 'Community TA' for r in member['roles'])
+
+    def test_revoke_forum_role(self):
+        """POST with action=revoke removes a forum role."""
+        seed_permissions_roles(self.course_key)
+        target = UserFactory.create()
+        role = Role.objects.get(course_id=self.course_key, name='Moderator')
+        role.users.add(target)
+        assert role.users.filter(pk=target.pk).exists()
+
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {
+            'identifiers': [target.username],
+            'role': 'Moderator',
+            'action': 'revoke',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['action'] == 'revoke'
+        results_by_id = {r['identifier']: r for r in response.data['results']}
+        assert results_by_id[target.username]['error'] is False
+        assert not role.users.filter(pk=target.pk).exists()
+
+
+class InstructorPermissionInvalidKeyTest(SimpleTestCase):
+    """InstructorPermission must translate InvalidKeyError into Http404."""
+
+    def test_invalid_course_key_raises_http404(self):
+        """A malformed course_id on the view kwargs raises Http404, not 500."""
+        permission = InstructorPermission()
+        request = APIRequestFactory().get('/irrelevant')
+        view = Mock(kwargs={'course_id': 'this-is-not-a-course-key'})
+
+        try:
+            permission.has_permission(request, view)
+        except Http404:
+            return
+        raise AssertionError('Expected Http404 for invalid course key')
+
+
+class CourseTeamMemberViewTest(SharedModuleStoreTestCase):
+    """Tests for CourseTeamMemberView (DELETE revoke) endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course = CourseFactory.create(
+            org='edX',
+            number='TeamX',
+            run='2024_revoke',
+            display_name='Team Revoke Test Course',
+        )
+        cls.course_key = cls.course.id
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.instructor = InstructorFactory.create(course_key=self.course_key)
+        self.staff_user = StaffFactory.create(course_key=self.course_key)
+        self.student = UserFactory.create()
+
+    def _get_url(self, email_or_username):
+        """Build URL for course team member endpoint."""
+        return reverse(
+            'instructor_api_v2:course_team_member',
+            kwargs={'course_id': str(self.course_key), 'email_or_username': email_or_username}
+        )
+
+    def test_revoke_staff_role(self):
+        """Revoke staff role from a user."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.delete(self._get_url(self.staff_user.username), {'role': ['staff']}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['success']
+        assert response.data['action'] == 'revoke'
+        assert response.data['roles'] == ['staff']
+        assert not CourseStaffRole(self.course_key).has_user(self.staff_user)
+
+    def test_revoke_multiple_roles(self):
+        """Revoke multiple roles from a user in one request."""
+        target = UserFactory.create()
+        CourseStaffRole(self.course_key).add_users(target)
+        CourseBetaTesterRole(self.course_key).add_users(target)
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.delete(self._get_url(target.username), {'role': ['staff', 'beta']}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['roles'] == ['staff', 'beta']
+        assert not CourseStaffRole(self.course_key).has_user(target)
+        assert not CourseBetaTesterRole(self.course_key).has_user(target)
+
+    def test_revoke_self_instructor_blocked(self):
+        """Instructors cannot revoke their own instructor access."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.delete(
+            self._get_url(self.instructor.username), {'role': ['instructor']}, format='json'
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_revoke_missing_role_param(self):
+        """DELETE without role returns 400."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.delete(self._get_url(self.staff_user.username), format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_revoke_user_not_found(self):
+        """Revoking from non-existent user returns 404."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.delete(
+            self._get_url('nonexistent_user_12345'), {'role': ['staff']}, format='json'
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_revoke_unauthenticated(self):
+        """Unauthenticated request returns 401."""
+        response = self.client.delete(self._get_url(self.staff_user.username), {'role': ['staff']}, format='json')
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_revoke_no_permission(self):
+        """Student without instructor access gets 403."""
+        self.client.force_authenticate(user=self.student)
+        response = self.client.delete(self._get_url(self.staff_user.username), {'role': ['staff']}, format='json')
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_revoke_forum_role(self):
+        """DELETE with a forum role revokes the role via the forum role system."""
+        seed_permissions_roles(self.course_key)
+        target = UserFactory.create()
+        role = Role.objects.get(course_id=self.course_key, name='Moderator')
+        role.users.add(target)
+
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.delete(self._get_url(target.username), {'role': ['Moderator']}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['roles'] == ['Moderator']
+        assert response.data['action'] == 'revoke'
+        assert not role.users.filter(pk=target.pk).exists()

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import ddt
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.http import Http404
 from django.test import SimpleTestCase, override_settings
@@ -2635,6 +2636,76 @@ class BetaTesterModifyViewTest(SharedModuleStoreTestCase):
         assert len(results) == 2
         assert results[0]['error'] is False
         assert results[1]['error'] is True
+
+
+class CourseTeamRolesViewTest(SharedModuleStoreTestCase):
+    """Tests for CourseTeamRolesView (GET available roles) endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course = CourseFactory.create(
+            org='edX',
+            number='RolesX',
+            run='2024',
+            display_name='Roles Test Course',
+        )
+        cls.course_key = cls.course.id
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.instructor = InstructorFactory.create(course_key=self.course_key)
+        self.student = UserFactory.create()
+        self.url = reverse('instructor_api_v2:course_team_roles', kwargs={'course_id': str(self.course_key)})
+
+    def test_list_roles_without_ccx(self):
+        """Returns roles excluding ccx_coach when CCX is not enabled; includes forum roles."""
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['course_id'] == str(self.course_key)
+        returned_roles = [r['role'] for r in response.data['results']]
+        assert 'ccx_coach' not in returned_roles
+        for expected in ['beta', 'data_researcher', 'instructor', 'limited_staff', 'staff']:
+            assert expected in returned_roles
+        for expected in ['Administrator', 'Moderator', 'Group Moderator', 'Community TA']:
+            assert expected in returned_roles
+
+    @override_settings(FEATURES={**settings.FEATURES, 'CUSTOM_COURSES_EDX': True})
+    def test_list_roles_with_ccx_enabled(self):
+        """Returns all roles including ccx_coach when CCX is enabled for the course."""
+        ccx_course = CourseFactory.create(
+            org='edX',
+            number='CcxX',
+            run='2024',
+            display_name='CCX Test Course',
+            enable_ccx=True,
+        )
+        url = reverse('instructor_api_v2:course_team_roles', kwargs={'course_id': str(ccx_course.id)})
+        instructor = InstructorFactory.create(course_key=ccx_course.id)
+        self.client.force_authenticate(user=instructor)
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        returned_roles = [r['role'] for r in response.data['results']]
+        assert 'ccx_coach' in returned_roles
+        ccx_entry = next(r for r in response.data['results'] if r['role'] == 'ccx_coach')
+        assert ccx_entry['display_name'] == 'CCX Coach'
+
+    def test_list_roles_unauthenticated(self):
+        """Unauthenticated request returns 401."""
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_list_roles_no_permission(self):
+        """Student without instructor access gets 403."""
+        self.client.force_authenticate(user=self.student)
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @ddt.ddt

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -3122,7 +3122,7 @@ class CourseTeamMemberViewTest(SharedModuleStoreTestCase):
     def test_revoke_staff_role(self):
         """Revoke staff role from a user."""
         self.client.force_authenticate(user=self.instructor)
-        response = self.client.delete(self._get_url(self.staff_user.username), {'role': ['staff']}, format='json')
+        response = self.client.delete(self._get_url(self.staff_user.username), {'roles': ['staff']}, format='json')
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['success']
@@ -3136,7 +3136,7 @@ class CourseTeamMemberViewTest(SharedModuleStoreTestCase):
         CourseStaffRole(self.course_key).add_users(target)
         CourseBetaTesterRole(self.course_key).add_users(target)
         self.client.force_authenticate(user=self.instructor)
-        response = self.client.delete(self._get_url(target.username), {'role': ['staff', 'beta']}, format='json')
+        response = self.client.delete(self._get_url(target.username), {'roles': ['staff', 'beta']}, format='json')
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['roles'] == ['staff', 'beta']
@@ -3147,7 +3147,7 @@ class CourseTeamMemberViewTest(SharedModuleStoreTestCase):
         """Instructors cannot revoke their own instructor access."""
         self.client.force_authenticate(user=self.instructor)
         response = self.client.delete(
-            self._get_url(self.instructor.username), {'role': ['instructor']}, format='json'
+            self._get_url(self.instructor.username), {'roles': ['instructor']}, format='json'
         )
 
         assert response.status_code == status.HTTP_409_CONFLICT
@@ -3163,21 +3163,21 @@ class CourseTeamMemberViewTest(SharedModuleStoreTestCase):
         """Revoking from non-existent user returns 404."""
         self.client.force_authenticate(user=self.instructor)
         response = self.client.delete(
-            self._get_url('nonexistent_user_12345'), {'role': ['staff']}, format='json'
+            self._get_url('nonexistent_user_12345'), {'roles': ['staff']}, format='json'
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_revoke_unauthenticated(self):
         """Unauthenticated request returns 401."""
-        response = self.client.delete(self._get_url(self.staff_user.username), {'role': ['staff']}, format='json')
+        response = self.client.delete(self._get_url(self.staff_user.username), {'roles': ['staff']}, format='json')
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_revoke_no_permission(self):
         """Student without instructor access gets 403."""
         self.client.force_authenticate(user=self.student)
-        response = self.client.delete(self._get_url(self.staff_user.username), {'role': ['staff']}, format='json')
+        response = self.client.delete(self._get_url(self.staff_user.username), {'roles': ['staff']}, format='json')
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -3189,7 +3189,7 @@ class CourseTeamMemberViewTest(SharedModuleStoreTestCase):
         role.users.add(target)
 
         self.client.force_authenticate(user=self.instructor)
-        response = self.client.delete(self._get_url(target.username), {'role': ['Moderator']}, format='json')
+        response = self.client.delete(self._get_url(target.username), {'roles': ['Moderator']}, format='json')
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['roles'] == ['Moderator']

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -121,6 +121,16 @@ v2_api_urls = [
         api_v2.BetaTesterModifyView.as_view(),
         name='beta_tester_modify'
     ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/team/(?P<email_or_username>[^/]+)$',
+        api_v2.CourseTeamMemberView.as_view(),
+        name='course_team_member'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/team$',
+        api_v2.CourseTeamView.as_view(),
+        name='course_team'
+    ),
 ]
 
 urlpatterns = [

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -122,6 +122,11 @@ v2_api_urls = [
         name='beta_tester_modify'
     ),
     re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/team/roles$',
+        api_v2.CourseTeamRolesView.as_view(),
+        name='course_team_roles'
+    ),
+    re_path(
         rf'^courses/{COURSE_ID_PATTERN}/team/(?P<email_or_username>[^/]+)$',
         api_v2.CourseTeamMemberView.as_view(),
         name='course_team_member'

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -27,6 +27,7 @@ from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_control
 from django_filters.rest_framework import DjangoFilterBackend
+from edx_rest_framework_extensions.paginators import DefaultPagination
 from edx_when import api as edx_when_api
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -38,6 +39,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from common.djangoapps.student.api import is_user_enrolled_in_course
 from common.djangoapps.student.models import (
     ALLOWEDTOENROLL_TO_ENROLLED,
     ALLOWEDTOENROLL_TO_UNENROLLED,
@@ -65,7 +67,17 @@ from lms.djangoapps.course_home_api.toggles import course_home_mfe_progress_tab_
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.instructor import permissions
-from lms.djangoapps.instructor.access import allow_access, revoke_access
+from lms.djangoapps.instructor.access import (
+    FORUM_ROLES,
+    ROLE_DISPLAY_NAMES,
+    ROLES,
+    allow_access,
+    is_forum_role,
+    list_forum_members,
+    list_with_level,
+    revoke_access,
+    update_forum_role,
+)
 from lms.djangoapps.instructor.constants import ReportType
 from lms.djangoapps.instructor.enrollment import (
     enroll_email,
@@ -99,6 +111,8 @@ from .serializers_v2 import (
     CertificateGenerationHistorySerializer,
     CourseEnrollmentSerializerV2,
     CourseInformationSerializerV2,
+    CourseTeamModifySerializer,
+    CourseTeamRevokeSerializer,
     EnrollmentModifyRequestSerializerV2,
     EnrollmentModifyResponseSerializerV2,
     GradingConfigSerializer,
@@ -114,6 +128,7 @@ from .serializers_v2 import (
 )
 from .tools import find_unit, get_units_with_due_date, keep_field_private, set_due_date_extension, title_or_url
 
+User = get_user_model()
 log = logging.getLogger(__name__)
 User = get_user_model()
 
@@ -2361,3 +2376,323 @@ class BetaTesterModifyView(DeveloperErrorViewMixin, APIView):
             'results': results,
         })
         return Response(response_serializer.data)
+
+
+@method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
+class CourseTeamView(DeveloperErrorViewMixin, APIView):
+    """
+    List course team members, or grant/revoke a role for one or more users.
+
+    **GET Example Requests**
+
+        GET /api/instructor/v2/courses/{course_id}/team
+        GET /api/instructor/v2/courses/{course_id}/team?role=staff
+
+    **GET Response Values**
+
+    Each result is one record per user, aggregating all of that user's roles
+    into a ``roles`` array. Each role object contains the ``role`` identifier
+    and its localized ``display_name``.
+
+    When ``role`` is omitted, returns all team members across all roles:
+
+        {
+            "course_id": "course-v1:edX+DemoX+Demo_Course",
+            "role": null,
+            "results": [
+                {
+                    "username": "jane_doe",
+                    "email": "jane@example.com",
+                    "first_name": "Jane",
+                    "last_name": "Doe",
+                    "roles": [
+                        {"role": "staff", "display_name": "Staff"},
+                        {"role": "beta", "display_name": "Beta Tester"},
+                        {"role": "ccx_coach", "display_name": "CCX Coach"}
+                    ]
+                }
+            ]
+        }
+
+    When ``role`` is specified, returns only members with that role (still
+    one record per user, with the ``roles`` array containing only that role):
+
+        {
+            "course_id": "course-v1:edX+DemoX+Demo_Course",
+            "role": "staff",
+            "results": [
+                {
+                    "username": "staff_user1",
+                    "email": "staff1@example.com",
+                    "first_name": "Bob",
+                    "last_name": "Jones",
+                    "roles": [
+                        {"role": "staff", "display_name": "Staff"}
+                    ]
+                }
+            ]
+        }
+
+    **POST Example Request (grant)**
+
+        POST /api/instructor/v2/courses/{course_id}/team
+        {
+            "identifiers": ["jane_doe", "john@example.com"],
+            "role": "staff",
+            "action": "allow"
+        }
+
+    **POST Example Request (revoke)**
+
+        POST /api/instructor/v2/courses/{course_id}/team
+        {
+            "identifiers": ["jane_doe"],
+            "role": "staff",
+            "action": "revoke"
+        }
+
+    **POST Response Values**
+
+        {
+            "action": "allow",
+            "role": "staff",
+            "results": [
+                {
+                    "identifier": "jane_doe",
+                    "error": false,
+                    "userDoesNotExist": false,
+                    "is_active": true
+                },
+                {
+                    "identifier": "john@example.com",
+                    "error": false,
+                    "userDoesNotExist": false,
+                    "is_active": true
+                }
+            ]
+        }
+
+    **Returns**
+
+        * 200: OK (GET, POST - role granted/revoked)
+        * 400: Invalid parameters
+        * 401: User is not authenticated
+        * 403: User lacks instructor permissions
+        * 404: Course not found
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EDIT_COURSE_ACCESS
+
+    def get(self, request, course_id):
+        """
+        List course team members, optionally filtered by role and identity.
+
+        If no role is specified, returns members across all course and forum
+        roles. The optional ``email_or_username`` query param performs a
+        case-insensitive substring match against username and email.
+
+        Results are paginated via ``page`` and ``page_size``.
+        """
+        course_key = CourseKey.from_string(course_id)
+        role = request.query_params.get('role')
+        email_or_username = (request.query_params.get('email_or_username') or '').strip()
+
+        valid_roles = set(ROLES.keys()) | set(FORUM_ROLES)
+        if role and role not in valid_roles:
+            return Response(
+                {'error': _("Invalid role '%(role)s'. Must be one of: %(valid)s") % {
+                    'role': role,
+                    'valid': ', '.join(sorted(valid_roles)),
+                }},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Verify course exists
+        get_course_by_id(course_key)
+
+        if role:
+            roles_to_query = [role]
+        else:
+            roles_to_query = list(ROLES.keys()) + list(FORUM_ROLES)
+
+        users_by_id = {}
+        for rolename in roles_to_query:
+            if is_forum_role(rolename):
+                users = list_forum_members(course_key, rolename)
+            else:
+                users = list_with_level(course_key, rolename)
+            for user in users:
+                entry = users_by_id.get(user.id)
+                if entry is None:
+                    entry = {
+                        'username': user.username,
+                        'email': user.email,
+                        'first_name': user.first_name,
+                        'last_name': user.last_name,
+                        'roles': [],
+                    }
+                    users_by_id[user.id] = entry
+                entry['roles'].append({
+                    'role': rolename,
+                    'display_name': str(ROLE_DISPLAY_NAMES.get(rolename, rolename)),
+                })
+
+        results = sorted(users_by_id.values(), key=lambda r: r['username'].lower())
+
+        if email_or_username:
+            needle = email_or_username.lower()
+            results = [
+                r for r in results
+                if needle in r['username'].lower() or needle in r['email'].lower()
+            ]
+
+        paginator = DefaultPagination()
+        page = paginator.paginate_queryset(results, request, view=self)
+        paginated = paginator.get_paginated_response(page).data
+        paginated['course_id'] = str(course_key)
+        paginated['role'] = role
+        paginated['email_or_username'] = email_or_username or None
+        return Response(paginated, status=status.HTTP_200_OK)
+
+    def post(self, request, course_id):
+        """Grant or revoke a course role for one or more users."""
+        course_key = CourseKey.from_string(course_id)
+        course = get_course_by_id(course_key)
+
+        serializer = CourseTeamModifySerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        identifiers = serializer.validated_data['identifiers']
+        rolename = serializer.validated_data['role']
+        action = serializer.validated_data['action']
+
+        results = []
+        for identifier in identifiers:
+            error = False
+            user_does_not_exist = False
+            user_active = None
+            try:
+                user = get_student_from_identifier(identifier)
+                user_active = user.is_active
+
+                if not user.is_active:
+                    error = True
+                elif action == 'allow':
+                    if is_forum_role(rolename):
+                        update_forum_role(course_key, user, rolename, 'allow')
+                    else:
+                        allow_access(course, user, rolename)
+                        if not is_user_enrolled_in_course(user, course_key):
+                            CourseEnrollment.enroll(user, course_key)
+                elif action == 'revoke':
+                    if rolename == 'instructor' and user == request.user:
+                        error = True
+                    elif is_forum_role(rolename):
+                        update_forum_role(course_key, user, rolename, 'revoke')
+                    else:
+                        revoke_access(course, user, rolename)
+            except User.DoesNotExist:
+                error = True
+                user_does_not_exist = True
+            except Exception:  # pylint: disable=broad-except
+                log.exception("Error while %s role %s for %s", action, rolename, identifier)
+                error = True
+            finally:
+                results.append({
+                    'identifier': identifier,
+                    'error': error,
+                    'userDoesNotExist': user_does_not_exist,
+                    'is_active': user_active,
+                })
+
+        return Response({
+            'action': action,
+            'role': rolename,
+            'results': results,
+        }, status=status.HTTP_200_OK)
+
+
+@method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
+class CourseTeamMemberView(DeveloperErrorViewMixin, APIView):
+    """
+    Revoke one or more course roles from a user.
+
+    **DELETE Example Request (single role)**
+
+        DELETE /api/instructor/v2/courses/{course_id}/team/jane_doe
+        {
+            "role": ["staff"]
+        }
+
+    **DELETE Example Request (multiple roles)**
+
+        DELETE /api/instructor/v2/courses/{course_id}/team/jane_doe
+        {
+            "role": ["staff", "beta"]
+        }
+
+    **DELETE Response Values**
+
+        {
+            "identifier": "jane_doe",
+            "roles": ["staff", "beta"],
+            "action": "revoke",
+            "success": true
+        }
+
+    **Returns**
+
+        * 200: Role(s) revoked successfully
+        * 400: Invalid parameters
+        * 401: User is not authenticated
+        * 403: User lacks instructor permissions
+        * 404: Course or user not found
+        * 409: Cannot remove own instructor access
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EDIT_COURSE_ACCESS
+
+    def delete(self, request, course_id, email_or_username):
+        """Revoke one or more course roles from a user."""
+        course_key = CourseKey.from_string(course_id)
+        course = get_course_by_id(course_key)
+
+        revoke_serializer = CourseTeamRevokeSerializer(data=request.data)
+        if not revoke_serializer.is_valid():
+            return Response(revoke_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        roles = revoke_serializer.validated_data['role']
+
+        try:
+            user = get_student_from_identifier(email_or_username)
+        except User.DoesNotExist:
+            return Response(
+                {'error': _("User '%(identifier)s' not found.") % {'identifier': email_or_username}},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        if not user.is_active:
+            return Response(
+                {'error': _("User '%(identifier)s' is inactive.") % {'identifier': email_or_username}},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if 'instructor' in roles and user == request.user:
+            return Response(
+                {'error': _('Instructors cannot remove their own instructor access.')},
+                status=status.HTTP_409_CONFLICT
+            )
+
+        for rolename in roles:
+            if is_forum_role(rolename):
+                update_forum_role(course_key, user, rolename, 'revoke')
+            else:
+                revoke_access(course, user, rolename)
+
+        return Response({
+            'identifier': user.username,
+            'roles': roles,
+            'action': 'revoke',
+            'success': True,
+        }, status=status.HTTP_200_OK)

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -130,7 +130,8 @@ from .tools import find_unit, get_units_with_due_date, keep_field_private, set_d
 
 User = get_user_model()
 log = logging.getLogger(__name__)
-User = get_user_model()
+
+VALID_TEAM_ROLES = frozenset(ROLES.keys()) | frozenset(FORUM_ROLES)
 
 
 class CourseMetadataView(DeveloperErrorViewMixin, APIView):
@@ -2554,12 +2555,11 @@ class CourseTeamView(DeveloperErrorViewMixin, APIView):
         role = request.query_params.get('role')
         email_or_username = (request.query_params.get('email_or_username') or '').strip()
 
-        valid_roles = set(ROLES.keys()) | set(FORUM_ROLES)
-        if role and role not in valid_roles:
+        if role and role not in VALID_TEAM_ROLES:
             return Response(
                 {'error': _("Invalid role '%(role)s'. Must be one of: %(valid)s") % {
                     'role': role,
-                    'valid': ', '.join(sorted(valid_roles)),
+                    'valid': ', '.join(sorted(VALID_TEAM_ROLES)),
                 }},
                 status=status.HTTP_400_BAD_REQUEST
             )

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -2622,14 +2622,14 @@ class CourseTeamMemberView(DeveloperErrorViewMixin, APIView):
 
         DELETE /api/instructor/v2/courses/{course_id}/team/jane_doe
         {
-            "role": ["staff"]
+            "roles": ["staff"]
         }
 
     **DELETE Example Request (multiple roles)**
 
         DELETE /api/instructor/v2/courses/{course_id}/team/jane_doe
         {
-            "role": ["staff", "beta"]
+            "roles": ["staff", "beta"]
         }
 
     **DELETE Response Values**
@@ -2662,7 +2662,7 @@ class CourseTeamMemberView(DeveloperErrorViewMixin, APIView):
         if not revoke_serializer.is_valid():
             return Response(revoke_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        roles = revoke_serializer.validated_data['role']
+        roles = revoke_serializer.validated_data['roles']
 
         try:
             user = get_student_from_identifier(email_or_username)

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -2378,6 +2378,63 @@ class BetaTesterModifyView(DeveloperErrorViewMixin, APIView):
         return Response(response_serializer.data)
 
 
+class CourseTeamRolesView(DeveloperErrorViewMixin, APIView):
+    """
+    List the available course team roles for a specific course.
+
+    The returned roles are filtered based on course configuration.
+    For example, the ``ccx_coach`` role is only included when the
+    ``CUSTOM_COURSES_EDX`` feature flag is enabled **and** the course
+    has CCX enabled (``course.enable_ccx``).
+
+    **GET Example Request**
+
+        GET /api/instructor/v2/courses/{course_id}/team/roles
+
+    **GET Response Values**
+
+        {
+            "course_id": "course-v1:edX+DemoX+Demo_Course",
+            "results": [
+                {"role": "beta", "display_name": "Beta Tester"},
+                {"role": "data_researcher", "display_name": "Data Researcher"},
+                {"role": "instructor", "display_name": "Admin"},
+                {"role": "limited_staff", "display_name": "Limited Staff"},
+                {"role": "staff", "display_name": "Staff"}
+            ]
+        }
+
+    **Returns**
+
+        * 200: OK
+        * 401: User is not authenticated
+        * 403: User lacks instructor permissions
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EDIT_COURSE_ACCESS
+
+    def get(self, request, course_id):
+        """Return the list of available course team roles for this course."""
+        course_key = CourseKey.from_string(course_id)
+        course = get_course_by_id(course_key)
+
+        roles = set(ROLES.keys()) | set(FORUM_ROLES)
+
+        ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
+        if not ccx_enabled:
+            roles.discard('ccx_coach')
+
+        results = [
+            {'role': rolename, 'display_name': str(ROLE_DISPLAY_NAMES[rolename])}
+            for rolename in sorted(roles)
+        ]
+
+        return Response({
+            'course_id': str(course_key),
+            'results': results,
+        }, status=status.HTTP_200_OK)
+
+
 @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
 class CourseTeamView(DeveloperErrorViewMixin, APIView):
     """

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -969,7 +969,7 @@ class CourseTeamModifySerializer(serializers.Serializer):
 
 class CourseTeamRevokeSerializer(serializers.Serializer):
     """Input serializer for revoking course team roles."""
-    role = serializers.ListField(
+    roles = serializers.ListField(
         child=serializers.ChoiceField(choices=list(ROLES.keys()) + list(FORUM_ROLES)),
         allow_empty=False,
         help_text="One or more roles to revoke (course access role or forum role)"

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -28,6 +28,7 @@ from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.discussion.django_comment_client.utils import has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from lms.djangoapps.instructor import permissions
+from lms.djangoapps.instructor.access import FORUM_ROLES, ROLES
 from lms.djangoapps.instructor.views.instructor_dashboard import get_analytics_dashboard_message
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR
 from xmodule.modulestore.django import modulestore
@@ -947,3 +948,29 @@ class BetaTesterModifyResponseSerializerV2(serializers.Serializer):
     """Documents the response shape for the bulk beta tester add/remove endpoint (mirrors v1)."""
     action = serializers.CharField()
     results = BetaTesterModifyResultSerializerV2(many=True)
+
+
+class CourseTeamModifySerializer(serializers.Serializer):
+    """Input serializer for granting or revoking a course team role."""
+    identifiers = serializers.ListField(
+        child=serializers.CharField(max_length=255, allow_blank=False),
+        allow_empty=False,
+        help_text="List of usernames or emails of users to modify"
+    )
+    role = serializers.ChoiceField(
+        choices=list(ROLES.keys()) + list(FORUM_ROLES),
+        help_text="The role to grant or revoke (course access role or forum role)"
+    )
+    action = serializers.ChoiceField(
+        choices=['allow', 'revoke'],
+        help_text="Whether to grant ('allow') or revoke ('revoke') the role"
+    )
+
+
+class CourseTeamRevokeSerializer(serializers.Serializer):
+    """Input serializer for revoking course team roles."""
+    role = serializers.ListField(
+        child=serializers.ChoiceField(choices=list(ROLES.keys()) + list(FORUM_ROLES)),
+        allow_empty=False,
+        help_text="One or more roles to revoke (course access role or forum role)"
+    )


### PR DESCRIPTION
### Description                                                                                                    
Adds v2 REST API for managing course team members (instructors, staff, beta testers, CCX coaches, etc.) on the LMS instructor dashboard. This includes an OpenAPI schema specification, serializers, views, URL routing, and tests.

The schema defines RESTful endpoints that will replace the legacy POST-based course team management endpoints on the LMS instructor dashboard.

### Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/instructor/v2/courses/{course_id}/team` | List all team members (optionally filter by `?role=staff`) |
| POST | `/api/instructor/v2/courses/{course_id}/team` | Grant or revoke a role for one or more users |
| DELETE | `/api/instructor/v2/courses/{course_id}/team/{email_or_username}` | Revoke one or more roles from a user |

### Supporting information
- Closes #37559

### Testing instructions
Manual API testing (optional):                                                                                                                                           
- Authenticate as an instructor for a course
- `GET /api/instructor/v2/courses/{course_id}/team?role=staff` — list staff members
- `GET /api/instructor/v2/courses/{course_id}/team` — list all team members across all roles
- `POST /api/instructor/v2/courses/{course_id}/team` with `{"identifiers": ["username"], "role": "staff", "action": "allow"}` — grant role
- `POST /api/instructor/v2/courses/{course_id}/team` with `{"identifiers": ["username"], "role": "staff", "action": "revoke"}` — revoke role (bulk)
- `DELETE /api/instructor/v2/courses/{course_id}/team/username` with `{"role": ["staff"]}` — revoke role from single user
- `DELETE /api/instructor/v2/courses/{course_id}/team/username` with `{"role": ["staff", "beta"]}` — revoke multiple roles

### Deadline
None

### Other information
- No database migrations, no runtime changes, no deprecations.