### PR TITLE
build: Fix the docs build.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,10 @@ sphinx:
 
 python:
   install:
+    # Need to install this to set the correct version of steuptools for now
+    # because it is needed by fs
+    # See https://github.com/openedx/openedx-platform/issues/38068 for details.
+  - requirements: "requirements/pip.txt"
   - requirements: "requirements/edx/doc.txt"
   - method: pip
     path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ sphinx:
 
 python:
   install:
-    # Need to install this to set the correct version of steuptools for now
+    # Need to install this to set the correct version of setuptools for now
     # because it is needed by fs
     # See https://github.com/openedx/openedx-platform/issues/38068 for details.
   - requirements: "requirements/pip.txt"


### PR DESCRIPTION
Our use of `fs` means we have a runtime dependency on setuptools. The
newest version is not compatible with the current version of `fs` so
we've added a constraint.  But the docs build didn't previously install
our specified version of setuptools.  This is to fix that.
