### PR TITLE
fix: add info logger instead of error when catalog is not enabled

### DIFF
--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -93,7 +93,7 @@ def check_catalog_integration_and_get_user(error_message_field):
             return None, catalog_integration
         return user, catalog_integration
     else:
-        logger.error(
+        logger.info(
             "Unable to retrieve details about {field} because Catalog Integration is not enabled".format(
                 field=error_message_field,
             )


### PR DESCRIPTION
### Related Ticket
https://github.com/mitodl/hq/issues/6650 (MIT Internal)

## Description

## Context: Catalog is optional so if its not enabled we should log error

This pull request makes a minor change to the logging level in the `check_catalog_integration_and_get_user` function. The log message for when Catalog Integration is not enabled has been changed from an error to an info level, which reduces noise in the error logs for expected conditions.