### PR TITLE
fix: add weight from max_weight if its missing from meta

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3533,7 +3533,7 @@ class TestGetMetadataWithProblemDefaults(ModuleStoreTestCase):
         xblock = self._make_problem()
         with patch.object(xblock, 'max_score', return_value=3.0):
             metadata = _get_metadata_with_problem_defaults(xblock)
-        self.assertEqual(metadata.get('weight'), 3.0)
+        assert metadata.get('weight') == 3.0
 
     def test_problem_without_weight_max_score_zero_does_not_inject(self):
         """
@@ -3542,7 +3542,7 @@ class TestGetMetadataWithProblemDefaults(ModuleStoreTestCase):
         xblock = self._make_problem()
         with patch.object(xblock, 'max_score', return_value=0):
             metadata = _get_metadata_with_problem_defaults(xblock)
-        self.assertNotIn('weight', metadata)
+        assert 'weight' not in metadata
 
     # ------------------------------------------------------------------
     # Problem blocks – weight already present in stored metadata
@@ -3555,7 +3555,7 @@ class TestGetMetadataWithProblemDefaults(ModuleStoreTestCase):
         xblock = self._make_problem(weight=5.0)
         with patch.object(xblock, 'max_score', return_value=2.0):
             metadata = _get_metadata_with_problem_defaults(xblock)
-        self.assertEqual(metadata.get('weight'), 5.0)
+        assert metadata.get('weight') == 5.0
 
     # ------------------------------------------------------------------
     # Non-problem blocks
@@ -3575,8 +3575,8 @@ class TestGetMetadataWithProblemDefaults(ModuleStoreTestCase):
         xblock = modulestore().get_item(video.location)
         metadata_before = dict(get_block_info(xblock).get('metadata', {}))
         metadata_result = _get_metadata_with_problem_defaults(xblock)
-        self.assertEqual(metadata_result, metadata_before)
-        self.assertNotIn('weight', metadata_result)
+        assert metadata_result == metadata_before
+        assert 'weight' not in metadata_result
 
 
 @patch.dict("django.conf.settings.FEATURES", {"ENABLE_SPECIAL_EXAMS": True})

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -38,6 +38,7 @@ from cms.djangoapps.contentstore.xblock_storage_handlers import view_handlers as
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import (
     ALWAYS,
     VisibilityState,
+    _get_metadata_with_problem_defaults,
     _get_source_index,
     _xblock_type_and_display_name,
     add_container_page_publishing_info,
@@ -3499,6 +3500,83 @@ class TestXBlockInfo(ItemTest):
                     )
         else:
             self.assertIsNone(xblock_info.get("child_info", None))  # noqa: PT009
+
+
+class TestGetMetadataWithProblemDefaults(ModuleStoreTestCase):
+    """
+    Unit tests for _get_metadata_with_problem_defaults.
+
+    The helper must inject a ``weight`` value (derived from ``max_score()``) for
+    problem xblocks that have never had ``weight`` explicitly saved, while leaving
+    every other combination untouched.
+    """
+
+    def _make_problem(self, **kwargs):
+        """Create and return a problem xblock from the modulestore."""
+        course = CourseFactory.create()
+        block = BlockFactory.create(
+            parent_location=course.location,
+            category='problem',
+            display_name='A Problem',
+            **kwargs,
+        )
+        return modulestore().get_item(block.location)
+
+    # ------------------------------------------------------------------
+    # Problem blocks – weight absent from stored metadata
+    # ------------------------------------------------------------------
+
+    def test_problem_without_weight_adds_weight_from_max_score(self):
+        """
+        When weight is absent and max_score() > 0, it is injected into metadata.
+        """
+        xblock = self._make_problem()
+        with patch.object(xblock, 'max_score', return_value=3.0):
+            metadata = _get_metadata_with_problem_defaults(xblock)
+        self.assertEqual(metadata.get('weight'), 3.0)
+
+    def test_problem_without_weight_max_score_zero_does_not_inject(self):
+        """
+        A zero max_score will not inject a weight.
+        """
+        xblock = self._make_problem()
+        with patch.object(xblock, 'max_score', return_value=0):
+            metadata = _get_metadata_with_problem_defaults(xblock)
+        self.assertNotIn('weight', metadata)
+
+    # ------------------------------------------------------------------
+    # Problem blocks – weight already present in stored metadata
+    # ------------------------------------------------------------------
+
+    def test_problem_with_explicit_weight_is_preserved(self):
+        """
+        When weight is already explicitly set, it will not be overwritten.
+        """
+        xblock = self._make_problem(weight=5.0)
+        with patch.object(xblock, 'max_score', return_value=2.0):
+            metadata = _get_metadata_with_problem_defaults(xblock)
+        self.assertEqual(metadata.get('weight'), 5.0)
+
+    # ------------------------------------------------------------------
+    # Non-problem blocks
+    # ------------------------------------------------------------------
+
+    def test_non_problem_block_is_unmodified(self):
+        """
+        Non-problem blocks must pass through untouched even if a max_score
+        method is available on them.
+        """
+        course = CourseFactory.create()
+        video = BlockFactory.create(
+            parent_location=course.location,
+            category='video',
+            display_name='A Video',
+        )
+        xblock = modulestore().get_item(video.location)
+        metadata_before = dict(get_block_info(xblock).get('metadata', {}))
+        metadata_result = _get_metadata_with_problem_defaults(xblock)
+        self.assertEqual(metadata_result, metadata_before)
+        self.assertNotIn('weight', metadata_result)
 
 
 @patch.dict("django.conf.settings.FEATURES", {"ENABLE_SPECIAL_EXAMS": True})

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -398,6 +398,26 @@ def modify_xblock(usage_key, request):
     )
 
 
+def _get_metadata_with_problem_defaults(xblock):
+    """
+    Returns own_metadata for the xblock, injecting a ``weight`` default for
+    problem blocks whose weight has never been explicitly saved.
+
+    Without this, the frontend falls back to displaying 1 (its own default)
+    even when the problem's actual point value differs. If ``max_score()``
+    returns a positive number, we inject it so the correct value is shown.
+    """
+    metadata = own_metadata(xblock)
+    if xblock.scope_ids.block_type == 'problem' and 'weight' not in metadata:
+        try:
+            max_score_value = xblock.max_score()
+            if max_score_value and max_score_value > 0:
+                metadata['weight'] = float(max_score_value)
+        except Exception:  # pylint: disable=broad-except
+            pass
+    return metadata
+
+
 def save_xblock_with_callback(xblock, user, old_metadata=None, old_content=None):
     """
     Updates the xblock in the modulestore.
