### PR TITLE
[FC-0118] feat: Standardize Enrollment Views

### DIFF
--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -22,7 +22,7 @@ Implementation requirements:
 * Replace manual JSON construction with serializer-based responses.
 * Use serializers for both input validation and output formatting.
 * Ensure serializers are properly documented with field descriptions and validation rules.
-* Maintain backward compatibility for all APIs during migration.
+* Maintain backward compatibility for all APIs during migration. While the goal is fully compatible DRF serializers, if that is not possible and we must make a backwards incompatible change, that change MUST be handled by creating a new version of the API and transitioning to that API using the deprecation process.
 
 Relevance in edx-platform
 -------------------------

--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -1,0 +1,113 @@
+Standardize Serializer Usage Across APIs
+========================================
+
+:Status: Proposed
+:Date: 2026-03-09
+:Deciders: API Working Group
+:Technical Story: Open edX REST API Standards - Serializer standardization for consistency
+
+Context
+-------
+
+Many Open edX platform API endpoints manually construct JSON responses using Python dictionaries instead of Django REST Framework (DRF) serializers. This leads to inconsistent schema responses, makes validation errors harder to manage, and creates unpredictable formats that AI and third-party systems struggle with.
+
+Decision
+--------
+
+We will standardize all Open edX REST APIs to use **DRF serializers** for request and response handling.
+
+Implementation requirements:
+
+* All API views MUST define explicit serializers for request and response handling.
+* Replace manual JSON construction with serializer-based responses.
+* Use serializers for both input validation and output formatting.
+* Ensure serializers are properly documented with field descriptions and validation rules.
+* Maintain backward compatibility for all APIs during migration.
+
+Relevance in edx-platform
+-------------------------
+
+Current patterns that should be migrated:
+
+* **Certificates API** (``/api/certificates/v0/``) constructs JSON manually with nested dictionaries.
+* **Enrollment API** endpoints manually build response objects without serializers.
+* **Course API** views use hand-coded JSON responses instead of structured serializers.
+
+Code example (target serializer usage)
+--------------------------------------
+
+**Example serializer and APIView using DRF best practices:**
+
+.. code-block:: python
+
+   # serializers.py
+   from rest_framework import serializers
+
+   class CertificateSerializer(serializers.Serializer):
+       username = serializers.CharField(
+           help_text="The username of the certificate holder"
+       )
+       course_id = serializers.CharField(
+           help_text="The course identifier"
+       )
+       status = serializers.CharField(
+           help_text="The certificate status (e.g., downloadable, generating)"
+       )
+       grade = serializers.FloatField(
+           help_text="The final grade achieved"
+       )
+
+   # views.py
+   from rest_framework.views import APIView
+   from rest_framework.response import Response
+   from rest_framework import status
+
+   class CertificateAPIView(APIView):
+       def get(self, request):
+           data = {
+               "username": "john_doe",
+               "course_id": "course-v1:edX+DemoX+1T2024",
+               "status": "downloadable",
+               "grade": 0.95,
+           }
+           serializer = CertificateSerializer(data)
+           return Response(serializer.data, status=status.HTTP_200_OK)
+
+Consequences
+------------
+
+Positive
+~~~~~~~~
+
+* Simplifies validation and ensures consistent response contracts.
+* Improves AI compatibility through predictable data structures.
+* Enables automatic schema generation and documentation.
+* Reduces code duplication and maintenance overhead.
+
+Negative / Trade-offs
+~~~~~~~~~~~~~~~~~~~~~
+
+* Requires refactoring existing endpoints that manually construct JSON.
+* Initial development overhead for creating comprehensive serializers.
+* May require updates to existing client code that expects legacy formats.
+
+Alternatives Considered
+-----------------------
+
+* **Keep manual JSON construction**: rejected due to inconsistency and maintenance burden.
+* **Use DRF defaults only**: rejected because explicit serializers provide better validation and documentation.
+* **Use newer ways of managing API responses such as dataclasses or pydantic**: rejected due to complexity and unknowns in transitioning from two existing patterns (manual JSON and DRF serializers) to a third approach. While these python libraries offer better ergonomics, migration would require checking nested serializers, complex validation, and ModelSerializer-heavy endpoints. To move to some new format, we would want to prevent using the basic DRF Serializers any more than we do right now, but preventing new DRF serializers via linting is more complex than anticipated.  This work can be revisited in the future once the platform is a bit more consistent.
+
+Rollout Plan
+------------
+
+1. Audit existing endpoints to identify those using manual JSON construction.
+2. Create a library of common serializers for shared data structures.
+3. Migrate high-impact endpoints first (certificates, enrollment, courses).
+4. Update tests to validate serializer-based responses.
+5. Update API documentation to reflect new serializer-based contracts.
+
+References
+----------
+
+* Open edX REST API Standards: "Serializer Usage" recommendations for API consistency.

--- a/openedx/core/djangoapps/enrollments/forms.py
+++ b/openedx/core/djangoapps/enrollments/forms.py
@@ -14,12 +14,67 @@ from openedx.core.djangoapps.user_authn.views.registration_form import validate_
 class CourseEnrollmentsApiListForm(Form):
     """
     A form that validates the query string parameters for the CourseEnrollmentsApiListView.
+
+    ADR 0033 – OEP-68 parameter naming standardization:
+    - ``course_key`` is the preferred parameter name; ``course_id`` is accepted
+      as a deprecated alias (BC strategy §1).  When both are present,
+      ``course_key`` wins.
+    - ``course_keys`` is the preferred parameter name; ``course_ids`` is
+      accepted as a deprecated alias (same precedence rule).
+    Internally the cleaned_data continues to expose ``course_id`` /
+    ``course_ids`` so call sites do not need to change.  Use
+    :meth:`legacy_param_aliases_used` to detect when the deprecated names were
+    sent by the client (used to emit the ``Deprecation`` HTTP header).
     """
     MAX_INPUT_COUNT = 100
+    # Legacy / OEP-68 alias pairs: (legacy, preferred).
+    _LEGACY_PARAM_ALIASES = (
+        ("course_id", "course_key"),
+        ("course_ids", "course_keys"),
+    )
+
     username = CharField(required=False)
     course_id = CharField(required=False)
+    course_key = CharField(required=False)
     course_ids = CharField(required=False)
+    course_keys = CharField(required=False)
     email = CharField(required=False)
+
+    def __init__(self, query_params, *args, **kwargs):
+        # Capture the raw param names supplied on the wire, *before* Django's
+        # form layer resolves aliases, so :meth:`legacy_param_aliases_used`
+        # can later report exactly which legacy names were used.
+        try:
+            raw_keys = set(query_params.keys())
+        except AttributeError:
+            raw_keys = set()
+        self._raw_param_names = raw_keys
+
+        # Coalesce OEP-68 preferred names into the legacy fields so the
+        # downstream view code keeps reading ``course_id`` / ``course_ids``
+        # without changes.  Preferred wins when both are sent.
+        if hasattr(query_params, "copy"):
+            data = query_params.copy()
+        else:
+            data = dict(query_params)
+        for legacy_name, preferred_name in self._LEGACY_PARAM_ALIASES:
+            preferred_value = data.get(preferred_name)
+            if preferred_value:
+                data[legacy_name] = preferred_value
+
+        super().__init__(data, *args, **kwargs)
+
+    def legacy_param_aliases_used(self):
+        """
+        Return the list of legacy (OEP-68-violating) parameter names actually
+        present in the request, in declaration order.
+
+        Used by the view layer to emit the ADR 0033 ``Deprecation`` header.
+        """
+        return [
+            legacy for legacy, _preferred in self._LEGACY_PARAM_ALIASES
+            if legacy in self._raw_param_names
+        ]
 
     def clean_course_id(self):
         """

--- a/openedx/core/djangoapps/enrollments/paginators.py
+++ b/openedx/core/djangoapps/enrollments/paginators.py
@@ -3,14 +3,19 @@ Paginators for the course enrollment related views.
 """
 
 
-from rest_framework.pagination import CursorPagination
+from edx_rest_framework_extensions.paginators import DefaultPagination  # ADR 0032
 
 
-class CourseEnrollmentsApiListPagination(CursorPagination):
+class CourseEnrollmentsApiListPagination(DefaultPagination):
     """
-    Paginator for the Course enrollments list API.
+    ADR 0032 – standard pagination for the admin enrollments list API
+    (GET /api/enrollment/v1/enrollments).
+
+    Extends DefaultPagination with a larger default page size appropriate
+    for an admin-facing, bulk-query endpoint.  The full 7-field response
+    envelope (count, num_pages, current_page, start, next, previous,
+    results) is provided by DefaultPagination.get_paginated_response.
     """
     page_size = 100
     page_size_query_param = 'page_size'
     max_page_size = 100
-    page_query_param = 'page'

--- a/openedx/core/djangoapps/enrollments/serializers.py
+++ b/openedx/core/djangoapps/enrollments/serializers.py
@@ -137,3 +137,22 @@ class CourseEnrollmentAllowedSerializer(serializers.ModelSerializer):
         model = CourseEnrollmentAllowed
         exclude = ["id"]
         lookup_field = "user"
+
+
+class UserRoleSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Serializes a single course-level role entry for a user."""
+
+    org = serializers.CharField()
+    course_id = serializers.SerializerMethodField()
+    role = serializers.CharField()
+
+    def get_course_id(self, obj):
+        """Return course_id as a string."""
+        return str(obj.course_id)
+
+
+class UserRolesResponseSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Serializes the full response payload for EnrollmentUserRolesView."""
+
+    roles = UserRoleSerializer(many=True)
+    is_staff = serializers.BooleanField()

--- a/openedx/core/djangoapps/enrollments/tests/test_view_services.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_view_services.py
@@ -1,0 +1,201 @@
+"""
+Tests for ``openedx.core.djangoapps.enrollments.view_services``.
+
+Per ADR 0031 (Merge Similar Endpoints) the enrollment HTTP operations live
+in a shared ``EnrollmentOperationsService`` so the canonical
+``EnrollmentViewSet`` and its deprecated APIView aliases cannot drift.  The
+tests here verify the shared contract directly — both as a unit-test of the
+service object and as a regression guard that the deprecated and canonical
+view layers both delegate to it.
+"""
+
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from common.djangoapps.student.models import CourseEnrollmentAllowed
+from common.djangoapps.student.tests.factories import SuperuserFactory, UserFactory
+from openedx.core.djangoapps.enrollments.view_services import EnrollmentOperationsService
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+@skip_unless_lms
+class EnrollmentOperationsServiceAllowedTest(APITestCase):
+    """
+    Unit-tests for the allowed-enrollment helpers in ``EnrollmentOperationsService``.
+
+    These exercise the service object directly (no HTTP layer involved) so a
+    bug in the view-to-service wiring will be caught here without depending
+    on the URL resolver or DRF dispatcher.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.service = EnrollmentOperationsService()
+        self.email = "allowed@example.com"
+        self.course_id = "course-v1:edX+DemoX+Demo_Course"
+
+    def test_list_allowed_for_email_returns_empty_when_no_rows(self):
+        assert not self.service.list_allowed_for_email(self.email).exists()
+
+    def test_list_allowed_for_email_returns_matching_rows(self):
+        CourseEnrollmentAllowed.objects.create(email=self.email, course_id=self.course_id)
+        CourseEnrollmentAllowed.objects.create(email=self.email, course_id="course-v1:edX+Other+Other")
+        CourseEnrollmentAllowed.objects.create(email="other@example.com", course_id=self.course_id)
+
+        rows = list(self.service.list_allowed_for_email(self.email))
+        assert len(rows) == 2
+        assert all(r.email == self.email for r in rows)
+
+    def test_delete_allowed_enrollment_removes_row(self):
+        CourseEnrollmentAllowed.objects.create(email=self.email, course_id=self.course_id)
+        self.service.delete_allowed_enrollment(self.email, self.course_id)
+        assert not CourseEnrollmentAllowed.objects.filter(
+            email=self.email, course_id=self.course_id,
+        ).exists()
+
+    def test_delete_allowed_enrollment_raises_when_missing(self):
+        # The view layer translates this to a 404; the service intentionally
+        # surfaces the underlying ORM exception (ADR 0031: per-operation
+        # error mapping stays in the view so OpenAPI schemas remain accurate).
+        from django.core.exceptions import ObjectDoesNotExist
+        with self.assertRaises(ObjectDoesNotExist):
+            self.service.delete_allowed_enrollment(self.email, self.course_id)
+
+
+@skip_unless_lms
+class EnrollmentOperationsServiceUnenrollTest(APITestCase):
+    """
+    Unit-tests for the retirement-pipeline unenroll helper.  Both
+    ``EnrollmentViewSet.unenroll`` and the deprecated ``UnenrollmentView.post``
+    must produce identical responses because they share this code path.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.service = EnrollmentOperationsService()
+
+    def test_unenroll_missing_username_returns_404(self):
+        response = self.service.unenroll_user_for_retirement(None)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unenroll_blank_username_returns_404(self):
+        response = self.service.unenroll_user_for_retirement("")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unenroll_unknown_retirement_status_returns_404(self):
+        # No UserRetirementStatus row exists for this username.
+        response = self.service.unenroll_user_for_retirement("does-not-exist")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@skip_unless_lms
+class EnrollmentOperationsServiceListEnrollmentsTest(APITestCase):
+    """
+    Unit-tests for the per-operation permission filter applied by
+    ``list_enrollments_for_user`` (ADR 0031 layer-2 authorization).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.service = EnrollmentOperationsService()
+        self.user = UserFactory.create(username="alice")
+        self.other = UserFactory.create(username="bob")
+
+    def test_self_lookup_returns_full_list_unfiltered(self):
+        # No enrollments exist, so the result is an empty list either way —
+        # what matters is that the service didn't raise and didn't filter the
+        # queryset down based on CourseStaffRole when the caller is asking
+        # about themselves.
+        result = self.service.list_enrollments_for_user(
+            request_user=self.user, target_username=self.user.username, has_api_key=False,
+        )
+        assert result == []
+
+    def test_api_key_bypasses_per_course_filter(self):
+        # Asking about another user with the api-key bit set returns the full
+        # list without applying the CourseStaffRole filter.
+        result = self.service.list_enrollments_for_user(
+            request_user=self.user, target_username=self.other.username, has_api_key=True,
+        )
+        assert result == []
+
+    def test_cross_user_without_privilege_filters_to_staffed_courses(self):
+        # ``self.user`` is not staff anywhere, so they see nothing of
+        # ``self.other``'s enrollments — even if any existed.
+        result = self.service.list_enrollments_for_user(
+            request_user=self.user, target_username=self.other.username, has_api_key=False,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# ADR 0031 – deprecated/canonical view-layer regression guard.
+#
+# These tests assert that the two URL paths sharing the same business logic
+# call into the *same* service-layer entry point.  If a future change skips
+# the service (e.g. by inlining logic back into a view), these will fail.
+# ---------------------------------------------------------------------------
+
+
+@skip_unless_lms
+class Adr0031SharedServiceRegressionTest(APITestCase):
+    """
+    Regression guard for ADR 0031: both the deprecated APIView aliases and
+    the canonical ``EnrollmentViewSet`` must delegate to the shared
+    ``EnrollmentOperationsService`` instance (``_OPS``) in
+    ``openedx.core.djangoapps.enrollments.views``.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # The unenroll routes require ``CanRetireUser`` (granted to
+        # superusers) and the allowed routes require ``IsAdminUser``
+        # (granted to staff).  Give the test user both flags so a single
+        # client satisfies the coarse permission checks (ADR 0031 layer 1)
+        # and the test can focus on the service-delegation contract
+        # (ADR 0031 layer 2) without auth getting in the way.
+        self.user = SuperuserFactory()
+        self.user.is_staff = True
+        self.user.save()
+        self.client.force_authenticate(user=self.user)
+
+    def test_deprecated_unenroll_path_routes_through_service(self):
+        """POST /unenroll/ must invoke ``unenroll_user_for_retirement`` on the shared service."""
+        target = "_OPS.unenroll_user_for_retirement"
+        with patch(f"openedx.core.djangoapps.enrollments.views.{target}") as mocked:
+            from rest_framework.response import Response
+            mocked.return_value = Response(status=status.HTTP_204_NO_CONTENT)
+            self.client.post(reverse("unenrollment"), data={"username": "anybody"}, format="json")
+        mocked.assert_called_once_with("anybody")
+
+    def test_canonical_unenroll_action_routes_through_service(self):
+        """POST /enrollment/unenroll/ must invoke the same service entry point."""
+        target = "_OPS.unenroll_user_for_retirement"
+        with patch(f"openedx.core.djangoapps.enrollments.views.{target}") as mocked:
+            from rest_framework.response import Response
+            mocked.return_value = Response(status=status.HTTP_204_NO_CONTENT)
+            self.client.post(reverse("enrollment-unenroll"), data={"username": "anybody"}, format="json")
+        mocked.assert_called_once_with("anybody")
+
+    def test_deprecated_allowed_get_routes_through_service(self):
+        """GET /enrollment_allowed/ must invoke ``list_allowed_for_email`` on the shared service."""
+        with patch(
+            "openedx.core.djangoapps.enrollments.views._OPS.list_allowed_for_email",
+            return_value=CourseEnrollmentAllowed.objects.none(),
+        ) as mocked:
+            response = self.client.get(reverse("courseenrollmentallowed"), {"email": "x@example.com"})
+        assert response.status_code == status.HTTP_200_OK
+        mocked.assert_called_once_with("x@example.com")
+
+    def test_canonical_allowed_get_routes_through_service(self):
+        """GET /enrollment/enrollment_allowed/ must invoke the same service entry point."""
+        with patch(
+            "openedx.core.djangoapps.enrollments.views._OPS.list_allowed_for_email",
+            return_value=CourseEnrollmentAllowed.objects.none(),
+        ) as mocked:
+            response = self.client.get(reverse("enrollment-allowed"), {"email": "x@example.com"})
+        assert response.status_code == status.HTTP_200_OK
+        mocked.assert_called_once_with("x@example.com")

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -2520,3 +2520,126 @@ class TestEnrollmentViewSetAllowed(APITestCase):
             content_type="application/json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------------------------------------------------------------
