### PR TITLE
feat: add authz permission checks for course grading configuration endpoints

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
@@ -1,0 +1,119 @@
+"""
+Unit tests for authoring grading views.
+"""
+import json
+
+from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from cms.djangoapps.contentstore.api.tests.base import BaseCourseViewTest
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthzTestMixin
+
+class AuthoringGradingViewAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
+    """
+    Tests Authoring Grading configuration API authorization using openedx-authz.
+    The endpoint uses the COURSES_EDIT_GRADING_SETTINGS permission.
+    """
+
+    view_name = "cms.djangoapps.contentstore:v1:course_grading"
+    authz_roles_to_assign = [COURSE_STAFF.external_key]
+    post_data = json.dumps({
+        "graders": [
+            {
+                "type": "Homework",
+                "min_count": 1,
+                "drop_count": 0,
+                "short_label": "",
+                "weight": 100,
+                "id": 0
+            }
+        ],
+        "grade_cutoffs": {
+            "A": 0.75,
+            "B": 0.63,
+            "C": 0.57,
+            "D": 0.5
+        },
+        "grace_period": {
+            "hours": 12,
+            "minutes": 0
+        },
+        "minimum_grade_credit": 0.7,
+        "is_credit_course": True
+    })
+
+    def test_authorized_user_can_access_post(self):
+        """User with COURSE_STAFF role can access."""
+        resp = self.authorized_client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_unauthorized_user_cannot_access_post(self):
+        """User without role cannot access."""
+        resp = self.unauthorized_client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_role_scoped_to_course_post(self):
+        """Authorization should only apply to the assigned course."""
+        other_course = self.store.create_course("OtherOrg", "OtherCourse", "Run", self.staff.id)
+
+        resp = self.authorized_client.post(
+            self.get_url(other_course.id),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user_allowed_via_legacy_post(self):
+        """
+        Staff users should still pass through legacy fallback.
+        """
+        self.client.login(username=self.staff.username, password=self.password)
+
+        resp = self.client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_superuser_allowed_post(self):
+        """Superusers should always be allowed."""
+        superuser = UserFactory(is_superuser=True)
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+
+        resp = client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_non_staff_user_cannot_access_post(self):
+        """
+        User without permissions should be denied.
+        This case validates that a non-staff user cannot access even
+        if they have course author access to the course.
+        """
+        non_staff_user = UserFactory()
+        non_staff_client = APIClient()
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key)
+        non_staff_client.force_authenticate(user=non_staff_user)
+
+        resp = non_staff_client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
@@ -17,7 +17,7 @@ class AuthoringGradingViewAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
     The endpoint uses the COURSES_EDIT_GRADING_SETTINGS permission.
     """
 
-    view_name = "cms.djangoapps.contentstore:v1:course_grading"
+    view_name = "cms.djangoapps.contentstore:v0:cms_api_update_grading"
     authz_roles_to_assign = [COURSE_STAFF.external_key]
     post_data = json.dumps({
         "graders": [
@@ -102,9 +102,8 @@ class AuthoringGradingViewAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
 
     def test_non_staff_user_cannot_access_post(self):
         """
-        User without permissions should be denied.
-        This case validates that a non-staff user cannot access even
-        if they have course author access to the course.
+        User without required permissions should be denied.
+        This case validates that a non-staff user doesn't get access.
         """
         non_staff_user = UserFactory()
         non_staff_client = APIClient()

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
@@ -2,12 +2,14 @@
 
 import edx_api_doc_tools as apidocs
 from opaque_keys.edx.keys import CourseKey
+from openedx_authz.constants.permissions import COURSES_EDIT_GRADING_SETTINGS
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
-from common.djangoapps.student.auth import has_studio_read_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import authz_permission_required
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
 from ..serializers import CourseGradingModelSerializer
@@ -31,7 +33,10 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
         },
     )
     @verify_course_exists()
-    def post(self, request: Request, course_id: str):
+    # Please note: previous legacy permisison was checking for has_studio_read_access
+    # So we are using LegacyAuthoringPermission.READ to keep compatibility
+    @authz_permission_required(COURSES_EDIT_GRADING_SETTINGS.identifier, LegacyAuthoringPermission.READ)
+    def post(self, request: Request, course_key: CourseKey):
         """
         Update a course's grading.
 
