### PR TITLE
fix: view problem bank in authoring instead of legacy view

### DIFF
--- a/xmodule/item_bank_block.py
+++ b/xmodule/item_bank_block.py
@@ -439,7 +439,7 @@ class ItemBankMixin(
             # Show a summary message and instructions.
             summary_html = loader.render_django_template('templates/item_bank/author_view.html', {
                 # Due to template interpolation limitations, we have to pass some HTML for the link here:
-                "view_link": f'<a target="_top" href="/container/{self.usage_key}">',
+                "view_link": f'<a href="/container/{self.usage_key}" class="xblock-view-action-button">',
                 "blocks": [
                     {"display_name": display_name_with_default(child)}
                     for child in self.get_children()


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

View link at the right top opens problem bank in authoring view, but the link at the bottom opens it in the legacy LMS. This PR fixes the link at the bottom to open it in the authoring.

Before:

https://github.com/user-attachments/assets/ab85928a-3d85-4842-813d-4b0ceb9b661b

After:

https://github.com/user-attachments/assets/bcd8c49a-2fe6-4501-b516-9330c37f9c0f



## Testing instructions

- Checkout master branch and add a problem bank in a course
- Add components from a library
- Click on the view link at the bottom and verify that it open up legacy CMS
- Checkout this branch and now click on the view and verify that it opens the authoring MFE view like the right top View link.