+# ADR 0032 – Pagination standardization tests
+# ---------------------------------------------------------------------------
+
+@skip_unless_lms
+class TestCourseEnrollmentsApiListPaginatorStructure(APITestCase):
+    """
+    ADR 0032 – structural checks for CourseEnrollmentsApiListPagination.
+
+    Verifies that the paginator subclasses DefaultPagination (not CursorPagination)
+    and that CourseEnrollmentsApiListView wires it up correctly.
+    """
+
+    def test_paginator_is_defaultpagination_subclass(self):
+        """CourseEnrollmentsApiListPagination must subclass DefaultPagination (not CursorPagination)."""
+        from edx_rest_framework_extensions.paginators import DefaultPagination
+        from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
+        assert issubclass(CourseEnrollmentsApiListPagination, DefaultPagination)
+
+    def test_view_uses_correct_paginator(self):
+        """CourseEnrollmentsApiListView.pagination_class must be CourseEnrollmentsApiListPagination."""
+        from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
+        from openedx.core.djangoapps.enrollments.views import CourseEnrollmentsApiListView
+        assert CourseEnrollmentsApiListView.pagination_class is CourseEnrollmentsApiListPagination
+
+    def test_enrollment_viewset_uses_defaultpagination(self):
+        """EnrollmentViewSet.pagination_class must be DefaultPagination (ADR 0032)."""
+        from edx_rest_framework_extensions.paginators import DefaultPagination
+        from openedx.core.djangoapps.enrollments.views import EnrollmentViewSet
+        assert EnrollmentViewSet.pagination_class is DefaultPagination
+
+
+@skip_unless_lms
+class TestCourseEnrollmentsApiListPaginationEnvelope(APITestCase):
+    """
+    ADR 0032 – pagination envelope regression tests for CourseEnrollmentsApiListView
+    (GET /api/enrollment/v1/enrollments).
+
+    Verifies that the response includes all 7 required envelope fields after
+    migration from CursorPagination to DefaultPagination.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.admin = UserFactory.create(is_staff=True, is_superuser=True)
+        self.client.force_authenticate(user=self.admin)
+        self.url = reverse("courseenrollmentsapilist")
+
+    def test_response_includes_full_envelope(self):
+        """All 7 ADR 0032 envelope fields must be present in every paginated response."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        for field in ('count', 'num_pages', 'current_page', 'start', 'next', 'previous', 'results'):
+            assert field in response.data, f"ADR 0032: missing envelope field '{field}'"
+
+    def test_current_page_is_one_on_first_page(self):
+        """?page=1 must return current_page=1 in the response envelope."""
+        response = self.client.get(self.url, {'page': 1})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['current_page'] == 1
+
+    def test_start_is_zero_on_first_page(self):
+        """start must be 0 for the first page (0-based index of first item on the page)."""
+        response = self.client.get(self.url, {'page': 1})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['start'] == 0
+
+    def test_results_is_a_list(self):
+        """results must be a list (not null or a dict)."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.data['results'], list)
+
+
+@skip_unless_lms
+class TestEnrollmentViewSetListPaginationEnvelope(APITestCase):
+    """
+    ADR 0032 – pagination envelope regression tests for EnrollmentViewSet.list
+    (GET /api/enrollment/v1/enrollment/).
+
+    Verifies that the response includes all 7 required envelope fields after
+    adding DefaultPagination to the ViewSet.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(password="test")
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse("enrollment-list")
+
+    def test_response_includes_full_envelope(self):
+        """All 7 ADR 0032 envelope fields must be present in the list response."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        for field in ('count', 'num_pages', 'current_page', 'start', 'next', 'previous', 'results'):
+            assert field in response.data, f"ADR 0032: missing envelope field '{field}'"
+
+    def test_current_page_is_one_on_first_page(self):
+        """?page=1 must return current_page=1 in the response envelope."""
+        response = self.client.get(self.url, {'page': 1})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['current_page'] == 1
+
+    def test_start_is_zero_on_first_page(self):
+        """start must be 0 for the first page."""
+        response = self.client.get(self.url, {'page': 1})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['start'] == 0
+
+    def test_results_is_a_list(self):
+        """results must be a list (empty for a new user with no enrollments)."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.data['results'], list)
+
+    def test_count_reflects_user_enrollment_count(self):
+        """count must equal the number of enrollments for the user."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        expected = CourseEnrollment.objects.filter(user=self.user).count()
+        assert response.data['count'] == expected

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -108,7 +108,10 @@ class EnrollmentTestMixin:
 
         # Verify that the modulestore is queried as expected.
         with check_mongo_calls_range(min_finds=min_mongo_calls, max_finds=max_mongo_calls):
-            with patch('openedx.core.djangoapps.enrollments.views.audit_log') as mock_audit_log:
+            # ADR 0031: audit_log is invoked from the shared EnrollmentOperationsService,
+            # not the view module. Patch the service-layer binding so the mock is observed
+            # for both the canonical viewset and the deprecated EnrollmentListView path.
+            with patch('openedx.core.djangoapps.enrollments.view_services.audit_log') as mock_audit_log:
                 url = reverse('courseenrollments')
                 response = self.client.post(url, json.dumps(data), content_type='application/json', **extra)
                 assert response.status_code == expected_status

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -2643,3 +2643,213 @@ class TestEnrollmentViewSetListPaginationEnvelope(APITestCase):
         assert response.status_code == status.HTTP_200_OK
         expected = CourseEnrollment.objects.filter(user=self.user).count()
         assert response.data['count'] == expected
+
+
+# ---------------------------------------------------------------------------
+# ADR 0033 – Sorting / OEP-68 parameter-naming standardization tests
+# ---------------------------------------------------------------------------
+
+
+_ADR_0033_DEPRECATION_HEADER_COURSE_ID = (
+    "Parameter 'course_id' is deprecated. Use 'course_key' instead. "
+    "Support will be removed in release '<release_name>'."
+)
+_ADR_0033_DEPRECATION_HEADER_COURSE_IDS = (
+    "Parameter 'course_ids' is deprecated. Use 'course_keys' instead. "
+    "Support will be removed in release '<release_name>'."
+)
+_ADR_0033_DEPRECATION_HEADER_COURSE_ID_AND_IDS = (
+    "Parameter 'course_id' is deprecated. Use 'course_key' instead. "
+    "Parameter 'course_ids' is deprecated. Use 'course_keys' instead. "
+    "Support will be removed in release '<release_name>'."
+)
+
+
+@skip_unless_lms
+class TestCourseEnrollmentsApiListAdr0033(APITestCase, ModuleStoreTestCase):
+    """
+    ADR 0033 – tests for CourseEnrollmentsApiListView (GET /api/enrollment/v1/enrollments).
+
+    Covers:
+      * OEP-68 §2: ``course_key`` / ``course_keys`` work identically to the
+        legacy ``course_id`` / ``course_ids`` filters.
+      * BC §1: legacy and preferred names are accepted simultaneously; preferred
+        wins when both are sent.
+      * BC §2: the ``Deprecation`` HTTP header is emitted when (and only when)
+        a legacy name appears in the request — even if the preferred name is
+        also present.
+      * §3: the standard ``ordering`` parameter applies a whitelisted ORDER BY.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("courseenrollmentsapilist")
+        self.admin = AdminFactory(username="adr33admin", email="adr33admin@example.com", password="edx")
+        self.student_a = UserFactory(username="adr33a", email="a@example.com", password="edx")
+        self.student_b = UserFactory(username="adr33b", email="b@example.com", password="edx")
+
+        self.course_a = CourseFactory.create(org="adr33", number="A", run="r", emit_signals=True)
+        self.course_b = CourseFactory.create(org="adr33", number="B", run="r", emit_signals=True)
+
+        for mode_slug in ("honor", "audit"):
+            CourseModeFactory.create(
+                course_id=self.course_a.id, mode_slug=mode_slug, mode_display_name=mode_slug,
+            )
+            CourseModeFactory.create(
+                course_id=self.course_b.id, mode_slug=mode_slug, mode_display_name=mode_slug,
+            )
+
+        data.create_course_enrollment(self.student_a.username, str(self.course_a.id), "honor", True)
+        data.create_course_enrollment(self.student_b.username, str(self.course_b.id), "audit", True)
+
+        self.client.login(username=self.admin.username, password="edx")
+
+    # ---- course_key / course_id ----
+
+    def test_new_course_key_param_no_header(self):
+        """``?course_key=…`` returns 200 and no ``Deprecation`` header."""
+        response = self.client.get(self.url, {"course_key": str(self.course_a.id)})
+        assert response.status_code == status.HTTP_200_OK
+        assert "Deprecation" not in response.headers
+        # Filtering still works through the alias path.
+        results = response.data["results"]
+        assert all(r["course_id"] == str(self.course_a.id) for r in results)
+        assert results
+
+    def test_legacy_course_id_param_emits_header(self):
+        """``?course_id=…`` returns 200 and emits the ADR 0033 header."""
+        response = self.client.get(self.url, {"course_id": str(self.course_a.id)})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers.get("Deprecation") == _ADR_0033_DEPRECATION_HEADER_COURSE_ID
+        assert response.data["results"]
+
+    def test_course_key_wins_when_both_sent_but_header_still_emitted(self):
+        """When both names are sent, the preferred name wins but the header is still emitted."""
+        response = self.client.get(self.url, {
+            "course_key": str(self.course_a.id),
+            "course_id": str(self.course_b.id),
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers.get("Deprecation") == _ADR_0033_DEPRECATION_HEADER_COURSE_ID
+        # course_key (course_a) must win — none of course_b's enrollments should appear.
+        results = response.data["results"]
+        assert all(r["course_id"] == str(self.course_a.id) for r in results)
+        assert results
+
+    # ---- course_keys / course_ids ----
+
+    def test_legacy_course_ids_param_emits_header(self):
+        """``?course_ids=…`` returns 200 and emits the ADR 0033 header."""
+        response = self.client.get(self.url, {
+            "course_ids": f"{self.course_a.id},{self.course_b.id}",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers.get("Deprecation") == _ADR_0033_DEPRECATION_HEADER_COURSE_IDS
+
+    def test_new_course_keys_param_no_header(self):
+        """``?course_keys=…`` returns 200 with no ``Deprecation`` header."""
+        response = self.client.get(self.url, {
+            "course_keys": f"{self.course_a.id},{self.course_b.id}",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert "Deprecation" not in response.headers
+
+    def test_both_legacy_names_combined_header(self):
+        """Sending both legacy names produces a combined deprecation header."""
+        response = self.client.get(self.url, {
+            "course_id": str(self.course_a.id),
+            "course_ids": f"{self.course_a.id},{self.course_b.id}",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers.get("Deprecation") == _ADR_0033_DEPRECATION_HEADER_COURSE_ID_AND_IDS
+
+    # ---- baseline / no params ----
+
+    def test_no_legacy_params_no_header(self):
+        """A plain unfiltered request emits no ``Deprecation`` header."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert "Deprecation" not in response.headers
+
+    # ---- ordering whitelist ----
+
+    def test_ordering_created_ascending(self):
+        """``?ordering=created`` orders results by ``created`` ascending."""
+        response = self.client.get(self.url, {"ordering": "created"})
+        assert response.status_code == status.HTTP_200_OK
+        created_values = [row["created"] for row in response.data["results"]]
+        assert created_values == sorted(created_values)
+
+    def test_ordering_created_descending(self):
+        """``?ordering=-created`` orders results by ``created`` descending."""
+        response = self.client.get(self.url, {"ordering": "-created"})
+        assert response.status_code == status.HTTP_200_OK
+        created_values = [row["created"] for row in response.data["results"]]
+        assert created_values == sorted(created_values, reverse=True)
+
+    def test_ordering_invalid_value_is_ignored(self):
+        """A value outside the whitelist is silently ignored (no 400, no ORDER BY)."""
+        response = self.client.get(self.url, {"ordering": "user__email"})  # not in whitelist
+        assert response.status_code == status.HTTP_200_OK
+
+
+@ddt.ddt
+@skip_unless_lms
+class TestEnrollmentUserRolesAdr0033(ModuleStoreTestCase):
+    """
+    ADR 0033 – tests for EnrollmentUserRolesView (GET /api/enrollment/v1/roles/).
+
+    Covers:
+      * OEP-68 §2: ``course_key`` is the preferred filter; ``course_id`` is a
+        deprecated alias.
+      * BC §2: ``Deprecation`` header is emitted when the legacy name is used.
+      * Tie-break: when both names are sent, ``course_key`` wins and the
+        header is still emitted.
+    """
+
+    USERNAME = "adr33-roles"
+    EMAIL = "adr33-roles@example.com"
+    PASSWORD = "edx"
+
+    def setUp(self):
+        super().setUp()
+        self.course_a = CourseFactory.create(emit_signals=True, org="adr33r", course="a", run="r")
+        self.course_b = CourseFactory.create(emit_signals=True, org="adr33r", course="b", run="r")
+        self.user = UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
+        CourseStaffRole(self.course_a.id).add_users(self.user)
+        CourseStaffRole(self.course_b.id).add_users(self.user)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+        self.url = reverse("roles")
+
+    def test_new_course_key_param_no_header(self):
+        """``?course_key=…`` returns 200 and no ``Deprecation`` header; filter applies."""
+        response = self.client.get(self.url, {"course_key": str(self.course_a.id)})
+        assert response.status_code == status.HTTP_200_OK
+        assert "Deprecation" not in response.headers
+        roles = json.loads(response.content.decode("utf-8"))["roles"]
+        assert {r["course_id"] for r in roles} == {str(self.course_a.id)}
+
+    def test_legacy_course_id_param_emits_header(self):
+        """``?course_id=…`` returns 200 and emits the ADR 0033 header; filter applies."""
+        response = self.client.get(self.url, {"course_id": str(self.course_a.id)})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers.get("Deprecation") == _ADR_0033_DEPRECATION_HEADER_COURSE_ID
+        roles = json.loads(response.content.decode("utf-8"))["roles"]
+        assert {r["course_id"] for r in roles} == {str(self.course_a.id)}
+
+    def test_course_key_wins_when_both_sent_header_still_emitted(self):
+        """When both names are sent, ``course_key`` wins and the header is still emitted."""
+        response = self.client.get(self.url, {
+            "course_key": str(self.course_a.id),
+            "course_id": str(self.course_b.id),
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers.get("Deprecation") == _ADR_0033_DEPRECATION_HEADER_COURSE_ID
+        roles = json.loads(response.content.decode("utf-8"))["roles"]
+        assert {r["course_id"] for r in roles} == {str(self.course_a.id)}
+
+    def test_no_filter_no_header(self):
+        """Plain ``GET /roles/`` does not emit the ``Deprecation`` header."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert "Deprecation" not in response.headers

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -2375,3 +2375,148 @@ class UserRoleViewResponseShapeTest(ModuleStoreTestCase):
         CourseStaffRole(course2.id).add_users(self.user)
         body = self._get_roles(course_id=str(self.course.id)).json()
         assert all(r['course_id'] == str(self.course.id) for r in body['roles'])
+
+
+# ---------------------------------------------------------------------------
+# ADR 0028 – EnrollmentViewSet permission regression tests
+# ---------------------------------------------------------------------------
+
+@skip_unless_lms
+class TestEnrollmentViewSetList(APITestCase):
+    """
+    ADR 0028 – permission regression tests for EnrollmentViewSet.list (GET /enrollment/).
+    Migrated from EnrollmentListView.
+    """
+    API_KEY = "test-api-key"
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(password="test")
+        self.url = reverse("enrollment-list")
+
+    def test_unauthenticated_gets_401(self):
+        """Unauthenticated request must be rejected."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("openedx.core.djangoapps.enrollments.views.CourseEnrollment.objects")
+    def test_authenticated_user_gets_200(self, mock_objects):
+        """An authenticated user must reach the list action (permission check passes)."""
+        mock_objects.filter.return_value.select_related.return_value = []
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("openedx.core.djangoapps.enrollments.views.CourseEnrollment.objects")
+    def test_valid_api_key_gets_200(self, mock_objects):
+        """A valid API key must bypass session auth and reach the list action."""
+        mock_objects.filter.return_value.select_related.return_value = []
+        with override_settings(EDX_API_KEY=self.API_KEY):
+            response = self.client.get(self.url, HTTP_X_EDX_API_KEY=self.API_KEY)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_invalid_api_key_without_session_gets_401(self):
+        """An invalid API key without session auth must be rejected."""
+        response = self.client.get(self.url, HTTP_X_EDX_API_KEY="wrong-key")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@skip_unless_lms
+class TestEnrollmentViewSetCreate(APITestCase):
+    """
+    ADR 0028 – permission regression tests for EnrollmentViewSet.create (POST /enrollment/).
+    Migrated from EnrollmentListView.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(password="test")
+        self.url = reverse("enrollment-list")
+
+    def test_unauthenticated_post_gets_401(self):
+        """Unauthenticated POST must be rejected."""
+        response = self.client.post(self.url, data={}, content_type="application/json")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_authenticated_post_missing_course_id_gets_400(self):
+        """Authenticated POST without course_id must return 400."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(self.url, data={}, content_type="application/json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@skip_unless_lms
+class TestEnrollmentViewSetUnenroll(APITestCase):
+    """
+    ADR 0028 – permission regression tests for EnrollmentViewSet.unenroll (POST /enrollment/unenroll/).
+    Migrated from UnenrollmentView. Requires IsAuthenticated + CanRetireUser.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(password="test")
+        self.url = reverse("enrollment-unenroll")
+
+    def test_unauthenticated_gets_401(self):
+        """Unauthenticated request must be rejected."""
+        response = self.client.post(self.url, data={"username": self.user.username}, content_type="application/json")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_authenticated_non_retirement_user_gets_403(self):
+        """An authenticated user without CanRetireUser permission must get 403."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(self.url, data={"username": self.user.username}, content_type="application/json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@skip_unless_lms
+class TestEnrollmentViewSetAllowed(APITestCase):
+    """
+    ADR 0028 – permission regression tests for EnrollmentViewSet.allowed
+    (GET/POST/DELETE /enrollment/enrollment_allowed/). Migrated from EnrollmentAllowedView.
+    Requires IsAdminUser.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(password="test")
+        self.admin = AdminFactory.create(password="test")
+        self.url = reverse("enrollment-allowed")
+
+    def test_unauthenticated_get_gets_401(self):
+        """Unauthenticated GET must be rejected."""
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_non_admin_get_gets_403(self):
+        """Regular authenticated user must get 403."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_admin_get_gets_200(self):
+        """Admin user must get 200 and an empty list."""
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
+
+    def test_non_admin_post_gets_403(self):
+        """Regular authenticated user POST must get 403."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.url,
+            data={"email": "test@example.com", "course_id": "course-v1:edX+DemoX+Demo_Course"},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_non_admin_delete_gets_403(self):
+        """Regular authenticated user DELETE must get 403."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            self.url,
+            data={"email": "test@example.com", "course_id": "course-v1:edX+DemoX+Demo_Course"},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -36,7 +36,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.course_groups import cohorts
 from openedx.core.djangoapps.embargo.models import Country, CountryAccessRule, RestrictedCourse
 from openedx.core.djangoapps.embargo.test_utils import restrict_course
-from openedx.core.djangoapps.enrollments import api, data
+from openedx.core.djangoapps.enrollments import data
 from openedx.core.djangoapps.enrollments.errors import CourseEnrollmentError
 from openedx.core.djangoapps.enrollments.views import EnrollmentUserThrottle
 from openedx.core.djangoapps.notifications.config.waffle import ENABLE_NOTIFICATIONS
@@ -711,9 +711,9 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         )
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
-    @patch.object(api, "get_enrollment")
-    def test_get_enrollment_internal_error(self, mock_get_enrollment):
-        mock_get_enrollment.side_effect = CourseEnrollmentError("Something bad happened.")
+    @patch.object(CourseEnrollment.objects, "get")
+    def test_get_enrollment_internal_error(self, mock_get):
+        mock_get.side_effect = CourseEnrollmentError("Something bad happened.")
         resp = self.client.get(
             reverse(
                 'courseenrollment',
@@ -2031,3 +2031,347 @@ class EnrollmentAllowedViewTest(APITestCase):
         self.client.post(self.url, self.data)
         response = self.client.delete(self.url, delete_data)
         assert response.status_code == expected_result
+
+    # --- Response-shape tests (ADR 0025 serializer migration) ---
+
+    def test_post_response_shape(self):
+        """POST 201 response contains the expected fields from CourseEnrollmentAllowedSerializer."""
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == status.HTTP_201_CREATED
+        body = response.json()
+        assert body['email'] == self.data['email']
+        assert body['course_id'] == self.data['course_id']
+        assert body['auto_enroll'] is False
+        assert 'created' in body
+
+    def test_post_auto_enroll_true_in_response(self):
+        """POST with auto_enroll=true is reflected in the 201 response."""
+        response = self.client.post(self.url, {**self.data, 'auto_enroll': True})
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()['auto_enroll'] is True
+
+    def test_post_missing_email_returns_field_error(self):
+        """POST without email returns a serializer field-level 400 with an 'email' key."""
+        response = self.client.post(self.url, {'course_id': self.data['course_id']})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'email' in response.json()
+
+    def test_post_missing_course_id_returns_field_error(self):
+        """POST without course_id returns a serializer field-level 400 with a 'course_id' key."""
+        response = self.client.post(self.url, {'email': self.data['email']})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'course_id' in response.json()
+
+    def test_post_duplicate_returns_409_with_message(self):
+        """A duplicate POST returns 409 with a 'message' key."""
+        self.client.post(self.url, self.data)
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert 'message' in response.json()
+
+    def test_get_response_is_list(self):
+        """GET response body is a JSON list."""
+        response = self.client.get(self.url, {'email': self.data['email']})
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.json(), list)
+
+    def test_get_empty_response_is_empty_list(self):
+        """GET with no matching enrollments returns an empty list, not null."""
+        response = self.client.get(self.url, {'email': 'nobody@example.com'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_get_item_shape(self):
+        """Each item in the GET response has the fields from CourseEnrollmentAllowedSerializer."""
+        self.client.post(self.url, self.data)
+        response = self.client.get(self.url, {'email': self.data['email']})
+        assert response.status_code == status.HTTP_200_OK
+        item = response.json()[0]
+        assert item['email'] == self.data['email']
+        assert item['course_id'] == self.data['course_id']
+        assert 'auto_enroll' in item
+        assert 'created' in item
+
+    def test_get_multiple_entries_returned(self):
+        """GET returns all enrollment-allowed records for a given email."""
+        second_course = 'course-v1:edX+OtherX+Other_Course'
+        self.client.post(self.url, self.data)
+        self.client.post(self.url, {'email': self.data['email'], 'course_id': second_course})
+        response = self.client.get(self.url, {'email': self.data['email']})
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()
+        assert len(results) == 2
+        assert all(r['email'] == self.data['email'] for r in results)
+
+    def test_delete_missing_email_returns_field_error(self):
+        """DELETE without email returns a serializer field-level 400 with an 'email' key."""
+        self.client.post(self.url, self.data)
+        response = self.client.delete(self.url, {'course_id': self.data['course_id']})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'email' in response.json()
+
+
+@skip_unless_lms
+class EnrollmentViewResponseShapeTest(ModuleStoreTestCase, APITestCase):
+    """
+    Tests that verify EnrollmentView (GET /enrollment/v1/enrollment/{course_id} and
+    /enrollment/v1/enrollment/{username},{course_id}) response structure is preserved
+    after migrating to direct serializer usage (ADR 0025).
+    """
+
+    USERNAME = "Bob"
+    PASSWORD = "edx"
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(emit_signals=True)
+        self.user = UserFactory.create(username=self.USERNAME, password=self.PASSWORD)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+        CourseModeFactory.create(
+            course_id=self.course.id,
+            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+        )
+        CourseEnrollment.enroll(self.user, self.course.id)
+
+    def _get_by_course_id(self):
+        return self.client.get(
+            reverse('courseenrollment', kwargs={'course_id': str(self.course.id)})
+        )
+
+    def _get_by_username_and_course_id(self):
+        return self.client.get(
+            reverse('courseenrollment', kwargs={'username': self.USERNAME, 'course_id': str(self.course.id)})
+        )
+
+    def test_get_by_course_id_returns_200(self):
+        assert self._get_by_course_id().status_code == status.HTTP_200_OK
+
+    def test_get_by_username_course_id_returns_200(self):
+        assert self._get_by_username_and_course_id().status_code == status.HTTP_200_OK
+
+    def test_get_response_top_level_fields(self):
+        """Response contains the expected top-level enrollment fields."""
+        body = self._get_by_course_id().json()
+        for field in ('created', 'mode', 'is_active', 'user', 'course_details'):
+            assert field in body, f"Missing top-level field: {field}"
+
+    def test_get_response_user_and_mode(self):
+        """user and mode values match the enrollment."""
+        body = self._get_by_course_id().json()
+        assert body['user'] == self.USERNAME
+        assert body['mode'] == CourseMode.DEFAULT_MODE_SLUG
+        assert body['is_active'] is True
+
+    def test_get_by_username_course_id_matches_by_course_id(self):
+        """Both URL shapes return identical response bodies."""
+        by_course = self._get_by_course_id().json()
+        by_username = self._get_by_username_and_course_id().json()
+        assert by_course == by_username
+
+    def test_get_course_details_fields(self):
+        """course_details contains the expected nested fields."""
+        course_details = self._get_by_course_id().json()['course_details']
+        for field in (
+            'course_id', 'course_name', 'enrollment_start', 'enrollment_end',
+            'course_start', 'course_end', 'invite_only', 'course_modes', 'pacing_type',
+        ):
+            assert field in course_details, f"Missing course_details field: {field}"
+        assert course_details['course_id'] == str(self.course.id)
+
+    def test_get_no_enrollment_returns_null(self):
+        """GET for a course the user never enrolled in returns HTTP 200 with a null body."""
+        unenrolled_course = CourseFactory.create(emit_signals=True)
+        resp = self.client.get(
+            reverse('courseenrollment', kwargs={'course_id': str(unenrolled_course.id)})
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.json() is None
+
+
+@skip_unless_lms
+class EnrollmentCourseDetailViewResponseShapeTest(ModuleStoreTestCase, APITestCase):
+    """
+    Tests that verify EnrollmentCourseDetailView (GET /enrollment/v1/course/{course_id})
+    response structure is preserved after migrating to CourseSerializer + direct ORM (ADR 0025).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(emit_signals=True)
+        CourseModeFactory.create(
+            course_id=self.course.id,
+            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+        )
+
+    def _get_course_details(self, course_id=None, include_expired=False):
+        url = reverse('courseenrollmentdetails', kwargs={'course_id': course_id or str(self.course.id)})
+        if include_expired:
+            url += '?include_expired=1'
+        return self.client.get(url)
+
+    def test_returns_200(self):
+        assert self._get_course_details().status_code == status.HTTP_200_OK
+
+    def test_response_top_level_fields(self):
+        """Response contains the expected top-level CourseSerializer fields."""
+        body = self._get_course_details().json()
+        for field in ('course_id', 'course_name', 'enrollment_start', 'enrollment_end',
+                      'course_start', 'course_end', 'invite_only', 'course_modes', 'pacing_type'):
+            assert field in body, f"Missing field: {field}"
+
+    def test_course_id_matches_requested_course(self):
+        body = self._get_course_details().json()
+        assert body['course_id'] == str(self.course.id)
+
+    def test_course_modes_is_list(self):
+        body = self._get_course_details().json()
+        assert isinstance(body['course_modes'], list)
+
+    def test_course_mode_fields(self):
+        """Each mode entry contains the expected fields."""
+        body = self._get_course_details().json()
+        mode = body['course_modes'][0]
+        for field in ('slug', 'name', 'min_price', 'suggested_prices', 'currency',
+                      'expiration_datetime', 'description', 'sku', 'bulk_sku'):
+            assert field in mode, f"Missing course_mode field: {field}"
+
+    def test_invalid_course_id_returns_400(self):
+        resp = self._get_course_details(course_id='not/a/real/course')
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_nonexistent_course_returns_400(self):
+        resp = self._get_course_details(course_id='course-v1:Org+NonExistent+2099')
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@skip_unless_lms
+class EnrollmentListViewResponseShapeTest(ModuleStoreTestCase, APITestCase):
+    """
+    Tests that verify EnrollmentListView (GET /enrollment/v1/enrollment)
+    response structure is preserved after migrating to CourseEnrollmentSerializer + ORM (ADR 0025).
+    """
+
+    USERNAME = "TestLearner"
+    PASSWORD = "edx"
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(emit_signals=True)
+        CourseModeFactory.create(
+            course_id=self.course.id,
+            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+        )
+        self.user = UserFactory.create(username=self.USERNAME, password=self.PASSWORD)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+        CourseEnrollment.enroll(self.user, self.course.id)
+
+    def _get_enrollments(self, user=None):
+        url = reverse('courseenrollments')
+        if user:
+            url += f'?user={user}'
+        return self.client.get(url)
+
+    def test_returns_200(self):
+        assert self._get_enrollments().status_code == status.HTTP_200_OK
+
+    def test_response_is_list(self):
+        body = self._get_enrollments().json()
+        assert isinstance(body, list)
+
+    def test_enrollment_top_level_fields(self):
+        """Each enrollment entry contains the expected top-level fields."""
+        body = self._get_enrollments().json()
+        assert len(body) >= 1
+        entry = body[0]
+        for field in ('created', 'mode', 'is_active', 'user', 'course_details'):
+            assert field in entry, f"Missing top-level field: {field}"
+
+    def test_enrollment_user_and_mode_values(self):
+        body = self._get_enrollments().json()
+        entry = body[0]
+        assert entry['user'] == self.USERNAME
+        assert entry['mode'] == CourseMode.DEFAULT_MODE_SLUG
+        assert entry['is_active'] is True
+
+    def test_enrollment_course_details_fields(self):
+        """course_details nested object contains the expected fields."""
+        body = self._get_enrollments().json()
+        course_details = body[0]['course_details']
+        for field in ('course_id', 'course_name', 'enrollment_start', 'enrollment_end',
+                      'course_start', 'course_end', 'invite_only', 'course_modes'):
+            assert field in course_details, f"Missing course_details field: {field}"
+
+    def test_no_enrollments_returns_empty_list(self):
+        """A user with no enrollments gets an empty list, not null or an error."""
+        new_user = UserFactory.create(password=self.PASSWORD)
+        self.client.login(username=new_user.username, password=self.PASSWORD)
+        body = self.client.get(reverse('courseenrollments')).json()
+        assert body == []
+
+
+@skip_unless_lms
+class UserRoleViewResponseShapeTest(ModuleStoreTestCase):
+    """
+    Tests that verify EnrollmentUserRolesView (GET /enrollment/v1/roles/)
+    response structure is preserved after migrating to UserRolesResponseSerializer (ADR 0025).
+    """
+
+    USERNAME = "RoleTester"
+    PASSWORD = "edx"
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(emit_signals=True, org="testorg", course="c1", run="r1")
+        self.user = UserFactory.create(username=self.USERNAME, password=self.PASSWORD)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+
+    def _get_roles(self, course_id=None):
+        url = reverse('roles')
+        if course_id:
+            url += f'?course_id={course_id}'
+        return self.client.get(url)
+
+    def test_returns_200(self):
+        assert self._get_roles().status_code == status.HTTP_200_OK
+
+    def test_response_top_level_keys(self):
+        """Response always contains 'roles' (list) and 'is_staff' (bool)."""
+        body = self._get_roles().json()
+        assert 'roles' in body
+        assert 'is_staff' in body
+        assert isinstance(body['roles'], list)
+        assert isinstance(body['is_staff'], bool)
+
+    def test_no_roles_returns_empty_list(self):
+        body = self._get_roles().json()
+        assert body['roles'] == []
+        assert body['is_staff'] is False
+
+    def test_role_entry_shape(self):
+        """A role entry contains org, course_id, and role fields."""
+        role = CourseStaffRole(self.course.id)
+        role.add_users(self.user)
+        body = self._get_roles().json()
+        assert len(body['roles']) == 1
+        entry = body['roles'][0]
+        for field in ('org', 'course_id', 'role'):
+            assert field in entry, f"Missing role field: {field}"
+        assert entry['org'] == self.course.org
+        assert entry['course_id'] == str(self.course.id)
+
+    def test_is_staff_true_for_staff_user(self):
+        staff_user = UserFactory.create(password=self.PASSWORD, is_staff=True)
+        self.client.login(username=staff_user.username, password=self.PASSWORD)
+        body = self._get_roles().json()
+        assert body['is_staff'] is True
+
+    def test_filter_by_course_id(self):
+        """course_id query param filters roles to that course only."""
+        course2 = CourseFactory.create(emit_signals=True, org="other", course="c2", run="r2")
+        CourseStaffRole(self.course.id).add_users(self.user)
+        CourseStaffRole(course2.id).add_users(self.user)
+        body = self._get_roles(course_id=str(self.course.id)).json()
+        assert all(r['course_id'] == str(self.course.id) for r in body['roles'])

--- a/openedx/core/djangoapps/enrollments/urls.py
+++ b/openedx/core/djangoapps/enrollments/urls.py
@@ -5,6 +5,7 @@ URLs for the Enrollment API
 
 from django.conf import settings
 from django.urls import path, re_path
+from rest_framework.routers import DefaultRouter
 
 from .views import (
     CourseEnrollmentsApiListView,
@@ -13,10 +14,18 @@ from .views import (
     EnrollmentListView,
     EnrollmentUserRolesView,
     EnrollmentView,
+    EnrollmentViewSet,
     UnenrollmentView,
 )
 
-urlpatterns = [
+# ADR 0028: EnrollmentViewSet registered via DefaultRouter.
+# Generates: GET/POST /enrollment/, POST /enrollment/unenroll/, GET/POST/DELETE /enrollment/enrollment_allowed/
+router = DefaultRouter()
+router.register(r"enrollment", EnrollmentViewSet, basename="enrollment")
+
+urlpatterns = router.urls + [
+    # EnrollmentView kept as-is: non-standard {username},{course_key} URL is incompatible with
+    # DefaultRouter lookup — migrate to ViewSet retrieve() in a follow-up (TODO ADR 0028).
     re_path(
         r"^enrollment/{username},{course_key}$".format(
             username=settings.USERNAME_PATTERN, course_key=settings.COURSE_ID_PATTERN
@@ -25,12 +34,15 @@ urlpatterns = [
         name="courseenrollment",
     ),
     re_path(rf"^enrollment/{settings.COURSE_ID_PATTERN}$", EnrollmentView.as_view(), name="courseenrollment"),
-    path("enrollment", EnrollmentListView.as_view(), name="courseenrollments"),
     re_path(r"^enrollments/?$", CourseEnrollmentsApiListView.as_view(), name="courseenrollmentsapilist"),
     re_path(
         rf"^course/{settings.COURSE_ID_PATTERN}$", EnrollmentCourseDetailView.as_view(), name="courseenrollmentdetails"
     ),
-    path("unenroll/", UnenrollmentView.as_view(), name="unenrollment"),
     path("roles/", EnrollmentUserRolesView.as_view(), name="roles"),
+
+    # DEPRECATED (ADR 0028): flat URL patterns kept for backward compatibility.
+    # Will be removed after one named release. Use the router-generated enrollment/ URLs instead.
+    path("enrollment", EnrollmentListView.as_view(), name="courseenrollments"),
+    path("unenroll/", UnenrollmentView.as_view(), name="unenrollment"),
     path("enrollment_allowed/", EnrollmentAllowedView.as_view(), name="courseenrollmentallowed"),
 ]

--- a/openedx/core/djangoapps/enrollments/view_services.py
+++ b/openedx/core/djangoapps/enrollments/view_services.py
@@ -1,0 +1,430 @@
+"""
+Shared service layer for enrollment HTTP operations.
+
+ADR 0031 (Merge Similar Endpoints) requires that closely related endpoints
+that operate on the same resource domain consolidate their *business logic*
+into a common service layer.  In this app three pairs of endpoints exist
+side by side and share substantial logic:
+
+* ``EnrollmentViewSet.create`` (canonical, ADR 0028) and
+  ``EnrollmentListView.post`` (deprecated alias) — full create/update flow.
+* ``EnrollmentViewSet.unenroll`` and ``UnenrollmentView.post`` — retirement
+  unenroll-all-courses flow.
+* ``EnrollmentViewSet.allowed`` and ``EnrollmentAllowedView`` — allowed-
+  enrollment GET / POST / DELETE flow.
+
+Without a shared service the deprecated alias and the canonical view drift
+apart over time, defeating the point of having both.  This module hosts the
+shared implementation that both sides call into.
+
+Authorization model (ADR 0031)
+------------------------------
+
+Each operation is enforced in two layers:
+
+1. The view declares a coarse permission class (``IsAuthenticated``,
+   ``IsAdminUser``, ``CanRetireUser``, ``ApiKeyHeaderPermissionIsAuthenticated``)
+   that filters out callers who have no business hitting the endpoint at all.
+2. The service method enforces the *operation-specific* permission — e.g.
+   only API-key callers or global staff may deactivate enrollments, downgrade
+   modes, or force-enroll a user.  These checks live next to the business
+   logic so the deprecated and canonical views cannot diverge on them.
+
+This keeps the distinct authorization requirements of the legacy endpoints
+intact while removing the duplicated boilerplate around them.
+"""
+
+import logging
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import status
+from rest_framework.response import Response
+
+from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.student.auth import user_has_role
+from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, EnrollmentNotAllowed
+from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
+from openedx.core.djangoapps.course_groups.cohorts import CourseUserGroup, add_user_to_cohort, get_cohort_by_name
+from openedx.core.djangoapps.embargo import api as embargo_api
+from openedx.core.djangoapps.enrollments import api
+from openedx.core.djangoapps.enrollments.errors import (
+    CourseEnrollmentError,
+    CourseEnrollmentExistsError,
+    CourseModeNotFoundError,
+    InvalidEnrollmentAttribute,
+)
+from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
+from openedx.core.lib.exceptions import CourseNotFoundError
+from openedx.core.lib.log_utils import audit_log
+from openedx.features.enterprise_support.api import (
+    ConsentApiServiceClient,
+    EnterpriseApiException,
+    EnterpriseApiServiceClient,
+    enterprise_enabled,
+)
+
+log = logging.getLogger(__name__)
+
+User = get_user_model()
+
+REQUIRED_ATTRIBUTES = {
+    "credit": ["credit:provider_id"],
+}
+
+
+class EnrollmentOperationsService:
+    """
+    Operation handlers shared between the canonical enrollment ViewSet and
+    its deprecated APIView aliases.  See module docstring for the rationale
+    and the two-layer authorization model required by ADR 0031.
+    """
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+    def list_enrollments_for_user(self, request_user, target_username, has_api_key):
+        """
+        Return the enrollments visible to ``request_user`` for the user
+        named by ``target_username``.
+
+        Per-operation permission (ADR 0031 layer 2):
+
+        * If the requester is asking about themselves, global staff, or a
+          server-to-server caller — the full enrollment list is returned.
+        * Otherwise the list is filtered to courses the requester has the
+          ``CourseStaffRole`` for (so a course team member can see whether
+          a particular learner is in their course, but nothing more).
+
+        Returns a list of ``CourseEnrollment`` instances.  Both the paginated
+        canonical ``EnrollmentViewSet.list`` and the unpaginated deprecated
+        ``EnrollmentListView.get`` call this helper.
+        """
+        enrollments = CourseEnrollment.objects.filter(
+            user__username=target_username
+        ).select_related("user", "course")
+        if (
+            target_username == request_user.username
+            or GlobalStaff().has_user(request_user)
+            or has_api_key
+        ):
+            return list(enrollments)
+        return [
+            enrollment for enrollment in enrollments
+            if user_has_role(request_user, CourseStaffRole(enrollment.course_id))
+        ]
+
+    # ------------------------------------------------------------------
+    # Create / update
+    # ------------------------------------------------------------------
+    def create_or_update_enrollment(self, request, has_api_key, course_id):
+        """
+        Handle the POST /enrollment/ create-or-update flow.
+
+        Returns a DRF ``Response`` with the appropriate status code.  Mode-
+        specific authorization (deactivation, mode-change, force-enroll) is
+        enforced inside this method so the deprecated alias and the canonical
+        view cannot drift on it.
+
+        ``course_id`` is the validated ``CourseKey`` instance — callers are
+        responsible for the up-front InvalidKeyError -> 400 mapping (because
+        DRF view error responses are tightly coupled to the view's request
+        parsing, and the deprecated and canonical wrappers handle that step
+        identically).
+        """
+        # pylint: disable=too-many-statements,too-many-branches
+        username = request.data.get("user")
+        mode = request.data.get("mode")
+        is_active = None  # populated below; referenced by the audit-log finally block
+        user = None
+        cohort_name = None
+
+        # Per-operation authz layer 1: only admin/api-key callers may enroll
+        # other users.  Anonymous and non-staff callers can only enroll
+        # themselves.
+        if (
+            username
+            and username != request.user.username
+            and not has_api_key
+            and not GlobalStaff().has_user(request.user)
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if not username:
+            email = request.data.get("email")
+            if email:
+                if not has_api_key and not GlobalStaff().has_user(request.user):
+                    return Response(status=status.HTTP_404_NOT_FOUND)
+                try:
+                    username = User.objects.get(email=email).username
+                except ObjectDoesNotExist:
+                    return Response(
+                        status=status.HTTP_406_NOT_ACCEPTABLE,
+                        data={"message": f"The user with the email address {email} does not exist."},
+                    )
+            else:
+                username = request.user.username
+
+        # Per-operation authz layer 2: non-default mode enrollments require
+        # api-key or global-staff privileges.
+        if (
+            mode not in (CourseMode.AUDIT, CourseMode.HONOR, None)
+            and not has_api_key
+            and not GlobalStaff().has_user(request.user)
+        ):
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={
+                    "message": "User does not have permission to create enrollment with mode [{mode}].".format(
+                        mode=mode,
+                    ),
+                },
+            )
+
+        try:
+            user = User.objects.get(username=username)
+        except ObjectDoesNotExist:
+            return Response(
+                status=status.HTTP_406_NOT_ACCEPTABLE,
+                data={"message": f"The user {username} does not exist."},
+            )
+
+        embargo_response = embargo_api.get_embargo_response(request, course_id, user)
+        if embargo_response:
+            return embargo_response
+
+        try:
+            is_active = request.data.get("is_active")
+            if is_active is not None and not isinstance(is_active, bool):
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={
+                        "message": "'{value}' is an invalid enrollment activation status.".format(value=is_active),
+                    },
+                )
+
+            explicit_linked_enterprise = request.data.get("linked_enterprise_customer")
+            if explicit_linked_enterprise and has_api_key and enterprise_enabled():
+                enterprise_api_client = EnterpriseApiServiceClient()
+                consent_client = ConsentApiServiceClient()
+                try:
+                    enterprise_api_client.post_enterprise_course_enrollment(username, str(course_id))
+                except EnterpriseApiException as error:
+                    log.exception(
+                        "An unexpected error occurred while creating the new EnterpriseCourseEnrollment "
+                        "for user [%s] in course run [%s]",
+                        username,
+                        course_id,
+                    )
+                    raise CourseEnrollmentError(str(error))  # lint-amnesty, pylint: disable=raise-missing-from
+                consent_client.provide_consent(
+                    username=username,
+                    course_id=str(course_id),
+                    enterprise_customer_uuid=explicit_linked_enterprise,
+                )
+
+            enrollment_attributes = request.data.get("enrollment_attributes")
+            force_enrollment = request.data.get("force_enrollment")
+            if force_enrollment is not None and not isinstance(force_enrollment, bool):
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={
+                        "message": "'{value}' is an invalid force enrollment status.".format(value=force_enrollment),
+                    },
+                )
+            # Per-operation authz layer 2: force-enrollment is global-staff-only.
+            force_enrollment = force_enrollment and GlobalStaff().has_user(request.user)
+
+            enrollment = api.get_enrollment(username, str(course_id))
+            mode_changed = enrollment and mode is not None and enrollment["mode"] != mode
+            active_changed = enrollment and is_active is not None and enrollment["is_active"] != is_active
+            missing_attrs = []
+            if enrollment_attributes:
+                actual_attrs = ["{namespace}:{name}".format(**attr) for attr in enrollment_attributes]
+                missing_attrs = set(REQUIRED_ATTRIBUTES.get(mode, [])) - set(actual_attrs)
+
+            # Per-operation authz layer 2: only api-key or global-staff
+            # callers may switch an existing enrollment's mode or activation.
+            if (GlobalStaff().has_user(request.user) or has_api_key) and (mode_changed or active_changed):
+                if mode_changed and active_changed and not is_active:
+                    msg = "Enrollment mode mismatch: active mode={}, requested mode={}. Won't deactivate.".format(
+                        enrollment["mode"], mode,
+                    )
+                    log.warning(msg)
+                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
+
+                if missing_attrs:
+                    msg = "Missing enrollment attributes: requested mode={} required attributes={}".format(
+                        mode, REQUIRED_ATTRIBUTES.get(mode),
+                    )
+                    log.warning(msg)
+                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
+
+                response_data = api.update_enrollment(
+                    username,
+                    str(course_id),
+                    mode=mode,
+                    is_active=is_active,
+                    enrollment_attributes=enrollment_attributes,
+                    include_expired=has_api_key,
+                )
+            else:
+                response_data = api.add_enrollment(
+                    username,
+                    str(course_id),
+                    mode=mode,
+                    is_active=is_active,
+                    enrollment_attributes=enrollment_attributes,
+                    enterprise_uuid=request.data.get("enterprise_uuid"),
+                    force_enrollment=force_enrollment,
+                    include_expired=force_enrollment,
+                )
+
+            cohort_name = request.data.get("cohort")
+            if cohort_name is not None:
+                cohort = get_cohort_by_name(course_id, cohort_name)
+                try:
+                    add_user_to_cohort(cohort, user)
+                except ValueError:
+                    log.exception("Cohort re-addition")
+
+            email_opt_in = request.data.get("email_opt_in", None)
+            if email_opt_in is not None:
+                org = course_id.org
+                update_email_opt_in(request.user, org, email_opt_in)
+
+            log.info("The user [%s] has already been enrolled in course run [%s].", username, course_id)
+            return Response(response_data)
+
+        except InvalidEnrollmentAttribute as error:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": str(error), "localizedMessage": str(error)},
+            )
+        except EnrollmentNotAllowed as error:
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={"message": str(error), "localizedMessage": str(error)},
+            )
+        except CourseModeNotFoundError as error:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": (
+                        "The [{mode}] course mode is expired or otherwise unavailable for course run [{course_id}]."
+                    ).format(mode=mode, course_id=course_id),
+                    "course_details": error.data,
+                },
+            )
+        except CourseNotFoundError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": f"No course '{course_id}' found for enrollment"},
+            )
+        except CourseEnrollmentExistsError as error:
+            log.warning("An enrollment already exists for user [%s] in course run [%s].", username, course_id)
+            return Response(data=error.enrollment)
+        except CourseEnrollmentError:
+            log.exception(
+                "An error occurred while creating the new course enrollment for user [%s] in course run [%s]",
+                username,
+                course_id,
+            )
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": (
+                        "An error occurred while creating the new course enrollment for user "
+                        "'{username}' in course '{course_id}'"
+                    ).format(username=username, course_id=course_id),
+                },
+            )
+        except CourseUserGroup.DoesNotExist:
+            log.exception("Missing cohort [%s] in course run [%s]", cohort_name, course_id)
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "An error occured while adding to cohort [%s]" % cohort_name},
+            )
+        finally:
+            # Audit-log every API-key-driven enrollment change so the
+            # ecommerce service's mode/activation requests can be traced.
+            if has_api_key and user is not None:
+                try:
+                    current_enrollment_obj = CourseEnrollment.objects.get(
+                        user__username=username, course_id=course_id,
+                    )
+                    actual_mode = current_enrollment_obj.mode
+                    actual_activation = current_enrollment_obj.is_active
+                except CourseEnrollment.DoesNotExist:
+                    actual_mode = None
+                    actual_activation = None
+                audit_log(
+                    "enrollment_change_requested",
+                    course_id=str(course_id),
+                    requested_mode=mode,
+                    actual_mode=actual_mode,
+                    requested_activation=is_active,
+                    actual_activation=actual_activation,
+                    user_id=user.id,
+                )
+
+    # ------------------------------------------------------------------
+    # Unenroll (retirement pipeline)
+    # ------------------------------------------------------------------
+    def unenroll_user_for_retirement(self, username):
+        """
+        Handle the retirement-pipeline POST /unenroll/ flow.
+
+        Returns a DRF ``Response``.  Caller is responsible for the coarse
+        ``IsAuthenticated + CanRetireUser`` permission check (ADR 0031 layer
+        1); this method handles the per-operation flow:
+
+        * 404 if no retirement-status row exists for the username.
+        * 204 if the user has no active enrollments.
+        * 200 with the unenroll-result list otherwise.
+        """
+        if not username:
+            return Response("Username not specified.", status=status.HTTP_404_NOT_FOUND)
+        try:
+            UserRetirementStatus.get_retirement_for_retirement_action(username)
+        except UserRetirementStatus.DoesNotExist:
+            return Response(
+                "No retirement request status for username.",
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        try:
+            active_enrollments = CourseEnrollment.objects.filter(
+                user__username=username, is_active=True,
+            )
+            if not active_enrollments.exists():
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            return Response(api.unenroll_user_from_all_courses(username))
+        except Exception as exc:  # pylint: disable=broad-except
+            return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    # ------------------------------------------------------------------
+    # Allowed enrollments
+    # ------------------------------------------------------------------
+    def list_allowed_for_email(self, email):
+        """Return the ``CourseEnrollmentAllowed`` rows for ``email``."""
+        return CourseEnrollmentAllowed.objects.filter(email=email)
+
+    def create_allowed_enrollment(self, serializer):
+        """
+        Persist the allowed-enrollment described by ``serializer``.
+
+        Raises ``IntegrityError`` if a row already exists for the
+        (email, course_id) pair so the calling view can translate it into
+        a 409 ``Conflict``.
+        """
+        return serializer.save()
+
+    def delete_allowed_enrollment(self, email, course_id):
+        """
+        Delete the allowed-enrollment row identified by (email, course_id).
+
+        Raises ``ObjectDoesNotExist`` if no such row exists so the calling
+        view can translate it into a 404.
+        """
+        CourseEnrollmentAllowed.objects.get(email=email, course_id=course_id).delete()

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -111,6 +111,45 @@ _RESP_NOT_FOUND = OpenApiResponse(description="The requested resource does not e
 _RESP_BAD_REQUEST = OpenApiResponse(description="Invalid request data or parameters.")
 
 
+# ADR 0033 – sorting / OEP-68 parameter naming standardization helpers.
+# Used by list endpoints that accept legacy parameter names (e.g. ``course_id``
+# instead of ``course_key``) so they can emit the BC-strategy §2 ``Deprecation``
+# HTTP header without each view duplicating the boilerplate.
+def _build_legacy_param_deprecation_header(legacy_to_preferred):
+    """
+    Build the ``Deprecation`` HTTP header value for one or more legacy parameter
+    names, each paired with its OEP-68-compliant replacement.
+
+    Example: ``[('course_id', 'course_key')]`` →
+    ``"Parameter 'course_id' is deprecated. Use 'course_key' instead. ..."``
+    """
+    parts = [
+        f"Parameter '{legacy}' is deprecated. Use '{preferred}' instead."
+        for legacy, preferred in legacy_to_preferred
+    ]
+    parts.append("Support will be removed in release '<release_name>'.")
+    return " ".join(parts)
+
+
+def _maybe_set_legacy_param_deprecation_header(request, response, alias_pairs):
+    """
+    Set the ADR 0033 ``Deprecation`` HTTP header on ``response`` when any of
+    the legacy parameter names in ``alias_pairs`` is present in the request's
+    query string.
+
+    ``alias_pairs`` is a sequence of ``(legacy, preferred)`` tuples (e.g.
+    ``[('course_id', 'course_key'), ('course_ids', 'course_keys')]``).  The
+    header is emitted whenever any *legacy* name appears, even if the
+    corresponding ``preferred`` name was also supplied (in which case the
+    preferred value wins, but the caller should still be told that the legacy
+    alias is deprecated).
+    """
+    used = [(legacy, preferred) for legacy, preferred in alias_pairs if legacy in request.query_params]
+    if used:
+        response['Deprecation'] = _build_legacy_param_deprecation_header(used)
+    return response
+
+
 class EnrollmentCrossDomainSessionAuth(SessionAuthenticationAllowInactiveUser, SessionAuthenticationCrossDomainCsrf):
     """Session authentication that allows inactive users and cross-domain requests."""
 
@@ -340,13 +379,27 @@ class EnrollmentUserRolesView(APIView):
     throttle_classes = (EnrollmentUserThrottle,)
     serializer_class = UserRolesResponseSerializer
 
+    # ADR 0033 §2 / OEP-68: ``course_key`` is the standardized name;
+    # ``course_id`` is retained as a deprecated alias.
+    _LEGACY_PARAM_ALIASES = (("course_id", "course_key"),)
+
     @extend_schema(
         summary="List the current user's course roles",
         description=(
             "Returns the list of course-level roles held by the currently logged-in user, plus an "
-            "is_staff flag. Optionally filters by course_id."
+            "is_staff flag. Optionally filters by course_key."
         ),
-        parameters=[_query_param("course_id", "If provided, only roles for this course are returned.")],
+        parameters=[
+            _query_param("course_key", "If provided, only roles for this course are returned (per OEP-68)."),
+            OpenApiParameter(
+                name="course_id",
+                description="Deprecated alias for 'course_key' (ADR 0033). Use 'course_key' instead.",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+        ],
         responses={
             200: OpenApiResponse(
                 response=UserRolesResponseSerializer,
@@ -358,13 +411,17 @@ class EnrollmentUserRolesView(APIView):
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def get(self, request):
         """
-        Gets a list of all roles for the currently logged-in user, filtered by course_id if supplied
+        Gets a list of all roles for the currently logged-in user, filtered by
+        ``course_key`` (preferred, ADR 0033 / OEP-68) or ``course_id`` (deprecated
+        alias).  When both are present, ``course_key`` wins; in either case the
+        response carries the ADR 0033 ``Deprecation`` header if the legacy name
+        was used.
         """
         try:
-            course_id = request.GET.get("course_id")
+            course_key = request.GET.get("course_key") or request.GET.get("course_id")
             roles_data = api.get_user_roles(request.user.username)
-            if course_id:
-                roles_data = [role for role in roles_data if str(role.course_id) == course_id]
+            if course_key:
+                roles_data = [role for role in roles_data if str(role.course_id) == course_key]
         except Exception:  # pylint: disable=broad-except
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -378,7 +435,10 @@ class EnrollmentUserRolesView(APIView):
             "roles": list(roles_data),
             "is_staff": request.user.is_staff,
         })
-        return Response(serializer.data)
+        response = Response(serializer.data)
+        return _maybe_set_legacy_param_deprecation_header(
+            request, response, self._LEGACY_PARAM_ALIASES,
+        )
 
 
 @can_disable_rate_limit
@@ -1612,13 +1672,37 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         summary="List all course enrollments (admin-only, paginated)",
         description=(
             "Admin-only paginated list of CourseEnrollment records, optionally filtered by "
-            "course_id, course_ids, username, or email."
+            "course_key, course_keys, username, or email, and optionally ordered."
         ),
         parameters=[
-            _query_param("course_id", "Filter to enrollments for this course."),
-            _query_param("course_ids", "Comma-separated list of course IDs."),
+            # ADR 0033 §2 / OEP-68: ``course_key`` and ``course_keys`` are the
+            # standardized names; ``course_id`` and ``course_ids`` are kept as
+            # deprecated aliases (BC strategy §1) and trigger a ``Deprecation``
+            # HTTP header (BC strategy §2).
+            _query_param("course_key", "Filter to enrollments for this course (per OEP-68)."),
+            _query_param("course_keys", "Comma-separated list of course keys (per OEP-68)."),
+            OpenApiParameter(
+                name="course_id",
+                description="Deprecated alias for 'course_key' (ADR 0033). Use 'course_key' instead.",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                name="course_ids",
+                description="Deprecated alias for 'course_keys' (ADR 0033). Use 'course_keys' instead.",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
             _query_param("username", "Comma-separated list of usernames."),
             _query_param("email", "Comma-separated list of emails."),
+            _query_param(
+                "ordering",
+                "Order results by one of: created, -created, id, -id (ADR 0033 §3).",
+            ),
             _PAGE_QUERY_PARAM,
             _PAGE_SIZE_QUERY_PARAM,
         ],
@@ -1728,9 +1812,35 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
     serializer_class = CourseEnrollmentsApiListSerializer
     pagination_class = CourseEnrollmentsApiListPagination
 
+    # ADR 0033 §3: whitelist of allowed values for the standard ``ordering``
+    # query parameter.  Any other value is silently ignored (the queryset
+    # falls back to the default ordering).
+    ALLOWED_ORDERING_FIELDS = frozenset({"created", "-created", "id", "-id"})
+
+    # ADR 0033 §2 / OEP-68 alias pairs accepted by this endpoint.  Used by
+    # the response post-processor to emit the ``Deprecation`` header when a
+    # caller still sends the legacy name.
+    _LEGACY_PARAM_ALIASES = (
+        ("course_id", "course_key"),
+        ("course_ids", "course_keys"),
+    )
+
     def get_queryset(self):
         """
-        Get all the course enrollments for the given course_id and/or given list of usernames.
+        Get all the course enrollments for the given course key(s) and/or given list of usernames.
+
+        ADR 0033 compliance notes:
+        - Filter parameters accept both the OEP-68-preferred names
+          (``course_key``, ``course_keys``) and the deprecated legacy names
+          (``course_id``, ``course_ids``).  Resolution is handled by
+          :class:`CourseEnrollmentsApiListForm`.
+        - The DRF-standard ``ordering`` query parameter is honored when its
+          value is in :pyattr:`ALLOWED_ORDERING_FIELDS`.
+        - Full migration to ``django-filter``/``DjangoFilterBackend`` is
+          tracked as a follow-up: the existing ``CourseEnrollmentsApiListForm``
+          performs nuanced parsing (CSV → list, MAX 100, course-key
+          validation, username validation) that is not a free conversion to
+          a ``FilterSet``.
         """
         form = CourseEnrollmentsApiListForm(self.request.query_params)
 
@@ -1755,7 +1865,21 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
             queryset = queryset.filter(user__username__in=usernames)
         if emails:
             queryset = queryset.filter(user__email__in=emails)
+
+        ordering = self.request.query_params.get("ordering")
+        if ordering in self.ALLOWED_ORDERING_FIELDS:
+            queryset = queryset.order_by(ordering)
         return queryset
+
+    def list(self, request, *args, **kwargs):
+        """
+        ADR 0033 BC §2: emit the ``Deprecation`` HTTP header when a caller
+        still uses the legacy ``course_id`` / ``course_ids`` parameter names.
+        """
+        response = super().list(request, *args, **kwargs)
+        return _maybe_set_legacy_param_deprecation_header(
+            request, response, self._LEGACY_PARAM_ALIASES,
+        )
 
 
 # DEPRECATED (ADR 0028): Use EnrollmentViewSet.allowed action instead. Will be removed after one named release.

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -35,19 +35,23 @@ from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.course_groups.cohorts import CourseUserGroup, add_user_to_cohort, get_cohort_by_name
-from openedx.core.djangoapps.embargo import api as embargo_api
-from openedx.core.djangoapps.enrollments import api
-from openedx.core.djangoapps.enrollments.errors import (
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.embargo import api as embargo_api  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.enrollments import api  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.enrollments.errors import (  # lint-amnesty, pylint: disable=wrong-import-order
     CourseEnrollmentError,
     CourseEnrollmentExistsError,
     CourseModeNotFoundError,
     InvalidEnrollmentAttribute,
 )
-from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm
-from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
-from openedx.core.djangoapps.enrollments.serializers import (
+from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.enrollments.serializers import (  # lint-amnesty, pylint: disable=wrong-import-order
     CourseEnrollmentAllowedSerializer,
+    CourseEnrollmentSerializer,
     CourseEnrollmentsApiListSerializer,
+    CourseSerializer,
+    UserRolesResponseSerializer,
 )
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
@@ -187,6 +191,7 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
     throttle_classes = (EnrollmentUserThrottle,)
+    serializer_class = CourseEnrollmentSerializer
 
     # Since the course about page on the marketing site uses this API to auto-enroll users,
     # we need to support cross-domain CSRF.
@@ -221,7 +226,17 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         try:
-            return Response(api.get_enrollment(username, course_id))
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": f"No course '{course_id}' found for enrollment"},
+            )
+
+        try:
+            enrollment = CourseEnrollment.objects.get(user__username=username, course_id=course_key)
+        except CourseEnrollment.DoesNotExist:
+            return Response(None)
         except CourseEnrollmentError:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -232,6 +247,9 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
                     ).format(username=username, course_id=course_id)
                 },
             )
+
+        serializer = self.serializer_class(enrollment)
+        return Response(serializer.data)
 
 
 class EnrollmentUserRolesView(APIView):
@@ -266,6 +284,7 @@ class EnrollmentUserRolesView(APIView):
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
     throttle_classes = (EnrollmentUserThrottle,)
+    serializer_class = UserRolesResponseSerializer
 
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def get(self, request):
@@ -286,14 +305,11 @@ class EnrollmentUserRolesView(APIView):
                     )
                 },
             )
