### PR TITLE
Test | Spike PR | Remove legacy XModule mixins 

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     runs-on: ${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.12"


### PR DESCRIPTION
### Purpose of the creation of the PR:

As per plans to remove the `xmodule` code altogether from the `edx-platform`

This PR, child PR's has been created using LLMs to have an idea of the impact of the changes to remove the url_name, category, course_id, location properties from edx-platform [XModuleMixin](https://github.com/openedx/openedx-platform/blob/master/xmodule/x_module.py#L313)

Main ticket: https://github.com/openedx/xblocks-contrib/issues/197
Relevant ticket having details: https://github.com/openedx/xblocks-contrib/issues/125

### Child PRs: 

- [ ] https://github.com/openedx/openedx-platform/pull/38239
- [ ] https://github.com/openedx/openedx-platform/pull/38240
- [ ] https://github.com/openedx/openedx-platform/pull/38237
- [ ] https://github.com/openedx/openedx-platform/pull/38238

### Summary of the spike:

Spike was to have an idea of the changes in the `edx-platform` required while removing `url-name, category, course_id, location` properties from [XModuleMixin](https://github.com/openedx/openedx-platform/blob/master/xmodule/x_module.py#L313)

- Removing `url-name` impacting around 20 file changes with small test cases fixing required.
- Removing `course-id` impacting atleast 12 file changes with small test cases fixing required.
- Removing `category` impacting atleast 40 file changes with atleast 5 test cases files fixings required.
- Removing `url-name` impacting atleast 365 file changes with atleast  many test cases fixing required.


Closing the PR as it seems lots of changes and make sense to plan it in the future.
