### PR TITLE
fix: match video download link font size with transcript download link

### DIFF
--- a/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/VideoBlockDisplay.css
@@ -96,6 +96,9 @@
 }
 
 .xmodule_display.xmodule_VideoBlock .video .wrapper-downloads .wrapper-download-video .video-sources {
+    /* Match it with Transcipts */
+    font-size: 16px !important;
+    font-weight: unset;
     margin: 0;
 }
 


### PR DESCRIPTION
### Related Issue
https://github.com/mitodl/hq/issues/10469

### For External Video (xblocks-contrib)
https://github.com/openedx/xblocks-contrib/pull/226

## Description
This pull request makes a minor style adjustment to the video block display. The font size for `.video-sources` within the downloads wrapper has been updated to match that of transcripts, ensuring visual consistency.

* Increased the font size of `.video-sources` to 16px and unset its font weight in `VideoBlockDisplay.css` for consistency with transcript styling.

## Testing instructions

Visual difference is clearly visible in Safari browsers, best to test it in Safari


## Before
<img width="1235" height="510" alt="image" src="https://github.com/user-attachments/assets/60fda670-df02-4dba-b43d-b7560942d165" />


## After
<img width="1235" height="510" alt="image" src="https://github.com/user-attachments/assets/b2d41b55-e900-466d-a36e-423946a58366" />