-        return Response(
-            {
-                "roles": [
-                    {"org": role.org, "course_id": str(role.course_id), "role": role.role} for role in roles_data
-                ],
-                "is_staff": request.user.is_staff,
-            }
-        )
+        serializer = self.serializer_class({
+            "roles": list(roles_data),
+            "is_staff": request.user.is_staff,
+        })
+        return Response(serializer.data)
 
 
 @can_disable_rate_limit
@@ -363,6 +379,7 @@ class EnrollmentCourseDetailView(APIView):
     authentication_classes = []
     permission_classes = []
     throttle_classes = (EnrollmentUserThrottle,)
+    serializer_class = CourseSerializer
 
     def get(self, request, course_id=None):
         """Read enrollment information for a particular course.
@@ -380,12 +397,22 @@ class EnrollmentCourseDetailView(APIView):
 
         """
         try:
-            return Response(api.get_course_enrollment_details(course_id, bool(request.GET.get("include_expired", ""))))
-        except CourseNotFoundError:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"message": ("No course found for course ID '{course_id}'").format(course_id=course_id)},
+                data={"message": f"No course found for course ID '{course_id}'"},
             )
+        try:
+            course_overview = CourseOverview.get_from_id(course_key)
+        except CourseOverview.DoesNotExist:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": f"No course found for course ID '{course_id}'"},
+            )
+        include_expired = bool(request.GET.get("include_expired", ""))
+        serializer = self.serializer_class(course_overview, include_expired=include_expired)
+        return Response(serializer.data)
 
 
 class UnenrollmentView(APIView):
