### PR TITLE
feat: remove `library_v2` and `itembank` from `BETA_COMPONENT_TYPES` [FC-0123]

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -63,7 +63,7 @@ COMPONENT_TYPES = [
     'drag-and-drop-v2',
 ]
 
-BETA_COMPONENT_TYPES = ['library_v2', 'itembank']
+BETA_COMPONENT_TYPES = []
 
 ADVANCED_COMPONENT_TYPES = sorted({name for name, class_ in XBlock.load_classes()} - set(COMPONENT_TYPES))
 


### PR DESCRIPTION
## Description

This PR removes `library_v2` (Library Content) and `itembank` (Problem Bank) from `BETA_COMPONENT_TYPES` since they are no longer in beta.

### Before
<img width="1044" height="380" alt="image" src="https://github.com/user-attachments/assets/e7af33ff-a2f4-4d7d-85ac-67244c4005dc" />

### After
<img width="597" height="432" alt="image" src="https://github.com/user-attachments/assets/93cd0f5f-6b76-4aae-a194-d908f2ce5ff1" />

- Which edX user roles will this change impact?
"Course Author" and "Developer"

## Supporting information

- Related to https://github.com/openedx/frontend-app-authoring/issues/2878

## Testing instructions

- Open a unit and check that the "Library Content" and the "Problem Bank" components don't show the `beta` tag.

## Deadline

Verawood

___
Private ref: [FAL-4334](https://tasks.opencraft.com/browse/FAL-4334)