@@ -75,11 +80,6 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
 
         If the request is successful, an HTTP 200 "OK" response is returned,
         """
-        course_key = CourseKey.from_string(course_id)
-
-        if not has_studio_read_access(request.user, course_key):
-            self.permission_denied(request)
-
         if 'minimum_grade_credit' in request.data:
             update_credit_course_requirements.delay(str(course_key))
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
@@ -3,12 +3,14 @@
 import edx_api_doc_tools as apidocs
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
+from openedx_authz.constants.permissions import COURSES_VIEW_GRADING_SETTINGS, COURSES_EDIT_GRADING_SETTINGS
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
-from common.djangoapps.student.auth import has_studio_read_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import authz_permission_required
 from openedx.core.djangoapps.credit.api import is_credit_course
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
@@ -36,7 +38,8 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
         },
     )
     @verify_course_exists()
-    def get(self, request: Request, course_id: str):
+    @authz_permission_required(COURSES_VIEW_GRADING_SETTINGS.identifier, LegacyAuthoringPermission.READ)
+    def get(self, request: Request, course_key: CourseKey):
         """
         Get an object containing course grading settings with model.
 
@@ -90,11 +93,6 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
         }
         ```
         """
-        course_key = CourseKey.from_string(course_id)
-
-        if not has_studio_read_access(request.user, course_key):
-            self.permission_denied(request)
-
         with modulestore().bulk_operations(course_key):
             credit_eligibility_enabled = settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False)
             show_credit_eligibility = is_credit_course(course_key) and credit_eligibility_enabled
@@ -118,13 +116,16 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
         },
     )
     @verify_course_exists()
-    def post(self, request: Request, course_id: str):
+    # Please note: previous legacy permisison was checking for has_studio_read_access
+    # So we are using LegacyAuthoringPermission.READ to keep compatibility
+    @authz_permission_required(COURSES_EDIT_GRADING_SETTINGS.identifier, LegacyAuthoringPermission.READ)
+    def post(self, request: Request, course_key: CourseKey):
         """
         Update a course's grading.
 
         **Example Request**
 
-            PUT /api/contentstore/v1/course_grading/{course_id}
+            POST /api/contentstore/v1/course_grading/{course_id}
 
         **POST Parameters**
 
@@ -162,11 +163,6 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
 
         If the request is successful, an HTTP 200 "OK" response is returned,
         """
-        course_key = CourseKey.from_string(course_id)
-
-        if not has_studio_read_access(request.user, course_key):
-            self.permission_denied(request)
-
         if 'minimum_grade_credit' in request.data:
             update_credit_course_requirements.delay(str(course_key))
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
@@ -6,11 +6,16 @@ from unittest.mock import patch
 
 import ddt
 from django.urls import reverse
+from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
 from rest_framework import status
+from rest_framework.test import APIClient
 
+from cms.djangoapps.contentstore.api.tests.base import BaseCourseViewTest
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import get_proctored_exam_settings_url
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthzTestMixin
 from openedx.core.djangoapps.credit.tests.factories import CreditCourseFactory
 
 from ...mixins import PermissionAccessMixin
@@ -117,3 +122,151 @@ class CourseGradingViewTest(CourseTestCase, PermissionAccessMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_update_credit_course_requirements.assert_called_once()
+
+
+class CourseGradingViewAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
+    """
+    Tests Course Grading Configuration API authorization using openedx-authz.
+    The endpoint uses COURSES_VIEW_GRADING_SETTINGS and COURSES_EDIT_GRADING_SETTINGS permissions.
+    """
+
+    view_name = "cms.djangoapps.contentstore:v1:course_grading"
+    authz_roles_to_assign = [COURSE_STAFF.external_key]
+    post_data = json.dumps({
+        "graders": [{
+            "type": "Homework",
+            "min_count": 1,
+            "drop_count": 0,
+            "short_label": "",
+            "weight": 100,
+            "id": 0
+        }],
+        "grade_cutoffs": {"A": 0.75, "B": 0.63, "C": 0.57, "D": 0.5},
+        "grace_period": {"hours": 12, "minutes": 0},
+        "minimum_grade_credit": 0.7,
+        "is_credit_course": False,
+    })
+
+    def test_authorized_user_can_access_get(self):
+        """User with COURSE_STAFF role can access."""
+        resp = self.authorized_client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_unauthorized_user_cannot_access_get(self):
+        """User without role cannot access."""
+        resp = self.unauthorized_client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_role_scoped_to_course_get(self):
+        """Authorization should only apply to the assigned course."""
+        other_course = self.store.create_course("OtherOrg", "OtherCourse", "Run", self.staff.id)
+
+        resp = self.authorized_client.get(self.get_url(other_course.id))
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user_allowed_via_legacy_get(self):
+        """
+        Staff users should still pass through legacy fallback.
+        """
+        self.client.login(username=self.staff.username, password=self.password)
+
+        resp = self.client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_superuser_allowed_get(self):
+        """Superusers should always be allowed."""
+        superuser = UserFactory(is_superuser=True)
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+
+        resp = client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_non_staff_user_cannot_access_get(self):
+        """
+        User without permissions should be denied.
+        This case validates that a non-staff user cannot access even
+        if they have course author access to the course.
+        """
+        non_staff_user = UserFactory()
+        non_staff_client = APIClient()
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key)
+        non_staff_client.force_authenticate(user=non_staff_user)
+
+        resp = non_staff_client.get(self.get_url(self.course_key))
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authorized_user_can_access_post(self):
+        """User with COURSE_STAFF role can access."""
+        resp = self.authorized_client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_unauthorized_user_cannot_access_post(self):
+        """User without role cannot access."""
+        resp = self.unauthorized_client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_role_scoped_to_course_post(self):
+        """Authorization should only apply to the assigned course."""
+        other_course = self.store.create_course("OtherOrg", "OtherCourse", "Run", self.staff.id)
+
+        resp = self.authorized_client.post(
+            self.get_url(other_course.id),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user_allowed_via_legacy_post(self):
+        """
+        Staff users should still pass through legacy fallback.
+        """
+        self.client.login(username=self.staff.username, password=self.password)
+
+        resp = self.client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_superuser_allowed_post(self):
+        """Superusers should always be allowed."""
+        superuser = UserFactory(is_superuser=True)
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+
+        resp = client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_non_staff_user_cannot_access_post(self):
+        """
+        User without permissions should be denied.
+        This case validates that a non-staff user cannot access even
+        if they have course author access to the course.
+        """
+        non_staff_user = UserFactory()
+        non_staff_client = APIClient()
+        self.add_user_to_role(non_staff_user, COURSE_DATA_RESEARCHER.external_key)
+        non_staff_client.force_authenticate(user=non_staff_user)
+
+        resp = non_staff_client.post(
+            self.get_url(self.course_key),
+            data=self.post_data,
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
@@ -185,9 +185,8 @@ class CourseGradingViewAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
 
     def test_non_staff_user_cannot_access_get(self):
         """
-        User without permissions should be denied.
-        This case validates that a non-staff user cannot access even
-        if they have course author access to the course.
+        User without required permissions should be denied.
+        This case validates that a non-staff user doesn't get access.
         """
         non_staff_user = UserFactory()
         non_staff_client = APIClient()
@@ -255,9 +254,8 @@ class CourseGradingViewAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
 
     def test_non_staff_user_cannot_access_post(self):
         """
-        User without permissions should be denied.
-        This case validates that a non-staff user cannot access even
-        if they have course author access to the course.
+        User without required permissions should be denied.
+        This case validates that a non-staff user doesn't get access.
         """
         non_staff_user = UserFactory()
         non_staff_client = APIClient()


### PR DESCRIPTION
## Description

Implement new AuthZ permission checks over endpoints related with course grading configurations in course authoring.

The new AuthZ permission checks only apply when the enable_authz_course_authoring feature flag is enabled for the specific course, or globally, otherwise existing behavior persist.

The following AuthZ permission is being used:

- courses.view_grading_settings
- course.edit_grading_settings

The following endpoints were updated:

- GET /api/contentstore/v1/course_grading/(courseid)/: Get course grading data
- POST /api/contentstore/v1/course_grading/(courseid)/: Update course grading
- POST /api/contentstore/v0/grading/(courseid)/: Update course grading

## Supporting information

https://github.com/openedx/openedx-authz/issues/196

## Testing

Verified that:

- Authorized users can access the endpoints.
- Unauthorized users receive a 403 response.
- Legacy permission fallback works as expected.

Running relevant tests manually:

On a cms container (run with `tutor dev exec cms bash`), do:

```bash
pytest -p no:randomly --ds=cms.envs.test cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py

pytest -p no:randomly --ds=cms.envs.test cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
```

## Deadline

Verawood