@@ -428,6 +455,7 @@ class UnenrollmentView(APIView):
         permissions.IsAuthenticated,
         CanRetireUser,
     )
+    serializer_class = CourseEnrollmentSerializer
 
     def post(self, request):
         """
@@ -438,9 +466,10 @@ class UnenrollmentView(APIView):
             username = request.data["username"]
             # Ensure that a retirement request status row exists for this username.
             UserRetirementStatus.get_retirement_for_retirement_action(username)
-            enrollments = api.get_enrollments(username)
-            active_enrollments = [enrollment for enrollment in enrollments if enrollment["is_active"]]
-            if len(active_enrollments) < 1:
+            active_enrollments = CourseEnrollment.objects.filter(
+                user__username=username, is_active=True
+            )
+            if not active_enrollments.exists():
                 return Response(status=status.HTTP_204_NO_CONTENT)
             return Response(api.unenroll_user_from_all_courses(username))
         except KeyError:
@@ -633,6 +662,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
     throttle_classes = (EnrollmentUserThrottle,)
+    serializer_class = CourseEnrollmentSerializer
 
     # Since the course about page on the marketing site
     # uses this API to auto-enroll users, we need to support
@@ -656,29 +686,22 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         courses.
         """
         username = request.GET.get("user", request.user.username)
