### PR TITLE
feat: Enhance SAML provider name resolution & update redirect handling

### DIFF
--- a/common/djangoapps/third_party_auth/middleware.py
+++ b/common/djangoapps/third_party_auth/middleware.py
@@ -1,18 +1,49 @@
 """Middleware classes for third_party_auth."""
 
 
+import json
+import urllib.parse
+
 import six.moves.urllib.parse
+from django.conf import settings
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import gettext as _
 from requests import HTTPError
+from social_core.exceptions import SocialAuthBaseException
 from social_django.middleware import SocialAuthExceptionMiddleware
 
 from common.djangoapps.student.helpers import get_next_url_for_login_page
 
-from . import pipeline
+from . import pipeline, provider
+
+
+def _get_saml_provider_name(request):
+    """
+    Try to resolve the human-readable provider name from the SAML RelayState
+    that is present in the POST body of /auth/complete/tpa-saml/.
+
+    Returns the provider display name (e.g. "Cartão de Cidadão") or None if
+    it cannot be determined.
+    """
+    try:
+        backend = getattr(request, 'backend', None)
+        if backend is None:
+            return None
+        relay_state_str = backend.strategy.request_data().get('RelayState', '')
+        relay_state = json.loads(relay_state_str)
+        idp_slug = relay_state.get('idp')
+        if not idp_slug:
+            return None
+        # provider_id for SAML providers is "saml-<slug>"
+        saml_provider = provider.Registry.get(f'saml-{idp_slug}')
+        if saml_provider:
+            return saml_provider.name
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return None
 
 
 class ExceptionMiddleware(SocialAuthExceptionMiddleware, MiddlewareMixin):
@@ -31,6 +62,25 @@ class ExceptionMiddleware(SocialAuthExceptionMiddleware, MiddlewareMixin):
         # Check if we have an auth entry key we can use instead
         if auth_entry and auth_entry in pipeline.AUTH_DISPATCH_URLS:
             redirect_uri = pipeline.AUTH_DISPATCH_URLS[auth_entry]
+
+        # For the account_settings SAML flow, /account/settings is a plain RedirectView
+        # that goes to the Account MFE without preserving Django messages. Build the
+        # MFE URL directly so the ?duplicate_provider param reaches the frontend.
+        # This only applies to the tpa-saml backend; OAuth providers are handled by
+        # the existing get_duplicate_provider() path in settings_views.account_settings().
+        backend_name = getattr(getattr(request, 'backend', None), 'name', None)
+        if (
+            auth_entry == pipeline.AUTH_ENTRY_ACCOUNT_SETTINGS
+            and isinstance(exception, SocialAuthBaseException)
+            and backend_name == 'tpa-saml'
+        ):
+            account_mfe_url = getattr(settings, 'ACCOUNT_MICROFRONTEND_URL', None)
+            if account_mfe_url:
+                provider_name = _get_saml_provider_name(request) or backend_name
+                redirect_uri = '{}?duplicate_provider={}'.format(
+                    account_mfe_url.rstrip('/') + '/',
+                    urllib.parse.quote(provider_name, safe=''),
+                )
 
         return redirect_uri
 


### PR DESCRIPTION
## Description

Fixes an issue where the TPA errors during the "link account" flow from the Account MFE were skipped, leaving the user with no feedback.

### Root cause

When a SAML authentication error occurs (e.g. `AuthAlreadyAssociated` — the IdP account is already
linked to a different platform account), `ExceptionMiddleware.get_redirect_uri()` returned
`/account/settings`. That path is registered as a plain
`django.views.generic.base.RedirectView` pointing directly to `ACCOUNT_MICROFRONTEND_URL`. This
redirect is stateless — it does not read or forward Django messages, nor does it preserve query
parameters — so any error context was lost before the MFE ever loaded.

### What changed

**`common/djangoapps/third_party_auth/middleware.py`**

- Added `_get_saml_provider_name(request)`: reads the `RelayState` field from the SAML POST body
  (which contains the IdP slug as `{"idp": "<slug>", ...}`), looks up the corresponding provider in
  the TPA registry, and returns its human-readable display name (e.g. *Cartão de Cidadão*). Falls
  back to `None` gracefully on any parsing or lookup failure.

- Extended `ExceptionMiddleware.get_redirect_uri()`: when `auth_entry == account_settings` and the
  exception is a `SocialAuthBaseException`, the method now bypasses `/account/settings` and builds
  the Account MFE URL directly with `?duplicate_provider=<name>`, using `urllib.parse.quote()` to
  encode the name as `%20`-spaced (not `+`-spaced) so the MFE renders it correctly. Falls back to
  the backend name (`tpa-saml`, OAuth provider name, etc.) if the SAML provider name cannot be
  resolved.

The Account MFE (`frontend-app-account`) already reads `?duplicate_provider=` in
`AccountSettingsPage.jsx` and renders a danger alert — no frontend changes were required.

### Impact

- **Learners**: The error message *"The [Provider Name] account you selected is already linked to
  another [Site Name] account."* is now correctly displayed in the Account MFE after a failed link
  attempt.
- **Operators / Developers**: No configuration changes required. The fix activates automatically for
  any `auth_entry=account_settings` TPA error.

### Screencast
[Screencast from 01-04-26 09:03:33.webm](https://github.com/user-attachments/assets/f4383584-92c5-4577-8e3f-9e8ef365effc)


---

## Testing instructions
*This change was tested by using `SimpleSAMLphp`

1. Configure two platform accounts (`user_a@example.com`, `user_b@example.com`) and a SAML IdP.
2. Link the SAML identity to `user_a` via the normal login flow.
3. Log in as `user_b`.
4. Navigate to Account MFE → **Linked Accounts**.
5. Click **"Sign in with \<Provider Name\>"** for the same SAML IdP.
6. Complete authentication with the same identity on the IdP side.
7. **Expected**: Account MFE reloads and shows a red alert:
   > *"The [Provider Display Name] account you selected is already linked to another [Site Name]
   > account."*

