### PR TITLE
refactor: Remove no-op ENABLE_FORUM_DAILY_DIGEST definition

### DIFF
--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -15,8 +15,6 @@ WAFFLE_NAMESPACE = 'discussion'
 #   for daily digest. This setting enables deprecation of daily digest.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-09
-ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
-
 
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -7,17 +7,17 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'discussion'
 
-# .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Settings for forums/discussions to on/off daily digest
-#   feature. Set this to True if you want to enable users to subscribe and unsubscribe
-#   for daily digest. This setting enables deprecation of daily digest.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2020-03-09
 
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""
+    # .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Settings for forums/discussions to on/off daily digest
+    #   feature. Set this to True if you want to enable users to subscribe and unsubscribe
+    #   for daily digest. This setting enables deprecation of daily digest.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2020-03-09
     return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST', False)
 
 # .. toggle_name: discussion.enable_captcha


### PR DESCRIPTION
This line was likely added here with the intent of defining an edx-toggles-style FeatureToggle object. Instead, it just declares a local variable named ENABLE_FORUM_DAILY_DIGEST, whereas the actual check occurs at either of:

* settings.ENABLE_FORUM_DAILY_DIGEST  # new way
* settings.FEATURES['ENABLE_FORUM_DAILY_DIGEST']  # old way

The local variable can be safely removed, reducing confusion.

The toggle annotation has already been correctly updated to reflect that the toggle default is effectively False.

Original context: https://github.com/openedx/openedx-platform/commit/e7e1a409b27dd47ce2261dcdac063c19b240ea74#commitcomment-179325396

I discovered this while working on larger refactoring of the FEATURES dictionary: https://github.com/openedx/openedx-platform/pull/38095