-        try:
-            enrollment_data = api.get_enrollments(username)
-        except CourseEnrollmentError:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": ("An error occurred while retrieving enrollments for user '{username}'").format(
-                        username=username
-                    )
-                },
-            )
+        enrollments = CourseEnrollment.objects.filter(
+            user__username=username
+        ).select_related("user", "course_overview")
         if (
             username == request.user.username
             or GlobalStaff().has_user(request.user)
             or self.has_api_key_permissions(request)
         ):
-            return Response(enrollment_data)
-        filtered_data = []
-        for enrollment in enrollment_data:
-            course_key = CourseKey.from_string(enrollment["course_details"]["course_id"])
-            if user_has_role(request.user, CourseStaffRole(course_key)):
-                filtered_data.append(enrollment)
-        return Response(filtered_data)
+            serializer = self.serializer_class(enrollments, many=True)
+            return Response(serializer.data)
+        filtered_enrollments = [
+            enrollment for enrollment in enrollments
+            if user_has_role(request.user, CourseStaffRole(enrollment.course_id))
+        ]
+        serializer = self.serializer_class(filtered_enrollments, many=True)
+        return Response(serializer.data)
 
     def post(self, request):
         # pylint: disable=too-many-statements
@@ -929,14 +952,22 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         finally:
             # Assumes that the ecommerce service uses an API key to authenticate.
             if has_api_key_permissions:
-                current_enrollment = api.get_enrollment(username, str(course_id))
+                try:
+                    current_enrollment_obj = CourseEnrollment.objects.get(
+                        user__username=username, course_id=course_id
+                    )
+                    actual_mode = current_enrollment_obj.mode
+                    actual_activation = current_enrollment_obj.is_active
+                except CourseEnrollment.DoesNotExist:
+                    actual_mode = None
+                    actual_activation = None
                 audit_log(
                     "enrollment_change_requested",
                     course_id=str(course_id),
                     requested_mode=mode,
-                    actual_mode=current_enrollment["mode"] if current_enrollment else None,
+                    actual_mode=actual_mode,
                     requested_activation=is_active,
-                    actual_activation=current_enrollment["is_active"] if current_enrollment else None,
+                    actual_activation=actual_activation,
                     user_id=user.id,
                 )
 
@@ -1087,12 +1118,9 @@ class EnrollmentAllowedView(APIView):
         if not user_email:
             user_email = request.user.email
 
-        enrollments_allowed = CourseEnrollmentAllowed.objects.filter(email=user_email) or []
-        serialized_enrollments_allowed = [
-            CourseEnrollmentAllowedSerializer(enrollment).data for enrollment in enrollments_allowed
-        ]
-
-        return Response(status=status.HTTP_200_OK, data=serialized_enrollments_allowed)
+        enrollments_allowed = CourseEnrollmentAllowed.objects.filter(email=user_email)
+        serializer = self.serializer_class(enrollments_allowed, many=True)
+        return Response(status=status.HTTP_200_OK, data=serializer.data)
 
     def post(self, request):
         """
@@ -1126,23 +1154,24 @@ class EnrollmentAllowedView(APIView):
         - 403: Forbidden, you need to be staff.
         - 409: Conflict, enrollment allowed already exists.
         """
-        is_bad_request_response, email, course_id = self.check_required_data(request)
-        auto_enroll = request.data.get("auto_enroll", False)
-        if is_bad_request_response:
-            return is_bad_request_response
+        serializer = self.serializer_class(data=request.data)
+        if not serializer.is_valid():
+            return Response(status=status.HTTP_400_BAD_REQUEST, data=serializer.errors)
 
         try:
-            enrollment_allowed = CourseEnrollmentAllowed.objects.create(
-                email=email, course_id=course_id, auto_enroll=auto_enroll
-            )
+            enrollment_allowed = serializer.save()
         except IntegrityError:
             return Response(
                 status=status.HTTP_409_CONFLICT,
-                data={"message": f"An enrollment allowed with email {email} and course {course_id} already exists."},
+                data={
+                    "message": (
+                        f"An enrollment allowed with email {serializer.validated_data.get('email')} "
+                        f"and course {serializer.validated_data.get('course_id')} already exists."
+                    )
+                },
             )
 
-        serializer = CourseEnrollmentAllowedSerializer(enrollment_allowed)
-        return Response(status=status.HTTP_201_CREATED, data=serializer.data)
+        return Response(status=status.HTTP_201_CREATED, data=self.serializer_class(enrollment_allowed).data)
 
     def delete(self, request):
         """
@@ -1174,32 +1203,18 @@ class EnrollmentAllowedView(APIView):
         - 403: Forbidden, you need to be staff.
         - 404: Not found, the course enrollment allowed doesn't exists.
         """
-        is_bad_request_response, email, course_id = self.check_required_data(request)
-        if is_bad_request_response:
-            return is_bad_request_response
+        serializer = self.serializer_class(data=request.data)
+        if not serializer.is_valid():
+            return Response(status=status.HTTP_400_BAD_REQUEST, data=serializer.errors)
+
+        email = serializer.validated_data.get("email")
+        course_id = serializer.validated_data.get("course_id")
 
         try:
             CourseEnrollmentAllowed.objects.get(email=email, course_id=course_id).delete()
-            return Response(
-                status=status.HTTP_204_NO_CONTENT,
-            )
+            return Response(status=status.HTTP_204_NO_CONTENT)
         except ObjectDoesNotExist:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
                 data={"message": f"An enrollment allowed with email {email} and course {course_id} doesn't exists."},
             )
-
-    def check_required_data(self, request):
-        """
-        Check if the request has email and course_id.
-        """
-        email = request.data.get("email")
-        course_id = request.data.get("course_id")
-        if not email or not course_id:
-            is_bad_request = Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "Please provide a value for 'email' and 'course_id' in the request data."},
-            )
-        else:
-            is_bad_request = None
-        return (is_bad_request, email, course_id)

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -36,23 +36,12 @@ from rest_framework.response import Response  # lint-amnesty, pylint: disable=wr
 from rest_framework.throttling import UserRateThrottle  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework.views import APIView  # lint-amnesty, pylint: disable=wrong-import-order
 
