### PR TITLE
feat: remove enterprise and consent from OPTIONAL_APPS

### DIFF
--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -774,9 +774,8 @@ OPTIONAL_APPS = [
     # edxval
     ('edxval', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 
-    # Enterprise Apps (http://github.com/openedx/edx-enterprise)
-    ('enterprise', None),
-    ('consent', None),
+    # Deprecated apps from the edx-enterprise package. We're working on removing these as part of
+    # pluginifying edx-enterprise (<https://discuss.openedx.org/t/18316>)
     ('integrated_channels.integrated_channel', None),
     ('integrated_channels.degreed', None),
     ('integrated_channels.degreed2', None),

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 
 import requests
 from crum import get_current_request
+from django.apps import apps as django_apps
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
@@ -373,7 +374,7 @@ def enterprise_enabled():
     """
     Determines whether the Enterprise app is installed
     """
-    return 'enterprise' in settings.INSTALLED_APPS and settings.FEATURES.get('ENABLE_ENTERPRISE_INTEGRATION', False)
+    return django_apps.is_installed('enterprise') and settings.FEATURES.get('ENABLE_ENTERPRISE_INTEGRATION', False)
 
 
 def enterprise_is_enabled(otherwise=None):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -44,7 +44,7 @@ django-stubs<6
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==6.7.0
+edx-enterprise==6.8.1
 
 # Date: 2023-07-26
 # Our legacy Sass code is incompatible with anything except this ancient libsass version.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -478,7 +478,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.7.0
+edx-enterprise==6.8.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -758,7 +758,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.7.0
+edx-enterprise==6.8.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -569,7 +569,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.7.0
+edx-enterprise==6.8.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -589,7 +589,7 @@ edx-drf-extensions==10.6.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-core
-edx-enterprise==6.7.0
+edx-enterprise==6.8.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
- Remove `enterprise` and `consent` from platform INSTALLED_APPS. They'll automatically load as openedx plugins via the plugin framework in edx-enterprise 6.8.0. Keeping them in OPTIONAL_APPS would cause duplicate app label errors.
- Update enterprise_enabled() to correctly check if the enterprise app is installed. The new plugin entry_point-based registration uses 'enterprise.apps.EnterpriseConfig' (not 'enterprise') in INSTALLED_APPS, so the raw string check no longer works.

IMPORTANT: bumping edx-enterprise to 6.8.0 AND removing apps from INSTALLED_APPS must happen in the same commit so that they don't end up in different deployments which would either break django startup or accidentally disable enterprise (depending on the merge order).

ENT-11663

---

Tickets/PRs blocked by this one:

- [ENT-11571](https://2u-internal.atlassian.net/browse/ENT-11571) — Learner Home Enterprise Dashboard                                                                                                                                                                                                                                    
  - [https://github.com/openedx/openedx-platform/pull/38107 ](https://github.com/openedx/openedx-platform/pull/38107)                                                                                                                                                                                                                                                                
  - [https://github.com/openedx/edx-enterprise/pull/2554 ](https://github.com/openedx/edx-enterprise/pull/2554)                                                                                                                                                                                                                                                              
- [ENT-11572](https://2u-internal.atlassian.net/browse/ENT-11572) — Course Home Progress Enterprise Name                                                                                                                                                                                                                                 
  - [https://github.com/openedx/openedx-platform/pull/38108 ](https://github.com/openedx/openedx-platform/pull/38108)
  - [https://github.com/openedx/edx-enterprise/pull/2555 ](https://github.com/openedx/edx-enterprise/pull/2555)
- [ENT-11575](https://2u-internal.atlassian.net/browse/ENT-11575) — Programs API Enterprise Enrollments
  - No PRs created yet
 
---

Related:
* https://github.com/openedx/edx-enterprise/pull/2575