@@ -1074,7 +1094,7 @@ def get_block_info(
         xblock_info = create_xblock_info(
             xblock,
             data=data,
-            metadata=own_metadata(xblock),
+            metadata=_get_metadata_with_problem_defaults(xblock),
             include_ancestor_info=include_ancestor_info,
             include_children_predicate=include_children_predicate
         )


### PR DESCRIPTION
### Related Ticket
https://github.com/mitodl/hq/issues/9447 (MIT Internal)
fixes: https://github.com/openedx/openedx-platform/issues/37993

## Description
This pull request introduces a new helper function to improve how problem block metadata is handled, specifically ensuring that the correct `weight` value is shown for problem blocks when it has not been explicitly set. The changes also include comprehensive unit tests for this new logic.

**Enhancements to problem block metadata handling:**

* Added a new helper function `_get_metadata_with_problem_defaults` in `view_handlers.py` to inject a `weight` value into problem block metadata when it is missing, using `max_score()` as the default. This prevents the frontend from defaulting to 1 when the actual point value is different.
* Updated the `get_block_info` function to use `_get_metadata_with_problem_defaults` instead of `own_metadata`, ensuring the new logic is applied wherever block info is retrieved.

**Testing improvements:**

* Added a new test class `TestGetMetadataWithProblemDefaults` in `test_block.py` to verify the behavior of the helper function, covering scenarios for problem blocks with and without explicit weights, as well as non-problem blocks.
* Updated imports in `test_block.py` to include `_get_metadata_with_problem_defaults` for testing.

## Testing instructions

1. Spin up a local Studio instance.
2. Create a course and add a Problem component (e.g. a Multiple Choice question worth 2 points).
3. Do not manually set the "Weight" field, leave it at the default.
4. Open the problem in Studio's unit editor and click the Edit button.
5. In the settings panel, verify the Weight field now shows the problem's actual point value (e.g. 2.0) instead of the frontend's hardcoded default of 1.