-from common.djangoapps.course_modes.models import CourseMode
-from common.djangoapps.student.auth import user_has_role
-from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, EnrollmentNotAllowed, User
-from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
+from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
-from openedx.core.djangoapps.course_groups.cohorts import CourseUserGroup, add_user_to_cohort, get_cohort_by_name
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # lint-amnesty, pylint: disable=wrong-import-order
-from openedx.core.djangoapps.embargo import api as embargo_api  # lint-amnesty, pylint: disable=wrong-import-order
-from openedx.core.djangoapps.enrollments import api  # lint-amnesty, pylint: disable=wrong-import-order
-from openedx.core.djangoapps.enrollments.errors import (  # lint-amnesty, pylint: disable=wrong-import-order
-    CourseEnrollmentError,
-    CourseEnrollmentExistsError,
-    CourseModeNotFoundError,
-    InvalidEnrollmentAttribute,
-)
+from openedx.core.djangoapps.enrollments.errors import CourseEnrollmentError  # lint-amnesty, pylint: disable=wrong-import-order
 from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm  # lint-amnesty, pylint: disable=wrong-import-order
 from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination  # lint-amnesty, pylint: disable=wrong-import-order
 from openedx.core.djangoapps.enrollments.serializers import (  # lint-amnesty, pylint: disable=wrong-import-order
@@ -62,25 +51,19 @@ from openedx.core.djangoapps.enrollments.serializers import (  # lint-amnesty, p
     CourseSerializer,
     UserRolesResponseSerializer,
 )
+from openedx.core.djangoapps.enrollments.view_services import EnrollmentOperationsService
+from openedx.core.djangoapps.enrollments import api  # lint-amnesty, pylint: disable=wrong-import-order
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
-from openedx.core.djangoapps.user_api.models import UserRetirementStatus
-from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
-from openedx.core.lib.exceptions import CourseNotFoundError
-from openedx.core.lib.log_utils import audit_log
-from openedx.features.enterprise_support.api import (
-    ConsentApiServiceClient,
-    EnterpriseApiException,
-    EnterpriseApiServiceClient,
-    enterprise_enabled,
-)
 
 log = logging.getLogger(__name__)
-REQUIRED_ATTRIBUTES = {
-    "credit": ["credit:provider_id"],
-}
+
+# ADR 0031 – single, shared service object for the enrollment operations
+# implemented across the canonical EnrollmentViewSet and its deprecated
+# APIView aliases (EnrollmentListView, UnenrollmentView, EnrollmentAllowedView).
+_OPS = EnrollmentOperationsService()
 
 
 # ADR 0027 — shared OpenAPI parameter and response building blocks
@@ -628,34 +611,30 @@ class UnenrollmentView(APIView):
     def post(self, request):
         """
         Unenrolls the specified user from all courses.
+
+        ADR 0031: shares ``EnrollmentOperationsService.unenroll_user_for_retirement``
+        with ``EnrollmentViewSet.unenroll``.
         """
-        try:
-            # Get the username from the request.
-            username = request.data["username"]
-            # Ensure that a retirement request status row exists for this username.
-            UserRetirementStatus.get_retirement_for_retirement_action(username)
-            active_enrollments = CourseEnrollment.objects.filter(
-                user__username=username, is_active=True
-            )
-            if not active_enrollments.exists():
-                return Response(status=status.HTTP_204_NO_CONTENT)
-            return Response(api.unenroll_user_from_all_courses(username))
-        except KeyError:
-            return Response("Username not specified.", status=status.HTTP_404_NOT_FOUND)
-        except UserRetirementStatus.DoesNotExist:
-            return Response("No retirement request status for username.", status=status.HTTP_404_NOT_FOUND)
-        except Exception as exc:  # pylint: disable=broad-except
-            return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return _OPS.unenroll_user_for_retirement(request.data.get("username"))
 
 
-# ADR 0028 – consolidated from EnrollmentListView, UnenrollmentView, EnrollmentAllowedView
+# ADR 0028 – consolidated URL surface from EnrollmentListView, UnenrollmentView, EnrollmentAllowedView.
+# ADR 0031 – business logic for every action below is delegated to ``EnrollmentOperationsService``
+# (``_OPS``) so the canonical ViewSet and its deprecated APIView aliases cannot drift over time.
+# Authorization is enforced in two layers per ADR 0031:
+#   1. The view declares a coarse permission class (``permission_classes`` /
+#      per-action ``permission_classes=`` override on ``@action``).
+#   2. The service method enforces the per-operation permission (e.g. only
+#      api-key/global-staff callers may deactivate or downgrade enrollments).
 @can_disable_rate_limit
 class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
     """
     DRF ViewSet for the Enrollment API.
 
     Consolidates EnrollmentListView, UnenrollmentView, and EnrollmentAllowedView into a single
-    ViewSet registered via DefaultRouter per ADR 0028.
+    ViewSet registered via DefaultRouter per ADR 0028.  Per ADR 0031 the business logic for each
+    action lives in ``EnrollmentOperationsService`` and is shared with the deprecated APIView
+    aliases so the two implementations stay in lock-step.
 
     Actions:
         list        GET  /enrollment/              List enrollments for the current user.
@@ -708,6 +687,10 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
         'user' GET parameter. If the username does not match that of the currently logged-in user,
         only courses for which the currently logged-in user has the Staff or Admin role are listed.
 
+        ADR 0031: the per-operation permission filter (self/global-staff/api-key vs. course-staff
+        filtering) lives in ``EnrollmentOperationsService.list_enrollments_for_user`` so the
+        canonical viewset and the deprecated ``EnrollmentListView.get`` apply the same rules.
+
         **Pagination Parameters**
 
             - ``page`` (int): Page number to retrieve. Default is 1.
@@ -724,22 +707,13 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
             - ``results`` (list): The list of enrollments for this page.
         """
         username = request.GET.get("user", request.user.username)
-        enrollments = CourseEnrollment.objects.filter(
-            user__username=username
-        ).select_related("user", "course")  # "course" is the FK field; "course_overview" is a property
+        enrollments = _OPS.list_enrollments_for_user(
+            request_user=request.user,
+            target_username=username,
+            has_api_key=self.has_api_key_permissions(request),
+        )
         paginator = self.pagination_class()
-        if (
-            username == request.user.username
-            or GlobalStaff().has_user(request.user)
-            or self.has_api_key_permissions(request)
-        ):
-            page = paginator.paginate_queryset(enrollments, request, view=self)
-            return paginator.get_paginated_response(self.get_serializer(page, many=True).data)
-        filtered_enrollments = [
-            enrollment for enrollment in enrollments
-            if user_has_role(request.user, CourseStaffRole(enrollment.course_id))
-        ]
-        page = paginator.paginate_queryset(filtered_enrollments, request, view=self)
+        page = paginator.paginate_queryset(enrollments, request, view=self)
         return paginator.get_paginated_response(self.get_serializer(page, many=True).data)
 
     @extend_schema(
@@ -763,251 +737,36 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
     )
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def create(self, request):
-        # pylint: disable=too-many-statements
         """Enrolls the currently logged-in user in a course.
 
         Server-to-server calls may deactivate or modify the mode of existing enrollments. All other
         requests go through add_enrollment(), which allows creation and reactivation of enrollments.
-        """
-        username = request.data.get("user")
-        course_id = request.data.get("course_details", {}).get("course_id")
 
+        ADR 0031: the full create/update body — embargo, enterprise consent, mode/activation
+        changes, cohort assignment, email opt-in, audit logging — lives in
+        ``EnrollmentOperationsService.create_or_update_enrollment``.  This view is responsible only
+        for parsing the ``course_details.course_id`` field and the up-front 400 mapping; the
+        per-operation authorization checks (deactivation, mode-change, force-enroll) live next to
+        the business logic in the service.
+        """
+        course_id = request.data.get("course_details", {}).get("course_id")
         if not course_id:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": "Course ID must be specified to create a new enrollment."},
             )
-
         try:
-            course_id = CourseKey.from_string(course_id)
+            course_key = CourseKey.from_string(course_id)
         except InvalidKeyError:
             return Response(
-                status=status.HTTP_400_BAD_REQUEST, data={"message": f"No course '{course_id}' found for enrollment"}
-            )
-
-        mode = request.data.get("mode")
-
-        has_api_key_permissions = self.has_api_key_permissions(request)
-
-        if (
-            username
-            and username != request.user.username
-            and not has_api_key_permissions
-            and not GlobalStaff().has_user(request.user)
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
-        if not username:
-            email = request.data.get("email")
-            if email:
-                if not has_api_key_permissions and not GlobalStaff().has_user(request.user):
-                    return Response(status=status.HTTP_404_NOT_FOUND)
-                try:
-                    username = User.objects.get(email=email).username
-                except ObjectDoesNotExist:
-                    return Response(
-                        status=status.HTTP_406_NOT_ACCEPTABLE,
-                        data={"message": f"The user with the email address {email} does not exist."},
-                    )
-            else:
-                username = request.user.username
-
-        if (
-            mode not in (CourseMode.AUDIT, CourseMode.HONOR, None)
-            and not has_api_key_permissions
-            and not GlobalStaff().has_user(request.user)
-        ):
-            return Response(
-                status=status.HTTP_403_FORBIDDEN,
-                data={
-                    "message": "User does not have permission to create enrollment with mode [{mode}].".format(
-                        mode=mode
-                    )
-                },
-            )
-
-        try:
-            user = User.objects.get(username=username)
-        except ObjectDoesNotExist:
-            return Response(
-                status=status.HTTP_406_NOT_ACCEPTABLE, data={"message": f"The user {username} does not exist."}
-            )
-
-        embargo_response = embargo_api.get_embargo_response(request, course_id, user)
-
-        if embargo_response:
-            return embargo_response
-
-        try:
-            is_active = request.data.get("is_active")
-            if is_active is not None and not isinstance(is_active, bool):
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={"message": ("'{value}' is an invalid enrollment activation status.").format(value=is_active)},
-                )
-
-            explicit_linked_enterprise = request.data.get("linked_enterprise_customer")
-            if explicit_linked_enterprise and has_api_key_permissions and enterprise_enabled():
-                enterprise_api_client = EnterpriseApiServiceClient()
-                consent_client = ConsentApiServiceClient()
-                try:
-                    enterprise_api_client.post_enterprise_course_enrollment(username, str(course_id))
-                except EnterpriseApiException as error:
-                    log.exception(
-                        "An unexpected error occurred while creating the new EnterpriseCourseEnrollment "
-                        "for user [%s] in course run [%s]",
-                        username,
-                        course_id,
-                    )
-                    raise CourseEnrollmentError(str(error))  # lint-amnesty, pylint: disable=raise-missing-from
-                kwargs = {
-                    "username": username,
-                    "course_id": str(course_id),
-                    "enterprise_customer_uuid": explicit_linked_enterprise,
-                }
-                consent_client.provide_consent(**kwargs)
-
-            enrollment_attributes = request.data.get("enrollment_attributes")
-            force_enrollment = request.data.get("force_enrollment")
-            if force_enrollment is not None and not isinstance(force_enrollment, bool):
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={
-                        "message": ("'{value}' is an invalid force enrollment status.").format(value=force_enrollment)
-                    },
-                )
-            force_enrollment = force_enrollment and GlobalStaff().has_user(request.user)
-            enrollment = api.get_enrollment(username, str(course_id))
-            mode_changed = enrollment and mode is not None and enrollment["mode"] != mode
-            active_changed = enrollment and is_active is not None and enrollment["is_active"] != is_active
-            missing_attrs = []
-            if enrollment_attributes:
-                actual_attrs = ["{namespace}:{name}".format(**attr) for attr in enrollment_attributes]
-                missing_attrs = set(REQUIRED_ATTRIBUTES.get(mode, [])) - set(actual_attrs)
-            if (GlobalStaff().has_user(request.user) or has_api_key_permissions) and (mode_changed or active_changed):
-                if mode_changed and active_changed and not is_active:
-                    msg = "Enrollment mode mismatch: active mode={}, requested mode={}. Won't deactivate.".format(
-                        enrollment["mode"], mode
-                    )
-                    log.warning(msg)
-                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
-
-                if missing_attrs:
-                    msg = "Missing enrollment attributes: requested mode={} required attributes={}".format(
-                        mode, REQUIRED_ATTRIBUTES.get(mode)
-                    )
-                    log.warning(msg)
-                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
-
-                response = api.update_enrollment(
-                    username,
-                    str(course_id),
-                    mode=mode,
-                    is_active=is_active,
-                    enrollment_attributes=enrollment_attributes,
-                    include_expired=has_api_key_permissions,
-                )
-            else:
-                response = api.add_enrollment(
-                    username,
-                    str(course_id),
-                    mode=mode,
-                    is_active=is_active,
-                    enrollment_attributes=enrollment_attributes,
-                    enterprise_uuid=request.data.get("enterprise_uuid"),
-                    force_enrollment=force_enrollment,
-                    include_expired=force_enrollment,
-                )
-
-            cohort_name = request.data.get("cohort")
-            if cohort_name is not None:
-                cohort = get_cohort_by_name(course_id, cohort_name)
-                try:
-                    add_user_to_cohort(cohort, user)
-                except ValueError:
-                    log.exception("Cohort re-addition")
-            email_opt_in = request.data.get("email_opt_in", None)
-            if email_opt_in is not None:
-                org = course_id.org
-                update_email_opt_in(request.user, org, email_opt_in)
-
-            log.info("The user [%s] has already been enrolled in course run [%s].", username, course_id)
-            return Response(response)
-
-        except InvalidEnrollmentAttribute as error:
-            return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": str(error),
-                    "localizedMessage": str(error),
-                }
+                data={"message": f"No course '{course_id}' found for enrollment"},
             )
-        except EnrollmentNotAllowed as error:
-            return Response(
-                status=status.HTTP_403_FORBIDDEN,
-                data={
-                    "message": str(error),
-                    "localizedMessage": str(error),
-                }
-            )
-        except CourseModeNotFoundError as error:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": (
-                        "The [{mode}] course mode is expired or otherwise unavailable for course run [{course_id}]."
-                    ).format(mode=mode, course_id=course_id),
-                    "course_details": error.data,
-                },
-            )
-        except CourseNotFoundError:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST, data={"message": f"No course '{course_id}' found for enrollment"}
-            )
-        except CourseEnrollmentExistsError as error:
-            log.warning("An enrollment already exists for user [%s] in course run [%s].", username, course_id)
-            return Response(data=error.enrollment)
-        except CourseEnrollmentError:
-            log.exception(
-                "An error occurred while creating the new course enrollment for user [%s] in course run [%s]",
-                username,
-                course_id,
-            )
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": (
-                        "An error occurred while creating the new course enrollment for user "
-                        "'{username}' in course '{course_id}'"
-                    ).format(username=username, course_id=course_id)
-                },
-            )
-        except CourseUserGroup.DoesNotExist:
-            log.exception("Missing cohort [%s] in course run [%s]", cohort_name, course_id)
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "An error occured while adding to cohort [%s]" % cohort_name},
-            )
-        finally:
-            if has_api_key_permissions:
-                try:
-                    current_enrollment_obj = CourseEnrollment.objects.get(
-                        user__username=username, course_id=course_id
-                    )
-                    actual_mode = current_enrollment_obj.mode
-                    actual_activation = current_enrollment_obj.is_active
-                except CourseEnrollment.DoesNotExist:
-                    actual_mode = None
-                    actual_activation = None
-                audit_log(
-                    "enrollment_change_requested",
-                    course_id=str(course_id),
-                    requested_mode=mode,
-                    actual_mode=actual_mode,
-                    requested_activation=is_active,
-                    actual_activation=actual_activation,
-                    user_id=user.id,
-                )
+        return _OPS.create_or_update_enrollment(
+            request=request,
+            has_api_key=self.has_api_key_permissions(request),
+            course_id=course_key,
+        )
 
     @extend_schema(
         summary="Unenroll a user from all courses (retirement)",
@@ -1040,23 +799,11 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
         """Unenrolls the specified user from all courses.
 
         Privileged retirement-pipeline use only. The request must be made by a service user
-        with CanRetireUser permission, not the user being unenrolled.
+        with CanRetireUser permission (enforced as ADR 0031 layer-1 by the @action decorator),
+        not the user being unenrolled.  The retirement-status / no-active-enrollments / 500
+        mapping lives in ``EnrollmentOperationsService.unenroll_user_for_retirement``.
         """
-        try:
-            username = request.data["username"]
-            UserRetirementStatus.get_retirement_for_retirement_action(username)
-            active_enrollments = CourseEnrollment.objects.filter(
-                user__username=username, is_active=True
-            )
-            if not active_enrollments.exists():
-                return Response(status=status.HTTP_204_NO_CONTENT)
-            return Response(api.unenroll_user_from_all_courses(username))
-        except KeyError:
-            return Response("Username not specified.", status=status.HTTP_404_NOT_FOUND)
-        except UserRetirementStatus.DoesNotExist:
-            return Response("No retirement request status for username.", status=status.HTTP_404_NOT_FOUND)
-        except Exception as exc:  # pylint: disable=broad-except
-            return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return _OPS.unenroll_user_for_retirement(request.data.get("username"))
 
     @extend_schema(
         summary="Manage CourseEnrollmentAllowed records (admin-only)",
@@ -1091,13 +838,18 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
     def allowed(self, request):
         """Retrieve, create, or delete CourseEnrollmentAllowed records. Admin-only.
 
+        ADR 0031: the GET / POST / DELETE handlers all dispatch through
+        ``EnrollmentOperationsService`` so the canonical viewset and the deprecated
+        ``EnrollmentAllowedView`` cannot drift.  Coarse admin authorization is enforced
+        by the ``permission_classes`` declared on the ``@action`` decorator above.
+
         GET    /enrollment/enrollment_allowed/?email=<email>   List allowed enrollments for an email.
         POST   /enrollment/enrollment_allowed/                  Create a new allowed enrollment.
         DELETE /enrollment/enrollment_allowed/                  Delete an existing allowed enrollment.
         """
         if request.method == "GET":
             user_email = request.query_params.get("email") or request.user.email
-            enrollments_allowed = CourseEnrollmentAllowed.objects.filter(email=user_email)
+            enrollments_allowed = _OPS.list_allowed_for_email(user_email)
             return Response(
                 status=status.HTTP_200_OK,
                 data=self.get_serializer(enrollments_allowed, many=True).data,
@@ -1109,7 +861,7 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
 
         if request.method == "POST":
             try:
-                enrollment_allowed = serializer.save()
+                enrollment_allowed = _OPS.create_allowed_enrollment(serializer)
             except IntegrityError:
                 return Response(
                     status=status.HTTP_409_CONFLICT,
@@ -1129,7 +881,7 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
         email = serializer.validated_data.get("email")
         course_id = serializer.validated_data.get("course_id")
         try:
-            CourseEnrollmentAllowed.objects.get(email=email, course_id=course_id).delete()
+            _OPS.delete_allowed_enrollment(email, course_id)
             return Response(status=status.HTTP_204_NO_CONTENT)
         except ObjectDoesNotExist:
             return Response(
@@ -1350,33 +1102,18 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         Returns a list for the currently logged in user, or for the user named by the 'user' GET
         parameter. If the username does not match that of the currently logged in user, only
         courses for which the currently logged in user has the Staff or Admin role are listed.
-        As a result, a course team member can find out which of their own courses a particular
-        learner is enrolled in.
 
-        Only the Staff or Admin role (granted on the Django administrative console as the staff
-        or instructor permission) in individual courses gives the requesting user access to
-        enrollment data. Permissions granted at the organizational level do not give a user
-        access to enrollment data for all of that organization's courses.
-
-        Users who have the global staff permission can access all enrollment data for all
-        courses.
+        ADR 0031: the per-user permission filter is shared with
+        ``EnrollmentViewSet.list`` via ``EnrollmentOperationsService.list_enrollments_for_user``.
+        Only the paginated wrapper differs.
         """
         username = request.GET.get("user", request.user.username)
-        enrollments = CourseEnrollment.objects.filter(
-            user__username=username
-        ).select_related("user", "course_overview")
-        if (
-            username == request.user.username
-            or GlobalStaff().has_user(request.user)
-            or self.has_api_key_permissions(request)
-        ):
-            serializer = self.serializer_class(enrollments, many=True)
-            return Response(serializer.data)
-        filtered_enrollments = [
-            enrollment for enrollment in enrollments
-            if user_has_role(request.user, CourseStaffRole(enrollment.course_id))
-        ]
-        serializer = self.serializer_class(filtered_enrollments, many=True)
+        enrollments = _OPS.list_enrollments_for_user(
+            request_user=request.user,
+            target_username=username,
+            has_api_key=self.has_api_key_permissions(request),
+        )
+        serializer = self.serializer_class(enrollments, many=True)
         return Response(serializer.data)
 
     @extend_schema(
@@ -1399,272 +1136,33 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         deprecated=True,
     )
     def post(self, request):
-        # pylint: disable=too-many-statements
         """Enrolls the currently logged-in user in a course.
 
-        Server-to-server calls may deactivate or modify the mode of existing enrollments. All other requests
-        go through `add_enrollment()`, which allows creation of new and reactivation of old enrollments.
+        ADR 0031: shares the full create/update flow with ``EnrollmentViewSet.create`` via
+        ``EnrollmentOperationsService.create_or_update_enrollment``.  This deprecated view is
+        responsible only for the up-front ``course_details.course_id`` parsing and the 400
+        mapping for an invalid key; everything else (embargo, enterprise consent, mode/active
+        changes, cohort, email opt-in, audit log, per-operation permission checks) lives in
+        the service.
         """
-        # Get the User, Course ID, and Mode from the request.
-
-        username = request.data.get("user")
         course_id = request.data.get("course_details", {}).get("course_id")
-
         if not course_id:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": "Course ID must be specified to create a new enrollment."},
             )
-
         try:
-            course_id = CourseKey.from_string(course_id)
+            course_key = CourseKey.from_string(course_id)
         except InvalidKeyError:
             return Response(
-                status=status.HTTP_400_BAD_REQUEST, data={"message": f"No course '{course_id}' found for enrollment"}
-            )
-
-        mode = request.data.get("mode")
-
-        has_api_key_permissions = self.has_api_key_permissions(request)
-
-        # Check that the user specified is either the same user, or this is a server-to-server request.
-        if (
-            username
-            and username != request.user.username
-            and not has_api_key_permissions
-            and not GlobalStaff().has_user(request.user)
-        ):
-            # Return a 404 instead of a 403 (Unauthorized). If one user is looking up
-            # other users, do not let them deduce the existence of an enrollment.
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
-        # A provided user has priority over a provided email.
-        # Fallback on request user if neither is provided.
-        if not username:
-            email = request.data.get("email")
-            if email:
-                # Only server-to-server or staff users can use the email for the request.
-                if not has_api_key_permissions and not GlobalStaff().has_user(request.user):
-                    return Response(status=status.HTTP_404_NOT_FOUND)
-                try:
-                    username = User.objects.get(email=email).username
-                except ObjectDoesNotExist:
-                    return Response(
-                        status=status.HTTP_406_NOT_ACCEPTABLE,
-                        data={"message": f"The user with the email address {email} does not exist."},
-                    )
-            else:
-                username = request.user.username
-
-        if (
-            mode not in (CourseMode.AUDIT, CourseMode.HONOR, None)
-            and not has_api_key_permissions
-            and not GlobalStaff().has_user(request.user)
-        ):
-            return Response(
-                status=status.HTTP_403_FORBIDDEN,
-                data={
-                    "message": "User does not have permission to create enrollment with mode [{mode}].".format(
-                        mode=mode
-                    )
-                },
-            )
-
-        try:
-            # Lookup the user, instead of using request.user, since request.user may not match the username POSTed.
-            user = User.objects.get(username=username)
-        except ObjectDoesNotExist:
-            return Response(
-                status=status.HTTP_406_NOT_ACCEPTABLE, data={"message": f"The user {username} does not exist."}
-            )
-
-        embargo_response = embargo_api.get_embargo_response(request, course_id, user)
-
-        if embargo_response:
-            return embargo_response
-
-        try:
-            is_active = request.data.get("is_active")
-            # Check if the requested activation status is None or a Boolean
-            if is_active is not None and not isinstance(is_active, bool):
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={"message": ("'{value}' is an invalid enrollment activation status.").format(value=is_active)},
-                )
-
-            explicit_linked_enterprise = request.data.get("linked_enterprise_customer")
-            if explicit_linked_enterprise and has_api_key_permissions and enterprise_enabled():
-                enterprise_api_client = EnterpriseApiServiceClient()
-                consent_client = ConsentApiServiceClient()
-                try:
-                    enterprise_api_client.post_enterprise_course_enrollment(username, str(course_id))
-                except EnterpriseApiException as error:
-                    log.exception(
-                        "An unexpected error occurred while creating the new EnterpriseCourseEnrollment "
-                        "for user [%s] in course run [%s]",
-                        username,
-                        course_id,
-                    )
-                    raise CourseEnrollmentError(str(error))  # lint-amnesty, pylint: disable=raise-missing-from
-                kwargs = {
-                    "username": username,
-                    "course_id": str(course_id),
-                    "enterprise_customer_uuid": explicit_linked_enterprise,
-                }
-                consent_client.provide_consent(**kwargs)
-
-            enrollment_attributes = request.data.get("enrollment_attributes")
-            force_enrollment = request.data.get("force_enrollment")
-            # Check if the force enrollment status is None or a Boolean
-            if force_enrollment is not None and not isinstance(force_enrollment, bool):
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={
-                        "message": ("'{value}' is an invalid force enrollment status.").format(value=force_enrollment)
-                    },
-                )
-            # Only a staff user role can enroll a user forcefully
-            force_enrollment = force_enrollment and GlobalStaff().has_user(request.user)
-            enrollment = api.get_enrollment(username, str(course_id))
-            mode_changed = enrollment and mode is not None and enrollment["mode"] != mode
-            active_changed = enrollment and is_active is not None and enrollment["is_active"] != is_active
-            missing_attrs = []
-            if enrollment_attributes:
-                actual_attrs = ["{namespace}:{name}".format(**attr) for attr in enrollment_attributes]
-                missing_attrs = set(REQUIRED_ATTRIBUTES.get(mode, [])) - set(actual_attrs)
-            if (GlobalStaff().has_user(request.user) or has_api_key_permissions) and (mode_changed or active_changed):
-                if mode_changed and active_changed and not is_active:
-                    # if the requester wanted to deactivate but specified the wrong mode, fail
-                    # the request (on the assumption that the requester had outdated information
-                    # about the currently active enrollment).
-                    msg = "Enrollment mode mismatch: active mode={}, requested mode={}. Won't deactivate.".format(
-                        enrollment["mode"], mode
-                    )
-                    log.warning(msg)
-                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
-
-                if missing_attrs:
-                    msg = "Missing enrollment attributes: requested mode={} required attributes={}".format(
-                        mode, REQUIRED_ATTRIBUTES.get(mode)
-                    )
-                    log.warning(msg)
-                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
-
-                response = api.update_enrollment(
-                    username,
-                    str(course_id),
-                    mode=mode,
-                    is_active=is_active,
-                    enrollment_attributes=enrollment_attributes,
-                    # If we are updating enrollment by authorized api caller, we should allow expired modes
-                    include_expired=has_api_key_permissions,
-                )
-            else:
-                # Will reactivate inactive enrollments.
-                response = api.add_enrollment(
-                    username,
-                    str(course_id),
-                    mode=mode,
-                    is_active=is_active,
-                    enrollment_attributes=enrollment_attributes,
-                    enterprise_uuid=request.data.get("enterprise_uuid"),
-                    force_enrollment=force_enrollment,
-                    # If we are creating enrollment by staff user with force_enrollment, we should allow expired modes
-                    include_expired=force_enrollment,
-                )
-
-            cohort_name = request.data.get("cohort")
-            if cohort_name is not None:
-                cohort = get_cohort_by_name(course_id, cohort_name)
-                try:
-                    add_user_to_cohort(cohort, user)
-                except ValueError:
-                    # user already in cohort, probably because they were un-enrolled and re-enrolled
-                    log.exception("Cohort re-addition")
-            email_opt_in = request.data.get("email_opt_in", None)
-            if email_opt_in is not None:
-                org = course_id.org
-                update_email_opt_in(request.user, org, email_opt_in)
-
-            log.info("The user [%s] has already been enrolled in course run [%s].", username, course_id)
-            return Response(response)
-
-        except InvalidEnrollmentAttribute as error:
-            return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": str(error),
-                    "localizedMessage": str(error),
-                }
+                data={"message": f"No course '{course_id}' found for enrollment"},
             )
