### PR TITLE
Drop xmodule mixin support from the xblocks-contrib blocks

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
     name: ${{ matrix.shard_name }}(py=${{ matrix.python-version }},dj=${{ matrix.django-version }},mongo=${{ matrix.mongo-version }})
     runs-on: ${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.12"

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -144,7 +144,7 @@ def wrap_xblock(
     template_context = {
         'content': block.display_name if display_name_only else frag.content,
         'classes': css_classes,
-        'display_name': block.display_name_with_default_escaped,  # xss-lint: disable=python-deprecated-display-name
+        'display_name': block.display_name_with_default,  # xss-lint: disable=python-deprecated-display-name
         'data_attributes': ' '.join(f'data-{markupsafe.escape(key)}="{markupsafe.escape(value)}"'
                                     for key, value in data.items()),
     }

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2988,3 +2988,7 @@ MAINTENANCE_BANNER_TEXT: str | None
 # .. setting_description: The name that will appear on the landing page of Studio, as well as in various emails and
 #   templates. (Note: set to 'Studio' by default in the LMS).
 STUDIO_NAME: str
+
+STANDARD_COMPLIANT_XBLOCKS = [
+    "WordCloudBlock",
+]

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1299,7 +1299,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==git+https://github.com/openedx/xblocks-contrib.git@farhan/drop-xmodule-mixin-support#egg=xblocks-contrib
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1273,7 +1273,7 @@ wrapt==2.1.2
     # via
     #   -r requirements/edx/kernel.in
     #   xblocks-contrib
-xblock[django]==5.3.0
+xblock[django]==git+https://github.com/openedx/xblock.git@farhan/test-xmodule-mixin-drop#egg=xblock
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2291,7 +2291,7 @@ wrapt==2.1.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblocks-contrib
-xblock[django]==5.3.0
+xblock[django]==git+https://github.com/openedx/xblock.git@farhan/test-xmodule-mixin-drop#egg=xblock
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2326,7 +2326,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==git+https://github.com/openedx/xblocks-contrib.git@farhan/drop-xmodule-mixin-support#egg=xblocks-contrib
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1610,7 +1610,7 @@ wrapt==2.1.2
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-xblock[django]==5.3.0
+xblock[django]==git+https://github.com/openedx/xblock.git@farhan/test-xmodule-mixin-drop#egg=xblock
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1637,7 +1637,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==git+https://github.com/openedx/xblocks-contrib.git@farhan/drop-xmodule-mixin-support#egg=xblocks-contrib
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1705,7 +1705,7 @@ wrapt==2.1.2
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-xblock[django]==5.3.0
+xblock[django]==git+https://github.com/openedx/xblock.git@farhan/test-xmodule-mixin-drop#egg=xblock
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1732,7 +1732,7 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.15.1
+xblocks-contrib==git+https://github.com/openedx/xblocks-contrib.git@farhan/drop-xmodule-mixin-support#egg=xblocks-contrib
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via


### PR DESCRIPTION
Ticket: https://github.com/openedx/xblocks-contrib/issues/223#issuecomment-4161413964

Drop xmodule mixin support from the xblocks-contrib blocks

We can consider it as the common branch for the support of all the xblocks-contrib blocks as most of the fixes will be common.

**Relevant xblocks-contrib PR**: https://github.com/openedx/xblocks-contrib/pull/225
**Relevant xblocks PR**: https://github.com/openedx/XBlock/pull/903

### Spelunking activity:
PR: https://github.com/openedx/openedx-platform/pull/38250
In this PR I tried to avoid the addition of `XModuleMixin` to xblocks-contrib blocks but it couldn't happen because of complexity of the code and its dependency on the [xblock/runtime.py:Mixologist](https://github.com/openedx/XBlock/blob/farhan/test-xmodule-mixin-drop/xblock/runtime.py#L1231) class


