### PR TITLE
Remove XModuleMixin legacy attibs from wordcloud, video block, lti block

### DIFF
--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -191,7 +191,7 @@ def validate_video_block(request, locator):
     error, item = None, None
     try:
         item = _get_item(request, {'locator': locator})
-        if item.category != 'video':
+        if item.usage_key.block_type != 'video':
             error = _('Transcripts are supported only for "video" blocks.')
 
     except (InvalidKeyError, ItemNotFoundError):
@@ -523,7 +523,7 @@ def _validate_transcripts_data(request):
     except (InvalidKeyError, ItemNotFoundError):
         raise TranscriptsRequestValidationException(_("Can't find item by locator."))  # lint-amnesty, pylint: disable=raise-missing-from
 
-    if item.category != 'video':
+    if item.usage_key.block_type != 'video':
         raise TranscriptsRequestValidationException(_('Transcripts are supported only for "video" blocks.'))
 
     # parse data form request.GET.['data']['video'] to useful format

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -798,7 +798,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
         if sub:
             assert ('Location', f'/static/dummy/static/subs_{sub}.srt.sjson') in response.headerlist
 
-    @patch('xmodule.video_block.VideoBlock.course_id', return_value='not_a_course_locator')
+    @patch('xmodule.video_block.VideoBlock.context_key', return_value='not_a_course_locator')
     def test_translation_static_non_course(self, __):
         """
         Test that get_static_transcript short-circuits in the case of a non-CourseLocator.
@@ -806,7 +806,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
         """
         self._set_static_asset_path()
 
-        # When course_id is not mocked out, these values would result in 307, as tested above.
+        # When context_key is not mocked out, these values would result in 307, as tested above.
         request = _create_djangowebobrequest_object_for_url('/translation/en?videoId=12345')
         response = self.block.transcript(request=request, dispatch='translation/en')
         assert response.status == '404 Not Found'

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1299,7 +1299,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==0.15.2
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2326,7 +2326,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==0.15.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1637,7 +1637,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==0.15.2
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1732,7 +1732,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==0.15.2
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/xmodule/tests/test_import.py
+++ b/xmodule/tests/test_import.py
@@ -428,7 +428,7 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
 
         def check_for_key(key, node, value):
             "recursive check for presence of key"
-            print(f"Checking {str(node.location)}")
+            print(f"Checking {str(node.usage_key)}")
             assert getattr(node, key) == value
             for c in node.get_children():
                 check_for_key(key, c, value)
@@ -442,8 +442,8 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         toy = self.get_course('toy')
         two_toys = self.get_course('two_toys')
 
-        assert toy.url_name == '2012_Fall'
-        assert two_toys.url_name == 'TT_2012_Fall'
+        assert toy.usage_key.block_id == '2012_Fall'
+        assert two_toys.usage_key.block_id == 'TT_2012_Fall'
 
         toy_ch = toy.get_children()[0]
         two_toys_ch = two_toys.get_children()[0]
@@ -513,7 +513,7 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         assert len(chapters) == 5
 
         ch2 = chapters[1]
-        assert ch2.url_name == 'secret:magic'
+        assert ch2.usage_key.block_id == 'secret:magic'
 
         print("Ch2 location: ", ch2.location)
 
@@ -567,8 +567,8 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         for i in (2, 3):
             video = sections[i]
             # Name should be 'video_{hash}'
-            print(f"video {i} url_name: {video.url_name}")
-            assert len(video.url_name) == (len('video_') + 12)
+            print(f"video {i} url_name: {video.usage_key.block_id}")
+            assert len(video.usage_key.block_id) == (len('video_') + 12)
 
     def test_poll_and_conditional_import(self):
         modulestore = XMLModuleStore(DATA_DIR, source_dirs=['conditional_and_poll'])

--- a/xmodule/tests/test_lti_unit.py
+++ b/xmodule/tests/test_lti_unit.py
@@ -325,8 +325,8 @@ class _TestLTIBase(TestCase):
         assert real_outcome_service_url == (mock_url_prefix + test_service_name)
 
     def test_resource_link_id(self):
-        with patch('xmodule.lti_block.LTIBlock.location', new_callable=PropertyMock):
-            self.xblock.location.html_id = lambda: 'i4x-2-3-lti-31de800015cf4afb973356dbe81496df'
+        with patch('xmodule.lti_block.LTIBlock.usage_key', new_callable=PropertyMock):
+            self.xblock.usage_key.html_id = lambda: 'i4x-2-3-lti-31de800015cf4afb973356dbe81496df'
             expected_resource_link_id = str(parse.quote(self.unquoted_resource_link_id))
             real_resource_link_id = self.xblock.get_resource_link_id()
             assert real_resource_link_id == expected_resource_link_id


### PR DESCRIPTION
It's the PR to fix the test cases for this xblocks-contrib PR: https://github.com/openedx/xblocks-contrib/pull/204

**PR on disabled blocks has been created to verify the test cases in disabled state:** 
https://github.com/openedx/openedx-platform/pull/38221

**Testing notes:**
Following things has been tested on the sandbox of this PR for Video, WordCloud & LTI block:

1. Block is working fine on studio, lms, content library
2. We can copy/paste the block
3. We can add a block from the content library
4. Video editor is working fine
5. Transcripts for videos are uploading, deleting and working fine on the video editor
6. Different format (mp4, hls, youtube ..) video formats are working fine for the video formats
7. Import/Export of the course having these blocks has been tested

Detailed test document team follows: [document](https://docs.google.com/document/d/1dAy2JLRlxdAu1ZP-KUza4j6Numc0LtIb9ucPQZ1_Bug/edit?tab=t.0)