-        except EnrollmentNotAllowed as error:
-            return Response(
-                status=status.HTTP_403_FORBIDDEN,
-                data={
-                    "message": str(error),
-                    "localizedMessage": str(error),
-                }
-            )
-        except CourseModeNotFoundError as error:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": (
-                        "The [{mode}] course mode is expired or otherwise unavailable for course run [{course_id}]."
-                    ).format(mode=mode, course_id=course_id),
-                    "course_details": error.data,
-                },
-            )
-        except CourseNotFoundError:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST, data={"message": f"No course '{course_id}' found for enrollment"}
-            )
-        except CourseEnrollmentExistsError as error:
-            log.warning("An enrollment already exists for user [%s] in course run [%s].", username, course_id)
-            return Response(data=error.enrollment)
-        except CourseEnrollmentError:
-            log.exception(
-                "An error occurred while creating the new course enrollment for user [%s] in course run [%s]",
-                username,
-                course_id,
-            )
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": (
-                        "An error occurred while creating the new course enrollment for user "
-                        "'{username}' in course '{course_id}'"
-                    ).format(username=username, course_id=course_id)
-                },
-            )
-
-        except CourseUserGroup.DoesNotExist:
-            log.exception("Missing cohort [%s] in course run [%s]", cohort_name, course_id)
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "An error occured while adding to cohort [%s]" % cohort_name},
-            )
-        finally:
-            # Assumes that the ecommerce service uses an API key to authenticate.
-            if has_api_key_permissions:
-                try:
-                    current_enrollment_obj = CourseEnrollment.objects.get(
-                        user__username=username, course_id=course_id
-                    )
-                    actual_mode = current_enrollment_obj.mode
-                    actual_activation = current_enrollment_obj.is_active
-                except CourseEnrollment.DoesNotExist:
-                    actual_mode = None
-                    actual_activation = None
-                audit_log(
-                    "enrollment_change_requested",
-                    course_id=str(course_id),
-                    requested_mode=mode,
-                    actual_mode=actual_mode,
-                    requested_activation=is_active,
-                    actual_activation=actual_activation,
-                    user_id=user.id,
-                )
+        return _OPS.create_or_update_enrollment(
+            request=request,
+            has_api_key=self.has_api_key_permissions(request),
+            course_id=course_key,
+        )
 
 
 @extend_schema_view(
@@ -1913,6 +1411,9 @@ class EnrollmentAllowedView(APIView):
         """
         Returns the enrollments allowed for a given user email.
 
+        ADR 0031: shares ``EnrollmentOperationsService.list_allowed_for_email`` with
+        ``EnrollmentViewSet.allowed`` (GET mode).
+
         **Example Requests**
 
         GET /api/enrollment/v1/enrollment_allowed?email=user@example.com
@@ -1925,11 +1426,8 @@ class EnrollmentAllowedView(APIView):
         - 200: Success.
         - 403: Forbidden, you need to be staff.
         """
-        user_email = request.query_params.get("email")
-        if not user_email:
-            user_email = request.user.email
-
-        enrollments_allowed = CourseEnrollmentAllowed.objects.filter(email=user_email)
+        user_email = request.query_params.get("email") or request.user.email
+        enrollments_allowed = _OPS.list_allowed_for_email(user_email)
         serializer = self.serializer_class(enrollments_allowed, many=True)
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
@@ -1989,7 +1487,7 @@ class EnrollmentAllowedView(APIView):
             return Response(status=status.HTTP_400_BAD_REQUEST, data=serializer.errors)
 
         try:
-            enrollment_allowed = serializer.save()
+            enrollment_allowed = _OPS.create_allowed_enrollment(serializer)
         except IntegrityError:
             return Response(
                 status=status.HTTP_409_CONFLICT,
@@ -2057,7 +1555,7 @@ class EnrollmentAllowedView(APIView):
         course_id = serializer.validated_data.get("course_id")
 
         try:
-            CourseEnrollmentAllowed.objects.get(email=email, course_id=course_id).delete()
+            _OPS.delete_allowed_enrollment(email, course_id)
             return Response(status=status.HTTP_204_NO_CONTENT)
         except ObjectDoesNotExist:
             return Response(

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -13,6 +13,13 @@ from django.core.exceptions import (  # lint-amnesty, pylint: disable=wrong-impo
 from django.db import IntegrityError  # lint-amnesty, pylint: disable=wrong-import-order
 from django.db.models import Q  # lint-amnesty, pylint: disable=wrong-import-order
 from django.utils.decorators import method_decorator  # lint-amnesty, pylint: disable=wrong-import-order
+from drf_spectacular.utils import (  # lint-amnesty, pylint: disable=wrong-import-order
+    extend_schema,
+    extend_schema_view,
+    OpenApiParameter,
+    OpenApiRequest,
+    OpenApiResponse,
+)
 from edx_rest_framework_extensions.auth.jwt.authentication import (
     JwtAuthentication,
 )  # lint-amnesty, pylint: disable=wrong-import-order
@@ -74,6 +81,34 @@ log = logging.getLogger(__name__)
 REQUIRED_ATTRIBUTES = {
     "credit": ["credit:provider_id"],
 }
+
+
+# ADR 0027 — shared OpenAPI parameter and response building blocks
+def _path_param(name: str, description: str) -> OpenApiParameter:
+    return OpenApiParameter(
+        name=name, description=description, required=True, type=str, location=OpenApiParameter.PATH,
+    )
+
+
+def _query_param(name: str, description: str, required: bool = False, type_=str) -> OpenApiParameter:
+    return OpenApiParameter(
+        name=name, description=description, required=required, type=type_, location=OpenApiParameter.QUERY,
+    )
+
+
+_COURSE_ID_PATH_PARAM = _path_param("course_id", "Course ID (e.g. course-v1:org+course+run).")
+_USERNAME_PATH_PARAM = _path_param("username", "Username of the user.")
+_USER_QUERY_PARAM = _query_param("user", "Username of the user whose enrollments to list.")
+_INCLUDE_EXPIRED_QUERY_PARAM = _query_param(
+    "include_expired", "If '1', include expired enrollment modes in the response.",
+)
+_PAGE_QUERY_PARAM = _query_param("page", "Page number to retrieve. Default 1.")
+_PAGE_SIZE_QUERY_PARAM = _query_param("page_size", "Items per page (default 10, max 100).")
+
+_RESP_UNAUTHENTICATED = OpenApiResponse(description="The requester is not authenticated.")
+_RESP_FORBIDDEN = OpenApiResponse(description="The requester does not have permission for this operation.")
+_RESP_NOT_FOUND = OpenApiResponse(description="The requested resource does not exist.")
+_RESP_BAD_REQUEST = OpenApiResponse(description="Invalid request data or parameters.")
 
 
 class EnrollmentCrossDomainSessionAuth(SessionAuthenticationAllowInactiveUser, SessionAuthenticationCrossDomainCsrf):
@@ -197,6 +232,23 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
 
     # Since the course about page on the marketing site uses this API to auto-enroll users,
     # we need to support cross-domain CSRF.
+    @extend_schema(
+        summary="Retrieve a user's enrollment in a course",
+        description=(
+            "Returns the current user's enrollment for the specified course, or the named user's "
+            "enrollment when invoked with the {username},{course_id} URL form (server-to-server or "
+            "staff only)."
+        ),
+        parameters=[_USERNAME_PATH_PARAM, _COURSE_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentSerializer,
+                description="Enrollment retrieved successfully (or empty body if no enrollment).",
+            ),
+            400: _RESP_BAD_REQUEST,
+            404: _RESP_NOT_FOUND,
+        },
+    )
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def get(self, request, course_id=None, username=None):
         """Create, read, or update enrollment information for a user.
@@ -288,6 +340,21 @@ class EnrollmentUserRolesView(APIView):
     throttle_classes = (EnrollmentUserThrottle,)
     serializer_class = UserRolesResponseSerializer
 
+    @extend_schema(
+        summary="List the current user's course roles",
+        description=(
+            "Returns the list of course-level roles held by the currently logged-in user, plus an "
+            "is_staff flag. Optionally filters by course_id."
+        ),
+        parameters=[_query_param("course_id", "If provided, only roles for this course are returned.")],
+        responses={
+            200: OpenApiResponse(
+                response=UserRolesResponseSerializer,
+                description="Roles retrieved successfully.",
+            ),
+            400: _RESP_BAD_REQUEST,
+        },
+    )
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def get(self, request):
         """
@@ -383,6 +450,22 @@ class EnrollmentCourseDetailView(APIView):
     throttle_classes = (EnrollmentUserThrottle,)
     serializer_class = CourseSerializer
 
+    @extend_schema(
+        summary="Get enrollment details for a course",
+        description=(
+            "Returns the course schedule and the enrollment modes supported by the course. "
+            "This endpoint does not require authentication. Use ?include_expired=1 to include "
+            "expired enrollment modes."
+        ),
+        parameters=[_COURSE_ID_PATH_PARAM, _INCLUDE_EXPIRED_QUERY_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=CourseSerializer,
+                description="Course enrollment details retrieved successfully.",
+            ),
+            400: _RESP_BAD_REQUEST,
+        },
+    )
     def get(self, request, course_id=None):
         """Read enrollment information for a particular course.
 
@@ -460,6 +543,28 @@ class UnenrollmentView(APIView):
     )
     serializer_class = CourseEnrollmentSerializer
 
+    @extend_schema(
+        operation_id="enrollment_v1_unenroll_deprecated",
+        summary="Unenroll a user from all courses (deprecated)",
+        description=(
+            "Deprecated. Use POST /api/enrollment/v1/enrollment/unenroll/ "
+            "(EnrollmentViewSet.unenroll action) instead. Privileged retirement-pipeline use only."
+        ),
+        request=OpenApiRequest(
+            request={
+                "type": "object",
+                "properties": {"username": {"type": "string"}},
+                "required": ["username"],
+            }
+        ),
+        responses={
+            200: OpenApiResponse(description="List of courses from which the user was unenrolled."),
+            204: OpenApiResponse(description="User has no active enrollments."),
+            404: OpenApiResponse(description="Username not specified or no retirement status for user."),
+            500: OpenApiResponse(description="Unexpected error during unenrollment."),
+        },
+        deprecated=True,
+    )
     def post(self, request):
         """
         Unenrolls the specified user from all courses.
@@ -519,6 +624,22 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
         """Instantiate and return the appropriate serializer for this action."""
         return self.get_serializer_class()(*args, **kwargs)
 
+    @extend_schema(
+        summary="List enrollments for a user (paginated)",
+        description=(
+            "Returns a paginated list of enrollments for the currently logged-in user, or for the "
+            "user named by the 'user' query parameter (staff/admin/api-key access required to view "
+            "another user's enrollments — otherwise filtered to courses the requester staffs)."
+        ),
+        parameters=[_USER_QUERY_PARAM, _PAGE_QUERY_PARAM, _PAGE_SIZE_QUERY_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentSerializer(many=True),
+                description="Paginated enrollment list.",
+            ),
+            401: _RESP_UNAUTHENTICATED,
+        },
+    )
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def list(self, request):
         """Gets a list of all course enrollments for a user.
@@ -561,6 +682,25 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
         page = paginator.paginate_queryset(filtered_enrollments, request, view=self)
         return paginator.get_paginated_response(self.get_serializer(page, many=True).data)
 
+    @extend_schema(
+        summary="Create or update an enrollment",
+        description=(
+            "Enrolls a user in a course. Server-to-server calls may deactivate or modify the mode "
+            "of existing enrollments; all other requests go through add_enrollment(), which creates "
+            "or reactivates enrollments. The request body must include course_details.course_id."
+        ),
+        request=OpenApiRequest(request=CourseEnrollmentSerializer),
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentSerializer,
+                description="Enrollment created, reactivated, or updated successfully.",
+            ),
+            400: _RESP_BAD_REQUEST,
+            403: _RESP_FORBIDDEN,
+            404: _RESP_NOT_FOUND,
+            406: OpenApiResponse(description="The specified user does not exist."),
+        },
+    )
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def create(self, request):
         # pylint: disable=too-many-statements
@@ -809,6 +949,27 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
                     user_id=user.id,
                 )
 
+    @extend_schema(
+        summary="Unenroll a user from all courses (retirement)",
+        description=(
+            "Privileged retirement-pipeline use only. Unenrolls the named user from every active "
+            "enrollment. The request must be made by a service user with CanRetireUser permission, "
+            "not the user being unenrolled."
+        ),
+        request=OpenApiRequest(
+            request={
+                "type": "object",
+                "properties": {"username": {"type": "string"}},
+                "required": ["username"],
+            }
+        ),
+        responses={
+            200: OpenApiResponse(description="List of courses from which the user was unenrolled."),
+            204: OpenApiResponse(description="User has no active enrollments."),
+            404: OpenApiResponse(description="Username not specified or no retirement status for user."),
+            500: OpenApiResponse(description="Unexpected error during unenrollment."),
+        },
+    )
     @action(
         detail=False,
         methods=["post"],
@@ -837,6 +998,29 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
         except Exception as exc:  # pylint: disable=broad-except
             return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    @extend_schema(
+        summary="Manage CourseEnrollmentAllowed records (admin-only)",
+        description=(
+            "GET lists allowed enrollments for an email; POST creates a new one; DELETE removes one "
+            "by email + course_id. Admin-only."
+        ),
+        request=OpenApiRequest(request=CourseEnrollmentAllowedSerializer),
+        parameters=[_query_param("email", "Email to query (GET only). Defaults to the requester's email.")],
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentAllowedSerializer(many=True),
+                description="GET success — list of allowed enrollments for the email.",
+            ),
+            201: OpenApiResponse(
+                response=CourseEnrollmentAllowedSerializer,
+                description="POST success — allowed enrollment created.",
+            ),
+            204: OpenApiResponse(description="DELETE success — allowed enrollment deleted."),
+            400: _RESP_BAD_REQUEST,
+            404: OpenApiResponse(description="DELETE: allowed enrollment not found for the given email/course."),
+            409: OpenApiResponse(description="POST: allowed enrollment already exists for this email/course."),
+        },
+    )
     @action(
         detail=False,
         methods=["get", "post", "delete"],
@@ -1082,6 +1266,23 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
     # Since the course about page on the marketing site
     # uses this API to auto-enroll users, we need to support
     # cross-domain CSRF.
+    @extend_schema(
+        operation_id="enrollment_v1_enrollment_list_deprecated",
+        summary="List enrollments for a user (deprecated)",
+        description=(
+            "Deprecated. Use GET /api/enrollment/v1/enrollment/ (EnrollmentViewSet.list) instead. "
+            "This legacy endpoint returns an unpaginated list."
+        ),
+        parameters=[_USER_QUERY_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentSerializer(many=True),
+                description="Enrollments retrieved successfully.",
+            ),
+            401: _RESP_UNAUTHENTICATED,
+        },
+        deprecated=True,
+    )
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def get(self, request):
         """Gets a list of all course enrollments for a user.
@@ -1118,6 +1319,25 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         serializer = self.serializer_class(filtered_enrollments, many=True)
         return Response(serializer.data)
 
+    @extend_schema(
+        operation_id="enrollment_v1_enrollment_create_deprecated",
+        summary="Create or update an enrollment (deprecated)",
+        description=(
+            "Deprecated. Use POST /api/enrollment/v1/enrollment/ (EnrollmentViewSet.create) instead."
+        ),
+        request=OpenApiRequest(request=CourseEnrollmentSerializer),
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentSerializer,
+                description="Enrollment created, reactivated, or updated successfully.",
+            ),
+            400: _RESP_BAD_REQUEST,
+            403: _RESP_FORBIDDEN,
+            404: _RESP_NOT_FOUND,
+            406: OpenApiResponse(description="The specified user does not exist."),
+        },
+        deprecated=True,
+    )
     def post(self, request):
         # pylint: disable=too-many-statements
         """Enrolls the currently logged-in user in a course.
@@ -1387,6 +1607,32 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 )
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="List all course enrollments (admin-only, paginated)",
+        description=(
+            "Admin-only paginated list of CourseEnrollment records, optionally filtered by "
+            "course_id, course_ids, username, or email."
+        ),
+        parameters=[
+            _query_param("course_id", "Filter to enrollments for this course."),
+            _query_param("course_ids", "Comma-separated list of course IDs."),
+            _query_param("username", "Comma-separated list of usernames."),
+            _query_param("email", "Comma-separated list of emails."),
+            _PAGE_QUERY_PARAM,
+            _PAGE_SIZE_QUERY_PARAM,
+        ],
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentsApiListSerializer(many=True),
+                description="Paginated list of course enrollments.",
+            ),
+            400: _RESP_BAD_REQUEST,
+            401: _RESP_UNAUTHENTICATED,
+            403: _RESP_FORBIDDEN,
+        },
+    ),
+)
 @can_disable_rate_limit
 class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
     """
@@ -1522,6 +1768,23 @@ class EnrollmentAllowedView(APIView):
     throttle_classes = (EnrollmentUserThrottle,)
     serializer_class = CourseEnrollmentAllowedSerializer
 
+    @extend_schema(
+        operation_id="enrollment_v1_enrollment_allowed_list_deprecated",
+        summary="List allowed enrollments by email (deprecated)",
+        description=(
+            "Deprecated. Use GET /api/enrollment/v1/enrollment/enrollment_allowed/ "
+            "(EnrollmentViewSet.allowed action) instead. Admin-only."
+        ),
+        parameters=[_query_param("email", "Email to query. Defaults to the requester's email if omitted.")],
+        responses={
+            200: OpenApiResponse(
+                response=CourseEnrollmentAllowedSerializer(many=True),
+                description="Allowed enrollments retrieved successfully.",
+            ),
+            403: _RESP_FORBIDDEN,
+        },
+        deprecated=True,
+    )
     def get(self, request):
         """
         Returns the enrollments allowed for a given user email.
@@ -1546,6 +1809,25 @@ class EnrollmentAllowedView(APIView):
         serializer = self.serializer_class(enrollments_allowed, many=True)
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
+    @extend_schema(
+        operation_id="enrollment_v1_enrollment_allowed_create_deprecated",
+        summary="Create an allowed enrollment (deprecated)",
+        description=(
+            "Deprecated. Use POST /api/enrollment/v1/enrollment/enrollment_allowed/ "
+            "(EnrollmentViewSet.allowed action) instead. Admin-only."
+        ),
+        request=OpenApiRequest(request=CourseEnrollmentAllowedSerializer),
+        responses={
+            201: OpenApiResponse(
+                response=CourseEnrollmentAllowedSerializer,
+                description="Allowed enrollment created.",
+            ),
+            400: _RESP_BAD_REQUEST,
+            403: _RESP_FORBIDDEN,
+            409: OpenApiResponse(description="Allowed enrollment already exists for this email/course."),
+        },
+        deprecated=True,
+    )
     def post(self, request):
         """
         Creates an enrollment allowed for a given user email and course id.
@@ -1597,6 +1879,22 @@ class EnrollmentAllowedView(APIView):
 
         return Response(status=status.HTTP_201_CREATED, data=self.serializer_class(enrollment_allowed).data)
 
+    @extend_schema(
+        operation_id="enrollment_v1_enrollment_allowed_destroy_deprecated",
+        summary="Delete an allowed enrollment (deprecated)",
+        description=(
+            "Deprecated. Use DELETE /api/enrollment/v1/enrollment/enrollment_allowed/ "
+            "(EnrollmentViewSet.allowed action) instead. Admin-only."
+        ),
+        request=OpenApiRequest(request=CourseEnrollmentAllowedSerializer),
+        responses={
+            204: OpenApiResponse(description="Allowed enrollment deleted."),
+            400: _RESP_BAD_REQUEST,
+            403: _RESP_FORBIDDEN,
+            404: OpenApiResponse(description="Allowed enrollment not found for the given email/course."),
+        },
+        deprecated=True,
+    )
     def delete(self, request):
         """
         Deletes an enrollment allowed for a given user email and course id.

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -21,7 +21,8 @@ from edx_rest_framework_extensions.auth.session.authentication import (
 )  # lint-amnesty, pylint: disable=wrong-import-order
 from opaque_keys import InvalidKeyError  # lint-amnesty, pylint: disable=wrong-import-order
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework import permissions, status  # lint-amnesty, pylint: disable=wrong-import-order
+from rest_framework import permissions, status, viewsets  # lint-amnesty, pylint: disable=wrong-import-order
+from rest_framework.decorators import action  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework.generics import ListAPIView  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework.response import Response  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework.throttling import UserRateThrottle  # lint-amnesty, pylint: disable=wrong-import-order
@@ -415,6 +416,7 @@ class EnrollmentCourseDetailView(APIView):
         return Response(serializer.data)
 
 
+# DEPRECATED (ADR 0028): Use EnrollmentViewSet.unenroll action instead. Will be removed after one named release.
 class UnenrollmentView(APIView):
     """
     **Use Cases**
