### PR TITLE
fix: use consistent password in CourseUpdateAuthzTest

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_course_updates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_updates.py
@@ -336,7 +336,7 @@ class CourseUpdateAuthzTest(CourseAuthzTestMixin, CourseTestCase):
 
     def setUp(self):
         super().setUp()
-        self.auditor_user = UserFactory()
+        self.auditor_user = UserFactory(password=self.password)
         self.add_user_to_role(self.auditor_user, COURSE_AUDITOR.external_key)
 
         self.staff_client = self._make_client_for_user(self.authorized_user)
@@ -345,7 +345,7 @@ class CourseUpdateAuthzTest(CourseAuthzTestMixin, CourseTestCase):
 
     def _make_client_for_user(self, user):
         client = AjaxEnabledTestClient()
-        client.login(username=user.username, password='Password1234')
+        client.login(username=user.username, password=self.password)
         return client
 
     def _create_update(self, client):
@@ -417,25 +417,25 @@ class CourseUpdateAuthzTest(CourseAuthzTestMixin, CourseTestCase):
     # -- Staff/superuser without authz role: access via enforcer admin check --
 
     def test_django_staff_without_role_can_get(self):
-        staff_user = UserFactory(is_staff=True)
+        staff_user = UserFactory(is_staff=True, password=self.password)
         client = self._make_client_for_user(staff_user)
         resp = client.get_json(self.create_update_url())
         self.assertEqual(resp.status_code, 200)
 
     def test_django_staff_without_role_can_post(self):
-        staff_user = UserFactory(is_staff=True)
+        staff_user = UserFactory(is_staff=True, password=self.password)
         client = self._make_client_for_user(staff_user)
         resp = self._create_update(client)
         self.assertEqual(resp.status_code, 200)
 
     def test_superuser_without_role_can_get(self):
-        superuser = UserFactory(is_superuser=True)
+        superuser = UserFactory(is_superuser=True, password=self.password)
         client = self._make_client_for_user(superuser)
         resp = client.get_json(self.create_update_url())
         self.assertEqual(resp.status_code, 200)
 
     def test_superuser_without_role_can_post(self):
-        superuser = UserFactory(is_superuser=True)
+        superuser = UserFactory(is_superuser=True, password=self.password)
         client = self._make_client_for_user(superuser)
         resp = self._create_update(client)
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Description

Fix password mismatch in CourseUpdateAuthzTest

### Problem

All 12 CourseUpdateAuthzTest tests were failing with 302 redirects instead of
expected 200 or 403 responses.

### Root Cause

CourseAuthoringAuthzTestMixin creates authorized_user and unauthorized_user with
password='test', but _make_client_for_user was calling client.login() with the
hardcoded 'Password1234'. Login silently failed, so all clients were unauthenticated
and every request redirected to the login page.

The same issue affected auditor_user, staff, and superuser tests — users created via
UserFactory() defaulted to 'Password1234' while login expected 'test'.

### Fix

- Use self.password in _make_client_for_user instead of hardcoding 'Password1234'
- Pass password=self.password to all UserFactory calls in the test class

## Testing instructions

`pytest cms/djangoapps/contentstore/views/tests/test_course_updates.py::CourseUpdateAuthzTest --ds=cms.envs.test`

## Deadline

ASAP