@@ -480,6 +482,399 @@ class UnenrollmentView(APIView):
             return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
+# ADR 0028 – consolidated from EnrollmentListView, UnenrollmentView, EnrollmentAllowedView
+@can_disable_rate_limit
+class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
+    """
+    DRF ViewSet for the Enrollment API.
+
+    Consolidates EnrollmentListView, UnenrollmentView, and EnrollmentAllowedView into a single
+    ViewSet registered via DefaultRouter per ADR 0028.
+
+    Actions:
+        list        GET  /enrollment/              List enrollments for the current user.
+        create      POST /enrollment/              Enroll the current user in a course.
+        unenroll    POST /enrollment/unenroll/     Unenroll a user from all courses (retirement pipeline).
+        allowed  GET/POST/DELETE /enrollment/enrollment_allowed/  Manage CourseEnrollmentAllowed records.
+    """
+
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        EnrollmentCrossDomainSessionAuth,
+    )
+    permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
+    throttle_classes = (EnrollmentUserThrottle,)
+    serializer_class = CourseEnrollmentSerializer
+
+    def get_serializer_class(self):
+        """Return CourseEnrollmentAllowedSerializer for the 'allowed' action, else the default."""
+        if self.action == "allowed":
+            return CourseEnrollmentAllowedSerializer
+        return self.serializer_class
+
+    def get_serializer(self, *args, **kwargs):
+        """Instantiate and return the appropriate serializer for this action."""
+        return self.get_serializer_class()(*args, **kwargs)
+
+    @method_decorator(ensure_csrf_cookie_cross_domain)
+    def list(self, request):
+        """Gets a list of all course enrollments for a user.
+
+        Returns a list for the currently logged-in user, or for the user named by the 'user' GET
+        parameter. If the username does not match that of the currently logged-in user, only
+        courses for which the currently logged-in user has the Staff or Admin role are listed.
+        """
+        username = request.GET.get("user", request.user.username)
+        enrollments = CourseEnrollment.objects.filter(
+            user__username=username
+        ).select_related("user", "course_overview")
+        if (
+            username == request.user.username
+            or GlobalStaff().has_user(request.user)
+            or self.has_api_key_permissions(request)
+        ):
+            return Response(self.get_serializer(enrollments, many=True).data)
+        filtered_enrollments = [
+            enrollment for enrollment in enrollments
+            if user_has_role(request.user, CourseStaffRole(enrollment.course_id))
+        ]
+        return Response(self.get_serializer(filtered_enrollments, many=True).data)
+
+    @method_decorator(ensure_csrf_cookie_cross_domain)
+    def create(self, request):
+        # pylint: disable=too-many-statements
+        """Enrolls the currently logged-in user in a course.
+
+        Server-to-server calls may deactivate or modify the mode of existing enrollments. All other
+        requests go through add_enrollment(), which allows creation and reactivation of enrollments.
+        """
+        username = request.data.get("user")
+        course_id = request.data.get("course_details", {}).get("course_id")
+
+        if not course_id:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "Course ID must be specified to create a new enrollment."},
+            )
+
+        try:
+            course_id = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data={"message": f"No course '{course_id}' found for enrollment"}
+            )
+
+        mode = request.data.get("mode")
+
+        has_api_key_permissions = self.has_api_key_permissions(request)
+
+        if (
+            username
+            and username != request.user.username
+            and not has_api_key_permissions
+            and not GlobalStaff().has_user(request.user)
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if not username:
+            email = request.data.get("email")
+            if email:
+                if not has_api_key_permissions and not GlobalStaff().has_user(request.user):
+                    return Response(status=status.HTTP_404_NOT_FOUND)
+                try:
+                    username = User.objects.get(email=email).username
+                except ObjectDoesNotExist:
+                    return Response(
+                        status=status.HTTP_406_NOT_ACCEPTABLE,
+                        data={"message": f"The user with the email address {email} does not exist."},
+                    )
+            else:
+                username = request.user.username
+
+        if (
+            mode not in (CourseMode.AUDIT, CourseMode.HONOR, None)
+            and not has_api_key_permissions
+            and not GlobalStaff().has_user(request.user)
+        ):
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={
+                    "message": "User does not have permission to create enrollment with mode [{mode}].".format(
+                        mode=mode
+                    )
+                },
+            )
+
+        try:
+            user = User.objects.get(username=username)
+        except ObjectDoesNotExist:
+            return Response(
+                status=status.HTTP_406_NOT_ACCEPTABLE, data={"message": f"The user {username} does not exist."}
+            )
+
+        embargo_response = embargo_api.get_embargo_response(request, course_id, user)
+
+        if embargo_response:
+            return embargo_response
+
+        try:
+            is_active = request.data.get("is_active")
+            if is_active is not None and not isinstance(is_active, bool):
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={"message": ("'{value}' is an invalid enrollment activation status.").format(value=is_active)},
+                )
+
+            explicit_linked_enterprise = request.data.get("linked_enterprise_customer")
+            if explicit_linked_enterprise and has_api_key_permissions and enterprise_enabled():
+                enterprise_api_client = EnterpriseApiServiceClient()
+                consent_client = ConsentApiServiceClient()
+                try:
+                    enterprise_api_client.post_enterprise_course_enrollment(username, str(course_id))
+                except EnterpriseApiException as error:
+                    log.exception(
+                        "An unexpected error occurred while creating the new EnterpriseCourseEnrollment "
+                        "for user [%s] in course run [%s]",
+                        username,
+                        course_id,
+                    )
+                    raise CourseEnrollmentError(str(error))  # lint-amnesty, pylint: disable=raise-missing-from
+                kwargs = {
+                    "username": username,
+                    "course_id": str(course_id),
+                    "enterprise_customer_uuid": explicit_linked_enterprise,
+                }
+                consent_client.provide_consent(**kwargs)
+
+            enrollment_attributes = request.data.get("enrollment_attributes")
+            force_enrollment = request.data.get("force_enrollment")
+            if force_enrollment is not None and not isinstance(force_enrollment, bool):
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={
+                        "message": ("'{value}' is an invalid force enrollment status.").format(value=force_enrollment)
+                    },
+                )
+            force_enrollment = force_enrollment and GlobalStaff().has_user(request.user)
+            enrollment = api.get_enrollment(username, str(course_id))
+            mode_changed = enrollment and mode is not None and enrollment["mode"] != mode
+            active_changed = enrollment and is_active is not None and enrollment["is_active"] != is_active
+            missing_attrs = []
+            if enrollment_attributes:
+                actual_attrs = ["{namespace}:{name}".format(**attr) for attr in enrollment_attributes]
+                missing_attrs = set(REQUIRED_ATTRIBUTES.get(mode, [])) - set(actual_attrs)
+            if (GlobalStaff().has_user(request.user) or has_api_key_permissions) and (mode_changed or active_changed):
+                if mode_changed and active_changed and not is_active:
+                    msg = "Enrollment mode mismatch: active mode={}, requested mode={}. Won't deactivate.".format(
+                        enrollment["mode"], mode
+                    )
+                    log.warning(msg)
+                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
+
+                if missing_attrs:
+                    msg = "Missing enrollment attributes: requested mode={} required attributes={}".format(
+                        mode, REQUIRED_ATTRIBUTES.get(mode)
+                    )
+                    log.warning(msg)
+                    return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": msg})
+
+                response = api.update_enrollment(
+                    username,
+                    str(course_id),
+                    mode=mode,
+                    is_active=is_active,
+                    enrollment_attributes=enrollment_attributes,
+                    include_expired=has_api_key_permissions,
+                )
+            else:
+                response = api.add_enrollment(
+                    username,
+                    str(course_id),
+                    mode=mode,
+                    is_active=is_active,
+                    enrollment_attributes=enrollment_attributes,
+                    enterprise_uuid=request.data.get("enterprise_uuid"),
+                    force_enrollment=force_enrollment,
+                    include_expired=force_enrollment,
+                )
+
+            cohort_name = request.data.get("cohort")
+            if cohort_name is not None:
+                cohort = get_cohort_by_name(course_id, cohort_name)
+                try:
+                    add_user_to_cohort(cohort, user)
+                except ValueError:
+                    log.exception("Cohort re-addition")
+            email_opt_in = request.data.get("email_opt_in", None)
+            if email_opt_in is not None:
+                org = course_id.org
+                update_email_opt_in(request.user, org, email_opt_in)
+
+            log.info("The user [%s] has already been enrolled in course run [%s].", username, course_id)
+            return Response(response)
+
+        except InvalidEnrollmentAttribute as error:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": str(error),
+                    "localizedMessage": str(error),
+                }
+            )
+        except EnrollmentNotAllowed as error:
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={
+                    "message": str(error),
+                    "localizedMessage": str(error),
+                }
+            )
+        except CourseModeNotFoundError as error:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": (
+                        "The [{mode}] course mode is expired or otherwise unavailable for course run [{course_id}]."
+                    ).format(mode=mode, course_id=course_id),
+                    "course_details": error.data,
+                },
+            )
+        except CourseNotFoundError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data={"message": f"No course '{course_id}' found for enrollment"}
+            )
+        except CourseEnrollmentExistsError as error:
+            log.warning("An enrollment already exists for user [%s] in course run [%s].", username, course_id)
+            return Response(data=error.enrollment)
+        except CourseEnrollmentError:
+            log.exception(
+                "An error occurred while creating the new course enrollment for user [%s] in course run [%s]",
+                username,
+                course_id,
+            )
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": (
+                        "An error occurred while creating the new course enrollment for user "
+                        "'{username}' in course '{course_id}'"
+                    ).format(username=username, course_id=course_id)
+                },
+            )
+        except CourseUserGroup.DoesNotExist:
+            log.exception("Missing cohort [%s] in course run [%s]", cohort_name, course_id)
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "An error occured while adding to cohort [%s]" % cohort_name},
+            )
+        finally:
+            if has_api_key_permissions:
+                try:
+                    current_enrollment_obj = CourseEnrollment.objects.get(
+                        user__username=username, course_id=course_id
+                    )
+                    actual_mode = current_enrollment_obj.mode
+                    actual_activation = current_enrollment_obj.is_active
+                except CourseEnrollment.DoesNotExist:
+                    actual_mode = None
+                    actual_activation = None
+                audit_log(
+                    "enrollment_change_requested",
+                    course_id=str(course_id),
+                    requested_mode=mode,
+                    actual_mode=actual_mode,
+                    requested_activation=is_active,
+                    actual_activation=actual_activation,
+                    user_id=user.id,
+                )
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="unenroll",
+        permission_classes=[permissions.IsAuthenticated, CanRetireUser],
+    )
+    def unenroll(self, request):
+        """Unenrolls the specified user from all courses.
+
+        Privileged retirement-pipeline use only. The request must be made by a service user
+        with CanRetireUser permission, not the user being unenrolled.
+        """
+        try:
+            username = request.data["username"]
+            UserRetirementStatus.get_retirement_for_retirement_action(username)
+            active_enrollments = CourseEnrollment.objects.filter(
+                user__username=username, is_active=True
+            )
+            if not active_enrollments.exists():
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            return Response(api.unenroll_user_from_all_courses(username))
+        except KeyError:
+            return Response("Username not specified.", status=status.HTTP_404_NOT_FOUND)
+        except UserRetirementStatus.DoesNotExist:
+            return Response("No retirement request status for username.", status=status.HTTP_404_NOT_FOUND)
+        except Exception as exc:  # pylint: disable=broad-except
+            return Response(str(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @action(
+        detail=False,
+        methods=["get", "post", "delete"],
+        url_path="enrollment_allowed",
+        permission_classes=[permissions.IsAdminUser],
+        throttle_classes=[EnrollmentUserThrottle],
+    )
+    def allowed(self, request):
+        """Retrieve, create, or delete CourseEnrollmentAllowed records. Admin-only.
+
+        GET    /enrollment/enrollment_allowed/?email=<email>   List allowed enrollments for an email.
+        POST   /enrollment/enrollment_allowed/                  Create a new allowed enrollment.
+        DELETE /enrollment/enrollment_allowed/                  Delete an existing allowed enrollment.
+        """
+        if request.method == "GET":
+            user_email = request.query_params.get("email") or request.user.email
+            enrollments_allowed = CourseEnrollmentAllowed.objects.filter(email=user_email)
+            return Response(
+                status=status.HTTP_200_OK,
+                data=self.get_serializer(enrollments_allowed, many=True).data,
+            )
+
+        serializer = self.get_serializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(status=status.HTTP_400_BAD_REQUEST, data=serializer.errors)
+
+        if request.method == "POST":
+            try:
+                enrollment_allowed = serializer.save()
+            except IntegrityError:
+                return Response(
+                    status=status.HTTP_409_CONFLICT,
+                    data={
+                        "message": (
+                            f"An enrollment allowed with email {serializer.validated_data.get('email')} "
+                            f"and course {serializer.validated_data.get('course_id')} already exists."
+                        )
+                    },
+                )
+            return Response(
+                status=status.HTTP_201_CREATED,
+                data=self.get_serializer(enrollment_allowed).data,
+            )
+
+        # DELETE
+        email = serializer.validated_data.get("email")
+        course_id = serializer.validated_data.get("course_id")
+        try:
+            CourseEnrollmentAllowed.objects.get(email=email, course_id=course_id).delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except ObjectDoesNotExist:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={"message": f"An enrollment allowed with email {email} and course {course_id} doesn't exists."},
+            )
+
+
+# DEPRECATED (ADR 0028): Use EnrollmentViewSet instead. Will be removed after one named release.
 @can_disable_rate_limit
 class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
     """
@@ -1089,6 +1484,7 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         return queryset
 
 
+# DEPRECATED (ADR 0028): Use EnrollmentViewSet.allowed action instead. Will be removed after one named release.
 class EnrollmentAllowedView(APIView):
     """
     A view that allows the retrieval and creation of enrollment allowed for a given user email and course id.

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -19,6 +19,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import (
 from edx_rest_framework_extensions.auth.session.authentication import (
     SessionAuthenticationAllowInactiveUser,
 )  # lint-amnesty, pylint: disable=wrong-import-order
+from edx_rest_framework_extensions.paginators import DefaultPagination  # lint-amnesty, pylint: disable=wrong-import-order
 from opaque_keys import InvalidKeyError  # lint-amnesty, pylint: disable=wrong-import-order
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework import permissions, status, viewsets  # lint-amnesty, pylint: disable=wrong-import-order
@@ -506,6 +507,7 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
     throttle_classes = (EnrollmentUserThrottle,)
     serializer_class = CourseEnrollmentSerializer
+    pagination_class = DefaultPagination  # ADR 0032
 
     def get_serializer_class(self):
         """Return CourseEnrollmentAllowedSerializer for the 'allowed' action, else the default."""
@@ -521,25 +523,43 @@ class EnrollmentViewSet(viewsets.ViewSet, ApiKeyPermissionMixIn):
     def list(self, request):
         """Gets a list of all course enrollments for a user.
 
-        Returns a list for the currently logged-in user, or for the user named by the 'user' GET
-        parameter. If the username does not match that of the currently logged-in user, only
-        courses for which the currently logged-in user has the Staff or Admin role are listed.
+        Returns a paginated list for the currently logged-in user, or for the user named by the
+        'user' GET parameter. If the username does not match that of the currently logged-in user,
+        only courses for which the currently logged-in user has the Staff or Admin role are listed.
+
+        **Pagination Parameters**
+
+            - ``page`` (int): Page number to retrieve. Default is 1.
+            - ``page_size`` (int): Items per page. Default is 10, max is 100.
+
+        **Response Envelope**
+
+            - ``count`` (int): Total number of results.
+            - ``num_pages`` (int): Total number of pages.
+            - ``current_page`` (int): The current page number.
+            - ``start`` (int): The 0-based index of the first item on this page.
+            - ``next`` (str|null): URL for the next page, or null.
+            - ``previous`` (str|null): URL for the previous page, or null.
+            - ``results`` (list): The list of enrollments for this page.
         """
         username = request.GET.get("user", request.user.username)
         enrollments = CourseEnrollment.objects.filter(
             user__username=username
-        ).select_related("user", "course_overview")
+        ).select_related("user", "course")  # "course" is the FK field; "course_overview" is a property
+        paginator = self.pagination_class()
         if (
             username == request.user.username
             or GlobalStaff().has_user(request.user)
             or self.has_api_key_permissions(request)
         ):
-            return Response(self.get_serializer(enrollments, many=True).data)
+            page = paginator.paginate_queryset(enrollments, request, view=self)
+            return paginator.get_paginated_response(self.get_serializer(page, many=True).data)
         filtered_enrollments = [
             enrollment for enrollment in enrollments
             if user_has_role(request.user, CourseStaffRole(enrollment.course_id))
         ]
-        return Response(self.get_serializer(filtered_enrollments, many=True).data)
+        page = paginator.paginate_queryset(filtered_enrollments, request, view=self)
+        return paginator.get_paginated_response(self.get_serializer(page, many=True).data)
 
     @method_decorator(ensure_csrf_cookie_cross_domain)
     def create(self, request):
@@ -1403,9 +1423,9 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         * email: List of comma-separated emails. Filters the result to the course enrollments
           of the given users. Optional.
 
-        * page_size: Number of results to return per page. Optional.
+        * page_size: Number of results to return per page. Default 100, max 100. Optional.
 
-        * page: Page number to retrieve. Optional.
+        * page: Page number to retrieve. Default is 1. Optional.
 
     **Response Values**
 
@@ -1413,6 +1433,20 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         is returned.
 
         The HTTP 200 response has the following values.
+
+        * count: Total number of course enrollments matching the request.
+
+        * num_pages: Total number of pages.
+
+        * current_page: The current page number.
+
+        * start: The 0-based index of the first item on this page.
+
+        * next: The URL to the next page of results, or null if this is the
+          last page.
+
+        * previous: The URL to the previous page of results, or null if this
+          is the first page.
 
         * results: A list of the course enrollments matching the request.
 
@@ -1425,12 +1459,6 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
             * user: Username of the user in the course enrollment.
 
             * course_id: Course ID of the course in the course enrollment.
-
-        * next: The URL to the next page of results, or null if this is the
-          last page.
-
-        * previous: The URL to the next page of results, or null if this
-          is the first page.
 
         If the user is not logged in, a 401 error is returned.
 


### PR DESCRIPTION
### Description:

The FC-0118 initiative introduces a comprehensive standardization of APIs across the platform, guided by 15 newly defined Architectural Decision Records (ADRs). These ADRs collectively establish consistent patterns for serializers, permissions, error handling, pagination, filtering, authentication, versioning, and overall API design. Through this effort, existing endpoints are being refactored and aligned to ensure uniformity, improved developer experience, and long-term maintainability, while also reducing redundancy and inconsistencies across services.

### Checklist:

- [x] 0025 – Standardize Serializer Usage
- [x] 0026 – Standardize Permission Classes
- [ ] 0027 – Standardize API Documentation & Schema Coverage
- [x] 0028 – Standardize RESTful API Endpoints using DRF ViewSets
- [ ] 0029 – Standardize Error Responses
- [ ] 0030 – Ensure GET Requests are Idempotent
- [ ] 0031 – Merge Similar Endpoints
- [x] 0032 – Standardize Pagination Usage
- [ ] 0033 – Standardize Filter & Sort using django-filter
- [ ] 0034 – Unify Auth (OAuth2 v2)
- [ ] 0035 – Port Legacy Django Views to DRF
- [ ] 0036 – Normalize Deeply Nested JSON APIs
- [ ] 0037 – API Versioning Strategy
- [ ] 0038 - Introduce Row level Security Layer
- [ ] 0040 – Document & Consolidate Internal APIs used by MFEs
